### PR TITLE
Bump undici to 7.27.0 to fix three open Dependabot alerts in extension/

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1021,7 +1021,7 @@
     "serialize-javascript": "7.0.5",
     "flatted": "3.4.2",
     "lodash": "4.18.1",
-    "undici": "7.21.0",
+    "undici": "7.27.0",
     "path-to-regexp": "8.4.2",
     "@sinonjs/fake-timers": "13.0.5",
     "picomatch": "2.3.2",

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -110,9 +110,9 @@ suite('E2E launch profile', () => {
         const internalFeed = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/';
 
         assert.strictEqual(packageJson.devDependencies['vscode-extension-tester'], '8.23.0');
-        assert.strictEqual(packageJson.resolutions.undici, '7.21.0');
+        assert.strictEqual(packageJson.resolutions.undici, '7.27.0');
         assert.ok(lockfile.includes('vscode-extension-tester@8.23.0'));
-        assert.ok(lockfile.includes('undici@7.21.0'));
+        assert.ok(lockfile.includes('undici@7.27.0'));
         assert.ok(lockfile.split(/\r?\n/).filter(l => /^\s*resolved\s+"/.test(l)).every(l => l.includes(internalFeed)));
         assert.ok(workflow.includes('NPM_REGISTRY: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/'));
         assert.ok(fs.existsSync(path.join(extensionRoot, 'scripts', 'validate-lockfile-registry.cjs')));

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -6325,10 +6325,10 @@ undici-types@~6.21.0:
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha1-aR0ArzkJvpOn+qE75hs6W1DvEss=
 
-undici@7.21.0, undici@^7.19.0:
-  version "7.21.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici/-/undici-7.21.0.tgz#b399c763368240d478f83740356836e945a258e0"
-  integrity sha1-s5nHYzaCQNR4+DdANWg26UWiWOA=
+undici@7.27.0, undici@^7.19.0:
+  version "7.27.0"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici/-/undici-7.27.0.tgz#8f1d99dfc28273fe8a5736aa93a507850fda78c9"
+  integrity sha1-jx2Z38KCc/6KVzaqk6UHhQ/aeMk=
 
 unicorn-magic@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary

Resolves the three open `undici` Dependabot alerts filed against `extension/yarn.lock`:

| Alert | Severity | Advisory |
|---|---|---|
| [#1182](https://github.com/microsoft/aspire/security/dependabot/1182) | medium | [GHSA-cxjh-pqwp-8mfp](https://github.com/advisories/GHSA-cxjh-pqwp-8mfp) - CRLF Injection in undici via `upgrade` option |
| [#1180](https://github.com/microsoft/aspire/security/dependabot/1180) | high   | [GHSA-f269-vfmq-vjvj](https://github.com/advisories/GHSA-f269-vfmq-vjvj) - Malicious WebSocket 64-bit length overflows parser and crashes the client |
| [#1179](https://github.com/microsoft/aspire/security/dependabot/1179) | medium | [GHSA-9f74-3xc5-r7g4](https://github.com/advisories/GHSA-9f74-3xc5-r7g4) - HTTP Request/Response Smuggling |

All three are first patched in `undici@7.24.0`.

## What changed

`extension/package.json` pins `undici` via the `resolutions` block (currently at `7.21.0`, which is in the vulnerable range). This PR bumps the pin to `7.27.0` - the latest 7.x release mirrored to the internal `dotnet-public-npm` feed - and regenerates `extension/yarn.lock` through that feed.

- `extension/package.json`: `"undici": "7.21.0"` -> `"undici": "7.27.0"`
- `extension/yarn.lock`: corresponding `undici@7.27.0` entry, `resolved` URL stays on the internal `pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm` registry.

`cheerio`'s `undici "^7.19.0"` constraint is still satisfied, so nothing else moves and the lockfile diff is minimal (3 lines per file). The pre-restore lockfile guard introduced in #17474 (no public registry URLs in `extension/yarn.lock`) still passes - I ran the same node one-liner the CI uses.

## Note on versions available in the internal feed

I checked the internal mirror before picking a target:

- `7.24.0` - 303 (available)
- `7.25.0` - 303 (available)
- `7.26.0` - 303 (available)
- `7.27.0` - 303 (available, latest 7.x)
- `8.x`    - mostly 401 (not mirrored), so kept on the 7.x line that `cheerio` already wants.

## Other open alerts

The other six open Dependabot alerts (ws, @nevware21/ts-utils, fast-uri x2, qs, vitest) are already addressed by Dependabot's group PR #17854.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
