### PR TITLE
Refine dynamic endpoint allocation

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -242,6 +242,8 @@ public sealed class EndpointReference : IExpressionValue, IManifestExpressionPro
             }
         }
 
+        // Waiting here preserves late allocation for cases that don't need the on-demand fallback,
+        // such as proxyless container endpoints whose actual port is reported by DCP after startup.
         return await endpointAnnotation.AllAllocatedEndpoints.GetAllocatedEndpointAsync(networkId, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -221,24 +221,57 @@ public sealed class EndpointReference : IExpressionValue, IManifestExpressionPro
         GetAllocatedEndpoint()
         ?? throw new InvalidOperationException($"The endpoint `{EndpointName}` is not allocated for the resource `{Resource.Name}`.");
 
-    internal Task<AllocatedEndpoint> GetAllocatedEndpointAsync(NetworkIdentifier networkId, CancellationToken cancellationToken = default)
+    internal async Task<AllocatedEndpoint> GetAllocatedEndpointAsync(NetworkIdentifier networkId, ValueProviderContext context, CancellationToken cancellationToken = default)
     {
         var endpointAnnotation = EndpointAnnotation;
         if (endpointAnnotation.AllAllocatedEndpoints.TryGetAllocatedEndpoint(networkId, out var endpoint))
         {
-            return Task.FromResult(endpoint);
+            return endpoint;
         }
 
-        foreach (var allocationAnnotation in Resource.Annotations.OfType<OnDemandEndpointAllocationAnnotation>())
+        var allocationAnnotations = Resource.Annotations.OfType<OnDemandEndpointAllocationAnnotation>().ToArray();
+        if (allocationAnnotations.Length > 0 && await ShouldAllocateEndpointOnDemandAsync(context, cancellationToken).ConfigureAwait(false))
         {
-            endpoint = allocationAnnotation.TryAllocate(endpointAnnotation, networkId);
-            if (endpoint is not null)
+            foreach (var allocationAnnotation in allocationAnnotations)
             {
-                return Task.FromResult(endpoint);
+                endpoint = allocationAnnotation.TryAllocate(endpointAnnotation, networkId);
+                if (endpoint is not null)
+                {
+                    return endpoint;
+                }
             }
         }
 
-        return endpointAnnotation.AllAllocatedEndpoints.GetAllocatedEndpointAsync(networkId, cancellationToken);
+        return await endpointAnnotation.AllAllocatedEndpoints.GetAllocatedEndpointAsync(networkId, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> ShouldAllocateEndpointOnDemandAsync(ValueProviderContext context, CancellationToken cancellationToken)
+    {
+        if (context.Caller is not { } caller)
+        {
+            return true;
+        }
+
+        if (Resource == caller)
+        {
+            return true;
+        }
+
+        if (context.ExecutionContext is not { } executionContext)
+        {
+            return true;
+        }
+
+        var dependencies = await Resource.GetResourceDependenciesAsync(
+            executionContext,
+            new ResourceDependencyDiscoveryOptions
+            {
+                DiscoveryMode = ResourceDependencyDiscoveryMode.Recursive,
+                CacheAnnotationCallbackResults = true
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        return dependencies.Contains(caller);
     }
 
     private EndpointAnnotation? GetEndpointAnnotation()
@@ -391,7 +424,7 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
 
         async ValueTask<string?> ResolveValueWithAllocatedAddress()
         {
-            var allocatedEndpoint = await Endpoint.GetAllocatedEndpointAsync(networkContext, cancellationToken).ConfigureAwait(false);
+            var allocatedEndpoint = await Endpoint.GetAllocatedEndpointAsync(networkContext, context, cancellationToken).ConfigureAwait(false);
 
             return Property switch
             {

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1154,6 +1154,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
 
         // Reset cached callback results so they are re-evaluated on restart.
         ForgetCachedCallbackResults(resource.ModelResource);
+        ForgetConnectionStringAvailableEvent(resource.ModelResource);
 
         var result = await DeleteResourceRetryPipeline.ExecuteAsync(async (resourceName, attemptCancellationToken) =>
         {
@@ -1224,6 +1225,14 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             {
                 ((ICallbackResourceAnnotation<CommandLineArgsCallbackContext, IList<object>>)callback).ForgetCachedResult();
             }
+        }
+    }
+
+    private void ForgetConnectionStringAvailableEvent(IResource resource)
+    {
+        lock (_connectionStringsAdvertised)
+        {
+            _connectionStringsAdvertised.Remove(resource.Name);
         }
     }
 

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -64,6 +64,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
     // There may be multiple physical replicas of the same app model resource
     // which can result in the event being raised multiple times if we are not careful.
     private readonly HashSet<string> _endpointsAdvertised = new(StringComparers.ResourceName);
+    private readonly HashSet<string> _connectionStringsAdvertised = new(StringComparers.ResourceName);
 
     private readonly CancellationTokenSource _shutdownCancellation = new();
     private readonly DcpExecutorEvents _executorEvents;
@@ -113,7 +114,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         _executionContext = executionContext;
         _appResources = appResources;
 
-        _resourceWatcher = new DcpResourceWatcher(logger, kubernetesService, loggerService, executorEvents, model, _appResources, _configuration, PublishLateEndpointsAllocatedEventAsync, profilingTelemetry, _shutdownCancellation.Token);
+        _resourceWatcher = new DcpResourceWatcher(logger, kubernetesService, loggerService, executorEvents, model, _appResources, _configuration, PublishEndpointAllocatedEventsAsync, profilingTelemetry, _shutdownCancellation.Token);
 
         DeleteResourceRetryPipeline = DcpPipelineBuilder.BuildDeleteRetryPipeline(logger);
 
@@ -214,6 +215,15 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
 
                 foreach (var container in containers)
                 {
+                    // A dependent resource can resolve this container's proxyless endpoint during
+                    // its starting callback. Commit required fallback ports before any container
+                    // objects are submitted so the rendered container exposes the same port.
+                    await DcpModelUtilities.TryAllocateDependentDynamicProxylessContainerEndpointsAsync(
+                        container,
+                        _executionContext,
+                        _logger,
+                        ct).ConfigureAwait(false);
+
                     if (DcpModelUtilities.TryAddWorkloadAllocatedEndpoints(
                         container,
                         _options.Value.EnableAspireContainerTunnel,
@@ -230,7 +240,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
                 // make a valid cross-resource callback observe an unallocated endpoint.
                 foreach (var resource in endpointAllocatedResources.Distinct())
                 {
-                    await PublishEndpointsAllocatedEventAsync(resource, ct).ConfigureAwait(false);
+                    await PublishEndpointAllocatedEventsAsync(resource, ct).ConfigureAwait(false);
                 }
             }, ct);
 
@@ -660,7 +670,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
 
                 var svc = Service.Create(serviceName);
 
-                endpoint.SetResolvedIsProxied(GetEffectiveIsProxied(sp.ModelResource, endpoint));
+                endpoint.SetResolvedIsProxied(GetEffectiveIsProxied(sp.ModelResource, endpoint, _options.Value.RandomizePorts));
 
                 int? port;
                 if (_options.Value.RandomizePorts && endpoint.IsProxied && endpoint.Port != null)
@@ -699,7 +709,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             }
         }
 
-        static bool GetEffectiveIsProxied(IResource resource, EndpointAnnotation endpoint)
+        static bool GetEffectiveIsProxied(IResource resource, EndpointAnnotation endpoint, bool randomizePorts)
         {
             if (!resource.SupportsProxy())
             {
@@ -709,6 +719,11 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             if (endpoint.IsExplicitlyProxied is bool isProxied)
             {
                 return isProxied;
+            }
+
+            if (randomizePorts)
+            {
+                return true;
             }
 
             return !resource.HasPersistentLifetime();
@@ -903,6 +918,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             try
             {
                 await creator.CreateObjectAsync(er, context, resourceLogger, this, cancellationToken).ConfigureAwait(false);
+                await PublishConnectionStringAvailableEventAsync(er.ModelResource, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -1098,6 +1114,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
                     await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, resourceReference.ModelResource, resourceReference.DcpResourceName)).ConfigureAwait(false);
                     var cctx = await _containerContextSource.Task.ConfigureAwait(false);
                     await _containerCreator.CreateObjectAsync(cr, cctx, resourceLogger, this, cancellationToken).ConfigureAwait(false);
+                    await PublishConnectionStringAvailableEventAsync(resourceReference.ModelResource, cancellationToken).ConfigureAwait(false);
                     break;
                 case RenderedModelResource<Executable> er:
                     await EnsureResourceDeletedAsync<Executable>(resourceReference, cancellationToken).ConfigureAwait(false);
@@ -1108,6 +1125,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
                     await PublishConnectionStringAvailableEventAsync(resourceReference.ModelResource, cancellationToken).ConfigureAwait(false);
                     await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, resourceReference.ModelResource, resourceReference.DcpResourceName)).ConfigureAwait(false);
                     await _executableCreator.CreateObjectAsync(er, EmptyCreationContext.s_instance, resourceLogger, this, cancellationToken).ConfigureAwait(false);
+                    await PublishConnectionStringAvailableEventAsync(resourceReference.ModelResource, cancellationToken).ConfigureAwait(false);
                     break;
 
                 default:
@@ -1224,7 +1242,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         return true;
     }
 
-    private async Task PublishLateEndpointsAllocatedEventAsync(IResource resource, CancellationToken ct)
+    private async Task PublishEndpointAllocatedEventsAsync(IResource resource, CancellationToken ct)
     {
         if (await PublishEndpointsAllocatedEventAsync(resource, ct).ConfigureAwait(false))
         {
@@ -1237,6 +1255,14 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         if (!DcpModelUtilities.AreResourceEndpointsAllocated(resource))
         {
             return;
+        }
+
+        lock (_connectionStringsAdvertised)
+        {
+            if (!_connectionStringsAdvertised.Add(resource.Name))
+            {
+                return;
+            }
         }
 
         await _executorEvents.PublishAsync(new OnConnectionStringAvailableContext(ct, resource)).ConfigureAwait(false);

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -142,6 +142,38 @@ internal static class DcpModelUtilities
         return AreResourceEndpointsAllocated(resource.ModelResource);
     }
 
+    internal static async Task TryAllocateDependentDynamicProxylessContainerEndpointsAsync<TDcpResource>(
+        RenderedModelResource<TDcpResource> resource,
+        DistributedApplicationExecutionContext executionContext,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+        where TDcpResource : CustomResource, IKubernetesStaticMetadata
+    {
+        if (resource.ServicesProduced.All(sp => !IsDynamicProxylessContainerEndpoint(resource, sp)))
+        {
+            return;
+        }
+
+        var dependencies = await resource.ModelResource.GetResourceDependenciesAsync(
+            executionContext,
+            new ResourceDependencyDiscoveryOptions
+            {
+                DiscoveryMode = ResourceDependencyDiscoveryMode.Recursive,
+                CacheAnnotationCallbackResults = true
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (!dependencies.Any())
+        {
+            return;
+        }
+
+        foreach (var sp in resource.ServicesProduced.Where(sp => IsDynamicProxylessContainerEndpoint(resource, sp)))
+        {
+            TryAllocateDynamicProxylessContainerEndpoint(resource, sp.EndpointAnnotation, KnownNetworkIdentifiers.LocalhostNetwork, logger);
+        }
+    }
+
     internal static bool TryApplyServiceAddressToEndpoint(Service observedService, IEnumerable<IAppResource> appResources, [NotNullWhen(true)] out IResource? modelResource)
     {
         var serviceResource = appResources.OfType<ServiceWithModelResource>()

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -158,7 +158,7 @@ internal static class DcpModelUtilities
             executionContext,
             new ResourceDependencyDiscoveryOptions
             {
-                DiscoveryMode = ResourceDependencyDiscoveryMode.Recursive,
+                DiscoveryMode = ResourceDependencyDiscoveryMode.DirectOnly,
                 CacheAnnotationCallbackResults = true
             },
             cancellationToken).ConfigureAwait(false);

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
@@ -246,4 +246,16 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
             useTestContainerRegistry: true);
     }
 
+    [Fact]
+    [RequiresFeature(TestFeature.Docker)]
+    public Task RabbitMQ_WithPersistentLifetimeAndRandomizedPorts_ReusesContainer()
+    {
+        return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(
+            testOutputHelper,
+            builder => builder.AddRabbitMQ("resource").WithPersistentLifetime(),
+            "resource",
+            useTestContainerRegistry: true,
+            randomizePorts: true);
+    }
+
 }

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -656,4 +656,16 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
             useTestContainerRegistry: true);
     }
 
+    [Fact]
+    [RequiresFeature(TestFeature.Docker)]
+    public Task Redis_WithPersistentLifetimeAndRandomizedPorts_ReusesContainer()
+    {
+        return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(
+            testOutputHelper,
+            builder => builder.AddRedis("resource").WithPersistentLifetime(),
+            "resource",
+            useTestContainerRegistry: true,
+            randomizePorts: true);
+    }
+
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -464,6 +464,16 @@ public class DcpExecutorTests
         var dcpOptions = new DcpOptions { DashboardPath = "./dashboard", ResourceNameSuffix = "suffix" };
 
         var events = new DcpExecutorEvents();
+        var connectionStringAvailableCount = 0;
+        events.Subscribe<OnConnectionStringAvailableContext>(context =>
+        {
+            if (ReferenceEquals(context.Resource, resource))
+            {
+                Interlocked.Increment(ref connectionStringAvailableCount);
+            }
+
+            return Task.CompletedTask;
+        });
         var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
 
         var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions, events: events);
@@ -480,6 +490,7 @@ public class DcpExecutorTests
         Assert.True(exe1.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations1));
         Assert.Single(argAnnotations1, a => a.Argument == "--test");
         AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations1, exe1.Spec.Args);
+        Assert.Equal(1, connectionStringAvailableCount);
 
         var reference = appExecutor.GetResource(exe1.Metadata.Name);
 
@@ -499,6 +510,7 @@ public class DcpExecutorTests
         Assert.True(exe2.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations2));
         Assert.Single(argAnnotations2, a => a.Argument == "--test");
         AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations2, exe2.Spec.Args);
+        Assert.Equal(2, connectionStringAvailableCount);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -745,6 +745,80 @@ public class DcpExecutorTests
     }
 
     [Fact]
+    public async Task EndpointPortsPersistentExecutableDefaultsToProxiedEndpointWhenPortsAreRandomized()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        const int desiredPort = TestKubernetesService.StartOfAutoPortRange - 1002;
+        builder.AddExecutable("CoolProgram", "cool", Environment.CurrentDirectory, "--alpha", "--bravo")
+            .WithPersistentLifetime()
+            .WithEndpoint(name: "PortSetNoTargetPort", port: desiredPort, env: "PORT_SET_NO_TARGET_PORT");
+
+        var configDict = new Dictionary<string, string?>
+        {
+            ["AppHost:Sha256"] = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var dcpOptions = new DcpOptions { DashboardPath = "./dashboard", RandomizePorts = true };
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions, configuration: configuration);
+        await appExecutor.RunApplicationAsync();
+
+        var dcpExe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>());
+        Assert.True(dcpExe.TryGetAnnotationAsObjectList<ServiceProducerAnnotation>(CustomResource.ServiceProducerAnnotation, out var spAnnList));
+
+        var svc = kubernetesService.CreatedResources.OfType<Service>().Single(s => s.Name() == "CoolProgram");
+        Assert.Equal(AddressAllocationModes.Localhost, svc.Spec.AddressAllocationMode);
+        Assert.Null(svc.Spec.Port);
+        Assert.True(svc.Status?.EffectivePort >= TestKubernetesService.StartOfAutoPortRange);
+        Assert.NotEqual(desiredPort, svc.Status?.EffectivePort);
+        Assert.Null(spAnnList.Single(ann => ann.ServiceName == "CoolProgram").Port);
+
+        var envVarVal = dcpExe.Spec.Env?.Single(v => v.Name == "PORT_SET_NO_TARGET_PORT").Value;
+        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
+        Assert.Contains("""portForServing "CoolProgram" """, envVarVal);
+    }
+
+    [Fact]
+    public async Task EndpointPortsPersistentExecutableExplicitProxylessStaysProxylessWhenPortsAreRandomized()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        const int desiredPort = TestKubernetesService.StartOfAutoPortRange - 1002;
+        builder.AddExecutable("CoolProgram", "cool", Environment.CurrentDirectory, "--alpha", "--bravo")
+            .WithPersistentLifetime()
+            .WithEndpoint(name: "PortSetNoTargetPort", port: desiredPort, env: "PORT_SET_NO_TARGET_PORT", isProxied: false);
+
+        var configDict = new Dictionary<string, string?>
+        {
+            ["AppHost:Sha256"] = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var dcpOptions = new DcpOptions { DashboardPath = "./dashboard", RandomizePorts = true };
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions, configuration: configuration);
+        await appExecutor.RunApplicationAsync();
+
+        var dcpExe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>());
+        Assert.True(dcpExe.TryGetAnnotationAsObjectList<ServiceProducerAnnotation>(CustomResource.ServiceProducerAnnotation, out var spAnnList));
+
+        var svc = kubernetesService.CreatedResources.OfType<Service>().Single(s => s.Name() == "CoolProgram");
+        Assert.Equal(AddressAllocationModes.Proxyless, svc.Spec.AddressAllocationMode);
+        Assert.Equal(desiredPort, svc.Status?.EffectivePort);
+        Assert.Equal(desiredPort, spAnnList.Single(ann => ann.ServiceName == "CoolProgram").Port);
+
+        var envVarVal = dcpExe.Spec.Env?.Single(v => v.Name == "PORT_SET_NO_TARGET_PORT").Value;
+        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
+        Assert.Equal(desiredPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
     public async Task EndpointPortsExecutableNotReplicatedProxylessPortSetNoTargetPort()
     {
         var builder = DistributedApplication.CreateBuilder();
@@ -1482,6 +1556,46 @@ public class DcpExecutorTests
     }
 
     [Fact]
+    public async Task EndpointPortsPersistentProjectDefaultsToProxiedEndpointWhenPortsAreRandomized()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        const int desiredPort = TestKubernetesService.StartOfAutoPortRange - 1002;
+        builder.AddProject<Projects.ServiceA>("ServiceA", launchProfileName: null)
+            .WithPersistentLifetime()
+            .WithHttpEndpoint(name: "stable", port: desiredPort);
+
+        var configDict = new Dictionary<string, string?>
+        {
+            ["AppHost:Sha256"] = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var dcpOptions = new DcpOptions { DashboardPath = "./dashboard", RandomizePorts = true };
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions, configuration: configuration);
+        await appExecutor.RunApplicationAsync();
+
+        var dcpExe = GetCreatedExecutableForResource(kubernetesService, "ServiceA");
+        Assert.True(dcpExe.TryGetAnnotationAsObjectList<ServiceProducerAnnotation>(CustomResource.ServiceProducerAnnotation, out var spAnnList));
+
+        var svc = kubernetesService.CreatedResources.OfType<Service>().Single(s => s.Name() == "ServiceA");
+        Assert.Equal(AddressAllocationModes.Localhost, svc.Spec.AddressAllocationMode);
+        Assert.Null(svc.Spec.Port);
+        Assert.True(svc.Status?.EffectivePort >= TestKubernetesService.StartOfAutoPortRange);
+        Assert.NotEqual(desiredPort, svc.Status?.EffectivePort);
+        Assert.Null(spAnnList.Single(ann => ann.ServiceName == "ServiceA").Port);
+
+        var aspnetCoreUrls = dcpExe.Spec.Env?.Single(v => v.Name == "ASPNETCORE_URLS").Value;
+        Assert.Contains("""portForServing "ServiceA" """, aspnetCoreUrls);
+    }
+
+    [Fact]
     public async Task EndpointPortsConainerProxiedNoPortTargetPortSet()
     {
         var builder = DistributedApplication.CreateBuilder();
@@ -1671,6 +1785,7 @@ public class DcpExecutorTests
             .WithEndpoint(name: "NoPortTargetPortSet", targetPort: desiredTargetPort, isProxied: false);
 
         var allocatedPortChannel = Channel.CreateUnbounded<int>();
+        var connectionStringAvailableChannel = Channel.CreateUnbounded<IResource>();
         var eventing = new Hosting.Eventing.DistributedApplicationEventing();
         eventing.Subscribe<ResourceEndpointsAllocatedEvent>((@event, ct) =>
         {
@@ -1685,17 +1800,29 @@ public class DcpExecutorTests
 
             return Task.CompletedTask;
         });
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnConnectionStringAvailableContext>(context =>
+        {
+            if (context.Resource.Name == "database")
+            {
+                connectionStringAvailableChannel.Writer.TryWrite(context.Resource);
+            }
+
+            return Task.CompletedTask;
+        });
 
         var kubernetesService = new TestKubernetesService();
         using var app = builder.Build();
         var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, distributedApplicationEventing: eventing);
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: events, distributedApplicationEventing: eventing);
         await appExecutor.RunApplicationAsync();
 
         var allocatedPort = await allocatedPortChannel.Reader.ReadAsync().AsTask().DefaultTimeout();
+        var connectionStringAvailableResource = await connectionStringAvailableChannel.Reader.ReadAsync().AsTask().DefaultTimeout();
         var dcpCtr = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
         var svc = kubernetesService.CreatedResources.OfType<Service>().Single(s => s.Name() == "database");
 
+        Assert.Same(database.Resource, connectionStringAvailableResource);
         Assert.NotNull(dcpCtr.Spec.Ports);
         Assert.Contains(dcpCtr.Spec.Ports!, p => p.HostPort is null && p.ContainerPort == desiredTargetPort);
         Assert.Equal(allocatedPort, svc.Status?.EffectivePort);
@@ -1715,17 +1842,31 @@ public class DcpExecutorTests
         database.WithEnvironment("PUBLIC_PORT", database.GetEndpoint("NoPortTargetPortSet").Property(EndpointProperty.Port));
         database.WithEnvironment("PUBLIC_PORT_AGAIN", database.GetEndpoint("NoPortTargetPortSet").Property(EndpointProperty.Port));
 
+        var connectionStringAvailableChannel = Channel.CreateUnbounded<IResource>();
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnConnectionStringAvailableContext>(context =>
+        {
+            if (context.Resource.Name == "database")
+            {
+                connectionStringAvailableChannel.Writer.TryWrite(context.Resource);
+            }
+
+            return Task.CompletedTask;
+        });
+
         var kubernetesService = new TestKubernetesService();
         var testSink = new TestSink();
         var containerCreatorLogger = new TestLogger<ContainerCreator>(new TestLoggerFactory(testSink, enabled: true));
         using var app = builder.Build();
         var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, containerCreatorLogger: containerCreatorLogger);
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: events, containerCreatorLogger: containerCreatorLogger);
         await appExecutor.RunApplicationAsync();
 
+        var connectionStringAvailableResource = await connectionStringAvailableChannel.Reader.ReadAsync().AsTask().DefaultTimeout();
         var dcpCtr = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
         var svc = kubernetesService.CreatedResources.OfType<Service>().Single(s => s.Name() == "database");
 
+        Assert.Same(database.Resource, connectionStringAvailableResource);
         Assert.Equal(AddressAllocationModes.Proxyless, svc.Spec.AddressAllocationMode);
         Assert.Equal(desiredTargetPort, svc.Status?.EffectivePort);
         Assert.NotNull(dcpCtr.Spec.Ports);
@@ -1767,6 +1908,89 @@ public class DcpExecutorTests
         Assert.Contains(dcpCtr.Spec.Ports!, p => p.HostPort == desiredTargetPort && p.ContainerPort == desiredTargetPort);
         var envVarVal = dcpCtr.Spec.Env?.Single(v => v.Name == "PUBLIC_HOST_AND_PORT").Value;
         Assert.Equal($"database.dev.internal:{desiredTargetPort}", envVarVal);
+    }
+
+    [Fact]
+    public async Task EndpointPortsContainerProxylessNoPortTargetPortSetCanBeResolvedWhileDependentResourceIsStarting()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        const int desiredTargetPort = TestKubernetesService.StartOfAutoPortRange - 999;
+        var client = builder.AddContainer("client", "image");
+        var database = builder.AddContainer("database", "image")
+            .WithEndpoint(name: "NoPortTargetPortSet", scheme: "http", targetPort: desiredTargetPort, isProxied: false)
+            .WaitFor(client);
+
+        var resolvedUrlChannel = Channel.CreateUnbounded<string?>();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceStartingContext>(async context =>
+        {
+            if (ReferenceEquals(context.Resource, client.Resource))
+            {
+                var url = await database.GetEndpoint("NoPortTargetPortSet").GetValueAsync(new ValueProviderContext
+                {
+                    Caller = context.Resource,
+                    ExecutionContext = executionContext
+                }, context.CancellationToken).ConfigureAwait(false);
+
+                resolvedUrlChannel.Writer.TryWrite(url);
+            }
+        });
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: events);
+        await appExecutor.RunApplicationAsync();
+
+        var resolvedUrl = await resolvedUrlChannel.Reader.ReadAsync().AsTask().DefaultTimeout();
+        var dcpCtr = kubernetesService.CreatedResources.OfType<Container>().Single(c => c.AppModelResourceName == "database");
+        var svc = kubernetesService.CreatedResources.OfType<Service>().Single(s => s.Name() == "database");
+
+        Assert.Equal($"http://database.dev.internal:{desiredTargetPort}", resolvedUrl);
+        Assert.Equal(AddressAllocationModes.Proxyless, svc.Spec.AddressAllocationMode);
+        Assert.NotNull(dcpCtr.Spec.Ports);
+        Assert.Contains(dcpCtr.Spec.Ports!, p => p.HostPort == desiredTargetPort && p.ContainerPort == desiredTargetPort);
+    }
+
+    [Fact]
+    public async Task EndpointPortsContainerProxylessNoPortTargetPortSetCanBeResolvedWithoutCallerWhileDependentResourceIsStarting()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        const int desiredTargetPort = TestKubernetesService.StartOfAutoPortRange - 999;
+        var client = builder.AddContainer("client", "image");
+        var database = builder.AddContainer("database", "image")
+            .WithEndpoint(name: "NoPortTargetPortSet", scheme: "http", targetPort: desiredTargetPort, isProxied: false)
+            .WaitFor(client);
+
+        var resolvedUrlChannel = Channel.CreateUnbounded<string?>();
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceStartingContext>(async context =>
+        {
+            if (ReferenceEquals(context.Resource, client.Resource))
+            {
+                var url = await database.GetEndpoint("NoPortTargetPortSet").GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+
+                resolvedUrlChannel.Writer.TryWrite(url);
+            }
+        });
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: events);
+        await appExecutor.RunApplicationAsync();
+
+        var resolvedUrl = await resolvedUrlChannel.Reader.ReadAsync().AsTask().DefaultTimeout();
+        var dcpCtr = kubernetesService.CreatedResources.OfType<Container>().Single(c => c.AppModelResourceName == "database");
+        var svc = kubernetesService.CreatedResources.OfType<Service>().Single(s => s.Name() == "database");
+
+        Assert.Equal($"http://localhost:{desiredTargetPort}", resolvedUrl);
+        Assert.Equal(AddressAllocationModes.Proxyless, svc.Spec.AddressAllocationMode);
+        Assert.NotNull(dcpCtr.Spec.Ports);
+        Assert.Contains(dcpCtr.Spec.Ports!, p => p.HostPort == desiredTargetPort && p.ContainerPort == desiredTargetPort);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
@@ -409,6 +409,94 @@ public class EndpointReferenceTests
     }
 
     [Fact]
+    public async Task GetValueAsync_AllocatesEndpointOnDemandWhenCallerIsUnknown()
+    {
+        var (_, _, expression, allocationCount) = CreateOnDemandEndpointExpression();
+
+        var url = await expression.GetValueAsync(new ValueProviderContext());
+
+        Assert.Equal("http://localhost:8080", url);
+        Assert.Equal(1, allocationCount());
+    }
+
+    [Fact]
+    public async Task GetValueAsync_AllocatesEndpointOnDemandForSelfReference()
+    {
+        var (resource, _, expression, allocationCount) = CreateOnDemandEndpointExpression();
+
+        var url = await expression.GetValueAsync(new ValueProviderContext { Caller = resource, ExecutionContext = CreateExecutionContext() });
+
+        Assert.Equal("http://localhost:8080", url);
+        Assert.Equal(1, allocationCount());
+    }
+
+    [Fact]
+    public async Task GetValueAsync_AllocatesEndpointOnDemandWhenEndpointResourceWaitsOnCaller()
+    {
+        var caller = new TestResource("caller");
+        var (resource, _, expression, allocationCount) = CreateOnDemandEndpointExpression();
+        resource.Annotations.Add(new WaitAnnotation(caller, WaitType.WaitUntilStarted));
+
+        var url = await expression.GetValueAsync(new ValueProviderContext { Caller = caller, ExecutionContext = CreateExecutionContext() });
+
+        Assert.Equal("http://localhost:8080", url);
+        Assert.Equal(1, allocationCount());
+    }
+
+    [Fact]
+    public async Task GetValueAsync_AllocatesEndpointOnDemandWhenEndpointResourceReferencesCaller()
+    {
+        var caller = new TestResource("caller");
+        var (resource, _, expression, allocationCount) = CreateOnDemandEndpointExpression();
+        var callerEndpoint = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        caller.Annotations.Add(callerEndpoint);
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["CALLER_URL"] = new EndpointReference(caller, callerEndpoint);
+        }));
+
+        var url = await expression.GetValueAsync(new ValueProviderContext { Caller = caller, ExecutionContext = CreateExecutionContext() });
+
+        Assert.Equal("http://localhost:8080", url);
+        Assert.Equal(1, allocationCount());
+    }
+
+    [Fact]
+    public async Task GetValueAsync_AllocatesEndpointOnDemandWhenEndpointResourceTransitivelyDependsOnCaller()
+    {
+        var caller = new TestResource("caller");
+        var intermediate = new TestResource("intermediate");
+        var (resource, _, expression, allocationCount) = CreateOnDemandEndpointExpression();
+
+        resource.Annotations.Add(new WaitAnnotation(intermediate, WaitType.WaitUntilStarted));
+        intermediate.Annotations.Add(new WaitAnnotation(caller, WaitType.WaitUntilStarted));
+
+        var url = await expression.GetValueAsync(new ValueProviderContext { Caller = caller, ExecutionContext = CreateExecutionContext() });
+
+        Assert.Equal("http://localhost:8080", url);
+        Assert.Equal(1, allocationCount());
+    }
+
+    [Fact]
+    public async Task GetValueAsync_WaitsForEndpointAllocationWhenContainerEndpointResourceDoesNotDependOnCaller()
+    {
+        var caller = new TestResource("caller");
+        var (_, annotation, expression, allocationCount) = CreateOnDemandEndpointExpression(isContainerEndpoint: true);
+
+        var getValueTask = expression.GetValueAsync(new ValueProviderContext { Caller = caller, ExecutionContext = CreateExecutionContext() });
+
+        Assert.False(getValueTask.IsCompleted);
+        Assert.Equal(0, allocationCount());
+
+        annotation.AllocatedEndpoint = new AllocatedEndpoint(annotation, "localhost", 8081);
+
+        var url = await getValueTask;
+
+        Assert.Equal("http://localhost:8081", url);
+        Assert.Equal(0, allocationCount());
+    }
+
+    [Fact]
     public void EndpointAnnotation_ThrowsWhenEndpointNameNotDefined_ListsAvailableEndpoints()
     {
         var resource = new TestResource("api-boston");
@@ -473,6 +561,29 @@ public class EndpointReferenceTests
     private sealed class TestResource(string name) : Resource(name), IResourceWithEndpoints
     {
     }
+
+    private static (TestResource Resource, EndpointAnnotation Endpoint, EndpointReferenceExpression Expression, Func<int> AllocationCount) CreateOnDemandEndpointExpression(bool isContainerEndpoint = false)
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        var allocationCount = 0;
+
+        if (isContainerEndpoint)
+        {
+            resource.Annotations.Add(new ContainerImageAnnotation { Image = "test-image" });
+        }
+
+        resource.Annotations.Add(annotation);
+        resource.Annotations.Add(new OnDemandEndpointAllocationAnnotation((endpoint, networkId) =>
+        {
+            allocationCount++;
+            return new AllocatedEndpoint(endpoint, "localhost", 8080, EndpointBindingMode.SingleAddress, networkId: networkId);
+        }));
+
+        return (resource, annotation, new EndpointReference(resource, annotation).Property(EndpointProperty.Url), () => allocationCount);
+    }
+
+    private static DistributedApplicationExecutionContext CreateExecutionContext() => new(DistributedApplicationOperation.Run);
 
     private struct WithWaitStartedNotification<T>
     {

--- a/tests/Aspire.Hosting.Tests/Utils/PersistentContainerTestHelpers.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/PersistentContainerTestHelpers.cs
@@ -19,12 +19,14 @@ public static class PersistentContainerTestHelpers
     /// <param name="configureResource">Configures the persistent resource on each AppHost run.</param>
     /// <param name="resourceName">The resource name whose persistent Docker container identity should be compared.</param>
     /// <param name="useTestContainerRegistry">Whether to apply the test container registry override for integrations that require CI-mirrored images.</param>
+    /// <param name="randomizePorts">Whether to force DCP to randomize ports for the AppHost runs.</param>
     /// <param name="timeout">The timeout for starting, stopping, and observing the resource. Defaults to 10 minutes because some container integrations have slow cold starts.</param>
     public static async Task AssertResourceReusesContainerAsync(
         ITestOutputHelper testOutputHelper,
         Action<IDistributedApplicationTestingBuilder> configureResource,
         string resourceName,
         bool useTestContainerRegistry = false,
+        bool randomizePorts = false,
         TimeSpan? timeout = null)
     {
         using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(10));
@@ -59,7 +61,11 @@ public static class PersistentContainerTestHelpers
             var args = new[]
             {
                 "--environment=Development",
-                $"{KnownConfigNames.AspireUserSecretsId}={userSecretsId}"
+                $"{KnownConfigNames.AspireUserSecretsId}={userSecretsId}",
+                // Persistent-container reuse tests default to normal run behavior. Individual
+                // tests opt into randomization when the integration doesn't publish the public
+                // proxy port into container configuration that participates in the lifecycle key.
+                $"DcpPublisher:RandomizePorts={(randomizePorts ? "true" : "false")}"
             };
 
             using var builder = (useTestContainerRegistry


### PR DESCRIPTION
## Description

This PR refines dynamic endpoint allocation for proxyless container endpoints so Aspire only falls back to early allocation when waiting would be unsafe. Endpoint resolution now uses the value provider caller and recursive resource dependency discovery to distinguish circular or unknown references from independent references that can remain lazily allocated.

The DCP path now:

- pre-allocates dependent dynamic proxyless container endpoints before container objects are submitted, so lifecycle callbacks that create a circular reference observe a consistent fallback port
- keeps safe independent endpoint references lazy until DCP reports the actual allocated container port
- treats `RandomizePorts` as an implicit default for proxying persistent endpoints without overriding explicit proxy settings
- publishes `ConnectionStringAvailableEvent` for both eager fallback allocation and post-container dynamic allocation, and resets that event de-dupe state when a resource is recreated for restart

### User-facing behavior

AppHost endpoint references that are safe to resolve later avoid unnecessary early fallback allocation. Circular, self, and unknown-caller references still resolve during startup when they need to. In isolated/randomized-port runs, persistent endpoints default to proxied behavior unless the app explicitly configured the endpoint as proxyless.

### Validation

- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-build --no-launch-profile -- --filter-class "*.DcpExecutorTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-method "*.ResourceRestarted_EnvironmentCallbacksApplied" --filter-method "*.EndpointPortsContainerProxylessNoPortTargetPortSetPublishesAllocatedEndpointAfterServiceUpdate" --filter-method "*.EndpointPortsContainerProxylessNoPortTargetPortSetUsesTargetPortFallbackWhenResolvedBeforeContainerCreation" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Focused `EndpointReferenceTests`
- `git diff --check`

Fixes: N/A

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No