### PR TITLE
Add proxyless endpoint on-demand allocation

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -386,7 +386,18 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     /// </summary>
     public NetworkEndpointSnapshotList AllAllocatedEndpoints { get; } = new();
 
-    internal Func<NetworkIdentifier, AllocatedEndpoint?>? OnDemandAllocatedEndpointProvider { get; set; }
+    private Func<NetworkIdentifier, AllocatedEndpoint?>? _onDemandAllocatedEndpointProvider;
+
+    internal Func<NetworkIdentifier, AllocatedEndpoint?>? OnDemandAllocatedEndpointProvider
+    {
+        get => Interlocked.CompareExchange(ref _onDemandAllocatedEndpointProvider, null, null);
+        set => Interlocked.Exchange(ref _onDemandAllocatedEndpointProvider, value);
+    }
+
+    internal void ClearOnDemandAllocatedEndpointProvider()
+    {
+        Interlocked.Exchange(ref _onDemandAllocatedEndpointProvider, null);
+    }
 
     internal Task<AllocatedEndpoint> GetAllocatedEndpointAsync(NetworkIdentifier networkId, CancellationToken cancellationToken = default)
     {
@@ -395,20 +406,12 @@ public sealed class EndpointAnnotation : IResourceAnnotation
             return Task.FromResult(endpoint);
         }
 
-        lock (this)
+        if (OnDemandAllocatedEndpointProvider is { } allocatedEndpointProvider)
         {
-            if (AllAllocatedEndpoints.TryGetAllocatedEndpoint(networkId, out endpoint))
+            endpoint = allocatedEndpointProvider(networkId);
+            if (endpoint is not null)
             {
                 return Task.FromResult(endpoint);
-            }
-
-            if (OnDemandAllocatedEndpointProvider is { } allocatedEndpointProvider)
-            {
-                endpoint = allocatedEndpointProvider(networkId);
-                if (endpoint is not null)
-                {
-                    return Task.FromResult(endpoint);
-                }
             }
         }
 

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -394,11 +394,6 @@ public sealed class EndpointAnnotation : IResourceAnnotation
         set => Interlocked.Exchange(ref _onDemandAllocatedEndpointProvider, value);
     }
 
-    internal void ClearOnDemandAllocatedEndpointProvider()
-    {
-        Interlocked.Exchange(ref _onDemandAllocatedEndpointProvider, null);
-    }
-
     internal Task<AllocatedEndpoint> GetAllocatedEndpointAsync(NetworkIdentifier networkId, CancellationToken cancellationToken = default)
     {
         if (AllAllocatedEndpoints.TryGetAllocatedEndpoint(networkId, out var endpoint))

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -386,13 +386,7 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     /// </summary>
     public NetworkEndpointSnapshotList AllAllocatedEndpoints { get; } = new();
 
-    private Func<NetworkIdentifier, AllocatedEndpoint?>? _onDemandAllocatedEndpointProvider;
-
-    internal Func<NetworkIdentifier, AllocatedEndpoint?>? OnDemandAllocatedEndpointProvider
-    {
-        get => Interlocked.CompareExchange(ref _onDemandAllocatedEndpointProvider, null, null);
-        set => Interlocked.Exchange(ref _onDemandAllocatedEndpointProvider, value);
-    }
+    internal Func<NetworkIdentifier, AllocatedEndpoint?>? _onDemandAllocatedEndpointProvider;
 
     internal Task<AllocatedEndpoint> GetAllocatedEndpointAsync(NetworkIdentifier networkId, CancellationToken cancellationToken = default)
     {
@@ -401,7 +395,7 @@ public sealed class EndpointAnnotation : IResourceAnnotation
             return Task.FromResult(endpoint);
         }
 
-        if (OnDemandAllocatedEndpointProvider is { } allocatedEndpointProvider)
+        if (_onDemandAllocatedEndpointProvider is { } allocatedEndpointProvider)
         {
             endpoint = allocatedEndpointProvider(networkId);
             if (endpoint is not null)

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -385,27 +385,6 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     /// Gets the list of all AllocatedEndpoints associated with this Endpoint.
     /// </summary>
     public NetworkEndpointSnapshotList AllAllocatedEndpoints { get; } = new();
-
-    internal Func<NetworkIdentifier, AllocatedEndpoint?>? _onDemandAllocatedEndpointProvider;
-
-    internal Task<AllocatedEndpoint> GetAllocatedEndpointAsync(NetworkIdentifier networkId, CancellationToken cancellationToken = default)
-    {
-        if (AllAllocatedEndpoints.TryGetAllocatedEndpoint(networkId, out var endpoint))
-        {
-            return Task.FromResult(endpoint);
-        }
-
-        if (_onDemandAllocatedEndpointProvider is { } allocatedEndpointProvider)
-        {
-            endpoint = allocatedEndpointProvider(networkId);
-            if (endpoint is not null)
-            {
-                return Task.FromResult(endpoint);
-            }
-        }
-
-        return AllAllocatedEndpoints.GetAllocatedEndpointAsync(networkId, cancellationToken);
-    }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -1,10 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
-using System.Collections.Concurrent;
-using System.Net.Sockets;
 using System.Collections;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Sockets;
 
 namespace Aspire.Hosting.ApplicationModel;
 
@@ -384,6 +385,35 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     /// Gets the list of all AllocatedEndpoints associated with this Endpoint.
     /// </summary>
     public NetworkEndpointSnapshotList AllAllocatedEndpoints { get; } = new();
+
+    internal Func<NetworkIdentifier, AllocatedEndpoint?>? OnDemandAllocatedEndpointProvider { get; set; }
+
+    internal Task<AllocatedEndpoint> GetAllocatedEndpointAsync(NetworkIdentifier networkId, CancellationToken cancellationToken = default)
+    {
+        if (AllAllocatedEndpoints.TryGetAllocatedEndpoint(networkId, out var endpoint))
+        {
+            return Task.FromResult(endpoint);
+        }
+
+        lock (this)
+        {
+            if (AllAllocatedEndpoints.TryGetAllocatedEndpoint(networkId, out endpoint))
+            {
+                return Task.FromResult(endpoint);
+            }
+
+            if (OnDemandAllocatedEndpointProvider is { } allocatedEndpointProvider)
+            {
+                endpoint = allocatedEndpointProvider(networkId);
+                if (endpoint is not null)
+                {
+                    return Task.FromResult(endpoint);
+                }
+            }
+        }
+
+        return AllAllocatedEndpoints.GetAllocatedEndpointAsync(networkId, cancellationToken);
+    }
 }
 
 /// <summary>
@@ -452,6 +482,24 @@ public class NetworkEndpointSnapshotList : IEnumerable<NetworkEndpointSnapshot>
     {
         var nes = GetSnapshotFor(networkId);
         return nes.Snapshot.GetValueAsync(cancellationToken);
+    }
+
+    internal bool TryGetAllocatedEndpoint(NetworkIdentifier networkId, [NotNullWhen(true)] out AllocatedEndpoint? endpoint)
+    {
+        endpoint = null;
+
+        foreach (var endpointSnapshot in _snapshots)
+        {
+            if (!endpointSnapshot.NetworkID.Equals(networkId) || !endpointSnapshot.Snapshot.IsValueSet)
+            {
+                continue;
+            }
+
+            endpoint = endpointSnapshot.Snapshot.GetValueAsync().GetAwaiter().GetResult();
+            return true;
+        }
+
+        return false;
     }
 
     private NetworkEndpointSnapshot GetSnapshotFor(NetworkIdentifier networkId)

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -242,20 +242,9 @@ public sealed class EndpointReference : IExpressionValue, IManifestExpressionPro
             return null;
         }
 
-        foreach (var nes in endpointAnnotation.AllAllocatedEndpoints)
-        {
-            if (string.Equals(nes.NetworkID.Value, (_contextNetworkId ?? KnownNetworkIdentifiers.LocalhostNetwork).Value, StringComparisons.NetworkId))
-            {
-                if (!nes.Snapshot.IsValueSet)
-                {
-                    continue;
-                }
-
-                return nes.Snapshot.GetValueAsync().GetAwaiter().GetResult();
-            }
-        }
-
-        return null;
+        return endpointAnnotation.AllAllocatedEndpoints.TryGetAllocatedEndpoint(_contextNetworkId ?? KnownNetworkIdentifiers.LocalhostNetwork, out var allocatedEndpoint)
+            ? allocatedEndpoint
+            : null;
     }
 
     /// <summary>
@@ -382,8 +371,7 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
 
         async ValueTask<string?> ResolveValueWithAllocatedAddress()
         {
-            var endpointSnapshots = Endpoint.EndpointAnnotation.AllAllocatedEndpoints;
-            var allocatedEndpoint = await endpointSnapshots.GetAllocatedEndpointAsync(networkContext, cancellationToken).ConfigureAwait(false);
+            var allocatedEndpoint = await Endpoint.EndpointAnnotation.GetAllocatedEndpointAsync(networkContext, cancellationToken).ConfigureAwait(false);
 
             return Property switch
             {

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -221,6 +221,26 @@ public sealed class EndpointReference : IExpressionValue, IManifestExpressionPro
         GetAllocatedEndpoint()
         ?? throw new InvalidOperationException($"The endpoint `{EndpointName}` is not allocated for the resource `{Resource.Name}`.");
 
+    internal Task<AllocatedEndpoint> GetAllocatedEndpointAsync(NetworkIdentifier networkId, CancellationToken cancellationToken = default)
+    {
+        var endpointAnnotation = EndpointAnnotation;
+        if (endpointAnnotation.AllAllocatedEndpoints.TryGetAllocatedEndpoint(networkId, out var endpoint))
+        {
+            return Task.FromResult(endpoint);
+        }
+
+        foreach (var allocationAnnotation in Resource.Annotations.OfType<OnDemandEndpointAllocationAnnotation>())
+        {
+            endpoint = allocationAnnotation.TryAllocate(endpointAnnotation, networkId);
+            if (endpoint is not null)
+            {
+                return Task.FromResult(endpoint);
+            }
+        }
+
+        return endpointAnnotation.AllAllocatedEndpoints.GetAllocatedEndpointAsync(networkId, cancellationToken);
+    }
+
     private EndpointAnnotation? GetEndpointAnnotation()
     {
         if (_endpointAnnotation is not null)
@@ -371,7 +391,7 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
 
         async ValueTask<string?> ResolveValueWithAllocatedAddress()
         {
-            var allocatedEndpoint = await Endpoint.EndpointAnnotation.GetAllocatedEndpointAsync(networkContext, cancellationToken).ConfigureAwait(false);
+            var allocatedEndpoint = await Endpoint.GetAllocatedEndpointAsync(networkContext, cancellationToken).ConfigureAwait(false);
 
             return Property switch
             {

--- a/src/Aspire.Hosting/ApplicationModel/OnDemandEndpointAllocationAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/OnDemandEndpointAllocationAnnotation.cs
@@ -10,7 +10,7 @@ internal sealed class OnDemandEndpointAllocationAnnotation : IResourceAnnotation
 {
     private readonly Dictionary<EndpointAnnotation, OnDemandEndpointAllocation> _allocations = [];
 
-    public void Add(EndpointAnnotation endpoint, Func<NetworkIdentifier, AllocatedEndpoint?> provider)
+    public void Register(EndpointAnnotation endpoint, Func<NetworkIdentifier, AllocatedEndpoint?> provider)
     {
         _allocations[endpoint] = new(provider);
     }
@@ -22,11 +22,11 @@ internal sealed class OnDemandEndpointAllocationAnnotation : IResourceAnnotation
             : null;
     }
 
-    public void Clear(EndpointAnnotation endpoint)
+    public void StopAllocating(EndpointAnnotation endpoint)
     {
         if (_allocations.TryGetValue(endpoint, out var allocation))
         {
-            allocation.Clear();
+            allocation.StopAllocating();
         }
     }
 
@@ -41,7 +41,7 @@ internal sealed class OnDemandEndpointAllocationAnnotation : IResourceAnnotation
             return provider?.Invoke(networkId);
         }
 
-        public void Clear()
+        public void StopAllocating()
         {
             Interlocked.Exchange(ref _provider, null);
         }

--- a/src/Aspire.Hosting/ApplicationModel/OnDemandEndpointAllocationAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/OnDemandEndpointAllocationAnnotation.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Stores resource-owned endpoint allocation callbacks that can run before normal allocation completes.
+/// </summary>
+internal sealed class OnDemandEndpointAllocationAnnotation : IResourceAnnotation
+{
+    private readonly Dictionary<EndpointAnnotation, OnDemandEndpointAllocation> _allocations = [];
+
+    public void Add(EndpointAnnotation endpoint, Func<NetworkIdentifier, AllocatedEndpoint?> provider)
+    {
+        _allocations[endpoint] = new(provider);
+    }
+
+    public AllocatedEndpoint? TryAllocate(EndpointAnnotation endpoint, NetworkIdentifier networkId)
+    {
+        return _allocations.TryGetValue(endpoint, out var allocation)
+            ? allocation.TryAllocate(networkId)
+            : null;
+    }
+
+    public void Clear(EndpointAnnotation endpoint)
+    {
+        if (_allocations.TryGetValue(endpoint, out var allocation))
+        {
+            allocation.Clear();
+        }
+    }
+
+    private sealed class OnDemandEndpointAllocation(Func<NetworkIdentifier, AllocatedEndpoint?> provider)
+    {
+        private Func<NetworkIdentifier, AllocatedEndpoint?>? _provider = provider;
+
+        public AllocatedEndpoint? TryAllocate(NetworkIdentifier networkId)
+        {
+            var provider = _provider;
+
+            return provider?.Invoke(networkId);
+        }
+
+        public void Clear()
+        {
+            Interlocked.Exchange(ref _provider, null);
+        }
+    }
+}

--- a/src/Aspire.Hosting/ApplicationModel/OnDemandEndpointAllocationAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/OnDemandEndpointAllocationAnnotation.cs
@@ -4,46 +4,21 @@
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Stores resource-owned endpoint allocation callbacks that can run before normal allocation completes.
+/// Stores a resource-owned endpoint allocator that can run before normal allocation completes.
 /// </summary>
-internal sealed class OnDemandEndpointAllocationAnnotation : IResourceAnnotation
+internal sealed class OnDemandEndpointAllocationAnnotation(Func<EndpointAnnotation, NetworkIdentifier, AllocatedEndpoint?> allocator) : IResourceAnnotation
 {
-    private readonly Dictionary<EndpointAnnotation, OnDemandEndpointAllocation> _allocations = [];
-
-    public void Register(EndpointAnnotation endpoint, Func<NetworkIdentifier, AllocatedEndpoint?> provider)
-    {
-        _allocations[endpoint] = new(provider);
-    }
+    private Func<EndpointAnnotation, NetworkIdentifier, AllocatedEndpoint?>? _allocator = allocator;
 
     public AllocatedEndpoint? TryAllocate(EndpointAnnotation endpoint, NetworkIdentifier networkId)
     {
-        return _allocations.TryGetValue(endpoint, out var allocation)
-            ? allocation.TryAllocate(networkId)
-            : null;
+        var allocator = _allocator;
+
+        return allocator?.Invoke(endpoint, networkId);
     }
 
-    public void StopAllocating(EndpointAnnotation endpoint)
+    public void StopAllocating()
     {
-        if (_allocations.TryGetValue(endpoint, out var allocation))
-        {
-            allocation.StopAllocating();
-        }
-    }
-
-    private sealed class OnDemandEndpointAllocation(Func<NetworkIdentifier, AllocatedEndpoint?> provider)
-    {
-        private Func<NetworkIdentifier, AllocatedEndpoint?>? _provider = provider;
-
-        public AllocatedEndpoint? TryAllocate(NetworkIdentifier networkId)
-        {
-            var provider = _provider;
-
-            return provider?.Invoke(networkId);
-        }
-
-        public void StopAllocating()
-        {
-            Interlocked.Exchange(ref _provider, null);
-        }
+        Interlocked.Exchange(ref _allocator, null);
     }
 }

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -979,6 +979,9 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
     private static List<ContainerPortSpec> BuildContainerPorts(RenderedModelResource<Container> cr)
     {
         var ports = new List<ContainerPortSpec>();
+        var onDemandEndpointAllocationAnnotation = cr.ModelResource.Annotations
+            .OfType<OnDemandEndpointAllocationAnnotation>()
+            .SingleOrDefault();
 
         foreach (var sp in cr.ServicesProduced)
         {
@@ -989,7 +992,7 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
                 ContainerPort = ea.TargetPort,
             };
 
-            Interlocked.Exchange(ref ea._onDemandAllocatedEndpointProvider, null);
+            onDemandEndpointAllocationAnnotation?.Clear(ea);
 
             if (!ea.IsProxied && ea.SpecifiedPort is int hostPort)
             {

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -318,6 +318,12 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
         spec.RunArgs = runArgs;
 
         var (configuration, pemCertificates, createFiles) = await BuildContainerConfiguration(cr, logger, cToken).ConfigureAwait(false);
+        // Configuration callbacks are the last pre-creation point where on-demand allocation can run.
+        cr.ModelResource.Annotations
+            .OfType<OnDemandEndpointAllocationAnnotation>()
+            .SingleOrDefault()
+            ?.StopAllocating();
+
         if (configuration.Exception is not null)
         {
             throw new FailedToApplyEnvironmentException($"Failed to apply configuration to container {cr.ModelResource.Name}", configuration.Exception);
@@ -979,10 +985,6 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
     private static List<ContainerPortSpec> BuildContainerPorts(RenderedModelResource<Container> cr)
     {
         var ports = new List<ContainerPortSpec>();
-        var onDemandEndpointAllocationAnnotation = cr.ModelResource.Annotations
-            .OfType<OnDemandEndpointAllocationAnnotation>()
-            .SingleOrDefault();
-        onDemandEndpointAllocationAnnotation?.StopAllocating();
 
         foreach (var sp in cr.ServicesProduced)
         {

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -323,14 +323,8 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
             throw new FailedToApplyEnvironmentException($"Failed to apply configuration to container {cr.ModelResource.Name}", configuration.Exception);
         }
 
-        // Environment callbacks can resolve proxyless endpoint ports and commit a fallback host port.
-        // Stop allowing on-demand allocation before building ports so the container spec consumes
-        // the finalized endpoint state.
-        foreach (var sp in cr.ServicesProduced)
-        {
-            Interlocked.Exchange(ref sp.EndpointAnnotation._onDemandAllocatedEndpointProvider, null);
-        }
-
+        // Environment callbacks can resolve proxyless endpoint ports and commit a fallback host port,
+        // so build ports afterward.
         if (cr.ServicesProduced.Count > 0)
         {
             spec.Ports = BuildContainerPorts(cr);
@@ -994,6 +988,8 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
             {
                 ContainerPort = ea.TargetPort,
             };
+
+            Interlocked.Exchange(ref ea._onDemandAllocatedEndpointProvider, null);
 
             if (!ea.IsProxied && ea.SpecifiedPort is int hostPort)
             {

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -982,6 +982,7 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
         var onDemandEndpointAllocationAnnotation = cr.ModelResource.Annotations
             .OfType<OnDemandEndpointAllocationAnnotation>()
             .SingleOrDefault();
+        onDemandEndpointAllocationAnnotation?.StopAllocating();
 
         foreach (var sp in cr.ServicesProduced)
         {
@@ -991,8 +992,6 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
             {
                 ContainerPort = ea.TargetPort,
             };
-
-            onDemandEndpointAllocationAnnotation?.StopAllocating(ea);
 
             if (!ea.IsProxied && ea.SpecifiedPort is int hostPort)
             {

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -199,7 +199,7 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
             }
 
             var containerAppResource = new RenderedModelResource<Container>(container, ctr);
-            DcpModelUtilities.AddServicesProducedInfo(containerAppResource, _appResources.Get());
+            DcpModelUtilities.AddServicesProducedInfo(containerAppResource, _appResources.Get(), _logger);
             _appResources.Add(containerAppResource);
             result.Add(containerAppResource);
         }

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -989,7 +989,7 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
                 ContainerPort = ea.TargetPort,
             };
 
-            ea.ClearOnDemandAllocatedEndpointProvider();
+            ea.OnDemandAllocatedEndpointProvider = null;
 
             if (!ea.IsProxied && ea.SpecifiedPort is int hostPort)
             {

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -992,7 +992,7 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
                 ContainerPort = ea.TargetPort,
             };
 
-            onDemandEndpointAllocationAnnotation?.Clear(ea);
+            onDemandEndpointAllocationAnnotation?.StopAllocating(ea);
 
             if (!ea.IsProxied && ea.SpecifiedPort is int hostPort)
             {

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -308,11 +308,6 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
 
         var spec = dcpContainer.Spec;
 
-        if (cr.ServicesProduced.Count > 0)
-        {
-            spec.Ports = BuildContainerPorts(cr);
-        }
-
         spec.VolumeMounts = BuildContainerMounts(cr.ModelResource);
 
         var (runArgs, failedToApplyRunArgs) = await BuildRunArgsAsync(logger, cr.ModelResource, cToken).ConfigureAwait(false);
@@ -326,6 +321,13 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
         if (configuration.Exception is not null)
         {
             throw new FailedToApplyEnvironmentException($"Failed to apply configuration to container {cr.ModelResource.Name}", configuration.Exception);
+        }
+
+        // Environment callbacks can resolve proxyless endpoint ports and commit a fallback host port,
+        // so build ports afterward and stop allowing on-demand allocation once container ports are fixed.
+        if (cr.ServicesProduced.Count > 0)
+        {
+            spec.Ports = BuildContainerPorts(cr);
         }
 
         var args = configuration.Arguments.ToList();
@@ -987,12 +989,18 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
                 ContainerPort = ea.TargetPort,
             };
 
-            if (!ea.IsProxied && ea.SpecifiedPort is int hostPort)
+            lock (ea)
             {
-                portSpec.HostPort = hostPort;
+                if (!ea.IsProxied && ea.SpecifiedPort is int hostPort)
+                {
+                    sp.Service.Spec.Port ??= hostPort;
+                    portSpec.HostPort = hostPort;
+                }
+
+                ea.OnDemandAllocatedEndpointProvider = null;
             }
 
-            switch (sp.EndpointAnnotation.Protocol)
+            switch (ea.Protocol)
             {
                 case ProtocolType.Tcp:
                     portSpec.Protocol = PortProtocol.TCP;
@@ -1002,9 +1010,9 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
                     break;
             }
 
-            if (sp.EndpointAnnotation.TargetHost != KnownHostNames.Localhost)
+            if (ea.TargetHost != KnownHostNames.Localhost)
             {
-                portSpec.HostIP = sp.EndpointAnnotation.TargetHost;
+                portSpec.HostIP = ea.TargetHost;
             }
 
             ports.Add(portSpec);

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -323,8 +323,14 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
             throw new FailedToApplyEnvironmentException($"Failed to apply configuration to container {cr.ModelResource.Name}", configuration.Exception);
         }
 
-        // Environment callbacks can resolve proxyless endpoint ports and commit a fallback host port,
-        // so build ports afterward and stop allowing on-demand allocation once container ports are fixed.
+        // Environment callbacks can resolve proxyless endpoint ports and commit a fallback host port.
+        // Stop allowing on-demand allocation before building ports so the container spec consumes
+        // the finalized endpoint state.
+        foreach (var sp in cr.ServicesProduced)
+        {
+            Interlocked.Exchange(ref sp.EndpointAnnotation._onDemandAllocatedEndpointProvider, null);
+        }
+
         if (cr.ServicesProduced.Count > 0)
         {
             spec.Ports = BuildContainerPorts(cr);
@@ -988,8 +994,6 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
             {
                 ContainerPort = ea.TargetPort,
             };
-
-            ea.OnDemandAllocatedEndpointProvider = null;
 
             if (!ea.IsProxied && ea.SpecifiedPort is int hostPort)
             {

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -989,15 +989,12 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
                 ContainerPort = ea.TargetPort,
             };
 
-            lock (ea)
-            {
-                if (!ea.IsProxied && ea.SpecifiedPort is int hostPort)
-                {
-                    sp.Service.Spec.Port ??= hostPort;
-                    portSpec.HostPort = hostPort;
-                }
+            ea.ClearOnDemandAllocatedEndpointProvider();
 
-                ea.OnDemandAllocatedEndpointProvider = null;
+            if (!ea.IsProxied && ea.SpecifiedPort is int hostPort)
+            {
+                sp.Service.Spec.Port ??= hostPort;
+                portSpec.HostPort = hostPort;
             }
 
             switch (ea.Protocol)

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -74,27 +74,16 @@ internal static class DcpModelUtilities
             spAnn.Port = ea.TargetPort;
             appResource.DcpResource.AnnotateAsObjectList(CustomResource.ServiceProducerAnnotation, spAnn);
             appResource.ServicesProduced.Add(sp);
-
-            if (IsDynamicProxylessContainerEndpoint(appResource, sp))
-            {
-                // These endpoints normally get their host port during container creation. If a
-                // reference needs the allocated endpoint while building the container configuration,
-                // commit the fallback port before waiting would deadlock resource creation.
-                GetOrAddOnDemandEndpointAllocationAnnotation(appResource.ModelResource)
-                    .Register(ea, networkId => TryAllocateDynamicProxylessContainerEndpoint(appResource, sp, networkId, logger));
-            }
         }
 
-        static OnDemandEndpointAllocationAnnotation GetOrAddOnDemandEndpointAllocationAnnotation(IResource resource)
+        if (appResource.ServicesProduced.Any(sp => IsDynamicProxylessContainerEndpoint(appResource, sp)) &&
+            !modelResource.Annotations.OfType<OnDemandEndpointAllocationAnnotation>().Any())
         {
-            var annotation = resource.Annotations.OfType<OnDemandEndpointAllocationAnnotation>().SingleOrDefault();
-            if (annotation is null)
-            {
-                annotation = new();
-                resource.Annotations.Add(annotation);
-            }
-
-            return annotation;
+            // These endpoints normally get their host port during container creation. If a
+            // reference needs the allocated endpoint while building the container configuration,
+            // commit the fallback port before waiting would deadlock resource creation.
+            modelResource.Annotations.Add(new OnDemandEndpointAllocationAnnotation(
+                (endpoint, networkId) => TryAllocateDynamicProxylessContainerEndpoint(appResource, endpoint, networkId, logger)));
         }
 
         static bool HasMultipleReplicas(CustomResource resource)
@@ -291,12 +280,18 @@ internal static class DcpModelUtilities
 
     private static AllocatedEndpoint? TryAllocateDynamicProxylessContainerEndpoint<TDcpResource>(
         RenderedModelResource<TDcpResource> resource,
-        ServiceWithModelResource sp,
+        EndpointAnnotation endpoint,
         NetworkIdentifier networkId,
         ILogger? logger)
         where TDcpResource : CustomResource, IKubernetesStaticMetadata
     {
-        var endpoint = sp.EndpointAnnotation;
+        var sp = resource.ServicesProduced.SingleOrDefault(sp =>
+            ReferenceEquals(sp.EndpointAnnotation, endpoint) &&
+            IsDynamicProxylessContainerEndpoint(resource, sp));
+        if (sp is null)
+        {
+            return null;
+        }
 
         Debug.Assert(endpoint.TargetPort is not null);
 

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Net;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Model;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Dcp;
 
@@ -20,7 +21,8 @@ internal static class DcpModelUtilities
     /// </summary>
     internal static void AddServicesProducedInfo<TDcpResource>(
         RenderedModelResource<TDcpResource> appResource,
-        IEnumerable<IAppResource> appResources)
+        IEnumerable<IAppResource> appResources,
+        ILogger? logger = null)
         where TDcpResource : CustomResource, IKubernetesStaticMetadata
     {
         var modelResource = appResource.ModelResource;
@@ -78,7 +80,7 @@ internal static class DcpModelUtilities
                 // These endpoints normally get their host port during container creation. If a
                 // reference needs the allocated endpoint while building the container configuration,
                 // commit the fallback port before waiting would deadlock resource creation.
-                ea.OnDemandAllocatedEndpointProvider = networkId => TryAllocateDynamicProxylessContainerEndpoint(appResource, sp, networkId);
+                ea.OnDemandAllocatedEndpointProvider = networkId => TryAllocateDynamicProxylessContainerEndpoint(appResource, sp, networkId, logger);
             }
         }
 
@@ -277,7 +279,8 @@ internal static class DcpModelUtilities
     private static AllocatedEndpoint? TryAllocateDynamicProxylessContainerEndpoint<TDcpResource>(
         RenderedModelResource<TDcpResource> resource,
         ServiceWithModelResource sp,
-        NetworkIdentifier networkId)
+        NetworkIdentifier networkId,
+        ILogger? logger)
         where TDcpResource : CustomResource, IKubernetesStaticMetadata
     {
         var endpoint = sp.EndpointAnnotation;
@@ -286,6 +289,12 @@ internal static class DcpModelUtilities
 
         var targetPort = endpoint.TargetPort.Value;
         endpoint.Port = targetPort;
+        logger?.LogInformation(
+            "Endpoint '{EndpointName}' on container resource '{ResourceName}' was resolved before the container was created, so Aspire is assigning public port {PublicPort} to match target port {TargetPort} for proxyless access.",
+            endpoint.Name,
+            sp.ModelResource.Name,
+            targetPort,
+            targetPort);
 
         if (TryAddLocalhostAllocatedEndpoint(sp, allowPending: false, fallbackPort: targetPort))
         {

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -80,8 +80,21 @@ internal static class DcpModelUtilities
                 // These endpoints normally get their host port during container creation. If a
                 // reference needs the allocated endpoint while building the container configuration,
                 // commit the fallback port before waiting would deadlock resource creation.
-                ea._onDemandAllocatedEndpointProvider = networkId => TryAllocateDynamicProxylessContainerEndpoint(appResource, sp, networkId, logger);
+                GetOrAddOnDemandEndpointAllocationAnnotation(appResource.ModelResource)
+                    .Add(ea, networkId => TryAllocateDynamicProxylessContainerEndpoint(appResource, sp, networkId, logger));
             }
+        }
+
+        static OnDemandEndpointAllocationAnnotation GetOrAddOnDemandEndpointAllocationAnnotation(IResource resource)
+        {
+            var annotation = resource.Annotations.OfType<OnDemandEndpointAllocationAnnotation>().SingleOrDefault();
+            if (annotation is null)
+            {
+                annotation = new();
+                resource.Annotations.Add(annotation);
+            }
+
+            return annotation;
         }
 
         static bool HasMultipleReplicas(CustomResource resource)

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -80,7 +80,7 @@ internal static class DcpModelUtilities
                 // These endpoints normally get their host port during container creation. If a
                 // reference needs the allocated endpoint while building the container configuration,
                 // commit the fallback port before waiting would deadlock resource creation.
-                ea.OnDemandAllocatedEndpointProvider = networkId => TryAllocateDynamicProxylessContainerEndpoint(appResource, sp, networkId, logger);
+                ea._onDemandAllocatedEndpointProvider = networkId => TryAllocateDynamicProxylessContainerEndpoint(appResource, sp, networkId, logger);
             }
         }
 

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -72,6 +72,14 @@ internal static class DcpModelUtilities
             spAnn.Port = ea.TargetPort;
             appResource.DcpResource.AnnotateAsObjectList(CustomResource.ServiceProducerAnnotation, spAnn);
             appResource.ServicesProduced.Add(sp);
+
+            if (IsDynamicProxylessContainerEndpoint(appResource, sp))
+            {
+                // These endpoints normally get their host port during container creation. If a
+                // reference needs the allocated endpoint while building the container configuration,
+                // commit the fallback port before waiting would deadlock resource creation.
+                ea.OnDemandAllocatedEndpointProvider = networkId => TryAllocateDynamicProxylessContainerEndpoint(appResource, sp, networkId);
+            }
         }
 
         static bool HasMultipleReplicas(CustomResource resource)
@@ -148,9 +156,10 @@ internal static class DcpModelUtilities
         return isDynamicProxylessContainerEndpoint && AreResourceEndpointsAllocated(modelResource);
     }
 
-    private static bool TryAddLocalhostAllocatedEndpoint(ServiceWithModelResource sp, bool allowPending)
+    private static bool TryAddLocalhostAllocatedEndpoint(ServiceWithModelResource sp, bool allowPending, int? fallbackPort = null)
     {
         var svc = sp.DcpResource;
+        var allocatedPort = svc.AllocatedPort ?? fallbackPort;
 
         if (sp.EndpointAnnotation.AllocatedEndpoint is not null)
         {
@@ -169,7 +178,7 @@ internal static class DcpModelUtilities
             throw new InvalidDataException($"Service {svc.Metadata.Name} should have valid address at this point");
         }
 
-        if (!sp.EndpointAnnotation.IsProxied && svc.AllocatedPort is null)
+        if (!sp.EndpointAnnotation.IsProxied && allocatedPort is null)
         {
             if (allowPending)
             {
@@ -179,7 +188,7 @@ internal static class DcpModelUtilities
             throw new InvalidOperationException($"Service '{svc.Metadata.Name}' needs to specify a port for endpoint '{sp.EndpointAnnotation.Name}' since it isn't using a proxy.");
         }
 
-        if (!svc.HasCompleteAddress)
+        if (allocatedPort is null || string.IsNullOrEmpty(svc.AllocatedAddress))
         {
             if (allowPending)
             {
@@ -194,7 +203,7 @@ internal static class DcpModelUtilities
         sp.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(
             sp.EndpointAnnotation,
             targetHost,
-            (int)svc.AllocatedPort!,
+            allocatedPort.Value,
             bindingMode,
             targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
             KnownNetworkIdentifiers.LocalhostNetwork);
@@ -263,6 +272,29 @@ internal static class DcpModelUtilities
         return resource.DcpResource is Container &&
             !sp.EndpointAnnotation.IsProxied &&
             sp.EndpointAnnotation.SpecifiedPort is null;
+    }
+
+    private static AllocatedEndpoint? TryAllocateDynamicProxylessContainerEndpoint<TDcpResource>(
+        RenderedModelResource<TDcpResource> resource,
+        ServiceWithModelResource sp,
+        NetworkIdentifier networkId)
+        where TDcpResource : CustomResource, IKubernetesStaticMetadata
+    {
+        var endpoint = sp.EndpointAnnotation;
+
+        Debug.Assert(endpoint.TargetPort is not null);
+
+        var targetPort = endpoint.TargetPort.Value;
+        endpoint.Port = targetPort;
+
+        if (TryAddLocalhostAllocatedEndpoint(sp, allowPending: false, fallbackPort: targetPort))
+        {
+            AddContainerNetworkAllocatedEndpoint(resource, sp);
+        }
+
+        return endpoint.AllAllocatedEndpoints.TryGetAllocatedEndpoint(networkId, out var allocatedEndpoint)
+            ? allocatedEndpoint
+            : null;
     }
 
     internal static void AddContainerTunnelAllocatedEndpoints(

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -81,7 +81,7 @@ internal static class DcpModelUtilities
                 // reference needs the allocated endpoint while building the container configuration,
                 // commit the fallback port before waiting would deadlock resource creation.
                 GetOrAddOnDemandEndpointAllocationAnnotation(appResource.ModelResource)
-                    .Add(ea, networkId => TryAllocateDynamicProxylessContainerEndpoint(appResource, sp, networkId, logger));
+                    .Register(ea, networkId => TryAllocateDynamicProxylessContainerEndpoint(appResource, sp, networkId, logger));
             }
         }
 

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1665,7 +1665,7 @@ public class DcpExecutorTests
         var builder = DistributedApplication.CreateBuilder();
 
         const int desiredTargetPort = TestKubernetesService.StartOfAutoPortRange - 999;
-        builder.AddContainer("database", "image")
+        var database = builder.AddContainer("database", "image")
             .WithEndpoint(name: "NoPortTargetPortSet", targetPort: desiredTargetPort, isProxied: false);
 
         var allocatedPortChannel = Channel.CreateUnbounded<int>();
@@ -1691,8 +1691,74 @@ public class DcpExecutorTests
         await appExecutor.RunApplicationAsync();
 
         var allocatedPort = await allocatedPortChannel.Reader.ReadAsync().AsTask().DefaultTimeout();
+        var dcpCtr = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        var svc = kubernetesService.CreatedResources.OfType<Service>().Single(s => s.Name() == "database");
 
+        Assert.NotNull(dcpCtr.Spec.Ports);
+        Assert.Contains(dcpCtr.Spec.Ports!, p => p.HostPort is null && p.ContainerPort == desiredTargetPort);
+        Assert.Equal(allocatedPort, svc.Status?.EffectivePort);
+        Assert.NotEqual(desiredTargetPort, allocatedPort);
         Assert.True(allocatedPort >= TestKubernetesService.StartOfAutoPortRange);
+        Assert.Equal(allocatedPort.ToString(CultureInfo.InvariantCulture), await database.GetEndpoint("NoPortTargetPortSet").Property(EndpointProperty.Port).GetValueAsync());
+    }
+
+    [Fact]
+    public async Task EndpointPortsContainerProxylessNoPortTargetPortSetUsesTargetPortFallbackWhenResolvedBeforeContainerCreation()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        const int desiredTargetPort = TestKubernetesService.StartOfAutoPortRange - 999;
+        var database = builder.AddContainer("database", "image")
+            .WithEndpoint(name: "NoPortTargetPortSet", targetPort: desiredTargetPort, isProxied: false);
+        database.WithEnvironment("PUBLIC_PORT", database.GetEndpoint("NoPortTargetPortSet").Property(EndpointProperty.Port));
+        database.WithEnvironment("PUBLIC_PORT_AGAIN", database.GetEndpoint("NoPortTargetPortSet").Property(EndpointProperty.Port));
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+        await appExecutor.RunApplicationAsync();
+
+        var dcpCtr = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        var svc = kubernetesService.CreatedResources.OfType<Service>().Single(s => s.Name() == "database");
+
+        Assert.Equal(AddressAllocationModes.Proxyless, svc.Spec.AddressAllocationMode);
+        Assert.Equal(desiredTargetPort, svc.Status?.EffectivePort);
+        Assert.NotNull(dcpCtr.Spec.Ports);
+        Assert.Contains(dcpCtr.Spec.Ports!, p => p.HostPort == desiredTargetPort && p.ContainerPort == desiredTargetPort);
+        var envVarVal = dcpCtr.Spec.Env?.Single(v => v.Name == "PUBLIC_PORT").Value;
+        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
+        Assert.Equal(desiredTargetPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+        var secondEnvVarVal = dcpCtr.Spec.Env?.Single(v => v.Name == "PUBLIC_PORT_AGAIN").Value;
+        Assert.False(string.IsNullOrWhiteSpace(secondEnvVarVal));
+        Assert.Equal(desiredTargetPort, int.Parse(secondEnvVarVal, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task EndpointPortsContainerProxylessNoPortTargetPortSetUsesTargetPortFallbackWhenHostAndPortResolvedBeforeContainerCreation()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        const int desiredTargetPort = TestKubernetesService.StartOfAutoPortRange - 999;
+        var database = builder.AddContainer("database", "image")
+            .WithEndpoint(name: "NoPortTargetPortSet", targetPort: desiredTargetPort, isProxied: false);
+        database.WithEnvironment("PUBLIC_HOST_AND_PORT", database.GetEndpoint("NoPortTargetPortSet").Property(EndpointProperty.HostAndPort));
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+        await appExecutor.RunApplicationAsync();
+
+        var dcpCtr = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        var svc = kubernetesService.CreatedResources.OfType<Service>().Single(s => s.Name() == "database");
+
+        Assert.Equal(AddressAllocationModes.Proxyless, svc.Spec.AddressAllocationMode);
+        Assert.Equal(desiredTargetPort, svc.Status?.EffectivePort);
+        Assert.NotNull(dcpCtr.Spec.Ports);
+        Assert.Contains(dcpCtr.Spec.Ports!, p => p.HostPort == desiredTargetPort && p.ContainerPort == desiredTargetPort);
+        var envVarVal = dcpCtr.Spec.Env?.Single(v => v.Name == "PUBLIC_HOST_AND_PORT").Value;
+        Assert.Equal($"database.dev.internal:{desiredTargetPort}", envVarVal);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -25,7 +25,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 using Polly;
 using Polly.Retry;
@@ -1714,9 +1716,11 @@ public class DcpExecutorTests
         database.WithEnvironment("PUBLIC_PORT_AGAIN", database.GetEndpoint("NoPortTargetPortSet").Property(EndpointProperty.Port));
 
         var kubernetesService = new TestKubernetesService();
+        var testSink = new TestSink();
+        var containerCreatorLogger = new TestLogger<ContainerCreator>(new TestLoggerFactory(testSink, enabled: true));
         using var app = builder.Build();
         var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, containerCreatorLogger: containerCreatorLogger);
         await appExecutor.RunApplicationAsync();
 
         var dcpCtr = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
@@ -1732,6 +1736,10 @@ public class DcpExecutorTests
         var secondEnvVarVal = dcpCtr.Spec.Env?.Single(v => v.Name == "PUBLIC_PORT_AGAIN").Value;
         Assert.False(string.IsNullOrWhiteSpace(secondEnvVarVal));
         Assert.Equal(desiredTargetPort, int.Parse(secondEnvVarVal, CultureInfo.InvariantCulture));
+
+        Assert.Contains(testSink.Writes, log =>
+            log.LogLevel == LogLevel.Information &&
+            log.Message == $"Endpoint 'NoPortTargetPortSet' on container resource 'database' was resolved before the container was created, so Aspire is assigning public port {desiredTargetPort} to match target port {desiredTargetPort} for proxyless access.");
     }
 
     [Fact]
@@ -4373,7 +4381,8 @@ public class DcpExecutorTests
         DcpOptions? dcpOptions = null,
         ResourceLoggerService? resourceLoggerService = null,
         DcpExecutorEvents? events = null,
-        Hosting.Eventing.IDistributedApplicationEventing? distributedApplicationEventing = null)
+        Hosting.Eventing.IDistributedApplicationEventing? distributedApplicationEventing = null,
+        ILogger<ContainerCreator>? containerCreatorLogger = null)
     {
         if (configuration == null)
         {
@@ -4438,7 +4447,7 @@ public class DcpExecutorTests
             resourceLoggerService,
             dcpDependencyCheckService,
             hostEnv,
-            NullLogger<ContainerCreator>.Instance,
+            containerCreatorLogger ?? NullLogger<ContainerCreator>.Instance,
             appResources);
 
         return new DcpExecutor(

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -142,9 +142,11 @@ internal sealed class TestKubernetesService : IKubernetesService
                 continue;
             }
 
+            var hostPort = container.Spec.Ports?.FirstOrDefault(port => port.ContainerPort == serviceProduced.Port)?.HostPort;
+
             service.Status ??= new ServiceStatus();
             service.Status.EffectiveAddress = service.Spec.Address ?? "localhost";
-            service.Status.EffectivePort = Interlocked.Increment(ref _nextPort);
+            service.Status.EffectivePort = hostPort ?? Interlocked.Increment(ref _nextPort);
             modifiedResources.Add(service);
         }
 


### PR DESCRIPTION
## Description

Proxyless container endpoints without an explicit host port normally defer host port assignment until DCP creates the container. That can deadlock or fail when an endpoint reference needs the allocated endpoint while container configuration is still being built, such as when a container exposes its own public port in an environment variable.

This change adds an on-demand allocation path for dynamic proxyless container endpoints. If an allocated endpoint is requested before container ports are finalized, Aspire commits the target port as the fallback host port and builds the container port spec with that host port. Once `BuildContainerPorts` runs, the on-demand allocator is disabled so any later endpoint resolution is fulfilled by normal DCP service updates, preserving random host-port assignment when the endpoint was not needed before container creation.

### User-facing usage

AppHost code that references a proxyless container endpoint before the container is created can now resolve that endpoint deterministically:

```csharp
var database = builder.AddContainer("database", "image")
    .WithEndpoint(name: "tcp", targetPort: 5432, isProxied: false);

database.WithEnvironment("PUBLIC_PORT", database.GetEndpoint("tcp").Property(EndpointProperty.Port));
```

If the endpoint is not resolved before container creation, DCP still assigns the host port dynamically.

Validation:

- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-method "*.EndpointPortsContainerProxylessNoPortTargetPortSet" --filter-method "*.EndpointPortsContainerProxylessNoPortTargetPortSetPublishesAllocatedEndpointAfterServiceUpdate" --filter-method "*.EndpointPortsContainerProxylessNoPortTargetPortSetUsesTargetPortFallbackWhenResolvedBeforeContainerCreation" --filter-method "*.EndpointPortsContainerProxylessNoPortTargetPortSetUsesTargetPortFallbackWhenHostAndPortResolvedBeforeContainerCreation" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No