### PR TITLE
[release/13.4] Update WinGet manifest tags

### DIFF
--- a/eng/winget/microsoft.aspire/Aspire.locale.en-US.yaml.template
+++ b/eng/winget/microsoft.aspire/Aspire.locale.en-US.yaml.template
@@ -19,9 +19,9 @@ Description: >
   Aspire applications. It provides commands for project scaffolding, local development,
   and deployment of cloud-native distributed applications.
 Tags:
-- aspire
 - csharp
 - typescript
+- aspire
 - cloud-native
 - distributed-systems
 - developer-tools

--- a/eng/winget/microsoft.aspire/Aspire.locale.en-US.yaml.template
+++ b/eng/winget/microsoft.aspire/Aspire.locale.en-US.yaml.template
@@ -19,8 +19,9 @@ Description: >
   Aspire applications. It provides commands for project scaffolding, local development,
   and deployment of cloud-native distributed applications.
 Tags:
-- dotnet
 - aspire
+- csharp
+- typescript
 - cloud-native
 - distributed-systems
 - developer-tools


### PR DESCRIPTION
## Description

The WinGet package metadata for the Aspire CLI still advertises the `dotnet` tag, but the package should instead surface the supported application language tags. This updates the default locale manifest template so generated WinGet manifests remove `dotnet` and include `csharp` and `typescript`.

### User-facing usage

Generated WinGet locale manifests now include:

```yaml
Tags:
- aspire
- csharp
- typescript
- cloud-native
- distributed-systems
- developer-tools
- cli
- microservices
- containers
```

`dotnet` no longer appears in the tag list.

Validation:

```powershell
pwsh -NoProfile -File eng/winget/generate-manifests.ps1 -Version 13.4.0 -TemplateDir eng/winget/microsoft.aspire -OutputPath <session-artifacts>/winget-validation -SkipUrlValidation
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
