### PR TITLE
Add polyglot interaction service APIs

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.Java/AtsJavaCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Java/AtsJavaCodeGenerator.cs
@@ -1442,8 +1442,8 @@ internal sealed class AtsJavaCodeGenerator : ICodeGenerator
     {
         var requiredParameterList = string.Join(", ", requiredParameters.Select(parameter => $"{MapParameterToJava(parameter)} {ToCamelCase(parameter.Name)}"));
         var publicParameterList = string.IsNullOrEmpty(requiredParameterList)
-            ? $"{optionsClassName} options"
-            : $"{requiredParameterList}, {optionsClassName} options";
+            ? $"{optionsClassName} optionsBag"
+            : $"{requiredParameterList}, {optionsClassName} optionsBag";
 
         if (!string.IsNullOrEmpty(capability.Description))
         {
@@ -1454,7 +1454,7 @@ internal sealed class AtsJavaCodeGenerator : ICodeGenerator
         foreach (var parameter in optionalParameters)
         {
             var paramName = ToCamelCase(parameter.Name);
-            WriteLine($"        var {paramName} = options == null ? null : options.{GetOptionGetterName(parameter)}();");
+            WriteLine($"        var {paramName} = optionsBag == null ? null : optionsBag.{GetOptionGetterName(parameter)}();");
         }
 
         var implementationArguments = requiredParameters

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -183,22 +183,22 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         // ReferenceExpression is a value type defined in base.mts, not a handle-based wrapper
         if (typeRef.TypeId == AtsConstants.ReferenceExpressionTypeId)
         {
-            return GetReferenceExpressionInterfaceName();
+            return ApplyNullableType(typeRef, GetReferenceExpressionInterfaceName());
         }
 
         if (typeRef.TypeId == InputTypeTypeId)
         {
-            return GetInputTypeEnumName();
+            return ApplyNullableType(typeRef, GetInputTypeEnumName());
         }
 
         if (typeRef.TypeId == InteractionInputTypeId)
         {
-            return GetInteractionInputInterfaceName();
+            return ApplyNullableType(typeRef, GetInteractionInputInterfaceName());
         }
 
         if (typeRef.TypeId == InteractionInputCollectionTypeId)
         {
-            return GetInteractionInputCollectionClassName();
+            return ApplyNullableType(typeRef, GetInteractionInputCollectionClassName());
         }
 
         // Check for wrapper class first (handles custom types like resource builders)
@@ -228,7 +228,7 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
     private static string ApplyNullableType(AtsTypeRef typeRef, string mappedType)
     {
-        if (typeRef.IsNullable != true || typeRef.Category is not (AtsTypeCategory.Primitive or AtsTypeCategory.Enum))
+        if (typeRef.IsNullable != true)
         {
             return mappedType;
         }
@@ -247,9 +247,9 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
         return typeRef.Category switch
         {
-            AtsTypeCategory.Array or AtsTypeCategory.List => $"{MapDtoPropertyTypeToTypeScript(typeRef.ElementType)}[]",
-            AtsTypeCategory.Dict => $"Record<{MapDtoPropertyTypeToTypeScript(typeRef.KeyType)}, {MapDtoPropertyTypeToTypeScript(typeRef.ValueType)}>",
-            AtsTypeCategory.Union => MapDtoUnionTypeToTypeScript(typeRef),
+            AtsTypeCategory.Array or AtsTypeCategory.List => ApplyNullableType(typeRef, $"{MapDtoPropertyTypeToTypeScript(typeRef.ElementType)}[]"),
+            AtsTypeCategory.Dict => ApplyNullableType(typeRef, $"Record<{MapDtoPropertyTypeToTypeScript(typeRef.KeyType)}, {MapDtoPropertyTypeToTypeScript(typeRef.ValueType)}>"),
+            AtsTypeCategory.Union => ApplyNullableType(typeRef, MapDtoUnionTypeToTypeScript(typeRef)),
             _ => MapTypeRefToTypeScript(typeRef)
         };
     }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -432,7 +432,6 @@ public sealed class ExecuteCommandContext
     /// <summary>
     /// The service provider.
     /// </summary>
-    [AspireExportIgnore(Reason = "IServiceProvider is not usable from polyglot command callbacks.")]
     public required IServiceProvider ServiceProvider { get; init; }
 
     /// <summary>

--- a/src/Aspire.Hosting/Ats/AtsTypeMappings.cs
+++ b/src/Aspire.Hosting/Ats/AtsTypeMappings.cs
@@ -1,3 +1,4 @@
+#pragma warning disable ASPIREINTERACTION001
 #pragma warning disable ASPIREPIPELINES001
 
 // Licensed to the .NET Foundation under one or more agreements.
@@ -53,6 +54,7 @@ using Microsoft.Extensions.Logging;
 
 // Service types
 [assembly: AspireExport(typeof(IServiceProvider))]
+[assembly: AspireExport(typeof(IInteractionService))]
 [assembly: AspireExport(typeof(ResourceNotificationService))]
 [assembly: AspireExport(typeof(ResourceLoggerService))]
 [assembly: AspireExport(typeof(ResourceCommandService))]

--- a/src/Aspire.Hosting/Ats/InteractionExports.cs
+++ b/src/Aspire.Hosting/Ats/InteractionExports.cs
@@ -1,0 +1,416 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREINTERACTION001
+
+using Microsoft.Extensions.DependencyInjection;
+using PublicInputsDialogInteractionOptions = Aspire.Hosting.InputsDialogInteractionOptions;
+using PublicInteractionOptions = Aspire.Hosting.InteractionOptions;
+using PublicMessageBoxInteractionOptions = Aspire.Hosting.MessageBoxInteractionOptions;
+using PublicNotificationInteractionOptions = Aspire.Hosting.NotificationInteractionOptions;
+
+namespace Aspire.Hosting.Ats;
+
+/// <summary>
+/// ATS exports for interaction service operations.
+/// </summary>
+internal static class InteractionExports
+{
+    /// <summary>
+    /// Gets the interaction service from the service provider.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider handle.</param>
+    /// <returns>An interaction service handle.</returns>
+    [AspireExport]
+    public static IInteractionService GetInteractionService(this IServiceProvider serviceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        return serviceProvider.GetRequiredService<IInteractionService>();
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the interaction service is available.
+    /// </summary>
+    /// <param name="interactionService">The interaction service handle.</param>
+    /// <returns><see langword="true"/> when the interaction service can interact with the user; otherwise, <see langword="false"/>.</returns>
+    [AspireExport("interactionServiceIsAvailable", MethodName = "isAvailable")]
+    public static bool IsAvailable(this IInteractionService interactionService)
+    {
+        ArgumentNullException.ThrowIfNull(interactionService);
+
+        return interactionService.IsAvailable;
+    }
+
+    /// <summary>
+    /// Prompts the user for confirmation with a dialog.
+    /// </summary>
+    /// <param name="interactionService">The interaction service handle.</param>
+    /// <param name="title">The title of the dialog.</param>
+    /// <param name="message">The message to display in the dialog.</param>
+    /// <param name="options">Optional configuration for the message box interaction.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The confirmation interaction result.</returns>
+    [AspireExport]
+    public static async Task<BooleanInteractionResult> PromptConfirmationAsync(
+        this IInteractionService interactionService,
+        string title,
+        string message,
+        MessageBoxInteractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(interactionService);
+
+        var result = await interactionService.PromptConfirmationAsync(
+            title,
+            message,
+            options?.ToMessageBoxInteractionOptions(),
+            cancellationToken).ConfigureAwait(false);
+
+        return BooleanInteractionResult.FromInteractionResult(result);
+    }
+
+    /// <summary>
+    /// Prompts the user with a message box dialog.
+    /// </summary>
+    /// <param name="interactionService">The interaction service handle.</param>
+    /// <param name="title">The title of the message box.</param>
+    /// <param name="message">The message to display in the message box.</param>
+    /// <param name="options">Optional configuration for the message box interaction.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The message box interaction result.</returns>
+    [AspireExport]
+    public static async Task<BooleanInteractionResult> PromptMessageBoxAsync(
+        this IInteractionService interactionService,
+        string title,
+        string message,
+        MessageBoxInteractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(interactionService);
+
+        var result = await interactionService.PromptMessageBoxAsync(
+            title,
+            message,
+            options?.ToMessageBoxInteractionOptions(),
+            cancellationToken).ConfigureAwait(false);
+
+        return BooleanInteractionResult.FromInteractionResult(result);
+    }
+
+    /// <summary>
+    /// Prompts the user for a single text input.
+    /// </summary>
+    /// <param name="interactionService">The interaction service handle.</param>
+    /// <param name="title">The title of the input dialog.</param>
+    /// <param name="message">The message to display in the dialog.</param>
+    /// <param name="inputLabel">The label for the input field.</param>
+    /// <param name="placeHolder">The placeholder text for the input field.</param>
+    /// <param name="options">Optional configuration for the input dialog interaction.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The input interaction result.</returns>
+    [AspireExport]
+    public static async Task<InputInteractionResult> PromptInputAsync(
+        this IInteractionService interactionService,
+        string title,
+        string? message,
+        string inputLabel,
+        string placeHolder,
+        InputsDialogInteractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(interactionService);
+
+        var result = await interactionService.PromptInputAsync(
+            title,
+            message,
+            inputLabel,
+            placeHolder,
+            options?.ToInputsDialogInteractionOptions(),
+            cancellationToken).ConfigureAwait(false);
+
+        return InputInteractionResult.FromInteractionResult(result);
+    }
+
+    /// <summary>
+    /// Prompts the user for a single input using a specified <see cref="InteractionInput"/>.
+    /// </summary>
+    /// <param name="interactionService">The interaction service handle.</param>
+    /// <param name="title">The title of the input dialog.</param>
+    /// <param name="message">The message to display in the dialog.</param>
+    /// <param name="input">The input configuration.</param>
+    /// <param name="options">Optional configuration for the input dialog interaction.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The input interaction result.</returns>
+    [AspireExport("promptInputWithInput", MethodName = "promptInputWithInputAsync")]
+    public static async Task<InputInteractionResult> PromptInputWithInputAsync(
+        this IInteractionService interactionService,
+        string title,
+        string? message,
+        InteractionInput input,
+        InputsDialogInteractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(interactionService);
+
+        var result = await interactionService.PromptInputAsync(
+            title,
+            message,
+            input,
+            options?.ToInputsDialogInteractionOptions(),
+            cancellationToken).ConfigureAwait(false);
+
+        return InputInteractionResult.FromInteractionResult(result);
+    }
+
+    /// <summary>
+    /// Prompts the user for multiple inputs.
+    /// </summary>
+    /// <param name="interactionService">The interaction service handle.</param>
+    /// <param name="title">The title of the input dialog.</param>
+    /// <param name="message">The message to display in the dialog.</param>
+    /// <param name="inputs">The input configurations.</param>
+    /// <param name="options">Optional configuration for the input dialog interaction.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The inputs interaction result.</returns>
+    [AspireExport]
+    public static async Task<InputsInteractionResult> PromptInputsAsync(
+        this IInteractionService interactionService,
+        string title,
+        string? message,
+        IReadOnlyList<InteractionInput> inputs,
+        InputsDialogInteractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(interactionService);
+
+        var result = await interactionService.PromptInputsAsync(
+            title,
+            message,
+            inputs,
+            options?.ToInputsDialogInteractionOptions(),
+            cancellationToken).ConfigureAwait(false);
+
+        return InputsInteractionResult.FromInteractionResult(result);
+    }
+
+    /// <summary>
+    /// Prompts the user with a notification.
+    /// </summary>
+    /// <param name="interactionService">The interaction service handle.</param>
+    /// <param name="title">The title of the notification.</param>
+    /// <param name="message">The message to display in the notification.</param>
+    /// <param name="options">Optional configuration for the notification interaction.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The notification interaction result.</returns>
+    [AspireExport]
+    public static async Task<BooleanInteractionResult> PromptNotificationAsync(
+        this IInteractionService interactionService,
+        string title,
+        string message,
+        NotificationInteractionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(interactionService);
+
+        var result = await interactionService.PromptNotificationAsync(
+            title,
+            message,
+            options?.ToNotificationInteractionOptions(),
+            cancellationToken).ConfigureAwait(false);
+
+        return BooleanInteractionResult.FromInteractionResult(result);
+    }
+}
+
+/// <summary>
+/// Shared polyglot options for interaction prompts.
+/// </summary>
+[AspireDto]
+internal class InteractionOptions
+{
+    /// <summary>
+    /// Optional primary button text to override the default text.
+    /// </summary>
+    public string? PrimaryButtonText { get; init; }
+
+    /// <summary>
+    /// Optional secondary button text to override the default text.
+    /// </summary>
+    public string? SecondaryButtonText { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether to show the secondary button.
+    /// </summary>
+    public bool? ShowSecondaryButton { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether to show the dismiss button.
+    /// </summary>
+    public bool? ShowDismiss { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether Markdown in the message is rendered.
+    /// </summary>
+    public bool? EnableMessageMarkdown { get; init; }
+
+    internal void ApplyTo(PublicInteractionOptions options)
+    {
+        options.PrimaryButtonText = PrimaryButtonText;
+        options.SecondaryButtonText = SecondaryButtonText;
+        options.ShowSecondaryButton = ShowSecondaryButton;
+        options.ShowDismiss = ShowDismiss;
+        options.EnableMessageMarkdown = EnableMessageMarkdown;
+    }
+}
+
+/// <summary>
+/// Polyglot options for message box interactions.
+/// </summary>
+[AspireDto]
+internal sealed class MessageBoxInteractionOptions : InteractionOptions
+{
+    /// <summary>
+    /// Gets the intent of the message box.
+    /// </summary>
+    public MessageIntent? Intent { get; init; }
+
+    internal PublicMessageBoxInteractionOptions ToMessageBoxInteractionOptions()
+    {
+        var options = new PublicMessageBoxInteractionOptions
+        {
+            Intent = Intent
+        };
+
+        ApplyTo(options);
+        return options;
+    }
+}
+
+/// <summary>
+/// Polyglot options for inputs dialog interactions.
+/// </summary>
+[AspireDto]
+internal sealed class InputsDialogInteractionOptions : InteractionOptions
+{
+    internal PublicInputsDialogInteractionOptions ToInputsDialogInteractionOptions()
+    {
+        var options = new PublicInputsDialogInteractionOptions();
+
+        ApplyTo(options);
+        return options;
+    }
+}
+
+/// <summary>
+/// Polyglot options for notification interactions.
+/// </summary>
+[AspireDto]
+internal sealed class NotificationInteractionOptions : InteractionOptions
+{
+    /// <summary>
+    /// Gets the intent of the notification.
+    /// </summary>
+    public MessageIntent? Intent { get; init; }
+
+    /// <summary>
+    /// Gets the text for a link in the notification.
+    /// </summary>
+    public string? LinkText { get; init; }
+
+    /// <summary>
+    /// Gets the URL for the link in the notification.
+    /// </summary>
+    public string? LinkUrl { get; init; }
+
+    internal PublicNotificationInteractionOptions ToNotificationInteractionOptions()
+    {
+        var options = new PublicNotificationInteractionOptions
+        {
+            Intent = Intent,
+            LinkText = LinkText,
+            LinkUrl = LinkUrl
+        };
+
+        ApplyTo(options);
+        return options;
+    }
+}
+
+/// <summary>
+/// The result of a boolean interaction prompt.
+/// </summary>
+[AspireDto]
+internal sealed class BooleanInteractionResult
+{
+    /// <summary>
+    /// The data returned from the interaction. The value is <see langword="null"/> when the interaction was canceled.
+    /// </summary>
+    public bool? Data { get; init; }
+
+    /// <summary>
+    /// A flag indicating whether the interaction was canceled by the user.
+    /// </summary>
+    public required bool Canceled { get; init; }
+
+    internal static BooleanInteractionResult FromInteractionResult(InteractionResult<bool> result)
+    {
+        return new BooleanInteractionResult
+        {
+            Data = result.Canceled ? null : result.Data,
+            Canceled = result.Canceled
+        };
+    }
+}
+
+/// <summary>
+/// The result of a single input interaction prompt.
+/// </summary>
+[AspireDto]
+internal sealed class InputInteractionResult
+{
+    /// <summary>
+    /// The data returned from the interaction. The value is <see langword="null"/> when the interaction was canceled.
+    /// </summary>
+    public InteractionInput? Data { get; init; }
+
+    /// <summary>
+    /// A flag indicating whether the interaction was canceled by the user.
+    /// </summary>
+    public required bool Canceled { get; init; }
+
+    internal static InputInteractionResult FromInteractionResult(InteractionResult<InteractionInput> result)
+    {
+        return new InputInteractionResult
+        {
+            Data = result.Canceled ? null : result.Data,
+            Canceled = result.Canceled
+        };
+    }
+}
+
+/// <summary>
+/// The result of a multi-input interaction prompt.
+/// </summary>
+[AspireDto]
+internal sealed class InputsInteractionResult
+{
+    /// <summary>
+    /// The data returned from the interaction. The value is <see langword="null"/> when the interaction was canceled.
+    /// </summary>
+    public InteractionInputCollection? Data { get; init; }
+
+    /// <summary>
+    /// A flag indicating whether the interaction was canceled by the user.
+    /// </summary>
+    public required bool Canceled { get; init; }
+
+    internal static InputsInteractionResult FromInteractionResult(InteractionResult<InteractionInputCollection> result)
+    {
+        return new InputsInteractionResult
+        {
+            Data = result.Canceled ? null : result.Data,
+            Canceled = result.Canceled
+        };
+    }
+}

--- a/src/Aspire.Hosting/Ats/InteractionExports.cs
+++ b/src/Aspire.Hosting/Ats/InteractionExports.cs
@@ -293,9 +293,17 @@ internal sealed class MessageBoxInteractionOptions : InteractionOptions
 [AspireDto]
 internal sealed class InputsDialogInteractionOptions : InteractionOptions
 {
+    /// <summary>
+    /// Gets the validation callback for the inputs dialog.
+    /// </summary>
+    public Func<InputsDialogValidationContext, Task>? ValidationCallback { get; init; }
+
     internal PublicInputsDialogInteractionOptions ToInputsDialogInteractionOptions()
     {
-        var options = new PublicInputsDialogInteractionOptions();
+        var options = new PublicInputsDialogInteractionOptions
+        {
+            ValidationCallback = ValidationCallback
+        };
 
         ApplyTo(options);
         return options;

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -203,6 +203,7 @@ internal sealed class InputLoadingState(InputLoadOptions options)
 /// scenarios where input loading behavior must be customized.
 /// </remarks>
 [Experimental(InteractionService.DiagnosticId, UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[AspireDto]
 public sealed class InputLoadOptions
 {
     /// <summary>
@@ -230,6 +231,7 @@ public sealed class InputLoadOptions
 /// The context for dynamic input loading. Used with <see cref="InputLoadOptions.LoadCallback"/>.
 /// </summary>
 [Experimental(InteractionService.DiagnosticId, UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[AspireExport(ExposeProperties = true)]
 public sealed class LoadInputContext
 {
     /// <summary>
@@ -245,12 +247,25 @@ public sealed class LoadInputContext
     /// <summary>
     /// Gets the service provider.
     /// </summary>
+    [AspireExportIgnore(Reason = "IServiceProvider is not part of the polyglot dynamic loading surface.")]
     public required IServiceProvider Services { get; init; }
 
     /// <summary>
     /// Gets the <see cref="CancellationToken"/>.
     /// </summary>
     public required CancellationToken CancellationToken { get; init; }
+
+    /// <summary>
+    /// Sets the available options for the loading input.
+    /// </summary>
+    /// <param name="options">The choice options to display for the loading input, keyed by submitted value.</param>
+    [AspireExport("LoadInputContext.setOptions", MethodName = "setOptions")]
+    internal void SetOptions(IReadOnlyDictionary<string, string> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        Input.Options = options.ToArray();
+    }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/api/Aspire.Hosting.ats.txt
+++ b/src/Aspire.Hosting/api/Aspire.Hosting.ats.txt
@@ -72,6 +72,7 @@ Aspire.Hosting/Aspire.Hosting.InputsDialogValidationContext [ExposeProperties]
 Aspire.Hosting/Aspire.Hosting.InteractionInputCollection
 Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles [interface]
 Aspire.Hosting/Aspire.Hosting.IUserSecretsManager [interface, ExposeProperties, ExposeMethods]
+Aspire.Hosting/Aspire.Hosting.LoadInputContext [ExposeProperties]
 Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedApplicationPipeline [interface]
 Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingStep [interface]
 Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingTask [interface]
@@ -220,6 +221,7 @@ Aspire.Hosting/Aspire.Hosting.Ats.InputsDialogInteractionOptions # Polyglot opti
   SecondaryButtonText?: string # Optional secondary button text to override the default text.
   ShowDismiss?: boolean # Gets a value indicating whether to show the dismiss button.
   ShowSecondaryButton?: boolean # Gets a value indicating whether to show the secondary button.
+  ValidationCallback?: callback # Gets the validation callback for the inputs dialog.
 Aspire.Hosting/Aspire.Hosting.Ats.InputsInteractionResult # The result of a multi-input interaction prompt.
   Canceled: boolean # A flag indicating whether the interaction was canceled by the user.
   Data?: Aspire.Hosting/Aspire.Hosting.InteractionInputCollection # The data returned from the interaction. The value is `null` when the interaction was canceled.
@@ -268,6 +270,10 @@ Aspire.Hosting/Aspire.Hosting.Ats.ResourceEventDto # DTO for resource events ret
   ResourceName: string # The resource name.
   State?: string # The current state text.
   StateStyle?: string # The state style (e.g., "success", "warn", "error").
+Aspire.Hosting/Aspire.Hosting.InputLoadOptions # Represents configuration options for dynamically loading input data.
+  AlwaysLoadOnStart?: boolean # Gets a value indicating whether `LoadCallback` should always be executed at the start of the input prompt.
+  DependsOnInputs?: string[] # Gets the list of input names that this input depends on. `LoadCallback` is executed whenever any of the specified inputs change.
+  LoadCallback: callback # Gets the callback function that is invoked to perform a load operation using the specified input context.
 Aspire.Hosting/Aspire.Hosting.InteractionInput # Represents an input for an interaction.
   AllowCustomChoice?: boolean # Gets a value indicating whether a custom choice is allowed. Only used by `Choice` inputs.
   Description?: string # Gets or sets the description for the input.
@@ -415,6 +421,7 @@ Aspire.Hosting.ApplicationModel/ExecuteCommandContext.arguments(context: Aspire.
 Aspire.Hosting.ApplicationModel/ExecuteCommandContext.cancellationToken(context: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext) -> cancellationToken
 Aspire.Hosting.ApplicationModel/ExecuteCommandContext.logger(context: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext) -> Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILogger
 Aspire.Hosting.ApplicationModel/ExecuteCommandContext.resourceName(context: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext) -> string
+Aspire.Hosting.ApplicationModel/ExecuteCommandContext.serviceProvider(context: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext) -> System.ComponentModel/System.IServiceProvider
 Aspire.Hosting.ApplicationModel/getEndpoint(context: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceUrlsCallbackContext, name: string) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointReference
 Aspire.Hosting.ApplicationModel/getValueAsync(context: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression, cancellationToken: cancellationToken) -> string
 Aspire.Hosting.ApplicationModel/IAspireStore.basePath(context: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IAspireStore) -> string
@@ -602,6 +609,10 @@ Aspire.Hosting/List.length() -> number
 Aspire.Hosting/List.removeAt(index: number) -> boolean
 Aspire.Hosting/List.set(index: number, value: any) -> void
 Aspire.Hosting/List.toArray() -> any[]
+Aspire.Hosting/LoadInputContext.allInputs(context: Aspire.Hosting/Aspire.Hosting.LoadInputContext) -> Aspire.Hosting/Aspire.Hosting.InteractionInputCollection
+Aspire.Hosting/LoadInputContext.cancellationToken(context: Aspire.Hosting/Aspire.Hosting.LoadInputContext) -> cancellationToken
+Aspire.Hosting/LoadInputContext.input(context: Aspire.Hosting/Aspire.Hosting.LoadInputContext) -> Aspire.Hosting/Aspire.Hosting.InteractionInput
+Aspire.Hosting/LoadInputContext.setOptions(context: Aspire.Hosting/Aspire.Hosting.LoadInputContext, options: Aspire.Hosting/Dict<string,string>) -> void
 Aspire.Hosting/log(level: string, message: string) -> void
 Aspire.Hosting/logDebug(message: string) -> void
 Aspire.Hosting/logError(message: string) -> void

--- a/src/Aspire.Hosting/api/Aspire.Hosting.ats.txt
+++ b/src/Aspire.Hosting/api/Aspire.Hosting.ats.txt
@@ -67,6 +67,7 @@ Aspire.Hosting/Aspire.Hosting.Eventing.IDistributedApplicationEventing [interfac
 Aspire.Hosting/Aspire.Hosting.Eventing.IDistributedApplicationResourceEvent [interface]
 Aspire.Hosting/Aspire.Hosting.ExternalServiceResource
 Aspire.Hosting/Aspire.Hosting.IDistributedApplicationBuilder [interface]
+Aspire.Hosting/Aspire.Hosting.IInteractionService [interface]
 Aspire.Hosting/Aspire.Hosting.InputsDialogValidationContext [ExposeProperties]
 Aspire.Hosting/Aspire.Hosting.InteractionInputCollection
 Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles [interface]
@@ -182,6 +183,9 @@ Aspire.Hosting/Aspire.Hosting.ApplicationModel.UpdateCommandStateResourceSnapsho
 Aspire.Hosting/Aspire.Hosting.Ats.AddContainerOptions # Options for configuring a container image in polyglot apphosts.
   Image: string # The container image name.
   Tag?: string # The container image tag.
+Aspire.Hosting/Aspire.Hosting.Ats.BooleanInteractionResult # The result of a boolean interaction prompt.
+  Canceled: boolean # A flag indicating whether the interaction was canceled by the user.
+  Data?: boolean # The data returned from the interaction. The value is `null` when the interaction was canceled.
 Aspire.Hosting/Aspire.Hosting.Ats.CertificateTrustExecutionConfigurationExportData # ATS-friendly certificate trust data returned from an execution-configuration result.
   CertificateSubjects: string[] # The certificate subjects included in the trust configuration.
   CustomBundlePaths: string[] # The relative custom bundle paths.
@@ -207,6 +211,40 @@ Aspire.Hosting/Aspire.Hosting.Ats.HttpsCertificateInfo # ATS-friendly certificat
   Issuer: string # The certificate issuer.
   Subject: string # The certificate subject.
   Thumbprint?: string # The certificate thumbprint.
+Aspire.Hosting/Aspire.Hosting.Ats.InputInteractionResult # The result of a single input interaction prompt.
+  Canceled: boolean # A flag indicating whether the interaction was canceled by the user.
+  Data?: Aspire.Hosting/Aspire.Hosting.InteractionInput # The data returned from the interaction. The value is `null` when the interaction was canceled.
+Aspire.Hosting/Aspire.Hosting.Ats.InputsDialogInteractionOptions # Polyglot options for inputs dialog interactions.
+  EnableMessageMarkdown?: boolean # Gets a value indicating whether Markdown in the message is rendered.
+  PrimaryButtonText?: string # Optional primary button text to override the default text.
+  SecondaryButtonText?: string # Optional secondary button text to override the default text.
+  ShowDismiss?: boolean # Gets a value indicating whether to show the dismiss button.
+  ShowSecondaryButton?: boolean # Gets a value indicating whether to show the secondary button.
+Aspire.Hosting/Aspire.Hosting.Ats.InputsInteractionResult # The result of a multi-input interaction prompt.
+  Canceled: boolean # A flag indicating whether the interaction was canceled by the user.
+  Data?: Aspire.Hosting/Aspire.Hosting.InteractionInputCollection # The data returned from the interaction. The value is `null` when the interaction was canceled.
+Aspire.Hosting/Aspire.Hosting.Ats.InteractionOptions # Shared polyglot options for interaction prompts.
+  EnableMessageMarkdown?: boolean # Gets a value indicating whether Markdown in the message is rendered.
+  PrimaryButtonText?: string # Optional primary button text to override the default text.
+  SecondaryButtonText?: string # Optional secondary button text to override the default text.
+  ShowDismiss?: boolean # Gets a value indicating whether to show the dismiss button.
+  ShowSecondaryButton?: boolean # Gets a value indicating whether to show the secondary button.
+Aspire.Hosting/Aspire.Hosting.Ats.MessageBoxInteractionOptions # Polyglot options for message box interactions.
+  EnableMessageMarkdown?: boolean # Gets a value indicating whether Markdown in the message is rendered.
+  Intent?: enum:Aspire.Hosting.MessageIntent # Gets the intent of the message box.
+  PrimaryButtonText?: string # Optional primary button text to override the default text.
+  SecondaryButtonText?: string # Optional secondary button text to override the default text.
+  ShowDismiss?: boolean # Gets a value indicating whether to show the dismiss button.
+  ShowSecondaryButton?: boolean # Gets a value indicating whether to show the secondary button.
+Aspire.Hosting/Aspire.Hosting.Ats.NotificationInteractionOptions # Polyglot options for notification interactions.
+  EnableMessageMarkdown?: boolean # Gets a value indicating whether Markdown in the message is rendered.
+  Intent?: enum:Aspire.Hosting.MessageIntent # Gets the intent of the notification.
+  LinkText?: string # Gets the text for a link in the notification.
+  LinkUrl?: string # Gets the URL for the link in the notification.
+  PrimaryButtonText?: string # Optional primary button text to override the default text.
+  SecondaryButtonText?: string # Optional secondary button text to override the default text.
+  ShowDismiss?: boolean # Gets a value indicating whether to show the dismiss button.
+  ShowSecondaryButton?: boolean # Gets a value indicating whether to show the secondary button.
 Aspire.Hosting/Aspire.Hosting.Ats.ParameterCustomInputOptions # Options for customizing parameter inputs from polyglot app hosts.
   AllowCustomChoice?: boolean # Gets or sets whether custom choices are allowed.
   Description: string # Gets or sets the description for the input.
@@ -261,6 +299,7 @@ enum:Aspire.Hosting.ApplicationModel.UrlDisplayLocation = SummaryAndDetails | De
 enum:Aspire.Hosting.ApplicationModel.WaitBehavior = WaitOnResourceUnavailable | StopOnResourceUnavailable
 enum:Aspire.Hosting.DistributedApplicationOperation = Run | Publish
 enum:Aspire.Hosting.InputType = Text | SecretText | Choice | Boolean | Number
+enum:Aspire.Hosting.MessageIntent = None | Success | Warning | Error | Information | Confirmation
 enum:Aspire.Hosting.OtlpProtocol = Grpc | HttpProtobuf | HttpJson
 enum:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus = Unhealthy | Degraded | Healthy
 enum:System.Net.Sockets.ProtocolType = IP | IPv6HopByHopOptions | Unspecified | Icmp | Igmp | Ggp | IPv4 | Tcp | Pup | Udp | Idp | IPv6 | IPv6RoutingHeader | IPv6FragmentHeader | IPSecEncapsulatingSecurityPayload | IPSecAuthenticationHeader | IcmpV6 | IPv6NoNextHeader | IPv6DestinationOptions | ND | Raw | Ipx | Spx | SpxII | Unknown
@@ -525,6 +564,7 @@ Aspire.Hosting/getEndpoint(name: string) -> Aspire.Hosting/Aspire.Hosting.Applic
 Aspire.Hosting/getEventing() -> Aspire.Hosting/Aspire.Hosting.Eventing.IDistributedApplicationEventing
 Aspire.Hosting/getFileNameWithContent(filenameTemplate: string, sourceFilename: string) -> string
 Aspire.Hosting/getHttpsCertificateData() -> Aspire.Hosting/Aspire.Hosting.Ats.HttpsCertificateExecutionConfigurationExportData
+Aspire.Hosting/getInteractionService() -> Aspire.Hosting/Aspire.Hosting.IInteractionService
 Aspire.Hosting/getLoggerFactory() -> Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILoggerFactory
 Aspire.Hosting/getOrSetSecret(resourceBuilder: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource, name: string, value: string) -> void
 Aspire.Hosting/getResourceCommandService() -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceCommandService
@@ -544,6 +584,7 @@ Aspire.Hosting/InputsDialogValidationContext.addValidationError(context: Aspire.
 Aspire.Hosting/InputsDialogValidationContext.cancellationToken(context: Aspire.Hosting/Aspire.Hosting.InputsDialogValidationContext) -> cancellationToken
 Aspire.Hosting/InputsDialogValidationContext.inputs(context: Aspire.Hosting/Aspire.Hosting.InputsDialogValidationContext) -> Aspire.Hosting/Aspire.Hosting.InteractionInputCollection
 Aspire.Hosting/InteractionInputCollection.toArray(context: Aspire.Hosting/Aspire.Hosting.InteractionInputCollection) -> Aspire.Hosting/Aspire.Hosting.InteractionInput[]
+Aspire.Hosting/interactionServiceIsAvailable() -> boolean
 Aspire.Hosting/isDevelopment() -> boolean
 Aspire.Hosting/isEnvironment(environmentName: string) -> boolean
 Aspire.Hosting/isProduction() -> boolean
@@ -580,6 +621,12 @@ Aspire.Hosting/ProjectResourceOptions.launchProfileName(context: Aspire.Hosting/
 Aspire.Hosting/ProjectResourceOptions.setExcludeKestrelEndpoints(context: Aspire.Hosting/Aspire.Hosting.ProjectResourceOptions, value: boolean) -> Aspire.Hosting/Aspire.Hosting.ProjectResourceOptions
 Aspire.Hosting/ProjectResourceOptions.setExcludeLaunchProfile(context: Aspire.Hosting/Aspire.Hosting.ProjectResourceOptions, value: boolean) -> Aspire.Hosting/Aspire.Hosting.ProjectResourceOptions
 Aspire.Hosting/ProjectResourceOptions.setLaunchProfileName(context: Aspire.Hosting/Aspire.Hosting.ProjectResourceOptions, value: string) -> Aspire.Hosting/Aspire.Hosting.ProjectResourceOptions
+Aspire.Hosting/promptConfirmationAsync(title: string, message: string, options?: Aspire.Hosting/Aspire.Hosting.Ats.MessageBoxInteractionOptions, cancellationToken?: cancellationToken) -> Aspire.Hosting/Aspire.Hosting.Ats.BooleanInteractionResult
+Aspire.Hosting/promptInputAsync(title: string, message: string, inputLabel: string, placeHolder: string, options?: Aspire.Hosting/Aspire.Hosting.Ats.InputsDialogInteractionOptions, cancellationToken?: cancellationToken) -> Aspire.Hosting/Aspire.Hosting.Ats.InputInteractionResult
+Aspire.Hosting/promptInputsAsync(title: string, message: string, inputs: Aspire.Hosting/Aspire.Hosting.InteractionInput[], options?: Aspire.Hosting/Aspire.Hosting.Ats.InputsDialogInteractionOptions, cancellationToken?: cancellationToken) -> Aspire.Hosting/Aspire.Hosting.Ats.InputsInteractionResult
+Aspire.Hosting/promptInputWithInput(title: string, message: string, input: Aspire.Hosting/Aspire.Hosting.InteractionInput, options?: Aspire.Hosting/Aspire.Hosting.Ats.InputsDialogInteractionOptions, cancellationToken?: cancellationToken) -> Aspire.Hosting/Aspire.Hosting.Ats.InputInteractionResult
+Aspire.Hosting/promptMessageBoxAsync(title: string, message: string, options?: Aspire.Hosting/Aspire.Hosting.Ats.MessageBoxInteractionOptions, cancellationToken?: cancellationToken) -> Aspire.Hosting/Aspire.Hosting.Ats.BooleanInteractionResult
+Aspire.Hosting/promptNotificationAsync(title: string, message: string, options?: Aspire.Hosting/Aspire.Hosting.Ats.NotificationInteractionOptions, cancellationToken?: cancellationToken) -> Aspire.Hosting/Aspire.Hosting.Ats.BooleanInteractionResult
 Aspire.Hosting/publishAsConnectionString() -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource
 Aspire.Hosting/publishAsContainer() -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource
 Aspire.Hosting/publishAsDockerFile(configure: callback) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecutableResource

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -246,6 +246,22 @@ const (
 // DTOs
 // ============================================================================
 
+// InputLoadOptions represents InputLoadOptions.
+type InputLoadOptions struct {
+	LoadCallback func(...any) any `json:"LoadCallback,omitempty"`
+	AlwaysLoadOnStart *bool `json:"AlwaysLoadOnStart,omitempty"`
+	DependsOnInputs []string `json:"DependsOnInputs,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *InputLoadOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if d.LoadCallback != nil { m["LoadCallback"] = serializeValue(d.LoadCallback) }
+	if d.AlwaysLoadOnStart != nil { m["AlwaysLoadOnStart"] = serializeValue(d.AlwaysLoadOnStart) }
+	if d.DependsOnInputs != nil { m["DependsOnInputs"] = serializeValue(d.DependsOnInputs) }
+	return m
+}
+
 // InteractionInput represents InteractionInput.
 type InteractionInput struct {
 	Name string `json:"Name,omitempty"`
@@ -255,7 +271,7 @@ type InteractionInput struct {
 	InputType InputType `json:"InputType,omitempty"`
 	Required *bool `json:"Required,omitempty"`
 	Options []any `json:"Options,omitempty"`
-	DynamicLoading any `json:"DynamicLoading,omitempty"`
+	DynamicLoading *InputLoadOptions `json:"DynamicLoading,omitempty"`
 	Value string `json:"Value,omitempty"`
 	Placeholder *string `json:"Placeholder,omitempty"`
 	AllowCustomChoice *bool `json:"AllowCustomChoice,omitempty"`
@@ -422,6 +438,7 @@ func (d *MessageBoxInteractionOptions) ToMap() map[string]any {
 
 // InputsDialogInteractionOptions represents InputsDialogInteractionOptions.
 type InputsDialogInteractionOptions struct {
+	ValidationCallback func(...any) any `json:"ValidationCallback,omitempty"`
 	PrimaryButtonText *string `json:"PrimaryButtonText,omitempty"`
 	SecondaryButtonText *string `json:"SecondaryButtonText,omitempty"`
 	ShowSecondaryButton *bool `json:"ShowSecondaryButton,omitempty"`
@@ -432,6 +449,7 @@ type InputsDialogInteractionOptions struct {
 // ToMap converts the DTO to a map for JSON serialization.
 func (d *InputsDialogInteractionOptions) ToMap() map[string]any {
 	m := map[string]any{}
+	if d.ValidationCallback != nil { m["ValidationCallback"] = serializeValue(d.ValidationCallback) }
 	if d.PrimaryButtonText != nil { m["PrimaryButtonText"] = serializeValue(d.PrimaryButtonText) }
 	if d.SecondaryButtonText != nil { m["SecondaryButtonText"] = serializeValue(d.SecondaryButtonText) }
 	if d.ShowSecondaryButton != nil { m["ShowSecondaryButton"] = serializeValue(d.ShowSecondaryButton) }
@@ -14308,6 +14326,7 @@ type ExecuteCommandContext interface {
 	CancellationToken() (*CancellationToken, error)
 	Logger() Logger
 	ResourceName() (string, error)
+	ServiceProvider() ServiceProvider
 	Err() error
 }
 
@@ -14387,6 +14406,25 @@ func (s *executeCommandContext) ResourceName() (string, error) {
 		return zero, err
 	}
 	return decodeAs[string](result)
+}
+
+// ServiceProvider the service provider.
+func (s *executeCommandContext) ServiceProvider() ServiceProvider {
+	if s.err != nil { return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ExecuteCommandContext.serviceProvider", reqArgs)
+	if err != nil {
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/ExecuteCommandContext.serviceProvider returned unexpected type %T", result)
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
 }
 
 // ExecutionConfigurationBuilder is the public interface for handle type ExecutionConfigurationBuilder.
@@ -16124,6 +16162,87 @@ func (s *interactionService) PromptNotificationAsync(title string, message strin
 		return zero, err
 	}
 	return decodeAs[*BooleanInteractionResult](result)
+}
+
+// LoadInputContext is the public interface for handle type LoadInputContext.
+type LoadInputContext interface {
+	handleReference
+	AllInputs() InteractionInputCollection
+	CancellationToken() (*CancellationToken, error)
+	Input() (*InteractionInput, error)
+	SetOptions(options map[string]string) error
+	Err() error
+}
+
+// loadInputContext is the unexported impl of LoadInputContext.
+type loadInputContext struct {
+	*resourceBuilderBase
+}
+
+// newLoadInputContextFromHandle wraps an existing handle as LoadInputContext.
+func newLoadInputContextFromHandle(h *handle, c *client) LoadInputContext {
+	return &loadInputContext{resourceBuilderBase: newResourceBuilderBase(h, c)}
+}
+
+// AllInputs gets the collection of all `InteractionInput` in this prompt.
+func (s *loadInputContext) AllInputs() InteractionInputCollection {
+	if s.err != nil { return &interactionInputCollection{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/LoadInputContext.allInputs", reqArgs)
+	if err != nil {
+		return &interactionInputCollection{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting/LoadInputContext.allInputs returned unexpected type %T", result)
+		return &interactionInputCollection{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &interactionInputCollection{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// CancellationToken gets the `CancellationToken`.
+func (s *loadInputContext) CancellationToken() (*CancellationToken, error) {
+	if s.err != nil { var zero *CancellationToken; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/LoadInputContext.cancellationToken", reqArgs)
+	if err != nil {
+		var zero *CancellationToken
+		return zero, err
+	}
+	return decodeAs[*CancellationToken](result)
+}
+
+// Input gets the loading input. This is the target of `InputLoadOptions`.
+func (s *loadInputContext) Input() (*InteractionInput, error) {
+	if s.err != nil { var zero *InteractionInput; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/LoadInputContext.input", reqArgs)
+	if err != nil {
+		var zero *InteractionInput
+		return zero, err
+	}
+	return decodeAs[*InteractionInput](result)
+}
+
+// SetOptions sets the available options for the loading input.
+func (s *loadInputContext) SetOptions(options map[string]string) error {
+	if s.err != nil { return s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	if options != nil { reqArgs["options"] = serializeValue(options) }
+	_, err := s.client.invokeCapability(ctx, "Aspire.Hosting/LoadInputContext.setOptions", reqArgs)
+	return err
 }
 
 // LogFacade is the public interface for handle type LogFacade.
@@ -26845,6 +26964,9 @@ func registerWrappers(c *client) {
 	})
 	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.IInteractionService", func(h *handle, c *client) any {
 		return newInteractionServiceFromHandle(h, c)
+	})
+	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.LoadInputContext", func(h *handle, c *client) any {
+		return newLoadInputContextFromHandle(h, c)
 	})
 	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.LogFacade", func(h *handle, c *client) any {
 		return newLogFacadeFromHandle(h, c)

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -157,6 +157,18 @@ const (
 	InputTypeNumber InputType = "Number"
 )
 
+// MessageIntent represents MessageIntent.
+type MessageIntent string
+
+const (
+	MessageIntentNone MessageIntent = "None"
+	MessageIntentSuccess MessageIntent = "Success"
+	MessageIntentWarning MessageIntent = "Warning"
+	MessageIntentError MessageIntent = "Error"
+	MessageIntentInformation MessageIntent = "Information"
+	MessageIntentConfirmation MessageIntent = "Confirmation"
+)
+
 // ResourceCommandVisibility represents ResourceCommandVisibility.
 type ResourceCommandVisibility string
 
@@ -363,6 +375,136 @@ func (d *HttpsCertificateExecutionConfigurationExportData) ToMap() map[string]an
 	m["IsKeyPathReferenced"] = serializeValue(d.IsKeyPathReferenced)
 	m["IsPfxPathReferenced"] = serializeValue(d.IsPfxPathReferenced)
 	if d.Password != nil { m["Password"] = serializeValue(d.Password) }
+	return m
+}
+
+// InteractionOptions represents InteractionOptions.
+type InteractionOptions struct {
+	PrimaryButtonText *string `json:"PrimaryButtonText,omitempty"`
+	SecondaryButtonText *string `json:"SecondaryButtonText,omitempty"`
+	ShowSecondaryButton *bool `json:"ShowSecondaryButton,omitempty"`
+	ShowDismiss *bool `json:"ShowDismiss,omitempty"`
+	EnableMessageMarkdown *bool `json:"EnableMessageMarkdown,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *InteractionOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if d.PrimaryButtonText != nil { m["PrimaryButtonText"] = serializeValue(d.PrimaryButtonText) }
+	if d.SecondaryButtonText != nil { m["SecondaryButtonText"] = serializeValue(d.SecondaryButtonText) }
+	if d.ShowSecondaryButton != nil { m["ShowSecondaryButton"] = serializeValue(d.ShowSecondaryButton) }
+	if d.ShowDismiss != nil { m["ShowDismiss"] = serializeValue(d.ShowDismiss) }
+	if d.EnableMessageMarkdown != nil { m["EnableMessageMarkdown"] = serializeValue(d.EnableMessageMarkdown) }
+	return m
+}
+
+// MessageBoxInteractionOptions represents MessageBoxInteractionOptions.
+type MessageBoxInteractionOptions struct {
+	Intent *MessageIntent `json:"Intent,omitempty"`
+	PrimaryButtonText *string `json:"PrimaryButtonText,omitempty"`
+	SecondaryButtonText *string `json:"SecondaryButtonText,omitempty"`
+	ShowSecondaryButton *bool `json:"ShowSecondaryButton,omitempty"`
+	ShowDismiss *bool `json:"ShowDismiss,omitempty"`
+	EnableMessageMarkdown *bool `json:"EnableMessageMarkdown,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *MessageBoxInteractionOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if d.Intent != nil { m["Intent"] = serializeValue(d.Intent) }
+	if d.PrimaryButtonText != nil { m["PrimaryButtonText"] = serializeValue(d.PrimaryButtonText) }
+	if d.SecondaryButtonText != nil { m["SecondaryButtonText"] = serializeValue(d.SecondaryButtonText) }
+	if d.ShowSecondaryButton != nil { m["ShowSecondaryButton"] = serializeValue(d.ShowSecondaryButton) }
+	if d.ShowDismiss != nil { m["ShowDismiss"] = serializeValue(d.ShowDismiss) }
+	if d.EnableMessageMarkdown != nil { m["EnableMessageMarkdown"] = serializeValue(d.EnableMessageMarkdown) }
+	return m
+}
+
+// InputsDialogInteractionOptions represents InputsDialogInteractionOptions.
+type InputsDialogInteractionOptions struct {
+	PrimaryButtonText *string `json:"PrimaryButtonText,omitempty"`
+	SecondaryButtonText *string `json:"SecondaryButtonText,omitempty"`
+	ShowSecondaryButton *bool `json:"ShowSecondaryButton,omitempty"`
+	ShowDismiss *bool `json:"ShowDismiss,omitempty"`
+	EnableMessageMarkdown *bool `json:"EnableMessageMarkdown,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *InputsDialogInteractionOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if d.PrimaryButtonText != nil { m["PrimaryButtonText"] = serializeValue(d.PrimaryButtonText) }
+	if d.SecondaryButtonText != nil { m["SecondaryButtonText"] = serializeValue(d.SecondaryButtonText) }
+	if d.ShowSecondaryButton != nil { m["ShowSecondaryButton"] = serializeValue(d.ShowSecondaryButton) }
+	if d.ShowDismiss != nil { m["ShowDismiss"] = serializeValue(d.ShowDismiss) }
+	if d.EnableMessageMarkdown != nil { m["EnableMessageMarkdown"] = serializeValue(d.EnableMessageMarkdown) }
+	return m
+}
+
+// NotificationInteractionOptions represents NotificationInteractionOptions.
+type NotificationInteractionOptions struct {
+	Intent *MessageIntent `json:"Intent,omitempty"`
+	LinkText *string `json:"LinkText,omitempty"`
+	LinkUrl *string `json:"LinkUrl,omitempty"`
+	PrimaryButtonText *string `json:"PrimaryButtonText,omitempty"`
+	SecondaryButtonText *string `json:"SecondaryButtonText,omitempty"`
+	ShowSecondaryButton *bool `json:"ShowSecondaryButton,omitempty"`
+	ShowDismiss *bool `json:"ShowDismiss,omitempty"`
+	EnableMessageMarkdown *bool `json:"EnableMessageMarkdown,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *NotificationInteractionOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if d.Intent != nil { m["Intent"] = serializeValue(d.Intent) }
+	if d.LinkText != nil { m["LinkText"] = serializeValue(d.LinkText) }
+	if d.LinkUrl != nil { m["LinkUrl"] = serializeValue(d.LinkUrl) }
+	if d.PrimaryButtonText != nil { m["PrimaryButtonText"] = serializeValue(d.PrimaryButtonText) }
+	if d.SecondaryButtonText != nil { m["SecondaryButtonText"] = serializeValue(d.SecondaryButtonText) }
+	if d.ShowSecondaryButton != nil { m["ShowSecondaryButton"] = serializeValue(d.ShowSecondaryButton) }
+	if d.ShowDismiss != nil { m["ShowDismiss"] = serializeValue(d.ShowDismiss) }
+	if d.EnableMessageMarkdown != nil { m["EnableMessageMarkdown"] = serializeValue(d.EnableMessageMarkdown) }
+	return m
+}
+
+// BooleanInteractionResult represents BooleanInteractionResult.
+type BooleanInteractionResult struct {
+	Data *bool `json:"Data,omitempty"`
+	Canceled bool `json:"Canceled,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *BooleanInteractionResult) ToMap() map[string]any {
+	m := map[string]any{}
+	if d.Data != nil { m["Data"] = serializeValue(d.Data) }
+	m["Canceled"] = serializeValue(d.Canceled)
+	return m
+}
+
+// InputInteractionResult represents InputInteractionResult.
+type InputInteractionResult struct {
+	Data *InteractionInput `json:"Data,omitempty"`
+	Canceled bool `json:"Canceled,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *InputInteractionResult) ToMap() map[string]any {
+	m := map[string]any{}
+	if d.Data != nil { m["Data"] = serializeValue(d.Data) }
+	m["Canceled"] = serializeValue(d.Canceled)
+	return m
+}
+
+// InputsInteractionResult represents InputsInteractionResult.
+type InputsInteractionResult struct {
+	Data *InteractionInputCollection `json:"Data,omitempty"`
+	Canceled bool `json:"Canceled,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *InputsInteractionResult) ToMap() map[string]any {
+	m := map[string]any{}
+	if d.Data != nil { m["Data"] = serializeValue(d.Data) }
+	m["Canceled"] = serializeValue(d.Canceled)
 	return m
 }
 
@@ -15762,6 +15904,228 @@ func (s *interactionInputCollection) ToArray() ([]*InteractionInput, error) {
 	return decodeAs[[]*InteractionInput](result)
 }
 
+// InteractionService is the public interface for handle type InteractionService.
+type InteractionService interface {
+	handleReference
+	IsAvailable() (bool, error)
+	PromptConfirmationAsync(title string, message string, options ...*PromptConfirmationAsyncOptions) (*BooleanInteractionResult, error)
+	PromptInputAsync(title string, message string, inputLabel string, placeHolder string, options ...*PromptInputAsyncOptions) (*InputInteractionResult, error)
+	PromptInputWithInputAsync(title string, message string, input *InteractionInput, options ...*PromptInputWithInputAsyncOptions) (*InputInteractionResult, error)
+	PromptInputsAsync(title string, message string, inputs []*InteractionInput, options ...*PromptInputsAsyncOptions) (*InputsInteractionResult, error)
+	PromptMessageBoxAsync(title string, message string, options ...*PromptMessageBoxAsyncOptions) (*BooleanInteractionResult, error)
+	PromptNotificationAsync(title string, message string, options ...*PromptNotificationAsyncOptions) (*BooleanInteractionResult, error)
+	Err() error
+}
+
+// interactionService is the unexported impl of InteractionService.
+type interactionService struct {
+	*resourceBuilderBase
+}
+
+// newInteractionServiceFromHandle wraps an existing handle as InteractionService.
+func newInteractionServiceFromHandle(h *handle, c *client) InteractionService {
+	return &interactionService{resourceBuilderBase: newResourceBuilderBase(h, c)}
+}
+
+// IsAvailable gets a value indicating whether the interaction service is available.
+func (s *interactionService) IsAvailable() (bool, error) {
+	if s.err != nil { var zero bool; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"interactionService": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/interactionServiceIsAvailable", reqArgs)
+	if err != nil {
+		var zero bool
+		return zero, err
+	}
+	return decodeAs[bool](result)
+}
+
+// PromptConfirmationAsync prompts the user for confirmation with a dialog.
+func (s *interactionService) PromptConfirmationAsync(title string, message string, options ...*PromptConfirmationAsyncOptions) (*BooleanInteractionResult, error) {
+	if s.err != nil { var zero *BooleanInteractionResult; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"interactionService": s.handle.ToJSON(),
+	}
+	reqArgs["title"] = serializeValue(title)
+	reqArgs["message"] = serializeValue(message)
+	if len(options) > 0 {
+		merged := &PromptConfirmationAsyncOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+		if merged.CancellationToken != nil {
+			ctx = merged.CancellationToken.Context()
+			if id := s.client.registerCancellation(merged.CancellationToken); id != "" {
+				reqArgs["cancellationToken"] = id
+			}
+		}
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/promptConfirmationAsync", reqArgs)
+	if err != nil {
+		var zero *BooleanInteractionResult
+		return zero, err
+	}
+	return decodeAs[*BooleanInteractionResult](result)
+}
+
+// PromptInputAsync prompts the user for a single text input.
+func (s *interactionService) PromptInputAsync(title string, message string, inputLabel string, placeHolder string, options ...*PromptInputAsyncOptions) (*InputInteractionResult, error) {
+	if s.err != nil { var zero *InputInteractionResult; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"interactionService": s.handle.ToJSON(),
+	}
+	reqArgs["title"] = serializeValue(title)
+	reqArgs["message"] = serializeValue(message)
+	reqArgs["inputLabel"] = serializeValue(inputLabel)
+	reqArgs["placeHolder"] = serializeValue(placeHolder)
+	if len(options) > 0 {
+		merged := &PromptInputAsyncOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+		if merged.CancellationToken != nil {
+			ctx = merged.CancellationToken.Context()
+			if id := s.client.registerCancellation(merged.CancellationToken); id != "" {
+				reqArgs["cancellationToken"] = id
+			}
+		}
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/promptInputAsync", reqArgs)
+	if err != nil {
+		var zero *InputInteractionResult
+		return zero, err
+	}
+	return decodeAs[*InputInteractionResult](result)
+}
+
+// PromptInputWithInputAsync prompts the user for a single input using a specified `InteractionInput`.
+func (s *interactionService) PromptInputWithInputAsync(title string, message string, input *InteractionInput, options ...*PromptInputWithInputAsyncOptions) (*InputInteractionResult, error) {
+	if s.err != nil { var zero *InputInteractionResult; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"interactionService": s.handle.ToJSON(),
+	}
+	reqArgs["title"] = serializeValue(title)
+	reqArgs["message"] = serializeValue(message)
+	if input != nil { reqArgs["input"] = serializeValue(input) }
+	if len(options) > 0 {
+		merged := &PromptInputWithInputAsyncOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+		if merged.CancellationToken != nil {
+			ctx = merged.CancellationToken.Context()
+			if id := s.client.registerCancellation(merged.CancellationToken); id != "" {
+				reqArgs["cancellationToken"] = id
+			}
+		}
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/promptInputWithInput", reqArgs)
+	if err != nil {
+		var zero *InputInteractionResult
+		return zero, err
+	}
+	return decodeAs[*InputInteractionResult](result)
+}
+
+// PromptInputsAsync prompts the user for multiple inputs.
+func (s *interactionService) PromptInputsAsync(title string, message string, inputs []*InteractionInput, options ...*PromptInputsAsyncOptions) (*InputsInteractionResult, error) {
+	if s.err != nil { var zero *InputsInteractionResult; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"interactionService": s.handle.ToJSON(),
+	}
+	reqArgs["title"] = serializeValue(title)
+	reqArgs["message"] = serializeValue(message)
+	if inputs != nil { reqArgs["inputs"] = serializeValue(inputs) }
+	if len(options) > 0 {
+		merged := &PromptInputsAsyncOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+		if merged.CancellationToken != nil {
+			ctx = merged.CancellationToken.Context()
+			if id := s.client.registerCancellation(merged.CancellationToken); id != "" {
+				reqArgs["cancellationToken"] = id
+			}
+		}
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/promptInputsAsync", reqArgs)
+	if err != nil {
+		var zero *InputsInteractionResult
+		return zero, err
+	}
+	return decodeAs[*InputsInteractionResult](result)
+}
+
+// PromptMessageBoxAsync prompts the user with a message box dialog.
+func (s *interactionService) PromptMessageBoxAsync(title string, message string, options ...*PromptMessageBoxAsyncOptions) (*BooleanInteractionResult, error) {
+	if s.err != nil { var zero *BooleanInteractionResult; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"interactionService": s.handle.ToJSON(),
+	}
+	reqArgs["title"] = serializeValue(title)
+	reqArgs["message"] = serializeValue(message)
+	if len(options) > 0 {
+		merged := &PromptMessageBoxAsyncOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+		if merged.CancellationToken != nil {
+			ctx = merged.CancellationToken.Context()
+			if id := s.client.registerCancellation(merged.CancellationToken); id != "" {
+				reqArgs["cancellationToken"] = id
+			}
+		}
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/promptMessageBoxAsync", reqArgs)
+	if err != nil {
+		var zero *BooleanInteractionResult
+		return zero, err
+	}
+	return decodeAs[*BooleanInteractionResult](result)
+}
+
+// PromptNotificationAsync prompts the user with a notification.
+func (s *interactionService) PromptNotificationAsync(title string, message string, options ...*PromptNotificationAsyncOptions) (*BooleanInteractionResult, error) {
+	if s.err != nil { var zero *BooleanInteractionResult; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"interactionService": s.handle.ToJSON(),
+	}
+	reqArgs["title"] = serializeValue(title)
+	reqArgs["message"] = serializeValue(message)
+	if len(options) > 0 {
+		merged := &PromptNotificationAsyncOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+		if merged.CancellationToken != nil {
+			ctx = merged.CancellationToken.Context()
+			if id := s.client.registerCancellation(merged.CancellationToken); id != "" {
+				reqArgs["cancellationToken"] = id
+			}
+		}
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/promptNotificationAsync", reqArgs)
+	if err != nil {
+		var zero *BooleanInteractionResult
+		return zero, err
+	}
+	return decodeAs[*BooleanInteractionResult](result)
+}
+
 // LogFacade is the public interface for handle type LogFacade.
 type LogFacade interface {
 	handleReference
@@ -20329,6 +20693,7 @@ type ServiceProvider interface {
 	GetAspireStore() AspireStore
 	GetDistributedApplicationModel() DistributedApplicationModel
 	GetEventing() DistributedApplicationEventing
+	GetInteractionService() InteractionService
 	GetLoggerFactory() LoggerFactory
 	GetResourceCommandService() ResourceCommandService
 	GetResourceLoggerService() ResourceLoggerService
@@ -20402,6 +20767,25 @@ func (s *serviceProvider) GetEventing() DistributedApplicationEventing {
 		return &distributedApplicationEventing{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
 	}
 	return &distributedApplicationEventing{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// GetInteractionService gets the interaction service from the service provider.
+func (s *serviceProvider) GetInteractionService() InteractionService {
+	if s.err != nil { return &interactionService{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"serviceProvider": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/getInteractionService", reqArgs)
+	if err != nil {
+		return &interactionService{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting/getInteractionService returned unexpected type %T", result)
+		return &interactionService{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &interactionService{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
 }
 
 // GetLoggerFactory gets the logger factory from the service provider.
@@ -25874,6 +26258,84 @@ func (o *BuildOptions) ToMap() map[string]any {
 	return m
 }
 
+// PromptConfirmationAsyncOptions carries optional parameters for PromptConfirmationAsync.
+type PromptConfirmationAsyncOptions struct {
+	Options *MessageBoxInteractionOptions `json:"options,omitempty"`
+	CancellationToken *CancellationToken `json:"-"`
+}
+
+func (o *PromptConfirmationAsyncOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if o == nil { return m }
+	if o.Options != nil { m["options"] = serializeValue(o.Options) }
+	return m
+}
+
+// PromptMessageBoxAsyncOptions carries optional parameters for PromptMessageBoxAsync.
+type PromptMessageBoxAsyncOptions struct {
+	Options *MessageBoxInteractionOptions `json:"options,omitempty"`
+	CancellationToken *CancellationToken `json:"-"`
+}
+
+func (o *PromptMessageBoxAsyncOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if o == nil { return m }
+	if o.Options != nil { m["options"] = serializeValue(o.Options) }
+	return m
+}
+
+// PromptInputAsyncOptions carries optional parameters for PromptInputAsync.
+type PromptInputAsyncOptions struct {
+	Options *InputsDialogInteractionOptions `json:"options,omitempty"`
+	CancellationToken *CancellationToken `json:"-"`
+}
+
+func (o *PromptInputAsyncOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if o == nil { return m }
+	if o.Options != nil { m["options"] = serializeValue(o.Options) }
+	return m
+}
+
+// PromptInputWithInputAsyncOptions carries optional parameters for PromptInputWithInputAsync.
+type PromptInputWithInputAsyncOptions struct {
+	Options *InputsDialogInteractionOptions `json:"options,omitempty"`
+	CancellationToken *CancellationToken `json:"-"`
+}
+
+func (o *PromptInputWithInputAsyncOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if o == nil { return m }
+	if o.Options != nil { m["options"] = serializeValue(o.Options) }
+	return m
+}
+
+// PromptInputsAsyncOptions carries optional parameters for PromptInputsAsync.
+type PromptInputsAsyncOptions struct {
+	Options *InputsDialogInteractionOptions `json:"options,omitempty"`
+	CancellationToken *CancellationToken `json:"-"`
+}
+
+func (o *PromptInputsAsyncOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if o == nil { return m }
+	if o.Options != nil { m["options"] = serializeValue(o.Options) }
+	return m
+}
+
+// PromptNotificationAsyncOptions carries optional parameters for PromptNotificationAsync.
+type PromptNotificationAsyncOptions struct {
+	Options *NotificationInteractionOptions `json:"options,omitempty"`
+	CancellationToken *CancellationToken `json:"-"`
+}
+
+func (o *PromptNotificationAsyncOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if o == nil { return m }
+	if o.Options != nil { m["options"] = serializeValue(o.Options) }
+	return m
+}
+
 // WaitForResourceStateOptions carries optional parameters for WaitForResourceState.
 type WaitForResourceStateOptions struct {
 	TargetState *string `json:"targetState,omitempty"`
@@ -26380,6 +26842,9 @@ func registerWrappers(c *client) {
 	})
 	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.InteractionInputCollection", func(h *handle, c *client) any {
 		return newInteractionInputCollectionFromHandle(h, c)
+	})
+	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.IInteractionService", func(h *handle, c *client) any {
+		return newInteractionServiceFromHandle(h, c)
 	})
 	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.LogFacade", func(h *handle, c *client) any {
 		return newLogFacadeFromHandle(h, c)

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AtsGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AtsGeneratedAspire.verified.java
@@ -1791,9 +1791,9 @@ public class TestDatabaseResource extends ResourceBuilderBase {
     }
 
     /** Adds an optional string parameter */
-    public TestDatabaseResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public TestDatabaseResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -2002,8 +2002,8 @@ public class TestDatabaseResource extends ResourceBuilderBase {
     }
 
     /** Adds a data volume */
-    public TestDatabaseResource withDataVolume(WithDataVolumeOptions options) {
-        var name = options == null ? null : options.getName();
+    public TestDatabaseResource withDataVolume(WithDataVolumeOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
         return withDataVolumeImpl(name);
     }
 
@@ -2063,9 +2063,9 @@ public class TestDatabaseResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging */
-    public TestDatabaseResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public TestDatabaseResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -2089,9 +2089,9 @@ public class TestDatabaseResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging with file path */
-    public TestDatabaseResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public TestDatabaseResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -2421,9 +2421,9 @@ public class TestRedisResource extends ResourceBuilderBase {
     }
 
     /** Adds an optional string parameter */
-    public TestRedisResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public TestRedisResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -2733,9 +2733,9 @@ public class TestRedisResource extends ResourceBuilderBase {
     }
 
     /** Adds a data volume with persistence */
-    public TestRedisResource withDataVolume(WithDataVolumeOptions options) {
-        var name = options == null ? null : options.getName();
-        var isReadOnly = options == null ? null : options.isReadOnly();
+    public TestRedisResource withDataVolume(WithDataVolumeOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var isReadOnly = optionsBag == null ? null : optionsBag.isReadOnly();
         return withDataVolumeImpl(name, isReadOnly);
     }
 
@@ -2798,9 +2798,9 @@ public class TestRedisResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging */
-    public TestRedisResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public TestRedisResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -2824,9 +2824,9 @@ public class TestRedisResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging with file path */
-    public TestRedisResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public TestRedisResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -2997,9 +2997,9 @@ public class TestVaultResource extends ResourceBuilderBase {
     }
 
     /** Adds an optional string parameter */
-    public TestVaultResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public TestVaultResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -3257,9 +3257,9 @@ public class TestVaultResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging */
-    public TestVaultResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public TestVaultResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -3283,9 +3283,9 @@ public class TestVaultResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging with file path */
-    public TestVaultResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public TestVaultResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1,4 +1,4 @@
-// ===== AddContainerOptions.java =====
+﻿// ===== AddContainerOptions.java =====
 // AddContainerOptions.java - GENERATED CODE - DO NOT EDIT
 
 package aspire;
@@ -1354,6 +1354,7 @@ public class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.Eventing.DistributedApplicationEventSubscription", (h, c) -> new DistributedApplicationEventSubscription(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.DistributedApplicationExecutionContext", (h, c) -> new DistributedApplicationExecutionContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.DistributedApplicationExecutionContextOptions", (h, c) -> new DistributedApplicationExecutionContextOptions(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.LoadInputContext", (h, c) -> new LoadInputContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.InteractionInputCollection", (h, c) -> new InteractionInputCollection(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.InputsDialogValidationContext", (h, c) -> new InputsDialogValidationContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ProjectResourceOptions", (h, c) -> new ProjectResourceOptions(h, c));
@@ -11166,6 +11167,14 @@ public class ExecuteCommandContext extends HandleWrapperBase {
         super(handle, client);
     }
 
+    /** The service provider. */
+    public IServiceProvider serviceProvider() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ExecuteCommandContext.serviceProvider", reqArgs);
+        return (IServiceProvider) result;
+    }
+
     /** The resource name. */
     public String resourceName() {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -14536,6 +14545,48 @@ public class InputInteractionResult implements JsonSerializable {
     }
 }
 
+// ===== InputLoadOptions.java =====
+// InputLoadOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** InputLoadOptions DTO. */
+public class InputLoadOptions implements JsonSerializable {
+    private Object loadCallback;
+    private Boolean alwaysLoadOnStart;
+    private String[] dependsOnInputs;
+
+    public Object getLoadCallback() { return loadCallback; }
+    public void setLoadCallback(Object value) { this.loadCallback = value; }
+    public Boolean getAlwaysLoadOnStart() { return alwaysLoadOnStart; }
+    public void setAlwaysLoadOnStart(Boolean value) { this.alwaysLoadOnStart = value; }
+    public String[] getDependsOnInputs() { return dependsOnInputs; }
+    public void setDependsOnInputs(String[] value) { this.dependsOnInputs = value; }
+
+    @SuppressWarnings("unchecked")
+    public static InputLoadOptions fromMap(Map<String, Object> map) {
+        var value = new InputLoadOptions();
+        var loadCallbackValue = map.get("LoadCallback");
+        value.setLoadCallback(loadCallbackValue);
+        var alwaysLoadOnStartValue = map.get("AlwaysLoadOnStart");
+        value.setAlwaysLoadOnStart(alwaysLoadOnStartValue == null ? null : (Boolean) alwaysLoadOnStartValue);
+        var dependsOnInputsValue = map.get("DependsOnInputs");
+        value.setDependsOnInputs((String[]) dependsOnInputsValue);
+        return value;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("LoadCallback", AspireClient.serializeValue(loadCallback));
+        map.put("AlwaysLoadOnStart", AspireClient.serializeValue(alwaysLoadOnStart));
+        map.put("DependsOnInputs", AspireClient.serializeValue(dependsOnInputs));
+        return map;
+    }
+}
+
 // ===== InputType.java =====
 // InputType.java - GENERATED CODE - DO NOT EDIT
 
@@ -14578,12 +14629,15 @@ import java.util.function.*;
 
 /** InputsDialogInteractionOptions DTO. */
 public class InputsDialogInteractionOptions implements JsonSerializable {
+    private Object validationCallback;
     private String primaryButtonText;
     private String secondaryButtonText;
     private Boolean showSecondaryButton;
     private Boolean showDismiss;
     private Boolean enableMessageMarkdown;
 
+    public Object getValidationCallback() { return validationCallback; }
+    public void setValidationCallback(Object value) { this.validationCallback = value; }
     public String getPrimaryButtonText() { return primaryButtonText; }
     public void setPrimaryButtonText(String value) { this.primaryButtonText = value; }
     public String getSecondaryButtonText() { return secondaryButtonText; }
@@ -14598,6 +14652,8 @@ public class InputsDialogInteractionOptions implements JsonSerializable {
     @SuppressWarnings("unchecked")
     public static InputsDialogInteractionOptions fromMap(Map<String, Object> map) {
         var value = new InputsDialogInteractionOptions();
+        var validationCallbackValue = map.get("ValidationCallback");
+        value.setValidationCallback(validationCallbackValue);
         var primaryButtonTextValue = map.get("PrimaryButtonText");
         value.setPrimaryButtonText(primaryButtonTextValue == null ? null : (String) primaryButtonTextValue);
         var secondaryButtonTextValue = map.get("SecondaryButtonText");
@@ -14613,6 +14669,7 @@ public class InputsDialogInteractionOptions implements JsonSerializable {
 
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
+        map.put("ValidationCallback", AspireClient.serializeValue(validationCallback));
         map.put("PrimaryButtonText", AspireClient.serializeValue(primaryButtonText));
         map.put("SecondaryButtonText", AspireClient.serializeValue(secondaryButtonText));
         map.put("ShowSecondaryButton", AspireClient.serializeValue(showSecondaryButton));
@@ -14716,7 +14773,7 @@ public class InteractionInput implements JsonSerializable {
     private InputType inputType;
     private Boolean required;
     private Object[] options;
-    private Object dynamicLoading;
+    private InputLoadOptions dynamicLoading;
     private String value;
     private String placeholder;
     private Boolean allowCustomChoice;
@@ -14737,8 +14794,8 @@ public class InteractionInput implements JsonSerializable {
     public void setRequired(Boolean value) { this.required = value; }
     public Object[] getOptions() { return options; }
     public void setOptions(Object[] value) { this.options = value; }
-    public Object getDynamicLoading() { return dynamicLoading; }
-    public void setDynamicLoading(Object value) { this.dynamicLoading = value; }
+    public InputLoadOptions getDynamicLoading() { return dynamicLoading; }
+    public void setDynamicLoading(InputLoadOptions value) { this.dynamicLoading = value; }
     public String getValue() { return value; }
     public void setValue(String value) { this.value = value; }
     public String getPlaceholder() { return placeholder; }
@@ -14768,7 +14825,7 @@ public class InteractionInput implements JsonSerializable {
         var optionsValue = map.get("Options");
         value.setOptions((Object[]) optionsValue);
         var dynamicLoadingValue = map.get("DynamicLoading");
-        value.setDynamicLoading(dynamicLoadingValue);
+        value.setDynamicLoading(dynamicLoadingValue == null ? null : InputLoadOptions.fromMap((Map<String, Object>) dynamicLoadingValue));
         var valueValue = map.get("Value");
         value.setValue(valueValue == null ? null : (String) valueValue);
         var placeholderValue = map.get("Placeholder");
@@ -14894,6 +14951,54 @@ import java.util.function.*;
 
 public interface JsonSerializable {
     Map<String, Object> toMap();
+}
+
+// ===== LoadInputContext.java =====
+// LoadInputContext.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.LoadInputContext. */
+public class LoadInputContext extends HandleWrapperBase {
+    LoadInputContext(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Gets the loading input. This is the target of `InputLoadOptions`. */
+    public InteractionInput input() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting/LoadInputContext.input", reqArgs);
+        return InteractionInput.fromMap((Map<String, Object>) result);
+    }
+
+    /** Gets the collection of all `InteractionInput` in this prompt. */
+    public InteractionInputCollection allInputs() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting/LoadInputContext.allInputs", reqArgs);
+        return (InteractionInputCollection) result;
+    }
+
+    /** Gets the `CancellationToken`. */
+    public CancellationToken cancellationToken() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting/LoadInputContext.cancellationToken", reqArgs);
+        return (CancellationToken) result;
+    }
+
+    /** Sets the available options for the loading input. */
+    public void setOptions(Map<String, String> options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("options", AspireClient.serializeValue(options));
+        getClient().invokeCapability("Aspire.Hosting/LoadInputContext.setOptions", reqArgs);
+    }
+
 }
 
 // ===== LogFacade.java =====
@@ -26558,6 +26663,7 @@ public final class WithVolumeOptions {
 .aspire/modules/ImagePullPolicy.java
 .aspire/modules/InitializeResourceEvent.java
 .aspire/modules/InputInteractionResult.java
+.aspire/modules/InputLoadOptions.java
 .aspire/modules/InputType.java
 .aspire/modules/InputsDialogInteractionOptions.java
 .aspire/modules/InputsDialogValidationContext.java
@@ -26566,6 +26672,7 @@ public final class WithVolumeOptions {
 .aspire/modules/InteractionInputCollection.java
 .aspire/modules/InteractionOptions.java
 .aspire/modules/JsonSerializable.java
+.aspire/modules/LoadInputContext.java
 .aspire/modules/LogFacade.java
 .aspire/modules/MessageBoxInteractionOptions.java
 .aspire/modules/MessageIntent.java

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1,4 +1,4 @@
-﻿// ===== AddContainerOptions.java =====
+// ===== AddContainerOptions.java =====
 // AddContainerOptions.java - GENERATED CODE - DO NOT EDIT
 
 package aspire;
@@ -1340,6 +1340,7 @@ public class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference", (h, c) -> new ContainerImageReference(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerPortReference", (h, c) -> new ContainerPortReference(h, c));
         AspireClient.registerHandleWrapper("System.ComponentModel/System.IServiceProvider", (h, c) -> new IServiceProvider(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.IInteractionService", (h, c) -> new IInteractionService(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceNotificationService", (h, c) -> new ResourceNotificationService(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceLoggerService", (h, c) -> new ResourceLoggerService(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceCommandService", (h, c) -> new ResourceCommandService(h, c));
@@ -1595,6 +1596,42 @@ public class BeforeStartEvent extends HandleWrapperBase {
 
 }
 
+// ===== BooleanInteractionResult.java =====
+// BooleanInteractionResult.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** BooleanInteractionResult DTO. */
+public class BooleanInteractionResult implements JsonSerializable {
+    private Boolean data;
+    private boolean canceled;
+
+    public Boolean getData() { return data; }
+    public void setData(Boolean value) { this.data = value; }
+    public boolean getCanceled() { return canceled; }
+    public void setCanceled(boolean value) { this.canceled = value; }
+
+    @SuppressWarnings("unchecked")
+    public static BooleanInteractionResult fromMap(Map<String, Object> map) {
+        var value = new BooleanInteractionResult();
+        var dataValue = map.get("Data");
+        value.setData(dataValue == null ? null : (Boolean) dataValue);
+        var canceledValue = map.get("Canceled");
+        value.setCanceled((Boolean) canceledValue);
+        return value;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("Data", AspireClient.serializeValue(data));
+        map.put("Canceled", AspireClient.serializeValue(canceled));
+        return map;
+    }
+}
+
 // ===== BuildOptions.java =====
 // BuildOptions.java - GENERATED CODE - DO NOT EDIT
 
@@ -1650,9 +1687,9 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Configures custom base images for generated Dockerfiles. */
-    public CSharpAppResource withDockerfileBaseImage(WithDockerfileBaseImageOptions options) {
-        var buildImage = options == null ? null : options.getBuildImage();
-        var runtimeImage = options == null ? null : options.getRuntimeImage();
+    public CSharpAppResource withDockerfileBaseImage(WithDockerfileBaseImageOptions optionsBag) {
+        var buildImage = optionsBag == null ? null : optionsBag.getBuildImage();
+        var runtimeImage = optionsBag == null ? null : optionsBag.getRuntimeImage();
         return withDockerfileBaseImageImpl(buildImage, runtimeImage);
     }
 
@@ -1675,9 +1712,9 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Marks the resource as hosting a Model Context Protocol (MCP) server on the specified endpoint. */
-    public CSharpAppResource withMcpServer(WithMcpServerOptions options) {
-        var path = options == null ? null : options.getPath();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public CSharpAppResource withMcpServer(WithMcpServerOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withMcpServerImpl(path, endpointName);
     }
 
@@ -1930,10 +1967,10 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Adds a reference to another resource */
-    public CSharpAppResource withReference(AspireUnion source, WithReferenceOptions options) {
-        var connectionName = options == null ? null : options.getConnectionName();
-        var optional = options == null ? null : options.getOptional();
-        var name = options == null ? null : options.getName();
+    public CSharpAppResource withReference(AspireUnion source, WithReferenceOptions optionsBag) {
+        var connectionName = optionsBag == null ? null : optionsBag.getConnectionName();
+        var optional = optionsBag == null ? null : optionsBag.getOptional();
+        var name = optionsBag == null ? null : optionsBag.getName();
         return withReferenceImpl(source, connectionName, optional, name);
     }
 
@@ -1984,9 +2021,9 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Updates an HTTP endpoint via callback */
-    public CSharpAppResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public CSharpAppResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -2017,9 +2054,9 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Updates an HTTPS endpoint via callback */
-    public CSharpAppResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public CSharpAppResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpsEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -2050,15 +2087,15 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Adds a network endpoint */
-    public CSharpAppResource withEndpoint(WithEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var scheme = options == null ? null : options.getScheme();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
-        var isExternal = options == null ? null : options.isExternal();
-        var protocol = options == null ? null : options.getProtocol();
+    public CSharpAppResource withEndpoint(WithEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var scheme = optionsBag == null ? null : optionsBag.getScheme();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
+        var isExternal = optionsBag == null ? null : optionsBag.isExternal();
+        var protocol = optionsBag == null ? null : optionsBag.getProtocol();
         return withEndpointImpl(port, targetPort, scheme, name, env, isProxied, isExternal, protocol);
     }
 
@@ -2108,12 +2145,12 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Adds an HTTP endpoint */
-    public CSharpAppResource withHttpEndpoint(WithHttpEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public CSharpAppResource withHttpEndpoint(WithHttpEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -2145,12 +2182,12 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Adds an HTTPS endpoint */
-    public CSharpAppResource withHttpsEndpoint(WithHttpsEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public CSharpAppResource withHttpsEndpoint(WithHttpsEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpsEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -2375,10 +2412,10 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Adds a health check to the resource which is mapped to a specific endpoint. */
-    public CSharpAppResource withHttpHealthCheck(WithHttpHealthCheckOptions options) {
-        var path = options == null ? null : options.getPath();
-        var statusCode = options == null ? null : options.getStatusCode();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public CSharpAppResource withHttpHealthCheck(WithHttpHealthCheckOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var statusCode = optionsBag == null ? null : optionsBag.getStatusCode();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpHealthCheckImpl(path, statusCode, endpointName);
     }
 
@@ -2590,14 +2627,14 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Adds an HTTP health probe to the resource */
-    public CSharpAppResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions options) {
-        var path = options == null ? null : options.getPath();
-        var initialDelaySeconds = options == null ? null : options.getInitialDelaySeconds();
-        var periodSeconds = options == null ? null : options.getPeriodSeconds();
-        var timeoutSeconds = options == null ? null : options.getTimeoutSeconds();
-        var failureThreshold = options == null ? null : options.getFailureThreshold();
-        var successThreshold = options == null ? null : options.getSuccessThreshold();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public CSharpAppResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var initialDelaySeconds = optionsBag == null ? null : optionsBag.getInitialDelaySeconds();
+        var periodSeconds = optionsBag == null ? null : optionsBag.getPeriodSeconds();
+        var timeoutSeconds = optionsBag == null ? null : optionsBag.getTimeoutSeconds();
+        var failureThreshold = optionsBag == null ? null : optionsBag.getFailureThreshold();
+        var successThreshold = optionsBag == null ? null : optionsBag.getSuccessThreshold();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpProbeImpl(probeType, path, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold, successThreshold, endpointName);
     }
 
@@ -2652,9 +2689,9 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Hides the resource from default resource lists after successful completion */
-    public CSharpAppResource withHiddenOnCompletion(WithHiddenOnCompletionOptions options) {
-        var exitCode = options == null ? null : options.getExitCode();
-        var exitCodes = options == null ? null : options.getExitCodes();
+    public CSharpAppResource withHiddenOnCompletion(WithHiddenOnCompletionOptions optionsBag) {
+        var exitCode = optionsBag == null ? null : optionsBag.getExitCode();
+        var exitCodes = optionsBag == null ? null : optionsBag.getExitCodes();
         return withHiddenOnCompletionImpl(exitCode, exitCodes);
     }
 
@@ -2711,11 +2748,11 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Adds a pipeline step to the resource that will be executed during deployment. */
-    public CSharpAppResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions options) {
-        var dependsOn = options == null ? null : options.getDependsOn();
-        var requiredBy = options == null ? null : options.getRequiredBy();
-        var tags = options == null ? null : options.getTags();
-        var description = options == null ? null : options.getDescription();
+    public CSharpAppResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions optionsBag) {
+        var dependsOn = optionsBag == null ? null : optionsBag.getDependsOn();
+        var requiredBy = optionsBag == null ? null : optionsBag.getRequiredBy();
+        var tags = optionsBag == null ? null : optionsBag.getTags();
+        var description = optionsBag == null ? null : optionsBag.getDescription();
         return withPipelineStepFactoryImpl(stepName, callback, dependsOn, requiredBy, tags, description);
     }
 
@@ -2865,9 +2902,9 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Adds an optional string parameter */
-    public CSharpAppResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public CSharpAppResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -3116,9 +3153,9 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Configures resource logging */
-    public CSharpAppResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public CSharpAppResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -3142,9 +3179,9 @@ public class CSharpAppResource extends ProjectResource {
     }
 
     /** Configures resource logging with file path */
-    public CSharpAppResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public CSharpAppResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -4078,9 +4115,9 @@ public class ContainerRegistryResource extends ResourceBuilderBase {
     }
 
     /** Configures custom base images for generated Dockerfiles. */
-    public ContainerRegistryResource withDockerfileBaseImage(WithDockerfileBaseImageOptions options) {
-        var buildImage = options == null ? null : options.getBuildImage();
-        var runtimeImage = options == null ? null : options.getRuntimeImage();
+    public ContainerRegistryResource withDockerfileBaseImage(WithDockerfileBaseImageOptions optionsBag) {
+        var buildImage = optionsBag == null ? null : optionsBag.getBuildImage();
+        var runtimeImage = optionsBag == null ? null : optionsBag.getRuntimeImage();
         return withDockerfileBaseImageImpl(buildImage, runtimeImage);
     }
 
@@ -4370,9 +4407,9 @@ public class ContainerRegistryResource extends ResourceBuilderBase {
     }
 
     /** Hides the resource from default resource lists after successful completion */
-    public ContainerRegistryResource withHiddenOnCompletion(WithHiddenOnCompletionOptions options) {
-        var exitCode = options == null ? null : options.getExitCode();
-        var exitCodes = options == null ? null : options.getExitCodes();
+    public ContainerRegistryResource withHiddenOnCompletion(WithHiddenOnCompletionOptions optionsBag) {
+        var exitCode = optionsBag == null ? null : optionsBag.getExitCode();
+        var exitCodes = optionsBag == null ? null : optionsBag.getExitCodes();
         return withHiddenOnCompletionImpl(exitCode, exitCodes);
     }
 
@@ -4395,11 +4432,11 @@ public class ContainerRegistryResource extends ResourceBuilderBase {
     }
 
     /** Adds a pipeline step to the resource that will be executed during deployment. */
-    public ContainerRegistryResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions options) {
-        var dependsOn = options == null ? null : options.getDependsOn();
-        var requiredBy = options == null ? null : options.getRequiredBy();
-        var tags = options == null ? null : options.getTags();
-        var description = options == null ? null : options.getDescription();
+    public ContainerRegistryResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions optionsBag) {
+        var dependsOn = optionsBag == null ? null : optionsBag.getDependsOn();
+        var requiredBy = optionsBag == null ? null : optionsBag.getRequiredBy();
+        var tags = optionsBag == null ? null : optionsBag.getTags();
+        var description = optionsBag == null ? null : optionsBag.getDescription();
         return withPipelineStepFactoryImpl(stepName, callback, dependsOn, requiredBy, tags, description);
     }
 
@@ -4533,9 +4570,9 @@ public class ContainerRegistryResource extends ResourceBuilderBase {
     }
 
     /** Adds an optional string parameter */
-    public ContainerRegistryResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public ContainerRegistryResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -4759,9 +4796,9 @@ public class ContainerRegistryResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging */
-    public ContainerRegistryResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public ContainerRegistryResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -4785,9 +4822,9 @@ public class ContainerRegistryResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging with file path */
-    public ContainerRegistryResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public ContainerRegistryResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -4970,9 +5007,9 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Causes Aspire to build the specified container image from a Dockerfile. */
-    public ContainerResource withDockerfile(String contextPath, WithDockerfileOptions options) {
-        var dockerfilePath = options == null ? null : options.getDockerfilePath();
-        var stage = options == null ? null : options.getStage();
+    public ContainerResource withDockerfile(String contextPath, WithDockerfileOptions optionsBag) {
+        var dockerfilePath = optionsBag == null ? null : optionsBag.getDockerfilePath();
+        var stage = optionsBag == null ? null : optionsBag.getStage();
         return withDockerfileImpl(contextPath, dockerfilePath, stage);
     }
 
@@ -5056,10 +5093,10 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Adds container certificate path overrides used for certificate trust at run time. */
-    public ContainerResource withContainerCertificatePaths(WithContainerCertificatePathsOptions options) {
-        var customCertificatesDestination = options == null ? null : options.getCustomCertificatesDestination();
-        var defaultCertificateBundlePaths = options == null ? null : options.getDefaultCertificateBundlePaths();
-        var defaultCertificateDirectoryPaths = options == null ? null : options.getDefaultCertificateDirectoryPaths();
+    public ContainerResource withContainerCertificatePaths(WithContainerCertificatePathsOptions optionsBag) {
+        var customCertificatesDestination = optionsBag == null ? null : optionsBag.getCustomCertificatesDestination();
+        var defaultCertificateBundlePaths = optionsBag == null ? null : optionsBag.getDefaultCertificateBundlePaths();
+        var defaultCertificateDirectoryPaths = optionsBag == null ? null : optionsBag.getDefaultCertificateDirectoryPaths();
         return withContainerCertificatePathsImpl(customCertificatesDestination, defaultCertificateBundlePaths, defaultCertificateDirectoryPaths);
     }
 
@@ -5109,9 +5146,9 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Configures custom base images for generated Dockerfiles. */
-    public ContainerResource withDockerfileBaseImage(WithDockerfileBaseImageOptions options) {
-        var buildImage = options == null ? null : options.getBuildImage();
-        var runtimeImage = options == null ? null : options.getRuntimeImage();
+    public ContainerResource withDockerfileBaseImage(WithDockerfileBaseImageOptions optionsBag) {
+        var buildImage = optionsBag == null ? null : optionsBag.getBuildImage();
+        var runtimeImage = optionsBag == null ? null : optionsBag.getRuntimeImage();
         return withDockerfileBaseImageImpl(buildImage, runtimeImage);
     }
 
@@ -5143,9 +5180,9 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Marks the resource as hosting a Model Context Protocol (MCP) server on the specified endpoint. */
-    public ContainerResource withMcpServer(WithMcpServerOptions options) {
-        var path = options == null ? null : options.getPath();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public ContainerResource withMcpServer(WithMcpServerOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withMcpServerImpl(path, endpointName);
     }
 
@@ -5369,10 +5406,10 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Adds a reference to another resource */
-    public ContainerResource withReference(AspireUnion source, WithReferenceOptions options) {
-        var connectionName = options == null ? null : options.getConnectionName();
-        var optional = options == null ? null : options.getOptional();
-        var name = options == null ? null : options.getName();
+    public ContainerResource withReference(AspireUnion source, WithReferenceOptions optionsBag) {
+        var connectionName = optionsBag == null ? null : optionsBag.getConnectionName();
+        var optional = optionsBag == null ? null : optionsBag.getOptional();
+        var name = optionsBag == null ? null : optionsBag.getName();
         return withReferenceImpl(source, connectionName, optional, name);
     }
 
@@ -5423,9 +5460,9 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Updates an HTTP endpoint via callback */
-    public ContainerResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public ContainerResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -5456,9 +5493,9 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Updates an HTTPS endpoint via callback */
-    public ContainerResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public ContainerResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpsEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -5489,15 +5526,15 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Adds a network endpoint */
-    public ContainerResource withEndpoint(WithEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var scheme = options == null ? null : options.getScheme();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
-        var isExternal = options == null ? null : options.isExternal();
-        var protocol = options == null ? null : options.getProtocol();
+    public ContainerResource withEndpoint(WithEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var scheme = optionsBag == null ? null : optionsBag.getScheme();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
+        var isExternal = optionsBag == null ? null : optionsBag.isExternal();
+        var protocol = optionsBag == null ? null : optionsBag.getProtocol();
         return withEndpointImpl(port, targetPort, scheme, name, env, isProxied, isExternal, protocol);
     }
 
@@ -5547,12 +5584,12 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Adds an HTTP endpoint */
-    public ContainerResource withHttpEndpoint(WithHttpEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public ContainerResource withHttpEndpoint(WithHttpEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -5584,12 +5621,12 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Adds an HTTPS endpoint */
-    public ContainerResource withHttpsEndpoint(WithHttpsEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public ContainerResource withHttpsEndpoint(WithHttpsEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpsEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -5800,10 +5837,10 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Adds a health check to the resource which is mapped to a specific endpoint. */
-    public ContainerResource withHttpHealthCheck(WithHttpHealthCheckOptions options) {
-        var path = options == null ? null : options.getPath();
-        var statusCode = options == null ? null : options.getStatusCode();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public ContainerResource withHttpHealthCheck(WithHttpHealthCheckOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var statusCode = optionsBag == null ? null : optionsBag.getStatusCode();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpHealthCheckImpl(path, statusCode, endpointName);
     }
 
@@ -6015,14 +6052,14 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Adds an HTTP health probe to the resource */
-    public ContainerResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions options) {
-        var path = options == null ? null : options.getPath();
-        var initialDelaySeconds = options == null ? null : options.getInitialDelaySeconds();
-        var periodSeconds = options == null ? null : options.getPeriodSeconds();
-        var timeoutSeconds = options == null ? null : options.getTimeoutSeconds();
-        var failureThreshold = options == null ? null : options.getFailureThreshold();
-        var successThreshold = options == null ? null : options.getSuccessThreshold();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public ContainerResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var initialDelaySeconds = optionsBag == null ? null : optionsBag.getInitialDelaySeconds();
+        var periodSeconds = optionsBag == null ? null : optionsBag.getPeriodSeconds();
+        var timeoutSeconds = optionsBag == null ? null : optionsBag.getTimeoutSeconds();
+        var failureThreshold = optionsBag == null ? null : optionsBag.getFailureThreshold();
+        var successThreshold = optionsBag == null ? null : optionsBag.getSuccessThreshold();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpProbeImpl(probeType, path, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold, successThreshold, endpointName);
     }
 
@@ -6077,9 +6114,9 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Hides the resource from default resource lists after successful completion */
-    public ContainerResource withHiddenOnCompletion(WithHiddenOnCompletionOptions options) {
-        var exitCode = options == null ? null : options.getExitCode();
-        var exitCodes = options == null ? null : options.getExitCodes();
+    public ContainerResource withHiddenOnCompletion(WithHiddenOnCompletionOptions optionsBag) {
+        var exitCode = optionsBag == null ? null : optionsBag.getExitCode();
+        var exitCodes = optionsBag == null ? null : optionsBag.getExitCodes();
         return withHiddenOnCompletionImpl(exitCode, exitCodes);
     }
 
@@ -6136,11 +6173,11 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Adds a pipeline step to the resource that will be executed during deployment. */
-    public ContainerResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions options) {
-        var dependsOn = options == null ? null : options.getDependsOn();
-        var requiredBy = options == null ? null : options.getRequiredBy();
-        var tags = options == null ? null : options.getTags();
-        var description = options == null ? null : options.getDescription();
+    public ContainerResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions optionsBag) {
+        var dependsOn = optionsBag == null ? null : optionsBag.getDependsOn();
+        var requiredBy = optionsBag == null ? null : optionsBag.getRequiredBy();
+        var tags = optionsBag == null ? null : optionsBag.getTags();
+        var description = optionsBag == null ? null : optionsBag.getDescription();
         return withPipelineStepFactoryImpl(stepName, callback, dependsOn, requiredBy, tags, description);
     }
 
@@ -6194,9 +6231,9 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Adds a volume to a container resource. */
-    public ContainerResource withVolume(String target, WithVolumeOptions options) {
-        var name = options == null ? null : options.getName();
-        var isReadOnly = options == null ? null : options.isReadOnly();
+    public ContainerResource withVolume(String target, WithVolumeOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var isReadOnly = optionsBag == null ? null : optionsBag.isReadOnly();
         return withVolumeImpl(target, name, isReadOnly);
     }
 
@@ -6316,9 +6353,9 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Adds an optional string parameter */
-    public ContainerResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public ContainerResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -6567,9 +6604,9 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging */
-    public ContainerResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public ContainerResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -6593,9 +6630,9 @@ public class ContainerResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging with file path */
-    public ContainerResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public ContainerResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -7313,9 +7350,9 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Configures custom base images for generated Dockerfiles. */
-    public DotnetToolResource withDockerfileBaseImage(WithDockerfileBaseImageOptions options) {
-        var buildImage = options == null ? null : options.getBuildImage();
-        var runtimeImage = options == null ? null : options.getRuntimeImage();
+    public DotnetToolResource withDockerfileBaseImage(WithDockerfileBaseImageOptions optionsBag) {
+        var buildImage = optionsBag == null ? null : optionsBag.getBuildImage();
+        var runtimeImage = optionsBag == null ? null : optionsBag.getRuntimeImage();
         return withDockerfileBaseImageImpl(buildImage, runtimeImage);
     }
 
@@ -7423,9 +7460,9 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Marks the resource as hosting a Model Context Protocol (MCP) server on the specified endpoint. */
-    public DotnetToolResource withMcpServer(WithMcpServerOptions options) {
-        var path = options == null ? null : options.getPath();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public DotnetToolResource withMcpServer(WithMcpServerOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withMcpServerImpl(path, endpointName);
     }
 
@@ -7641,10 +7678,10 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Adds a reference to another resource */
-    public DotnetToolResource withReference(AspireUnion source, WithReferenceOptions options) {
-        var connectionName = options == null ? null : options.getConnectionName();
-        var optional = options == null ? null : options.getOptional();
-        var name = options == null ? null : options.getName();
+    public DotnetToolResource withReference(AspireUnion source, WithReferenceOptions optionsBag) {
+        var connectionName = optionsBag == null ? null : optionsBag.getConnectionName();
+        var optional = optionsBag == null ? null : optionsBag.getOptional();
+        var name = optionsBag == null ? null : optionsBag.getName();
         return withReferenceImpl(source, connectionName, optional, name);
     }
 
@@ -7695,9 +7732,9 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Updates an HTTP endpoint via callback */
-    public DotnetToolResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public DotnetToolResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -7728,9 +7765,9 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Updates an HTTPS endpoint via callback */
-    public DotnetToolResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public DotnetToolResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpsEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -7761,15 +7798,15 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Adds a network endpoint */
-    public DotnetToolResource withEndpoint(WithEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var scheme = options == null ? null : options.getScheme();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
-        var isExternal = options == null ? null : options.isExternal();
-        var protocol = options == null ? null : options.getProtocol();
+    public DotnetToolResource withEndpoint(WithEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var scheme = optionsBag == null ? null : optionsBag.getScheme();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
+        var isExternal = optionsBag == null ? null : optionsBag.isExternal();
+        var protocol = optionsBag == null ? null : optionsBag.getProtocol();
         return withEndpointImpl(port, targetPort, scheme, name, env, isProxied, isExternal, protocol);
     }
 
@@ -7819,12 +7856,12 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Adds an HTTP endpoint */
-    public DotnetToolResource withHttpEndpoint(WithHttpEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public DotnetToolResource withHttpEndpoint(WithHttpEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -7856,12 +7893,12 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Adds an HTTPS endpoint */
-    public DotnetToolResource withHttpsEndpoint(WithHttpsEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public DotnetToolResource withHttpsEndpoint(WithHttpsEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpsEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -8072,10 +8109,10 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Adds a health check to the resource which is mapped to a specific endpoint. */
-    public DotnetToolResource withHttpHealthCheck(WithHttpHealthCheckOptions options) {
-        var path = options == null ? null : options.getPath();
-        var statusCode = options == null ? null : options.getStatusCode();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public DotnetToolResource withHttpHealthCheck(WithHttpHealthCheckOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var statusCode = optionsBag == null ? null : optionsBag.getStatusCode();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpHealthCheckImpl(path, statusCode, endpointName);
     }
 
@@ -8287,14 +8324,14 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Adds an HTTP health probe to the resource */
-    public DotnetToolResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions options) {
-        var path = options == null ? null : options.getPath();
-        var initialDelaySeconds = options == null ? null : options.getInitialDelaySeconds();
-        var periodSeconds = options == null ? null : options.getPeriodSeconds();
-        var timeoutSeconds = options == null ? null : options.getTimeoutSeconds();
-        var failureThreshold = options == null ? null : options.getFailureThreshold();
-        var successThreshold = options == null ? null : options.getSuccessThreshold();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public DotnetToolResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var initialDelaySeconds = optionsBag == null ? null : optionsBag.getInitialDelaySeconds();
+        var periodSeconds = optionsBag == null ? null : optionsBag.getPeriodSeconds();
+        var timeoutSeconds = optionsBag == null ? null : optionsBag.getTimeoutSeconds();
+        var failureThreshold = optionsBag == null ? null : optionsBag.getFailureThreshold();
+        var successThreshold = optionsBag == null ? null : optionsBag.getSuccessThreshold();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpProbeImpl(probeType, path, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold, successThreshold, endpointName);
     }
 
@@ -8349,9 +8386,9 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Hides the resource from default resource lists after successful completion */
-    public DotnetToolResource withHiddenOnCompletion(WithHiddenOnCompletionOptions options) {
-        var exitCode = options == null ? null : options.getExitCode();
-        var exitCodes = options == null ? null : options.getExitCodes();
+    public DotnetToolResource withHiddenOnCompletion(WithHiddenOnCompletionOptions optionsBag) {
+        var exitCode = optionsBag == null ? null : optionsBag.getExitCode();
+        var exitCodes = optionsBag == null ? null : optionsBag.getExitCodes();
         return withHiddenOnCompletionImpl(exitCode, exitCodes);
     }
 
@@ -8408,11 +8445,11 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Adds a pipeline step to the resource that will be executed during deployment. */
-    public DotnetToolResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions options) {
-        var dependsOn = options == null ? null : options.getDependsOn();
-        var requiredBy = options == null ? null : options.getRequiredBy();
-        var tags = options == null ? null : options.getTags();
-        var description = options == null ? null : options.getDescription();
+    public DotnetToolResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions optionsBag) {
+        var dependsOn = optionsBag == null ? null : optionsBag.getDependsOn();
+        var requiredBy = optionsBag == null ? null : optionsBag.getRequiredBy();
+        var tags = optionsBag == null ? null : optionsBag.getTags();
+        var description = optionsBag == null ? null : optionsBag.getDescription();
         return withPipelineStepFactoryImpl(stepName, callback, dependsOn, requiredBy, tags, description);
     }
 
@@ -8562,9 +8599,9 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Adds an optional string parameter */
-    public DotnetToolResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public DotnetToolResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -8813,9 +8850,9 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Configures resource logging */
-    public DotnetToolResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public DotnetToolResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -8839,9 +8876,9 @@ public class DotnetToolResource extends ExecutableResource {
     }
 
     /** Configures resource logging with file path */
-    public DotnetToolResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public DotnetToolResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -9560,9 +9597,9 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Configures custom base images for generated Dockerfiles. */
-    public ExecutableResource withDockerfileBaseImage(WithDockerfileBaseImageOptions options) {
-        var buildImage = options == null ? null : options.getBuildImage();
-        var runtimeImage = options == null ? null : options.getRuntimeImage();
+    public ExecutableResource withDockerfileBaseImage(WithDockerfileBaseImageOptions optionsBag) {
+        var buildImage = optionsBag == null ? null : optionsBag.getBuildImage();
+        var runtimeImage = optionsBag == null ? null : optionsBag.getRuntimeImage();
         return withDockerfileBaseImageImpl(buildImage, runtimeImage);
     }
 
@@ -9619,9 +9656,9 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Marks the resource as hosting a Model Context Protocol (MCP) server on the specified endpoint. */
-    public ExecutableResource withMcpServer(WithMcpServerOptions options) {
-        var path = options == null ? null : options.getPath();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public ExecutableResource withMcpServer(WithMcpServerOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withMcpServerImpl(path, endpointName);
     }
 
@@ -9837,10 +9874,10 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Adds a reference to another resource */
-    public ExecutableResource withReference(AspireUnion source, WithReferenceOptions options) {
-        var connectionName = options == null ? null : options.getConnectionName();
-        var optional = options == null ? null : options.getOptional();
-        var name = options == null ? null : options.getName();
+    public ExecutableResource withReference(AspireUnion source, WithReferenceOptions optionsBag) {
+        var connectionName = optionsBag == null ? null : optionsBag.getConnectionName();
+        var optional = optionsBag == null ? null : optionsBag.getOptional();
+        var name = optionsBag == null ? null : optionsBag.getName();
         return withReferenceImpl(source, connectionName, optional, name);
     }
 
@@ -9891,9 +9928,9 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Updates an HTTP endpoint via callback */
-    public ExecutableResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public ExecutableResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -9924,9 +9961,9 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Updates an HTTPS endpoint via callback */
-    public ExecutableResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public ExecutableResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpsEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -9957,15 +9994,15 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Adds a network endpoint */
-    public ExecutableResource withEndpoint(WithEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var scheme = options == null ? null : options.getScheme();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
-        var isExternal = options == null ? null : options.isExternal();
-        var protocol = options == null ? null : options.getProtocol();
+    public ExecutableResource withEndpoint(WithEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var scheme = optionsBag == null ? null : optionsBag.getScheme();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
+        var isExternal = optionsBag == null ? null : optionsBag.isExternal();
+        var protocol = optionsBag == null ? null : optionsBag.getProtocol();
         return withEndpointImpl(port, targetPort, scheme, name, env, isProxied, isExternal, protocol);
     }
 
@@ -10015,12 +10052,12 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Adds an HTTP endpoint */
-    public ExecutableResource withHttpEndpoint(WithHttpEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public ExecutableResource withHttpEndpoint(WithHttpEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -10052,12 +10089,12 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Adds an HTTPS endpoint */
-    public ExecutableResource withHttpsEndpoint(WithHttpsEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public ExecutableResource withHttpsEndpoint(WithHttpsEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpsEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -10268,10 +10305,10 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Adds a health check to the resource which is mapped to a specific endpoint. */
-    public ExecutableResource withHttpHealthCheck(WithHttpHealthCheckOptions options) {
-        var path = options == null ? null : options.getPath();
-        var statusCode = options == null ? null : options.getStatusCode();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public ExecutableResource withHttpHealthCheck(WithHttpHealthCheckOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var statusCode = optionsBag == null ? null : optionsBag.getStatusCode();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpHealthCheckImpl(path, statusCode, endpointName);
     }
 
@@ -10483,14 +10520,14 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Adds an HTTP health probe to the resource */
-    public ExecutableResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions options) {
-        var path = options == null ? null : options.getPath();
-        var initialDelaySeconds = options == null ? null : options.getInitialDelaySeconds();
-        var periodSeconds = options == null ? null : options.getPeriodSeconds();
-        var timeoutSeconds = options == null ? null : options.getTimeoutSeconds();
-        var failureThreshold = options == null ? null : options.getFailureThreshold();
-        var successThreshold = options == null ? null : options.getSuccessThreshold();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public ExecutableResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var initialDelaySeconds = optionsBag == null ? null : optionsBag.getInitialDelaySeconds();
+        var periodSeconds = optionsBag == null ? null : optionsBag.getPeriodSeconds();
+        var timeoutSeconds = optionsBag == null ? null : optionsBag.getTimeoutSeconds();
+        var failureThreshold = optionsBag == null ? null : optionsBag.getFailureThreshold();
+        var successThreshold = optionsBag == null ? null : optionsBag.getSuccessThreshold();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpProbeImpl(probeType, path, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold, successThreshold, endpointName);
     }
 
@@ -10545,9 +10582,9 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Hides the resource from default resource lists after successful completion */
-    public ExecutableResource withHiddenOnCompletion(WithHiddenOnCompletionOptions options) {
-        var exitCode = options == null ? null : options.getExitCode();
-        var exitCodes = options == null ? null : options.getExitCodes();
+    public ExecutableResource withHiddenOnCompletion(WithHiddenOnCompletionOptions optionsBag) {
+        var exitCode = optionsBag == null ? null : optionsBag.getExitCode();
+        var exitCodes = optionsBag == null ? null : optionsBag.getExitCodes();
         return withHiddenOnCompletionImpl(exitCode, exitCodes);
     }
 
@@ -10604,11 +10641,11 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Adds a pipeline step to the resource that will be executed during deployment. */
-    public ExecutableResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions options) {
-        var dependsOn = options == null ? null : options.getDependsOn();
-        var requiredBy = options == null ? null : options.getRequiredBy();
-        var tags = options == null ? null : options.getTags();
-        var description = options == null ? null : options.getDescription();
+    public ExecutableResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions optionsBag) {
+        var dependsOn = optionsBag == null ? null : optionsBag.getDependsOn();
+        var requiredBy = optionsBag == null ? null : optionsBag.getRequiredBy();
+        var tags = optionsBag == null ? null : optionsBag.getTags();
+        var description = optionsBag == null ? null : optionsBag.getDescription();
         return withPipelineStepFactoryImpl(stepName, callback, dependsOn, requiredBy, tags, description);
     }
 
@@ -10758,9 +10795,9 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Adds an optional string parameter */
-    public ExecutableResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public ExecutableResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -11009,9 +11046,9 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging */
-    public ExecutableResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public ExecutableResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -11035,9 +11072,9 @@ public class ExecutableResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging with file path */
-    public ExecutableResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public ExecutableResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -11245,9 +11282,9 @@ public class ExternalServiceResource extends ResourceBuilderBase {
     }
 
     /** Configures custom base images for generated Dockerfiles. */
-    public ExternalServiceResource withDockerfileBaseImage(WithDockerfileBaseImageOptions options) {
-        var buildImage = options == null ? null : options.getBuildImage();
-        var runtimeImage = options == null ? null : options.getRuntimeImage();
+    public ExternalServiceResource withDockerfileBaseImage(WithDockerfileBaseImageOptions optionsBag) {
+        var buildImage = optionsBag == null ? null : optionsBag.getBuildImage();
+        var runtimeImage = optionsBag == null ? null : optionsBag.getRuntimeImage();
         return withDockerfileBaseImageImpl(buildImage, runtimeImage);
     }
 
@@ -11270,10 +11307,10 @@ public class ExternalServiceResource extends ResourceBuilderBase {
     }
 
     /** Adds an HTTP health check to the external service for polyglot app hosts. */
-    public ExternalServiceResource withHttpHealthCheck(WithHttpHealthCheckOptions options) {
-        var path = options == null ? null : options.getPath();
-        var statusCode = options == null ? null : options.getStatusCode();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public ExternalServiceResource withHttpHealthCheck(WithHttpHealthCheckOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var statusCode = optionsBag == null ? null : optionsBag.getStatusCode();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpHealthCheckImpl(path, statusCode, endpointName);
     }
 
@@ -11566,9 +11603,9 @@ public class ExternalServiceResource extends ResourceBuilderBase {
     }
 
     /** Hides the resource from default resource lists after successful completion */
-    public ExternalServiceResource withHiddenOnCompletion(WithHiddenOnCompletionOptions options) {
-        var exitCode = options == null ? null : options.getExitCode();
-        var exitCodes = options == null ? null : options.getExitCodes();
+    public ExternalServiceResource withHiddenOnCompletion(WithHiddenOnCompletionOptions optionsBag) {
+        var exitCode = optionsBag == null ? null : optionsBag.getExitCode();
+        var exitCodes = optionsBag == null ? null : optionsBag.getExitCodes();
         return withHiddenOnCompletionImpl(exitCode, exitCodes);
     }
 
@@ -11591,11 +11628,11 @@ public class ExternalServiceResource extends ResourceBuilderBase {
     }
 
     /** Adds a pipeline step to the resource that will be executed during deployment. */
-    public ExternalServiceResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions options) {
-        var dependsOn = options == null ? null : options.getDependsOn();
-        var requiredBy = options == null ? null : options.getRequiredBy();
-        var tags = options == null ? null : options.getTags();
-        var description = options == null ? null : options.getDescription();
+    public ExternalServiceResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions optionsBag) {
+        var dependsOn = optionsBag == null ? null : optionsBag.getDependsOn();
+        var requiredBy = optionsBag == null ? null : optionsBag.getRequiredBy();
+        var tags = optionsBag == null ? null : optionsBag.getTags();
+        var description = optionsBag == null ? null : optionsBag.getDescription();
         return withPipelineStepFactoryImpl(stepName, callback, dependsOn, requiredBy, tags, description);
     }
 
@@ -11729,9 +11766,9 @@ public class ExternalServiceResource extends ResourceBuilderBase {
     }
 
     /** Adds an optional string parameter */
-    public ExternalServiceResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public ExternalServiceResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -11955,9 +11992,9 @@ public class ExternalServiceResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging */
-    public ExternalServiceResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public ExternalServiceResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -11981,9 +12018,9 @@ public class ExternalServiceResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging with file path */
-    public ExternalServiceResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public ExternalServiceResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -12727,9 +12764,9 @@ public class IDistributedApplicationBuilder extends HandleWrapperBase {
     }
 
     /** Adds a Dockerfile to the application model that can be treated like a container resource. */
-    public ContainerResource addDockerfile(String name, String contextPath, AddDockerfileOptions options) {
-        var dockerfilePath = options == null ? null : options.getDockerfilePath();
-        var stage = options == null ? null : options.getStage();
+    public ContainerResource addDockerfile(String name, String contextPath, AddDockerfileOptions optionsBag) {
+        var dockerfilePath = optionsBag == null ? null : optionsBag.getDockerfilePath();
+        var stage = optionsBag == null ? null : optionsBag.getStage();
         return addDockerfileImpl(name, contextPath, dockerfilePath, stage);
     }
 
@@ -12899,10 +12936,10 @@ public class IDistributedApplicationBuilder extends HandleWrapperBase {
     }
 
     /** Adds a parameter resource */
-    public ParameterResource addParameter(String name, AddParameterOptions options) {
-        var value = options == null ? null : options.getValue();
-        var publishValueAsDefault = options == null ? null : options.getPublishValueAsDefault();
-        var secret = options == null ? null : options.getSecret();
+    public ParameterResource addParameter(String name, AddParameterOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var publishValueAsDefault = optionsBag == null ? null : optionsBag.getPublishValueAsDefault();
+        var secret = optionsBag == null ? null : optionsBag.getSecret();
         return addParameterImpl(name, value, publishValueAsDefault, secret);
     }
 
@@ -12946,9 +12983,9 @@ public class IDistributedApplicationBuilder extends HandleWrapperBase {
     }
 
     /** Adds a parameter with a generated default value */
-    public ParameterResource addParameterWithGeneratedValue(String name, GenerateParameterDefault value, AddParameterWithGeneratedValueOptions options) {
-        var secret = options == null ? null : options.getSecret();
-        var persist = options == null ? null : options.getPersist();
+    public ParameterResource addParameterWithGeneratedValue(String name, GenerateParameterDefault value, AddParameterWithGeneratedValueOptions optionsBag) {
+        var secret = optionsBag == null ? null : optionsBag.getSecret();
+        var persist = optionsBag == null ? null : optionsBag.getPersist();
         return addParameterWithGeneratedValueImpl(name, value, secret, persist);
     }
 
@@ -13230,9 +13267,9 @@ public class IDistributedApplicationPipeline extends HandleWrapperBase {
     }
 
     /** Adds an application-level pipeline step in a TypeScript-friendly shape. */
-    public void addStep(String stepName, AspireAction1<PipelineStepContext> callback, AddStepOptions options) {
-        var dependsOn = options == null ? null : options.getDependsOn();
-        var requiredBy = options == null ? null : options.getRequiredBy();
+    public void addStep(String stepName, AspireAction1<PipelineStepContext> callback, AddStepOptions optionsBag) {
+        var dependsOn = optionsBag == null ? null : optionsBag.getDependsOn();
+        var requiredBy = optionsBag == null ? null : optionsBag.getRequiredBy();
         addStepImpl(stepName, callback, dependsOn, requiredBy);
     }
 
@@ -13310,9 +13347,9 @@ public class IExecutionConfigurationBuilder extends HandleWrapperBase {
     }
 
     /** Builds the execution configuration for the specified builder. */
-    public IExecutionConfigurationResult build(DistributedApplicationExecutionContext executionContext, BuildOptions options) {
-        var resourceLogger = options == null ? null : options.getResourceLogger();
-        var cancellationToken = options == null ? null : options.getCancellationToken();
+    public IExecutionConfigurationResult build(DistributedApplicationExecutionContext executionContext, BuildOptions optionsBag) {
+        var resourceLogger = optionsBag == null ? null : optionsBag.getResourceLogger();
+        var cancellationToken = optionsBag == null ? null : optionsBag.getCancellationToken();
         return buildImpl(executionContext, resourceLogger, cancellationToken);
     }
 
@@ -13531,6 +13568,196 @@ public class IHostEnvironment extends HandleWrapperBase {
 
 }
 
+// ===== IInteractionService.java =====
+// IInteractionService.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.IInteractionService. */
+public class IInteractionService extends HandleWrapperBase {
+    IInteractionService(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Gets a value indicating whether the interaction service is available. */
+    public boolean isAvailable() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("interactionService", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting/interactionServiceIsAvailable", reqArgs);
+        return (Boolean) result;
+    }
+
+    /** Prompts the user for confirmation with a dialog. */
+    public BooleanInteractionResult promptConfirmationAsync(String title, String message, PromptConfirmationAsyncOptions optionsBag) {
+        var options = optionsBag == null ? null : optionsBag.getOptions();
+        var cancellationToken = optionsBag == null ? null : optionsBag.getCancellationToken();
+        return promptConfirmationAsyncImpl(title, message, options, cancellationToken);
+    }
+
+    public BooleanInteractionResult promptConfirmationAsync(String title, String message) {
+        return promptConfirmationAsync(title, message, null);
+    }
+
+    /** Prompts the user for confirmation with a dialog. */
+    private BooleanInteractionResult promptConfirmationAsyncImpl(String title, String message, MessageBoxInteractionOptions options, CancellationToken cancellationToken) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("interactionService", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("title", AspireClient.serializeValue(title));
+        reqArgs.put("message", AspireClient.serializeValue(message));
+        if (options != null) {
+            reqArgs.put("options", AspireClient.serializeValue(options));
+        }
+        if (cancellationToken != null) {
+            reqArgs.put("cancellationToken", getClient().registerCancellation(cancellationToken));
+        }
+        var result = getClient().invokeCapability("Aspire.Hosting/promptConfirmationAsync", reqArgs);
+        return BooleanInteractionResult.fromMap((Map<String, Object>) result);
+    }
+
+    /** Prompts the user with a message box dialog. */
+    public BooleanInteractionResult promptMessageBoxAsync(String title, String message, PromptMessageBoxAsyncOptions optionsBag) {
+        var options = optionsBag == null ? null : optionsBag.getOptions();
+        var cancellationToken = optionsBag == null ? null : optionsBag.getCancellationToken();
+        return promptMessageBoxAsyncImpl(title, message, options, cancellationToken);
+    }
+
+    public BooleanInteractionResult promptMessageBoxAsync(String title, String message) {
+        return promptMessageBoxAsync(title, message, null);
+    }
+
+    /** Prompts the user with a message box dialog. */
+    private BooleanInteractionResult promptMessageBoxAsyncImpl(String title, String message, MessageBoxInteractionOptions options, CancellationToken cancellationToken) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("interactionService", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("title", AspireClient.serializeValue(title));
+        reqArgs.put("message", AspireClient.serializeValue(message));
+        if (options != null) {
+            reqArgs.put("options", AspireClient.serializeValue(options));
+        }
+        if (cancellationToken != null) {
+            reqArgs.put("cancellationToken", getClient().registerCancellation(cancellationToken));
+        }
+        var result = getClient().invokeCapability("Aspire.Hosting/promptMessageBoxAsync", reqArgs);
+        return BooleanInteractionResult.fromMap((Map<String, Object>) result);
+    }
+
+    /** Prompts the user for a single text input. */
+    public InputInteractionResult promptInputAsync(String title, String message, String inputLabel, String placeHolder, PromptInputAsyncOptions optionsBag) {
+        var options = optionsBag == null ? null : optionsBag.getOptions();
+        var cancellationToken = optionsBag == null ? null : optionsBag.getCancellationToken();
+        return promptInputAsyncImpl(title, message, inputLabel, placeHolder, options, cancellationToken);
+    }
+
+    public InputInteractionResult promptInputAsync(String title, String message, String inputLabel, String placeHolder) {
+        return promptInputAsync(title, message, inputLabel, placeHolder, null);
+    }
+
+    /** Prompts the user for a single text input. */
+    private InputInteractionResult promptInputAsyncImpl(String title, String message, String inputLabel, String placeHolder, InputsDialogInteractionOptions options, CancellationToken cancellationToken) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("interactionService", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("title", AspireClient.serializeValue(title));
+        reqArgs.put("message", AspireClient.serializeValue(message));
+        reqArgs.put("inputLabel", AspireClient.serializeValue(inputLabel));
+        reqArgs.put("placeHolder", AspireClient.serializeValue(placeHolder));
+        if (options != null) {
+            reqArgs.put("options", AspireClient.serializeValue(options));
+        }
+        if (cancellationToken != null) {
+            reqArgs.put("cancellationToken", getClient().registerCancellation(cancellationToken));
+        }
+        var result = getClient().invokeCapability("Aspire.Hosting/promptInputAsync", reqArgs);
+        return InputInteractionResult.fromMap((Map<String, Object>) result);
+    }
+
+    /** Prompts the user for a single input using a specified `InteractionInput`. */
+    public InputInteractionResult promptInputWithInputAsync(String title, String message, InteractionInput input, PromptInputWithInputAsyncOptions optionsBag) {
+        var options = optionsBag == null ? null : optionsBag.getOptions();
+        var cancellationToken = optionsBag == null ? null : optionsBag.getCancellationToken();
+        return promptInputWithInputAsyncImpl(title, message, input, options, cancellationToken);
+    }
+
+    public InputInteractionResult promptInputWithInputAsync(String title, String message, InteractionInput input) {
+        return promptInputWithInputAsync(title, message, input, null);
+    }
+
+    /** Prompts the user for a single input using a specified `InteractionInput`. */
+    private InputInteractionResult promptInputWithInputAsyncImpl(String title, String message, InteractionInput input, InputsDialogInteractionOptions options, CancellationToken cancellationToken) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("interactionService", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("title", AspireClient.serializeValue(title));
+        reqArgs.put("message", AspireClient.serializeValue(message));
+        reqArgs.put("input", AspireClient.serializeValue(input));
+        if (options != null) {
+            reqArgs.put("options", AspireClient.serializeValue(options));
+        }
+        if (cancellationToken != null) {
+            reqArgs.put("cancellationToken", getClient().registerCancellation(cancellationToken));
+        }
+        var result = getClient().invokeCapability("Aspire.Hosting/promptInputWithInput", reqArgs);
+        return InputInteractionResult.fromMap((Map<String, Object>) result);
+    }
+
+    /** Prompts the user for multiple inputs. */
+    public InputsInteractionResult promptInputsAsync(String title, String message, InteractionInput[] inputs, PromptInputsAsyncOptions optionsBag) {
+        var options = optionsBag == null ? null : optionsBag.getOptions();
+        var cancellationToken = optionsBag == null ? null : optionsBag.getCancellationToken();
+        return promptInputsAsyncImpl(title, message, inputs, options, cancellationToken);
+    }
+
+    public InputsInteractionResult promptInputsAsync(String title, String message, InteractionInput[] inputs) {
+        return promptInputsAsync(title, message, inputs, null);
+    }
+
+    /** Prompts the user for multiple inputs. */
+    private InputsInteractionResult promptInputsAsyncImpl(String title, String message, InteractionInput[] inputs, InputsDialogInteractionOptions options, CancellationToken cancellationToken) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("interactionService", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("title", AspireClient.serializeValue(title));
+        reqArgs.put("message", AspireClient.serializeValue(message));
+        reqArgs.put("inputs", AspireClient.serializeValue(inputs));
+        if (options != null) {
+            reqArgs.put("options", AspireClient.serializeValue(options));
+        }
+        if (cancellationToken != null) {
+            reqArgs.put("cancellationToken", getClient().registerCancellation(cancellationToken));
+        }
+        var result = getClient().invokeCapability("Aspire.Hosting/promptInputsAsync", reqArgs);
+        return InputsInteractionResult.fromMap((Map<String, Object>) result);
+    }
+
+    /** Prompts the user with a notification. */
+    public BooleanInteractionResult promptNotificationAsync(String title, String message, PromptNotificationAsyncOptions optionsBag) {
+        var options = optionsBag == null ? null : optionsBag.getOptions();
+        var cancellationToken = optionsBag == null ? null : optionsBag.getCancellationToken();
+        return promptNotificationAsyncImpl(title, message, options, cancellationToken);
+    }
+
+    public BooleanInteractionResult promptNotificationAsync(String title, String message) {
+        return promptNotificationAsync(title, message, null);
+    }
+
+    /** Prompts the user with a notification. */
+    private BooleanInteractionResult promptNotificationAsyncImpl(String title, String message, NotificationInteractionOptions options, CancellationToken cancellationToken) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("interactionService", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("title", AspireClient.serializeValue(title));
+        reqArgs.put("message", AspireClient.serializeValue(message));
+        if (options != null) {
+            reqArgs.put("options", AspireClient.serializeValue(options));
+        }
+        if (cancellationToken != null) {
+            reqArgs.put("cancellationToken", getClient().registerCancellation(cancellationToken));
+        }
+        var result = getClient().invokeCapability("Aspire.Hosting/promptNotificationAsync", reqArgs);
+        return BooleanInteractionResult.fromMap((Map<String, Object>) result);
+    }
+
+}
+
 // ===== ILogger.java =====
 // ILogger.java - GENERATED CODE - DO NOT EDIT
 
@@ -13678,9 +13905,9 @@ public class IReportingStep extends HandleWrapperBase {
     }
 
     /** Completes the reporting step with plain-text completion text. */
-    public void completeStep(String completionText, CompleteStepOptions options) {
-        var completionState = options == null ? null : options.getCompletionState();
-        var cancellationToken = options == null ? null : options.getCancellationToken();
+    public void completeStep(String completionText, CompleteStepOptions optionsBag) {
+        var completionState = optionsBag == null ? null : optionsBag.getCompletionState();
+        var cancellationToken = optionsBag == null ? null : optionsBag.getCancellationToken();
         completeStepImpl(completionText, completionState, cancellationToken);
     }
 
@@ -13703,9 +13930,9 @@ public class IReportingStep extends HandleWrapperBase {
     }
 
     /** Completes the reporting step with Markdown-formatted completion text. */
-    public void completeStepMarkdown(String markdownString, CompleteStepMarkdownOptions options) {
-        var completionState = options == null ? null : options.getCompletionState();
-        var cancellationToken = options == null ? null : options.getCancellationToken();
+    public void completeStepMarkdown(String markdownString, CompleteStepMarkdownOptions optionsBag) {
+        var completionState = optionsBag == null ? null : optionsBag.getCompletionState();
+        var cancellationToken = optionsBag == null ? null : optionsBag.getCancellationToken();
         completeStepMarkdownImpl(markdownString, completionState, cancellationToken);
     }
 
@@ -13774,10 +14001,10 @@ public class IReportingTask extends HandleWrapperBase {
     }
 
     /** Completes the reporting task with plain-text completion text. */
-    public void completeTask(CompleteTaskOptions options) {
-        var completionMessage = options == null ? null : options.getCompletionMessage();
-        var completionState = options == null ? null : options.getCompletionState();
-        var cancellationToken = options == null ? null : options.getCancellationToken();
+    public void completeTask(CompleteTaskOptions optionsBag) {
+        var completionMessage = optionsBag == null ? null : optionsBag.getCompletionMessage();
+        var completionState = optionsBag == null ? null : optionsBag.getCompletionState();
+        var cancellationToken = optionsBag == null ? null : optionsBag.getCancellationToken();
         completeTaskImpl(completionMessage, completionState, cancellationToken);
     }
 
@@ -13802,9 +14029,9 @@ public class IReportingTask extends HandleWrapperBase {
     }
 
     /** Completes the reporting task with Markdown-formatted completion text. */
-    public void completeTaskMarkdown(String markdownString, CompleteTaskMarkdownOptions options) {
-        var completionState = options == null ? null : options.getCompletionState();
-        var cancellationToken = options == null ? null : options.getCancellationToken();
+    public void completeTaskMarkdown(String markdownString, CompleteTaskMarkdownOptions optionsBag) {
+        var completionState = optionsBag == null ? null : optionsBag.getCompletionState();
+        var cancellationToken = optionsBag == null ? null : optionsBag.getCancellationToken();
         completeTaskMarkdownImpl(markdownString, completionState, cancellationToken);
     }
 
@@ -13993,6 +14220,14 @@ public class IServiceProvider extends HandleWrapperBase {
         reqArgs.put("serviceProvider", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting/getEventing", reqArgs);
         return (IDistributedApplicationEventing) result;
+    }
+
+    /** Gets the interaction service from the service provider. */
+    public IInteractionService getInteractionService() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("serviceProvider", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting/getInteractionService", reqArgs);
+        return (IInteractionService) result;
     }
 
     /** Gets the logger factory from the service provider. */
@@ -14265,6 +14500,42 @@ public class InitializeResourceEvent extends HandleWrapperBase {
 
 }
 
+// ===== InputInteractionResult.java =====
+// InputInteractionResult.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** InputInteractionResult DTO. */
+public class InputInteractionResult implements JsonSerializable {
+    private InteractionInput data;
+    private boolean canceled;
+
+    public InteractionInput getData() { return data; }
+    public void setData(InteractionInput value) { this.data = value; }
+    public boolean getCanceled() { return canceled; }
+    public void setCanceled(boolean value) { this.canceled = value; }
+
+    @SuppressWarnings("unchecked")
+    public static InputInteractionResult fromMap(Map<String, Object> map) {
+        var value = new InputInteractionResult();
+        var dataValue = map.get("Data");
+        value.setData(dataValue == null ? null : InteractionInput.fromMap((Map<String, Object>) dataValue));
+        var canceledValue = map.get("Canceled");
+        value.setCanceled((Boolean) canceledValue);
+        return value;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("Data", AspireClient.serializeValue(data));
+        map.put("Canceled", AspireClient.serializeValue(canceled));
+        return map;
+    }
+}
+
 // ===== InputType.java =====
 // InputType.java - GENERATED CODE - DO NOT EDIT
 
@@ -14294,6 +14565,60 @@ public enum InputType implements WireValueEnum {
             if (e.value.equals(value)) return e;
         }
         throw new IllegalArgumentException("Unknown value: " + value);
+    }
+}
+
+// ===== InputsDialogInteractionOptions.java =====
+// InputsDialogInteractionOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** InputsDialogInteractionOptions DTO. */
+public class InputsDialogInteractionOptions implements JsonSerializable {
+    private String primaryButtonText;
+    private String secondaryButtonText;
+    private Boolean showSecondaryButton;
+    private Boolean showDismiss;
+    private Boolean enableMessageMarkdown;
+
+    public String getPrimaryButtonText() { return primaryButtonText; }
+    public void setPrimaryButtonText(String value) { this.primaryButtonText = value; }
+    public String getSecondaryButtonText() { return secondaryButtonText; }
+    public void setSecondaryButtonText(String value) { this.secondaryButtonText = value; }
+    public Boolean getShowSecondaryButton() { return showSecondaryButton; }
+    public void setShowSecondaryButton(Boolean value) { this.showSecondaryButton = value; }
+    public Boolean getShowDismiss() { return showDismiss; }
+    public void setShowDismiss(Boolean value) { this.showDismiss = value; }
+    public Boolean getEnableMessageMarkdown() { return enableMessageMarkdown; }
+    public void setEnableMessageMarkdown(Boolean value) { this.enableMessageMarkdown = value; }
+
+    @SuppressWarnings("unchecked")
+    public static InputsDialogInteractionOptions fromMap(Map<String, Object> map) {
+        var value = new InputsDialogInteractionOptions();
+        var primaryButtonTextValue = map.get("PrimaryButtonText");
+        value.setPrimaryButtonText(primaryButtonTextValue == null ? null : (String) primaryButtonTextValue);
+        var secondaryButtonTextValue = map.get("SecondaryButtonText");
+        value.setSecondaryButtonText(secondaryButtonTextValue == null ? null : (String) secondaryButtonTextValue);
+        var showSecondaryButtonValue = map.get("ShowSecondaryButton");
+        value.setShowSecondaryButton(showSecondaryButtonValue == null ? null : (Boolean) showSecondaryButtonValue);
+        var showDismissValue = map.get("ShowDismiss");
+        value.setShowDismiss(showDismissValue == null ? null : (Boolean) showDismissValue);
+        var enableMessageMarkdownValue = map.get("EnableMessageMarkdown");
+        value.setEnableMessageMarkdown(enableMessageMarkdownValue == null ? null : (Boolean) enableMessageMarkdownValue);
+        return value;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("PrimaryButtonText", AspireClient.serializeValue(primaryButtonText));
+        map.put("SecondaryButtonText", AspireClient.serializeValue(secondaryButtonText));
+        map.put("ShowSecondaryButton", AspireClient.serializeValue(showSecondaryButton));
+        map.put("ShowDismiss", AspireClient.serializeValue(showDismiss));
+        map.put("EnableMessageMarkdown", AspireClient.serializeValue(enableMessageMarkdown));
+        return map;
     }
 }
 
@@ -14336,6 +14661,42 @@ public class InputsDialogValidationContext extends HandleWrapperBase {
         getClient().invokeCapability("Aspire.Hosting/InputsDialogValidationContext.addValidationError", reqArgs);
     }
 
+}
+
+// ===== InputsInteractionResult.java =====
+// InputsInteractionResult.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** InputsInteractionResult DTO. */
+public class InputsInteractionResult implements JsonSerializable {
+    private InteractionInputCollection data;
+    private boolean canceled;
+
+    public InteractionInputCollection getData() { return data; }
+    public void setData(InteractionInputCollection value) { this.data = value; }
+    public boolean getCanceled() { return canceled; }
+    public void setCanceled(boolean value) { this.canceled = value; }
+
+    @SuppressWarnings("unchecked")
+    public static InputsInteractionResult fromMap(Map<String, Object> map) {
+        var value = new InputsInteractionResult();
+        var dataValue = map.get("Data");
+        value.setData((InteractionInputCollection) dataValue);
+        var canceledValue = map.get("Canceled");
+        value.setCanceled((Boolean) canceledValue);
+        return value;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("Data", AspireClient.serializeValue(data));
+        map.put("Canceled", AspireClient.serializeValue(canceled));
+        return map;
+    }
 }
 
 // ===== InteractionInput.java =====
@@ -14464,6 +14825,60 @@ public class InteractionInputCollection extends HandleWrapperBase {
 
 }
 
+// ===== InteractionOptions.java =====
+// InteractionOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** InteractionOptions DTO. */
+public class InteractionOptions implements JsonSerializable {
+    private String primaryButtonText;
+    private String secondaryButtonText;
+    private Boolean showSecondaryButton;
+    private Boolean showDismiss;
+    private Boolean enableMessageMarkdown;
+
+    public String getPrimaryButtonText() { return primaryButtonText; }
+    public void setPrimaryButtonText(String value) { this.primaryButtonText = value; }
+    public String getSecondaryButtonText() { return secondaryButtonText; }
+    public void setSecondaryButtonText(String value) { this.secondaryButtonText = value; }
+    public Boolean getShowSecondaryButton() { return showSecondaryButton; }
+    public void setShowSecondaryButton(Boolean value) { this.showSecondaryButton = value; }
+    public Boolean getShowDismiss() { return showDismiss; }
+    public void setShowDismiss(Boolean value) { this.showDismiss = value; }
+    public Boolean getEnableMessageMarkdown() { return enableMessageMarkdown; }
+    public void setEnableMessageMarkdown(Boolean value) { this.enableMessageMarkdown = value; }
+
+    @SuppressWarnings("unchecked")
+    public static InteractionOptions fromMap(Map<String, Object> map) {
+        var value = new InteractionOptions();
+        var primaryButtonTextValue = map.get("PrimaryButtonText");
+        value.setPrimaryButtonText(primaryButtonTextValue == null ? null : (String) primaryButtonTextValue);
+        var secondaryButtonTextValue = map.get("SecondaryButtonText");
+        value.setSecondaryButtonText(secondaryButtonTextValue == null ? null : (String) secondaryButtonTextValue);
+        var showSecondaryButtonValue = map.get("ShowSecondaryButton");
+        value.setShowSecondaryButton(showSecondaryButtonValue == null ? null : (Boolean) showSecondaryButtonValue);
+        var showDismissValue = map.get("ShowDismiss");
+        value.setShowDismiss(showDismissValue == null ? null : (Boolean) showDismissValue);
+        var enableMessageMarkdownValue = map.get("EnableMessageMarkdown");
+        value.setEnableMessageMarkdown(enableMessageMarkdownValue == null ? null : (Boolean) enableMessageMarkdownValue);
+        return value;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("PrimaryButtonText", AspireClient.serializeValue(primaryButtonText));
+        map.put("SecondaryButtonText", AspireClient.serializeValue(secondaryButtonText));
+        map.put("ShowSecondaryButton", AspireClient.serializeValue(showSecondaryButton));
+        map.put("ShowDismiss", AspireClient.serializeValue(showDismiss));
+        map.put("EnableMessageMarkdown", AspireClient.serializeValue(enableMessageMarkdown));
+        return map;
+    }
+}
+
 // ===== JsonSerializable.java =====
 // JsonSerializable.java - GENERATED CODE - DO NOT EDIT
 
@@ -14527,6 +14942,171 @@ public class LogFacade extends HandleWrapperBase {
         getClient().invokeCapability("Aspire.Hosting.ApplicationModel/debug", reqArgs);
     }
 
+}
+
+// ===== MessageBoxInteractionOptions.java =====
+// MessageBoxInteractionOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** MessageBoxInteractionOptions DTO. */
+public class MessageBoxInteractionOptions implements JsonSerializable {
+    private MessageIntent intent;
+    private String primaryButtonText;
+    private String secondaryButtonText;
+    private Boolean showSecondaryButton;
+    private Boolean showDismiss;
+    private Boolean enableMessageMarkdown;
+
+    public MessageIntent getIntent() { return intent; }
+    public void setIntent(MessageIntent value) { this.intent = value; }
+    public String getPrimaryButtonText() { return primaryButtonText; }
+    public void setPrimaryButtonText(String value) { this.primaryButtonText = value; }
+    public String getSecondaryButtonText() { return secondaryButtonText; }
+    public void setSecondaryButtonText(String value) { this.secondaryButtonText = value; }
+    public Boolean getShowSecondaryButton() { return showSecondaryButton; }
+    public void setShowSecondaryButton(Boolean value) { this.showSecondaryButton = value; }
+    public Boolean getShowDismiss() { return showDismiss; }
+    public void setShowDismiss(Boolean value) { this.showDismiss = value; }
+    public Boolean getEnableMessageMarkdown() { return enableMessageMarkdown; }
+    public void setEnableMessageMarkdown(Boolean value) { this.enableMessageMarkdown = value; }
+
+    @SuppressWarnings("unchecked")
+    public static MessageBoxInteractionOptions fromMap(Map<String, Object> map) {
+        var value = new MessageBoxInteractionOptions();
+        var intentValue = map.get("Intent");
+        value.setIntent(intentValue == null ? null : MessageIntent.fromValue((String) intentValue));
+        var primaryButtonTextValue = map.get("PrimaryButtonText");
+        value.setPrimaryButtonText(primaryButtonTextValue == null ? null : (String) primaryButtonTextValue);
+        var secondaryButtonTextValue = map.get("SecondaryButtonText");
+        value.setSecondaryButtonText(secondaryButtonTextValue == null ? null : (String) secondaryButtonTextValue);
+        var showSecondaryButtonValue = map.get("ShowSecondaryButton");
+        value.setShowSecondaryButton(showSecondaryButtonValue == null ? null : (Boolean) showSecondaryButtonValue);
+        var showDismissValue = map.get("ShowDismiss");
+        value.setShowDismiss(showDismissValue == null ? null : (Boolean) showDismissValue);
+        var enableMessageMarkdownValue = map.get("EnableMessageMarkdown");
+        value.setEnableMessageMarkdown(enableMessageMarkdownValue == null ? null : (Boolean) enableMessageMarkdownValue);
+        return value;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("Intent", AspireClient.serializeValue(intent));
+        map.put("PrimaryButtonText", AspireClient.serializeValue(primaryButtonText));
+        map.put("SecondaryButtonText", AspireClient.serializeValue(secondaryButtonText));
+        map.put("ShowSecondaryButton", AspireClient.serializeValue(showSecondaryButton));
+        map.put("ShowDismiss", AspireClient.serializeValue(showDismiss));
+        map.put("EnableMessageMarkdown", AspireClient.serializeValue(enableMessageMarkdown));
+        return map;
+    }
+}
+
+// ===== MessageIntent.java =====
+// MessageIntent.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** MessageIntent enum. */
+public enum MessageIntent implements WireValueEnum {
+    NONE("None"),
+    SUCCESS("Success"),
+    WARNING("Warning"),
+    ERROR("Error"),
+    INFORMATION("Information"),
+    CONFIRMATION("Confirmation");
+
+    private final String value;
+
+    MessageIntent(String value) {
+        this.value = value;
+    }
+
+    public String getValue() { return value; }
+
+    public static MessageIntent fromValue(String value) {
+        for (MessageIntent e : values()) {
+            if (e.value.equals(value)) return e;
+        }
+        throw new IllegalArgumentException("Unknown value: " + value);
+    }
+}
+
+// ===== NotificationInteractionOptions.java =====
+// NotificationInteractionOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** NotificationInteractionOptions DTO. */
+public class NotificationInteractionOptions implements JsonSerializable {
+    private MessageIntent intent;
+    private String linkText;
+    private String linkUrl;
+    private String primaryButtonText;
+    private String secondaryButtonText;
+    private Boolean showSecondaryButton;
+    private Boolean showDismiss;
+    private Boolean enableMessageMarkdown;
+
+    public MessageIntent getIntent() { return intent; }
+    public void setIntent(MessageIntent value) { this.intent = value; }
+    public String getLinkText() { return linkText; }
+    public void setLinkText(String value) { this.linkText = value; }
+    public String getLinkUrl() { return linkUrl; }
+    public void setLinkUrl(String value) { this.linkUrl = value; }
+    public String getPrimaryButtonText() { return primaryButtonText; }
+    public void setPrimaryButtonText(String value) { this.primaryButtonText = value; }
+    public String getSecondaryButtonText() { return secondaryButtonText; }
+    public void setSecondaryButtonText(String value) { this.secondaryButtonText = value; }
+    public Boolean getShowSecondaryButton() { return showSecondaryButton; }
+    public void setShowSecondaryButton(Boolean value) { this.showSecondaryButton = value; }
+    public Boolean getShowDismiss() { return showDismiss; }
+    public void setShowDismiss(Boolean value) { this.showDismiss = value; }
+    public Boolean getEnableMessageMarkdown() { return enableMessageMarkdown; }
+    public void setEnableMessageMarkdown(Boolean value) { this.enableMessageMarkdown = value; }
+
+    @SuppressWarnings("unchecked")
+    public static NotificationInteractionOptions fromMap(Map<String, Object> map) {
+        var value = new NotificationInteractionOptions();
+        var intentValue = map.get("Intent");
+        value.setIntent(intentValue == null ? null : MessageIntent.fromValue((String) intentValue));
+        var linkTextValue = map.get("LinkText");
+        value.setLinkText(linkTextValue == null ? null : (String) linkTextValue);
+        var linkUrlValue = map.get("LinkUrl");
+        value.setLinkUrl(linkUrlValue == null ? null : (String) linkUrlValue);
+        var primaryButtonTextValue = map.get("PrimaryButtonText");
+        value.setPrimaryButtonText(primaryButtonTextValue == null ? null : (String) primaryButtonTextValue);
+        var secondaryButtonTextValue = map.get("SecondaryButtonText");
+        value.setSecondaryButtonText(secondaryButtonTextValue == null ? null : (String) secondaryButtonTextValue);
+        var showSecondaryButtonValue = map.get("ShowSecondaryButton");
+        value.setShowSecondaryButton(showSecondaryButtonValue == null ? null : (Boolean) showSecondaryButtonValue);
+        var showDismissValue = map.get("ShowDismiss");
+        value.setShowDismiss(showDismissValue == null ? null : (Boolean) showDismissValue);
+        var enableMessageMarkdownValue = map.get("EnableMessageMarkdown");
+        value.setEnableMessageMarkdown(enableMessageMarkdownValue == null ? null : (Boolean) enableMessageMarkdownValue);
+        return value;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("Intent", AspireClient.serializeValue(intent));
+        map.put("LinkText", AspireClient.serializeValue(linkText));
+        map.put("LinkUrl", AspireClient.serializeValue(linkUrl));
+        map.put("PrimaryButtonText", AspireClient.serializeValue(primaryButtonText));
+        map.put("SecondaryButtonText", AspireClient.serializeValue(secondaryButtonText));
+        map.put("ShowSecondaryButton", AspireClient.serializeValue(showSecondaryButton));
+        map.put("ShowDismiss", AspireClient.serializeValue(showDismiss));
+        map.put("EnableMessageMarkdown", AspireClient.serializeValue(enableMessageMarkdown));
+        return map;
+    }
 }
 
 // ===== OtlpProtocol.java =====
@@ -14671,9 +15251,9 @@ public class ParameterResource extends ResourceBuilderBase {
     }
 
     /** Configures custom base images for generated Dockerfiles. */
-    public ParameterResource withDockerfileBaseImage(WithDockerfileBaseImageOptions options) {
-        var buildImage = options == null ? null : options.getBuildImage();
-        var runtimeImage = options == null ? null : options.getRuntimeImage();
+    public ParameterResource withDockerfileBaseImage(WithDockerfileBaseImageOptions optionsBag) {
+        var buildImage = optionsBag == null ? null : optionsBag.getBuildImage();
+        var runtimeImage = optionsBag == null ? null : optionsBag.getRuntimeImage();
         return withDockerfileBaseImageImpl(buildImage, runtimeImage);
     }
 
@@ -14988,9 +15568,9 @@ public class ParameterResource extends ResourceBuilderBase {
     }
 
     /** Hides the resource from default resource lists after successful completion */
-    public ParameterResource withHiddenOnCompletion(WithHiddenOnCompletionOptions options) {
-        var exitCode = options == null ? null : options.getExitCode();
-        var exitCodes = options == null ? null : options.getExitCodes();
+    public ParameterResource withHiddenOnCompletion(WithHiddenOnCompletionOptions optionsBag) {
+        var exitCode = optionsBag == null ? null : optionsBag.getExitCode();
+        var exitCodes = optionsBag == null ? null : optionsBag.getExitCodes();
         return withHiddenOnCompletionImpl(exitCode, exitCodes);
     }
 
@@ -15013,11 +15593,11 @@ public class ParameterResource extends ResourceBuilderBase {
     }
 
     /** Adds a pipeline step to the resource that will be executed during deployment. */
-    public ParameterResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions options) {
-        var dependsOn = options == null ? null : options.getDependsOn();
-        var requiredBy = options == null ? null : options.getRequiredBy();
-        var tags = options == null ? null : options.getTags();
-        var description = options == null ? null : options.getDescription();
+    public ParameterResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions optionsBag) {
+        var dependsOn = optionsBag == null ? null : optionsBag.getDependsOn();
+        var requiredBy = optionsBag == null ? null : optionsBag.getRequiredBy();
+        var tags = optionsBag == null ? null : optionsBag.getTags();
+        var description = optionsBag == null ? null : optionsBag.getDescription();
         return withPipelineStepFactoryImpl(stepName, callback, dependsOn, requiredBy, tags, description);
     }
 
@@ -15151,9 +15731,9 @@ public class ParameterResource extends ResourceBuilderBase {
     }
 
     /** Adds an optional string parameter */
-    public ParameterResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public ParameterResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -15377,9 +15957,9 @@ public class ParameterResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging */
-    public ParameterResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public ParameterResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -15403,9 +15983,9 @@ public class ParameterResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging with file path */
-    public ParameterResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public ParameterResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -16096,9 +16676,9 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Configures custom base images for generated Dockerfiles. */
-    public ProjectResource withDockerfileBaseImage(WithDockerfileBaseImageOptions options) {
-        var buildImage = options == null ? null : options.getBuildImage();
-        var runtimeImage = options == null ? null : options.getRuntimeImage();
+    public ProjectResource withDockerfileBaseImage(WithDockerfileBaseImageOptions optionsBag) {
+        var buildImage = optionsBag == null ? null : optionsBag.getBuildImage();
+        var runtimeImage = optionsBag == null ? null : optionsBag.getRuntimeImage();
         return withDockerfileBaseImageImpl(buildImage, runtimeImage);
     }
 
@@ -16121,9 +16701,9 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Marks the resource as hosting a Model Context Protocol (MCP) server on the specified endpoint. */
-    public ProjectResource withMcpServer(WithMcpServerOptions options) {
-        var path = options == null ? null : options.getPath();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public ProjectResource withMcpServer(WithMcpServerOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withMcpServerImpl(path, endpointName);
     }
 
@@ -16376,10 +16956,10 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Adds a reference to another resource */
-    public ProjectResource withReference(AspireUnion source, WithReferenceOptions options) {
-        var connectionName = options == null ? null : options.getConnectionName();
-        var optional = options == null ? null : options.getOptional();
-        var name = options == null ? null : options.getName();
+    public ProjectResource withReference(AspireUnion source, WithReferenceOptions optionsBag) {
+        var connectionName = optionsBag == null ? null : optionsBag.getConnectionName();
+        var optional = optionsBag == null ? null : optionsBag.getOptional();
+        var name = optionsBag == null ? null : optionsBag.getName();
         return withReferenceImpl(source, connectionName, optional, name);
     }
 
@@ -16430,9 +17010,9 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Updates an HTTP endpoint via callback */
-    public ProjectResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public ProjectResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -16463,9 +17043,9 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Updates an HTTPS endpoint via callback */
-    public ProjectResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public ProjectResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpsEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -16496,15 +17076,15 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Adds a network endpoint */
-    public ProjectResource withEndpoint(WithEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var scheme = options == null ? null : options.getScheme();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
-        var isExternal = options == null ? null : options.isExternal();
-        var protocol = options == null ? null : options.getProtocol();
+    public ProjectResource withEndpoint(WithEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var scheme = optionsBag == null ? null : optionsBag.getScheme();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
+        var isExternal = optionsBag == null ? null : optionsBag.isExternal();
+        var protocol = optionsBag == null ? null : optionsBag.getProtocol();
         return withEndpointImpl(port, targetPort, scheme, name, env, isProxied, isExternal, protocol);
     }
 
@@ -16554,12 +17134,12 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Adds an HTTP endpoint */
-    public ProjectResource withHttpEndpoint(WithHttpEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public ProjectResource withHttpEndpoint(WithHttpEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -16591,12 +17171,12 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Adds an HTTPS endpoint */
-    public ProjectResource withHttpsEndpoint(WithHttpsEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public ProjectResource withHttpsEndpoint(WithHttpsEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpsEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -16821,10 +17401,10 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Adds a health check to the resource which is mapped to a specific endpoint. */
-    public ProjectResource withHttpHealthCheck(WithHttpHealthCheckOptions options) {
-        var path = options == null ? null : options.getPath();
-        var statusCode = options == null ? null : options.getStatusCode();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public ProjectResource withHttpHealthCheck(WithHttpHealthCheckOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var statusCode = optionsBag == null ? null : optionsBag.getStatusCode();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpHealthCheckImpl(path, statusCode, endpointName);
     }
 
@@ -17036,14 +17616,14 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Adds an HTTP health probe to the resource */
-    public ProjectResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions options) {
-        var path = options == null ? null : options.getPath();
-        var initialDelaySeconds = options == null ? null : options.getInitialDelaySeconds();
-        var periodSeconds = options == null ? null : options.getPeriodSeconds();
-        var timeoutSeconds = options == null ? null : options.getTimeoutSeconds();
-        var failureThreshold = options == null ? null : options.getFailureThreshold();
-        var successThreshold = options == null ? null : options.getSuccessThreshold();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public ProjectResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var initialDelaySeconds = optionsBag == null ? null : optionsBag.getInitialDelaySeconds();
+        var periodSeconds = optionsBag == null ? null : optionsBag.getPeriodSeconds();
+        var timeoutSeconds = optionsBag == null ? null : optionsBag.getTimeoutSeconds();
+        var failureThreshold = optionsBag == null ? null : optionsBag.getFailureThreshold();
+        var successThreshold = optionsBag == null ? null : optionsBag.getSuccessThreshold();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpProbeImpl(probeType, path, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold, successThreshold, endpointName);
     }
 
@@ -17098,9 +17678,9 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Hides the resource from default resource lists after successful completion */
-    public ProjectResource withHiddenOnCompletion(WithHiddenOnCompletionOptions options) {
-        var exitCode = options == null ? null : options.getExitCode();
-        var exitCodes = options == null ? null : options.getExitCodes();
+    public ProjectResource withHiddenOnCompletion(WithHiddenOnCompletionOptions optionsBag) {
+        var exitCode = optionsBag == null ? null : optionsBag.getExitCode();
+        var exitCodes = optionsBag == null ? null : optionsBag.getExitCodes();
         return withHiddenOnCompletionImpl(exitCode, exitCodes);
     }
 
@@ -17157,11 +17737,11 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Adds a pipeline step to the resource that will be executed during deployment. */
-    public ProjectResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions options) {
-        var dependsOn = options == null ? null : options.getDependsOn();
-        var requiredBy = options == null ? null : options.getRequiredBy();
-        var tags = options == null ? null : options.getTags();
-        var description = options == null ? null : options.getDescription();
+    public ProjectResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions optionsBag) {
+        var dependsOn = optionsBag == null ? null : optionsBag.getDependsOn();
+        var requiredBy = optionsBag == null ? null : optionsBag.getRequiredBy();
+        var tags = optionsBag == null ? null : optionsBag.getTags();
+        var description = optionsBag == null ? null : optionsBag.getDescription();
         return withPipelineStepFactoryImpl(stepName, callback, dependsOn, requiredBy, tags, description);
     }
 
@@ -17311,9 +17891,9 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Adds an optional string parameter */
-    public ProjectResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public ProjectResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -17562,9 +18142,9 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging */
-    public ProjectResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public ProjectResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -17588,9 +18168,9 @@ public class ProjectResource extends ResourceBuilderBase {
     }
 
     /** Configures resource logging with file path */
-    public ProjectResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public ProjectResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -17704,6 +18284,168 @@ public class ProjectResourceOptions extends HandleWrapperBase {
         reqArgs.put("value", AspireClient.serializeValue(value));
         var result = getClient().invokeCapability("Aspire.Hosting/ProjectResourceOptions.setExcludeKestrelEndpoints", reqArgs);
         return (ProjectResourceOptions) result;
+    }
+
+}
+
+// ===== PromptConfirmationAsyncOptions.java =====
+// PromptConfirmationAsyncOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Options for PromptConfirmationAsync. */
+public final class PromptConfirmationAsyncOptions {
+    private MessageBoxInteractionOptions options;
+    private CancellationToken cancellationToken;
+
+    public MessageBoxInteractionOptions getOptions() { return options; }
+    public PromptConfirmationAsyncOptions options(MessageBoxInteractionOptions value) {
+        this.options = value;
+        return this;
+    }
+
+    public CancellationToken getCancellationToken() { return cancellationToken; }
+    public PromptConfirmationAsyncOptions cancellationToken(CancellationToken value) {
+        this.cancellationToken = value;
+        return this;
+    }
+
+}
+
+// ===== PromptInputAsyncOptions.java =====
+// PromptInputAsyncOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Options for PromptInputAsync. */
+public final class PromptInputAsyncOptions {
+    private InputsDialogInteractionOptions options;
+    private CancellationToken cancellationToken;
+
+    public InputsDialogInteractionOptions getOptions() { return options; }
+    public PromptInputAsyncOptions options(InputsDialogInteractionOptions value) {
+        this.options = value;
+        return this;
+    }
+
+    public CancellationToken getCancellationToken() { return cancellationToken; }
+    public PromptInputAsyncOptions cancellationToken(CancellationToken value) {
+        this.cancellationToken = value;
+        return this;
+    }
+
+}
+
+// ===== PromptInputWithInputAsyncOptions.java =====
+// PromptInputWithInputAsyncOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Options for PromptInputWithInputAsync. */
+public final class PromptInputWithInputAsyncOptions {
+    private InputsDialogInteractionOptions options;
+    private CancellationToken cancellationToken;
+
+    public InputsDialogInteractionOptions getOptions() { return options; }
+    public PromptInputWithInputAsyncOptions options(InputsDialogInteractionOptions value) {
+        this.options = value;
+        return this;
+    }
+
+    public CancellationToken getCancellationToken() { return cancellationToken; }
+    public PromptInputWithInputAsyncOptions cancellationToken(CancellationToken value) {
+        this.cancellationToken = value;
+        return this;
+    }
+
+}
+
+// ===== PromptInputsAsyncOptions.java =====
+// PromptInputsAsyncOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Options for PromptInputsAsync. */
+public final class PromptInputsAsyncOptions {
+    private InputsDialogInteractionOptions options;
+    private CancellationToken cancellationToken;
+
+    public InputsDialogInteractionOptions getOptions() { return options; }
+    public PromptInputsAsyncOptions options(InputsDialogInteractionOptions value) {
+        this.options = value;
+        return this;
+    }
+
+    public CancellationToken getCancellationToken() { return cancellationToken; }
+    public PromptInputsAsyncOptions cancellationToken(CancellationToken value) {
+        this.cancellationToken = value;
+        return this;
+    }
+
+}
+
+// ===== PromptMessageBoxAsyncOptions.java =====
+// PromptMessageBoxAsyncOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Options for PromptMessageBoxAsync. */
+public final class PromptMessageBoxAsyncOptions {
+    private MessageBoxInteractionOptions options;
+    private CancellationToken cancellationToken;
+
+    public MessageBoxInteractionOptions getOptions() { return options; }
+    public PromptMessageBoxAsyncOptions options(MessageBoxInteractionOptions value) {
+        this.options = value;
+        return this;
+    }
+
+    public CancellationToken getCancellationToken() { return cancellationToken; }
+    public PromptMessageBoxAsyncOptions cancellationToken(CancellationToken value) {
+        this.cancellationToken = value;
+        return this;
+    }
+
+}
+
+// ===== PromptNotificationAsyncOptions.java =====
+// PromptNotificationAsyncOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Options for PromptNotificationAsync. */
+public final class PromptNotificationAsyncOptions {
+    private NotificationInteractionOptions options;
+    private CancellationToken cancellationToken;
+
+    public NotificationInteractionOptions getOptions() { return options; }
+    public PromptNotificationAsyncOptions options(NotificationInteractionOptions value) {
+        this.options = value;
+        return this;
+    }
+
+    public CancellationToken getCancellationToken() { return cancellationToken; }
+    public PromptNotificationAsyncOptions cancellationToken(CancellationToken value) {
+        this.cancellationToken = value;
+        return this;
     }
 
 }
@@ -18084,9 +18826,9 @@ public class ResourceCommandService extends HandleWrapperBase {
     }
 
     /** Executes a command for the specified resource. */
-    public ExecuteCommandResult executeCommandAsync(AspireUnion resource, String commandName, ExecuteCommandAsyncOptions options) {
-        var arguments = options == null ? null : options.getArguments();
-        var cancellationToken = options == null ? null : options.getCancellationToken();
+    public ExecuteCommandResult executeCommandAsync(AspireUnion resource, String commandName, ExecuteCommandAsyncOptions optionsBag) {
+        var arguments = optionsBag == null ? null : optionsBag.getArguments();
+        var cancellationToken = optionsBag == null ? null : optionsBag.getCancellationToken();
         return executeCommandAsyncImpl(resource, commandName, arguments, cancellationToken);
     }
 
@@ -18370,9 +19112,9 @@ public class ResourceNotificationService extends HandleWrapperBase {
     }
 
     /** Publishes an update for a resource's state. */
-    public void publishResourceUpdate(IResource resource, PublishResourceUpdateOptions options) {
-        var state = options == null ? null : options.getState();
-        var stateStyle = options == null ? null : options.getStateStyle();
+    public void publishResourceUpdate(IResource resource, PublishResourceUpdateOptions optionsBag) {
+        var state = optionsBag == null ? null : optionsBag.getState();
+        var stateStyle = optionsBag == null ? null : optionsBag.getStateStyle();
         publishResourceUpdateImpl(resource, state, stateStyle);
     }
 
@@ -18953,9 +19695,9 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Causes Aspire to build the specified container image from a Dockerfile. */
-    public TestDatabaseResource withDockerfile(String contextPath, WithDockerfileOptions options) {
-        var dockerfilePath = options == null ? null : options.getDockerfilePath();
-        var stage = options == null ? null : options.getStage();
+    public TestDatabaseResource withDockerfile(String contextPath, WithDockerfileOptions optionsBag) {
+        var dockerfilePath = optionsBag == null ? null : optionsBag.getDockerfilePath();
+        var stage = optionsBag == null ? null : optionsBag.getStage();
         return withDockerfileImpl(contextPath, dockerfilePath, stage);
     }
 
@@ -19039,10 +19781,10 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Adds container certificate path overrides used for certificate trust at run time. */
-    public TestDatabaseResource withContainerCertificatePaths(WithContainerCertificatePathsOptions options) {
-        var customCertificatesDestination = options == null ? null : options.getCustomCertificatesDestination();
-        var defaultCertificateBundlePaths = options == null ? null : options.getDefaultCertificateBundlePaths();
-        var defaultCertificateDirectoryPaths = options == null ? null : options.getDefaultCertificateDirectoryPaths();
+    public TestDatabaseResource withContainerCertificatePaths(WithContainerCertificatePathsOptions optionsBag) {
+        var customCertificatesDestination = optionsBag == null ? null : optionsBag.getCustomCertificatesDestination();
+        var defaultCertificateBundlePaths = optionsBag == null ? null : optionsBag.getDefaultCertificateBundlePaths();
+        var defaultCertificateDirectoryPaths = optionsBag == null ? null : optionsBag.getDefaultCertificateDirectoryPaths();
         return withContainerCertificatePathsImpl(customCertificatesDestination, defaultCertificateBundlePaths, defaultCertificateDirectoryPaths);
     }
 
@@ -19092,9 +19834,9 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Configures custom base images for generated Dockerfiles. */
-    public TestDatabaseResource withDockerfileBaseImage(WithDockerfileBaseImageOptions options) {
-        var buildImage = options == null ? null : options.getBuildImage();
-        var runtimeImage = options == null ? null : options.getRuntimeImage();
+    public TestDatabaseResource withDockerfileBaseImage(WithDockerfileBaseImageOptions optionsBag) {
+        var buildImage = optionsBag == null ? null : optionsBag.getBuildImage();
+        var runtimeImage = optionsBag == null ? null : optionsBag.getRuntimeImage();
         return withDockerfileBaseImageImpl(buildImage, runtimeImage);
     }
 
@@ -19126,9 +19868,9 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Marks the resource as hosting a Model Context Protocol (MCP) server on the specified endpoint. */
-    public TestDatabaseResource withMcpServer(WithMcpServerOptions options) {
-        var path = options == null ? null : options.getPath();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public TestDatabaseResource withMcpServer(WithMcpServerOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withMcpServerImpl(path, endpointName);
     }
 
@@ -19352,10 +20094,10 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Adds a reference to another resource */
-    public TestDatabaseResource withReference(AspireUnion source, WithReferenceOptions options) {
-        var connectionName = options == null ? null : options.getConnectionName();
-        var optional = options == null ? null : options.getOptional();
-        var name = options == null ? null : options.getName();
+    public TestDatabaseResource withReference(AspireUnion source, WithReferenceOptions optionsBag) {
+        var connectionName = optionsBag == null ? null : optionsBag.getConnectionName();
+        var optional = optionsBag == null ? null : optionsBag.getOptional();
+        var name = optionsBag == null ? null : optionsBag.getName();
         return withReferenceImpl(source, connectionName, optional, name);
     }
 
@@ -19406,9 +20148,9 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Updates an HTTP endpoint via callback */
-    public TestDatabaseResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public TestDatabaseResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -19439,9 +20181,9 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Updates an HTTPS endpoint via callback */
-    public TestDatabaseResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public TestDatabaseResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpsEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -19472,15 +20214,15 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Adds a network endpoint */
-    public TestDatabaseResource withEndpoint(WithEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var scheme = options == null ? null : options.getScheme();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
-        var isExternal = options == null ? null : options.isExternal();
-        var protocol = options == null ? null : options.getProtocol();
+    public TestDatabaseResource withEndpoint(WithEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var scheme = optionsBag == null ? null : optionsBag.getScheme();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
+        var isExternal = optionsBag == null ? null : optionsBag.isExternal();
+        var protocol = optionsBag == null ? null : optionsBag.getProtocol();
         return withEndpointImpl(port, targetPort, scheme, name, env, isProxied, isExternal, protocol);
     }
 
@@ -19530,12 +20272,12 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Adds an HTTP endpoint */
-    public TestDatabaseResource withHttpEndpoint(WithHttpEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public TestDatabaseResource withHttpEndpoint(WithHttpEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -19567,12 +20309,12 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Adds an HTTPS endpoint */
-    public TestDatabaseResource withHttpsEndpoint(WithHttpsEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public TestDatabaseResource withHttpsEndpoint(WithHttpsEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpsEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -19783,10 +20525,10 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Adds a health check to the resource which is mapped to a specific endpoint. */
-    public TestDatabaseResource withHttpHealthCheck(WithHttpHealthCheckOptions options) {
-        var path = options == null ? null : options.getPath();
-        var statusCode = options == null ? null : options.getStatusCode();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public TestDatabaseResource withHttpHealthCheck(WithHttpHealthCheckOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var statusCode = optionsBag == null ? null : optionsBag.getStatusCode();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpHealthCheckImpl(path, statusCode, endpointName);
     }
 
@@ -19998,14 +20740,14 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Adds an HTTP health probe to the resource */
-    public TestDatabaseResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions options) {
-        var path = options == null ? null : options.getPath();
-        var initialDelaySeconds = options == null ? null : options.getInitialDelaySeconds();
-        var periodSeconds = options == null ? null : options.getPeriodSeconds();
-        var timeoutSeconds = options == null ? null : options.getTimeoutSeconds();
-        var failureThreshold = options == null ? null : options.getFailureThreshold();
-        var successThreshold = options == null ? null : options.getSuccessThreshold();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public TestDatabaseResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var initialDelaySeconds = optionsBag == null ? null : optionsBag.getInitialDelaySeconds();
+        var periodSeconds = optionsBag == null ? null : optionsBag.getPeriodSeconds();
+        var timeoutSeconds = optionsBag == null ? null : optionsBag.getTimeoutSeconds();
+        var failureThreshold = optionsBag == null ? null : optionsBag.getFailureThreshold();
+        var successThreshold = optionsBag == null ? null : optionsBag.getSuccessThreshold();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpProbeImpl(probeType, path, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold, successThreshold, endpointName);
     }
 
@@ -20060,9 +20802,9 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Hides the resource from default resource lists after successful completion */
-    public TestDatabaseResource withHiddenOnCompletion(WithHiddenOnCompletionOptions options) {
-        var exitCode = options == null ? null : options.getExitCode();
-        var exitCodes = options == null ? null : options.getExitCodes();
+    public TestDatabaseResource withHiddenOnCompletion(WithHiddenOnCompletionOptions optionsBag) {
+        var exitCode = optionsBag == null ? null : optionsBag.getExitCode();
+        var exitCodes = optionsBag == null ? null : optionsBag.getExitCodes();
         return withHiddenOnCompletionImpl(exitCode, exitCodes);
     }
 
@@ -20119,11 +20861,11 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Adds a pipeline step to the resource that will be executed during deployment. */
-    public TestDatabaseResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions options) {
-        var dependsOn = options == null ? null : options.getDependsOn();
-        var requiredBy = options == null ? null : options.getRequiredBy();
-        var tags = options == null ? null : options.getTags();
-        var description = options == null ? null : options.getDescription();
+    public TestDatabaseResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions optionsBag) {
+        var dependsOn = optionsBag == null ? null : optionsBag.getDependsOn();
+        var requiredBy = optionsBag == null ? null : optionsBag.getRequiredBy();
+        var tags = optionsBag == null ? null : optionsBag.getTags();
+        var description = optionsBag == null ? null : optionsBag.getDescription();
         return withPipelineStepFactoryImpl(stepName, callback, dependsOn, requiredBy, tags, description);
     }
 
@@ -20177,9 +20919,9 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Adds a volume to a container resource. */
-    public TestDatabaseResource withVolume(String target, WithVolumeOptions options) {
-        var name = options == null ? null : options.getName();
-        var isReadOnly = options == null ? null : options.isReadOnly();
+    public TestDatabaseResource withVolume(String target, WithVolumeOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var isReadOnly = optionsBag == null ? null : optionsBag.isReadOnly();
         return withVolumeImpl(target, name, isReadOnly);
     }
 
@@ -20299,9 +21041,9 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Adds an optional string parameter */
-    public TestDatabaseResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public TestDatabaseResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -20550,9 +21292,9 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Configures resource logging */
-    public TestDatabaseResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public TestDatabaseResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -20576,9 +21318,9 @@ public class TestDatabaseResource extends ContainerResource {
     }
 
     /** Configures resource logging with file path */
-    public TestDatabaseResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public TestDatabaseResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -20994,9 +21736,9 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Causes Aspire to build the specified container image from a Dockerfile. */
-    public TestRedisResource withDockerfile(String contextPath, WithDockerfileOptions options) {
-        var dockerfilePath = options == null ? null : options.getDockerfilePath();
-        var stage = options == null ? null : options.getStage();
+    public TestRedisResource withDockerfile(String contextPath, WithDockerfileOptions optionsBag) {
+        var dockerfilePath = optionsBag == null ? null : optionsBag.getDockerfilePath();
+        var stage = optionsBag == null ? null : optionsBag.getStage();
         return withDockerfileImpl(contextPath, dockerfilePath, stage);
     }
 
@@ -21080,10 +21822,10 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Adds container certificate path overrides used for certificate trust at run time. */
-    public TestRedisResource withContainerCertificatePaths(WithContainerCertificatePathsOptions options) {
-        var customCertificatesDestination = options == null ? null : options.getCustomCertificatesDestination();
-        var defaultCertificateBundlePaths = options == null ? null : options.getDefaultCertificateBundlePaths();
-        var defaultCertificateDirectoryPaths = options == null ? null : options.getDefaultCertificateDirectoryPaths();
+    public TestRedisResource withContainerCertificatePaths(WithContainerCertificatePathsOptions optionsBag) {
+        var customCertificatesDestination = optionsBag == null ? null : optionsBag.getCustomCertificatesDestination();
+        var defaultCertificateBundlePaths = optionsBag == null ? null : optionsBag.getDefaultCertificateBundlePaths();
+        var defaultCertificateDirectoryPaths = optionsBag == null ? null : optionsBag.getDefaultCertificateDirectoryPaths();
         return withContainerCertificatePathsImpl(customCertificatesDestination, defaultCertificateBundlePaths, defaultCertificateDirectoryPaths);
     }
 
@@ -21133,9 +21875,9 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Configures custom base images for generated Dockerfiles. */
-    public TestRedisResource withDockerfileBaseImage(WithDockerfileBaseImageOptions options) {
-        var buildImage = options == null ? null : options.getBuildImage();
-        var runtimeImage = options == null ? null : options.getRuntimeImage();
+    public TestRedisResource withDockerfileBaseImage(WithDockerfileBaseImageOptions optionsBag) {
+        var buildImage = optionsBag == null ? null : optionsBag.getBuildImage();
+        var runtimeImage = optionsBag == null ? null : optionsBag.getRuntimeImage();
         return withDockerfileBaseImageImpl(buildImage, runtimeImage);
     }
 
@@ -21167,9 +21909,9 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Marks the resource as hosting a Model Context Protocol (MCP) server on the specified endpoint. */
-    public TestRedisResource withMcpServer(WithMcpServerOptions options) {
-        var path = options == null ? null : options.getPath();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public TestRedisResource withMcpServer(WithMcpServerOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withMcpServerImpl(path, endpointName);
     }
 
@@ -21411,10 +22153,10 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Adds a reference to another resource */
-    public TestRedisResource withReference(AspireUnion source, WithReferenceOptions options) {
-        var connectionName = options == null ? null : options.getConnectionName();
-        var optional = options == null ? null : options.getOptional();
-        var name = options == null ? null : options.getName();
+    public TestRedisResource withReference(AspireUnion source, WithReferenceOptions optionsBag) {
+        var connectionName = optionsBag == null ? null : optionsBag.getConnectionName();
+        var optional = optionsBag == null ? null : optionsBag.getOptional();
+        var name = optionsBag == null ? null : optionsBag.getName();
         return withReferenceImpl(source, connectionName, optional, name);
     }
 
@@ -21474,9 +22216,9 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Updates an HTTP endpoint via callback */
-    public TestRedisResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public TestRedisResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -21507,9 +22249,9 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Updates an HTTPS endpoint via callback */
-    public TestRedisResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public TestRedisResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpsEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -21540,15 +22282,15 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Adds a network endpoint */
-    public TestRedisResource withEndpoint(WithEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var scheme = options == null ? null : options.getScheme();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
-        var isExternal = options == null ? null : options.isExternal();
-        var protocol = options == null ? null : options.getProtocol();
+    public TestRedisResource withEndpoint(WithEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var scheme = optionsBag == null ? null : optionsBag.getScheme();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
+        var isExternal = optionsBag == null ? null : optionsBag.isExternal();
+        var protocol = optionsBag == null ? null : optionsBag.getProtocol();
         return withEndpointImpl(port, targetPort, scheme, name, env, isProxied, isExternal, protocol);
     }
 
@@ -21598,12 +22340,12 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Adds an HTTP endpoint */
-    public TestRedisResource withHttpEndpoint(WithHttpEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public TestRedisResource withHttpEndpoint(WithHttpEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -21635,12 +22377,12 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Adds an HTTPS endpoint */
-    public TestRedisResource withHttpsEndpoint(WithHttpsEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public TestRedisResource withHttpsEndpoint(WithHttpsEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpsEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -21851,10 +22593,10 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Adds a health check to the resource which is mapped to a specific endpoint. */
-    public TestRedisResource withHttpHealthCheck(WithHttpHealthCheckOptions options) {
-        var path = options == null ? null : options.getPath();
-        var statusCode = options == null ? null : options.getStatusCode();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public TestRedisResource withHttpHealthCheck(WithHttpHealthCheckOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var statusCode = optionsBag == null ? null : optionsBag.getStatusCode();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpHealthCheckImpl(path, statusCode, endpointName);
     }
 
@@ -22066,14 +22808,14 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Adds an HTTP health probe to the resource */
-    public TestRedisResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions options) {
-        var path = options == null ? null : options.getPath();
-        var initialDelaySeconds = options == null ? null : options.getInitialDelaySeconds();
-        var periodSeconds = options == null ? null : options.getPeriodSeconds();
-        var timeoutSeconds = options == null ? null : options.getTimeoutSeconds();
-        var failureThreshold = options == null ? null : options.getFailureThreshold();
-        var successThreshold = options == null ? null : options.getSuccessThreshold();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public TestRedisResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var initialDelaySeconds = optionsBag == null ? null : optionsBag.getInitialDelaySeconds();
+        var periodSeconds = optionsBag == null ? null : optionsBag.getPeriodSeconds();
+        var timeoutSeconds = optionsBag == null ? null : optionsBag.getTimeoutSeconds();
+        var failureThreshold = optionsBag == null ? null : optionsBag.getFailureThreshold();
+        var successThreshold = optionsBag == null ? null : optionsBag.getSuccessThreshold();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpProbeImpl(probeType, path, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold, successThreshold, endpointName);
     }
 
@@ -22128,9 +22870,9 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Hides the resource from default resource lists after successful completion */
-    public TestRedisResource withHiddenOnCompletion(WithHiddenOnCompletionOptions options) {
-        var exitCode = options == null ? null : options.getExitCode();
-        var exitCodes = options == null ? null : options.getExitCodes();
+    public TestRedisResource withHiddenOnCompletion(WithHiddenOnCompletionOptions optionsBag) {
+        var exitCode = optionsBag == null ? null : optionsBag.getExitCode();
+        var exitCodes = optionsBag == null ? null : optionsBag.getExitCodes();
         return withHiddenOnCompletionImpl(exitCode, exitCodes);
     }
 
@@ -22187,11 +22929,11 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Adds a pipeline step to the resource that will be executed during deployment. */
-    public TestRedisResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions options) {
-        var dependsOn = options == null ? null : options.getDependsOn();
-        var requiredBy = options == null ? null : options.getRequiredBy();
-        var tags = options == null ? null : options.getTags();
-        var description = options == null ? null : options.getDescription();
+    public TestRedisResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions optionsBag) {
+        var dependsOn = optionsBag == null ? null : optionsBag.getDependsOn();
+        var requiredBy = optionsBag == null ? null : optionsBag.getRequiredBy();
+        var tags = optionsBag == null ? null : optionsBag.getTags();
+        var description = optionsBag == null ? null : optionsBag.getDescription();
         return withPipelineStepFactoryImpl(stepName, callback, dependsOn, requiredBy, tags, description);
     }
 
@@ -22245,9 +22987,9 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Adds a volume to a container resource. */
-    public TestRedisResource withVolume(String target, WithVolumeOptions options) {
-        var name = options == null ? null : options.getName();
-        var isReadOnly = options == null ? null : options.isReadOnly();
+    public TestRedisResource withVolume(String target, WithVolumeOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var isReadOnly = optionsBag == null ? null : optionsBag.isReadOnly();
         return withVolumeImpl(target, name, isReadOnly);
     }
 
@@ -22414,9 +23156,9 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Adds an optional string parameter */
-    public TestRedisResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public TestRedisResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -22726,9 +23468,9 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Adds a data volume with persistence */
-    public TestRedisResource withDataVolume(WithDataVolumeOptions options) {
-        var name = options == null ? null : options.getName();
-        var isReadOnly = options == null ? null : options.isReadOnly();
+    public TestRedisResource withDataVolume(WithDataVolumeOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var isReadOnly = optionsBag == null ? null : optionsBag.isReadOnly();
         return withDataVolumeImpl(name, isReadOnly);
     }
 
@@ -22791,9 +23533,9 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Configures resource logging */
-    public TestRedisResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public TestRedisResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -22817,9 +23559,9 @@ public class TestRedisResource extends ContainerResource {
     }
 
     /** Configures resource logging with file path */
-    public TestRedisResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public TestRedisResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -23107,9 +23849,9 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Causes Aspire to build the specified container image from a Dockerfile. */
-    public TestVaultResource withDockerfile(String contextPath, WithDockerfileOptions options) {
-        var dockerfilePath = options == null ? null : options.getDockerfilePath();
-        var stage = options == null ? null : options.getStage();
+    public TestVaultResource withDockerfile(String contextPath, WithDockerfileOptions optionsBag) {
+        var dockerfilePath = optionsBag == null ? null : optionsBag.getDockerfilePath();
+        var stage = optionsBag == null ? null : optionsBag.getStage();
         return withDockerfileImpl(contextPath, dockerfilePath, stage);
     }
 
@@ -23193,10 +23935,10 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Adds container certificate path overrides used for certificate trust at run time. */
-    public TestVaultResource withContainerCertificatePaths(WithContainerCertificatePathsOptions options) {
-        var customCertificatesDestination = options == null ? null : options.getCustomCertificatesDestination();
-        var defaultCertificateBundlePaths = options == null ? null : options.getDefaultCertificateBundlePaths();
-        var defaultCertificateDirectoryPaths = options == null ? null : options.getDefaultCertificateDirectoryPaths();
+    public TestVaultResource withContainerCertificatePaths(WithContainerCertificatePathsOptions optionsBag) {
+        var customCertificatesDestination = optionsBag == null ? null : optionsBag.getCustomCertificatesDestination();
+        var defaultCertificateBundlePaths = optionsBag == null ? null : optionsBag.getDefaultCertificateBundlePaths();
+        var defaultCertificateDirectoryPaths = optionsBag == null ? null : optionsBag.getDefaultCertificateDirectoryPaths();
         return withContainerCertificatePathsImpl(customCertificatesDestination, defaultCertificateBundlePaths, defaultCertificateDirectoryPaths);
     }
 
@@ -23246,9 +23988,9 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Configures custom base images for generated Dockerfiles. */
-    public TestVaultResource withDockerfileBaseImage(WithDockerfileBaseImageOptions options) {
-        var buildImage = options == null ? null : options.getBuildImage();
-        var runtimeImage = options == null ? null : options.getRuntimeImage();
+    public TestVaultResource withDockerfileBaseImage(WithDockerfileBaseImageOptions optionsBag) {
+        var buildImage = optionsBag == null ? null : optionsBag.getBuildImage();
+        var runtimeImage = optionsBag == null ? null : optionsBag.getRuntimeImage();
         return withDockerfileBaseImageImpl(buildImage, runtimeImage);
     }
 
@@ -23280,9 +24022,9 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Marks the resource as hosting a Model Context Protocol (MCP) server on the specified endpoint. */
-    public TestVaultResource withMcpServer(WithMcpServerOptions options) {
-        var path = options == null ? null : options.getPath();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public TestVaultResource withMcpServer(WithMcpServerOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withMcpServerImpl(path, endpointName);
     }
 
@@ -23506,10 +24248,10 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Adds a reference to another resource */
-    public TestVaultResource withReference(AspireUnion source, WithReferenceOptions options) {
-        var connectionName = options == null ? null : options.getConnectionName();
-        var optional = options == null ? null : options.getOptional();
-        var name = options == null ? null : options.getName();
+    public TestVaultResource withReference(AspireUnion source, WithReferenceOptions optionsBag) {
+        var connectionName = optionsBag == null ? null : optionsBag.getConnectionName();
+        var optional = optionsBag == null ? null : optionsBag.getOptional();
+        var name = optionsBag == null ? null : optionsBag.getName();
         return withReferenceImpl(source, connectionName, optional, name);
     }
 
@@ -23560,9 +24302,9 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Updates an HTTP endpoint via callback */
-    public TestVaultResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public TestVaultResource withHttpEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -23593,9 +24335,9 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Updates an HTTPS endpoint via callback */
-    public TestVaultResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions options) {
-        var name = options == null ? null : options.getName();
-        var createIfNotExists = options == null ? null : options.getCreateIfNotExists();
+    public TestVaultResource withHttpsEndpointCallback(AspireAction1<EndpointUpdateContext> callback, WithHttpsEndpointCallbackOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var createIfNotExists = optionsBag == null ? null : optionsBag.getCreateIfNotExists();
         return withHttpsEndpointCallbackImpl(callback, name, createIfNotExists);
     }
 
@@ -23626,15 +24368,15 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Adds a network endpoint */
-    public TestVaultResource withEndpoint(WithEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var scheme = options == null ? null : options.getScheme();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
-        var isExternal = options == null ? null : options.isExternal();
-        var protocol = options == null ? null : options.getProtocol();
+    public TestVaultResource withEndpoint(WithEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var scheme = optionsBag == null ? null : optionsBag.getScheme();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
+        var isExternal = optionsBag == null ? null : optionsBag.isExternal();
+        var protocol = optionsBag == null ? null : optionsBag.getProtocol();
         return withEndpointImpl(port, targetPort, scheme, name, env, isProxied, isExternal, protocol);
     }
 
@@ -23684,12 +24426,12 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Adds an HTTP endpoint */
-    public TestVaultResource withHttpEndpoint(WithHttpEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public TestVaultResource withHttpEndpoint(WithHttpEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -23721,12 +24463,12 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Adds an HTTPS endpoint */
-    public TestVaultResource withHttpsEndpoint(WithHttpsEndpointOptions options) {
-        var port = options == null ? null : options.getPort();
-        var targetPort = options == null ? null : options.getTargetPort();
-        var name = options == null ? null : options.getName();
-        var env = options == null ? null : options.getEnv();
-        var isProxied = options == null ? null : options.isProxied();
+    public TestVaultResource withHttpsEndpoint(WithHttpsEndpointOptions optionsBag) {
+        var port = optionsBag == null ? null : optionsBag.getPort();
+        var targetPort = optionsBag == null ? null : optionsBag.getTargetPort();
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var env = optionsBag == null ? null : optionsBag.getEnv();
+        var isProxied = optionsBag == null ? null : optionsBag.isProxied();
         return withHttpsEndpointImpl(port, targetPort, name, env, isProxied);
     }
 
@@ -23937,10 +24679,10 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Adds a health check to the resource which is mapped to a specific endpoint. */
-    public TestVaultResource withHttpHealthCheck(WithHttpHealthCheckOptions options) {
-        var path = options == null ? null : options.getPath();
-        var statusCode = options == null ? null : options.getStatusCode();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public TestVaultResource withHttpHealthCheck(WithHttpHealthCheckOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var statusCode = optionsBag == null ? null : optionsBag.getStatusCode();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpHealthCheckImpl(path, statusCode, endpointName);
     }
 
@@ -24152,14 +24894,14 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Adds an HTTP health probe to the resource */
-    public TestVaultResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions options) {
-        var path = options == null ? null : options.getPath();
-        var initialDelaySeconds = options == null ? null : options.getInitialDelaySeconds();
-        var periodSeconds = options == null ? null : options.getPeriodSeconds();
-        var timeoutSeconds = options == null ? null : options.getTimeoutSeconds();
-        var failureThreshold = options == null ? null : options.getFailureThreshold();
-        var successThreshold = options == null ? null : options.getSuccessThreshold();
-        var endpointName = options == null ? null : options.getEndpointName();
+    public TestVaultResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
+        var path = optionsBag == null ? null : optionsBag.getPath();
+        var initialDelaySeconds = optionsBag == null ? null : optionsBag.getInitialDelaySeconds();
+        var periodSeconds = optionsBag == null ? null : optionsBag.getPeriodSeconds();
+        var timeoutSeconds = optionsBag == null ? null : optionsBag.getTimeoutSeconds();
+        var failureThreshold = optionsBag == null ? null : optionsBag.getFailureThreshold();
+        var successThreshold = optionsBag == null ? null : optionsBag.getSuccessThreshold();
+        var endpointName = optionsBag == null ? null : optionsBag.getEndpointName();
         return withHttpProbeImpl(probeType, path, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold, successThreshold, endpointName);
     }
 
@@ -24214,9 +24956,9 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Hides the resource from default resource lists after successful completion */
-    public TestVaultResource withHiddenOnCompletion(WithHiddenOnCompletionOptions options) {
-        var exitCode = options == null ? null : options.getExitCode();
-        var exitCodes = options == null ? null : options.getExitCodes();
+    public TestVaultResource withHiddenOnCompletion(WithHiddenOnCompletionOptions optionsBag) {
+        var exitCode = optionsBag == null ? null : optionsBag.getExitCode();
+        var exitCodes = optionsBag == null ? null : optionsBag.getExitCodes();
         return withHiddenOnCompletionImpl(exitCode, exitCodes);
     }
 
@@ -24273,11 +25015,11 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Adds a pipeline step to the resource that will be executed during deployment. */
-    public TestVaultResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions options) {
-        var dependsOn = options == null ? null : options.getDependsOn();
-        var requiredBy = options == null ? null : options.getRequiredBy();
-        var tags = options == null ? null : options.getTags();
-        var description = options == null ? null : options.getDescription();
+    public TestVaultResource withPipelineStepFactory(String stepName, AspireAction1<PipelineStepContext> callback, WithPipelineStepFactoryOptions optionsBag) {
+        var dependsOn = optionsBag == null ? null : optionsBag.getDependsOn();
+        var requiredBy = optionsBag == null ? null : optionsBag.getRequiredBy();
+        var tags = optionsBag == null ? null : optionsBag.getTags();
+        var description = optionsBag == null ? null : optionsBag.getDescription();
         return withPipelineStepFactoryImpl(stepName, callback, dependsOn, requiredBy, tags, description);
     }
 
@@ -24331,9 +25073,9 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Adds a volume to a container resource. */
-    public TestVaultResource withVolume(String target, WithVolumeOptions options) {
-        var name = options == null ? null : options.getName();
-        var isReadOnly = options == null ? null : options.isReadOnly();
+    public TestVaultResource withVolume(String target, WithVolumeOptions optionsBag) {
+        var name = optionsBag == null ? null : optionsBag.getName();
+        var isReadOnly = optionsBag == null ? null : optionsBag.isReadOnly();
         return withVolumeImpl(target, name, isReadOnly);
     }
 
@@ -24453,9 +25195,9 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Adds an optional string parameter */
-    public TestVaultResource withOptionalString(WithOptionalStringOptions options) {
-        var value = options == null ? null : options.getValue();
-        var enabled = options == null ? null : options.getEnabled();
+    public TestVaultResource withOptionalString(WithOptionalStringOptions optionsBag) {
+        var value = optionsBag == null ? null : optionsBag.getValue();
+        var enabled = optionsBag == null ? null : optionsBag.getEnabled();
         return withOptionalStringImpl(value, enabled);
     }
 
@@ -24713,9 +25455,9 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Configures resource logging */
-    public TestVaultResource withMergeLogging(String logLevel, WithMergeLoggingOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public TestVaultResource withMergeLogging(String logLevel, WithMergeLoggingOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingImpl(logLevel, enableConsole, maxFiles);
     }
 
@@ -24739,9 +25481,9 @@ public class TestVaultResource extends ContainerResource {
     }
 
     /** Configures resource logging with file path */
-    public TestVaultResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions options) {
-        var enableConsole = options == null ? null : options.getEnableConsole();
-        var maxFiles = options == null ? null : options.getMaxFiles();
+    public TestVaultResource withMergeLoggingPath(String logLevel, String logPath, WithMergeLoggingPathOptions optionsBag) {
+        var enableConsole = optionsBag == null ? null : optionsBag.getEnableConsole();
+        var maxFiles = optionsBag == null ? null : optionsBag.getMaxFiles();
         return withMergeLoggingPathImpl(logLevel, logPath, enableConsole, maxFiles);
     }
 
@@ -25720,6 +26462,7 @@ public final class WithVolumeOptions {
 .aspire/modules/BeforePublishEvent.java
 .aspire/modules/BeforeResourceStartedEvent.java
 .aspire/modules/BeforeStartEvent.java
+.aspire/modules/BooleanInteractionResult.java
 .aspire/modules/BuildOptions.java
 .aspire/modules/CSharpAppResource.java
 .aspire/modules/CancellationToken.java
@@ -25795,6 +26538,7 @@ public final class WithVolumeOptions {
 .aspire/modules/IExecutionConfigurationResult.java
 .aspire/modules/IExpressionValue.java
 .aspire/modules/IHostEnvironment.java
+.aspire/modules/IInteractionService.java
 .aspire/modules/ILogger.java
 .aspire/modules/ILoggerFactory.java
 .aspire/modules/IReportingStep.java
@@ -25813,12 +26557,19 @@ public final class WithVolumeOptions {
 .aspire/modules/IconVariant.java
 .aspire/modules/ImagePullPolicy.java
 .aspire/modules/InitializeResourceEvent.java
+.aspire/modules/InputInteractionResult.java
 .aspire/modules/InputType.java
+.aspire/modules/InputsDialogInteractionOptions.java
 .aspire/modules/InputsDialogValidationContext.java
+.aspire/modules/InputsInteractionResult.java
 .aspire/modules/InteractionInput.java
 .aspire/modules/InteractionInputCollection.java
+.aspire/modules/InteractionOptions.java
 .aspire/modules/JsonSerializable.java
 .aspire/modules/LogFacade.java
+.aspire/modules/MessageBoxInteractionOptions.java
+.aspire/modules/MessageIntent.java
+.aspire/modules/NotificationInteractionOptions.java
 .aspire/modules/OtlpProtocol.java
 .aspire/modules/ParameterCustomInputOptions.java
 .aspire/modules/ParameterResource.java
@@ -25835,6 +26586,12 @@ public final class WithVolumeOptions {
 .aspire/modules/ProcessCommandSpecExportData.java
 .aspire/modules/ProjectResource.java
 .aspire/modules/ProjectResourceOptions.java
+.aspire/modules/PromptConfirmationAsyncOptions.java
+.aspire/modules/PromptInputAsyncOptions.java
+.aspire/modules/PromptInputWithInputAsyncOptions.java
+.aspire/modules/PromptInputsAsyncOptions.java
+.aspire/modules/PromptMessageBoxAsyncOptions.java
+.aspire/modules/PromptNotificationAsyncOptions.java
 .aspire/modules/ProtocolType.java
 .aspire/modules/PublishResourceUpdateOptions.java
 .aspire/modules/ReferenceEnvironmentInjectionOptions.java

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1833,7 +1833,13 @@ class InputInteractionResult(typing.TypedDict, total=False):
     Data: InteractionInput
     Canceled: bool
 
+class InputLoadOptions(typing.TypedDict, total=False):
+    LoadCallback: typing.Callable
+    AlwaysLoadOnStart: bool
+    DependsOnInputs: typing.Iterable[str]
+
 class InputsDialogInteractionOptions(typing.TypedDict, total=False):
+    ValidationCallback: typing.Callable
     PrimaryButtonText: str | None
     SecondaryButtonText: str | None
     ShowSecondaryButton: bool | None
@@ -1852,7 +1858,7 @@ class InteractionInput(typing.TypedDict, total=False):
     InputType: InputType
     Required: bool
     Options: typing.Iterable[typing.Any]
-    DynamicLoading: typing.Any
+    DynamicLoading: InputLoadOptions
     Value: str | None
     Placeholder: str | None
     AllowCustomChoice: bool
@@ -4931,6 +4937,15 @@ class ExecuteCommandContext:
         return self._handle
 
     @_cached_property
+    def service_provider(self) -> AbstractServiceProvider:
+        """The service provider."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.serviceProvider',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractServiceProvider, result)
+
+    @_cached_property
     def resource_name(self) -> str:
         """The resource name."""
         result = self._client.invoke_capability(
@@ -5093,6 +5108,57 @@ class InteractionInputCollection:
             rpc_args,
         )
         return result
+
+
+class LoadInputContext:
+    """Type class for LoadInputContext."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"LoadInputContext(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    @_cached_property
+    def input(self) -> InteractionInput:
+        """Gets the loading input. This is the target of `InputLoadOptions`."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/LoadInputContext.input',
+            {'context': self._handle}
+        )
+        return typing.cast(InteractionInput, result)
+
+    @_cached_property
+    def all_inputs(self) -> InteractionInputCollection:
+        """Gets the collection of all `InteractionInput` in this prompt."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/LoadInputContext.allInputs',
+            {'context': self._handle}
+        )
+        return typing.cast(InteractionInputCollection, result)
+
+    def cancel(self) -> None:
+        """Cancel the operation."""
+        token: CancellationToken = self._client.invoke_capability(
+            'Aspire.Hosting/LoadInputContext.cancellationToken',
+            {'context': self._handle}
+        )
+        token.cancel()
+
+    def set_options(self, options: typing.Mapping[str, str]) -> None:
+        """Sets the available options for the loading input."""
+        rpc_args: dict[str, typing.Any] = {'context': self._handle}
+        rpc_args['options'] = options
+        self._client.invoke_capability(
+            'Aspire.Hosting/LoadInputContext.setOptions',
+            rpc_args
+        )
 
 
 class LogFacade:
@@ -11622,9 +11688,9 @@ def create_builder(
 
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression", lambda handle, _: ReferenceExpression(handle))
 _register_handle_wrapper("System.Private.CoreLib/System.Threading.CancellationToken", CancellationToken)
+_register_handle_wrapper("Aspire.Hosting/Dict<string,string>", AspireDict)
 _register_handle_wrapper("Aspire.Hosting/List<string>", AspireList)
 _register_handle_wrapper("Aspire.Hosting/Dict<string,any>", AspireDict)
-_register_handle_wrapper("Aspire.Hosting/Dict<string,string>", AspireDict)
 _register_handle_wrapper("Aspire.Hosting/Dict<string,number>", AspireDict)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IAspireStore", AbstractAspireStore)
 _register_handle_wrapper("Microsoft.Extensions.Configuration.Abstractions/Microsoft.Extensions.Configuration.IConfiguration", AbstractConfiguration)
@@ -11672,6 +11738,7 @@ _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.Execute
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent", InitializeResourceEvent)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.InputsDialogValidationContext", InputsDialogValidationContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.InteractionInputCollection", InteractionInputCollection)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.LoadInputContext", LoadInputContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.LogFacade", LogFacade)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineConfigurationContext", PipelineConfigurationContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineContext", PipelineContext)

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1526,6 +1526,8 @@ ImagePullPolicy = typing.Literal["Default", "Always", "Missing", "Never"]
 
 InputType = typing.Literal["Text", "SecretText", "Choice", "Boolean", "Number"]
 
+MessageIntent = typing.Literal["None", "Success", "Warning", "Error", "Information", "Confirmation"]
+
 OtlpProtocol = typing.Literal["Grpc", "HttpProtobuf", "HttpJson"]
 
 ProbeType = typing.Literal["Startup", "Readiness", "Liveness"]
@@ -1737,6 +1739,10 @@ class AddContainerOptions(typing.TypedDict, total=False):
     Image: str
     Tag: str | None
 
+class BooleanInteractionResult(typing.TypedDict, total=False):
+    Data: bool | None
+    Canceled: bool
+
 class CertificateTrustExecutionConfigurationContext(typing.TypedDict, total=False):
     CertificateBundlePath: ReferenceExpression
     CertificateDirectoriesPath: ReferenceExpression
@@ -1823,6 +1829,21 @@ class HttpsCertificateInfo(typing.TypedDict, total=False):
     Issuer: str
     Thumbprint: str | None
 
+class InputInteractionResult(typing.TypedDict, total=False):
+    Data: InteractionInput
+    Canceled: bool
+
+class InputsDialogInteractionOptions(typing.TypedDict, total=False):
+    PrimaryButtonText: str | None
+    SecondaryButtonText: str | None
+    ShowSecondaryButton: bool | None
+    ShowDismiss: bool | None
+    EnableMessageMarkdown: bool | None
+
+class InputsInteractionResult(typing.TypedDict, total=False):
+    Data: InteractionInputCollection
+    Canceled: bool
+
 class InteractionInput(typing.TypedDict, total=False):
     Name: str
     Label: str | None
@@ -1837,6 +1858,31 @@ class InteractionInput(typing.TypedDict, total=False):
     AllowCustomChoice: bool
     Disabled: bool
     MaxLength: int | None
+
+class InteractionOptions(typing.TypedDict, total=False):
+    PrimaryButtonText: str | None
+    SecondaryButtonText: str | None
+    ShowSecondaryButton: bool | None
+    ShowDismiss: bool | None
+    EnableMessageMarkdown: bool | None
+
+class MessageBoxInteractionOptions(typing.TypedDict, total=False):
+    Intent: MessageIntent | None
+    PrimaryButtonText: str | None
+    SecondaryButtonText: str | None
+    ShowSecondaryButton: bool | None
+    ShowDismiss: bool | None
+    EnableMessageMarkdown: bool | None
+
+class NotificationInteractionOptions(typing.TypedDict, total=False):
+    Intent: MessageIntent | None
+    LinkText: str | None
+    LinkUrl: str | None
+    PrimaryButtonText: str | None
+    SecondaryButtonText: str | None
+    ShowSecondaryButton: bool | None
+    ShowDismiss: bool | None
+    EnableMessageMarkdown: bool | None
 
 class ParameterCustomInputOptions(typing.TypedDict, total=False):
     InputType: InputType | None
@@ -2817,6 +2863,125 @@ class AbstractHostEnvironment:
         return result
 
 
+class AbstractInteractionService:
+    """Type class for AbstractInteractionService."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"AbstractInteractionService(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    def is_available(self) -> bool:
+        """Gets a value indicating whether the interaction service is available."""
+        rpc_args: dict[str, typing.Any] = {'interactionService': self._handle}
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/interactionServiceIsAvailable',
+            rpc_args,
+        )
+        return result
+
+    def prompt_confirmation(self, title: str, message: str, *, options: MessageBoxInteractionOptions | None = None, timeout: int | None = None) -> BooleanInteractionResult:
+        """Prompts the user for confirmation with a dialog."""
+        rpc_args: dict[str, typing.Any] = {'interactionService': self._handle}
+        rpc_args['title'] = title
+        rpc_args['message'] = message
+        if options is not None:
+            rpc_args['options'] = options
+        if timeout is not None:
+            rpc_args['cancellationToken'] = self._client.register_cancellation_token(timeout)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/promptConfirmationAsync',
+            rpc_args,
+        )
+        return typing.cast(BooleanInteractionResult, result)
+
+    def prompt_message_box(self, title: str, message: str, *, options: MessageBoxInteractionOptions | None = None, timeout: int | None = None) -> BooleanInteractionResult:
+        """Prompts the user with a message box dialog."""
+        rpc_args: dict[str, typing.Any] = {'interactionService': self._handle}
+        rpc_args['title'] = title
+        rpc_args['message'] = message
+        if options is not None:
+            rpc_args['options'] = options
+        if timeout is not None:
+            rpc_args['cancellationToken'] = self._client.register_cancellation_token(timeout)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/promptMessageBoxAsync',
+            rpc_args,
+        )
+        return typing.cast(BooleanInteractionResult, result)
+
+    def prompt_input(self, title: str, message: str, input_label: str, place_holder: str, *, options: InputsDialogInteractionOptions | None = None, timeout: int | None = None) -> InputInteractionResult:
+        """Prompts the user for a single text input."""
+        rpc_args: dict[str, typing.Any] = {'interactionService': self._handle}
+        rpc_args['title'] = title
+        rpc_args['message'] = message
+        rpc_args['inputLabel'] = input_label
+        rpc_args['placeHolder'] = place_holder
+        if options is not None:
+            rpc_args['options'] = options
+        if timeout is not None:
+            rpc_args['cancellationToken'] = self._client.register_cancellation_token(timeout)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/promptInputAsync',
+            rpc_args,
+        )
+        return typing.cast(InputInteractionResult, result)
+
+    def prompt_input_with_input(self, title: str, message: str, input: InteractionInput, *, options: InputsDialogInteractionOptions | None = None, timeout: int | None = None) -> InputInteractionResult:
+        """Prompts the user for a single input using a specified `InteractionInput`."""
+        rpc_args: dict[str, typing.Any] = {'interactionService': self._handle}
+        rpc_args['title'] = title
+        rpc_args['message'] = message
+        rpc_args['input'] = input
+        if options is not None:
+            rpc_args['options'] = options
+        if timeout is not None:
+            rpc_args['cancellationToken'] = self._client.register_cancellation_token(timeout)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/promptInputWithInput',
+            rpc_args,
+        )
+        return typing.cast(InputInteractionResult, result)
+
+    def prompt_inputs(self, title: str, message: str, inputs: typing.Iterable[InteractionInput], *, options: InputsDialogInteractionOptions | None = None, timeout: int | None = None) -> InputsInteractionResult:
+        """Prompts the user for multiple inputs."""
+        rpc_args: dict[str, typing.Any] = {'interactionService': self._handle}
+        rpc_args['title'] = title
+        rpc_args['message'] = message
+        rpc_args['inputs'] = inputs
+        if options is not None:
+            rpc_args['options'] = options
+        if timeout is not None:
+            rpc_args['cancellationToken'] = self._client.register_cancellation_token(timeout)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/promptInputsAsync',
+            rpc_args,
+        )
+        return typing.cast(InputsInteractionResult, result)
+
+    def prompt_notification(self, title: str, message: str, *, options: NotificationInteractionOptions | None = None, timeout: int | None = None) -> BooleanInteractionResult:
+        """Prompts the user with a notification."""
+        rpc_args: dict[str, typing.Any] = {'interactionService': self._handle}
+        rpc_args['title'] = title
+        rpc_args['message'] = message
+        if options is not None:
+            rpc_args['options'] = options
+        if timeout is not None:
+            rpc_args['cancellationToken'] = self._client.register_cancellation_token(timeout)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/promptNotificationAsync',
+            rpc_args,
+        )
+        return typing.cast(BooleanInteractionResult, result)
+
+
 class AbstractLogger:
     """Type class for AbstractLogger."""
 
@@ -3091,6 +3256,15 @@ class AbstractServiceProvider:
             rpc_args,
         )
         return typing.cast(AbstractDistributedApplicationEventing, result)
+
+    def get_interaction_service(self) -> AbstractInteractionService:
+        """Gets the interaction service from the service provider."""
+        rpc_args: dict[str, typing.Any] = {'serviceProvider': self._handle}
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/getInteractionService',
+            rpc_args,
+        )
+        return typing.cast(AbstractInteractionService, result)
 
     def get_logger_factory(self) -> AbstractLoggerFactory:
         """Gets the logger factory from the service provider."""
@@ -11460,6 +11634,7 @@ _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedAp
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationBuilder", AbstractExecutionConfigurationBuilder)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationResult", AbstractExecutionConfigurationResult)
 _register_handle_wrapper("Microsoft.Extensions.Hosting.Abstractions/Microsoft.Extensions.Hosting.IHostEnvironment", AbstractHostEnvironment)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.IInteractionService", AbstractInteractionService)
 _register_handle_wrapper("Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILogger", AbstractLogger)
 _register_handle_wrapper("Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILoggerFactory", AbstractLoggerFactory)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingStep", AbstractReportingStep)

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -576,6 +576,31 @@ impl std::fmt::Display for TestResourceStatus {
 // DTOs
 // ============================================================================
 
+/// InputLoadOptions
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct InputLoadOptions {
+    #[serde(rename = "LoadCallback")]
+    pub load_callback: Value,
+    #[serde(rename = "AlwaysLoadOnStart", skip_serializing_if = "Option::is_none")]
+    pub always_load_on_start: Option<bool>,
+    #[serde(rename = "DependsOnInputs", skip_serializing_if = "Option::is_none")]
+    pub depends_on_inputs: Option<Vec<String>>,
+}
+
+impl InputLoadOptions {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("LoadCallback".to_string(), serde_json::to_value(&self.load_callback).unwrap_or(Value::Null));
+        if let Some(ref v) = self.always_load_on_start {
+            map.insert("AlwaysLoadOnStart".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.depends_on_inputs {
+            map.insert("DependsOnInputs".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        map
+    }
+}
+
 /// InteractionInput
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct InteractionInput {
@@ -594,7 +619,7 @@ pub struct InteractionInput {
     #[serde(rename = "Options")]
     pub options: Vec<Value>,
     #[serde(rename = "DynamicLoading", skip_serializing_if = "Option::is_none")]
-    pub dynamic_loading: Option<Value>,
+    pub dynamic_loading: Option<InputLoadOptions>,
     #[serde(rename = "Value")]
     pub value: String,
     #[serde(rename = "Placeholder", skip_serializing_if = "Option::is_none")]
@@ -862,6 +887,8 @@ impl MessageBoxInteractionOptions {
 /// InputsDialogInteractionOptions
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct InputsDialogInteractionOptions {
+    #[serde(rename = "ValidationCallback", skip_serializing_if = "Option::is_none")]
+    pub validation_callback: Option<Value>,
     #[serde(rename = "PrimaryButtonText", skip_serializing_if = "Option::is_none")]
     pub primary_button_text: Option<String>,
     #[serde(rename = "SecondaryButtonText", skip_serializing_if = "Option::is_none")]
@@ -877,6 +904,9 @@ pub struct InputsDialogInteractionOptions {
 impl InputsDialogInteractionOptions {
     pub fn to_map(&self) -> HashMap<String, Value> {
         let mut map = HashMap::new();
+        if let Some(ref v) = self.validation_callback {
+            map.insert("ValidationCallback".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
         if let Some(ref v) = self.primary_button_text {
             map.insert("PrimaryButtonText".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
@@ -9098,6 +9128,15 @@ impl ExecuteCommandContext {
         &self.client
     }
 
+    /// The service provider.
+    pub fn service_provider(&self) -> Result<IServiceProvider, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ExecuteCommandContext.serviceProvider", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IServiceProvider::new(handle, self.client.clone()))
+    }
+
     /// The resource name.
     pub fn resource_name(&self) -> Result<String, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -11879,6 +11918,67 @@ impl InteractionInputCollection {
         args.insert("context".to_string(), self.handle.to_json());
         let result = self.client.invoke_capability("Aspire.Hosting/InteractionInputCollection.toArray", args)?;
         Ok(serde_json::from_value(result)?)
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.LoadInputContext
+pub struct LoadInputContext {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for LoadInputContext {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl LoadInputContext {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Gets the loading input. This is the target of `InputLoadOptions`.
+    pub fn input(&self) -> Result<InteractionInput, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/LoadInputContext.input", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Gets the collection of all `InteractionInput` in this prompt.
+    pub fn all_inputs(&self) -> Result<InteractionInputCollection, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/LoadInputContext.allInputs", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(InteractionInputCollection::new(handle, self.client.clone()))
+    }
+
+    /// Gets the `CancellationToken`.
+    pub fn cancellation_token(&self) -> Result<CancellationToken, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/LoadInputContext.cancellationToken", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(CancellationToken::new(handle, self.client.clone()))
+    }
+
+    /// Sets the available options for the loading input.
+    pub fn set_options(&self, options: HashMap<String, String>) -> Result<(), Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/LoadInputContext.setOptions", args)?;
+        Ok(())
     }
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -362,6 +362,37 @@ impl std::fmt::Display for InputType {
     }
 }
 
+/// MessageIntent
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MessageIntent {
+    #[default]
+    #[serde(rename = "None")]
+    None,
+    #[serde(rename = "Success")]
+    Success,
+    #[serde(rename = "Warning")]
+    Warning,
+    #[serde(rename = "Error")]
+    Error,
+    #[serde(rename = "Information")]
+    Information,
+    #[serde(rename = "Confirmation")]
+    Confirmation,
+}
+
+impl std::fmt::Display for MessageIntent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "None"),
+            Self::Success => write!(f, "Success"),
+            Self::Warning => write!(f, "Warning"),
+            Self::Error => write!(f, "Error"),
+            Self::Information => write!(f, "Information"),
+            Self::Confirmation => write!(f, "Confirmation"),
+        }
+    }
+}
+
 /// ResourceCommandVisibility
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ResourceCommandVisibility {
@@ -745,6 +776,234 @@ impl HttpsCertificateExecutionConfigurationExportData {
         if let Some(ref v) = self.password {
             map.insert("Password".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
+        map
+    }
+}
+
+/// InteractionOptions
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct InteractionOptions {
+    #[serde(rename = "PrimaryButtonText", skip_serializing_if = "Option::is_none")]
+    pub primary_button_text: Option<String>,
+    #[serde(rename = "SecondaryButtonText", skip_serializing_if = "Option::is_none")]
+    pub secondary_button_text: Option<String>,
+    #[serde(rename = "ShowSecondaryButton", skip_serializing_if = "Option::is_none")]
+    pub show_secondary_button: Option<bool>,
+    #[serde(rename = "ShowDismiss", skip_serializing_if = "Option::is_none")]
+    pub show_dismiss: Option<bool>,
+    #[serde(rename = "EnableMessageMarkdown", skip_serializing_if = "Option::is_none")]
+    pub enable_message_markdown: Option<bool>,
+}
+
+impl InteractionOptions {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        if let Some(ref v) = self.primary_button_text {
+            map.insert("PrimaryButtonText".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.secondary_button_text {
+            map.insert("SecondaryButtonText".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.show_secondary_button {
+            map.insert("ShowSecondaryButton".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.show_dismiss {
+            map.insert("ShowDismiss".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.enable_message_markdown {
+            map.insert("EnableMessageMarkdown".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        map
+    }
+}
+
+/// MessageBoxInteractionOptions
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MessageBoxInteractionOptions {
+    #[serde(rename = "Intent", skip_serializing_if = "Option::is_none")]
+    pub intent: Option<MessageIntent>,
+    #[serde(rename = "PrimaryButtonText", skip_serializing_if = "Option::is_none")]
+    pub primary_button_text: Option<String>,
+    #[serde(rename = "SecondaryButtonText", skip_serializing_if = "Option::is_none")]
+    pub secondary_button_text: Option<String>,
+    #[serde(rename = "ShowSecondaryButton", skip_serializing_if = "Option::is_none")]
+    pub show_secondary_button: Option<bool>,
+    #[serde(rename = "ShowDismiss", skip_serializing_if = "Option::is_none")]
+    pub show_dismiss: Option<bool>,
+    #[serde(rename = "EnableMessageMarkdown", skip_serializing_if = "Option::is_none")]
+    pub enable_message_markdown: Option<bool>,
+}
+
+impl MessageBoxInteractionOptions {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        if let Some(ref v) = self.intent {
+            map.insert("Intent".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.primary_button_text {
+            map.insert("PrimaryButtonText".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.secondary_button_text {
+            map.insert("SecondaryButtonText".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.show_secondary_button {
+            map.insert("ShowSecondaryButton".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.show_dismiss {
+            map.insert("ShowDismiss".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.enable_message_markdown {
+            map.insert("EnableMessageMarkdown".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        map
+    }
+}
+
+/// InputsDialogInteractionOptions
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct InputsDialogInteractionOptions {
+    #[serde(rename = "PrimaryButtonText", skip_serializing_if = "Option::is_none")]
+    pub primary_button_text: Option<String>,
+    #[serde(rename = "SecondaryButtonText", skip_serializing_if = "Option::is_none")]
+    pub secondary_button_text: Option<String>,
+    #[serde(rename = "ShowSecondaryButton", skip_serializing_if = "Option::is_none")]
+    pub show_secondary_button: Option<bool>,
+    #[serde(rename = "ShowDismiss", skip_serializing_if = "Option::is_none")]
+    pub show_dismiss: Option<bool>,
+    #[serde(rename = "EnableMessageMarkdown", skip_serializing_if = "Option::is_none")]
+    pub enable_message_markdown: Option<bool>,
+}
+
+impl InputsDialogInteractionOptions {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        if let Some(ref v) = self.primary_button_text {
+            map.insert("PrimaryButtonText".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.secondary_button_text {
+            map.insert("SecondaryButtonText".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.show_secondary_button {
+            map.insert("ShowSecondaryButton".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.show_dismiss {
+            map.insert("ShowDismiss".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.enable_message_markdown {
+            map.insert("EnableMessageMarkdown".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        map
+    }
+}
+
+/// NotificationInteractionOptions
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NotificationInteractionOptions {
+    #[serde(rename = "Intent", skip_serializing_if = "Option::is_none")]
+    pub intent: Option<MessageIntent>,
+    #[serde(rename = "LinkText", skip_serializing_if = "Option::is_none")]
+    pub link_text: Option<String>,
+    #[serde(rename = "LinkUrl", skip_serializing_if = "Option::is_none")]
+    pub link_url: Option<String>,
+    #[serde(rename = "PrimaryButtonText", skip_serializing_if = "Option::is_none")]
+    pub primary_button_text: Option<String>,
+    #[serde(rename = "SecondaryButtonText", skip_serializing_if = "Option::is_none")]
+    pub secondary_button_text: Option<String>,
+    #[serde(rename = "ShowSecondaryButton", skip_serializing_if = "Option::is_none")]
+    pub show_secondary_button: Option<bool>,
+    #[serde(rename = "ShowDismiss", skip_serializing_if = "Option::is_none")]
+    pub show_dismiss: Option<bool>,
+    #[serde(rename = "EnableMessageMarkdown", skip_serializing_if = "Option::is_none")]
+    pub enable_message_markdown: Option<bool>,
+}
+
+impl NotificationInteractionOptions {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        if let Some(ref v) = self.intent {
+            map.insert("Intent".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.link_text {
+            map.insert("LinkText".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.link_url {
+            map.insert("LinkUrl".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.primary_button_text {
+            map.insert("PrimaryButtonText".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.secondary_button_text {
+            map.insert("SecondaryButtonText".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.show_secondary_button {
+            map.insert("ShowSecondaryButton".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.show_dismiss {
+            map.insert("ShowDismiss".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.enable_message_markdown {
+            map.insert("EnableMessageMarkdown".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        map
+    }
+}
+
+/// BooleanInteractionResult
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BooleanInteractionResult {
+    #[serde(rename = "Data", skip_serializing_if = "Option::is_none")]
+    pub data: Option<bool>,
+    #[serde(rename = "Canceled")]
+    pub canceled: bool,
+}
+
+impl BooleanInteractionResult {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        if let Some(ref v) = self.data {
+            map.insert("Data".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        map.insert("Canceled".to_string(), serde_json::to_value(&self.canceled).unwrap_or(Value::Null));
+        map
+    }
+}
+
+/// InputInteractionResult
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct InputInteractionResult {
+    #[serde(rename = "Data", skip_serializing_if = "Option::is_none")]
+    pub data: Option<InteractionInput>,
+    #[serde(rename = "Canceled")]
+    pub canceled: bool,
+}
+
+impl InputInteractionResult {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        if let Some(ref v) = self.data {
+            map.insert("Data".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        map.insert("Canceled".to_string(), serde_json::to_value(&self.canceled).unwrap_or(Value::Null));
+        map
+    }
+}
+
+/// InputsInteractionResult
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct InputsInteractionResult {
+    #[serde(rename = "Data", skip_serializing_if = "Option::is_none")]
+    pub data: Option<Handle>,
+    #[serde(rename = "Canceled")]
+    pub canceled: bool,
+}
+
+impl InputsInteractionResult {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        if let Some(ref v) = self.data {
+            map.insert("Data".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        map.insert("Canceled".to_string(), serde_json::to_value(&self.canceled).unwrap_or(Value::Null));
         map
     }
 }
@@ -10579,6 +10838,146 @@ impl IHostEnvironment {
     }
 }
 
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.IInteractionService
+pub struct IInteractionService {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for IInteractionService {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl IInteractionService {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Gets a value indicating whether the interaction service is available.
+    pub fn is_available(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("interactionService".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/interactionServiceIsAvailable", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Prompts the user for confirmation with a dialog.
+    pub fn prompt_confirmation_async(&self, title: &str, message: &str, options: Option<MessageBoxInteractionOptions>, cancellation_token: Option<&CancellationToken>) -> Result<BooleanInteractionResult, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("interactionService".to_string(), self.handle.to_json());
+        args.insert("title".to_string(), serde_json::to_value(&title).unwrap_or(Value::Null));
+        args.insert("message".to_string(), serde_json::to_value(&message).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(token) = cancellation_token {
+            let token_id = register_cancellation(token, self.client.clone());
+            args.insert("cancellationToken".to_string(), Value::String(token_id));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/promptConfirmationAsync", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Prompts the user with a message box dialog.
+    pub fn prompt_message_box_async(&self, title: &str, message: &str, options: Option<MessageBoxInteractionOptions>, cancellation_token: Option<&CancellationToken>) -> Result<BooleanInteractionResult, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("interactionService".to_string(), self.handle.to_json());
+        args.insert("title".to_string(), serde_json::to_value(&title).unwrap_or(Value::Null));
+        args.insert("message".to_string(), serde_json::to_value(&message).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(token) = cancellation_token {
+            let token_id = register_cancellation(token, self.client.clone());
+            args.insert("cancellationToken".to_string(), Value::String(token_id));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/promptMessageBoxAsync", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Prompts the user for a single text input.
+    pub fn prompt_input_async(&self, title: &str, message: &str, input_label: &str, place_holder: &str, options: Option<InputsDialogInteractionOptions>, cancellation_token: Option<&CancellationToken>) -> Result<InputInteractionResult, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("interactionService".to_string(), self.handle.to_json());
+        args.insert("title".to_string(), serde_json::to_value(&title).unwrap_or(Value::Null));
+        args.insert("message".to_string(), serde_json::to_value(&message).unwrap_or(Value::Null));
+        args.insert("inputLabel".to_string(), serde_json::to_value(&input_label).unwrap_or(Value::Null));
+        args.insert("placeHolder".to_string(), serde_json::to_value(&place_holder).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(token) = cancellation_token {
+            let token_id = register_cancellation(token, self.client.clone());
+            args.insert("cancellationToken".to_string(), Value::String(token_id));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/promptInputAsync", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Prompts the user for a single input using a specified `InteractionInput`.
+    pub fn prompt_input_with_input_async(&self, title: &str, message: &str, input: InteractionInput, options: Option<InputsDialogInteractionOptions>, cancellation_token: Option<&CancellationToken>) -> Result<InputInteractionResult, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("interactionService".to_string(), self.handle.to_json());
+        args.insert("title".to_string(), serde_json::to_value(&title).unwrap_or(Value::Null));
+        args.insert("message".to_string(), serde_json::to_value(&message).unwrap_or(Value::Null));
+        args.insert("input".to_string(), serde_json::to_value(&input).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(token) = cancellation_token {
+            let token_id = register_cancellation(token, self.client.clone());
+            args.insert("cancellationToken".to_string(), Value::String(token_id));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/promptInputWithInput", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Prompts the user for multiple inputs.
+    pub fn prompt_inputs_async(&self, title: &str, message: &str, inputs: Vec<InteractionInput>, options: Option<InputsDialogInteractionOptions>, cancellation_token: Option<&CancellationToken>) -> Result<InputsInteractionResult, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("interactionService".to_string(), self.handle.to_json());
+        args.insert("title".to_string(), serde_json::to_value(&title).unwrap_or(Value::Null));
+        args.insert("message".to_string(), serde_json::to_value(&message).unwrap_or(Value::Null));
+        args.insert("inputs".to_string(), serde_json::to_value(&inputs).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(token) = cancellation_token {
+            let token_id = register_cancellation(token, self.client.clone());
+            args.insert("cancellationToken".to_string(), Value::String(token_id));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/promptInputsAsync", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Prompts the user with a notification.
+    pub fn prompt_notification_async(&self, title: &str, message: &str, options: Option<NotificationInteractionOptions>, cancellation_token: Option<&CancellationToken>) -> Result<BooleanInteractionResult, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("interactionService".to_string(), self.handle.to_json());
+        args.insert("title".to_string(), serde_json::to_value(&title).unwrap_or(Value::Null));
+        args.insert("message".to_string(), serde_json::to_value(&message).unwrap_or(Value::Null));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(token) = cancellation_token {
+            let token_id = register_cancellation(token, self.client.clone());
+            args.insert("cancellationToken".to_string(), Value::String(token_id));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/promptNotificationAsync", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+}
+
 /// Wrapper for Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILogger
 pub struct ILogger {
     handle: Handle,
@@ -11138,6 +11537,15 @@ impl IServiceProvider {
         let result = self.client.invoke_capability("Aspire.Hosting/getEventing", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IDistributedApplicationEventing::new(handle, self.client.clone()))
+    }
+
+    /// Gets the interaction service from the service provider.
+    pub fn get_interaction_service(&self) -> Result<IInteractionService, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("serviceProvider".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/getInteractionService", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IInteractionService::new(handle, self.client.clone()))
     }
 
     /// Gets the logger factory from the service provider.

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
@@ -141,7 +141,7 @@ export interface TestDeeplyNestedDto {
 /** Test DTO with complex nested types. */
 export interface TestNestedDto {
     id?: string;
-    config?: TestConfigDto;
+    config?: TestConfigDto | null;
     tags?: string[];
     counts?: Record<string, number>;
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -327,6 +327,9 @@ type ExternalServiceResourceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Exter
 /** A builder for creating instances of {@link DistributedApplication}. */
 type IDistributedApplicationBuilderHandle = Handle<'Aspire.Hosting/Aspire.Hosting.IDistributedApplicationBuilder'>;
 
+/** A service to interact with the current development environment. */
+type IInteractionServiceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.IInteractionService'>;
+
 /** Represents the context for validating inputs in an inputs dialog interaction. */
 type InputsDialogValidationContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.InputsDialogValidationContext'>;
 
@@ -530,6 +533,22 @@ export enum ImagePullPolicy {
     Never = "Never",
 }
 
+/** Specifies the intent or purpose of a message in an interaction. */
+export enum MessageIntent {
+    /** No specific intent. */
+    None = "None",
+    /** Indicates a successful operation. */
+    Success = "Success",
+    /** Indicates a warning. */
+    Warning = "Warning",
+    /** Indicates an error. */
+    Error = "Error",
+    /** Provides informational content. */
+    Information = "Information",
+    /** Requests confirmation from the user. */
+    Confirmation = "Confirmation",
+}
+
 /** Protocols available for OTLP exporters. */
 export enum OtlpProtocol {
     /** A gRPC-based OTLP exporter. */
@@ -644,6 +663,14 @@ export interface AddContainerOptions {
     image?: string;
     /** The container image tag. */
     tag?: string | null;
+}
+
+/** The result of a boolean interaction prompt. */
+export interface BooleanInteractionResult {
+    /** The data returned from the interaction. The value is `null` when the interaction was canceled. */
+    data?: boolean | null;
+    /** A flag indicating whether the interaction was canceled by the user. */
+    canceled?: boolean;
 }
 
 /** Context for configuring certificate trust configuration properties. */
@@ -863,6 +890,86 @@ export interface HttpsCertificateInfo {
     issuer?: string;
     /** The certificate thumbprint. */
     thumbprint?: string | null;
+}
+
+/** The result of a single input interaction prompt. */
+export interface InputInteractionResult {
+    /** The data returned from the interaction. The value is `null` when the interaction was canceled. */
+    data?: InteractionInput;
+    /** A flag indicating whether the interaction was canceled by the user. */
+    canceled?: boolean;
+}
+
+/** Polyglot options for inputs dialog interactions. */
+export interface InputsDialogInteractionOptions {
+    /** Optional primary button text to override the default text. */
+    primaryButtonText?: string | null;
+    /** Optional secondary button text to override the default text. */
+    secondaryButtonText?: string | null;
+    /** Gets a value indicating whether to show the secondary button. */
+    showSecondaryButton?: boolean | null;
+    /** Gets a value indicating whether to show the dismiss button. */
+    showDismiss?: boolean | null;
+    /** Gets a value indicating whether Markdown in the message is rendered. */
+    enableMessageMarkdown?: boolean | null;
+}
+
+/** The result of a multi-input interaction prompt. */
+export interface InputsInteractionResult {
+    /** The data returned from the interaction. The value is `null` when the interaction was canceled. */
+    data?: InteractionInputCollection;
+    /** A flag indicating whether the interaction was canceled by the user. */
+    canceled?: boolean;
+}
+
+/** Shared polyglot options for interaction prompts. */
+export interface InteractionOptions {
+    /** Optional primary button text to override the default text. */
+    primaryButtonText?: string | null;
+    /** Optional secondary button text to override the default text. */
+    secondaryButtonText?: string | null;
+    /** Gets a value indicating whether to show the secondary button. */
+    showSecondaryButton?: boolean | null;
+    /** Gets a value indicating whether to show the dismiss button. */
+    showDismiss?: boolean | null;
+    /** Gets a value indicating whether Markdown in the message is rendered. */
+    enableMessageMarkdown?: boolean | null;
+}
+
+/** Polyglot options for message box interactions. */
+export interface MessageBoxInteractionOptions {
+    /** Gets the intent of the message box. */
+    intent?: MessageIntent | null;
+    /** Optional primary button text to override the default text. */
+    primaryButtonText?: string | null;
+    /** Optional secondary button text to override the default text. */
+    secondaryButtonText?: string | null;
+    /** Gets a value indicating whether to show the secondary button. */
+    showSecondaryButton?: boolean | null;
+    /** Gets a value indicating whether to show the dismiss button. */
+    showDismiss?: boolean | null;
+    /** Gets a value indicating whether Markdown in the message is rendered. */
+    enableMessageMarkdown?: boolean | null;
+}
+
+/** Polyglot options for notification interactions. */
+export interface NotificationInteractionOptions {
+    /** Gets the intent of the notification. */
+    intent?: MessageIntent | null;
+    /** Gets the text for a link in the notification. */
+    linkText?: string | null;
+    /** Gets the URL for the link in the notification. */
+    linkUrl?: string | null;
+    /** Optional primary button text to override the default text. */
+    primaryButtonText?: string | null;
+    /** Optional secondary button text to override the default text. */
+    secondaryButtonText?: string | null;
+    /** Gets a value indicating whether to show the secondary button. */
+    showSecondaryButton?: boolean | null;
+    /** Gets a value indicating whether to show the dismiss button. */
+    showDismiss?: boolean | null;
+    /** Gets a value indicating whether Markdown in the message is rendered. */
+    enableMessageMarkdown?: boolean | null;
 }
 
 /** Options for customizing parameter inputs from polyglot app hosts. */
@@ -1270,6 +1377,48 @@ export interface GetStatusAsyncOptions {
 
 export interface GetValueAsyncOptions {
     /** The cancellation token. */
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface PromptConfirmationAsyncOptions {
+    /** Optional configuration for the message box interaction. */
+    options?: MessageBoxInteractionOptions;
+    /** A token to cancel the operation. */
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface PromptInputAsyncOptions {
+    /** Optional configuration for the input dialog interaction. */
+    options?: InputsDialogInteractionOptions;
+    /** A token to cancel the operation. */
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface PromptInputsAsyncOptions {
+    /** Optional configuration for the input dialog interaction. */
+    options?: InputsDialogInteractionOptions;
+    /** A token to cancel the operation. */
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface PromptInputWithInputAsyncOptions {
+    /** Optional configuration for the input dialog interaction. */
+    options?: InputsDialogInteractionOptions;
+    /** A token to cancel the operation. */
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface PromptMessageBoxAsyncOptions {
+    /** Optional configuration for the message box interaction. */
+    options?: MessageBoxInteractionOptions;
+    /** A token to cancel the operation. */
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface PromptNotificationAsyncOptions {
+    /** Optional configuration for the notification interaction. */
+    options?: NotificationInteractionOptions;
+    /** A token to cancel the operation. */
     cancellationToken?: AbortSignal | CancellationToken;
 }
 
@@ -10523,6 +10672,320 @@ class HostEnvironmentPromiseImpl implements HostEnvironmentPromise {
 }
 
 // ============================================================================
+// InteractionService
+// ============================================================================
+
+/** A service to interact with the current development environment. */
+export interface InteractionService {
+    toJSON(): MarshalledHandle;
+    /**
+     * Gets a value indicating whether the interaction service is available.
+     * @returns `true` when the interaction service can interact with the user; otherwise, `false`.
+     */
+    isAvailable(): Promise<boolean>;
+    /**
+     * Prompts the user for confirmation with a dialog.
+     * @param title The title of the dialog.
+     * @param message The message to display in the dialog.
+     * @param options Additional options.
+     * @returns The confirmation interaction result.
+     */
+    promptConfirmationAsync(title: string, message: string, options?: PromptConfirmationAsyncOptions): Promise<BooleanInteractionResult>;
+    /**
+     * Prompts the user with a message box dialog.
+     * @param title The title of the message box.
+     * @param message The message to display in the message box.
+     * @param options Additional options.
+     * @returns The message box interaction result.
+     */
+    promptMessageBoxAsync(title: string, message: string, options?: PromptMessageBoxAsyncOptions): Promise<BooleanInteractionResult>;
+    /**
+     * Prompts the user for a single text input.
+     * @param title The title of the input dialog.
+     * @param message The message to display in the dialog.
+     * @param inputLabel The label for the input field.
+     * @param placeHolder The placeholder text for the input field.
+     * @param options Additional options.
+     * @returns The input interaction result.
+     */
+    promptInputAsync(title: string, message: string, inputLabel: string, placeHolder: string, options?: PromptInputAsyncOptions): Promise<InputInteractionResult>;
+    /**
+     * Prompts the user for a single input using a specified `InteractionInput`.
+     * @param title The title of the input dialog.
+     * @param message The message to display in the dialog.
+     * @param input The input configuration.
+     * @param options Additional options.
+     * @returns The input interaction result.
+     */
+    promptInputWithInputAsync(title: string, message: string, input: InteractionInput, options?: PromptInputWithInputAsyncOptions): Promise<InputInteractionResult>;
+    /**
+     * Prompts the user for multiple inputs.
+     * @param title The title of the input dialog.
+     * @param message The message to display in the dialog.
+     * @param inputs The input configurations.
+     * @param options Additional options.
+     * @returns The inputs interaction result.
+     */
+    promptInputsAsync(title: string, message: string, inputs: InteractionInput[], options?: PromptInputsAsyncOptions): Promise<InputsInteractionResult>;
+    /**
+     * Prompts the user with a notification.
+     * @param title The title of the notification.
+     * @param message The message to display in the notification.
+     * @param options Additional options.
+     * @returns The notification interaction result.
+     */
+    promptNotificationAsync(title: string, message: string, options?: PromptNotificationAsyncOptions): Promise<BooleanInteractionResult>;
+}
+
+export interface InteractionServicePromise extends PromiseLike<InteractionService> {
+    /**
+     * Gets a value indicating whether the interaction service is available.
+     * @returns `true` when the interaction service can interact with the user; otherwise, `false`.
+     */
+    isAvailable(): Promise<boolean>;
+    /**
+     * Prompts the user for confirmation with a dialog.
+     * @param title The title of the dialog.
+     * @param message The message to display in the dialog.
+     * @param options Additional options.
+     * @returns The confirmation interaction result.
+     */
+    promptConfirmationAsync(title: string, message: string, options?: PromptConfirmationAsyncOptions): Promise<BooleanInteractionResult>;
+    /**
+     * Prompts the user with a message box dialog.
+     * @param title The title of the message box.
+     * @param message The message to display in the message box.
+     * @param options Additional options.
+     * @returns The message box interaction result.
+     */
+    promptMessageBoxAsync(title: string, message: string, options?: PromptMessageBoxAsyncOptions): Promise<BooleanInteractionResult>;
+    /**
+     * Prompts the user for a single text input.
+     * @param title The title of the input dialog.
+     * @param message The message to display in the dialog.
+     * @param inputLabel The label for the input field.
+     * @param placeHolder The placeholder text for the input field.
+     * @param options Additional options.
+     * @returns The input interaction result.
+     */
+    promptInputAsync(title: string, message: string, inputLabel: string, placeHolder: string, options?: PromptInputAsyncOptions): Promise<InputInteractionResult>;
+    /**
+     * Prompts the user for a single input using a specified `InteractionInput`.
+     * @param title The title of the input dialog.
+     * @param message The message to display in the dialog.
+     * @param input The input configuration.
+     * @param options Additional options.
+     * @returns The input interaction result.
+     */
+    promptInputWithInputAsync(title: string, message: string, input: InteractionInput, options?: PromptInputWithInputAsyncOptions): Promise<InputInteractionResult>;
+    /**
+     * Prompts the user for multiple inputs.
+     * @param title The title of the input dialog.
+     * @param message The message to display in the dialog.
+     * @param inputs The input configurations.
+     * @param options Additional options.
+     * @returns The inputs interaction result.
+     */
+    promptInputsAsync(title: string, message: string, inputs: InteractionInput[], options?: PromptInputsAsyncOptions): Promise<InputsInteractionResult>;
+    /**
+     * Prompts the user with a notification.
+     * @param title The title of the notification.
+     * @param message The message to display in the notification.
+     * @param options Additional options.
+     * @returns The notification interaction result.
+     */
+    promptNotificationAsync(title: string, message: string, options?: PromptNotificationAsyncOptions): Promise<BooleanInteractionResult>;
+}
+
+// ============================================================================
+// InteractionServiceImpl
+// ============================================================================
+
+/** A service to interact with the current development environment. */
+class InteractionServiceImpl implements InteractionService {
+    constructor(private _handle: IInteractionServiceHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /**
+     * Gets a value indicating whether the interaction service is available.
+     * @returns `true` when the interaction service can interact with the user; otherwise, `false`.
+     */
+    async isAvailable(): Promise<boolean> {
+        const rpcArgs: Record<string, unknown> = { interactionService: this._handle };
+        return await this._client.invokeCapability<boolean>(
+            'Aspire.Hosting/interactionServiceIsAvailable',
+            rpcArgs
+        );
+    }
+
+    /**
+     * Prompts the user for confirmation with a dialog.
+     * @param title The title of the dialog.
+     * @param message The message to display in the dialog.
+     * @param optionsBag Additional options.
+     * @returns The confirmation interaction result.
+     */
+    async promptConfirmationAsync(title: string, message: string, optionsBag?: PromptConfirmationAsyncOptions): Promise<BooleanInteractionResult> {
+        const options = optionsBag?.options;
+        const cancellationToken = optionsBag?.cancellationToken;
+        const rpcArgs: Record<string, unknown> = { interactionService: this._handle, title, message };
+        if (options !== undefined) rpcArgs.options = options;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        return await this._client.invokeCapability<BooleanInteractionResult>(
+            'Aspire.Hosting/promptConfirmationAsync',
+            rpcArgs
+        );
+    }
+
+    /**
+     * Prompts the user with a message box dialog.
+     * @param title The title of the message box.
+     * @param message The message to display in the message box.
+     * @param optionsBag Additional options.
+     * @returns The message box interaction result.
+     */
+    async promptMessageBoxAsync(title: string, message: string, optionsBag?: PromptMessageBoxAsyncOptions): Promise<BooleanInteractionResult> {
+        const options = optionsBag?.options;
+        const cancellationToken = optionsBag?.cancellationToken;
+        const rpcArgs: Record<string, unknown> = { interactionService: this._handle, title, message };
+        if (options !== undefined) rpcArgs.options = options;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        return await this._client.invokeCapability<BooleanInteractionResult>(
+            'Aspire.Hosting/promptMessageBoxAsync',
+            rpcArgs
+        );
+    }
+
+    /**
+     * Prompts the user for a single text input.
+     * @param title The title of the input dialog.
+     * @param message The message to display in the dialog.
+     * @param inputLabel The label for the input field.
+     * @param placeHolder The placeholder text for the input field.
+     * @param optionsBag Additional options.
+     * @returns The input interaction result.
+     */
+    async promptInputAsync(title: string, message: string, inputLabel: string, placeHolder: string, optionsBag?: PromptInputAsyncOptions): Promise<InputInteractionResult> {
+        const options = optionsBag?.options;
+        const cancellationToken = optionsBag?.cancellationToken;
+        const rpcArgs: Record<string, unknown> = { interactionService: this._handle, title, message, inputLabel, placeHolder };
+        if (options !== undefined) rpcArgs.options = options;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        return await this._client.invokeCapability<InputInteractionResult>(
+            'Aspire.Hosting/promptInputAsync',
+            rpcArgs
+        );
+    }
+
+    /**
+     * Prompts the user for a single input using a specified `InteractionInput`.
+     * @param title The title of the input dialog.
+     * @param message The message to display in the dialog.
+     * @param input The input configuration.
+     * @param optionsBag Additional options.
+     * @returns The input interaction result.
+     */
+    async promptInputWithInputAsync(title: string, message: string, input: InteractionInput, optionsBag?: PromptInputWithInputAsyncOptions): Promise<InputInteractionResult> {
+        const options = optionsBag?.options;
+        const cancellationToken = optionsBag?.cancellationToken;
+        const rpcArgs: Record<string, unknown> = { interactionService: this._handle, title, message, input };
+        if (options !== undefined) rpcArgs.options = options;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        return await this._client.invokeCapability<InputInteractionResult>(
+            'Aspire.Hosting/promptInputWithInput',
+            rpcArgs
+        );
+    }
+
+    /**
+     * Prompts the user for multiple inputs.
+     * @param title The title of the input dialog.
+     * @param message The message to display in the dialog.
+     * @param inputs The input configurations.
+     * @param optionsBag Additional options.
+     * @returns The inputs interaction result.
+     */
+    async promptInputsAsync(title: string, message: string, inputs: InteractionInput[], optionsBag?: PromptInputsAsyncOptions): Promise<InputsInteractionResult> {
+        const options = optionsBag?.options;
+        const cancellationToken = optionsBag?.cancellationToken;
+        const rpcArgs: Record<string, unknown> = { interactionService: this._handle, title, message, inputs };
+        if (options !== undefined) rpcArgs.options = options;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        return await this._client.invokeCapability<InputsInteractionResult>(
+            'Aspire.Hosting/promptInputsAsync',
+            rpcArgs
+        );
+    }
+
+    /**
+     * Prompts the user with a notification.
+     * @param title The title of the notification.
+     * @param message The message to display in the notification.
+     * @param optionsBag Additional options.
+     * @returns The notification interaction result.
+     */
+    async promptNotificationAsync(title: string, message: string, optionsBag?: PromptNotificationAsyncOptions): Promise<BooleanInteractionResult> {
+        const options = optionsBag?.options;
+        const cancellationToken = optionsBag?.cancellationToken;
+        const rpcArgs: Record<string, unknown> = { interactionService: this._handle, title, message };
+        if (options !== undefined) rpcArgs.options = options;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        return await this._client.invokeCapability<BooleanInteractionResult>(
+            'Aspire.Hosting/promptNotificationAsync',
+            rpcArgs
+        );
+    }
+
+}
+
+/**
+ * Thenable wrapper for InteractionService that enables fluent chaining.
+ */
+class InteractionServicePromiseImpl implements InteractionServicePromise {
+    constructor(private _promise: Promise<InteractionService>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = InteractionService, TResult2 = never>(
+        onfulfilled?: ((value: InteractionService) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    isAvailable(): Promise<boolean> {
+        return this._promise.then(obj => obj.isAvailable());
+    }
+
+    promptConfirmationAsync(title: string, message: string, options?: PromptConfirmationAsyncOptions): Promise<BooleanInteractionResult> {
+        return this._promise.then(obj => obj.promptConfirmationAsync(title, message, options));
+    }
+
+    promptMessageBoxAsync(title: string, message: string, options?: PromptMessageBoxAsyncOptions): Promise<BooleanInteractionResult> {
+        return this._promise.then(obj => obj.promptMessageBoxAsync(title, message, options));
+    }
+
+    promptInputAsync(title: string, message: string, inputLabel: string, placeHolder: string, options?: PromptInputAsyncOptions): Promise<InputInteractionResult> {
+        return this._promise.then(obj => obj.promptInputAsync(title, message, inputLabel, placeHolder, options));
+    }
+
+    promptInputWithInputAsync(title: string, message: string, input: InteractionInput, options?: PromptInputWithInputAsyncOptions): Promise<InputInteractionResult> {
+        return this._promise.then(obj => obj.promptInputWithInputAsync(title, message, input, options));
+    }
+
+    promptInputsAsync(title: string, message: string, inputs: InteractionInput[], options?: PromptInputsAsyncOptions): Promise<InputsInteractionResult> {
+        return this._promise.then(obj => obj.promptInputsAsync(title, message, inputs, options));
+    }
+
+    promptNotificationAsync(title: string, message: string, options?: PromptNotificationAsyncOptions): Promise<BooleanInteractionResult> {
+        return this._promise.then(obj => obj.promptNotificationAsync(title, message, options));
+    }
+
+}
+
+// ============================================================================
 // Logger
 // ============================================================================
 
@@ -11178,6 +11641,11 @@ export interface ServiceProvider {
      */
     getEventing(): DistributedApplicationEventingPromise;
     /**
+     * Gets the interaction service from the service provider.
+     * @returns An interaction service handle.
+     */
+    getInteractionService(): InteractionServicePromise;
+    /**
      * Gets the logger factory from the service provider.
      * @returns A logger factory handle.
      */
@@ -11220,6 +11688,11 @@ export interface ServiceProviderPromise extends PromiseLike<ServiceProvider> {
      * @returns The distributed application eventing handle.
      */
     getEventing(): DistributedApplicationEventingPromise;
+    /**
+     * Gets the interaction service from the service provider.
+     * @returns An interaction service handle.
+     */
+    getInteractionService(): InteractionServicePromise;
     /**
      * Gets the logger factory from the service provider.
      * @returns A logger factory handle.
@@ -11284,6 +11757,24 @@ class ServiceProviderImpl implements ServiceProvider {
      */
     getEventing(): DistributedApplicationEventingPromise {
         return new DistributedApplicationEventingPromiseImpl(this._getEventingInternal(), this._client);
+    }
+
+    /** @internal */
+    async _getInteractionServiceInternal(): Promise<InteractionService> {
+        const rpcArgs: Record<string, unknown> = { serviceProvider: this._handle };
+        const result = await this._client.invokeCapability<IInteractionServiceHandle>(
+            'Aspire.Hosting/getInteractionService',
+            rpcArgs
+        );
+        return new InteractionServiceImpl(result, this._client);
+    }
+
+    /**
+     * Gets the interaction service from the service provider.
+     * @returns An interaction service handle.
+     */
+    getInteractionService(): InteractionServicePromise {
+        return new InteractionServicePromiseImpl(this._getInteractionServiceInternal(), this._client);
     }
 
     /** @internal */
@@ -11431,6 +11922,10 @@ class ServiceProviderPromiseImpl implements ServiceProviderPromise {
 
     getEventing(): DistributedApplicationEventingPromise {
         return new DistributedApplicationEventingPromiseImpl(this._promise.then(obj => obj.getEventing()), this._client);
+    }
+
+    getInteractionService(): InteractionServicePromise {
+        return new InteractionServicePromiseImpl(this._promise.then(obj => obj.getInteractionService()), this._client);
     }
 
     getLoggerFactory(): LoggerFactoryPromise {
@@ -53561,6 +54056,7 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedAppli
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationBuilder', (handle, client) => new ExecutionConfigurationBuilderImpl(handle as IExecutionConfigurationBuilderHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExecutionConfigurationResult', (handle, client) => new ExecutionConfigurationResultImpl(handle as IExecutionConfigurationResultHandle, client));
 registerHandleWrapper('Microsoft.Extensions.Hosting.Abstractions/Microsoft.Extensions.Hosting.IHostEnvironment', (handle, client) => new HostEnvironmentImpl(handle as IHostEnvironmentHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IInteractionService', (handle, client) => new InteractionServiceImpl(handle as IInteractionServiceHandle, client));
 registerHandleWrapper('Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILogger', (handle, client) => new LoggerImpl(handle as ILoggerHandle, client));
 registerHandleWrapper('Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILoggerFactory', (handle, client) => new LoggerFactoryImpl(handle as ILoggerFactoryHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingStep', (handle, client) => new ReportingStepImpl(handle as IReportingStepHandle, client));

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -342,6 +342,9 @@ type IResourceWithContainerFilesHandle = Handle<'Aspire.Hosting/Aspire.Hosting.I
 /** Defines an interface for managing user secrets with support for read and write operations. */
 type IUserSecretsManagerHandle = Handle<'Aspire.Hosting/Aspire.Hosting.IUserSecretsManager'>;
 
+/** The context for dynamic input loading. Used with `LoadCallback`. */
+type LoadInputContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.LoadInputContext'>;
+
 /** Represents a pipeline for executing deployment steps in a distributed application. */
 type IDistributedApplicationPipelineHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Pipelines.IDistributedApplicationPipeline'>;
 
@@ -900,8 +903,30 @@ export interface InputInteractionResult {
     canceled?: boolean;
 }
 
+/**
+ * Represents configuration options for dynamically loading input data.
+ *
+ * Use this class to specify how and when dynamic input data should be loaded. This type is intended for advanced
+ * scenarios where input loading behavior must be customized.
+ */
+export interface InputLoadOptions {
+    /** Gets the callback function that is invoked to perform a load operation using the specified input context. */
+    loadCallback?: (arg: LoadInputContext) => Promise<void>;
+    /**
+     * Gets a value indicating whether `LoadCallback` should always be executed at the start of the input prompt.
+     *
+     * `LoadCallback` is executed at the start of the input prompt except when it depends on other inputs with `DependsOnInputs`.
+     * Setting this to `true` forces the load to always occur at the start of the prompt, regardless of dependencies.
+     */
+    alwaysLoadOnStart?: boolean;
+    /** Gets the list of input names that this input depends on. `LoadCallback` is executed whenever any of the specified inputs change. */
+    dependsOnInputs?: string[] | null;
+}
+
 /** Polyglot options for inputs dialog interactions. */
 export interface InputsDialogInteractionOptions {
+    /** Gets the validation callback for the inputs dialog. */
+    validationCallback?: (arg: InputsDialogValidationContext) => Promise<void>;
     /** Optional primary button text to override the default text. */
     primaryButtonText?: string | null;
     /** Optional secondary button text to override the default text. */
@@ -5071,6 +5096,8 @@ class EventingSubscriberRegistrationContextPromiseImpl implements EventingSubscr
 /** Context for {@link ResourceCommandAnnotation.ExecuteCommand}. */
 export interface ExecuteCommandContext {
     toJSON(): MarshalledHandle;
+    /** The service provider. */
+    serviceProvider(): ServiceProviderPromise;
     /** The resource name. */
     resourceName(): Promise<string>;
     /** The cancellation token. */
@@ -5088,6 +5115,8 @@ export interface ExecuteCommandContext {
 }
 
 export interface ExecuteCommandContextPromise extends PromiseLike<ExecuteCommandContext> {
+    /** The service provider. */
+    serviceProvider(): ServiceProviderPromise;
     /** The resource name. */
     resourceName(): Promise<string>;
     /** The cancellation token. */
@@ -5114,6 +5143,17 @@ class ExecuteCommandContextImpl implements ExecuteCommandContext {
 
     /** Serialize for JSON-RPC transport */
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    serviceProvider(): ServiceProviderPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IServiceProviderHandle>(
+                'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.serviceProvider',
+                { context: this._handle }
+            );
+            return new ServiceProviderImpl(handle, this._client);
+        })();
+        return new ServiceProviderPromiseImpl(promise, this._client, false);
+    }
 
     async resourceName(): Promise<string> {
         return await this._client.invokeCapability<string>(
@@ -5163,6 +5203,10 @@ class ExecuteCommandContextPromiseImpl implements ExecuteCommandContextPromise {
         onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
     ): PromiseLike<TResult1 | TResult2> {
         return this._promise.then(onfulfilled, onrejected);
+    }
+
+    serviceProvider(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.serviceProvider()), this._client, false);
     }
 
     resourceName(): Promise<string> {
@@ -5434,6 +5478,126 @@ class InputsDialogValidationContextPromiseImpl implements InputsDialogValidation
 
     addValidationError(inputName: string, errorMessage: string): InputsDialogValidationContextPromise {
         return new InputsDialogValidationContextPromiseImpl(this._promise.then(obj => obj.addValidationError(inputName, errorMessage)), this._client);
+    }
+
+}
+
+// ============================================================================
+// LoadInputContext
+// ============================================================================
+
+/** The context for dynamic input loading. Used with `LoadCallback`. */
+export interface LoadInputContext {
+    toJSON(): MarshalledHandle;
+    /** Gets the loading input. This is the target of `InputLoadOptions`. */
+    input(): Promise<InteractionInput>;
+    /** Gets the collection of all `InteractionInput` in this prompt. */
+    allInputs(): Promise<InteractionInputCollection>;
+    /** Gets the `CancellationToken`. */
+    cancellationToken(): Promise<CancellationToken>;
+    /**
+     * Sets the available options for the loading input.
+     * @param options The choice options to display for the loading input, keyed by submitted value.
+     */
+    setOptions(options: Record<string, string>): LoadInputContextPromise;
+}
+
+export interface LoadInputContextPromise extends PromiseLike<LoadInputContext> {
+    /** Gets the loading input. This is the target of `InputLoadOptions`. */
+    input(): Promise<InteractionInput>;
+    /** Gets the collection of all `InteractionInput` in this prompt. */
+    allInputs(): Promise<InteractionInputCollection>;
+    /** Gets the `CancellationToken`. */
+    cancellationToken(): Promise<CancellationToken>;
+    /**
+     * Sets the available options for the loading input.
+     * @param options The choice options to display for the loading input, keyed by submitted value.
+     */
+    setOptions(options: Record<string, string>): LoadInputContextPromise;
+}
+
+// ============================================================================
+// LoadInputContextImpl
+// ============================================================================
+
+/** The context for dynamic input loading. Used with `LoadCallback`. */
+class LoadInputContextImpl implements LoadInputContext {
+    constructor(private _handle: LoadInputContextHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    async input(): Promise<InteractionInput> {
+        return await this._client.invokeCapability<InteractionInput>(
+            'Aspire.Hosting/LoadInputContext.input',
+            { context: this._handle }
+        );
+    }
+
+    async allInputs(): Promise<InteractionInputCollection> {
+        return await this._client.invokeCapability<InteractionInputCollection>(
+            'Aspire.Hosting/LoadInputContext.allInputs',
+            { context: this._handle }
+        );
+    }
+
+    async cancellationToken(): Promise<CancellationToken> {
+        const result = await this._client.invokeCapability<string | null>(
+            'Aspire.Hosting/LoadInputContext.cancellationToken',
+            { context: this._handle }
+        );
+        return CancellationToken.fromValue(result);
+    }
+
+    /** @internal */
+    async _setOptionsInternal(options: Record<string, string>): Promise<LoadInputContext> {
+        const rpcArgs: Record<string, unknown> = { context: this._handle, options };
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/LoadInputContext.setOptions',
+            rpcArgs
+        );
+        return this;
+    }
+
+    /**
+     * Sets the available options for the loading input.
+     * @param options The choice options to display for the loading input, keyed by submitted value.
+     */
+    setOptions(options: Record<string, string>): LoadInputContextPromise {
+        return new LoadInputContextPromiseImpl(this._setOptionsInternal(options), this._client);
+    }
+
+}
+
+/**
+ * Thenable wrapper for LoadInputContext that enables fluent chaining.
+ */
+class LoadInputContextPromiseImpl implements LoadInputContextPromise {
+    constructor(private _promise: Promise<LoadInputContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = LoadInputContext, TResult2 = never>(
+        onfulfilled?: ((value: LoadInputContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    input(): Promise<InteractionInput> {
+        return this._promise.then(obj => obj.input());
+    }
+
+    allInputs(): Promise<InteractionInputCollection> {
+        return this._promise.then(obj => obj.allInputs());
+    }
+
+    cancellationToken(): Promise<CancellationToken> {
+        return this._promise.then(obj => obj.cancellationToken());
+    }
+
+    setOptions(options: Record<string, string>): LoadInputContextPromise {
+        return new LoadInputContextPromiseImpl(this._promise.then(obj => obj.setOptions(options)), this._client);
     }
 
 }
@@ -54023,6 +54187,7 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegis
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext', (handle, client) => new ExecuteCommandContextImpl(handle as ExecuteCommandContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent', (handle, client) => new InitializeResourceEventImpl(handle as InitializeResourceEventHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.InputsDialogValidationContext', (handle, client) => new InputsDialogValidationContextImpl(handle as InputsDialogValidationContextHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.LoadInputContext', (handle, client) => new LoadInputContextImpl(handle as LoadInputContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.LogFacade', (handle, client) => new LogFacadeImpl(handle as LogFacadeHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineConfigurationContext', (handle, client) => new PipelineConfigurationContextImpl(handle as PipelineConfigurationContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineContext', (handle, client) => new PipelineContextImpl(handle as PipelineContextHandle, client));

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -752,7 +752,7 @@ export interface CommandResultData {
 /** Options for creating a distributed application builder from polyglot apphosts. */
 export interface CreateBuilderOptions {
     /** The command line arguments. */
-    args?: string[];
+    args?: string[] | null;
     /** The directory containing the AppHost project file. */
     projectDirectory?: string | null;
     /** The full path to the AppHost file (e.g., apphost.ts, apphost.py). Used for consistent socket path computation across CLI and AppHost. */
@@ -782,7 +782,7 @@ export interface ExecuteCommandResult {
     /** An optional message associated with the command result. */
     message?: string | null;
     /** An optional value produced by the command. */
-    data?: CommandResultData;
+    data?: CommandResultData | null;
 }
 
 /**
@@ -895,7 +895,7 @@ export interface HttpsCertificateInfo {
 /** The result of a single input interaction prompt. */
 export interface InputInteractionResult {
     /** The data returned from the interaction. The value is `null` when the interaction was canceled. */
-    data?: InteractionInput;
+    data?: InteractionInput | null;
     /** A flag indicating whether the interaction was canceled by the user. */
     canceled?: boolean;
 }
@@ -917,7 +917,7 @@ export interface InputsDialogInteractionOptions {
 /** The result of a multi-input interaction prompt. */
 export interface InputsInteractionResult {
     /** The data returned from the interaction. The value is `null` when the interaction was canceled. */
-    data?: InteractionInputCollection;
+    data?: InteractionInputCollection | null;
     /** A flag indicating whether the interaction was canceled by the user. */
     canceled?: boolean;
 }
@@ -975,7 +975,7 @@ export interface NotificationInteractionOptions {
 /** Options for customizing parameter inputs from polyglot app hosts. */
 export interface ParameterCustomInputOptions {
     /** Gets or sets the type of the input. */
-    inputType?: InputType;
+    inputType?: InputType | null;
     /** Gets or sets the label for the input. */
     label?: string | null;
     /** Gets or sets the description for the input. */
@@ -983,7 +983,7 @@ export interface ParameterCustomInputOptions {
     /** Gets or sets whether the description should be rendered as Markdown. */
     enableDescriptionMarkdown?: boolean | null;
     /** Gets or sets the choice options keyed by submitted value. */
-    options?: Record<string, string>;
+    options?: Record<string, string> | null;
     /** Gets or sets the initial value of the input. */
     value?: string | null;
     /** Gets or sets the placeholder text for the input. */
@@ -1001,11 +1001,11 @@ export interface ProcessCommandExportOptions {
     /** The executable path or command name to start. */
     executablePath?: string | null;
     /** The command-line arguments for the process. */
-    arguments?: string[];
+    arguments?: string[] | null;
     /** The working directory for the process. */
     workingDirectory?: string | null;
     /** The environment variables to set for the process. */
-    environmentVariables?: Record<string, string>;
+    environmentVariables?: Record<string, string> | null;
     /** A value indicating whether the process should inherit the current environment variables. */
     inheritEnvironmentVariables?: boolean | null;
     /** Standard input content to write to the process after it starts. */
@@ -1013,25 +1013,25 @@ export interface ProcessCommandExportOptions {
     /** A value indicating whether the entire process tree should be killed when the process is disposed. */
     killEntireProcessTree?: boolean | null;
     /** Optional command configuration. */
-    commandOptions?: CommandOptions;
+    commandOptions?: CommandOptions | null;
     /** The maximum number of stdout and stderr output lines returned as command result data. */
     maxOutputLineCount?: number | null;
     /** A value indicating whether returned command output should be displayed immediately in the dashboard. */
     displayImmediately?: boolean | null;
     /** The exit codes that are treated as a successful command invocation. */
-    successExitCodes?: number[];
+    successExitCodes?: number[] | null;
 }
 
 /** ATS-friendly result and command configuration for resource process commands. */
 export interface ProcessCommandResultExportOptions {
     /** Optional command configuration. */
-    commandOptions?: CommandOptions;
+    commandOptions?: CommandOptions | null;
     /** The maximum number of stdout and stderr output lines returned as command result data. */
     maxOutputLineCount?: number | null;
     /** A value indicating whether returned command output should be displayed immediately in the dashboard. */
     displayImmediately?: boolean | null;
     /** The exit codes that are treated as a successful command invocation. */
-    successExitCodes?: number[];
+    successExitCodes?: number[] | null;
 }
 
 /** ATS-friendly process specification for resource process command callbacks. */
@@ -1039,11 +1039,11 @@ export interface ProcessCommandSpecExportData {
     /** The executable path or command name to start. */
     executablePath?: string | null;
     /** The command-line arguments for the process. */
-    arguments?: string[];
+    arguments?: string[] | null;
     /** The working directory for the process. */
     workingDirectory?: string | null;
     /** The environment variables to set for the process. */
-    environmentVariables?: Record<string, string>;
+    environmentVariables?: Record<string, string> | null;
     /** A value indicating whether the process should inherit the current environment variables. */
     inheritEnvironmentVariables?: boolean | null;
     /** Standard input content to write to the process after it starts. */
@@ -1115,7 +1115,7 @@ export interface TestDeeplyNestedDto {
 /** Test DTO with complex nested types. */
 export interface TestNestedDto {
     id?: string;
-    config?: TestConfigDto;
+    config?: TestConfigDto | null;
     tags?: string[];
     counts?: Record<string, number>;
 }

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Go/apphost.go
@@ -11,6 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatalf(aspire.FormatError(err))
 	}
+	var resourceCommandService aspire.ResourceCommandService
 
 	// ===================================================================
 	// Factory methods on builder
@@ -382,12 +383,6 @@ ENTRYPOINT ["dotnet", "App.dll"]
 	_, _ = builderConfiguration.Exists("MyConfig:Key")
 
 	builderExecutionContext := builder.ExecutionContext()
-	executionContextServiceProvider := builderExecutionContext.ServiceProvider()
-	_ = executionContextServiceProvider.GetDistributedApplicationModel()
-	resourceCommandService := executionContextServiceProvider.GetResourceCommandService()
-	interactionService := executionContextServiceProvider.GetInteractionService()
-	_, _ = interactionService.IsAvailable()
-	validateInteractionServicePromptApis(interactionService)
 
 	// Subscriptions (typed callbacks)
 	beforeStartSub := builder.SubscribeBeforeStart(func(e aspire.BeforeStartEvent) {
@@ -585,6 +580,15 @@ ENTRYPOINT ["dotnet", "App.dll"]
 	if err != nil {
 		log.Fatalf(aspire.FormatError(err))
 	}
+
+	// The execution context service provider is populated by Build(); accessing it before this point throws.
+	executionContextServiceProvider := builderExecutionContext.ServiceProvider()
+	_ = executionContextServiceProvider.GetDistributedApplicationModel()
+	resourceCommandService = executionContextServiceProvider.GetResourceCommandService()
+	interactionService := executionContextServiceProvider.GetInteractionService()
+	_, _ = interactionService.IsAvailable()
+	validateInteractionServicePromptApis(interactionService)
+
 	if err := app.Run(); err != nil {
 		log.Fatalf(aspire.FormatError(err))
 	}

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Go/apphost.go
@@ -385,6 +385,9 @@ ENTRYPOINT ["dotnet", "App.dll"]
 	executionContextServiceProvider := builderExecutionContext.ServiceProvider()
 	_ = executionContextServiceProvider.GetDistributedApplicationModel()
 	resourceCommandService := executionContextServiceProvider.GetResourceCommandService()
+	interactionService := executionContextServiceProvider.GetInteractionService()
+	_, _ = interactionService.IsAvailable()
+	validateInteractionServicePromptApis(interactionService)
 
 	// Subscriptions (typed callbacks)
 	beforeStartSub := builder.SubscribeBeforeStart(func(e aspire.BeforeStartEvent) {
@@ -585,4 +588,51 @@ ENTRYPOINT ["dotnet", "App.dll"]
 	if err := app.Run(); err != nil {
 		log.Fatalf(aspire.FormatError(err))
 	}
+}
+
+func validateInteractionServicePromptApis(interactionService aspire.InteractionService) {
+	confirmationIntent := aspire.MessageIntentConfirmation
+	informationIntent := aspire.MessageIntentInformation
+	interactionInput := &aspire.InteractionInput{
+		Name:      "validation",
+		InputType: aspire.InputTypeText,
+		Value:     "default",
+		Disabled:  false,
+	}
+
+	_, _ = interactionService.PromptConfirmationAsync("Confirm", "Continue?", &aspire.PromptConfirmationAsyncOptions{
+		Options: &aspire.MessageBoxInteractionOptions{
+			Intent:            &confirmationIntent,
+			PrimaryButtonText: aspire.StringPtr("Continue"),
+		},
+	})
+	_, _ = interactionService.PromptMessageBoxAsync("Message", "Message body", &aspire.PromptMessageBoxAsyncOptions{
+		Options: &aspire.MessageBoxInteractionOptions{
+			Intent:                &informationIntent,
+			EnableMessageMarkdown: aspire.BoolPtr(true),
+		},
+	})
+	_, _ = interactionService.PromptInputAsync("Input", "Input body", "Name", "Placeholder", &aspire.PromptInputAsyncOptions{
+		Options: &aspire.InputsDialogInteractionOptions{
+			PrimaryButtonText: aspire.StringPtr("Submit"),
+		},
+	})
+	_, _ = interactionService.PromptInputWithInputAsync("Input", "Input body", interactionInput, &aspire.PromptInputWithInputAsyncOptions{
+		Options: &aspire.InputsDialogInteractionOptions{
+			ShowDismiss: aspire.BoolPtr(true),
+		},
+	})
+	_, _ = interactionService.PromptInputsAsync("Inputs", "Inputs body", []*aspire.InteractionInput{interactionInput}, &aspire.PromptInputsAsyncOptions{
+		Options: &aspire.InputsDialogInteractionOptions{
+			ShowSecondaryButton: aspire.BoolPtr(true),
+			SecondaryButtonText: aspire.StringPtr("Skip"),
+		},
+	})
+	_, _ = interactionService.PromptNotificationAsync("Notification", "Notification body", &aspire.PromptNotificationAsyncOptions{
+		Options: &aspire.NotificationInteractionOptions{
+			Intent:   &informationIntent,
+			LinkText: aspire.StringPtr("Docs"),
+			LinkUrl:  aspire.StringPtr("https://aspire.dev"),
+		},
+	})
 }

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Go/apphost.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"time"
 
 	"apphost/modules/aspire"
 )
@@ -11,7 +12,6 @@ func main() {
 	if err != nil {
 		log.Fatalf(aspire.FormatError(err))
 	}
-	var resourceCommandService aspire.ResourceCommandService
 
 	// ===================================================================
 	// Factory methods on builder
@@ -382,8 +382,6 @@ ENTRYPOINT ["dotnet", "App.dll"]
 	_, _ = builderConfiguration.GetChildren()
 	_, _ = builderConfiguration.Exists("MyConfig:Key")
 
-	builderExecutionContext := builder.ExecutionContext()
-
 	// Subscriptions (typed callbacks)
 	beforeStartSub := builder.SubscribeBeforeStart(func(e aspire.BeforeStartEvent) {
 		beforeStartModel := e.Model()
@@ -546,8 +544,8 @@ ENTRYPOINT ["dotnet", "App.dll"]
 			UpdateState: updateCommandState,
 		},
 	})
-	_ = container.WithCommand("echo", "Echo", func(ctx aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
-		commandArguments, err := ctx.Arguments().ToArray()
+	_ = container.WithCommand("echo", "Echo", func(commandContext aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
+		commandArguments, err := commandContext.Arguments().ToArray()
 		if err != nil {
 			return &aspire.ExecuteCommandResult{Success: false, ErrorMessage: aspire.StringPtr(aspire.FormatError(err))}
 		}
@@ -563,11 +561,14 @@ ENTRYPOINT ["dotnet", "App.dll"]
 			},
 		},
 	})
-	_ = container.WithCommand("restart", "Restart", func(ctx aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
-		cancellationToken, err := ctx.CancellationToken()
+	_ = container.WithCommand("restart", "Restart", func(commandContext aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
+		cancellationToken, err := commandContext.CancellationToken()
 		if err != nil {
 			return &aspire.ExecuteCommandResult{Success: false, ErrorMessage: aspire.StringPtr(aspire.FormatError(err))}
 		}
+		// Command callbacks run after Build(), when the execution context service provider is populated; accessing it before Build() throws.
+		serviceProvider := commandContext.ServiceProvider()
+		resourceCommandService := serviceProvider.GetResourceCommandService()
 		result, err := resourceCommandService.ExecuteCommandAsync(container, "echo", &aspire.ExecuteCommandAsyncOptions{Arguments: map[string]string{"message": "hello"}, CancellationToken: cancellationToken})
 		if err != nil {
 			return &aspire.ExecuteCommandResult{Success: false, ErrorMessage: aspire.StringPtr(aspire.FormatError(err))}
@@ -575,26 +576,34 @@ ENTRYPOINT ["dotnet", "App.dll"]
 
 		return result
 	})
+	_ = container.WithCommand("interaction-validation", "Interaction Validation", func(commandContext aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
+		// Command callbacks run after Build(), when the execution context service provider is populated; accessing it before Build() throws.
+		interactionService := commandContext.ServiceProvider().GetInteractionService()
+		isAvailable, _ := interactionService.IsAvailable()
+		dynamicChoiceValue := validateInteractionServicePromptApis(interactionService)
+		_ = commandContext.Logger().LogInformation("Dynamic choice selected: " + dynamicChoiceValue)
+		resultFormat := aspire.CommandResultFormatText
+
+		return &aspire.ExecuteCommandResult{
+			Success: isAvailable,
+			Data: &aspire.CommandResultData{
+				Value:  dynamicChoiceValue,
+				Format: &resultFormat,
+			},
+		}
+	})
 
 	app, err := builder.Build()
 	if err != nil {
 		log.Fatalf(aspire.FormatError(err))
 	}
 
-	// The execution context service provider is populated by Build(); accessing it before this point throws.
-	executionContextServiceProvider := builderExecutionContext.ServiceProvider()
-	_ = executionContextServiceProvider.GetDistributedApplicationModel()
-	resourceCommandService = executionContextServiceProvider.GetResourceCommandService()
-	interactionService := executionContextServiceProvider.GetInteractionService()
-	_, _ = interactionService.IsAvailable()
-	validateInteractionServicePromptApis(interactionService)
-
 	if err := app.Run(); err != nil {
 		log.Fatalf(aspire.FormatError(err))
 	}
 }
 
-func validateInteractionServicePromptApis(interactionService aspire.InteractionService) {
+func validateInteractionServicePromptApis(interactionService aspire.InteractionService) string {
 	confirmationIntent := aspire.MessageIntentConfirmation
 	informationIntent := aspire.MessageIntentInformation
 	interactionInput := &aspire.InteractionInput{
@@ -602,6 +611,28 @@ func validateInteractionServicePromptApis(interactionService aspire.InteractionS
 		InputType: aspire.InputTypeText,
 		Value:     "default",
 		Disabled:  false,
+	}
+	dynamicChoiceInput := &aspire.InteractionInput{
+		Name:        "dynamic-choice",
+		InputType:   aspire.InputTypeChoice,
+		Placeholder: aspire.StringPtr("Loading choices..."),
+		Required:    aspire.BoolPtr(true),
+		DynamicLoading: &aspire.InputLoadOptions{
+			AlwaysLoadOnStart: aspire.BoolPtr(true),
+			LoadCallback: func(args ...any) any {
+				loadContext, ok := args[0].(aspire.LoadInputContext)
+				if !ok {
+					return nil
+				}
+
+				time.Sleep(time.Second)
+				_ = loadContext.SetOptions(map[string]string{
+					"dynamic1": "Dynamic Option 1",
+					"dynamic2": "Dynamic Option 2",
+				})
+				return nil
+			},
+		},
 	}
 
 	_, _ = interactionService.PromptConfirmationAsync("Confirm", "Continue?", &aspire.PromptConfirmationAsyncOptions{
@@ -632,6 +663,35 @@ func validateInteractionServicePromptApis(interactionService aspire.InteractionS
 			SecondaryButtonText: aspire.StringPtr("Skip"),
 		},
 	})
+	dynamicChoiceResult, _ := interactionService.PromptInputsAsync("Dynamic choice", "Select a dynamically loaded option.", []*aspire.InteractionInput{dynamicChoiceInput}, &aspire.PromptInputsAsyncOptions{
+		Options: &aspire.InputsDialogInteractionOptions{
+			PrimaryButtonText: aspire.StringPtr("Submit"),
+			ValidationCallback: func(args ...any) any {
+				validationContext, ok := args[0].(aspire.InputsDialogValidationContext)
+				if !ok {
+					return nil
+				}
+
+				inputs, err := validationContext.Inputs().ToArray()
+				if err != nil {
+					_ = validationContext.AddValidationError("dynamic-choice", aspire.FormatError(err))
+					return nil
+				}
+
+				selectedValue := ""
+				for _, input := range inputs {
+					if input.Name == "dynamic-choice" {
+						selectedValue = input.Value
+						break
+					}
+				}
+				if selectedValue != "dynamic1" && selectedValue != "dynamic2" {
+					_ = validationContext.AddValidationError("dynamic-choice", "Select a dynamically loaded option.")
+				}
+				return nil
+			},
+		},
+	})
 	_, _ = interactionService.PromptNotificationAsync("Notification", "Notification body", &aspire.PromptNotificationAsyncOptions{
 		Options: &aspire.NotificationInteractionOptions{
 			Intent:   &informationIntent,
@@ -639,4 +699,21 @@ func validateInteractionServicePromptApis(interactionService aspire.InteractionS
 			LinkUrl:  aspire.StringPtr("https://aspire.dev"),
 		},
 	})
+
+	if dynamicChoiceResult == nil || dynamicChoiceResult.Canceled || dynamicChoiceResult.Data == nil {
+		return "default"
+	}
+
+	inputs, err := (*dynamicChoiceResult.Data).ToArray()
+	if err != nil {
+		return "default"
+	}
+
+	for _, input := range inputs {
+		if input.Name == "dynamic-choice" && input.Value != "" {
+			return input.Value
+		}
+	}
+
+	return "default"
 }

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
@@ -4,6 +4,7 @@ import java.util.function.Function;
 
 void main() throws Exception {
         var builder = DistributedApplication.CreateBuilder();
+        var resourceCommandService = new ResourceCommandService[1];
         var container = builder.addContainer("mycontainer", "nginx");
         container.withOtlpExporter(OtlpProtocol.HTTP_JSON);
         var dockerContainer = builder.addDockerfile("dockerapp", "./app");
@@ -139,61 +140,6 @@ void main() throws Exception {
         var _configChildren = builderConfiguration.getChildren();
         var _configExists = builderConfiguration.exists("MyConfig:Key");
         var builderExecutionContext = builder.executionContext();
-        var executionContextServiceProvider = builderExecutionContext.serviceProvider();
-        var _distributedApplicationModelFromExecutionContext = executionContextServiceProvider.getDistributedApplicationModel();
-        var resourceCommandService = executionContextServiceProvider.getResourceCommandService();
-        var interactionService = executionContextServiceProvider.getInteractionService();
-        var _interactionServiceAvailable = interactionService.isAvailable();
-        var interactionInput = new InteractionInput();
-        interactionInput.setName("validation");
-        interactionInput.setInputType(InputType.TEXT);
-        interactionInput.setValue("default");
-        interactionInput.setDisabled(false);
-        var confirmationOptions = new MessageBoxInteractionOptions();
-        confirmationOptions.setIntent(MessageIntent.CONFIRMATION);
-        confirmationOptions.setPrimaryButtonText("Continue");
-        interactionService.promptConfirmationAsync(
-            "Confirm",
-            "Continue?",
-            new PromptConfirmationAsyncOptions().options(confirmationOptions));
-        var messageBoxOptions = new MessageBoxInteractionOptions();
-        messageBoxOptions.setIntent(MessageIntent.INFORMATION);
-        messageBoxOptions.setEnableMessageMarkdown(true);
-        interactionService.promptMessageBoxAsync(
-            "Message",
-            "Message body",
-            new PromptMessageBoxAsyncOptions().options(messageBoxOptions));
-        var inputOptions = new InputsDialogInteractionOptions();
-        inputOptions.setPrimaryButtonText("Submit");
-        interactionService.promptInputAsync(
-            "Input",
-            "Input body",
-            "Name",
-            "Placeholder",
-            new PromptInputAsyncOptions().options(inputOptions));
-        var inputWithInputOptions = new InputsDialogInteractionOptions();
-        inputWithInputOptions.setShowDismiss(true);
-        interactionService.promptInputWithInputAsync(
-            "Input",
-            "Input body",
-            interactionInput,
-            new PromptInputWithInputAsyncOptions().options(inputWithInputOptions));
-        var inputsOptions = new InputsDialogInteractionOptions();
-        inputsOptions.setShowSecondaryButton(true);
-        inputsOptions.setSecondaryButtonText("Skip");
-        interactionService.promptInputsAsync(
-            "Inputs",
-            "Inputs body",
-            new InteractionInput[] { interactionInput },
-            new PromptInputsAsyncOptions().options(inputsOptions));
-        var notificationOptions = new NotificationInteractionOptions();
-        notificationOptions.setIntent(MessageIntent.INFORMATION);
-        notificationOptions.setLinkText("Docs");
-        notificationOptions.setLinkUrl("https://aspire.dev");
-        interactionService.promptNotificationAsync(
-            "Notification",
-            "Notification body",
-            new PromptNotificationAsyncOptions().options(notificationOptions));
         builder.addEventingSubscriber((registrationContext) -> {
             var subscriberExecutionContext = registrationContext.executionContext();
             var _subscriberIsRunMode = subscriberExecutionContext.isRunMode();
@@ -308,7 +254,7 @@ void main() throws Exception {
         }, echoCommandOptions);
         container.withCommand("restart", "Restart", (ctx) -> {
             var cancellationToken = ctx.cancellationToken();
-            return resourceCommandService.executeCommandAsync(
+            return resourceCommandService[0].executeCommandAsync(
                 container,
                 "echo",
                 new ExecuteCommandAsyncOptions()
@@ -321,5 +267,63 @@ void main() throws Exception {
         httpCmdOptions.setConfirmationMessage("Are you sure?");
         container.withHttpCommand("/api/reset", "Reset", httpCmdOptions);
         var app = builder.build();
+
+        // The execution context service provider is populated by build(); accessing it before this point throws.
+        var executionContextServiceProvider = builderExecutionContext.serviceProvider();
+        var _distributedApplicationModelFromExecutionContext = executionContextServiceProvider.getDistributedApplicationModel();
+        resourceCommandService[0] = executionContextServiceProvider.getResourceCommandService();
+        var interactionService = executionContextServiceProvider.getInteractionService();
+        var _interactionServiceAvailable = interactionService.isAvailable();
+        var interactionInput = new InteractionInput();
+        interactionInput.setName("validation");
+        interactionInput.setInputType(InputType.TEXT);
+        interactionInput.setValue("default");
+        interactionInput.setDisabled(false);
+        var confirmationOptions = new MessageBoxInteractionOptions();
+        confirmationOptions.setIntent(MessageIntent.CONFIRMATION);
+        confirmationOptions.setPrimaryButtonText("Continue");
+        interactionService.promptConfirmationAsync(
+            "Confirm",
+            "Continue?",
+            new PromptConfirmationAsyncOptions().options(confirmationOptions));
+        var messageBoxOptions = new MessageBoxInteractionOptions();
+        messageBoxOptions.setIntent(MessageIntent.INFORMATION);
+        messageBoxOptions.setEnableMessageMarkdown(true);
+        interactionService.promptMessageBoxAsync(
+            "Message",
+            "Message body",
+            new PromptMessageBoxAsyncOptions().options(messageBoxOptions));
+        var inputOptions = new InputsDialogInteractionOptions();
+        inputOptions.setPrimaryButtonText("Submit");
+        interactionService.promptInputAsync(
+            "Input",
+            "Input body",
+            "Name",
+            "Placeholder",
+            new PromptInputAsyncOptions().options(inputOptions));
+        var inputWithInputOptions = new InputsDialogInteractionOptions();
+        inputWithInputOptions.setShowDismiss(true);
+        interactionService.promptInputWithInputAsync(
+            "Input",
+            "Input body",
+            interactionInput,
+            new PromptInputWithInputAsyncOptions().options(inputWithInputOptions));
+        var inputsOptions = new InputsDialogInteractionOptions();
+        inputsOptions.setShowSecondaryButton(true);
+        inputsOptions.setSecondaryButtonText("Skip");
+        interactionService.promptInputsAsync(
+            "Inputs",
+            "Inputs body",
+            new InteractionInput[] { interactionInput },
+            new PromptInputsAsyncOptions().options(inputsOptions));
+        var notificationOptions = new NotificationInteractionOptions();
+        notificationOptions.setIntent(MessageIntent.INFORMATION);
+        notificationOptions.setLinkText("Docs");
+        notificationOptions.setLinkUrl("https://aspire.dev");
+        interactionService.promptNotificationAsync(
+            "Notification",
+            "Notification body",
+            new PromptNotificationAsyncOptions().options(notificationOptions));
+
         app.run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
@@ -142,6 +142,58 @@ void main() throws Exception {
         var executionContextServiceProvider = builderExecutionContext.serviceProvider();
         var _distributedApplicationModelFromExecutionContext = executionContextServiceProvider.getDistributedApplicationModel();
         var resourceCommandService = executionContextServiceProvider.getResourceCommandService();
+        var interactionService = executionContextServiceProvider.getInteractionService();
+        var _interactionServiceAvailable = interactionService.isAvailable();
+        var interactionInput = new InteractionInput();
+        interactionInput.setName("validation");
+        interactionInput.setInputType(InputType.TEXT);
+        interactionInput.setValue("default");
+        interactionInput.setDisabled(false);
+        var confirmationOptions = new MessageBoxInteractionOptions();
+        confirmationOptions.setIntent(MessageIntent.CONFIRMATION);
+        confirmationOptions.setPrimaryButtonText("Continue");
+        interactionService.promptConfirmationAsync(
+            "Confirm",
+            "Continue?",
+            new PromptConfirmationAsyncOptions().options(confirmationOptions));
+        var messageBoxOptions = new MessageBoxInteractionOptions();
+        messageBoxOptions.setIntent(MessageIntent.INFORMATION);
+        messageBoxOptions.setEnableMessageMarkdown(true);
+        interactionService.promptMessageBoxAsync(
+            "Message",
+            "Message body",
+            new PromptMessageBoxAsyncOptions().options(messageBoxOptions));
+        var inputOptions = new InputsDialogInteractionOptions();
+        inputOptions.setPrimaryButtonText("Submit");
+        interactionService.promptInputAsync(
+            "Input",
+            "Input body",
+            "Name",
+            "Placeholder",
+            new PromptInputAsyncOptions().options(inputOptions));
+        var inputWithInputOptions = new InputsDialogInteractionOptions();
+        inputWithInputOptions.setShowDismiss(true);
+        interactionService.promptInputWithInputAsync(
+            "Input",
+            "Input body",
+            interactionInput,
+            new PromptInputWithInputAsyncOptions().options(inputWithInputOptions));
+        var inputsOptions = new InputsDialogInteractionOptions();
+        inputsOptions.setShowSecondaryButton(true);
+        inputsOptions.setSecondaryButtonText("Skip");
+        interactionService.promptInputsAsync(
+            "Inputs",
+            "Inputs body",
+            new InteractionInput[] { interactionInput },
+            new PromptInputsAsyncOptions().options(inputsOptions));
+        var notificationOptions = new NotificationInteractionOptions();
+        notificationOptions.setIntent(MessageIntent.INFORMATION);
+        notificationOptions.setLinkText("Docs");
+        notificationOptions.setLinkUrl("https://aspire.dev");
+        interactionService.promptNotificationAsync(
+            "Notification",
+            "Notification body",
+            new PromptNotificationAsyncOptions().options(notificationOptions));
         builder.addEventingSubscriber((registrationContext) -> {
             var subscriberExecutionContext = registrationContext.executionContext();
             var _subscriberIsRunMode = subscriberExecutionContext.isRunMode();

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
@@ -4,7 +4,6 @@ import java.util.function.Function;
 
 void main() throws Exception {
         var builder = DistributedApplication.CreateBuilder();
-        var resourceCommandService = new ResourceCommandService[1];
         var container = builder.addContainer("mycontainer", "nginx");
         container.withOtlpExporter(OtlpProtocol.HTTP_JSON);
         var dockerContainer = builder.addDockerfile("dockerapp", "./app");
@@ -252,14 +251,146 @@ void main() throws Exception {
             result.setSuccess("hello".equals(commandArguments[0].getValue()));
             return result;
         }, echoCommandOptions);
-        container.withCommand("restart", "Restart", (ctx) -> {
-            var cancellationToken = ctx.cancellationToken();
-            return resourceCommandService[0].executeCommandAsync(
+        container.withCommand("restart", "Restart", (commandContext) -> {
+            var cancellationToken = commandContext.cancellationToken();
+            // Command callbacks run after build(), when the execution context service provider is populated; accessing it before build() throws.
+            var serviceProvider = commandContext.serviceProvider();
+            var resourceCommandService = serviceProvider.getResourceCommandService();
+            return resourceCommandService.executeCommandAsync(
                 container,
                 "echo",
                 new ExecuteCommandAsyncOptions()
                     .arguments(Map.of("message", "hello"))
                     .cancellationToken(cancellationToken));
+        });
+        container.withCommand("interaction-validation", "Interaction Validation", (commandContext) -> {
+            // Command callbacks run after build(), when the execution context service provider is populated; accessing it before build() throws.
+            var interactionService = commandContext.serviceProvider().getInteractionService();
+            var interactionServiceAvailable = interactionService.isAvailable();
+            var interactionInput = new InteractionInput();
+            interactionInput.setName("validation");
+            interactionInput.setInputType(InputType.TEXT);
+            interactionInput.setValue("default");
+            interactionInput.setDisabled(false);
+            var choiceInput = new InteractionInput();
+            choiceInput.setName("choice");
+            choiceInput.setInputType(InputType.CHOICE);
+            choiceInput.setPlaceholder("Placeholder!");
+            choiceInput.setRequired(true);
+            choiceInput.setOptions(new Object[] {
+                Map.of("Value", "option1", "Label", "Option 1"),
+                Map.of("Value", "option2", "Label", "Option 2"),
+                Map.of("Value", "option3", "Label", "Option 3")
+            });
+            var dynamicLoading = new InputLoadOptions();
+            dynamicLoading.setAlwaysLoadOnStart(true);
+            dynamicLoading.setLoadCallback((Function<Object[], Object>) (args) -> {
+                var loadContext = (LoadInputContext) args[0];
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(ex);
+                }
+
+                loadContext.setOptions(Map.of(
+                    "dynamic1", "Dynamic Option 1",
+                    "dynamic2", "Dynamic Option 2"));
+                return null;
+            });
+            var dynamicChoiceInput = new InteractionInput();
+            dynamicChoiceInput.setName("dynamic-choice");
+            dynamicChoiceInput.setInputType(InputType.CHOICE);
+            dynamicChoiceInput.setPlaceholder("Loading choices...");
+            dynamicChoiceInput.setRequired(true);
+            dynamicChoiceInput.setDynamicLoading(dynamicLoading);
+            var confirmationOptions = new MessageBoxInteractionOptions();
+            confirmationOptions.setIntent(MessageIntent.CONFIRMATION);
+            confirmationOptions.setPrimaryButtonText("Continue");
+            interactionService.promptConfirmationAsync(
+                "Confirm",
+                "Continue?",
+                new PromptConfirmationAsyncOptions().options(confirmationOptions));
+            var messageBoxOptions = new MessageBoxInteractionOptions();
+            messageBoxOptions.setIntent(MessageIntent.INFORMATION);
+            messageBoxOptions.setEnableMessageMarkdown(true);
+            interactionService.promptMessageBoxAsync(
+                "Message",
+                "Message body",
+                new PromptMessageBoxAsyncOptions().options(messageBoxOptions));
+            var inputOptions = new InputsDialogInteractionOptions();
+            inputOptions.setPrimaryButtonText("Submit");
+            interactionService.promptInputAsync(
+                "Input",
+                "Input body",
+                "Name",
+                "Placeholder",
+                new PromptInputAsyncOptions().options(inputOptions));
+            var inputWithInputOptions = new InputsDialogInteractionOptions();
+            inputWithInputOptions.setPrimaryButtonText("Submit");
+            inputWithInputOptions.setSecondaryButtonText("Skip");
+            inputWithInputOptions.setShowSecondaryButton(true);
+            inputWithInputOptions.setEnableMessageMarkdown(true);
+            inputWithInputOptions.setShowDismiss(true);
+            interactionService.promptInputWithInputAsync(
+                "Choice inputs",
+                "Range of choice inputs",
+                choiceInput,
+                new PromptInputWithInputAsyncOptions().options(inputWithInputOptions));
+            var inputsOptions = new InputsDialogInteractionOptions();
+            inputsOptions.setShowSecondaryButton(true);
+            inputsOptions.setSecondaryButtonText("Skip");
+            interactionService.promptInputsAsync(
+                "Inputs",
+                "Inputs body",
+                new InteractionInput[] { interactionInput, choiceInput },
+                new PromptInputsAsyncOptions().options(inputsOptions));
+            var dynamicChoiceOptions = new InputsDialogInteractionOptions();
+            dynamicChoiceOptions.setPrimaryButtonText("Submit");
+            dynamicChoiceOptions.setValidationCallback((Function<Object[], Object>) (args) -> {
+                var validationContext = (InputsDialogValidationContext) args[0];
+                var selectedValue = "";
+                for (var input : validationContext.inputs().toArray()) {
+                    if ("dynamic-choice".equals(input.getName())) {
+                        selectedValue = input.getValue();
+                        break;
+                    }
+                }
+                if (!"dynamic1".equals(selectedValue) && !"dynamic2".equals(selectedValue)) {
+                    validationContext.addValidationError("dynamic-choice", "Select a dynamically loaded option.");
+                }
+                return null;
+            });
+            var dynamicChoiceResult = interactionService.promptInputsAsync(
+                "Dynamic choice",
+                "Select a dynamically loaded option.",
+                new InteractionInput[] { dynamicChoiceInput },
+                new PromptInputsAsyncOptions().options(dynamicChoiceOptions));
+            var notificationOptions = new NotificationInteractionOptions();
+            notificationOptions.setIntent(MessageIntent.INFORMATION);
+            notificationOptions.setLinkText("Docs");
+            notificationOptions.setLinkUrl("https://aspire.dev");
+            interactionService.promptNotificationAsync(
+                "Notification",
+                "Notification body",
+                new PromptNotificationAsyncOptions().options(notificationOptions));
+            var dynamicChoiceValue = "default";
+            if (!dynamicChoiceResult.getCanceled() && dynamicChoiceResult.getData() != null) {
+                for (var input : dynamicChoiceResult.getData().toArray()) {
+                    if ("dynamic-choice".equals(input.getName()) && input.getValue() != null && !input.getValue().isEmpty()) {
+                        dynamicChoiceValue = input.getValue();
+                        break;
+                    }
+                }
+            }
+            commandContext.logger().logInformation("Dynamic choice selected: " + dynamicChoiceValue);
+            var data = new CommandResultData();
+            data.setValue(dynamicChoiceValue);
+            data.setFormat(CommandResultFormat.TEXT);
+            var result = new ExecuteCommandResult();
+            result.setSuccess(interactionServiceAvailable);
+            result.setData(data);
+            return result;
         });
         container.withHttpCommand("/health", "Health Check");
         var httpCmdOptions = new HttpCommandExportOptions();
@@ -267,63 +398,5 @@ void main() throws Exception {
         httpCmdOptions.setConfirmationMessage("Are you sure?");
         container.withHttpCommand("/api/reset", "Reset", httpCmdOptions);
         var app = builder.build();
-
-        // The execution context service provider is populated by build(); accessing it before this point throws.
-        var executionContextServiceProvider = builderExecutionContext.serviceProvider();
-        var _distributedApplicationModelFromExecutionContext = executionContextServiceProvider.getDistributedApplicationModel();
-        resourceCommandService[0] = executionContextServiceProvider.getResourceCommandService();
-        var interactionService = executionContextServiceProvider.getInteractionService();
-        var _interactionServiceAvailable = interactionService.isAvailable();
-        var interactionInput = new InteractionInput();
-        interactionInput.setName("validation");
-        interactionInput.setInputType(InputType.TEXT);
-        interactionInput.setValue("default");
-        interactionInput.setDisabled(false);
-        var confirmationOptions = new MessageBoxInteractionOptions();
-        confirmationOptions.setIntent(MessageIntent.CONFIRMATION);
-        confirmationOptions.setPrimaryButtonText("Continue");
-        interactionService.promptConfirmationAsync(
-            "Confirm",
-            "Continue?",
-            new PromptConfirmationAsyncOptions().options(confirmationOptions));
-        var messageBoxOptions = new MessageBoxInteractionOptions();
-        messageBoxOptions.setIntent(MessageIntent.INFORMATION);
-        messageBoxOptions.setEnableMessageMarkdown(true);
-        interactionService.promptMessageBoxAsync(
-            "Message",
-            "Message body",
-            new PromptMessageBoxAsyncOptions().options(messageBoxOptions));
-        var inputOptions = new InputsDialogInteractionOptions();
-        inputOptions.setPrimaryButtonText("Submit");
-        interactionService.promptInputAsync(
-            "Input",
-            "Input body",
-            "Name",
-            "Placeholder",
-            new PromptInputAsyncOptions().options(inputOptions));
-        var inputWithInputOptions = new InputsDialogInteractionOptions();
-        inputWithInputOptions.setShowDismiss(true);
-        interactionService.promptInputWithInputAsync(
-            "Input",
-            "Input body",
-            interactionInput,
-            new PromptInputWithInputAsyncOptions().options(inputWithInputOptions));
-        var inputsOptions = new InputsDialogInteractionOptions();
-        inputsOptions.setShowSecondaryButton(true);
-        inputsOptions.setSecondaryButtonText("Skip");
-        interactionService.promptInputsAsync(
-            "Inputs",
-            "Inputs body",
-            new InteractionInput[] { interactionInput },
-            new PromptInputsAsyncOptions().options(inputsOptions));
-        var notificationOptions = new NotificationInteractionOptions();
-        notificationOptions.setIntent(MessageIntent.INFORMATION);
-        notificationOptions.setLinkText("Docs");
-        notificationOptions.setLinkUrl("https://aspire.dev");
-        interactionService.promptNotificationAsync(
-            "Notification",
-            "Notification body",
-            new PromptNotificationAsyncOptions().options(notificationOptions));
-
         app.run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
@@ -291,6 +291,48 @@ ENTRYPOINT ["dotnet", "App.dll"]"""
     execution_context_service_provider = builder_execution_context.service_provider
     _distributed_application_model_from_execution_context = execution_context_service_provider.get_distributed_app_model()
     resource_command_service = execution_context_service_provider.get_resource_command_service()
+    interaction_service = execution_context_service_provider.get_interaction_service()
+    _interaction_service_available = interaction_service.is_available()
+    _interaction_input = {
+        "Name": "validation",
+        "InputType": "Text",
+        "Value": "default",
+        "Disabled": False,
+    }
+    interaction_service.prompt_confirmation(
+        "Confirm",
+        "Continue?",
+        options={"Intent": "Confirmation", "PrimaryButtonText": "Continue"},
+    )
+    interaction_service.prompt_message_box(
+        "Message",
+        "Message body",
+        options={"Intent": "Information", "EnableMessageMarkdown": True},
+    )
+    interaction_service.prompt_input(
+        "Input",
+        "Input body",
+        "Name",
+        "Placeholder",
+        options={"PrimaryButtonText": "Submit"},
+    )
+    interaction_service.prompt_input_with_input(
+        "Input",
+        "Input body",
+        _interaction_input,
+        options={"ShowDismiss": True},
+    )
+    interaction_service.prompt_inputs(
+        "Inputs",
+        "Inputs body",
+        [_interaction_input],
+        options={"ShowSecondaryButton": True, "SecondaryButtonText": "Skip"},
+    )
+    interaction_service.prompt_notification(
+        "Notification",
+        "Notification body",
+        options={"Intent": "Information", "LinkText": "Docs", "LinkUrl": "https://aspire.dev"},
+    )
 
     def configure_eventing_subscriber(registration_context):
         _subscriber_execution_context = registration_context.execution_context

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
@@ -5,6 +5,8 @@ from aspire_app import AksNodeVmSizes, AzureServiceTags, ReferenceExpression, We
 
 
 with create_builder() as builder:
+    resource_command_service = None
+
     def update_existing_http_endpoint(endpoint):
         endpoint.port = 8080
         endpoint.is_proxied = False
@@ -288,51 +290,6 @@ ENTRYPOINT ["dotnet", "App.dll"]"""
     _config_children = builder_configuration.get_children()
     _config_exists = builder_configuration.exists()
     builder_execution_context = builder.execution_context
-    execution_context_service_provider = builder_execution_context.service_provider
-    _distributed_application_model_from_execution_context = execution_context_service_provider.get_distributed_app_model()
-    resource_command_service = execution_context_service_provider.get_resource_command_service()
-    interaction_service = execution_context_service_provider.get_interaction_service()
-    _interaction_service_available = interaction_service.is_available()
-    _interaction_input = {
-        "Name": "validation",
-        "InputType": "Text",
-        "Value": "default",
-        "Disabled": False,
-    }
-    interaction_service.prompt_confirmation(
-        "Confirm",
-        "Continue?",
-        options={"Intent": "Confirmation", "PrimaryButtonText": "Continue"},
-    )
-    interaction_service.prompt_message_box(
-        "Message",
-        "Message body",
-        options={"Intent": "Information", "EnableMessageMarkdown": True},
-    )
-    interaction_service.prompt_input(
-        "Input",
-        "Input body",
-        "Name",
-        "Placeholder",
-        options={"PrimaryButtonText": "Submit"},
-    )
-    interaction_service.prompt_input_with_input(
-        "Input",
-        "Input body",
-        _interaction_input,
-        options={"ShowDismiss": True},
-    )
-    interaction_service.prompt_inputs(
-        "Inputs",
-        "Inputs body",
-        [_interaction_input],
-        options={"ShowSecondaryButton": True, "SecondaryButtonText": "Skip"},
-    )
-    interaction_service.prompt_notification(
-        "Notification",
-        "Notification body",
-        options={"Intent": "Information", "LinkText": "Docs", "LinkUrl": "https://aspire.dev"},
-    )
 
     def configure_eventing_subscriber(registration_context):
         _subscriber_execution_context = registration_context.execution_context
@@ -473,6 +430,54 @@ ENTRYPOINT ["dotnet", "App.dll"]"""
     container.with_http_command("/health", "Health Check")
     container.with_http_command("/api/reset", "Reset", options={"MethodName": "POST", "ConfirmationMessage": "Are you sure?"})
     app = builder.build()
+
+    # The execution context service provider is populated by build(); accessing it before this point throws.
+    execution_context_service_provider = builder_execution_context.service_provider
+    _distributed_application_model_from_execution_context = execution_context_service_provider.get_distributed_app_model()
+    resource_command_service = execution_context_service_provider.get_resource_command_service()
+    interaction_service = execution_context_service_provider.get_interaction_service()
+    _interaction_service_available = interaction_service.is_available()
+    _interaction_input = {
+        "Name": "validation",
+        "InputType": "Text",
+        "Value": "default",
+        "Disabled": False,
+    }
+    interaction_service.prompt_confirmation(
+        "Confirm",
+        "Continue?",
+        options={"Intent": "Confirmation", "PrimaryButtonText": "Continue"},
+    )
+    interaction_service.prompt_message_box(
+        "Message",
+        "Message body",
+        options={"Intent": "Information", "EnableMessageMarkdown": True},
+    )
+    interaction_service.prompt_input(
+        "Input",
+        "Input body",
+        "Name",
+        "Placeholder",
+        options={"PrimaryButtonText": "Submit"},
+    )
+    interaction_service.prompt_input_with_input(
+        "Input",
+        "Input body",
+        _interaction_input,
+        options={"ShowDismiss": True},
+    )
+    interaction_service.prompt_inputs(
+        "Inputs",
+        "Inputs body",
+        [_interaction_input],
+        options={"ShowSecondaryButton": True, "SecondaryButtonText": "Skip"},
+    )
+    interaction_service.prompt_notification(
+        "Notification",
+        "Notification body",
+        options={"Intent": "Information", "LinkText": "Docs", "LinkUrl": "https://aspire.dev"},
+    )
+
     _distributed_app_connection_string = app.get_connection_string()
     _distributed_app_endpoint = app.get_endpoint("default")
     _distributed_app_endpoint_for_network = app.get_endpoint_for_network("resource")

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
@@ -5,8 +5,6 @@ from aspire_app import AksNodeVmSizes, AzureServiceTags, ReferenceExpression, We
 
 
 with create_builder() as builder:
-    resource_command_service = None
-
     def update_existing_http_endpoint(endpoint):
         endpoint.port = 8080
         endpoint.is_proxied = False
@@ -412,12 +410,121 @@ ENTRYPOINT ["dotnet", "App.dll"]"""
     container.with_command(
         "noop",
         "Noop",
-        lambda *_args, **_kwargs: {"success": True},
+        lambda command_context: {"success": True},
         command_options={"UpdateState": update_command_state}
     )
 
-    def restart_command(_ctx):
+    def restart_command(command_context):
+        # Command callbacks run after build(), when the execution context service provider is populated; accessing it before build() throws.
+        service_provider = command_context.service_provider
+        resource_command_service = service_provider.get_resource_command_service()
         return resource_command_service.execute_command(container, "echo", arguments={"message": "hello"})
+
+    def interaction_validation_command(command_context):
+        # Command callbacks run after build(), when the execution context service provider is populated; accessing it before build() throws.
+        service_provider = command_context.service_provider
+        interaction_service = service_provider.get_interaction_service()
+        is_available = interaction_service.is_available()
+        text_input = {
+            "Name": "validation",
+            "InputType": "Text",
+            "Value": "default",
+            "Disabled": False,
+        }
+        choice_input = {
+            "Name": "choice",
+            "InputType": "Choice",
+            "Placeholder": "Placeholder!",
+            "Required": True,
+            "Options": [
+                {"Key": "option1", "Value": "Option 1"},
+                {"Key": "option2", "Value": "Option 2"},
+                {"Key": "option3", "Value": "Option 3"},
+            ],
+        }
+
+        def load_dynamic_choices(load_context):
+            import time
+            time.sleep(1)
+            load_context.set_options({
+                "dynamic1": "Dynamic Option 1",
+                "dynamic2": "Dynamic Option 2",
+            })
+
+        def validate_dynamic_choice(validation_context):
+            dynamic_choice = validation_context.inputs.required("dynamic-choice")
+            if dynamic_choice.get("Value") not in ("dynamic1", "dynamic2"):
+                validation_context.add_validation_error("dynamic-choice", "Select one of the dynamically loaded values.")
+
+        dynamic_choice_input = {
+            "Name": "dynamic-choice",
+            "InputType": "Choice",
+            "Placeholder": "Choose a dynamically loaded value",
+            "Required": True,
+            "DynamicLoading": {
+                "AlwaysLoadOnStart": True,
+                "LoadCallback": load_dynamic_choices,
+            },
+        }
+        interaction_service.prompt_confirmation(
+            "Confirm",
+            "Continue?",
+            options={"Intent": "Confirmation", "PrimaryButtonText": "Continue"},
+        )
+        interaction_service.prompt_message_box(
+            "Message",
+            "Message body",
+            options={"Intent": "Information", "EnableMessageMarkdown": True},
+        )
+        input_result = interaction_service.prompt_input(
+            "Input",
+            "Input body",
+            "Name",
+            "Placeholder",
+            options={"PrimaryButtonText": "Submit"},
+        )
+        choice_result = interaction_service.prompt_input_with_input(
+            "Choice inputs",
+            "Range of choice inputs",
+            choice_input,
+            options={
+                "PrimaryButtonText": "Submit",
+                "SecondaryButtonText": "Skip",
+                "ShowSecondaryButton": True,
+                "EnableMessageMarkdown": True,
+                "ShowDismiss": True,
+            },
+        )
+        interaction_service.prompt_inputs(
+            "Inputs",
+            "Inputs body",
+            [text_input, choice_input],
+            options={"ShowSecondaryButton": True, "SecondaryButtonText": "Skip"},
+        )
+        dynamic_choice_result = interaction_service.prompt_input_with_input(
+            "Dynamic choice input",
+            "Options are loaded after the prompt opens.",
+            dynamic_choice_input,
+            options={
+                "PrimaryButtonText": "Submit",
+                "ValidationCallback": validate_dynamic_choice,
+            },
+        )
+        dynamic_choice_value = (dynamic_choice_result.get("data") or {}).get("Value", "canceled")
+        command_context.logger.log_information("Dynamic choice selected: %s", dynamic_choice_value)
+        interaction_service.prompt_notification(
+            "Notification",
+            "Notification body",
+            options={"Intent": "Information", "LinkText": "Docs", "LinkUrl": "https://aspire.dev"},
+        )
+
+        return {
+            "success": is_available or input_result.get("canceled") is True or choice_result.get("canceled") is True,
+            "data": {
+                "value": dynamic_choice_value,
+                "format": "Text",
+            },
+        }
 
     container.with_command(
         "echo",
@@ -426,58 +533,11 @@ ENTRYPOINT ["dotnet", "App.dll"]"""
         command_options={"Arguments": [{"Name": "message", "InputType": "Text", "Required": True}]}
     )
     container.with_command("restart", "Restart", restart_command)
+    container.with_command("interaction-validation", "Interaction Validation", interaction_validation_command)
     # withHttpCommand
     container.with_http_command("/health", "Health Check")
     container.with_http_command("/api/reset", "Reset", options={"MethodName": "POST", "ConfirmationMessage": "Are you sure?"})
     app = builder.build()
-
-    # The execution context service provider is populated by build(); accessing it before this point throws.
-    execution_context_service_provider = builder_execution_context.service_provider
-    _distributed_application_model_from_execution_context = execution_context_service_provider.get_distributed_app_model()
-    resource_command_service = execution_context_service_provider.get_resource_command_service()
-    interaction_service = execution_context_service_provider.get_interaction_service()
-    _interaction_service_available = interaction_service.is_available()
-    _interaction_input = {
-        "Name": "validation",
-        "InputType": "Text",
-        "Value": "default",
-        "Disabled": False,
-    }
-    interaction_service.prompt_confirmation(
-        "Confirm",
-        "Continue?",
-        options={"Intent": "Confirmation", "PrimaryButtonText": "Continue"},
-    )
-    interaction_service.prompt_message_box(
-        "Message",
-        "Message body",
-        options={"Intent": "Information", "EnableMessageMarkdown": True},
-    )
-    interaction_service.prompt_input(
-        "Input",
-        "Input body",
-        "Name",
-        "Placeholder",
-        options={"PrimaryButtonText": "Submit"},
-    )
-    interaction_service.prompt_input_with_input(
-        "Input",
-        "Input body",
-        _interaction_input,
-        options={"ShowDismiss": True},
-    )
-    interaction_service.prompt_inputs(
-        "Inputs",
-        "Inputs body",
-        [_interaction_input],
-        options={"ShowSecondaryButton": True, "SecondaryButtonText": "Skip"},
-    )
-    interaction_service.prompt_notification(
-        "Notification",
-        "Notification body",
-        options={"Intent": "Information", "LinkText": "Docs", "LinkUrl": "https://aspire.dev"},
-    )
-
     _distributed_app_connection_string = app.get_connection_string()
     _distributed_app_endpoint = app.get_endpoint("default")
     _distributed_app_endpoint_for_network = app.get_endpoint_for_network("resource")

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
@@ -5,6 +5,7 @@ import {
     WellKnownPipelineTags,
     createBuilder,
     CertificateTrustScope,
+    CommandResultFormat,
     EndpointProperty,
     HealthStatus,
     IconVariant,
@@ -15,12 +16,11 @@ import {
     ResourceCommandState,
     refExpr,
 } from './.aspire/modules/aspire.mjs';
-import type { DockerfileBuilderCallbackContext, DockerfileFactoryContext, ResourceCommandService } from './.aspire/modules/aspire.mjs';
+import type { DockerfileBuilderCallbackContext, DockerfileFactoryContext, InputLoadOptions, InteractionInput, LoadInputContext } from './.aspire/modules/aspire.mjs';
 import { fileURLToPath } from 'node:url';
 
 const builder = await createBuilder();
 const processCommandStdinScriptPath = fileURLToPath(new URL("./process-command-scripts/stdin.js", import.meta.url));
-let resourceCommandService: ResourceCommandService;
 
 // ===================================================================
 // Factory methods on builder
@@ -718,8 +718,8 @@ await container.withCommand("noop", "Noop", async () => {
         },
     },
 });
-await container.withCommand("echo", "Echo", async (ctx) => {
-    const commandInputs = await ctx.arguments();
+await container.withCommand("echo", "Echo", async (commandContext) => {
+    const commandInputs = await commandContext.arguments();
     const commandArguments = await commandInputs.toArray();
 
     return { success: commandArguments[0]?.value === "hello" };
@@ -734,13 +734,106 @@ await container.withCommand("echo", "Echo", async (ctx) => {
         ]
     }
 });
-await container.withCommand("restart", "Restart", async (ctx) => {
-    const cancellationToken = await ctx.cancellationToken();
+await container.withCommand("restart", "Restart", async (commandContext) => {
+    const cancellationToken = await commandContext.cancellationToken();
+    // Command callbacks run after build(), when the execution context service provider is populated; accessing it before build() throws.
+    const resourceCommandService = await commandContext.serviceProvider().getResourceCommandService();
 
     return await resourceCommandService.executeCommandAsync(container, "echo", {
         arguments: { message: "hello" },
         cancellationToken
     });
+});
+await container.withCommand("interaction-validation", "Interaction Validation", async (commandContext) => {
+    // Command callbacks run after build(), when the execution context service provider is populated; accessing it before build() throws.
+    const interactionService = await commandContext.serviceProvider().getInteractionService();
+    const interactionServiceAvailable = await interactionService.isAvailable();
+    const textInput = {
+        name: "validation",
+        inputType: InputType.Text,
+        value: "default",
+        disabled: false,
+    };
+    const choiceInput = {
+        name: "choice",
+        inputType: InputType.Choice,
+        placeholder: "Placeholder!",
+        required: true,
+        options: [
+            { key: "option1", value: "Option 1" },
+            { key: "option2", value: "Option 2" },
+            { key: "option3", value: "Option 3" },
+        ],
+    };
+    const dynamicLoading: InputLoadOptions = {
+        alwaysLoadOnStart: true,
+        loadCallback: async (loadContext: LoadInputContext) => {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            await loadContext.setOptions({
+                dynamic1: "Dynamic Option 1",
+                dynamic2: "Dynamic Option 2",
+            });
+        },
+    };
+    const dynamicChoiceInput: InteractionInput = {
+        name: "dynamic-choice",
+        inputType: InputType.Choice,
+        placeholder: "Choose a dynamically loaded value",
+        required: true,
+        dynamicLoading,
+    };
+
+    await interactionService.promptConfirmationAsync("Confirm", "Continue?", {
+        options: { intent: MessageIntent.Confirmation, primaryButtonText: "Continue" },
+    });
+    await interactionService.promptMessageBoxAsync("Message", "Message body", {
+        options: { intent: MessageIntent.Information, enableMessageMarkdown: true },
+    });
+    await interactionService.promptInputAsync("Input", "Input body", "Name", "Placeholder", {
+        options: { primaryButtonText: "Submit" },
+    });
+    await interactionService.promptInputWithInputAsync("Choice inputs", "Range of choice inputs", choiceInput, {
+        options: {
+            primaryButtonText: "Submit",
+            secondaryButtonText: "Skip",
+            showSecondaryButton: true,
+            enableMessageMarkdown: true,
+            showDismiss: true,
+        },
+    });
+    await interactionService.promptInputsAsync("Inputs", "Inputs body", [textInput, choiceInput], {
+        options: { showSecondaryButton: true, secondaryButtonText: "Skip" },
+    });
+    const dynamicChoiceResult = await interactionService.promptInputWithInputAsync(
+        "Dynamic choice input",
+        "Options are loaded after the prompt opens.",
+        dynamicChoiceInput,
+        {
+            options: {
+                primaryButtonText: "Submit",
+                validationCallback: async (validationContext) => {
+                    const inputs = await validationContext.inputs();
+                    const dynamicChoice = await inputs.required("dynamic-choice");
+                    if (dynamicChoice.value !== "dynamic1" && dynamicChoice.value !== "dynamic2") {
+                        await validationContext.addValidationError("dynamic-choice", "Select one of the dynamically loaded values.");
+                    }
+                },
+            },
+        });
+    const dynamicChoiceValue = dynamicChoiceResult.data?.value ?? "canceled";
+    const commandLogger = await commandContext.logger();
+    await commandLogger.logInformation(`Dynamic choice selected: ${dynamicChoiceValue}`);
+    await interactionService.promptNotificationAsync("Notification", "Notification body", {
+        options: { intent: MessageIntent.Information, linkText: "Docs", linkUrl: "https://aspire.dev" },
+    });
+
+    return {
+        success: interactionServiceAvailable,
+        data: {
+            value: dynamicChoiceValue,
+            format: CommandResultFormat.Text,
+        },
+    };
 });
 
 // withProcessCommand
@@ -770,36 +863,4 @@ await container.withHttpCommand("/health", "Health Check");
 await container.withHttpCommand("/api/reset", "Reset", { methodName: "POST", confirmationMessage: "Are you sure?" });
 
 const app = await builder.build();
-
-// The execution context service provider is populated by build(); accessing it before this point throws.
-const executionContextServiceProvider = await builderExecutionContext.serviceProvider();
-const _distributedApplicationModelFromExecutionContext = await executionContextServiceProvider.getDistributedApplicationModel();
-resourceCommandService = await executionContextServiceProvider.getResourceCommandService();
-const interactionService = await executionContextServiceProvider.getInteractionService();
-const _interactionServiceAvailable = await interactionService.isAvailable();
-const interactionInput = {
-    name: "validation",
-    inputType: InputType.Text,
-    value: "default",
-    disabled: false,
-};
-void await interactionService.promptConfirmationAsync("Confirm", "Continue?", {
-    options: { intent: MessageIntent.Confirmation, primaryButtonText: "Continue" },
-});
-void await interactionService.promptMessageBoxAsync("Message", "Message body", {
-    options: { intent: MessageIntent.Information, enableMessageMarkdown: true },
-});
-void await interactionService.promptInputAsync("Input", "Input body", "Name", "Placeholder", {
-    options: { primaryButtonText: "Submit" },
-});
-void await interactionService.promptInputWithInputAsync("Input", "Input body", interactionInput, {
-    options: { showDismiss: true },
-});
-void await interactionService.promptInputsAsync("Inputs", "Inputs body", [interactionInput], {
-    options: { showSecondaryButton: true, secondaryButtonText: "Skip" },
-});
-void await interactionService.promptNotificationAsync("Notification", "Notification body", {
-    options: { intent: MessageIntent.Information, linkText: "Docs", linkUrl: "https://aspire.dev" },
-});
-
 await app.run();

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
@@ -15,11 +15,12 @@ import {
     ResourceCommandState,
     refExpr,
 } from './.aspire/modules/aspire.mjs';
-import type { DockerfileBuilderCallbackContext, DockerfileFactoryContext } from './.aspire/modules/aspire.mjs';
+import type { DockerfileBuilderCallbackContext, DockerfileFactoryContext, ResourceCommandService } from './.aspire/modules/aspire.mjs';
 import { fileURLToPath } from 'node:url';
 
 const builder = await createBuilder();
 const processCommandStdinScriptPath = fileURLToPath(new URL("./process-command-scripts/stdin.js", import.meta.url));
+let resourceCommandService: ResourceCommandService;
 
 // ===================================================================
 // Factory methods on builder
@@ -443,35 +444,6 @@ const _configChildren = await builderConfiguration.getChildren();
 const _configExists: boolean = await builderConfiguration.exists("MyConfig:Key");
 
 const builderExecutionContext = builder.executionContext();
-const executionContextServiceProvider = await builderExecutionContext.serviceProvider();
-const _distributedApplicationModelFromExecutionContext = await executionContextServiceProvider.getDistributedApplicationModel();
-const resourceCommandService = await executionContextServiceProvider.getResourceCommandService();
-const interactionService = await executionContextServiceProvider.getInteractionService();
-const _interactionServiceAvailable = await interactionService.isAvailable();
-const interactionInput = {
-    name: "validation",
-    inputType: InputType.Text,
-    value: "default",
-    disabled: false,
-};
-void await interactionService.promptConfirmationAsync("Confirm", "Continue?", {
-    options: { intent: MessageIntent.Confirmation, primaryButtonText: "Continue" },
-});
-void await interactionService.promptMessageBoxAsync("Message", "Message body", {
-    options: { intent: MessageIntent.Information, enableMessageMarkdown: true },
-});
-void await interactionService.promptInputAsync("Input", "Input body", "Name", "Placeholder", {
-    options: { primaryButtonText: "Submit" },
-});
-void await interactionService.promptInputWithInputAsync("Input", "Input body", interactionInput, {
-    options: { showDismiss: true },
-});
-void await interactionService.promptInputsAsync("Inputs", "Inputs body", [interactionInput], {
-    options: { showSecondaryButton: true, secondaryButtonText: "Skip" },
-});
-void await interactionService.promptNotificationAsync("Notification", "Notification body", {
-    options: { intent: MessageIntent.Information, linkText: "Docs", linkUrl: "https://aspire.dev" },
-});
 
 await builder.addEventingSubscriber(async (registrationContext) => {
     const _subscriberIsRunMode: boolean = await registrationContext.executionContext().isRunMode();
@@ -798,4 +770,36 @@ await container.withHttpCommand("/health", "Health Check");
 await container.withHttpCommand("/api/reset", "Reset", { methodName: "POST", confirmationMessage: "Are you sure?" });
 
 const app = await builder.build();
+
+// The execution context service provider is populated by build(); accessing it before this point throws.
+const executionContextServiceProvider = await builderExecutionContext.serviceProvider();
+const _distributedApplicationModelFromExecutionContext = await executionContextServiceProvider.getDistributedApplicationModel();
+resourceCommandService = await executionContextServiceProvider.getResourceCommandService();
+const interactionService = await executionContextServiceProvider.getInteractionService();
+const _interactionServiceAvailable = await interactionService.isAvailable();
+const interactionInput = {
+    name: "validation",
+    inputType: InputType.Text,
+    value: "default",
+    disabled: false,
+};
+void await interactionService.promptConfirmationAsync("Confirm", "Continue?", {
+    options: { intent: MessageIntent.Confirmation, primaryButtonText: "Continue" },
+});
+void await interactionService.promptMessageBoxAsync("Message", "Message body", {
+    options: { intent: MessageIntent.Information, enableMessageMarkdown: true },
+});
+void await interactionService.promptInputAsync("Input", "Input body", "Name", "Placeholder", {
+    options: { primaryButtonText: "Submit" },
+});
+void await interactionService.promptInputWithInputAsync("Input", "Input body", interactionInput, {
+    options: { showDismiss: true },
+});
+void await interactionService.promptInputsAsync("Inputs", "Inputs body", [interactionInput], {
+    options: { showSecondaryButton: true, secondaryButtonText: "Skip" },
+});
+void await interactionService.promptNotificationAsync("Notification", "Notification body", {
+    options: { intent: MessageIntent.Information, linkText: "Docs", linkUrl: "https://aspire.dev" },
+});
+
 await app.run();

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
@@ -9,6 +9,7 @@ import {
     HealthStatus,
     IconVariant,
     InputType,
+    MessageIntent,
     OtlpProtocol,
     ProbeType,
     ResourceCommandState,
@@ -445,6 +446,32 @@ const builderExecutionContext = builder.executionContext();
 const executionContextServiceProvider = await builderExecutionContext.serviceProvider();
 const _distributedApplicationModelFromExecutionContext = await executionContextServiceProvider.getDistributedApplicationModel();
 const resourceCommandService = await executionContextServiceProvider.getResourceCommandService();
+const interactionService = await executionContextServiceProvider.getInteractionService();
+const _interactionServiceAvailable = await interactionService.isAvailable();
+const interactionInput = {
+    name: "validation",
+    inputType: InputType.Text,
+    value: "default",
+    disabled: false,
+};
+void await interactionService.promptConfirmationAsync("Confirm", "Continue?", {
+    options: { intent: MessageIntent.Confirmation, primaryButtonText: "Continue" },
+});
+void await interactionService.promptMessageBoxAsync("Message", "Message body", {
+    options: { intent: MessageIntent.Information, enableMessageMarkdown: true },
+});
+void await interactionService.promptInputAsync("Input", "Input body", "Name", "Placeholder", {
+    options: { primaryButtonText: "Submit" },
+});
+void await interactionService.promptInputWithInputAsync("Input", "Input body", interactionInput, {
+    options: { showDismiss: true },
+});
+void await interactionService.promptInputsAsync("Inputs", "Inputs body", [interactionInput], {
+    options: { showSecondaryButton: true, secondaryButtonText: "Skip" },
+});
+void await interactionService.promptNotificationAsync("Notification", "Notification body", {
+    options: { intent: MessageIntent.Information, linkText: "Docs", linkUrl: "https://aspire.dev" },
+});
 
 await builder.addEventingSubscriber(async (registrationContext) => {
     const _subscriberIsRunMode: boolean = await registrationContext.executionContext().isRunMode();


### PR DESCRIPTION
## Description

Expose Aspire's interaction service to polyglot AppHosts through callback `IServiceProvider` instances, matching the existing pattern for other services available from callback service providers. Polyglot integration authors can now resolve the interaction service and prompt users from TypeScript, Python, Go, and Java AppHosts.

This adds ATS-friendly interaction wrappers for availability checks, confirmation prompts, message boxes, single input prompts, multiple input prompts, and notifications. The wrappers return non-generic result DTOs so the generated SDKs do not need to model `InteractionResult<T>` directly. The generated SDK baselines and compile-time validation AppHosts were updated across TypeScript, Python, Go, Java, and Rust, and Java option DTO names were kept idiomatic without a `Dto` suffix.

### User-facing usage

TypeScript AppHosts can resolve and use the interaction service from callback service providers:

```typescript
const interactionService = executionContext.serviceProvider.getInteractionService();
const isAvailable = interactionService.isAvailable();

interactionService.promptMessageBoxAsync("Message", "Message body", {
  options: {
    intent: MessageIntent.INFORMATION
  }
});
```

Java AppHosts get natural generated option names:

```java
var interactionService = executionContextServiceProvider.getInteractionService();
var options = new MessageBoxInteractionOptions();
options.setIntent(MessageIntent.INFORMATION);

interactionService.promptMessageBoxAsync(
    "Message",
    "Message body",
    new PromptMessageBoxAsyncOptions().options(options));
```

Validation:

- `RunAnalyzers=false dotnet run --project src/Aspire.Cli/Aspire.Cli.csproj -- sdk dump --format ci --output src/Aspire.Hosting/api/Aspire.Hosting.ats.txt`
- `dotnet test` for the ATS scanner tests and TypeScript, Go, Python, Java, and Rust code generation test projects
- Compile-time validation for the edited `tests/PolyglotAppHosts/Aspire.Hosting` TypeScript, Python, Go, and Java AppHosts after `aspire restore`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No