### PR TITLE
Allow release gh-aw workflows for bot events

### DIFF
--- a/.github/workflows/release-notes-generate.lock.yml
+++ b/.github/workflows/release-notes-generate.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"ba68a4b89ef8c5cb217c63c13d1b46794076b637ca2579d9336f319c830ef7fd","body_hash":"f7037a8bcaddb595d94ba127f7aa7eebc46591c66a9c427f917b79ef34ea258b","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"74e2745cfbe4c7609245040ef1f4fe4dff82fa1737913c78485304c82b5446a2","body_hash":"f38b4c1674fbbd210f225c757a6a63f2b91fc2c9c0d4fb151b38a01b56c75288","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["ASPIRE_BOT_APP_ID","ASPIRE_BOT_PRIVATE_KEY","COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -56,6 +56,8 @@
 
 name: "Generate release notes for a new stable Aspire release"
 on:
+  # bots: # Bots processed as bot check in pre-activation job
+  # - aspire-repo-bot # Bots processed as bot check in pre-activation job
   release:
     types:
     - published
@@ -200,20 +202,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_2709dc85f5a379b6_EOF'
+          cat << 'GH_AW_PROMPT_a24f839bbe45c854_EOF'
           <system>
-          GH_AW_PROMPT_2709dc85f5a379b6_EOF
+          GH_AW_PROMPT_a24f839bbe45c854_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2709dc85f5a379b6_EOF'
+          cat << 'GH_AW_PROMPT_a24f839bbe45c854_EOF'
           <safe-output-tools>
           Tools: update_release, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_2709dc85f5a379b6_EOF
+          GH_AW_PROMPT_a24f839bbe45c854_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_2709dc85f5a379b6_EOF'
+          cat << 'GH_AW_PROMPT_a24f839bbe45c854_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -242,12 +244,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_2709dc85f5a379b6_EOF
+          GH_AW_PROMPT_a24f839bbe45c854_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2709dc85f5a379b6_EOF'
+          cat << 'GH_AW_PROMPT_a24f839bbe45c854_EOF'
           </system>
           {{#runtime-import .github/workflows/release-notes-generate.md}}
-          GH_AW_PROMPT_2709dc85f5a379b6_EOF
+          GH_AW_PROMPT_a24f839bbe45c854_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -483,9 +485,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_785dadefdca542eb_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c39d7719749bceff_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_release":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_785dadefdca542eb_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_c39d7719749bceff_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -680,7 +682,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_2ff0f5f9d5fd07df_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_5228452b4d36af30_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -726,7 +728,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_2ff0f5f9d5fd07df_EOF
+          GH_AW_MCP_CONFIG_5228452b4d36af30_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1381,6 +1383,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
+          GH_AW_ALLOWED_BOTS: "aspire-repo-bot"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-notes-generate.md
+++ b/.github/workflows/release-notes-generate.md
@@ -21,6 +21,11 @@ on:
   # to bail us out, and the lock file shouldn't drift just because the
   # frontmatter changed.
   stale-check: false
+  # Stable releases are published by the `aspire-repo-bot` GitHub App. gh-aw's
+  # activation gate checks the triggering actor's repo permission and GitHub
+  # Apps do not appear as collaborators, so allow-list the App the same way as
+  # other bot-triggered gh-aw workflows in this repo.
+  bots: [aspire-repo-bot]
 
 if: >-
   github.repository == 'microsoft/aspire'

--- a/.github/workflows/release-update-support-mdx.lock.yml
+++ b/.github/workflows/release-update-support-mdx.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"917012e2ec7cd5966dbf43197e1672408030f8f294fc4fccf4be5acb97a137ad","body_hash":"ee06b8272af9af9cd76372820c984f916fe02381f141b9fbc1090c3dfaac9b00","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"069d14c223ad2c399773bb1089f6038aa6a445ab0a7ce35ef14d91f1dbe6dba0","body_hash":"ee06b8272af9af9cd76372820c984f916fe02381f141b9fbc1090c3dfaac9b00","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["ASPIRE_BOT_APP_ID","ASPIRE_BOT_PRIVATE_KEY","COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -60,6 +60,8 @@
 
 name: "Update aspire.dev support page for a new Aspire release"
 on:
+  # bots: # Bots processed as bot check in pre-activation job
+  # - aspire-repo-bot # Bots processed as bot check in pre-activation job
   release:
     types:
     - published
@@ -204,23 +206,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_7db24b7e6cb9df0d_EOF'
+          cat << 'GH_AW_PROMPT_9319c808c03e59a2_EOF'
           <system>
-          GH_AW_PROMPT_7db24b7e6cb9df0d_EOF
+          GH_AW_PROMPT_9319c808c03e59a2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7db24b7e6cb9df0d_EOF'
+          cat << 'GH_AW_PROMPT_9319c808c03e59a2_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_7db24b7e6cb9df0d_EOF
+          GH_AW_PROMPT_9319c808c03e59a2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_7db24b7e6cb9df0d_EOF'
+          cat << 'GH_AW_PROMPT_9319c808c03e59a2_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_7db24b7e6cb9df0d_EOF
+          GH_AW_PROMPT_9319c808c03e59a2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_7db24b7e6cb9df0d_EOF'
+          cat << 'GH_AW_PROMPT_9319c808c03e59a2_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -253,12 +255,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_7db24b7e6cb9df0d_EOF
+          GH_AW_PROMPT_9319c808c03e59a2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7db24b7e6cb9df0d_EOF'
+          cat << 'GH_AW_PROMPT_9319c808c03e59a2_EOF'
           </system>
           {{#runtime-import .github/workflows/release-update-support-mdx.md}}
-          GH_AW_PROMPT_7db24b7e6cb9df0d_EOF
+          GH_AW_PROMPT_9319c808c03e59a2_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -531,9 +533,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4766c533b243e088_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e6d4e6e808b6a2fb_EOF'
           {"create_pull_request":{"allowed_base_branches":["main"],"base_branch":"main","draft":true,"fallback_as_issue":false,"labels":["docs-from-code"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked","reviewers":["IEvangelist"],"target-repo":"microsoft/aspire.dev","title_prefix":"[support] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4766c533b243e088_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_e6d4e6e808b6a2fb_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -744,7 +746,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_dcabbae9430a560e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_d2c545749f726bbb_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -790,7 +792,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dcabbae9430a560e_EOF
+          GH_AW_MCP_CONFIG_d2c545749f726bbb_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1502,6 +1504,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
+          GH_AW_ALLOWED_BOTS: "aspire-repo-bot"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-update-support-mdx.md
+++ b/.github/workflows/release-update-support-mdx.md
@@ -20,6 +20,11 @@ on:
         required: true
         type: string
   stale-check: false
+  # Stable releases are published by the `aspire-repo-bot` GitHub App. gh-aw's
+  # activation gate checks the triggering actor's repo permission and GitHub
+  # Apps do not appear as collaborators, so allow-list the App the same way as
+  # other bot-triggered gh-aw workflows in this repo.
+  bots: [aspire-repo-bot]
 
 if: >-
   github.repository == 'microsoft/aspire'


### PR DESCRIPTION
## Description

Allow the bot-authored stable release events to activate the release-triggered gh-aw workflows instead of stopping after `pre_activation`.

The linked run for `Update aspire.dev support page for a new Aspire release` was triggered by `aspire-repo-bot[bot]`, but gh-aw's activation gate checked the actor's repository permission, saw `none`, and skipped the agent, detection, safe output, and conclusion jobs. This adds `bots: [aspire-repo-bot]` to the release support-page workflow and the companion release-notes workflow, matching the existing bot-triggered gh-aw workflow pattern used by `extension-changelog.md`, and regenerates the lock files so `GH_AW_ALLOWED_BOTS` is passed to the pre-activation membership check.

Fixes # (issue)

Validation:

- `gh aw compile release-notes-generate release-update-support-mdx --no-emit --validate --no-check-update`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
