### PR TITLE
Fix Redis persistent lifetime startup

### DIFF
--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -191,9 +191,9 @@ public static class RedisBuilderExtensions
                     .WithArgs(argsCtx =>
                     {
                         argsCtx.Args.Add("--tls-port");
-                        argsCtx.Args.Add(redis.GetEndpoint(RedisResource.PrimaryEndpointName).Property(EndpointProperty.Port));
+                        argsCtx.Args.Add(redis.GetEndpoint(RedisResource.PrimaryEndpointName).Property(EndpointProperty.TargetPort));
                         argsCtx.Args.Add("--port");
-                        argsCtx.Args.Add(redis.GetEndpoint(RedisResource.SecondaryEndpointName).Property(EndpointProperty.Port));
+                        argsCtx.Args.Add(redis.GetEndpoint(RedisResource.SecondaryEndpointName).Property(EndpointProperty.TargetPort));
                     });
             });
         }

--- a/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
@@ -850,7 +850,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
 
         await builder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, appModel));
 
-        var args = await ArgumentEvaluator.GetArgumentListAsync(redis.Resource, app.Services);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(redis.Resource, app.Services).AsTask().WaitAsync(TimeSpan.FromSeconds(60));
 
         Assert.Equal("6379", args[args.IndexOf("--tls-port") + 1]);
         Assert.Equal("6380", args[args.IndexOf("--port") + 1]);

--- a/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
@@ -13,6 +13,7 @@ using Aspire.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 
 #pragma warning disable ASPIRECERTIFICATES001
+#pragma warning disable ASPIREPERSISTENCE001
 
 namespace Aspire.Hosting.Redis.Tests;
 
@@ -832,6 +833,27 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
         // Verify the URI expression uses the endpoint scheme
         var uriExpression = redis.Resource.UriExpression;
         Assert.Contains("{myredis.bindings.tcp.scheme}", uriExpression.ValueExpression);
+    }
+
+    [Fact]
+    public async Task RedisWithCertificateUsesTargetPortsForCommandLineArgs()
+    {
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+        using var cert = CreateTestCertificate();
+
+        var redis = builder.AddRedis("myredis", port: 12345)
+            .WithLifetime(ContainerLifetime.Persistent)
+            .WithHttpsCertificate(cert);
+
+        using var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        await builder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, appModel));
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(redis.Resource, app.Services);
+
+        Assert.Equal("6379", args[args.IndexOf("--tls-port") + 1]);
+        Assert.Equal("6380", args[args.IndexOf("--port") + 1]);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Redis persistent containers could deadlock before container creation when Redis TLS startup arguments resolved allocated endpoint ports. Those arguments configure the ports Redis listens on inside the container, so they should use endpoint target ports instead of public/allocated ports, which may differ and may not be available before a proxyless persistent container exists.

This updates Redis TLS startup arguments to use target-port bindings for both the primary TLS endpoint and secondary non-TLS endpoint. With this change, the reported AppHost shape starts Redis instead of waiting forever on endpoint allocation:

```csharp
builder.AddRedis("redis")
       .WithLifetime(ContainerLifetime.Persistent);
```

Fixes: #17822

Validation:

- `dotnet test --project tests/Aspire.Hosting.Redis.Tests/Aspire.Hosting.Redis.Tests.csproj --no-launch-profile -- --filter-method "*.RedisWithCertificateUsesTargetPortsForCommandLineArgs" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.Redis.Tests/Aspire.Hosting.Redis.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No