### PR TITLE
Refactor IdentityChannelReader to Try pattern and log CLI channel at startup

### DIFF
--- a/src/Aspire.Cli/Acquisition/IdentityChannelReader.cs
+++ b/src/Aspire.Cli/Acquisition/IdentityChannelReader.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Aspire.Cli.Packaging;
 
@@ -22,17 +23,12 @@ namespace Aspire.Cli.Acquisition;
 internal interface IIdentityChannelReader
 {
     /// <summary>
-    /// Returns the channel baked into the CLI assembly.
+    /// Attempts to read the channel baked into the CLI assembly.
     /// </summary>
-    /// <returns>
-    /// One of <c>stable</c>, <c>staging</c>, <c>daily</c>, <c>local</c>, or
-    /// <c>pr-&lt;N&gt;</c> (with <c>&lt;N&gt;</c> one or more ASCII digits).
-    /// </returns>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when the <c>AspireCliChannel</c> assembly metadata is missing,
-    /// empty, or does not match the accepted shape.
-    /// </exception>
-    string ReadChannel();
+    /// <param name="channel">When this method returns <see langword="true"/>, contains the resolved channel value.</param>
+    /// <param name="error">When this method returns <see langword="false"/>, contains the error message describing the failure.</param>
+    /// <returns><see langword="true"/> if the channel was successfully read; otherwise, <see langword="false"/>.</returns>
+    bool TryReadChannel([NotNullWhen(true)] out string? channel, [NotNullWhen(false)] out string? error);
 }
 
 /// <summary>
@@ -51,7 +47,7 @@ internal sealed class IdentityChannelReader : IIdentityChannelReader
     private const string PrChannelPrefix = "pr-";
 
     private readonly Assembly _assembly;
-    private readonly Lazy<string> _channel;
+    private readonly Lazy<(bool Success, string? Channel, string? Error)> _cached;
 
     /// <summary>
     /// Initializes a new instance that reads metadata from the supplied
@@ -70,48 +66,61 @@ internal sealed class IdentityChannelReader : IIdentityChannelReader
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="assembly"/> is <see langword="null"/>.
     /// </exception>
-    /// <remarks>
-    /// The constructor does NOT read or validate the metadata; that is deferred
-    /// to the first <see cref="ReadChannel"/> call so DI consumers see the
-    /// validation error eagerly when they first try to read the channel rather
-    /// than at container build time. The resolved value is cached for the
-    /// lifetime of this instance via <see cref="Lazy{T}"/> with
-    /// <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/> (the default),
-    /// avoiding repeated <see cref="AssemblyMetadataAttribute"/> scans under
-    /// the singleton DI registration.
-    /// </remarks>
     public IdentityChannelReader(Assembly assembly)
     {
         ArgumentNullException.ThrowIfNull(assembly);
         _assembly = assembly;
-        _channel = new Lazy<string>(ResolveChannel, LazyThreadSafetyMode.ExecutionAndPublication);
+        _cached = new Lazy<(bool, string?, string?)>(() =>
+        {
+            var success = TryResolveChannel(_assembly, out var ch, out var err);
+            return (success, ch, err);
+        }, LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
     /// <inheritdoc />
-    public string ReadChannel() => _channel.Value;
-
-    private string ResolveChannel()
+    public bool TryReadChannel([NotNullWhen(true)] out string? channel, [NotNullWhen(false)] out string? error)
     {
-        var metadata = _assembly
+        var result = _cached.Value;
+        channel = result.Channel;
+        error = result.Error;
+        return result.Success;
+    }
+
+    /// <summary>
+    /// Attempts to resolve the channel from the specified assembly's metadata.
+    /// </summary>
+    /// <param name="assembly">The assembly to read <c>AspireCliChannel</c> metadata from.</param>
+    /// <param name="channel">When this method returns <see langword="true"/>, contains the resolved channel value.</param>
+    /// <param name="error">When this method returns <see langword="false"/>, contains the error message describing the failure.</param>
+    /// <returns><see langword="true"/> if the channel was successfully resolved; otherwise, <see langword="false"/>.</returns>
+    private static bool TryResolveChannel(Assembly assembly, [NotNullWhen(true)] out string? channel, [NotNullWhen(false)] out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        var metadata = assembly
             .GetCustomAttributes<AssemblyMetadataAttribute>()
             .FirstOrDefault(a => string.Equals(a.Key, ChannelMetadataKey, StringComparison.Ordinal));
 
         if (metadata is null || string.IsNullOrEmpty(metadata.Value))
         {
-            throw new InvalidOperationException(
-                $"Assembly metadata '{ChannelMetadataKey}' is missing or empty on '{_assembly.GetName().Name}'. " +
-                "The CLI must be built with /p:AspireCliChannel=<channel> (one of stable, staging, daily, local, or pr-<N>).");
+            channel = null;
+            error = $"Assembly metadata '{ChannelMetadataKey}' is missing or empty on '{assembly.GetName().Name}'. " +
+                "The CLI must be built with /p:AspireCliChannel=<channel> (one of stable, staging, daily, local, or pr-<N>).";
+            return false;
         }
 
         var value = metadata.Value;
         if (!IsValidChannel(value))
         {
-            throw new InvalidOperationException(
-                $"Assembly metadata '{ChannelMetadataKey}' on '{_assembly.GetName().Name}' has invalid value '{value}'. " +
-                "Expected one of: stable, staging, daily, local, or pr-<N> where <N> is one or more ASCII digits.");
+            channel = null;
+            error = $"Assembly metadata '{ChannelMetadataKey}' on '{assembly.GetName().Name}' has invalid value '{value}'. " +
+                "Expected one of: stable, staging, daily, local, or pr-<N> where <N> is one or more ASCII digits.";
+            return false;
         }
 
-        return value;
+        channel = value;
+        error = null;
+        return true;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Acquisition/InstallationDiscovery.cs
+++ b/src/Aspire.Cli/Acquisition/InstallationDiscovery.cs
@@ -396,18 +396,16 @@ internal sealed partial class InstallationDiscovery : IInstallationDiscovery
 
     private string? TryReadChannel()
     {
-        try
+        if (_channelReader.TryReadChannel(out var channel, out var error))
         {
-            return _channelReader.ReadChannel();
+            return channel;
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            // Same defensive posture as doctor: a misconfigured dev build
-            // with no AspireCliChannel assembly metadata must not break
-            // aspire doctor.
-            _logger.LogDebug(ex, "Could not read identity channel for InstallationDiscovery.");
-            return null;
-        }
+
+        // Same defensive posture as doctor: a misconfigured dev build
+        // with no AspireCliChannel assembly metadata must not break
+        // aspire doctor.
+        _logger.LogDebug("Could not read identity channel for InstallationDiscovery: {Error}", error);
+        return null;
     }
 
     private static string GetNotProbedReason(InstallSidecarReadResult result)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -82,7 +82,8 @@ public class Program
         FileLoggerProvider FileLoggerProvider,
         ConsoleLogBufferContext LogBufferContext,
         ILogger Logger,
-        ConsoleCancellationManager CancellationManager) : IDisposable
+        ConsoleCancellationManager CancellationManager,
+        IdentityChannelReader IdentityChannelReader) : IDisposable
     {
         public void Dispose()
         {
@@ -343,7 +344,7 @@ public class Program
         builder.Services.AddSingleton(sp => new TelemetryManager(sp.GetRequiredService<IConfiguration>(), args));
 
         // Shared services.
-        builder.Services.AddSingleton<IIdentityChannelReader>(_ => new IdentityChannelReader(typeof(Program).Assembly));
+        builder.Services.AddSingleton<IIdentityChannelReader>(startupContext.IdentityChannelReader);
         if (OperatingSystem.IsWindows())
         {
             builder.Services.AddSingleton<IWindowsRegistryReader, WindowsRegistryReader>();
@@ -356,7 +357,10 @@ public class Program
         builder.Services.AddSingleton(sp =>
         {
             var channelReader = sp.GetRequiredService<IIdentityChannelReader>();
-            var channel = channelReader.ReadChannel();
+            if (!channelReader.TryReadChannel(out var channel, out var error))
+            {
+                throw new InvalidOperationException(error);
+            }
             return BuildCliExecutionContext(startupContext.LoggingOptions.DebugMode, startupContext.LoggingOptions.LogsDirectory, startupContext.LoggingOptions.LogFilePath, channel);
         });
         builder.Services.AddSingleton(s => new ConsoleEnvironment(
@@ -807,10 +811,20 @@ public class Program
         var (loggerFactory, fileLoggerProvider) = CreateLoggerFactory(args, loggingOptions, errorWriter, logBufferContext);
         var logger = loggerFactory.CreateLogger(RootLoggerName);
         cancellationManager.SetLogger(logger);
-        using var startupContext = new CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logBufferContext, logger, cancellationManager);
+        var identityChannelReader = new IdentityChannelReader(typeof(Program).Assembly);
+        using var startupContext = new CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logBufferContext, logger, cancellationManager, identityChannelReader);
 
         logger.LogInformation("Aspire CLI version: {Version}", AspireCliTelemetry.GetCliVersion());
         logger.LogInformation("Aspire CLI build ID: {BuildId}", AspireCliTelemetry.GetCliBuildId());
+        logger.LogInformation("Aspire CLI path: {CliPath}", Environment.ProcessPath);
+        if (identityChannelReader.TryReadChannel(out var channel, out var channelError))
+        {
+            logger.LogInformation("Aspire CLI channel: {Channel}", channel);
+        }
+        else
+        {
+            logger.LogWarning("Failed to resolve CLI channel: {Error}", channelError);
+        }
         logger.LogInformation("Working directory: {WorkingDirectory}", Environment.CurrentDirectory);
         // Logging the log file path is useful so that when console logging is enabled (for example with --log-level debug),
         // the path is written to the console logger (stderr) for easier discovery.

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
@@ -194,17 +194,15 @@ internal sealed class AspireVersionCheck(
 
     private string? TryReadIdentityChannel()
     {
-        try
+        if (identityChannelReader.TryReadChannel(out var channel, out var error))
         {
-            return identityChannelReader.ReadChannel();
+            return channel;
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            // Identity channel is informational; a misconfigured dev build
-            // (no AspireCliChannel assembly metadata) must not break doctor.
-            logger.LogDebug(ex, "Could not read identity channel for doctor output.");
-            return null;
-        }
+
+        // Identity channel is informational; a misconfigured dev build
+        // (no AspireCliChannel assembly metadata) must not break doctor.
+        logger.LogDebug("Could not read identity channel for doctor output: {Error}", error);
+        return null;
     }
 
     private async Task<EnvironmentCheckResult?> GetAppHostVersionCheckAsync(CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/Acquisition/IdentityChannelReaderTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/IdentityChannelReaderTests.cs
@@ -31,34 +31,35 @@ public class IdentityChannelReaderTests
 
         var reader = new IdentityChannelReader(assembly);
 
-        Assert.Equal("pr-12345", reader.ReadChannel());
+        Assert.True(reader.TryReadChannel(out var channel, out _));
+        Assert.Equal("pr-12345", channel);
     }
 
     [Fact]
-    public void ReadChannel_AssemblyMissingChannelMetadata_ThrowsWithAssemblyName()
+    public void ReadChannel_AssemblyMissingChannelMetadata_ReturnsFalseWithError()
     {
         const string assemblyName = "FakeCli_NoChannel";
         var assembly = BuildFakeAssemblyWithChannelMetadata(assemblyName, channelValue: null);
 
         var reader = new IdentityChannelReader(assembly);
 
-        var ex = Assert.Throws<InvalidOperationException>(reader.ReadChannel);
-        Assert.Contains(ChannelMetadataKey, ex.Message, StringComparison.Ordinal);
-        Assert.Contains(assemblyName, ex.Message, StringComparison.Ordinal);
+        Assert.False(reader.TryReadChannel(out _, out var error));
+        Assert.Contains(ChannelMetadataKey, error, StringComparison.Ordinal);
+        Assert.Contains(assemblyName, error, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void ReadChannel_AssemblyHasInvalidChannelMetadata_Throws()
+    public void ReadChannel_AssemblyHasInvalidChannelMetadata_ReturnsFalseWithError()
     {
-        // Integration smoke that an invalid baked value surfaces as InvalidOperationException
+        // Integration smoke that an invalid baked value surfaces as a failure
         // through the reader. The exhaustive invalid-value matrix is in
         // IsValidChannel_MatchesExpectedTruthTable below.
         var assembly = BuildFakeAssemblyWithChannelMetadata("FakeCli_Invalid", "pr");
 
         var reader = new IdentityChannelReader(assembly);
 
-        var ex = Assert.Throws<InvalidOperationException>(reader.ReadChannel);
-        Assert.Contains(ChannelMetadataKey, ex.Message, StringComparison.Ordinal);
+        Assert.False(reader.TryReadChannel(out _, out var error));
+        Assert.Contains(ChannelMetadataKey, error, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -73,7 +74,8 @@ public class IdentityChannelReaderTests
 
         var reader = new IdentityChannelReader(assembly);
 
-        Assert.Equal("staging", reader.ReadChannel());
+        Assert.True(reader.TryReadChannel(out var channel, out _));
+        Assert.Equal("staging", channel);
     }
 
     [Fact]
@@ -85,8 +87,8 @@ public class IdentityChannelReaderTests
 
         var reader = new IdentityChannelReader(assembly);
 
-        var ex = Assert.Throws<InvalidOperationException>(reader.ReadChannel);
-        Assert.Contains(ChannelMetadataKey, ex.Message, StringComparison.Ordinal);
+        Assert.False(reader.TryReadChannel(out _, out var error));
+        Assert.Contains(ChannelMetadataKey, error, StringComparison.Ordinal);
     }
 
     // IsValidChannel is the gate for the baked value. We assert its exact

--- a/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
+++ b/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
@@ -28,7 +28,8 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
         var errorWriter = new TestStartupErrorWriter();
         var logBufferContext = new ConsoleLogBufferContext();
         var (loggerFactory, fileLoggerProvider) = Program.CreateLoggerFactory([], loggingOptions, errorWriter, logBufferContext);
-        var startupContext = new Program.CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logBufferContext, loggerFactory.CreateLogger(Program.RootLoggerName), new ConsoleCancellationManager(processTerminationTimeout: Timeout.InfiniteTimeSpan));
+        var identityChannelReader = new IdentityChannelReader(typeof(Program).Assembly);
+        var startupContext = new Program.CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logBufferContext, loggerFactory.CreateLogger(Program.RootLoggerName), new ConsoleCancellationManager(processTerminationTimeout: Timeout.InfiniteTimeSpan), identityChannelReader);
         return await Program.BuildApplicationAsync([], startupContext);
     }
 
@@ -49,7 +50,7 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
     {
         var reader = new IdentityChannelReader(typeof(Aspire.Cli.Program).Assembly);
 
-        var channel = reader.ReadChannel();
+        Assert.True(reader.TryReadChannel(out var channel, out _));
 
         // Test host can be built with /p:AspireCliChannel=<anything in the accepted set>;
         // assert shape, not a single literal, so this test stops being an accidental
@@ -85,7 +86,8 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
         var reader = host.Services.GetRequiredService<IIdentityChannelReader>();
         var context = host.Services.GetRequiredService<CliExecutionContext>();
 
-        Assert.Equal(reader.ReadChannel(), context.IdentityChannel);
+        Assert.True(reader.TryReadChannel(out var channel, out _));
+        Assert.Equal(channel, context.IdentityChannel);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -422,7 +422,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
             {
                 services.RemoveAll<IIdentityChannelReader>();
                 // Throws to simulate a misconfigured dev build with no AspireCliChannel metadata.
-                services.AddSingleton<IIdentityChannelReader>(_ => new FakeIdentityChannelReader(throwOnRead: true));
+                services.AddSingleton<IIdentityChannelReader>(_ => new FakeIdentityChannelReader(failOnRead: true));
             });
 
         // The channel lookup failing is informational; the rest of doctor should still complete.

--- a/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using Aspire.Cli.Acquisition;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Telemetry;
@@ -40,7 +41,8 @@ public class TelemetryConfigurationTests
         var errorWriter = new TestStartupErrorWriter();
         var logBufferContext = new ConsoleLogBufferContext();
         var (loggerFactory, fileLoggerProvider) = Program.CreateLoggerFactory([], loggingOptions, errorWriter, logBufferContext);
-        var startupContext = new Program.CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logBufferContext, loggerFactory.CreateLogger(Program.RootLoggerName), new ConsoleCancellationManager(processTerminationTimeout: Timeout.InfiniteTimeSpan));
+        var identityChannelReader = new IdentityChannelReader(typeof(Program).Assembly);
+        var startupContext = new Program.CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logBufferContext, loggerFactory.CreateLogger(Program.RootLoggerName), new ConsoleCancellationManager(processTerminationTimeout: Timeout.InfiniteTimeSpan), identityChannelReader);
         return await Program.BuildApplicationAsync([], startupContext, config);
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/FakeIdentityChannelReader.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakeIdentityChannelReader.cs
@@ -1,40 +1,44 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Aspire.Cli.Acquisition;
 
 namespace Aspire.Cli.Tests.TestServices;
 
 /// <summary>
 /// In-memory <see cref="IIdentityChannelReader"/> for tests. Returns a fixed
-/// channel string, or throws <see cref="InvalidOperationException"/> when
-/// configured to simulate a misconfigured build with missing
-/// <c>AspireCliChannel</c> assembly metadata.
+/// channel string, or returns false when configured to simulate a misconfigured
+/// build with missing <c>AspireCliChannel</c> assembly metadata.
 /// </summary>
 internal sealed class FakeIdentityChannelReader : IIdentityChannelReader
 {
     private readonly string? _channel;
-    private readonly bool _throw;
+    private readonly bool _fail;
 
     public FakeIdentityChannelReader(string channel)
     {
         _channel = channel;
-        _throw = false;
+        _fail = false;
     }
 
-    public FakeIdentityChannelReader(bool throwOnRead)
+    public FakeIdentityChannelReader(bool failOnRead)
     {
         _channel = null;
-        _throw = throwOnRead;
+        _fail = failOnRead;
     }
 
-    public string ReadChannel()
+    public bool TryReadChannel([NotNullWhen(true)] out string? channel, [NotNullWhen(false)] out string? error)
     {
-        if (_throw)
+        if (_fail)
         {
-            throw new InvalidOperationException("Simulated missing AspireCliChannel metadata.");
+            channel = null;
+            error = "Simulated missing AspireCliChannel metadata.";
+            return false;
         }
 
-        return _channel!;
+        channel = _channel!;
+        error = null;
+        return true;
     }
 }


### PR DESCRIPTION
## Description

Refactors `IdentityChannelReader` to use the Try pattern and adds CLI path/channel logging at startup.

Changes:
- Rename `ReadChannel` to `TryReadChannel` with `bool` return + `out` params for channel and error
- Add CLI path and channel to startup logging (after version)
- Create `IdentityChannelReader` early in `Main` and pass it via `CliStartupContext` for DI reuse
- Make `TryResolveChannel` private; keep `Lazy` caching for the resolved result
- Update all callers (`InstallationDiscovery`, `AspireVersionCheck`) to use the Try pattern instead of try/catch
- Update tests to match new interface signature

Log output:

```
[2026-06-02 06:09:23.996] [INFO] [Cli] Aspire CLI version: 13.5.0-dev
[2026-06-02 06:09:23.997] [INFO] [Cli] Aspire CLI build ID: 42.42.42.42424
[2026-06-02 06:09:23.997] [INFO] [Cli] Aspire CLI path: C:\Development\Source\aspire\artifacts\bin\Aspire.Cli\Debug\net10.0\aspire.exe
[2026-06-02 06:09:23.998] [INFO] [Cli] Aspire CLI channel: local
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
