### PR TITLE
Fix VS Code telemetry event names

### DIFF
--- a/extension/src/dcp/AspireDcpServer.ts
+++ b/extension/src/dcp/AspireDcpServer.ts
@@ -48,7 +48,7 @@ export default class AspireDcpServer {
     // the WebSocket notification arrives without that context.
     private readonly _runTelemetryById: Map<string, { startTimeMs: number; resourceType: string; mode: string; debugSessionId: string }>;
     // Per AppHost debug-session aggregate stats accumulated across the lifetime of the
-    // session. Used to emit the `debug/appHost/end` summary when an AppHost debug session
+    // session. Used to emit the `debug/apphost/end` summary when an AppHost debug session
     // terminates. Entries are added on first run_session for a debugSessionId and removed
     // (and returned) by takeDebugSessionAggregateStats().
     private readonly _debugSessionStats: Map<string, DebugSessionAggregateStats>;
@@ -79,7 +79,7 @@ export default class AspireDcpServer {
     /**
      * Returns and clears accumulated per-AppHost-debug-session telemetry stats for the
      * given debug session id. Called from AspireDebugSession.dispose() to emit the
-     * `debug/appHost/end` summary event. Returns undefined if no run_session was ever
+     * `debug/apphost/end` summary event. Returns undefined if no run_session was ever
      * accepted for this debug session.
      */
     takeDebugSessionAggregateStats(debugSessionId: string): { totalChildSessions: number; distinctResourceTypes: string[]; anyNonZeroExit: boolean } | undefined {
@@ -315,15 +315,15 @@ export default class AspireDcpServer {
                 // because the user did try to run something through us.
                 hooks.onRunSessionAccepted?.({ resourceType: launchConfig.type, mode });
                 const runSessionStartTimeMs = Date.now();
-                sendTelemetryEvent('debug/runSession/start', {
+                sendTelemetryEvent('debug/runsession/start', {
                     resource_type: supportedResourceType,
                     debugger_extension_matched: foundDebuggerExtension ? 'true' : 'false',
                     mode,
                 });
 
-                // Emits a `debug/runSession/end` event paired with the start above and
+                // Emits a `debug/runsession/end` event paired with the start above and
                 // updates the parent AppHost aggregate so failures captured on early-
-                // return paths still surface in the `debug/appHost/end` summary. All
+                // return paths still surface in the `debug/apphost/end` summary. All
                 // post-start failure paths in this handler must route through here so
                 // we never leave an orphaned start event in the telemetry pipeline.
                 const emitRunSessionFailureEnd = (endReason: string, errorKind?: string): void => {
@@ -332,7 +332,7 @@ export default class AspireDcpServer {
                     aggregate.distinctResourceTypes.add(supportedResourceType);
                     aggregate.anyNonZeroExit = true;
 
-                    sendTelemetryErrorEvent('debug/runSession/end', {
+                    sendTelemetryErrorEvent('debug/runsession/end', {
                         resource_type: supportedResourceType,
                         mode,
                         exit_code_bucket: 'nonzero',
@@ -409,7 +409,7 @@ export default class AspireDcpServer {
                     runTelemetryById.set(runId, { startTimeMs: runSessionStartTimeMs, resourceType: supportedResourceType, mode, debugSessionId });
 
                     // Track aggregate stats for the parent AppHost debug session so we can
-                    // emit a single `debug/appHost/end` summary when the AppHost terminates.
+                    // emit a single `debug/apphost/end` summary when the AppHost terminates.
                     const aggregate = getOrCreateDebugSessionStats(debugSessionId);
                     aggregate.totalChildSessions += 1;
                     aggregate.distinctResourceTypes.add(supportedResourceType);
@@ -421,7 +421,7 @@ export default class AspireDcpServer {
 
                     // Synchronous launch failure — emit the matching end event and update
                     // aggregate stats via the shared helper before responding so the eventual
-                    // `debug/appHost/end` summary reflects the failure.
+                    // `debug/apphost/end` summary reflects the failure.
                     emitRunSessionFailureEnd('launch_failed', err instanceof Error ? err.name || 'Error' : typeof err);
 
                     // Clean up any processes associated with this run (registered by resource-type extensions)
@@ -580,7 +580,7 @@ export default class AspireDcpServer {
                 // telemetry pipeline (consistent with the synchronous launch-failure path
                 // above and the dashboard fault path in DashboardTelemetryPassthrough).
                 const emitEnd = exitBucket === 'nonzero' ? sendTelemetryErrorEvent : sendTelemetryEvent;
-                emitEnd('debug/runSession/end', {
+                emitEnd('debug/runsession/end', {
                     resource_type: entry.resourceType,
                     mode: entry.mode,
                     exit_code_bucket: exitBucket,
@@ -590,7 +590,7 @@ export default class AspireDcpServer {
                 });
 
                 // Surface a non-zero exit on the parent AppHost debug-session aggregate so
-                // the eventual `debug/appHost/end` summary reflects whether any child
+                // the eventual `debug/apphost/end` summary reflects whether any child
                 // resource session ended unsuccessfully.
                 if (exitBucket === 'nonzero') {
                     this.recordAppHostProcessExit(entry.debugSessionId, exitCode);

--- a/extension/src/dcp/DashboardTelemetryPassthrough.ts
+++ b/extension/src/dcp/DashboardTelemetryPassthrough.ts
@@ -270,7 +270,7 @@ export class DashboardTelemetryPassthrough {
         });
 
         app.post('/telemetry/userTask', requireHeaders, (req: Request, res: Response) => {
-            this._handlePostResultEvent(req, res, 'dashboard/userTask', 'UserTask');
+            this._handlePostResultEvent(req, res, 'dashboard/usertask', 'UserTask');
         });
 
         app.post('/telemetry/fault', requireHeaders, (req: Request, res: Response) => {
@@ -314,11 +314,11 @@ export class DashboardTelemetryPassthrough {
 
         app.post('/telemetry/commandLineFlags', requireHeaders, (req: Request, res: Response) => {
             const payload = req.body as PostCommandLineFlagsRequest;
-            const properties: EventProperties<'dashboard/commandLineFlags'> = {
+            const properties: EventProperties<'dashboard/commandlineflags'> = {
                 flag_prefixes: formatFlagPrefixes(payload.flagPrefixes),
             };
             applyBundleFields(properties, payload.additionalProperties);
-            sendTelemetryEvent('dashboard/commandLineFlags', properties);
+            sendTelemetryEvent('dashboard/commandlineflags', properties);
             res.status(200).end();
         });
     }
@@ -471,11 +471,11 @@ export class DashboardTelemetryPassthrough {
     private _handlePostResultEvent(
         req: Request,
         res: Response,
-        eventName: 'dashboard/operation' | 'dashboard/userTask',
+        eventName: 'dashboard/operation' | 'dashboard/usertask',
         correlationType: 'Operation' | 'UserTask',
     ): void {
         const payload = req.body as PostOperationRequest;
-        const properties: EventProperties<'dashboard/operation' | 'dashboard/userTask'> = {
+        const properties: EventProperties<'dashboard/operation' | 'dashboard/usertask'> = {
             dashboard_event_name: clampDashboardKey(payload.eventName),
             result: telemetryResultLabel(payload.result),
         };
@@ -1005,7 +1005,7 @@ function formatAssetEventVersion(value: unknown): string {
 
 /**
  * Formats the dashboard-supplied `flagPrefixes` array into the comma-joined
- * string we put on `dashboard/commandLineFlags`. Validates the input shape and
+ * string we put on `dashboard/commandlineflags`. Validates the input shape and
  * caps both count ({@link MAX_FLAG_PREFIXES}) and per-element length
  * ({@link clampDashboardKey}) so a malformed or malicious payload cannot
  * crash the request handler or produce a huge property value.

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -41,7 +41,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
   private _dashboardDebugSession: vscode.DebugSession | null = null;
   private readonly _disposables: vscode.Disposable[] = [];
   private _disposed = false;
-  // Timestamp for the `debug/appHost/end` duration measurement. Captured the first
+  // Timestamp for the `debug/apphost/end` duration measurement. Captured the first
   // time we observe a `launch` request so it covers the actual user-visible session
   // lifetime, not the moment the AspireDebugSession object was constructed.
   private _appHostStartTimeMs: number | undefined = undefined;
@@ -102,7 +102,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       const appHostIsDirectory = isDirectory(appHostPath);
       const extensionArgs: string[] = [];
 
-      // Telemetry: emit `debug/appHost/start` once per AppHost launch. We do it
+      // Telemetry: emit `debug/apphost/start` once per AppHost launch. We do it
       // here (rather than in the constructor) because the constructor runs
       // before VS Code's debug-launch UX completes; this branch is the single
       // entry point that triggers an actual CLI spawn. The matching end event
@@ -119,7 +119,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       // set so the dimension stays bounded.
       const knownCommands: ReadonlySet<string> = new Set(['run', 'deploy', 'publish', 'do']);
       const commandForTelemetry = knownCommands.has(command) ? command : 'other';
-      sendTelemetryEvent('debug/appHost/start', {
+      sendTelemetryEvent('debug/apphost/start', {
         mode: this._appHostModeAtLaunch,
         apphost_language: this._appHostLanguageAtLaunch,
         apphost_is_directory: appHostIsDirectory ? 'true' : 'false',
@@ -549,7 +549,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     extensionLogOutputChannel.info('Stopping the Aspire debug session');
 
     // Snapshot start-event metadata before we run disposables so the deferred
-    // `debug/appHost/end` callback has a stable view even if instance state
+    // `debug/apphost/end` callback has a stable view even if instance state
     // mutates further (or the instance is reaped by VS Code before the timer
     // fires).
     const startMs = this._appHostStartTimeMs;
@@ -561,14 +561,14 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     // Stop child debug sessions first so their `sessionTerminated`
     // notifications can flow back through `AspireDcpServer.sendNotification`
     // and update the aggregate stats BEFORE we snapshot them for
-    // `debug/appHost/end`. Without this ordering, late nonzero exits (notably
+    // `debug/apphost/end`. Without this ordering, late nonzero exits (notably
     // Windows' SIGTERM → 143 exit code which is not normalized to 0) would
     // be missed and the summary would under-report failures.
     this._disposables.forEach(disposable => disposable.dispose());
     this._trackedDebugAdapters = [];
     vscode.debug.stopDebugging(this._session);
 
-    // Telemetry: emit `debug/appHost/end` after a short grace window so any
+    // Telemetry: emit `debug/apphost/end` after a short grace window so any
     // pending `sessionTerminated` notifications kicked off by the child-stop
     // disposables above have time to flow through the adapterTracker → DCP
     // notification pipeline and update `anyNonZeroExit`. 500ms is enough for
@@ -579,7 +579,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     if (startMs !== undefined) {
       setTimeout(() => {
         const aggregate = dcpServer.takeDebugSessionAggregateStats(debugSessionId);
-        sendTelemetryEvent('debug/appHost/end', {
+        sendTelemetryEvent('debug/apphost/end', {
           mode,
           apphost_language: language,
           ended_with_error: aggregate?.anyNonZeroExit ? 'true' : 'false',

--- a/extension/src/test/dashboardTelemetryRoutes.test.ts
+++ b/extension/src/test/dashboardTelemetryRoutes.test.ts
@@ -125,7 +125,7 @@ suite('DashboardTelemetryPassthrough route-level normalization', () => {
         assert.strictEqual(event.isError, undefined);
     });
 
-    test('POST /telemetry/userTask emits dashboard/userTask, not the raw dashboard name', async () => {
+    test('POST /telemetry/userTask emits dashboard/usertask, not the raw dashboard name', async () => {
         const { status } = await postJson(h.baseUrl, '/telemetry/userTask', {
             eventName: 'aspire/dashboard/mcp/toolcall',
             properties: {},
@@ -133,7 +133,7 @@ suite('DashboardTelemetryPassthrough route-level normalization', () => {
         });
         assert.strictEqual(status, 200);
         assert.strictEqual(h.fake.events.length, 1);
-        assert.strictEqual(h.fake.events[0].name, 'dashboard/userTask');
+        assert.strictEqual(h.fake.events[0].name, 'dashboard/usertask');
         assert.strictEqual(h.fake.events[0].properties?.dashboard_event_name, 'aspire/dashboard/mcp/toolcall');
     });
 

--- a/extension/src/test/telemetry.test.ts
+++ b/extension/src/test/telemetry.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
+import type { TelemetryReporter } from '@vscode/extension-telemetry';
 import * as vscode from 'vscode';
-import { __resetCommonPropertiesForTests, __setReporterForTests, __setTelemetryReporterFactoryForTests, initializeTelemetry, isCommandCancellation, sendTelemetryEvent, setCommandInvocationListener, setCommonTelemetryProperties, withCommandTelemetry } from '../utils/telemetry';
+import { __resetCommonPropertiesForTests, __resetTelemetryReporterFactoryForTests, __setReporterForTests, __setTelemetryReporterFactoryForTests, initializeTelemetry, isCommandCancellation, sendTelemetryEvent, setCommandInvocationListener, setCommonTelemetryProperties, withCommandTelemetry } from '../utils/telemetry';
 
 interface RecordedEvent {
     name: string;
@@ -45,6 +46,7 @@ suite('telemetry utilities', () => {
     teardown(() => {
         setCommandInvocationListener(undefined);
         restore();
+        __resetTelemetryReporterFactoryForTests();
         __resetCommonPropertiesForTests();
     });
 
@@ -79,7 +81,7 @@ suite('telemetry utilities', () => {
         let createdWithKey: string | undefined;
         const restoreFactory = __setTelemetryReporterFactoryForTests((aiKey) => {
             createdWithKey = aiKey;
-            return fake as unknown as ReturnType<Parameters<typeof __setTelemetryReporterFactoryForTests>[0]>;
+            return fake as unknown as TelemetryReporter;
         });
 
         try {

--- a/extension/src/test/telemetry.test.ts
+++ b/extension/src/test/telemetry.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
-import { __resetCommonPropertiesForTests, __resetTelemetryEventPrefixForTests, __setReporterForTests, __setTelemetryEventPrefixForTests, isCommandCancellation, sendTelemetryEvent, setCommandInvocationListener, setCommonTelemetryProperties, withCommandTelemetry } from '../utils/telemetry';
+import * as vscode from 'vscode';
+import { __resetCommonPropertiesForTests, __setReporterForTests, __setTelemetryReporterFactoryForTests, initializeTelemetry, isCommandCancellation, sendTelemetryEvent, setCommandInvocationListener, setCommonTelemetryProperties, withCommandTelemetry } from '../utils/telemetry';
 
 interface RecordedEvent {
     name: string;
@@ -44,7 +45,6 @@ suite('telemetry utilities', () => {
     teardown(() => {
         setCommandInvocationListener(undefined);
         restore();
-        __resetTelemetryEventPrefixForTests();
         __resetCommonPropertiesForTests();
     });
 
@@ -68,16 +68,41 @@ suite('telemetry utilities', () => {
         assert.deepStrictEqual(fake.events[0].properties, { apphost_present: 'keep', command: 'cmd.y' });
     });
 
-    test('sendTelemetryEvent prefixes reporter event names when initialized by VS Code', () => {
-        const restorePrefix = __setTelemetryEventPrefixForTests('microsoft-aspire.aspire-vscode');
+    test('sendTelemetryEvent leaves reporter event names unprefixed because VS Code prefixes extension telemetry', () => {
+        sendTelemetryEvent('command/invoked', { command: 'cmd.prefixed' });
+
+        assert.strictEqual(fake.events[0].name, 'command/invoked');
+    });
+
+    test('initializeTelemetry does not prefix reporter event names with the extension id', () => {
+        restore();
+        let createdWithKey: string | undefined;
+        const restoreFactory = __setTelemetryReporterFactoryForTests((aiKey) => {
+            createdWithKey = aiKey;
+            return fake as unknown as ReturnType<Parameters<typeof __setTelemetryReporterFactoryForTests>[0]>;
+        });
+
         try {
-            sendTelemetryEvent('command/invoked', { command: 'cmd.prefixed' });
+            const subscriptions: vscode.Disposable[] = [];
+            initializeTelemetry({
+                extension: {
+                    id: 'microsoft-aspire.aspire-vscode',
+                    packageJSON: {
+                        aiKey: 'test-key'
+                    }
+                },
+                subscriptions
+            } as unknown as vscode.ExtensionContext);
+
+            sendTelemetryEvent('command/invoked', { command: 'cmd.initialized' });
+
+            assert.strictEqual(createdWithKey, 'test-key');
+            assert.strictEqual(subscriptions.length, 1);
+            assert.strictEqual(fake.events[0].name, 'command/invoked');
         }
         finally {
-            restorePrefix();
+            restoreFactory();
         }
-
-        assert.strictEqual(fake.events[0].name, 'microsoft-aspire.aspire-vscode/command/invoked');
     });
 
     test('withCommandTelemetry emits success outcome', async () => {

--- a/extension/src/test/telemetryInventory.test.ts
+++ b/extension/src/test/telemetryInventory.test.ts
@@ -1,0 +1,21 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+type TelemetryInventory = {
+    events: Record<string, unknown>;
+};
+
+function readTelemetryInventory(): TelemetryInventory {
+    const inventoryPath = path.resolve(__dirname, '../../telemetry.json');
+    return JSON.parse(fs.readFileSync(inventoryPath, 'utf8')) as TelemetryInventory;
+}
+
+suite('extension/telemetry.json', () => {
+    test('event entity names are lowercase to match VS Code telemetry ingestion', () => {
+        const inventory = readTelemetryInventory();
+        const mixedCaseEntityNames = Object.keys(inventory.events).filter(name => name !== name.toLowerCase());
+
+        assert.deepStrictEqual(mixedCaseEntityNames, []);
+    });
+});

--- a/extension/src/utils/telemetry.ts
+++ b/extension/src/utils/telemetry.ts
@@ -24,7 +24,8 @@ export type {
 // the command wrapper, the engagement reporter, the tree view, the debug
 // session, and the dashboard telemetry passthrough server.
 let reporter: TelemetryReporter | undefined;
-let telemetryReporterFactory = (aiKey: string): TelemetryReporter => new TelemetryReporter(aiKey);
+const defaultTelemetryReporterFactory = (aiKey: string): TelemetryReporter => new TelemetryReporter(aiKey);
+let telemetryReporterFactory = defaultTelemetryReporterFactory;
 
 // Common properties merged into every event we emit. The TelemetryReporter
 // already injects extension version, OS, machine id, etc., so this map is
@@ -261,6 +262,11 @@ export function __setTelemetryReporterFactoryForTests(factory: (aiKey: string) =
     const previous = telemetryReporterFactory;
     telemetryReporterFactory = factory;
     return () => { telemetryReporterFactory = previous; };
+}
+
+/** Test seam: reset TelemetryReporter construction so tests don't bleed into each other. */
+export function __resetTelemetryReporterFactoryForTests(): void {
+    telemetryReporterFactory = defaultTelemetryReporterFactory;
 }
 
 /** Test seam: clear common properties so tests don't bleed into each other. */

--- a/extension/src/utils/telemetry.ts
+++ b/extension/src/utils/telemetry.ts
@@ -24,7 +24,7 @@ export type {
 // the command wrapper, the engagement reporter, the tree view, the debug
 // session, and the dashboard telemetry passthrough server.
 let reporter: TelemetryReporter | undefined;
-let telemetryEventPrefix: string | undefined;
+let telemetryReporterFactory = (aiKey: string): TelemetryReporter => new TelemetryReporter(aiKey);
 
 // Common properties merged into every event we emit. The TelemetryReporter
 // already injects extension version, OS, machine id, etc., so this map is
@@ -52,8 +52,7 @@ export function initializeTelemetry(context: vscode.ExtensionContext): void {
     // telemetry initialization read from the same extension manifest.
     const aiKey = context.extension.packageJSON.aiKey;
     if (aiKey) {
-        telemetryEventPrefix = context.extension.id;
-        reporter = new TelemetryReporter(aiKey);
+        reporter = telemetryReporterFactory(aiKey);
         context.subscriptions.push({ dispose: () => reporter?.dispose() });
     }
 }
@@ -104,10 +103,6 @@ function mergeProperties<E extends KnownTelemetryEventName>(properties?: EventPr
     return { ...commonProperties, ...((properties ?? {}) as { [key: string]: string }) };
 }
 
-function formatEventName(eventName: KnownTelemetryEventName): string {
-    return telemetryEventPrefix ? `${telemetryEventPrefix}/${eventName}` : eventName;
-}
-
 /**
  * Emit a telemetry event. The `eventName` is constrained to entries in
  * {@link KnownTelemetryEventName} (see telemetryRegistry.ts) and the
@@ -120,7 +115,7 @@ export function sendTelemetryEvent<E extends KnownTelemetryEventName>(
     properties?: EventProperties<E>,
     measurements?: EventMeasurements<E>
 ): void {
-    reporter?.sendTelemetryEvent(formatEventName(eventName), mergeProperties(properties), measurements as { [key: string]: number } | undefined);
+    reporter?.sendTelemetryEvent(eventName, mergeProperties(properties), measurements as { [key: string]: number } | undefined);
 }
 
 /**
@@ -133,7 +128,7 @@ export function sendTelemetryErrorEvent<E extends KnownTelemetryEventName>(
     properties?: EventProperties<E>,
     measurements?: EventMeasurements<E>
 ): void {
-    reporter?.sendTelemetryErrorEvent(formatEventName(eventName), mergeProperties(properties), measurements as { [key: string]: number } | undefined);
+    reporter?.sendTelemetryErrorEvent(eventName, mergeProperties(properties), measurements as { [key: string]: number } | undefined);
 }
 
 /**
@@ -261,16 +256,11 @@ export function __setReporterForTests(fake: TelemetryReporter | undefined): () =
     return () => { reporter = previous; };
 }
 
-/** Test seam: override the event prefix applied at the reporter boundary. */
-export function __setTelemetryEventPrefixForTests(prefix: string | undefined): () => void {
-    const previous = telemetryEventPrefix;
-    telemetryEventPrefix = prefix;
-    return () => { telemetryEventPrefix = previous; };
-}
-
-/** Test seam: clear the event prefix so tests don't bleed into each other. */
-export function __resetTelemetryEventPrefixForTests(): void {
-    telemetryEventPrefix = undefined;
+/** Test seam: replace TelemetryReporter construction without initializing the real VS Code sender. */
+export function __setTelemetryReporterFactoryForTests(factory: (aiKey: string) => TelemetryReporter): () => void {
+    const previous = telemetryReporterFactory;
+    telemetryReporterFactory = factory;
+    return () => { telemetryReporterFactory = previous; };
 }
 
 /** Test seam: clear common properties so tests don't bleed into each other. */

--- a/extension/src/utils/telemetryRegistry.ts
+++ b/extension/src/utils/telemetryRegistry.ts
@@ -57,23 +57,23 @@ export interface TelemetryEventSchema {
         properties: 'trigger' | 'has_csharp_devkit';
         measurements: 'workspace_folders';
     };
-    'runningAppHostsView/shown': {
+    'runningapphostsview/shown': {
         properties: 'view_mode' | 'initial_visibility';
         measurements: 'running_apphosts' | 'total_resources';
     };
-    'debug/appHost/start': {
+    'debug/apphost/start': {
         properties: 'mode' | 'apphost_language' | 'apphost_is_directory' | 'command';
         measurements: never;
     };
-    'debug/appHost/end': {
+    'debug/apphost/end': {
         properties: 'mode' | 'apphost_language' | 'ended_with_error' | 'distinct_resource_types';
         measurements: 'duration_ms' | 'total_child_sessions' | 'distinct_resource_type_count';
     };
-    'debug/runSession/start': {
+    'debug/runsession/start': {
         properties: 'resource_type' | 'debugger_extension_matched' | 'mode';
         measurements: never;
     };
-    'debug/runSession/end': {
+    'debug/runsession/end': {
         properties: 'resource_type' | 'mode' | 'exit_code_bucket' | 'end_reason' | 'error_kind';
         measurements: 'duration_ms' | 'exit_code';
     };
@@ -99,7 +99,7 @@ export interface TelemetryEventSchema {
             | 'result';
         measurements: never;
     };
-    'dashboard/userTask': {
+    'dashboard/usertask': {
         properties:
             | 'dashboard_event_name'
             | 'dashboard_properties'
@@ -165,7 +165,7 @@ export interface TelemetryEventSchema {
         properties: 'property_name' | 'dashboard_properties' | 'dashboard_measurements';
         measurements: never;
     };
-    'dashboard/commandLineFlags': {
+    'dashboard/commandlineflags': {
         properties: 'flag_prefixes' | 'dashboard_properties' | 'dashboard_measurements';
         measurements: never;
     };

--- a/extension/src/views/AppHostsViewTelemetry.ts
+++ b/extension/src/views/AppHostsViewTelemetry.ts
@@ -74,7 +74,7 @@ export class AppHostsViewTelemetry implements vscode.Disposable {
         const appHosts = this._dataRepository.appHosts;
         const runningAppHosts = appHosts.length;
         const totalResources = this._getDisplayedResourceCount();
-        sendTelemetryEvent('runningAppHostsView/shown', {
+        sendTelemetryEvent('runningapphostsview/shown', {
             view_mode: this._dataRepository.viewMode,
             initial_visibility: initial ? 'true' : 'false',
         }, {

--- a/extension/telemetry.json
+++ b/extension/telemetry.json
@@ -44,7 +44,7 @@
         "comment": "The number of workspace folders in the VS Code window."
       }
     },
-    "microsoft-aspire.aspire-vscode/runningAppHostsView/shown": {
+    "microsoft-aspire.aspire-vscode/runningapphostsview/shown": {
       "view_mode": {
         "classification": "SystemMetaData",
         "purpose": "FeatureInsight",
@@ -66,7 +66,7 @@
         "comment": "The number of resources displayed across running AppHosts."
       }
     },
-    "microsoft-aspire.aspire-vscode/debug/appHost/start": {
+    "microsoft-aspire.aspire-vscode/debug/apphost/start": {
       "mode": {
         "classification": "SystemMetaData",
         "purpose": "FeatureInsight",
@@ -88,7 +88,7 @@
         "comment": "The Aspire command used to start the AppHost."
       }
     },
-    "microsoft-aspire.aspire-vscode/debug/appHost/end": {
+    "microsoft-aspire.aspire-vscode/debug/apphost/end": {
       "mode": {
         "classification": "SystemMetaData",
         "purpose": "FeatureInsight",
@@ -125,7 +125,7 @@
         "comment": "The number of distinct Aspire resource types observed in child debug sessions."
       }
     },
-    "microsoft-aspire.aspire-vscode/debug/runSession/start": {
+    "microsoft-aspire.aspire-vscode/debug/runsession/start": {
       "resource_type": {
         "classification": "SystemMetaData",
         "purpose": "FeatureInsight",
@@ -142,7 +142,7 @@
         "comment": "Whether the resource was launched in run or debug mode."
       }
     },
-    "microsoft-aspire.aspire-vscode/debug/runSession/end": {
+    "microsoft-aspire.aspire-vscode/debug/runsession/end": {
       "resource_type": {
         "classification": "SystemMetaData",
         "purpose": "FeatureInsight",
@@ -206,7 +206,7 @@
         "comment": "The dashboard operation result classification."
       }
     },
-    "microsoft-aspire.aspire-vscode/dashboard/userTask": {
+    "microsoft-aspire.aspire-vscode/dashboard/usertask": {
       "dashboard_event_name": {
         "classification": "SystemMetaData",
         "purpose": "FeatureInsight",
@@ -395,7 +395,7 @@
         "comment": "A JSON object containing numeric dashboard measurements."
       }
     },
-    "microsoft-aspire.aspire-vscode/dashboard/commandLineFlags": {
+    "microsoft-aspire.aspire-vscode/dashboard/commandlineflags": {
       "flag_prefixes": {
         "classification": "SystemMetaData",
         "purpose": "FeatureInsight",


### PR DESCRIPTION
## Summary
- stop prepending the Aspire VS Code extension id before sending telemetry events
- rely on VS Code's telemetry logger to apply the extension prefix once
- normalize Aspire VS Code telemetry event names to lowercase so emitted ADX entity names match `telemetry.json`
- add regression coverage for the initialized telemetry path and inventory casing

## Why
1.12.0 telemetry currently lands in `RawEventsVSCodeExtUnclassified` as double-prefixed event names such as `microsoft-aspire.aspire-vscode/microsoft-aspire.aspire-vscode/command/invoked`. VS Code already prefixes extension telemetry, so the extension should pass unprefixed registered event names to `TelemetryReporter`.

ADX also shows VS Code ingestion lowercases event names such as `debug/apphost/start`, `debug/runsession/start`, and `dashboard/usertask`. The inventory now uses the same lowercase entity names.

## Testing
- `cd extension && yarn run compile-tests && yarn run unit-test --grep "telemetry utilities"`
- `cd extension && yarn run compile-tests && yarn run unit-test --grep "extension/telemetry.json|telemetry utilities|Dashboard telemetry routes"`
- `cd extension && yarn run unit-test --grep "DashboardTelemetryPassthrough route-level normalization"`
- `cd extension && yarn test`

## Reviews
- Opus code review: no significant issues found after the casing update
- GPT-5.5 code review: no significant issues found after the casing update
- Copilot PR review: no comments on the initial prefix fix
