### PR TITLE
Use session working directory in loc-breakdown canvas

### DIFF
--- a/.github/extensions/loc-breakdown/README.md
+++ b/.github/extensions/loc-breakdown/README.md
@@ -40,7 +40,7 @@ action the agent can invoke to recompute the report.
 
 Optional inputs when opening the canvas:
 
-- `cwd` — working directory inside a git repo (defaults to the agent's cwd)
+- `cwd` — working directory inside a git repo (defaults to the active session's working directory, falling back to the extension process cwd)
 - `base` — base ref to diff against (defaults to `origin/HEAD`)
 - `head` — head ref (defaults to `HEAD`)
 

--- a/.github/extensions/loc-breakdown/extension.mjs
+++ b/.github/extensions/loc-breakdown/extension.mjs
@@ -483,7 +483,7 @@ await joinSession({
             inputSchema: {
                 type: "object",
                 properties: {
-                    cwd: { type: "string", description: "Working directory inside the target git repo. Defaults to the canvas process cwd." },
+                    cwd: { type: "string", description: "Working directory inside the target git repo. Defaults to the active session's working directory (the user's worktree/repo); falls back to the extension process cwd only if the runtime did not supply one." },
                     base: { type: "string", description: "Base ref to diff against. Defaults to origin/HEAD." },
                     head: { type: "string", description: "Head ref. Defaults to HEAD." },
                 },
@@ -517,8 +517,9 @@ await joinSession({
                 const input = ctx.input || {};
                 // Prefer the explicit input.cwd, then the session's working directory supplied by
                 // the runtime (CanvasSessionContext.workingDirectory). process.cwd() is a last resort
-                // because forked extension processes inherit ~/.copilot, which is not a git repo and
-                // causes every git command in buildReport to fail with HTTP 500 on /data.
+                // because the extension process cwd is not necessarily the target session's repo —
+                // for forked extensions it's typically ~/.copilot, which is the wrong repo for this
+                // report even on the rare setups where it happens to be a git repo itself.
                 const opts = {
                     cwd: input.cwd || ctx.session?.workingDirectory || process.cwd(),
                     base: input.base,

--- a/.github/extensions/loc-breakdown/extension.mjs
+++ b/.github/extensions/loc-breakdown/extension.mjs
@@ -494,7 +494,9 @@ await joinSession({
                     description: "Recompute the LOC breakdown by re-running git diff and return the latest report as JSON.",
                     handler: async (ctx) => {
                         const entry = servers.get(ctx.instanceId);
-                        const opts = entry ? entry.opts : { cwd: process.cwd() };
+                        // Fall back to the session working directory (the user's worktree/repo) before
+                        // process.cwd(), which for forked extensions is typically ~/.copilot and not a git repo.
+                        const opts = entry ? entry.opts : { cwd: ctx.session?.workingDirectory || process.cwd() };
                         const report = await buildReport(opts);
                         return {
                             ok: true,
@@ -513,8 +515,12 @@ await joinSession({
             ],
             open: async (ctx) => {
                 const input = ctx.input || {};
+                // Prefer the explicit input.cwd, then the session's working directory supplied by
+                // the runtime (CanvasSessionContext.workingDirectory). process.cwd() is a last resort
+                // because forked extension processes inherit ~/.copilot, which is not a git repo and
+                // causes every git command in buildReport to fail with HTTP 500 on /data.
                 const opts = {
-                    cwd: input.cwd || process.cwd(),
+                    cwd: input.cwd || ctx.session?.workingDirectory || process.cwd(),
                     base: input.base,
                     head: input.head,
                 };


### PR DESCRIPTION
## Description

Fixes an error when opening the LOC breakdown canvas (`load@http://127.0.0.1:.../:98:34`).

## Root cause

Forked extension processes inherit a `process.cwd()` of `~/.copilot`, which is not a git repo. When the canvas was opened without an explicit `cwd` input, `buildReport` ran `git` commands in `~/.copilot`, the `/data` endpoint returned HTTP 500, and the client-side `load()` threw at the `throw new Error("HTTP " + ...)` line.

## Fix

The Copilot SDK supplies `ctx.session.workingDirectory` to canvas `open` / action handlers (the active session's working directory — i.e. the user's worktree or repo). The `open` handler and the `refresh` action's fallback path now prefer that over `process.cwd()`:

```js
cwd: input.cwd || ctx.session?.workingDirectory || process.cwd()
```

## Verification

Reloaded the extension and opened the canvas locally — `/data` now returns 200 with the expected report (resolved cwd is the worktree, base is `origin/main`).