### PR TITLE
Fix Azure Storage emulator endpoint timing

### DIFF
--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -208,16 +208,16 @@ public static class AzureStorageExtensions
         QueueServiceClient? queueServiceClient = null;
 
         builder
-            .OnBeforeResourceStarted(async (storage, @event, ct) =>
+            .OnResourceEndpointsAllocated(async (storage, @event, ct) =>
             {
                 // The BlobServiceClient and QueueServiceClient are created before the health check is run.
                 // We can't use ConnectionStringAvailableEvent here because the resource doesn't have a connection string, so
-                // we use BeforeResourceStartedEvent
+                // we use ResourceEndpointsAllocatedEvent.
 
-                var blobConnectionString = await builder.Resource.GetBlobConnectionString().GetValueAsync(ct).ConfigureAwait(false) ?? throw new DistributedApplicationException($"{nameof(ConnectionStringAvailableEvent)} was published for the '{builder.Resource.Name}' resource but the connection string was null.");
+                var blobConnectionString = await builder.Resource.GetBlobConnectionString().GetValueAsync(ct).ConfigureAwait(false) ?? throw new DistributedApplicationException($"{nameof(ResourceEndpointsAllocatedEvent)} was published for the '{builder.Resource.Name}' resource but the connection string was null.");
                 blobServiceClient = CreateBlobServiceClient(blobConnectionString);
 
-                var queueConnectionString = await builder.Resource.GetQueueConnectionString().GetValueAsync(ct).ConfigureAwait(false) ?? throw new DistributedApplicationException($"{nameof(ConnectionStringAvailableEvent)} was published for the '{builder.Resource.Name}' resource but the connection string was null.");
+                var queueConnectionString = await builder.Resource.GetQueueConnectionString().GetValueAsync(ct).ConfigureAwait(false) ?? throw new DistributedApplicationException($"{nameof(ResourceEndpointsAllocatedEvent)} was published for the '{builder.Resource.Name}' resource but the connection string was null.");
                 queueServiceClient = CreateQueueServiceClient(queueConnectionString);
             })
             .OnResourceReady(async (storage, @event, ct) =>

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -993,8 +993,11 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
                 ContainerPort = ea.TargetPort,
             };
 
-            if (!ea.IsProxied && ea.SpecifiedPort is int hostPort)
+            if (!ea.IsProxied && (ea.SpecifiedPort ?? sp.Service.AllocatedPort ?? ea.AllocatedEndpoint?.Port) is int hostPort)
             {
+                // Dynamic proxyless endpoints get their host port from DCP on the first start.
+                // Reuse that port for later container recreations so endpoint references and one-shot
+                // endpoint allocation subscribers remain valid across resource restarts.
                 sp.Service.Spec.Port ??= hostPort;
                 portSpec.HostPort = hostPort;
             }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
@@ -1,13 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
+using System.Text;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;
@@ -168,6 +172,57 @@ public class AzureStorageExtensionsTests(ITestOutputHelper output)
 
         Assert.Contains("--skipApiVersionCheck", args);
         Assert.Contains("--disableProductStyleUrl", args);
+    }
+
+    [Fact]
+    public async Task RunAsEmulatorInitializesStorageClientsWhenEndpointsAreAllocatedBeforeHealthCheckRuns()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        using var blobEndpointListener = new TcpListener(IPAddress.Loopback, 0);
+        blobEndpointListener.Start();
+        var blobEndpointPort = ((IPEndPoint)blobEndpointListener.LocalEndpoint).Port;
+
+        try
+        {
+            var storage = builder.AddAzureStorage("storage").RunAsEmulator(emulator =>
+            {
+                emulator.WithEndpoint("blob", e => e.AllocatedEndpoint = new(e, "127.0.0.1", blobEndpointPort));
+                emulator.WithEndpoint("queue", e => e.AllocatedEndpoint = new(e, "127.0.0.1", 2));
+                emulator.WithEndpoint("table", e => e.AllocatedEndpoint = new(e, "127.0.0.1", 3));
+            });
+
+            using var app = builder.Build();
+
+            var healthCheckKey = $"{storage.Resource.Name}_check";
+            var healthCheckService = app.Services.GetRequiredService<HealthCheckService>();
+
+            var initializationException = await Assert.ThrowsAsync<InvalidOperationException>(() => healthCheckService.CheckHealthAsync(r => r.Name == healthCheckKey));
+            Assert.Equal("BlobServiceClient is not initialized.", initializationException.Message);
+
+            await builder.Eventing.PublishAsync(
+                new ResourceEndpointsAllocatedEvent(storage.Resource, app.Services),
+                EventDispatchBehavior.BlockingSequential);
+
+            using var healthCheckResponseCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var blobEndpointTask = ServeSuccessfulStorageHealthCheckResponseAsync(blobEndpointListener, healthCheckResponseCts.Token);
+
+            try
+            {
+                var afterAllocationReport = await healthCheckService.CheckHealthAsync(r => r.Name == healthCheckKey, healthCheckResponseCts.Token);
+                Assert.True(afterAllocationReport.Entries.TryGetValue(healthCheckKey, out var afterAllocationEntry));
+                Assert.Equal(HealthStatus.Healthy, afterAllocationEntry.Status);
+            }
+            finally
+            {
+                await healthCheckResponseCts.CancelAsync();
+            }
+
+            await blobEndpointTask.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        finally
+        {
+            blobEndpointListener.Stop();
+        }
     }
 
     [Fact]
@@ -981,5 +1036,61 @@ public class AzureStorageExtensionsTests(ITestOutputHelper output)
             method.Invoke(null, [container, storage, roles]));
 
         Assert.Null(exception);
+    }
+
+    private static async Task ServeSuccessfulStorageHealthCheckResponseAsync(TcpListener listener, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var client = await listener.AcceptTcpClientAsync(cancellationToken);
+            await using var stream = client.GetStream();
+            var buffer = new byte[4096];
+            var requestText = new StringBuilder();
+
+            while (true)
+            {
+                var bytesRead = await stream.ReadAsync(buffer, cancellationToken);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                requestText.Append(Encoding.ASCII.GetString(buffer, 0, bytesRead));
+
+                // HTTP request headers end with an empty line. Accumulate chunks so the
+                // delimiter is still detected when "\r\n\r\n" spans two reads.
+                if (requestText.ToString().Contains("\r\n\r\n", StringComparison.Ordinal))
+                {
+                    break;
+                }
+            }
+
+            // AzureBlobStorageHealthCheck lists blob containers, so return the minimal service response
+            // shape that BlobServiceClient can deserialize without needing a real Azurite instance.
+            var responseBodyBytes = Encoding.ASCII.GetBytes("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <EnumerationResults ServiceEndpoint="http://127.0.0.1/devstoreaccount1">
+                  <Prefix />
+                  <Marker />
+                  <MaxResults>5000</MaxResults>
+                  <Containers />
+                  <NextMarker />
+                </EnumerationResults>
+                """.ReplaceLineEndings(""));
+            var responseHeader = Encoding.ASCII.GetBytes(
+                "HTTP/1.1 200 OK\r\n" +
+                "Content-Type: application/xml\r\n" +
+                $"Content-Length: {responseBodyBytes.Length}\r\n" +
+                "x-ms-request-id: health-check-test\r\n" +
+                "x-ms-version: 2023-11-03\r\n" +
+                "Date: Mon, 01 Jan 2001 00:00:00 GMT\r\n" +
+                "Connection: close\r\n" +
+                "\r\n");
+            await stream.WriteAsync(responseHeader, cancellationToken);
+            await stream.WriteAsync(responseBodyBytes, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1844,6 +1844,42 @@ public class DcpExecutorTests
     }
 
     [Fact]
+    public async Task EndpointPortsContainerProxylessNoPortTargetPortSetReusesAllocatedPortOnRestart()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        const int desiredTargetPort = TestKubernetesService.StartOfAutoPortRange - 999;
+        var database = builder.AddContainer("database", "image")
+            .WithEndpoint(name: "NoPortTargetPortSet", targetPort: desiredTargetPort, isProxied: false);
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+        await appExecutor.RunApplicationAsync();
+
+        var firstContainer = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        var allocatedPortString = await database.GetEndpoint("NoPortTargetPortSet").Property(EndpointProperty.Port).GetValueAsync();
+        Assert.False(string.IsNullOrWhiteSpace(allocatedPortString));
+        var allocatedPort = int.Parse(allocatedPortString, CultureInfo.InvariantCulture);
+
+        Assert.True(allocatedPort >= TestKubernetesService.StartOfAutoPortRange);
+        Assert.NotNull(firstContainer.Spec.Ports);
+        Assert.Contains(firstContainer.Spec.Ports!, p => p.HostPort is null && p.ContainerPort == desiredTargetPort);
+
+        var resourceReference = appExecutor.GetResource(firstContainer.Metadata.Name);
+        await appExecutor.StopResourceAsync(resourceReference, CancellationToken.None);
+        await appExecutor.StartResourceAsync(resourceReference, CancellationToken.None);
+
+        var restartedContainer = kubernetesService.CreatedResources.OfType<Container>().Last();
+
+        Assert.NotSame(firstContainer, restartedContainer);
+        Assert.NotNull(restartedContainer.Spec.Ports);
+        Assert.Contains(restartedContainer.Spec.Ports!, p => p.HostPort == allocatedPort && p.ContainerPort == desiredTargetPort);
+        Assert.Equal(allocatedPortString, await database.GetEndpoint("NoPortTargetPortSet").Property(EndpointProperty.Port).GetValueAsync());
+    }
+
+    [Fact]
     public async Task EndpointPortsContainerProxylessNoPortTargetPortSetUsesTargetPortFallbackWhenResolvedBeforeContainerCreation()
     {
         var builder = DistributedApplication.CreateBuilder();


### PR DESCRIPTION
## Description

Azure Storage emulation creates blob and queue clients before its health checks run, but resolving endpoint-backed emulator connection strings in `OnBeforeResourceStarted` happens too early for proxyless container endpoints that do not have a public port yet.

This changes `RunAsEmulator` to initialize those clients from `OnResourceEndpointsAllocated`, so `GetBlobConnectionString()` and `GetQueueConnectionString()` are evaluated only after endpoint allocation. The ready callback still creates containers and queues after the resource becomes healthy.

Validation:
- `./restore.sh`
- `dotnet test --project tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj --no-launch-profile -- --filter-class "*.AzureStorageExtensionsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No