### PR TITLE
Shorten long CLI E2E test names and improve recording comment table

### DIFF
--- a/.agents/skills/cli-e2e-testing/troubleshooting.md
+++ b/.agents/skills/cli-e2e-testing/troubleshooting.md
@@ -67,7 +67,7 @@ Tests rely on a deterministic shell prompt for "command finished" detection:
 
 ## Step 4 — Diagnose the "Y/n input race"
 
-This is the most-observed flake class so far. It is what broke `ChannelUpdateWorkflowTests.UpdateProjectChannelToStable_TypeScript_PreviewsStablePackagesAndPreservesChannel` on PR #17522 (run `26489967289`, job `78006625708`).
+This is the most-observed flake class so far. It is what broke `ChannelUpdateWorkflowTests.UpdateToStable_TypeScript_PreviewsStablePkgsAndKeepsChannel` on PR #17522 (run `26489967289`, job `78006625708`).
 
 ### Symptom
 

--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -451,7 +451,7 @@ jobs:
                   fi
                 fi
 
-                # Build the detail cell with links separated by <br />
+                # Build the detail cell with links separated by ·
                 DETAIL_PARTS=""
                 if [ -n "$ASCIINEMA_URL" ]; then
                   DETAIL_PARTS="[Recording](${ASCIINEMA_URL})"
@@ -463,10 +463,10 @@ jobs:
                   FAIL_COUNT=$((FAIL_COUNT + 1))
                 fi
                 if [ -n "$JOB_URL" ]; then
-                  DETAIL_PARTS="${DETAIL_PARTS} <br /> [Job](${JOB_URL})"
+                  DETAIL_PARTS="${DETAIL_PARTS} · [Job](${JOB_URL})"
                 fi
                 if [ -n "$ARTIFACTS_URL" ]; then
-                  DETAIL_PARTS="${DETAIL_PARTS} <br /> [CLI logs](${ARTIFACTS_URL})"
+                  DETAIL_PARTS="${DETAIL_PARTS} · [CLI logs](${ARTIFACTS_URL})"
                 fi
 
                 # Build the table row once; append to both tables as needed.

--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -407,20 +407,15 @@ jobs:
                 # Look up test outcome from TRX data.
                 # .cast files are named after the test method name (via [CallerMemberName] in CreateTestTerminal),
                 # so the filename matches the method name key in the outcomes JSON.
-                # Per-link label carries the outcome too, so a recording URL copied out of
-                # the table still tells reviewers whether it represents a pass or a failure.
                 TEST_OUTCOME=$(jq -r --arg name "$filename" '.[$name] // "Unknown"' test_outcomes.json)
                 if [ "$TEST_OUTCOME" = "Passed" ]; then
                   STATUS_EMOJI="✅"
-                  LINK_LABEL="Recording"
                   TEST_PASS_COUNT=$((TEST_PASS_COUNT + 1))
                 elif [ "$TEST_OUTCOME" = "Failed" ]; then
                   STATUS_EMOJI="❌"
-                  LINK_LABEL="Recording"
                   TEST_FAIL_COUNT=$((TEST_FAIL_COUNT + 1))
                 else
                   STATUS_EMOJI="❔"
-                  LINK_LABEL="Recording"
                   TEST_UNKNOWN_COUNT=$((TEST_UNKNOWN_COUNT + 1))
                 fi
 
@@ -456,30 +451,26 @@ jobs:
                   fi
                 fi
 
-                # Build the job and artifacts link cells for the table
-                JOB_CELL=""
-                if [ -n "$JOB_URL" ]; then
-                  JOB_CELL="[#${JOB_ID}](${JOB_URL})"
-                else
-                  JOB_CELL="—"
-                fi
-                ARTIFACTS_CELL=""
-                if [ -n "$ARTIFACTS_URL" ]; then
-                  ARTIFACTS_CELL="[Logs](${ARTIFACTS_URL})"
-                else
-                  ARTIFACTS_CELL="—"
-                fi
-
-                # Build the table row once; append to both tables as needed.
+                # Build the detail cell with links separated by <br />
+                DETAIL_PARTS=""
                 if [ -n "$ASCIINEMA_URL" ]; then
-                  ROW="| ${STATUS_EMOJI} | ${safe_filename} | [${LINK_LABEL}](${ASCIINEMA_URL}) | ${JOB_CELL} | ${ARTIFACTS_CELL} |"
+                  DETAIL_PARTS="[Recording](${ASCIINEMA_URL})"
                   echo "Uploaded: $ASCIINEMA_URL"
                   UPLOAD_COUNT=$((UPLOAD_COUNT + 1))
                 else
-                  ROW="| ${STATUS_EMOJI} | ${safe_filename} | ⚠️ Upload failed | ${JOB_CELL} | ${ARTIFACTS_CELL} |"
+                  DETAIL_PARTS="⚠️ Upload failed"
                   echo "Failed to upload $castfile after $MAX_UPLOAD_RETRIES attempts"
                   FAIL_COUNT=$((FAIL_COUNT + 1))
                 fi
+                if [ -n "$JOB_URL" ]; then
+                  DETAIL_PARTS="${DETAIL_PARTS} <br /> [Job](${JOB_URL})"
+                fi
+                if [ -n "$ARTIFACTS_URL" ]; then
+                  DETAIL_PARTS="${DETAIL_PARTS} <br /> [CLI logs](${ARTIFACTS_URL})"
+                fi
+
+                # Build the table row once; append to both tables as needed.
+                ROW="| ${STATUS_EMOJI} | ${safe_filename} | ${DETAIL_PARTS} |"
 
                 TABLE_BODY="${TABLE_BODY}
           ${ROW}"
@@ -537,8 +528,8 @@ jobs:
               FAILED_SECTION="
           ### ❌ Failed Tests
 
-          | Status | Test | Recording | Job | Artifacts |
-          |--------|------|-----------|-----|-----------|${FAILED_TESTS_BODY}
+          | - | Test | Detail |
+          |--------|------|-----------|${FAILED_TESTS_BODY}
           "
             fi
 
@@ -548,8 +539,8 @@ jobs:
           <details>
           <summary>View all recordings</summary>
 
-          | Status | Test | Recording | Job | Artifacts |
-          |--------|------|-----------|-----|-----------|${TABLE_BODY}
+          | - | Test | Detail |
+          |--------|------|-----------|${TABLE_BODY}
 
           ---
           <sub>📹 Recordings uploaded automatically from [CI run #${RUN_ID}](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID})</sub>

--- a/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
@@ -231,7 +231,7 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
     /// aren't part of the regression and are covered by the broader integration test.
     /// </summary>
     [Fact]
-    public async Task AgentInitCommand_NonInteractive_BundleOnlySkillsBeyondCliCatalog_AreInstallable()
+    public async Task AgentInit_NonInteractive_BundleOnlySkillsNotInCatalog()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);

--- a/tests/Aspire.Cli.EndToEnd.Tests/CSharpProjectModeInitTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CSharpProjectModeInitTests.cs
@@ -56,7 +56,7 @@ public sealed class CSharpProjectModeInitTests(ITestOutputHelper output)
     [Theory]
     [InlineData("Test.sln")]
     [InlineData("Test.slnx")]
-    public async Task AspireInitWithSolutionFileGeneratesAppHostThatBuildsAgainstChannelHive(string solutionFileName)
+    public async Task AspireInit_SolutionFile_BuildsAgainstChannelHive(string solutionFileName)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -127,7 +127,7 @@ public sealed class CSharpProjectModeInitTests(ITestOutputHelper output)
     /// </remarks>
     [CaptureWorkspaceOnFailure]
     [Fact]
-    public async Task AspireInitWithExistingAppHostDirRecreatesMissingNuGetConfigAndPreservesFiles()
+    public async Task AspireInit_ExistingAppHostDir_RecreatesNuGetConfigKeepsFiles()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);

--- a/tests/Aspire.Cli.EndToEnd.Tests/ChannelUpdateWorkflowTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ChannelUpdateWorkflowTests.cs
@@ -41,7 +41,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
 {
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task UpdateProjectChannelToStable_TypeScript_PreviewsStablePackagesAndPreservesChannel()
+    public async Task UpdateToStable_TypeScript_PreviewsStablePkgsAndKeepsChannel()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -227,7 +227,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task UpdateProjectChannelToStable_CSharpSingleFileInit_PreservesAspireConfigChannel()
+    public async Task UpdateToStable_CSharpSingleFileInit_KeepsConfigChannel()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -270,7 +270,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task UpdateProjectChannelToStable_CSharpEmptyAppHost_PreservesAspireConfigChannel()
+    public async Task UpdateToStable_CSharpEmptyAppHost_KeepsConfigChannel()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -310,7 +310,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task UpdateProjectChannelToStable_TypeScriptSingleFileInit_PreservesAspireConfigChannel()
+    public async Task UpdateToStable_TypeScriptSingleFileInit_KeepsConfigChannel()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);

--- a/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
@@ -84,7 +84,7 @@ public sealed class PlaywrightCliInstallTests(ITestOutputHelper output)
     /// to be dropped in the CLI process's current working directory.
     /// </summary>
     [Fact]
-    public async Task AgentInit_WhenCwdDiffersFromWorkspaceRoot_PlacesSkillFilesInWorkspaceRoot()
+    public async Task AgentInit_CwdDiffersFromRoot_PlacesSkillsInWorkspaceRoot()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);

--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -210,7 +210,7 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task ResourceCommand_FailedExecution_DisplaysAppHostLogPathAndLogContainsEntries()
+    public async Task ResourceCommand_FailedExec_ShowsLogPathAndLogHasEntries()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -157,7 +157,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task CreateTypeScriptAppHostWithViteApp_AllowsGuestAppPackageManagerToDiffer()
+    public async Task TypeScriptAppHostWithVite_AllowsDifferentGuestPkgManager()
     {
         const string appHostToolchain = "pnpm";
         const string guestToolchain = "npm";

--- a/tests/Aspire.Cli.EndToEnd.Tests/UpdateChannelNuGetConfigOrderingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/UpdateChannelNuGetConfigOrderingTests.cs
@@ -40,7 +40,7 @@ public sealed class UpdateChannelNuGetConfigOrderingTests(ITestOutputHelper outp
 {
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task AspireUpdateAppliesAllPackageEditsBeforeRestoringWhenNuGetConfigGainsSourceMapping()
+    public async Task AspireUpdate_AppliesPkgEditsBeforeRestore_OnSourceMapping()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);


### PR DESCRIPTION
## Summary

Two related improvements to CLI E2E test ergonomics:

### 1. Shorten long test method names

The longest test name (`UpdateProjectChannelToStable_TypeScript_PreviewsStablePackagesAndPreservesChannel` at 81 chars) caused readability issues in CI logs, PR comments, and the recording table. Shortened 11 test names exceeding 70 chars to ~55-60 chars while preserving meaning.

### 2. Compact recording comment table format

Changed the PR recording comment from a 5-column table (`Status | Test | Recording | Job | Artifacts`) to a more compact 3-column table (`- | Test | Detail`) where links are combined in the Detail cell with `<br />` separators. This reduces horizontal scrolling on narrower views.

Example output:
| - | Test | Detail |
|--------|------|-----------|
| ✅ | UpdateToStable_TypeScript_PreviewsStablePkgsAndKeepsChannel | [Recording](https://asciinema.org/a/example) <br /> [Job](https://github.com/microsoft/aspire/actions/runs/123/job/456)<br /> [CLI logs](https://github.com/microsoft/aspire/actions/runs/123/artifacts/789) |
