### PR TITLE
Defer explicit-start DCP registration

### DIFF
--- a/playground/Stress/Stress.AppHost/AppHost.cs
+++ b/playground/Stress/Stress.AppHost/AppHost.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 #pragma warning disable ASPIREDOTNETTOOL
+#pragma warning disable ASPIREINTERACTION001
 #pragma warning disable ASPIREPERSISTENCE001 // Resource lifetime APIs are experimental.
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -18,6 +19,10 @@ builder.Services.AddHealthChecks().AddAsyncCheck("health-test", async (ct) =>
 var manualArgSource = builder.AddExecutable("manual-arg-source", "dotnet", Environment.CurrentDirectory)
     .WithHttpEndpoint(targetPort: 8088);
 var manualArgEndpoint = manualArgSource.GetEndpoint("http");
+var stressEmptyProjectPath = new Projects.Stress_Empty().ProjectPath;
+const string interactionContainerImage = "alpine";
+const string interactionContainerEntrypoint = "/bin/sh";
+string[] interactionContainerArgs = ["-c", "while true; do sleep 3600; done"];
 
 manualArgSource.WithArgs("--dashboard-port")
     .WithArgs(c => c.Args.Add(manualArgEndpoint.Property(EndpointProperty.Port)));
@@ -35,6 +40,45 @@ builder.AddDotnetTool("manual-dotnet-tool-args", "dotnet-dump")
     .WithArgs("--version", "--dashboard-port")
     .WithArgs(c => c.Args.Add(manualArgEndpoint.Property(EndpointProperty.Port)))
     .WithExplicitStart();
+
+builder.AddExecutable("manual-environment-interaction", "dotnet", Environment.CurrentDirectory, "run", "--project", stressEmptyProjectPath, "--no-build")
+    .WithExplicitStart()
+    .WithEnvironment(context => PromptForEnvironmentValueAsync(
+        context,
+        "MANUAL_ENVIRONMENT_INTERACTION_VALUE",
+        "Explicit start executable environment callback",
+        "This prompt should only appear after manually starting the session-scoped executable."));
+
+builder.AddExecutable("persistent-environment-interaction", "dotnet", Environment.CurrentDirectory, "run", "--project", stressEmptyProjectPath, "--no-build")
+    .WithPersistentLifetime()
+    .WithExplicitStart()
+    .WithEnvironment(context => PromptForEnvironmentValueAsync(
+        context,
+        "PERSISTENT_EXECUTABLE_ENVIRONMENT_INTERACTION_VALUE",
+        "Persistent executable environment callback",
+        "This prompt appears during startup because persistent executable resources are registered with DCP immediately."));
+
+builder.AddContainer("manual-container-environment-interaction", interactionContainerImage)
+    .WithEntrypoint(interactionContainerEntrypoint)
+    .WithArgs(interactionContainerArgs)
+    .WithExplicitStart()
+    .WithEnvironment(context => PromptForEnvironmentValueAsync(
+        context,
+        "MANUAL_CONTAINER_ENVIRONMENT_INTERACTION_VALUE",
+        "Explicit start container environment callback",
+        "This prompt should only appear after manually starting the session-scoped container."));
+
+builder.AddContainer("persistent-container-environment-interaction", interactionContainerImage)
+    .WithContainerName("stress-persistent-container-environment-interaction")
+    .WithEntrypoint(interactionContainerEntrypoint)
+    .WithArgs(interactionContainerArgs)
+    .WithPersistentLifetime()
+    .WithExplicitStart()
+    .WithEnvironment(context => PromptForEnvironmentValueAsync(
+        context,
+        "PERSISTENT_CONTAINER_ENVIRONMENT_INTERACTION_VALUE",
+        "Persistent container environment callback",
+        "This prompt appears during startup because persistent container resources are registered with DCP immediately."));
 
 for (var i = 0; i < 2; i++)
 {
@@ -100,7 +144,6 @@ builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard
 builder.AddExecutable("executableWithSingleArg", "dotnet", Environment.CurrentDirectory, "--version");
 builder.AddExecutable("executableWithSingleEscapedArg", "dotnet", Environment.CurrentDirectory, "one two");
 builder.AddExecutable("executableWithMultipleArgs", "dotnet", Environment.CurrentDirectory, "--version", "one two");
-var stressEmptyProjectPath = new Projects.Stress_Empty().ProjectPath;
 builder.AddExecutable("persistentExecutable", "dotnet", Environment.CurrentDirectory, "run", "--project", stressEmptyProjectPath, "--no-build")
     .WithPersistentLifetime();
 
@@ -128,3 +171,23 @@ builder.AddProject<Projects.Stress_Empty>("empty-profile-2", launchProfileName: 
 builder.AddNoStatusResource("no-status-resource");
 
 builder.Build().Run();
+
+static async Task PromptForEnvironmentValueAsync(
+    EnvironmentCallbackContext context,
+    string environmentVariableName,
+    string title,
+    string message)
+{
+    var interactionService = context.ExecutionContext.ServiceProvider.GetRequiredService<IInteractionService>();
+    var result = await interactionService.PromptInputAsync(
+        title: title,
+        message: message,
+        inputLabel: "Environment value",
+        placeHolder: "Value from WithEnvironment callback",
+        cancellationToken: context.CancellationToken);
+
+    if (!result.Canceled && result.Data.Value is { } value)
+    {
+        context.EnvironmentVariables[environmentVariableName] = value;
+    }
+}

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -251,9 +251,7 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
 
     public bool IsReadyToCreate(RenderedModelResource<Container> resource, ContainerCreationContext cctx)
     {
-        // Containers are always "created" (submitted to DCP), they just get Spec.Start = false initially
-        // if explicit startup is used.
-        return true;
+        return !DcpModelUtilities.ShouldDeferCreateForExplicitStart(resource.ModelResource, resource.DcpResource.Spec.Start);
     }
 
     public async Task CreateObjectAsync(RenderedModelResource<Container> cr, ContainerCreationContext cctx, ILogger logger, IDcpObjectFactory factory, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -376,7 +376,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
     Task IDcpObjectFactory.UpdateWithEffectiveAddressInfo(IEnumerable<Service> services, CancellationToken cancellationToken, TimeSpan? timeout)
         => UpdateWithEffectiveAddressInfo(services, cancellationToken, timeout);
 
-    // Watches DCP object updates via a Kubernetes watch wrapped in the supplied retry pipeline, 
+    // Watches DCP object updates via a Kubernetes watch wrapped in the supplied retry pipeline,
     // till all objects reach desired state or a timeout occurs.
     // Returns names of objects that did not reach the desired state.
     private async Task<HashSet<string>> WatchUntilDesiredStateAsync<TDcpResource>(
@@ -591,8 +591,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
     Task IDcpObjectFactory.CreateDcpObjectsAsync<T>(IEnumerable<T> objects, CancellationToken cancellationToken)
         => CreateDcpObjectsAsync(objects, cancellationToken);
 
-    async Task<T> IDcpObjectFactory.PatchDcpObjectAsync<T>(T obj, Action<T> change, CancellationToken cancellationToken)
-        => await PatchDcpObjectAsync(obj, change, cancellationToken).ConfigureAwait(false);
+    Task<T> IDcpObjectFactory.PatchDcpObjectAsync<T>(T obj, Action<T> change, CancellationToken cancellationToken)
+        => PatchDcpObjectAsync(obj, change, cancellationToken);
 
     private async Task<T> PatchDcpObjectAsync<T>(T obj, Action<T> change, CancellationToken cancellationToken)
         where T : CustomResource, IKubernetesStaticMetadata
@@ -1071,20 +1071,25 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             await appResource.Initialized.WaitAsync(cancellationToken).ConfigureAwait(false);
             using var _ = await ConcurrencyUtils.AcquireAllAsync([appResource.SerializedOpSemaphore], cancellationToken).ConfigureAwait(false);
 
-            if (await TryStartCreatedDelayedStartResourceAsync(resourceReference, resourceType, cancellationToken).ConfigureAwait(false))
-            {
-                return;
-            }
-
-            // Reset cached callback results so they are re-evaluated on restart.
-            ForgetCachedCallbackResults(resourceReference.ModelResource);
-
-            // Raise event after resource has been deleted. This is required because the event sets the status to "Starting" and resources being
-            // deleted will temporarily override the status to a terminal state, such as "Exited".
+            // For resources that need delete/recreate startup, raise the starting event after deletion. This is required because
+            // deleting the existing DCP object temporarily overrides the status with a terminal state, such as "Exited".
             switch (resourceReference)
             {
+                // We need to handle explicit start persistent resources specially on first launch as they may already be running, so we need to register them with DCP to discover their status.
+                case RenderedModelResource<Container> { DcpResource.Spec.Start: false } cr when !DcpModelUtilities.ShouldDeferCreateForExplicitStart(cr.ModelResource, cr.DcpResource.Spec.Start):
+                    await PublishConnectionStringAvailableEventAsync(cr.ModelResource, cancellationToken).ConfigureAwait(false);
+                    await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, cr.ModelResource, cr.DcpResourceName)).ConfigureAwait(false);
+                    await PatchDcpObjectAsync(cr.DcpResource, static c => c.Spec.Start = true, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case RenderedModelResource<Executable> { DcpResource.Spec.Start: false } er when !DcpModelUtilities.ShouldDeferCreateForExplicitStart(er.ModelResource, er.DcpResource.Spec.Start):
+                    await PublishConnectionStringAvailableEventAsync(er.ModelResource, cancellationToken).ConfigureAwait(false);
+                    await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, er.ModelResource, er.DcpResourceName)).ConfigureAwait(false);
+                    await PatchDcpObjectAsync(er.DcpResource, static e => e.Spec.Start = true, cancellationToken).ConfigureAwait(false);
+                    break;
+
                 case RenderedModelResource<Container> cr:
-                    await EnsureResourceDeletedAsync<Container>(resourceReference.DcpResourceName, cancellationToken).ConfigureAwait(false);
+                    await EnsureResourceDeletedAsync<Container>(resourceReference, cancellationToken).ConfigureAwait(false);
 
                     // Ensure we explicitly start the container even if original container was created in "delay-start" mode.
                     cr.DcpResource.Spec.Start = true;
@@ -1095,7 +1100,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
                     await _containerCreator.CreateObjectAsync(cr, cctx, resourceLogger, this, cancellationToken).ConfigureAwait(false);
                     break;
                 case RenderedModelResource<Executable> er:
-                    await EnsureResourceDeletedAsync<Executable>(resourceReference.DcpResourceName, cancellationToken).ConfigureAwait(false);
+                    await EnsureResourceDeletedAsync<Executable>(resourceReference, cancellationToken).ConfigureAwait(false);
 
                     // Ensure we explicitly start the executable even if original executable was created in "delay-start" mode.
                     er.DcpResource.Spec.Start = true;
@@ -1125,32 +1130,12 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         }
     }
 
-    private async Task<bool> TryStartCreatedDelayedStartResourceAsync(IResourceReference resourceReference, string resourceType, CancellationToken cancellationToken)
+    private async Task EnsureResourceDeletedAsync<T>(IResourceReference resource, CancellationToken cancellationToken) where T : CustomResource, IKubernetesStaticMetadata
     {
-        switch (resourceReference)
-        {
-            case RenderedModelResource<Container> { DcpResource.Spec.Start: false } cr
-                when !DcpModelUtilities.ShouldDeferCreateForExplicitStart(cr.ModelResource, cr.DcpResource.Spec.Start):
-                await PublishConnectionStringAvailableEventAsync(cr.ModelResource, cancellationToken).ConfigureAwait(false);
-                await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, cr.ModelResource, cr.DcpResourceName)).ConfigureAwait(false);
-                await PatchDcpObjectAsync(cr.DcpResource, static c => c.Spec.Start = true, cancellationToken).ConfigureAwait(false);
-                return true;
+        _logger.LogDebug("Ensuring '{ResourceName}' is deleted.", resource.DcpResourceName);
 
-            case RenderedModelResource<Executable> { DcpResource.Spec.Start: false } er
-                when !DcpModelUtilities.ShouldDeferCreateForExplicitStart(er.ModelResource, er.DcpResource.Spec.Start):
-                await PublishConnectionStringAvailableEventAsync(er.ModelResource, cancellationToken).ConfigureAwait(false);
-                await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, er.ModelResource, er.DcpResourceName)).ConfigureAwait(false);
-                await PatchDcpObjectAsync(er.DcpResource, static e => e.Spec.Start = true, cancellationToken).ConfigureAwait(false);
-                return true;
-
-            default:
-                return false;
-        }
-    }
-
-    private async Task EnsureResourceDeletedAsync<T>(string resourceName, CancellationToken cancellationToken) where T : CustomResource, IKubernetesStaticMetadata
-    {
-        _logger.LogDebug("Ensuring '{ResourceName}' is deleted.", resourceName);
+        // Reset cached callback results so they are re-evaluated on restart.
+        ForgetCachedCallbackResults(resource.ModelResource);
 
         var result = await DeleteResourceRetryPipeline.ExecuteAsync(async (resourceName, attemptCancellationToken) =>
         {
@@ -1194,11 +1179,11 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
                 // Success.
                 return true;
             }
-        }, resourceName, cancellationToken).ConfigureAwait(false);
+        }, resource.DcpResourceName, cancellationToken).ConfigureAwait(false);
 
         if (!result)
         {
-            throw new DistributedApplicationException($"Failed to delete '{resourceName}' successfully before restart.");
+            throw new DistributedApplicationException($"Failed to delete '{resource.DcpResourceName}' successfully before restart.");
         }
     }
 

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -592,6 +592,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         => CreateDcpObjectsAsync(objects, cancellationToken);
 
     async Task<T> IDcpObjectFactory.PatchDcpObjectAsync<T>(T obj, Action<T> change, CancellationToken cancellationToken)
+        => await PatchDcpObjectAsync(obj, change, cancellationToken).ConfigureAwait(false);
+
+    private async Task<T> PatchDcpObjectAsync<T>(T obj, Action<T> change, CancellationToken cancellationToken)
+        where T : CustomResource, IKubernetesStaticMetadata
     {
         var patch = CreatePatch(obj, change);
         var result = await _kubernetesService.PatchAsync(obj, patch, cancellationToken).ConfigureAwait(false);
@@ -1067,6 +1071,11 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             await appResource.Initialized.WaitAsync(cancellationToken).ConfigureAwait(false);
             using var _ = await ConcurrencyUtils.AcquireAllAsync([appResource.SerializedOpSemaphore], cancellationToken).ConfigureAwait(false);
 
+            if (await TryStartCreatedDelayedStartResourceAsync(resourceReference, resourceType, cancellationToken).ConfigureAwait(false))
+            {
+                return;
+            }
+
             // Reset cached callback results so they are re-evaluated on restart.
             ForgetCachedCallbackResults(resourceReference.ModelResource);
 
@@ -1113,6 +1122,29 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             _logger.LogError(ex, "Failed to start resource {ResourceName}", resourceReference.ModelResource.Name);
             await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, resourceType, resourceReference.ModelResource, resourceReference.DcpResourceName)).ConfigureAwait(false);
             throw;
+        }
+    }
+
+    private async Task<bool> TryStartCreatedDelayedStartResourceAsync(IResourceReference resourceReference, string resourceType, CancellationToken cancellationToken)
+    {
+        switch (resourceReference)
+        {
+            case RenderedModelResource<Container> { DcpResource.Spec.Start: false } cr
+                when !DcpModelUtilities.ShouldDeferCreateForExplicitStart(cr.ModelResource, cr.DcpResource.Spec.Start):
+                await PublishConnectionStringAvailableEventAsync(cr.ModelResource, cancellationToken).ConfigureAwait(false);
+                await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, cr.ModelResource, cr.DcpResourceName)).ConfigureAwait(false);
+                await PatchDcpObjectAsync(cr.DcpResource, static c => c.Spec.Start = true, cancellationToken).ConfigureAwait(false);
+                return true;
+
+            case RenderedModelResource<Executable> { DcpResource.Spec.Start: false } er
+                when !DcpModelUtilities.ShouldDeferCreateForExplicitStart(er.ModelResource, er.DcpResource.Spec.Start):
+                await PublishConnectionStringAvailableEventAsync(er.ModelResource, cancellationToken).ConfigureAwait(false);
+                await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, er.ModelResource, er.DcpResourceName)).ConfigureAwait(false);
+                await PatchDcpObjectAsync(er.DcpResource, static e => e.Spec.Start = true, cancellationToken).ConfigureAwait(false);
+                return true;
+
+            default:
+                return false;
         }
     }
 

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -16,6 +16,19 @@ namespace Aspire.Hosting.Dcp;
 internal static class DcpModelUtilities
 {
     /// <summary>
+    /// Determines whether DCP registration should be deferred until an explicit manual start.
+    /// </summary>
+    internal static bool ShouldDeferCreateForExplicitStart(IResource modelResource, bool? start)
+    {
+        // Explicit-start, non-persistent resources use manual snapshots for dashboard visibility.
+        // Do not register them with DCP until the manual start path flips Spec.Start=true; creation
+        // evaluates callbacks that can prompt for input or depend on start-time state.
+        return start == false &&
+            modelResource.TryGetLastAnnotation<ExplicitStartupAnnotation>(out _) &&
+            modelResource.GetLifetimeType() != Lifetime.Persistent;
+    }
+
+    /// <summary>
     /// Examines the Aspire resource annotations and adds equivalent ServiceProducerAnnotations to the corresponding DCP resource.
     /// </summary>
     internal static void AddServicesProducedInfo<TDcpResource>(

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -16,12 +16,12 @@ namespace Aspire.Hosting.Dcp;
 internal static class DcpModelUtilities
 {
     /// <summary>
-    /// Determines whether DCP registration should be deferred until an explicit manual start.
+    /// Determines whether DCP object creation should be deferred until an explicit manual start.
     /// </summary>
     internal static bool ShouldDeferCreateForExplicitStart(IResource modelResource, bool? start)
     {
         // Explicit-start, non-persistent resources use manual snapshots for dashboard visibility.
-        // Do not register them with DCP until the manual start path flips Spec.Start=true; creation
+        // Do not create corresponding DCP objects until the manual start path flips Spec.Start=true; creation
         // evaluates callbacks that can prompt for input or depend on start-time state.
         return start == false &&
             modelResource.TryGetLastAnnotation<ExplicitStartupAnnotation>(out _) &&

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -64,8 +64,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
 
     public bool IsReadyToCreate(RenderedModelResource<Executable> resource, EmptyCreationContext context)
     {
-        // Executables are always created. When explicit startup is used, DCP receives Spec.Start = false.
-        return true;
+        return !DcpModelUtilities.ShouldDeferCreateForExplicitStart(resource.ModelResource, resource.DcpResource.Spec.Start);
     }
 
     public async Task CreateObjectAsync(RenderedModelResource<Executable> er, EmptyCreationContext context, ILogger resourceLogger, IDcpObjectFactory factory, CancellationToken cancellationToken)

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -2586,11 +2586,11 @@ public class DcpExecutorTests
     }
 
     [Fact]
-    public async Task ExplicitStartPlainExecutable_IsCreatedWithStartFalse()
+    public async Task ExplicitStartPlainExecutable_IsNotCreatedUntilManualStart()
     {
         var builder = DistributedApplication.CreateBuilder();
 
-        builder.AddExecutable("CoolProgram", "cool", Environment.CurrentDirectory, "--alpha", "--bravo")
+        var resource = builder.AddExecutable("CoolProgram", "cool", Environment.CurrentDirectory, "--alpha", "--bravo")
             .WithExplicitStart();
 
         var kubernetesService = new TestKubernetesService();
@@ -2600,8 +2600,13 @@ public class DcpExecutorTests
 
         await appExecutor.RunApplicationAsync();
 
-        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "CoolProgram");
-        Assert.False(exe.Spec.Start.GetValueOrDefault(true));
+        Assert.Empty(GetCreatedExecutablesForResource(kubernetesService, "CoolProgram"));
+
+        var reference = appExecutor.GetResource(DcpExecutor.GetDcpInstance(resource.Resource, instanceIndex: 0).Name);
+        await appExecutor.StartResourceAsync(reference, CancellationToken.None);
+
+        var exe = Assert.Single(GetCreatedExecutablesForResource(kubernetesService, "CoolProgram"));
+        Assert.True(exe.Spec.Start);
     }
 
     [Fact]
@@ -3806,6 +3811,202 @@ public class DcpExecutorTests
         var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == "aContainer");
         Assert.True(container.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations));
         AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations, container.Spec.Args);
+    }
+
+    [Fact]
+    public async Task ExecutionConfigurationCallbacksDeferredForExplicitStartExecutableUntilManualStart()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var argsCallCount = 0;
+        var envCallCount = 0;
+        var resource = builder.AddExecutable("anExecutable", "command", "")
+            .WithExplicitStart()
+            .WithArgs(c =>
+            {
+                Interlocked.Increment(ref argsCallCount);
+                c.Args.Add("--deferred");
+            })
+            .WithEnvironment(c =>
+            {
+                Interlocked.Increment(ref envCallCount);
+                c.EnvironmentVariables["DEFERRED_ENV"] = "true";
+            });
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+        await appExecutor.RunApplicationAsync();
+
+        Assert.Equal(0, argsCallCount);
+        Assert.Equal(0, envCallCount);
+        Assert.Empty(GetCreatedExecutablesForResource(kubernetesService, "anExecutable"));
+
+        var reference = appExecutor.GetResource(DcpExecutor.GetDcpInstance(resource.Resource, instanceIndex: 0).Name);
+        await appExecutor.StartResourceAsync(reference, CancellationToken.None);
+
+        Assert.Equal(1, argsCallCount);
+        Assert.Equal(1, envCallCount);
+
+        var startedExecutable = Assert.Single(GetCreatedExecutablesForResource(kubernetesService, "anExecutable"), e => e.Spec.Start == true);
+        Assert.Contains("--deferred", startedExecutable.Spec.Args!);
+        Assert.Contains(startedExecutable.Spec.Env!, e => e is { Name: "DEFERRED_ENV", Value: "true" });
+        Assert.True(startedExecutable.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations));
+        Assert.Single(argAnnotations, a => a.Argument == "--deferred");
+        AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations, startedExecutable.Spec.Args);
+    }
+
+    [Fact]
+    public async Task ExecutionConfigurationCallbacksDeferredForExplicitStartContainerUntilManualStart()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var argsCallCount = 0;
+        var envCallCount = 0;
+        var resource = builder.AddContainer("aContainer", "image")
+            .WithExplicitStart()
+            .WithArgs(c =>
+            {
+                Interlocked.Increment(ref argsCallCount);
+                c.Args.Add("--deferred");
+            })
+            .WithEnvironment(c =>
+            {
+                Interlocked.Increment(ref envCallCount);
+                c.EnvironmentVariables["DEFERRED_ENV"] = "true";
+            });
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+        await appExecutor.RunApplicationAsync();
+
+        Assert.Equal(0, argsCallCount);
+        Assert.Equal(0, envCallCount);
+        Assert.DoesNotContain(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == "aContainer");
+
+        var reference = appExecutor.GetResource(DcpExecutor.GetDcpInstance(resource.Resource, instanceIndex: 0).Name);
+        await appExecutor.StartResourceAsync(reference, CancellationToken.None);
+
+        Assert.Equal(1, argsCallCount);
+        Assert.Equal(1, envCallCount);
+
+        var startedContainer = Assert.Single(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == "aContainer" && c.Spec.Start == true);
+        Assert.Contains("--deferred", startedContainer.Spec.Args!);
+        Assert.Contains(startedContainer.Spec.Env!, e => e is { Name: "DEFERRED_ENV", Value: "true" });
+        Assert.True(startedContainer.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations));
+        Assert.Single(argAnnotations, a => a.Argument == "--deferred");
+        AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations, startedContainer.Spec.Args);
+    }
+
+    [Fact]
+    public async Task ExecutionConfigurationCallbacksNotReevaluatedWhenStartingCreatedExplicitStartPersistentExecutable()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var argsCallCount = 0;
+        var envCallCount = 0;
+        var resource = builder.AddExecutable("anExecutable", "command", "")
+            .WithPersistentLifetime()
+            .WithExplicitStart()
+            .WithArgs(c =>
+            {
+                Interlocked.Increment(ref argsCallCount);
+                c.Args.Add("--persistent");
+            })
+            .WithEnvironment(c =>
+            {
+                Interlocked.Increment(ref envCallCount);
+                c.EnvironmentVariables["PERSISTENT_ENV"] = "true";
+            });
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var configDict = new Dictionary<string, string?>
+        {
+            ["AppHost:Sha256"] = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+        await appExecutor.RunApplicationAsync();
+
+        Assert.Equal(1, argsCallCount);
+        Assert.Equal(1, envCallCount);
+
+        var executable = Assert.Single(GetCreatedExecutablesForResource(kubernetesService, "anExecutable"));
+        Assert.False(executable.Spec.Start);
+        Assert.True(executable.Spec.Persistent);
+        Assert.Contains("--persistent", executable.Spec.Args!);
+        Assert.Contains(executable.Spec.Env!, e => e is { Name: "PERSISTENT_ENV", Value: "true" });
+
+        var reference = appExecutor.GetResource(DcpExecutor.GetDcpInstance(resource.Resource, instanceIndex: 0).Name);
+        await appExecutor.StartResourceAsync(reference, CancellationToken.None);
+
+        Assert.Equal(1, argsCallCount);
+        Assert.Equal(1, envCallCount);
+        Assert.Empty(kubernetesService.DeletedResources);
+        Assert.Single(GetCreatedExecutablesForResource(kubernetesService, "anExecutable"));
+        Assert.True(executable.Spec.Start);
+    }
+
+    [Fact]
+    public async Task ExecutionConfigurationCallbacksNotDeferredForExplicitStartPersistentContainer()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var argsCallCount = 0;
+        var envCallCount = 0;
+        var resource = builder.AddContainer("aContainer", "image")
+            .WithPersistentLifetime()
+            .WithExplicitStart()
+            .WithArgs(c =>
+            {
+                Interlocked.Increment(ref argsCallCount);
+                c.Args.Add("--persistent");
+            })
+            .WithEnvironment(c =>
+            {
+                Interlocked.Increment(ref envCallCount);
+                c.EnvironmentVariables["PERSISTENT_ENV"] = "true";
+            });
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var configDict = new Dictionary<string, string?>
+        {
+            ["AppHost:Sha256"] = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+        await appExecutor.RunApplicationAsync();
+
+        Assert.Equal(1, argsCallCount);
+        Assert.Equal(1, envCallCount);
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == "aContainer");
+        Assert.False(container.Spec.Start);
+        Assert.True(container.Spec.Persistent);
+        Assert.Contains("--persistent", container.Spec.Args!);
+        Assert.Contains(container.Spec.Env!, e => e is { Name: "PERSISTENT_ENV", Value: "true" });
+
+        var reference = appExecutor.GetResource(DcpExecutor.GetDcpInstance(resource.Resource, instanceIndex: 0).Name);
+        await appExecutor.StartResourceAsync(reference, CancellationToken.None);
+
+        Assert.Equal(1, argsCallCount);
+        Assert.Equal(1, envCallCount);
+        Assert.Empty(kubernetesService.DeletedResources);
+        Assert.Single(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == "aContainer");
+        Assert.True(container.Spec.Start);
     }
 
     // Ensures that command-line argument callbacks are invoked after the OnResourceStarting event is raised for the resource,

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -2586,7 +2586,7 @@ public class DcpExecutorTests
     }
 
     [Fact]
-    public async Task ExplicitStartPlainExecutable_IsNotCreatedUntilManualStart()
+    public async Task SessionScopedExplicitStartPlainExecutable_DefersDcpObjectCreationUntilManualStart()
     {
         var builder = DistributedApplication.CreateBuilder();
 

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -249,6 +249,11 @@ internal sealed class TestKubernetesService : IKubernetesService
 
             if (res is Executable exe && result is Executable eu)
             {
+                if (eu.Spec.Start is not null)
+                {
+                    exe.Spec.Start = eu.Spec.Start;
+                }
+
                 if (eu.Spec.Stop == true)
                 {
                     exe.Spec.Stop = true;
@@ -262,6 +267,11 @@ internal sealed class TestKubernetesService : IKubernetesService
 
             if (res is Container ctr && result is Container cu)
             {
+                if (cu.Spec.Start is not null)
+                {
+                    ctr.Spec.Start = cu.Spec.Start;
+                }
+
                 if (cu.Spec.Stop == true)
                 {
                     ctr.Spec.Stop = true;


### PR DESCRIPTION
## Description

Session-scoped resources marked with `WithExplicitStart()` should not evaluate execution configuration callbacks during AppHost/dashboard startup. Those callbacks can prompt for user input or contribute arguments, environment variables, certificates, and other start-time configuration before the user has explicitly started the resource.

This change defers DCP registration for session-scoped explicit-start containers and executables until manual start. Persistent explicit-start resources are still registered immediately so DCP can evaluate the lifecycle key and discover existing instances, but manual start now patches the existing DCP resource to `Spec.Start = true` instead of deleting and recreating it, avoiding a second callback prompt.

### User-facing usage

The Stress playground now includes prompt-based examples for validating this behavior:

```csharp
builder.AddExecutable("manual-environment-interaction", "dotnet", Environment.CurrentDirectory, "run", "--project", stressEmptyProjectPath, "--no-build")
    .WithExplicitStart()
    .WithEnvironment(context => PromptForEnvironmentValueAsync(...));

builder.AddContainer("persistent-container-environment-interaction", interactionContainerImage)
    .WithContainerName("stress-persistent-container-environment-interaction")
    .WithEntrypoint("/bin/sh")
    .WithArgs("-c", "while true; do sleep 3600; done")
    .WithPersistentLifetime()
    .WithExplicitStart()
    .WithEnvironment(context => PromptForEnvironmentValueAsync(...));
```

Manual session-scoped resources should prompt only when manually started. Persistent resources prompt during startup because they must be registered with DCP immediately, and should not prompt again when manually started.

Validation:

```text
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.DcpExecutorTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-method "*.ExplicitStart_StartExecutable" --filter-method "*.BeforeResourceStartedEvent_NotFiredForExplicitStartOnInitialCreation" --filter-method "*.BeforeResourceStartedEvent_FiredWhenExplicitStartResourceIsManuallyStarted" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet build playground/Stress/Stress.AppHost/Stress.AppHost.csproj --no-restore
```

Fixes: #17813

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No