### PR TITLE
Bump release patch version to 13.4.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
     <!-- This repo version -->
     <MajorVersion>13</MajorVersion>
     <MinorVersion>4</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>
     <DefaultTargetFramework>net8.0</DefaultTargetFramework>


### PR DESCRIPTION
## Description

Bumps the release branch patch version from 13.4.1 to 13.4.2 so the next release build produces 13.4.2 artifacts. This updates the central `PatchVersion` in `eng/Versions.props`; the derived `VersionPrefix` now resolves to `13.4.2`.

Validation:

```text
dotnet msbuild eng/Versions.props -nologo -getProperty:VersionPrefix
13.4.2
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No