### PR TITLE
Allow choosing the Service Bus emulator SQL instance

### DIFF
--- a/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
+++ b/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
@@ -14,6 +14,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.SqlServer\Aspire.Hosting.SqlServer.csproj" />
     <PackageReference Include="Azure.Provisioning" />
     <PackageReference Include="Azure.Provisioning.ServiceBus" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
+++ b/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)src\Shared\AzureRoleAssignmentUtils.cs" />
+    <Compile Include="$(SharedDir)Model\KnownRelationshipTypes.cs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
+++ b/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
@@ -10,10 +10,12 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)src\Shared\AzureRoleAssignmentUtils.cs" />
+    <Compile Include="$(SharedDir)Model\KnownRelationshipTypes.cs" />
   </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.SqlServer\Aspire.Hosting.SqlServer.csproj" />
     <PackageReference Include="Azure.Provisioning" />
     <PackageReference Include="Azure.Provisioning.ServiceBus" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
+++ b/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)src\Shared\AzureRoleAssignmentUtils.cs" />
-    <Compile Include="$(SharedDir)Model\KnownRelationshipTypes.cs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -24,6 +24,8 @@ namespace Aspire.Hosting;
 public static class AzureServiceBusExtensions
 {
     private const string EmulatorHealthEndpointName = "emulatorhealth";
+    private const string SqlServerEndpointName = "tcp";
+    private const string SqlServerConflictMessage = "The Azure Service Bus emulator cannot use both an existing SQL Server resource and a customized SQL Server container. Remove either the 'WithSqlServerContainer' or the 'WithSqlServer' call.";
 
     /// <summary>
     /// Adds an Azure Service Bus Namespace resource to the application model. This resource can be used to create queue, topic, and subscription resources.
@@ -408,9 +410,6 @@ public static class AzureServiceBusExtensions
 
         // Add emulator container
 
-        // The password must be at least 8 characters long and contain characters from three of the following four sets: Uppercase letters, Lowercase letters, Base 10 digits, and Symbols
-        var passwordParameter = ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder.ApplicationBuilder, $"{builder.Resource.Name}-sql-pwd", minLower: 1, minUpper: 1, minNumeric: 1);
-
         builder
             .WithEndpoint(name: "emulator", targetPort: 5672)
             .WithHttpEndpoint(name: EmulatorHealthEndpointName, targetPort: 5300)
@@ -423,36 +422,69 @@ public static class AzureServiceBusExtensions
             })
             .WithUrlForEndpoint(EmulatorHealthEndpointName, u => u.DisplayLocation = UrlDisplayLocation.DetailsOnly);
 
-        var sqlServerResource = builder.ApplicationBuilder
-                .AddContainer($"{builder.Resource.Name}-mssql",
-                    image: ServiceBusEmulatorContainerImageTags.SqlServerImage,
-                    tag: ServiceBusEmulatorContainerImageTags.SqlServerTag)
-                .WithImageRegistry(ServiceBusEmulatorContainerImageTags.SqlServerRegistry)
-                .WithEndpoint(targetPort: 1433, name: "tcp")
-                .WithEnvironment("ACCEPT_EULA", "Y")
-                .WithEnvironment(context =>
-                {
-                    context.EnvironmentVariables["MSSQL_SA_PASSWORD"] = passwordParameter;
-                })
-                .WithParentRelationship(builder);
-
-        builder.WithAnnotation(new EnvironmentCallbackAnnotation((EnvironmentCallbackContext context) =>
-        {
-            var sqlEndpoint = sqlServerResource.Resource.GetEndpoint("tcp");
-
-            context.EnvironmentVariables["ACCEPT_EULA"] = "Y";
-            context.EnvironmentVariables["SQL_SERVER"] = $"{sqlEndpoint.Resource.Name}:{sqlEndpoint.TargetPort}";
-            context.EnvironmentVariables["MSSQL_SA_PASSWORD"] = passwordParameter;
-        }));
-
         var surrogate = new AzureServiceBusEmulatorResource(builder.Resource);
         var surrogateBuilder = builder.ApplicationBuilder.CreateResourceBuilder(surrogate);
 
-        if (configureContainer != null)
+        configureContainer?.Invoke(surrogateBuilder);
+
+        // The emulator needs a SQL Server instance to store its state. By default a dedicated container is
+        // created, but WithSqlServer can be used to point the emulator at an existing SQL Server instance, in
+        // which case a SqlServerConnectionAnnotation is already present. The two options are mutually
+        // exclusive, which WithSqlServer and WithSqlServerContainer enforce. Annotations added through the
+        // surrogate land on the inner resource (AzureServiceBusEmulatorResource forwards its Annotations
+        // collection), so they are visible on builder.Resource here.
+        if (!builder.Resource.HasAnnotationOfType<SqlServerConnectionAnnotation>())
         {
-            configureContainer(surrogateBuilder);
-            sqlServerResource = sqlServerResource.WithLifetimeOf(surrogateBuilder);
+            // The password must be at least 8 characters long and contain characters from three of the following four sets: Uppercase letters, Lowercase letters, Base 10 digits, and Symbols
+            var passwordParameter = ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder.ApplicationBuilder, $"{builder.Resource.Name}-sql-pwd", minLower: 1, minUpper: 1, minNumeric: 1);
+
+            var sqlServerResource = builder.ApplicationBuilder
+                    .AddContainer($"{builder.Resource.Name}-mssql",
+                        image: ServiceBusEmulatorContainerImageTags.SqlServerImage,
+                        tag: ServiceBusEmulatorContainerImageTags.SqlServerTag)
+                    .WithImageRegistry(ServiceBusEmulatorContainerImageTags.SqlServerRegistry)
+                    .WithEndpoint(targetPort: 1433, name: SqlServerEndpointName)
+                    .WithEnvironment("ACCEPT_EULA", "Y")
+                    .WithEnvironment(context =>
+                    {
+                        context.EnvironmentVariables["MSSQL_SA_PASSWORD"] = passwordParameter;
+                    })
+                    .WithParentRelationship(builder);
+
+            if (configureContainer != null)
+            {
+                sqlServerResource = sqlServerResource.WithLifetimeOf(surrogateBuilder);
+            }
+
+            // Apply WithSqlServerContainer customizations last so they take precedence over the defaults.
+            foreach (var sqlContainerConfiguration in builder.Resource.Annotations.OfType<SqlServerContainerConfigurationAnnotation>())
+            {
+                sqlContainerConfiguration.Configure(sqlServerResource);
+            }
+
+            if (!sqlServerResource.Resource.Annotations.OfType<EndpointAnnotation>().Any(e => e.Name == SqlServerEndpointName))
+            {
+                throw new InvalidOperationException($"The SQL Server container for the Azure Service Bus emulator must keep its '{SqlServerEndpointName}' endpoint. Update the 'WithSqlServerContainer' callback so it does not remove or rename the endpoint.");
+            }
+
+            builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServerResource.Resource.GetEndpoint(SqlServerEndpointName), passwordParameter));
         }
+
+        // The environment callback is registered after the SQL Server connection has been resolved so a failed
+        // configuration callback doesn't leak a callback into the model. The values are set as defaults (only
+        // when not already present) so user-provided overrides always win, regardless of the order in which the
+        // environment callbacks run.
+        builder.WithAnnotation(new EnvironmentCallbackAnnotation((EnvironmentCallbackContext context) =>
+        {
+            if (!builder.Resource.TryGetLastAnnotation<SqlServerConnectionAnnotation>(out var sqlConnection))
+            {
+                throw new InvalidOperationException("The SQL Server instance for the Azure Service Bus emulator was not configured. This indicates that 'RunAsEmulator' did not complete successfully.");
+            }
+
+            context.EnvironmentVariables.TryAdd("ACCEPT_EULA", "Y");
+            context.EnvironmentVariables.TryAdd("SQL_SERVER", $"{sqlConnection.Endpoint.Resource.Name}:{sqlConnection.Endpoint.TargetPort}");
+            context.EnvironmentVariables.TryAdd("MSSQL_SA_PASSWORD", sqlConnection.Password);
+        }));
 
         // RunAsEmulator() can be followed by custom model configuration so we need to delay the creation of the Config.json file
         // until all resources are about to be prepared and annotations can't be updated anymore.
@@ -578,6 +610,86 @@ public static class AzureServiceBusExtensions
         {
             endpoint.Port = port;
         });
+    }
+
+    /// <summary>
+    /// Customizes the SQL Server container that backs the Azure Service Bus emulator, allowing the image,
+    /// tag, container name and other container settings to be changed.
+    /// </summary>
+    /// <param name="builder">Builder for the Azure Service Bus emulator container</param>
+    /// <param name="configureContainer">Callback that exposes the SQL Server container used by the emulator to allow for customization.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// This method can be called multiple times; the callbacks are applied in order. It cannot be combined
+    /// with <see cref="WithSqlServer"/>. The emulator connects to the SQL Server container through its
+    /// <c>tcp</c> endpoint, which must not be removed or renamed by the callback.
+    /// <example>
+    /// Here is an example of how to use a different SQL Server image and container name:
+    /// <code language="csharp">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// builder.AddAzureServiceBus("servicebusns")
+    ///        .RunAsEmulator(configure => configure
+    ///            .WithSqlServerContainer(sql => sql
+    ///                .WithImageTag("2019-latest")
+    ///                .WithContainerName("myproject-servicebus-sql")));
+    /// </code>
+    /// </example>
+    /// </remarks>
+    [AspireExportIgnore(Reason = "Action<IResourceBuilder<ContainerResource>> callbacks are not ATS-compatible.")]
+    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServerContainer(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, Action<IResourceBuilder<ContainerResource>> configureContainer)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureContainer);
+
+        if (builder.Resource.HasAnnotationOfType<SqlServerConnectionAnnotation>())
+        {
+            throw new InvalidOperationException(SqlServerConflictMessage);
+        }
+
+        return builder.WithAnnotation(new SqlServerContainerConfigurationAnnotation(configureContainer));
+    }
+
+    /// <summary>
+    /// Configures the Azure Service Bus emulator to use an existing SQL Server instance instead of
+    /// creating a dedicated SQL Server container.
+    /// </summary>
+    /// <param name="builder">Builder for the Azure Service Bus emulator container</param>
+    /// <param name="sqlServerEndpoint">The endpoint of the SQL Server instance the emulator should use to store its state.</param>
+    /// <param name="saPasswordParameter">The parameter that contains the SQL Server administrator password.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// The emulator connects to the SQL Server instance over the container network using the provided endpoint
+    /// and administrator password. If this method is called multiple times the last call wins. It cannot be
+    /// combined with <see cref="WithSqlServerContainer"/>.
+    /// <example>
+    /// Here is an example of how to share a SQL Server resource with the emulator:
+    /// <code language="csharp">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// var sql = builder.AddSqlServer("sql");
+    ///
+    /// builder.AddAzureServiceBus("servicebusns")
+    ///        .RunAsEmulator(configure => configure
+    ///            .WithSqlServer(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter));
+    /// </code>
+    /// </example>
+    /// </remarks>
+    /// <ats-remarks />
+    [AspireExport]
+    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServer(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, EndpointReference sqlServerEndpoint, ParameterResource saPasswordParameter)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(sqlServerEndpoint);
+        ArgumentNullException.ThrowIfNull(saPasswordParameter);
+
+        if (builder.Resource.HasAnnotationOfType<SqlServerContainerConfigurationAnnotation>())
+        {
+            throw new InvalidOperationException(SqlServerConflictMessage);
+        }
+
+        return builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServerEndpoint, saPasswordParameter), ResourceAnnotationMutationBehavior.Replace);
     }
 
     private static string CreateEmulatorConfigJson(AzureServiceBusResource emulatorResource)

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -25,7 +25,7 @@ public static class AzureServiceBusExtensions
 {
     private const string EmulatorHealthEndpointName = "emulatorhealth";
     private const string SqlServerEndpointName = "tcp";
-    private const string SqlServerConflictMessage = "The Azure Service Bus emulator cannot use both an existing SQL Server resource and a customized SQL Server container. Remove either the 'WithSqlServerContainer' or the 'WithSqlServer' call.";
+    private const string SqlServerConflictMessage = "The Azure Service Bus emulator cannot use both an existing SQL Server resource and a customized SQL Server container. Remove either the 'WithSqlServerContainer' call or the 'WithSqlServer'/'WithSqlServerConnection' call.";
 
     /// <summary>
     /// Adds an Azure Service Bus Namespace resource to the application model. This resource can be used to create queue, topic, and subscription resources.
@@ -427,47 +427,35 @@ public static class AzureServiceBusExtensions
 
         configureContainer?.Invoke(surrogateBuilder);
 
-        // The emulator needs a SQL Server instance to store its state. By default a dedicated container is
-        // created, but WithSqlServer can be used to point the emulator at an existing SQL Server instance, in
-        // which case a SqlServerConnectionAnnotation is already present. The two options are mutually
-        // exclusive, which WithSqlServer and WithSqlServerContainer enforce. Annotations added through the
-        // surrogate land on the inner resource (AzureServiceBusEmulatorResource forwards its Annotations
-        // collection), so they are visible on builder.Resource here.
+        // The emulator needs a SQL Server instance to store its state. By default a dedicated SQL Server
+        // resource is created, but WithSqlServer/WithSqlServerConnection can be used to point the emulator at
+        // an existing SQL Server instance, in which case a SqlServerConnectionAnnotation is already present.
+        // The two options are mutually exclusive, which the extension methods enforce. Annotations added
+        // through the surrogate land on the inner resource (AzureServiceBusEmulatorResource forwards its
+        // Annotations collection), so they are visible on builder.Resource here.
         if (!builder.Resource.HasAnnotationOfType<SqlServerConnectionAnnotation>())
         {
-            // The password must be at least 8 characters long and contain characters from three of the following four sets: Uppercase letters, Lowercase letters, Base 10 digits, and Symbols
-            var passwordParameter = ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder.ApplicationBuilder, $"{builder.Resource.Name}-sql-pwd", minLower: 1, minUpper: 1, minNumeric: 1);
-
-            var sqlServerResource = builder.ApplicationBuilder
-                    .AddContainer($"{builder.Resource.Name}-mssql",
-                        image: ServiceBusEmulatorContainerImageTags.SqlServerImage,
-                        tag: ServiceBusEmulatorContainerImageTags.SqlServerTag)
-                    .WithImageRegistry(ServiceBusEmulatorContainerImageTags.SqlServerRegistry)
-                    .WithEndpoint(targetPort: 1433, name: SqlServerEndpointName)
-                    .WithEnvironment("ACCEPT_EULA", "Y")
-                    .WithEnvironment(context =>
-                    {
-                        context.EnvironmentVariables["MSSQL_SA_PASSWORD"] = passwordParameter;
-                    })
+            var sqlServerBuilder = builder.ApplicationBuilder
+                    .AddSqlServer($"{builder.Resource.Name}-mssql")
                     .WithParentRelationship(builder);
 
             if (configureContainer != null)
             {
-                sqlServerResource = sqlServerResource.WithLifetimeOf(surrogateBuilder);
+                sqlServerBuilder = sqlServerBuilder.WithLifetimeOf(surrogateBuilder);
             }
 
             // Apply WithSqlServerContainer customizations last so they take precedence over the defaults.
             foreach (var sqlContainerConfiguration in builder.Resource.Annotations.OfType<SqlServerContainerConfigurationAnnotation>())
             {
-                sqlContainerConfiguration.Configure(sqlServerResource);
+                sqlContainerConfiguration.Configure(sqlServerBuilder);
             }
 
-            if (!sqlServerResource.Resource.Annotations.OfType<EndpointAnnotation>().Any(e => e.Name == SqlServerEndpointName))
+            if (!sqlServerBuilder.Resource.Annotations.OfType<EndpointAnnotation>().Any(e => e.Name == SqlServerEndpointName))
             {
                 throw new InvalidOperationException($"The SQL Server container for the Azure Service Bus emulator must keep its '{SqlServerEndpointName}' endpoint. Update the 'WithSqlServerContainer' callback so it does not remove or rename the endpoint.");
             }
 
-            builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServerResource.Resource.GetEndpoint(SqlServerEndpointName), passwordParameter));
+            builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServerBuilder.Resource.PrimaryEndpoint, () => sqlServerBuilder.Resource.PasswordParameter));
         }
 
         // The environment callback is registered after the SQL Server connection has been resolved so a failed
@@ -613,31 +601,32 @@ public static class AzureServiceBusExtensions
     }
 
     /// <summary>
-    /// Customizes the SQL Server container that backs the Azure Service Bus emulator, allowing the image,
-    /// tag, container name and other container settings to be changed.
+    /// Customizes the SQL Server resource that backs the Azure Service Bus emulator, allowing the regular
+    /// SQL Server integration APIs (such as data volumes, host ports or the password) to be used.
     /// </summary>
     /// <param name="builder">Builder for the Azure Service Bus emulator container</param>
-    /// <param name="configureContainer">Callback that exposes the SQL Server container used by the emulator to allow for customization.</param>
+    /// <param name="configureContainer">Callback that exposes the SQL Server resource used by the emulator to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>
     /// This method can be called multiple times; the callbacks are applied in order. It cannot be combined
-    /// with <see cref="WithSqlServer"/>. The emulator connects to the SQL Server container through its
-    /// <c>tcp</c> endpoint, which must not be removed or renamed by the callback.
+    /// with <see cref="WithSqlServer"/> or <see cref="WithSqlServerConnection"/>. The emulator connects to
+    /// the SQL Server container through its <c>tcp</c> endpoint, which must not be removed or renamed by
+    /// the callback.
     /// <example>
-    /// Here is an example of how to use a different SQL Server image and container name:
+    /// Here is an example of how to persist the emulator state in a data volume and use a specific container name:
     /// <code language="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// builder.AddAzureServiceBus("servicebusns")
     ///        .RunAsEmulator(configure => configure
     ///            .WithSqlServerContainer(sql => sql
-    ///                .WithImageTag("2019-latest")
+    ///                .WithDataVolume()
     ///                .WithContainerName("myproject-servicebus-sql")));
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExportIgnore(Reason = "Action<IResourceBuilder<ContainerResource>> callbacks are not ATS-compatible.")]
-    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServerContainer(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, Action<IResourceBuilder<ContainerResource>> configureContainer)
+    [AspireExportIgnore(Reason = "Action<IResourceBuilder<SqlServerServerResource>> callbacks are not ATS-compatible. Use WithSqlServer with a SQL Server resource instead.")]
+    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServerContainer(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, Action<IResourceBuilder<SqlServerServerResource>> configureContainer)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(configureContainer);
@@ -651,18 +640,18 @@ public static class AzureServiceBusExtensions
     }
 
     /// <summary>
-    /// Configures the Azure Service Bus emulator to use an existing SQL Server instance instead of
+    /// Configures the Azure Service Bus emulator to use an existing SQL Server resource instead of
     /// creating a dedicated SQL Server container.
     /// </summary>
     /// <param name="builder">Builder for the Azure Service Bus emulator container</param>
-    /// <param name="sqlServerEndpoint">The endpoint of the SQL Server instance the emulator should use to store its state.</param>
-    /// <param name="saPasswordParameter">The parameter that contains the SQL Server administrator password.</param>
+    /// <param name="sqlServer">The SQL Server resource the emulator should use to store its state.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
-    /// The emulator connects to the SQL Server instance over the container network using the provided endpoint
+    /// The emulator connects to the SQL Server resource over the container network using its primary endpoint
     /// and administrator password. If this method is called multiple times the last call wins. It cannot be
-    /// combined with <see cref="WithSqlServerContainer"/>.
+    /// combined with <see cref="WithSqlServerContainer"/>. To connect to a SQL Server instance that is not
+    /// modeled as a <see cref="SqlServerServerResource"/>, use <see cref="WithSqlServerConnection"/>.
     /// <example>
     /// Here is an example of how to share a SQL Server resource with the emulator:
     /// <code language="csharp">
@@ -672,24 +661,56 @@ public static class AzureServiceBusExtensions
     ///
     /// builder.AddAzureServiceBus("servicebusns")
     ///        .RunAsEmulator(configure => configure
-    ///            .WithSqlServer(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter));
+    ///            .WithSqlServer(sql));
     /// </code>
     /// </example>
     /// </remarks>
     /// <ats-remarks />
     [AspireExport]
-    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServer(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, EndpointReference sqlServerEndpoint, ParameterResource saPasswordParameter)
+    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServer(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, IResourceBuilder<SqlServerServerResource> sqlServer)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(sqlServer);
+
+        // The password is resolved lazily so a WithPassword call on the SQL Server resource after this
+        // call is still honored.
+        return WithSqlServerConnectionCore(builder, sqlServer.Resource.PrimaryEndpoint, () => sqlServer.Resource.PasswordParameter);
+    }
+
+    /// <summary>
+    /// Configures the Azure Service Bus emulator to use an existing SQL Server instance, identified by its
+    /// endpoint and administrator password, instead of creating a dedicated SQL Server container.
+    /// </summary>
+    /// <param name="builder">Builder for the Azure Service Bus emulator container</param>
+    /// <param name="sqlServerEndpoint">The endpoint of the SQL Server instance the emulator should use to store its state.</param>
+    /// <param name="saPasswordParameter">The parameter that contains the SQL Server administrator password.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// This is a lower-level alternative to <see cref="WithSqlServer"/> for SQL Server instances that are not
+    /// modeled as a <see cref="SqlServerServerResource"/>. The emulator connects to the SQL Server instance
+    /// over the container network using the provided endpoint and administrator password. If this method is
+    /// called multiple times the last call wins. It cannot be combined with <see cref="WithSqlServerContainer"/>.
+    /// </remarks>
+    /// <ats-remarks />
+    [AspireExport]
+    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServerConnection(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, EndpointReference sqlServerEndpoint, ParameterResource saPasswordParameter)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(sqlServerEndpoint);
         ArgumentNullException.ThrowIfNull(saPasswordParameter);
 
+        return WithSqlServerConnectionCore(builder, sqlServerEndpoint, () => saPasswordParameter);
+    }
+
+    private static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServerConnectionCore(IResourceBuilder<AzureServiceBusEmulatorResource> builder, EndpointReference endpoint, Func<ParameterResource> passwordResolver)
+    {
         if (builder.Resource.HasAnnotationOfType<SqlServerContainerConfigurationAnnotation>())
         {
             throw new InvalidOperationException(SqlServerConflictMessage);
         }
 
-        return builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServerEndpoint, saPasswordParameter), ResourceAnnotationMutationBehavior.Replace);
+        return builder.WithAnnotation(new SqlServerConnectionAnnotation(endpoint, passwordResolver), ResourceAnnotationMutationBehavior.Replace);
     }
 
     private static string CreateEmulatorConfigJson(AzureServiceBusResource emulatorResource)

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -470,7 +470,10 @@ public static class AzureServiceBusExtensions
             }
 
             context.EnvironmentVariables.TryAdd("ACCEPT_EULA", "Y");
-            context.EnvironmentVariables.TryAdd("SQL_SERVER", $"{sqlConnection.Endpoint.Resource.Name}:{sqlConnection.Endpoint.TargetPort}");
+            // The endpoint is resolved in the emulator container's network context, so a containerized SQL
+            // Server resolves to its container-network address and a SQL Server hosted by an executable or
+            // project resolves to the container host address.
+            context.EnvironmentVariables.TryAdd("SQL_SERVER", sqlConnection.Endpoint.Property(EndpointProperty.HostAndPort));
             context.EnvironmentVariables.TryAdd("MSSQL_SA_PASSWORD", sqlConnection.Password);
         }));
 
@@ -688,9 +691,10 @@ public static class AzureServiceBusExtensions
     /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
     /// This is a lower-level alternative to <see cref="WithSqlServer"/> for SQL Server instances that are not
-    /// modeled as a <see cref="SqlServerServerResource"/>. The emulator connects to the SQL Server instance
-    /// over the container network using the provided endpoint and administrator password. If this method is
-    /// called multiple times the last call wins. It cannot be combined with <see cref="WithSqlServerContainer"/>.
+    /// modeled as a <see cref="SqlServerServerResource"/>. The endpoint is resolved in the context of the
+    /// emulator's container network: a containerized SQL Server resolves to its container-network address and
+    /// a SQL Server hosted by an executable or project resolves to the container host address. If this method
+    /// is called multiple times the last call wins. It cannot be combined with <see cref="WithSqlServerContainer"/>.
     /// </remarks>
     /// <ats-remarks />
     [AspireExport]

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -7,6 +7,7 @@
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Aspire.Dashboard.Model;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
@@ -25,7 +26,7 @@ public static class AzureServiceBusExtensions
 {
     private const string EmulatorHealthEndpointName = "emulatorhealth";
     private const string SqlServerEndpointName = "tcp";
-    private const string SqlServerConflictMessage = "The Azure Service Bus emulator cannot use both an existing SQL Server resource and a customized SQL Server container. Remove either the 'WithSqlServerContainer' call or the 'WithSqlServer'/'WithSqlServerConnection' call.";
+    private const string SqlServerConflictMessage = "The Azure Service Bus emulator cannot use both an existing SQL Server resource and a customized built-in SQL Server resource. Remove either the 'WithSqlServer(sqlServer)' call or the 'WithSqlServer(configureSqlServer)' call.";
 
     /// <summary>
     /// Adds an Azure Service Bus Namespace resource to the application model. This resource can be used to create queue, topic, and subscription resources.
@@ -428,11 +429,11 @@ public static class AzureServiceBusExtensions
         configureContainer?.Invoke(surrogateBuilder);
 
         // The emulator needs a SQL Server instance to store its state. By default a dedicated SQL Server
-        // resource is created, but WithSqlServer/WithSqlServerConnection can be used to point the emulator at
-        // an existing SQL Server instance, in which case a SqlServerConnectionAnnotation is already present.
-        // The two options are mutually exclusive, which the extension methods enforce. Annotations added
-        // through the surrogate land on the inner resource (AzureServiceBusEmulatorResource forwards its
-        // Annotations collection), so they are visible on builder.Resource here.
+        // resource is created, but WithSqlServer can be used to point the emulator at an existing SQL Server
+        // resource, in which case a SqlServerConnectionAnnotation is already present. The two options are
+        // mutually exclusive, which the extension methods enforce. Annotations added through the surrogate
+        // land on the inner resource (AzureServiceBusEmulatorResource forwards its Annotations collection),
+        // so they are visible on builder.Resource here.
         if (!builder.Resource.HasAnnotationOfType<SqlServerConnectionAnnotation>())
         {
             var sqlServerBuilder = builder.ApplicationBuilder
@@ -444,18 +445,21 @@ public static class AzureServiceBusExtensions
                 sqlServerBuilder = sqlServerBuilder.WithLifetimeOf(surrogateBuilder);
             }
 
-            // Apply WithSqlServerContainer customizations last so they take precedence over the defaults.
-            foreach (var sqlContainerConfiguration in builder.Resource.Annotations.OfType<SqlServerContainerConfigurationAnnotation>())
+            // Apply the WithSqlServer customizations last so they take precedence over the defaults.
+            foreach (var sqlServerConfiguration in builder.Resource.Annotations.OfType<SqlServerConfigurationAnnotation>())
             {
-                sqlContainerConfiguration.Configure(sqlServerBuilder);
+                sqlServerConfiguration.Configure(sqlServerBuilder);
             }
 
             if (!sqlServerBuilder.Resource.Annotations.OfType<EndpointAnnotation>().Any(e => e.Name == SqlServerEndpointName))
             {
-                throw new InvalidOperationException($"The SQL Server container for the Azure Service Bus emulator must keep its '{SqlServerEndpointName}' endpoint. Update the 'WithSqlServerContainer' callback so it does not remove or rename the endpoint.");
+                throw new InvalidOperationException($"The SQL Server resource for the Azure Service Bus emulator must keep its '{SqlServerEndpointName}' endpoint. Update the 'WithSqlServer' callback so it does not remove or rename the endpoint.");
             }
 
-            builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServerBuilder.Resource.PrimaryEndpoint, () => sqlServerBuilder.Resource.PasswordParameter));
+            // The emulator fails to start when its backing store isn't accepting connections yet.
+            surrogateBuilder.WaitFor(sqlServerBuilder);
+
+            builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServerBuilder.Resource));
         }
 
         // The environment callback is registered after the SQL Server connection has been resolved so a failed
@@ -470,9 +474,9 @@ public static class AzureServiceBusExtensions
             }
 
             context.EnvironmentVariables.TryAdd("ACCEPT_EULA", "Y");
-            // The endpoint is resolved in the emulator container's network context, so a containerized SQL
-            // Server resolves to its container-network address and a SQL Server hosted by an executable or
-            // project resolves to the container host address.
+            // The endpoint is resolved in the emulator container's network context, so the SQL Server
+            // resolves to its container-network address rather than to an address that is only reachable
+            // from the host.
             context.EnvironmentVariables.TryAdd("SQL_SERVER", sqlConnection.Endpoint.Property(EndpointProperty.HostAndPort));
             context.EnvironmentVariables.TryAdd("MSSQL_SA_PASSWORD", sqlConnection.Password);
         }));
@@ -604,17 +608,35 @@ public static class AzureServiceBusExtensions
     }
 
     /// <summary>
+    /// Configures the Azure Service Bus emulator to store its state in the SQL Server resource that is
+    /// created for it.
+    /// </summary>
+    /// <param name="builder">Builder for the Azure Service Bus emulator container</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// This is the default behavior, so this method only needs to be called to state that intent explicitly.
+    /// It cannot be combined with <see cref="WithSqlServer(IResourceBuilder{AzureServiceBusEmulatorResource}, IResourceBuilder{SqlServerServerResource})"/>.
+    /// </remarks>
+    [AspireExportIgnore(Reason = "The emulator creates its own SQL Server resource by default, so there is nothing to configure. Use the WithSqlServer overload that takes a SQL Server resource to reuse an existing one.")]
+    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServer(this IResourceBuilder<AzureServiceBusEmulatorResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithSqlServer(static _ => { });
+    }
+
+    /// <summary>
     /// Customizes the SQL Server resource that backs the Azure Service Bus emulator, allowing the regular
     /// SQL Server integration APIs (such as data volumes, host ports or the password) to be used.
     /// </summary>
     /// <param name="builder">Builder for the Azure Service Bus emulator container</param>
-    /// <param name="configureContainer">Callback that exposes the SQL Server resource used by the emulator to allow for customization.</param>
+    /// <param name="configureSqlServer">Callback that exposes the SQL Server resource used by the emulator to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>
     /// This method can be called multiple times; the callbacks are applied in order. It cannot be combined
-    /// with <see cref="WithSqlServer"/> or <see cref="WithSqlServerConnection"/>. The emulator connects to
-    /// the SQL Server container through its <c>tcp</c> endpoint, which must not be removed or renamed by
-    /// the callback.
+    /// with <see cref="WithSqlServer(IResourceBuilder{AzureServiceBusEmulatorResource}, IResourceBuilder{SqlServerServerResource})"/>.
+    /// The emulator connects to the SQL Server resource through its <c>tcp</c> endpoint, which must not be
+    /// removed or renamed by the callback.
     /// <example>
     /// Here is an example of how to persist the emulator state in a data volume and use a specific container name:
     /// <code language="csharp">
@@ -622,39 +644,39 @@ public static class AzureServiceBusExtensions
     ///
     /// builder.AddAzureServiceBus("servicebusns")
     ///        .RunAsEmulator(configure => configure
-    ///            .WithSqlServerContainer(sql => sql
+    ///            .WithSqlServer(sql => sql
     ///                .WithDataVolume()
     ///                .WithContainerName("myproject-servicebus-sql")));
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExportIgnore(Reason = "Action<IResourceBuilder<SqlServerServerResource>> callbacks are not ATS-compatible. Use WithSqlServer with a SQL Server resource instead.")]
-    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServerContainer(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, Action<IResourceBuilder<SqlServerServerResource>> configureContainer)
+    [AspireExportIgnore(Reason = "Action<IResourceBuilder<SqlServerServerResource>> callbacks are not ATS-compatible. Use the WithSqlServer overload that takes a SQL Server resource instead.")]
+    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServer(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, Action<IResourceBuilder<SqlServerServerResource>> configureSqlServer)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(configureContainer);
+        ArgumentNullException.ThrowIfNull(configureSqlServer);
 
         if (builder.Resource.HasAnnotationOfType<SqlServerConnectionAnnotation>())
         {
             throw new InvalidOperationException(SqlServerConflictMessage);
         }
 
-        return builder.WithAnnotation(new SqlServerContainerConfigurationAnnotation(configureContainer));
+        return builder.WithAnnotation(new SqlServerConfigurationAnnotation(configureSqlServer));
     }
 
     /// <summary>
     /// Configures the Azure Service Bus emulator to use an existing SQL Server resource instead of
-    /// creating a dedicated SQL Server container.
+    /// creating one for it.
     /// </summary>
     /// <param name="builder">Builder for the Azure Service Bus emulator container</param>
     /// <param name="sqlServer">The SQL Server resource the emulator should use to store its state.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
-    /// The emulator connects to the SQL Server resource over the container network using its primary endpoint
-    /// and administrator password. If this method is called multiple times the last call wins. It cannot be
-    /// combined with <see cref="WithSqlServerContainer"/>. To connect to a SQL Server instance that is not
-    /// modeled as a <see cref="SqlServerServerResource"/>, use <see cref="WithSqlServerConnection"/>.
+    /// The emulator waits for the SQL Server resource to become healthy and connects to it over the container
+    /// network using its primary endpoint and administrator password. If this method is called multiple times
+    /// the last call wins. It cannot be combined with
+    /// <see cref="WithSqlServer(IResourceBuilder{AzureServiceBusEmulatorResource}, Action{IResourceBuilder{SqlServerServerResource}})"/>.
     /// <example>
     /// Here is an example of how to share a SQL Server resource with the emulator:
     /// <code language="csharp">
@@ -675,46 +697,39 @@ public static class AzureServiceBusExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(sqlServer);
 
-        // The password is resolved lazily so a WithPassword call on the SQL Server resource after this
-        // call is still honored.
-        return WithSqlServerConnectionCore(builder, sqlServer.Resource.PrimaryEndpoint, () => sqlServer.Resource.PasswordParameter);
-    }
-
-    /// <summary>
-    /// Configures the Azure Service Bus emulator to use an existing SQL Server instance, identified by its
-    /// endpoint and administrator password, instead of creating a dedicated SQL Server container.
-    /// </summary>
-    /// <param name="builder">Builder for the Azure Service Bus emulator container</param>
-    /// <param name="sqlServerEndpoint">The endpoint of the SQL Server instance the emulator should use to store its state.</param>
-    /// <param name="saPasswordParameter">The parameter that contains the SQL Server administrator password.</param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    /// <ats-returns>The resource builder.</ats-returns>
-    /// <remarks>
-    /// This is a lower-level alternative to <see cref="WithSqlServer"/> for SQL Server instances that are not
-    /// modeled as a <see cref="SqlServerServerResource"/>. The endpoint is resolved in the context of the
-    /// emulator's container network: a containerized SQL Server resolves to its container-network address and
-    /// a SQL Server hosted by an executable or project resolves to the container host address. If this method
-    /// is called multiple times the last call wins. It cannot be combined with <see cref="WithSqlServerContainer"/>.
-    /// </remarks>
-    /// <ats-remarks />
-    [AspireExport]
-    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServerConnection(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, EndpointReference sqlServerEndpoint, ParameterResource saPasswordParameter)
-    {
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(sqlServerEndpoint);
-        ArgumentNullException.ThrowIfNull(saPasswordParameter);
-
-        return WithSqlServerConnectionCore(builder, sqlServerEndpoint, () => saPasswordParameter);
-    }
-
-    private static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServerConnectionCore(IResourceBuilder<AzureServiceBusEmulatorResource> builder, EndpointReference endpoint, Func<ParameterResource> passwordResolver)
-    {
-        if (builder.Resource.HasAnnotationOfType<SqlServerContainerConfigurationAnnotation>())
+        if (builder.Resource.HasAnnotationOfType<SqlServerConfigurationAnnotation>())
         {
             throw new InvalidOperationException(SqlServerConflictMessage);
         }
 
-        return builder.WithAnnotation(new SqlServerConnectionAnnotation(endpoint, passwordResolver), ResourceAnnotationMutationBehavior.Replace);
+        // A previous call is replaced entirely, so the emulator doesn't keep waiting for a SQL Server
+        // resource it no longer uses.
+        if (builder.Resource.TryGetLastAnnotation<SqlServerConnectionAnnotation>(out var previousConnection))
+        {
+            RemoveWaitFor(builder.Resource, previousConnection.SqlServer);
+        }
+
+        // The emulator fails to start when its backing store isn't accepting connections yet.
+        builder.WaitFor(sqlServer);
+
+        return builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServer.Resource), ResourceAnnotationMutationBehavior.Replace);
+    }
+
+    private static void RemoveWaitFor(IResource resource, IResource dependency)
+    {
+        var staleAnnotations = resource.Annotations
+            .Where(annotation => annotation switch
+            {
+                WaitAnnotation wait => wait.Resource == dependency,
+                ResourceRelationshipAnnotation relationship => relationship.Resource == dependency && relationship.Type == KnownRelationshipTypes.WaitFor,
+                _ => false
+            })
+            .ToList();
+
+        foreach (var staleAnnotation in staleAnnotations)
+        {
+            resource.Annotations.Remove(staleAnnotation);
+        }
     }
 
     private static string CreateEmulatorConfigJson(AzureServiceBusResource emulatorResource)

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -7,7 +7,6 @@
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Aspire.Dashboard.Model;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
@@ -440,9 +439,19 @@ public static class AzureServiceBusExtensions
         // so they are visible on builder.Resource here.
         if (!builder.Resource.HasAnnotationOfType<SqlServerConnectionAnnotation>())
         {
+            // Preserve the password parameter name used before the SQL Server integration owned this resource.
+            // Existing configuration and persisted emulator stores can depend on that stable parameter name.
+            var password = ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(
+                builder.ApplicationBuilder,
+                $"{builder.Resource.Name}-sql-pwd",
+                minLower: 1,
+                minUpper: 1,
+                minNumeric: 1);
+            var passwordBuilder = builder.ApplicationBuilder.CreateResourceBuilder(password);
+
             var sqlServerBuilder = builder.ApplicationBuilder
-                    .AddSqlServer($"{builder.Resource.Name}-mssql")
-                    .WithParentRelationship(builder);
+                .AddSqlServer($"{builder.Resource.Name}-mssql", passwordBuilder)
+                .WithParentRelationship(builder);
 
             if (configureContainer != null)
             {
@@ -463,7 +472,7 @@ public static class AzureServiceBusExtensions
             // The emulator fails to start when its backing store isn't accepting connections yet.
             surrogateBuilder.WaitFor(sqlServerBuilder);
 
-            builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServerBuilder.Resource));
+            builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServerBuilder.Resource, []));
         }
 
         // The environment callback is registered after the SQL Server connection has been resolved so a failed
@@ -710,29 +719,24 @@ public static class AzureServiceBusExtensions
         // resource it no longer uses.
         if (builder.Resource.TryGetLastAnnotation<SqlServerConnectionAnnotation>(out var previousConnection))
         {
-            RemoveWaitFor(builder.Resource, previousConnection.SqlServer);
+            RemoveWaitFor(builder.Resource, previousConnection.WaitAnnotations);
         }
 
         // The emulator fails to start when its backing store isn't accepting connections yet.
+        var existingAnnotations = builder.Resource.Annotations.ToHashSet();
         builder.WaitFor(sqlServer);
+        var waitAnnotations = builder.Resource.Annotations
+            .Where(annotation => !existingAnnotations.Contains(annotation))
+            .ToArray();
 
-        return builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServer.Resource), ResourceAnnotationMutationBehavior.Replace);
+        return builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServer.Resource, waitAnnotations), ResourceAnnotationMutationBehavior.Replace);
     }
 
-    private static void RemoveWaitFor(IResource resource, IResource dependency)
+    private static void RemoveWaitFor(IResource resource, IReadOnlyList<IResourceAnnotation> waitAnnotations)
     {
-        var staleAnnotations = resource.Annotations
-            .Where(annotation => annotation switch
-            {
-                WaitAnnotation wait => wait.Resource == dependency,
-                ResourceRelationshipAnnotation relationship => relationship.Resource == dependency && relationship.Type == KnownRelationshipTypes.WaitFor,
-                _ => false
-            })
-            .ToList();
-
-        foreach (var staleAnnotation in staleAnnotations)
+        foreach (var waitAnnotation in waitAnnotations)
         {
-            resource.Annotations.Remove(staleAnnotation);
+            resource.Annotations.Remove(waitAnnotation);
         }
     }
 

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -7,6 +7,7 @@
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Aspire.Dashboard.Model;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
@@ -24,6 +25,8 @@ namespace Aspire.Hosting;
 public static class AzureServiceBusExtensions
 {
     private const string EmulatorHealthEndpointName = "emulatorhealth";
+    private const string SqlServerEndpointName = "tcp";
+    private const string SqlServerConflictMessage = "The Azure Service Bus emulator cannot use both an existing SQL Server resource and a customized built-in SQL Server resource. Remove either the 'WithSqlServer(sqlServer)' call or the 'WithSqlServer(configureSqlServer)' call.";
 
     /// <summary>
     /// Adds an Azure Service Bus Namespace resource to the application model. This resource can be used to create queue, topic, and subscription resources.
@@ -412,9 +415,6 @@ public static class AzureServiceBusExtensions
 
         // Add emulator container
 
-        // The password must be at least 8 characters long and contain characters from three of the following four sets: Uppercase letters, Lowercase letters, Base 10 digits, and Symbols
-        var passwordParameter = ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder.ApplicationBuilder, $"{builder.Resource.Name}-sql-pwd", minLower: 1, minUpper: 1, minNumeric: 1);
-
         builder
             .WithEndpoint(name: "emulator", targetPort: 5672)
             .WithHttpEndpoint(name: EmulatorHealthEndpointName, targetPort: 5300)
@@ -427,36 +427,63 @@ public static class AzureServiceBusExtensions
             })
             .WithUrlForEndpoint(EmulatorHealthEndpointName, u => u.DisplayLocation = UrlDisplayLocation.DetailsOnly);
 
-        var sqlServerResource = builder.ApplicationBuilder
-                .AddContainer($"{builder.Resource.Name}-mssql",
-                    image: ServiceBusEmulatorContainerImageTags.SqlServerImage,
-                    tag: ServiceBusEmulatorContainerImageTags.SqlServerTag)
-                .WithImageRegistry(ServiceBusEmulatorContainerImageTags.SqlServerRegistry)
-                .WithEndpoint(targetPort: 1433, name: "tcp")
-                .WithEnvironment("ACCEPT_EULA", "Y")
-                .WithEnvironment(context =>
-                {
-                    context.EnvironmentVariables["MSSQL_SA_PASSWORD"] = passwordParameter;
-                })
-                .WithParentRelationship(builder);
-
-        builder.WithAnnotation(new EnvironmentCallbackAnnotation((EnvironmentCallbackContext context) =>
-        {
-            var sqlEndpoint = sqlServerResource.Resource.GetEndpoint("tcp");
-
-            context.EnvironmentVariables["ACCEPT_EULA"] = "Y";
-            context.EnvironmentVariables["SQL_SERVER"] = $"{sqlEndpoint.Resource.Name}:{sqlEndpoint.TargetPort}";
-            context.EnvironmentVariables["MSSQL_SA_PASSWORD"] = passwordParameter;
-        }));
-
         var surrogate = new AzureServiceBusEmulatorResource(builder.Resource);
         var surrogateBuilder = builder.ApplicationBuilder.CreateResourceBuilder(surrogate);
 
-        if (configureContainer != null)
+        configureContainer?.Invoke(surrogateBuilder);
+
+        // The emulator needs a SQL Server instance to store its state. By default a dedicated SQL Server
+        // resource is created, but WithSqlServer can be used to point the emulator at an existing SQL Server
+        // resource, in which case a SqlServerConnectionAnnotation is already present. The two options are
+        // mutually exclusive, which the extension methods enforce. Annotations added through the surrogate
+        // land on the inner resource (AzureServiceBusEmulatorResource forwards its Annotations collection),
+        // so they are visible on builder.Resource here.
+        if (!builder.Resource.HasAnnotationOfType<SqlServerConnectionAnnotation>())
         {
-            configureContainer(surrogateBuilder);
-            sqlServerResource = sqlServerResource.WithLifetimeOf(surrogateBuilder);
+            var sqlServerBuilder = builder.ApplicationBuilder
+                    .AddSqlServer($"{builder.Resource.Name}-mssql")
+                    .WithParentRelationship(builder);
+
+            if (configureContainer != null)
+            {
+                sqlServerBuilder = sqlServerBuilder.WithLifetimeOf(surrogateBuilder);
+            }
+
+            // Apply the WithSqlServer customizations last so they take precedence over the defaults.
+            foreach (var sqlServerConfiguration in builder.Resource.Annotations.OfType<SqlServerConfigurationAnnotation>())
+            {
+                sqlServerConfiguration.Configure(sqlServerBuilder);
+            }
+
+            if (!sqlServerBuilder.Resource.Annotations.OfType<EndpointAnnotation>().Any(e => e.Name == SqlServerEndpointName))
+            {
+                throw new InvalidOperationException($"The SQL Server resource for the Azure Service Bus emulator must keep its '{SqlServerEndpointName}' endpoint. Update the 'WithSqlServer' callback so it does not remove or rename the endpoint.");
+            }
+
+            // The emulator fails to start when its backing store isn't accepting connections yet.
+            surrogateBuilder.WaitFor(sqlServerBuilder);
+
+            builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServerBuilder.Resource));
         }
+
+        // The environment callback is registered after the SQL Server connection has been resolved so a failed
+        // configuration callback doesn't leak a callback into the model. The values are set as defaults (only
+        // when not already present) so user-provided overrides always win, regardless of the order in which the
+        // environment callbacks run.
+        builder.WithAnnotation(new EnvironmentCallbackAnnotation((EnvironmentCallbackContext context) =>
+        {
+            if (!builder.Resource.TryGetLastAnnotation<SqlServerConnectionAnnotation>(out var sqlConnection))
+            {
+                throw new InvalidOperationException("The SQL Server instance for the Azure Service Bus emulator was not configured. This indicates that 'RunAsEmulator' did not complete successfully.");
+            }
+
+            context.EnvironmentVariables.TryAdd("ACCEPT_EULA", "Y");
+            // The endpoint is resolved in the emulator container's network context, so the SQL Server
+            // resolves to its container-network address rather than to an address that is only reachable
+            // from the host.
+            context.EnvironmentVariables.TryAdd("SQL_SERVER", sqlConnection.Endpoint.Property(EndpointProperty.HostAndPort));
+            context.EnvironmentVariables.TryAdd("MSSQL_SA_PASSWORD", sqlConnection.Password);
+        }));
 
         // RunAsEmulator() can be followed by custom model configuration so we need to delay the creation of the Config.json file
         // until all resources are about to be prepared and annotations can't be updated anymore.
@@ -582,6 +609,131 @@ public static class AzureServiceBusExtensions
         {
             endpoint.Port = port;
         });
+    }
+
+    /// <summary>
+    /// Configures the Azure Service Bus emulator to store its state in the SQL Server resource that is
+    /// created for it.
+    /// </summary>
+    /// <param name="builder">Builder for the Azure Service Bus emulator container</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// This is the default behavior, so this method only needs to be called to state that intent explicitly.
+    /// It cannot be combined with <see cref="WithSqlServer(IResourceBuilder{AzureServiceBusEmulatorResource}, IResourceBuilder{SqlServerServerResource})"/>.
+    /// </remarks>
+    [AspireExportIgnore(Reason = "The emulator creates its own SQL Server resource by default, so there is nothing to configure. Use the WithSqlServer overload that takes a SQL Server resource to reuse an existing one.")]
+    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServer(this IResourceBuilder<AzureServiceBusEmulatorResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithSqlServer(static _ => { });
+    }
+
+    /// <summary>
+    /// Customizes the SQL Server resource that backs the Azure Service Bus emulator, allowing the regular
+    /// SQL Server integration APIs (such as data volumes, host ports or the password) to be used.
+    /// </summary>
+    /// <param name="builder">Builder for the Azure Service Bus emulator container</param>
+    /// <param name="configureSqlServer">Callback that exposes the SQL Server resource used by the emulator to allow for customization.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// This method can be called multiple times; the callbacks are applied in order. It cannot be combined
+    /// with <see cref="WithSqlServer(IResourceBuilder{AzureServiceBusEmulatorResource}, IResourceBuilder{SqlServerServerResource})"/>.
+    /// The emulator connects to the SQL Server resource through its <c>tcp</c> endpoint, which must not be
+    /// removed or renamed by the callback.
+    /// <example>
+    /// Here is an example of how to persist the emulator state in a data volume and use a specific container name:
+    /// <code language="csharp">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// builder.AddAzureServiceBus("servicebusns")
+    ///        .RunAsEmulator(configure => configure
+    ///            .WithSqlServer(sql => sql
+    ///                .WithDataVolume()
+    ///                .WithContainerName("myproject-servicebus-sql")));
+    /// </code>
+    /// </example>
+    /// </remarks>
+    [AspireExportIgnore(Reason = "Action<IResourceBuilder<SqlServerServerResource>> callbacks are not ATS-compatible. Use the WithSqlServer overload that takes a SQL Server resource instead.")]
+    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServer(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, Action<IResourceBuilder<SqlServerServerResource>> configureSqlServer)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureSqlServer);
+
+        if (builder.Resource.HasAnnotationOfType<SqlServerConnectionAnnotation>())
+        {
+            throw new InvalidOperationException(SqlServerConflictMessage);
+        }
+
+        return builder.WithAnnotation(new SqlServerConfigurationAnnotation(configureSqlServer));
+    }
+
+    /// <summary>
+    /// Configures the Azure Service Bus emulator to use an existing SQL Server resource instead of
+    /// creating one for it.
+    /// </summary>
+    /// <param name="builder">Builder for the Azure Service Bus emulator container</param>
+    /// <param name="sqlServer">The SQL Server resource the emulator should use to store its state.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// The emulator waits for the SQL Server resource to become healthy and connects to it over the container
+    /// network using its primary endpoint and administrator password. If this method is called multiple times
+    /// the last call wins. It cannot be combined with
+    /// <see cref="WithSqlServer(IResourceBuilder{AzureServiceBusEmulatorResource}, Action{IResourceBuilder{SqlServerServerResource}})"/>.
+    /// <example>
+    /// Here is an example of how to share a SQL Server resource with the emulator:
+    /// <code language="csharp">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// var sql = builder.AddSqlServer("sql");
+    ///
+    /// builder.AddAzureServiceBus("servicebusns")
+    ///        .RunAsEmulator(configure => configure
+    ///            .WithSqlServer(sql));
+    /// </code>
+    /// </example>
+    /// </remarks>
+    /// <ats-remarks />
+    [AspireExport]
+    public static IResourceBuilder<AzureServiceBusEmulatorResource> WithSqlServer(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, IResourceBuilder<SqlServerServerResource> sqlServer)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(sqlServer);
+
+        if (builder.Resource.HasAnnotationOfType<SqlServerConfigurationAnnotation>())
+        {
+            throw new InvalidOperationException(SqlServerConflictMessage);
+        }
+
+        // A previous call is replaced entirely, so the emulator doesn't keep waiting for a SQL Server
+        // resource it no longer uses.
+        if (builder.Resource.TryGetLastAnnotation<SqlServerConnectionAnnotation>(out var previousConnection))
+        {
+            RemoveWaitFor(builder.Resource, previousConnection.SqlServer);
+        }
+
+        // The emulator fails to start when its backing store isn't accepting connections yet.
+        builder.WaitFor(sqlServer);
+
+        return builder.WithAnnotation(new SqlServerConnectionAnnotation(sqlServer.Resource), ResourceAnnotationMutationBehavior.Replace);
+    }
+
+    private static void RemoveWaitFor(IResource resource, IResource dependency)
+    {
+        var staleAnnotations = resource.Annotations
+            .Where(annotation => annotation switch
+            {
+                WaitAnnotation wait => wait.Resource == dependency,
+                ResourceRelationshipAnnotation relationship => relationship.Resource == dependency && relationship.Type == KnownRelationshipTypes.WaitFor,
+                _ => false
+            })
+            .ToList();
+
+        foreach (var staleAnnotation in staleAnnotations)
+        {
+            resource.Annotations.Remove(staleAnnotation);
+        }
     }
 
     private static string CreateEmulatorConfigJson(AzureServiceBusResource emulatorResource)

--- a/src/Aspire.Hosting.Azure.ServiceBus/README.md
+++ b/src/Aspire.Hosting.Azure.ServiceBus/README.md
@@ -84,7 +84,7 @@ var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(emulator => emul
     .WithSqlServer(sql));
 ```
 
-For SQL Server instances that are not modeled as a SQL Server resource, the lower-level `WithSqlServerConnection(endpoint, saPasswordParameter)` overload accepts an endpoint and administrator password directly.
+For SQL Server instances that are not modeled as a SQL Server resource, the lower-level `WithSqlServerConnection(endpoint, saPasswordParameter)` overload accepts an endpoint and administrator password directly. The endpoint is resolved in the context of the emulator's container network, so it can point at a containerized SQL Server as well as one hosted by an executable or project resource.
 
 > NOTE: `WithSqlServerContainer` and `WithSqlServer`/`WithSqlServerConnection` are mutually exclusive and throw an exception when combined.
 

--- a/src/Aspire.Hosting.Azure.ServiceBus/README.md
+++ b/src/Aspire.Hosting.Azure.ServiceBus/README.md
@@ -53,6 +53,39 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
                        .withReference(serviceBus);
 ```
 
+### Emulator usage
+
+Aspire supports using the Azure Service Bus emulator. To use the emulator, add the following to your AppHost project:
+
+```csharp
+// AppHost
+var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator();
+```
+
+When the AppHost starts up, a local container running the Azure Service Bus emulator will be started. By default it is accompanied by a SQL Server container that the emulator uses to store its state, unless an existing SQL Server resource is provided with `WithSqlServer` (see below).
+
+The SQL Server container can be customized, for instance to use a specific image tag or container name:
+
+```csharp
+// AppHost
+var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(emulator => emulator
+    .WithSqlServerContainer(sql => sql
+        .WithImageTag("2019-latest")
+        .WithContainerName("myproject-servicebus-sql")));
+```
+
+Alternatively, the emulator can reuse an existing SQL Server instance instead of creating a dedicated container by providing its endpoint and administrator password:
+
+```csharp
+// AppHost
+var sql = builder.AddSqlServer("sql");
+
+var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(emulator => emulator
+    .WithSqlServer(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter));
+```
+
+> NOTE: `WithSqlServerContainer` and `WithSqlServer` are mutually exclusive and throw an exception when combined.
+
 ## Connection Properties
 
 When you reference Azure Service Bus resources using `WithReference`, the following connection properties are made available to the consuming project:

--- a/src/Aspire.Hosting.Azure.ServiceBus/README.md
+++ b/src/Aspire.Hosting.Azure.ServiceBus/README.md
@@ -64,27 +64,29 @@ var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator();
 
 When the AppHost starts up, a local container running the Azure Service Bus emulator will be started. By default it is accompanied by a SQL Server container that the emulator uses to store its state, unless an existing SQL Server resource is provided with `WithSqlServer` (see below).
 
-The SQL Server container can be customized, for instance to use a specific image tag or container name:
+The SQL Server container can be customized using the regular SQL Server integration APIs, for instance to persist its state in a data volume or use a specific container name:
 
 ```csharp
 // AppHost
 var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(emulator => emulator
     .WithSqlServerContainer(sql => sql
-        .WithImageTag("2019-latest")
+        .WithDataVolume()
         .WithContainerName("myproject-servicebus-sql")));
 ```
 
-Alternatively, the emulator can reuse an existing SQL Server instance instead of creating a dedicated container by providing its endpoint and administrator password:
+Alternatively, the emulator can reuse an existing SQL Server resource instead of creating a dedicated container:
 
 ```csharp
 // AppHost
 var sql = builder.AddSqlServer("sql");
 
 var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(emulator => emulator
-    .WithSqlServer(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter));
+    .WithSqlServer(sql));
 ```
 
-> NOTE: `WithSqlServerContainer` and `WithSqlServer` are mutually exclusive and throw an exception when combined.
+For SQL Server instances that are not modeled as a SQL Server resource, the lower-level `WithSqlServerConnection(endpoint, saPasswordParameter)` overload accepts an endpoint and administrator password directly.
+
+> NOTE: `WithSqlServerContainer` and `WithSqlServer`/`WithSqlServerConnection` are mutually exclusive and throw an exception when combined.
 
 ## Connection Properties
 

--- a/src/Aspire.Hosting.Azure.ServiceBus/README.md
+++ b/src/Aspire.Hosting.Azure.ServiceBus/README.md
@@ -62,19 +62,19 @@ Aspire supports using the Azure Service Bus emulator. To use the emulator, add t
 var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator();
 ```
 
-When the AppHost starts up, a local container running the Azure Service Bus emulator will be started. By default it is accompanied by a SQL Server container that the emulator uses to store its state, unless an existing SQL Server resource is provided with `WithSqlServer` (see below).
+When the AppHost starts up, a local container running the Azure Service Bus emulator will be started. By default it is accompanied by a SQL Server resource that the emulator uses to store its state, unless an existing SQL Server resource is provided with `WithSqlServer` (see below). The emulator waits for its SQL Server to become healthy before it starts.
 
-The SQL Server container can be customized using the regular SQL Server integration APIs, for instance to persist its state in a data volume or use a specific container name:
+That SQL Server resource can be customized using the regular SQL Server integration APIs, for instance to persist its state in a data volume or use a specific container name:
 
 ```csharp
 // AppHost
 var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(emulator => emulator
-    .WithSqlServerContainer(sql => sql
+    .WithSqlServer(sql => sql
         .WithDataVolume()
         .WithContainerName("myproject-servicebus-sql")));
 ```
 
-Alternatively, the emulator can reuse an existing SQL Server resource instead of creating a dedicated container:
+Alternatively, the emulator can reuse an existing SQL Server resource instead of creating one for itself:
 
 ```csharp
 // AppHost
@@ -84,9 +84,7 @@ var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(emulator => emul
     .WithSqlServer(sql));
 ```
 
-For SQL Server instances that are not modeled as a SQL Server resource, the lower-level `WithSqlServerConnection(endpoint, saPasswordParameter)` overload accepts an endpoint and administrator password directly. The endpoint is resolved in the context of the emulator's container network, so it can point at a containerized SQL Server as well as one hosted by an executable or project resource.
-
-> NOTE: `WithSqlServerContainer` and `WithSqlServer`/`WithSqlServerConnection` are mutually exclusive and throw an exception when combined.
+> NOTE: Customizing the SQL Server resource created for the emulator and reusing an existing one are mutually exclusive and throw an exception when combined.
 
 ## Connection Properties
 

--- a/src/Aspire.Hosting.Azure.ServiceBus/README.md
+++ b/src/Aspire.Hosting.Azure.ServiceBus/README.md
@@ -53,6 +53,39 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
                        .withReference(serviceBus);
 ```
 
+### Emulator usage
+
+Aspire supports using the Azure Service Bus emulator. To use the emulator, add the following to your AppHost project:
+
+```csharp
+// AppHost
+var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator();
+```
+
+When the AppHost starts up, a local container running the Azure Service Bus emulator will be started. By default it is accompanied by a SQL Server resource that the emulator uses to store its state, unless an existing SQL Server resource is provided with `WithSqlServer` (see below). The emulator waits for its SQL Server to become healthy before it starts.
+
+That SQL Server resource can be customized using the regular SQL Server integration APIs, for instance to persist its state in a data volume or use a specific container name:
+
+```csharp
+// AppHost
+var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(emulator => emulator
+    .WithSqlServer(sql => sql
+        .WithDataVolume()
+        .WithContainerName("myproject-servicebus-sql")));
+```
+
+Alternatively, the emulator can reuse an existing SQL Server resource instead of creating one for itself:
+
+```csharp
+// AppHost
+var sql = builder.AddSqlServer("sql");
+
+var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(emulator => emulator
+    .WithSqlServer(sql));
+```
+
+> NOTE: Customizing the SQL Server resource created for the emulator and reusing an existing one are mutually exclusive and throw an exception when combined.
+
 ## Connection Properties
 
 When you reference Azure Service Bus resources using `WithReference`, the following connection properties are made available to the consuming project:

--- a/src/Aspire.Hosting.Azure.ServiceBus/ServiceBusEmulatorContainerImageTags.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/ServiceBusEmulatorContainerImageTags.cs
@@ -13,13 +13,4 @@ internal static class ServiceBusEmulatorContainerImageTags
 
     /// <remarks>2.0.0</remarks>
     public const string Tag = "2.0.0";
-
-    /// <remarks>mcr.microsoft.com</remarks>
-    public const string SqlServerRegistry = "mcr.microsoft.com";
-
-    /// <remarks>mssql/server</remarks>
-    public const string SqlServerImage = "mssql/server";
-
-    /// <remarks>2022-latest</remarks>
-    public const string SqlServerTag = "2022-latest";
 }

--- a/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConfigurationAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConfigurationAnnotation.cs
@@ -9,9 +9,9 @@ namespace Aspire.Hosting.Azure.ServiceBus;
 /// Represents an annotation holding a callback that customizes the SQL Server resource
 /// backing the Azure Service Bus emulator.
 /// </summary>
-internal sealed class SqlServerContainerConfigurationAnnotation : IResourceAnnotation
+internal sealed class SqlServerConfigurationAnnotation : IResourceAnnotation
 {
-    public SqlServerContainerConfigurationAnnotation(Action<IResourceBuilder<SqlServerServerResource>> configure)
+    public SqlServerConfigurationAnnotation(Action<IResourceBuilder<SqlServerServerResource>> configure)
     {
         Configure = configure ?? throw new ArgumentNullException(nameof(configure));
     }

--- a/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConfigurationAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConfigurationAnnotation.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.ServiceBus;
+
+/// <summary>
+/// Represents an annotation holding a callback that customizes the SQL Server resource
+/// backing the Azure Service Bus emulator.
+/// </summary>
+internal sealed class SqlServerConfigurationAnnotation : IResourceAnnotation
+{
+    public SqlServerConfigurationAnnotation(Action<IResourceBuilder<SqlServerServerResource>> configure)
+    {
+        Configure = configure ?? throw new ArgumentNullException(nameof(configure));
+    }
+
+    public Action<IResourceBuilder<SqlServerServerResource>> Configure { get; }
+}

--- a/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConnectionAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConnectionAnnotation.cs
@@ -10,13 +10,17 @@ namespace Aspire.Hosting.Azure.ServiceBus;
 /// </summary>
 internal sealed class SqlServerConnectionAnnotation : IResourceAnnotation
 {
-    public SqlServerConnectionAnnotation(EndpointReference endpoint, ParameterResource password)
+    private readonly Func<ParameterResource> _passwordResolver;
+
+    // The password is resolved lazily because SqlServerServerResource.PasswordParameter can be replaced
+    // after this annotation is created (e.g. by a later WithPassword call on the SQL Server resource).
+    public SqlServerConnectionAnnotation(EndpointReference endpoint, Func<ParameterResource> passwordResolver)
     {
         Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
-        Password = password ?? throw new ArgumentNullException(nameof(password));
+        _passwordResolver = passwordResolver ?? throw new ArgumentNullException(nameof(passwordResolver));
     }
 
     public EndpointReference Endpoint { get; }
 
-    public ParameterResource Password { get; }
+    public ParameterResource Password => _passwordResolver();
 }

--- a/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConnectionAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConnectionAnnotation.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.ServiceBus;
+
+/// <summary>
+/// Represents an annotation holding the resolved SQL Server connection inputs for the Azure Service Bus emulator.
+/// </summary>
+internal sealed class SqlServerConnectionAnnotation : IResourceAnnotation
+{
+    public SqlServerConnectionAnnotation(EndpointReference endpoint, ParameterResource password)
+    {
+        Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+        Password = password ?? throw new ArgumentNullException(nameof(password));
+    }
+
+    public EndpointReference Endpoint { get; }
+
+    public ParameterResource Password { get; }
+}

--- a/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConnectionAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConnectionAnnotation.cs
@@ -6,21 +6,20 @@ using Aspire.Hosting.ApplicationModel;
 namespace Aspire.Hosting.Azure.ServiceBus;
 
 /// <summary>
-/// Represents an annotation holding the resolved SQL Server connection inputs for the Azure Service Bus emulator.
+/// Represents an annotation holding the SQL Server resource the Azure Service Bus emulator stores its state in.
 /// </summary>
 internal sealed class SqlServerConnectionAnnotation : IResourceAnnotation
 {
-    private readonly Func<ParameterResource> _passwordResolver;
-
-    // The password is resolved lazily because SqlServerServerResource.PasswordParameter can be replaced
-    // after this annotation is created (e.g. by a later WithPassword call on the SQL Server resource).
-    public SqlServerConnectionAnnotation(EndpointReference endpoint, Func<ParameterResource> passwordResolver)
+    public SqlServerConnectionAnnotation(SqlServerServerResource sqlServer)
     {
-        Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
-        _passwordResolver = passwordResolver ?? throw new ArgumentNullException(nameof(passwordResolver));
+        SqlServer = sqlServer ?? throw new ArgumentNullException(nameof(sqlServer));
     }
 
-    public EndpointReference Endpoint { get; }
+    public SqlServerServerResource SqlServer { get; }
 
-    public ParameterResource Password => _passwordResolver();
+    public EndpointReference Endpoint => SqlServer.PrimaryEndpoint;
+
+    // The password is read lazily because SqlServerServerResource.PasswordParameter can be replaced after
+    // this annotation is created (e.g. by a later WithPassword call on the SQL Server resource).
+    public ParameterResource Password => SqlServer.PasswordParameter;
 }

--- a/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConnectionAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConnectionAnnotation.cs
@@ -10,12 +10,17 @@ namespace Aspire.Hosting.Azure.ServiceBus;
 /// </summary>
 internal sealed class SqlServerConnectionAnnotation : IResourceAnnotation
 {
-    public SqlServerConnectionAnnotation(SqlServerServerResource sqlServer)
+    public SqlServerConnectionAnnotation(SqlServerServerResource sqlServer, IReadOnlyList<IResourceAnnotation> waitAnnotations)
     {
         SqlServer = sqlServer ?? throw new ArgumentNullException(nameof(sqlServer));
+        WaitAnnotations = waitAnnotations ?? throw new ArgumentNullException(nameof(waitAnnotations));
     }
 
     public SqlServerServerResource SqlServer { get; }
+
+    // Track only waits added by WithSqlServer so replacing the connection does not remove waits
+    // the user independently added for the previous SQL Server resource.
+    public IReadOnlyList<IResourceAnnotation> WaitAnnotations { get; }
 
     public EndpointReference Endpoint => SqlServer.PrimaryEndpoint;
 

--- a/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConnectionAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/SqlServerConnectionAnnotation.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.ServiceBus;
+
+/// <summary>
+/// Represents an annotation holding the SQL Server resource the Azure Service Bus emulator stores its state in.
+/// </summary>
+internal sealed class SqlServerConnectionAnnotation : IResourceAnnotation
+{
+    public SqlServerConnectionAnnotation(SqlServerServerResource sqlServer)
+    {
+        SqlServer = sqlServer ?? throw new ArgumentNullException(nameof(sqlServer));
+    }
+
+    public SqlServerServerResource SqlServer { get; }
+
+    public EndpointReference Endpoint => SqlServer.PrimaryEndpoint;
+
+    // The password is read lazily because SqlServerServerResource.PasswordParameter can be replaced after
+    // this annotation is created (e.g. by a later WithPassword call on the SQL Server resource).
+    public ParameterResource Password => SqlServer.PasswordParameter;
+}

--- a/src/Aspire.Hosting.Azure.ServiceBus/SqlServerContainerConfigurationAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/SqlServerContainerConfigurationAnnotation.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.ServiceBus;
+
+/// <summary>
+/// Represents an annotation holding a callback that customizes the SQL Server container
+/// backing the Azure Service Bus emulator.
+/// </summary>
+internal sealed class SqlServerContainerConfigurationAnnotation : IResourceAnnotation
+{
+    public SqlServerContainerConfigurationAnnotation(Action<IResourceBuilder<ContainerResource>> configure)
+    {
+        Configure = configure ?? throw new ArgumentNullException(nameof(configure));
+    }
+
+    public Action<IResourceBuilder<ContainerResource>> Configure { get; }
+}

--- a/src/Aspire.Hosting.Azure.ServiceBus/SqlServerContainerConfigurationAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/SqlServerContainerConfigurationAnnotation.cs
@@ -6,15 +6,15 @@ using Aspire.Hosting.ApplicationModel;
 namespace Aspire.Hosting.Azure.ServiceBus;
 
 /// <summary>
-/// Represents an annotation holding a callback that customizes the SQL Server container
+/// Represents an annotation holding a callback that customizes the SQL Server resource
 /// backing the Azure Service Bus emulator.
 /// </summary>
 internal sealed class SqlServerContainerConfigurationAnnotation : IResourceAnnotation
 {
-    public SqlServerContainerConfigurationAnnotation(Action<IResourceBuilder<ContainerResource>> configure)
+    public SqlServerContainerConfigurationAnnotation(Action<IResourceBuilder<SqlServerServerResource>> configure)
     {
         Configure = configure ?? throw new ArgumentNullException(nameof(configure));
     }
 
-    public Action<IResourceBuilder<ContainerResource>> Configure { get; }
+    public Action<IResourceBuilder<SqlServerServerResource>> Configure { get; }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Nodes;
 using System.Reflection;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.ServiceBus;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Aspire.TestUtilities;
 using Azure.Messaging.ServiceBus;
@@ -649,6 +650,171 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator();
 
         Assert.Throws<InvalidOperationException>(() => serviceBus.RunAsEmulator());
+    }
+
+    [Fact]
+    public async Task AddAzureServiceBusWithEmulator_CreatesDefaultSqlServerContainer()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator();
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+        var imageAnnotation = Assert.Single(sql.Annotations.OfType<ContainerImageAnnotation>());
+        Assert.Equal("mssql/server", imageAnnotation.Image);
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("Y", env["ACCEPT_EULA"]);
+        Assert.Equal("sb-mssql:1433", env["SQL_SERVER"]);
+        Assert.False(string.IsNullOrEmpty(env["MSSQL_SA_PASSWORD"]));
+    }
+
+    [Fact]
+    public void WithSqlServerContainer_CustomizesSqlServerContainer()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServerContainer(sql => sql
+                .WithImageTag("2019-latest")
+                .WithContainerName("custom-sql")));
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+
+        var imageAnnotation = Assert.Single(sql.Annotations.OfType<ContainerImageAnnotation>());
+        Assert.Equal("2019-latest", imageAnnotation.Tag);
+
+        var nameAnnotation = Assert.Single(sql.Annotations.OfType<ContainerNameAnnotation>());
+        Assert.Equal("custom-sql", nameAnnotation.Name);
+    }
+
+    [Fact]
+    public async Task WithSqlServer_ReusesExistingSqlServerResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql = builder.AddSqlServer("sql");
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServer(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter));
+
+        Assert.DoesNotContain(builder.Resources, x => x.Name == "sb-mssql");
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("Y", env["ACCEPT_EULA"]);
+        Assert.Equal("sql:1433", env["SQL_SERVER"]);
+        Assert.Equal(await sql.Resource.PasswordParameter.GetValueAsync(CancellationToken.None), env["MSSQL_SA_PASSWORD"]);
+    }
+
+    [Fact]
+    public void WithSqlServerContainer_RemovingTcpEndpoint_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+                .WithSqlServerContainer(sql =>
+                {
+                    var endpoint = sql.Resource.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == "tcp");
+                    sql.Resource.Annotations.Remove(endpoint);
+                })));
+
+        Assert.Contains("must keep its 'tcp' endpoint", exception.Message);
+    }
+
+    [Fact]
+    public void WithSqlServerContainer_CalledMultipleTimes_AppliesCallbacksInOrder()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServerContainer(sql => sql.WithImageTag("2019-latest"))
+            .WithSqlServerContainer(sql => sql.WithImageTag("2022-latest")));
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+        var imageAnnotation = Assert.Single(sql.Annotations.OfType<ContainerImageAnnotation>());
+        Assert.Equal("2022-latest", imageAnnotation.Tag);
+    }
+
+    [Fact]
+    public async Task WithSqlServer_CalledMultipleTimes_LastWins()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql1 = builder.AddSqlServer("sql1");
+        var sql2 = builder.AddSqlServer("sql2");
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServer(sql1.Resource.PrimaryEndpoint, sql1.Resource.PasswordParameter)
+            .WithSqlServer(sql2.Resource.PrimaryEndpoint, sql2.Resource.PasswordParameter));
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("sql2:1433", env["SQL_SERVER"]);
+        Assert.Equal(await sql2.Resource.PasswordParameter.GetValueAsync(CancellationToken.None), env["MSSQL_SA_PASSWORD"]);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithSqlServerAndWithSqlServerContainer_AreMutuallyExclusive(bool sqlServerFirst)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql = builder.AddSqlServer("sql");
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            builder.AddAzureServiceBus("sb").RunAsEmulator(configure =>
+            {
+                if (sqlServerFirst)
+                {
+                    configure.WithSqlServer(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter)
+                        .WithSqlServerContainer(container => container.WithImageTag("2019-latest"));
+                }
+                else
+                {
+                    configure.WithSqlServerContainer(container => container.WithImageTag("2019-latest"))
+                        .WithSqlServer(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter);
+                }
+            }));
+
+        Assert.Contains("cannot use both", exception.Message);
+    }
+
+    [Fact]
+    public async Task AddAzureServiceBusWithEmulator_EnvironmentOverridesInCallbackTakePrecedence()
+    {
+        // Users have historically pointed the emulator at their own SQL Server by overriding the
+        // SQL_SERVER/MSSQL_SA_PASSWORD environment variables in the configuration callback. Such
+        // overrides must keep taking precedence over the values set by RunAsEmulator.
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithEnvironment("SQL_SERVER", "external-sql:1433"));
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("external-sql:1433", env["SQL_SERVER"]);
+    }
+
+    [Fact]
+    public void AddAzureServiceBusWithEmulator_SqlServerContainerIsInModelAfterRunAsEmulatorReturns()
+    {
+        // Users work around the lack of configurability by locating the SQL container in the model
+        // after RunAsEmulator returns (e.g. to rename or remove it). Keep that working.
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzureServiceBus("servicebus").RunAsEmulator(configure => configure.WithLifetime(ContainerLifetime.Persistent));
+
+        var serviceBusSql = builder.Resources.OfType<ContainerResource>().Last(x => x.Name == "servicebus-mssql");
+        serviceBusSql.Annotations.Add(new ContainerNameAnnotation { Name = "my-servicebus-mssql-container" });
+
+        var nameAnnotation = Assert.Single(serviceBusSql.Annotations.OfType<ContainerNameAnnotation>());
+        Assert.Equal("my-servicebus-mssql-container", nameAnnotation.Name);
+
+        Assert.True(builder.Resources.Remove(serviceBusSql));
     }
 
     private static IResource GetPersistenceReferenceSource(IResource resource)

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -664,10 +664,12 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var imageAnnotation = Assert.Single(sql.Annotations.OfType<ContainerImageAnnotation>());
         Assert.Equal("mssql/server", imageAnnotation.Image);
 
+        AllocateContainerNetworkEndpoint(sql, "sb-mssql.dev.internal", 1433);
+
         var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
 
         Assert.Equal("Y", env["ACCEPT_EULA"]);
-        Assert.Equal("sb-mssql:1433", env["SQL_SERVER"]);
+        Assert.Equal("sb-mssql.dev.internal:1433", env["SQL_SERVER"]);
         Assert.False(string.IsNullOrEmpty(env["MSSQL_SA_PASSWORD"]));
     }
 
@@ -713,6 +715,9 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
             .WithSqlServerContainer(sql => sql.WithPassword(password)));
 
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+        AllocateContainerNetworkEndpoint(sql, "sb-mssql.dev.internal", 1433);
+
         var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
 
         Assert.Equal("p@ssw0rd1", env["MSSQL_SA_PASSWORD"]);
@@ -730,10 +735,12 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 
         Assert.DoesNotContain(builder.Resources, x => x.Name == "sb-mssql");
 
+        AllocateContainerNetworkEndpoint(sql.Resource, "sql.dev.internal", 1433);
+
         var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
 
         Assert.Equal("Y", env["ACCEPT_EULA"]);
-        Assert.Equal("sql:1433", env["SQL_SERVER"]);
+        Assert.Equal("sql.dev.internal:1433", env["SQL_SERVER"]);
         Assert.Equal(await sql.Resource.PasswordParameter.GetValueAsync(CancellationToken.None), env["MSSQL_SA_PASSWORD"]);
     }
 
@@ -748,6 +755,8 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
             .WithSqlServer(sql));
 
         sql.WithPassword(builder.AddParameter("new-password", "p@ssw0rd2"));
+
+        AllocateContainerNetworkEndpoint(sql.Resource, "sql.dev.internal", 1433);
 
         var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
 
@@ -766,11 +775,36 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 
         Assert.DoesNotContain(builder.Resources, x => x.Name == "sb-mssql");
 
+        AllocateContainerNetworkEndpoint(sql.Resource, "sql.dev.internal", 1433);
+
         var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
 
         Assert.Equal("Y", env["ACCEPT_EULA"]);
-        Assert.Equal("sql:1433", env["SQL_SERVER"]);
+        Assert.Equal("sql.dev.internal:1433", env["SQL_SERVER"]);
         Assert.Equal(await sql.Resource.PasswordParameter.GetValueAsync(CancellationToken.None), env["MSSQL_SA_PASSWORD"]);
+    }
+
+    [Fact]
+    public async Task WithSqlServerConnection_HostProcessEndpoint_ResolvesToContainerHostAddress()
+    {
+        // A SQL Server instance that is not a container (e.g. hosted by an executable resource) is not
+        // reachable from the emulator container via its resource name. The endpoint must resolve to the
+        // address the orchestrator projects into the container network (the container host address).
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var password = builder.AddParameter("sa-password", "p@ssw0rd1");
+        var sqlHost = builder.AddExecutable("sql-host", "sqlservr", ".")
+            .WithEndpoint(name: "tcp");
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServerConnection(sqlHost.GetEndpoint("tcp"), password.Resource));
+
+        AllocateContainerNetworkEndpoint(sqlHost.Resource, "host.docker.internal", 52133);
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("host.docker.internal:52133", env["SQL_SERVER"]);
+        Assert.Equal("p@ssw0rd1", env["MSSQL_SA_PASSWORD"]);
     }
 
     [Fact]
@@ -815,9 +849,12 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
             .WithSqlServer(sql1)
             .WithSqlServer(sql2));
 
+        // Only sql2's endpoint is allocated; resolving successfully also proves sql1 is not consulted.
+        AllocateContainerNetworkEndpoint(sql2.Resource, "sql2.dev.internal", 1433);
+
         var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
 
-        Assert.Equal("sql2:1433", env["SQL_SERVER"]);
+        Assert.Equal("sql2.dev.internal:1433", env["SQL_SERVER"]);
         Assert.Equal(await sql2.Resource.PasswordParameter.GetValueAsync(CancellationToken.None), env["MSSQL_SA_PASSWORD"]);
     }
 
@@ -913,6 +950,16 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     {
         var annotation = Assert.Single(resource.Annotations.OfType<PersistenceAnnotation>());
         return Assert.IsAssignableFrom<IResource>(annotation.SourceResource);
+    }
+
+    // Simulates the orchestrator allocating the resource's 'tcp' endpoint on the container network,
+    // which is the network context the emulator resolves its SQL Server endpoint in.
+    private static void AllocateContainerNetworkEndpoint(IResource resource, string address, int port)
+    {
+        var endpoint = resource.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == "tcp");
+        endpoint.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(
+            KnownNetworkIdentifiers.DefaultAspireContainerNetwork,
+            new AllocatedEndpoint(endpoint, address, port, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkId: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
     }
 
     private static PersistenceMode ToPersistenceMode(Lifetime lifetime) =>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -660,6 +660,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator();
 
         var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+        Assert.IsType<SqlServerServerResource>(sql);
         var imageAnnotation = Assert.Single(sql.Annotations.OfType<ContainerImageAnnotation>());
         Assert.Equal("mssql/server", imageAnnotation.Image);
 
@@ -690,6 +691,34 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void WithSqlServerContainer_SupportsSqlServerIntegrationApis()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServerContainer(sql => sql.WithHostPort(12345)));
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+        var endpoint = Assert.Single(sql.Annotations.OfType<EndpointAnnotation>());
+        Assert.Equal(12345, endpoint.Port);
+    }
+
+    [Fact]
+    public async Task WithSqlServerContainer_PasswordChangedInCallback_IsUsedByEmulator()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var password = builder.AddParameter("sql-password", "p@ssw0rd1");
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServerContainer(sql => sql.WithPassword(password)));
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("p@ssw0rd1", env["MSSQL_SA_PASSWORD"]);
+    }
+
+    [Fact]
     public async Task WithSqlServer_ReusesExistingSqlServerResource()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -697,7 +726,43 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var sql = builder.AddSqlServer("sql");
 
         var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
-            .WithSqlServer(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter));
+            .WithSqlServer(sql));
+
+        Assert.DoesNotContain(builder.Resources, x => x.Name == "sb-mssql");
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("Y", env["ACCEPT_EULA"]);
+        Assert.Equal("sql:1433", env["SQL_SERVER"]);
+        Assert.Equal(await sql.Resource.PasswordParameter.GetValueAsync(CancellationToken.None), env["MSSQL_SA_PASSWORD"]);
+    }
+
+    [Fact]
+    public async Task WithSqlServer_PasswordChangedAfterCall_IsUsedByEmulator()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql = builder.AddSqlServer("sql");
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServer(sql));
+
+        sql.WithPassword(builder.AddParameter("new-password", "p@ssw0rd2"));
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("p@ssw0rd2", env["MSSQL_SA_PASSWORD"]);
+    }
+
+    [Fact]
+    public async Task WithSqlServerConnection_UsesProvidedEndpointAndPassword()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql = builder.AddSqlServer("sql");
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServerConnection(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter));
 
         Assert.DoesNotContain(builder.Resources, x => x.Name == "sb-mssql");
 
@@ -747,8 +812,8 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var sql2 = builder.AddSqlServer("sql2");
 
         var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
-            .WithSqlServer(sql1.Resource.PrimaryEndpoint, sql1.Resource.PasswordParameter)
-            .WithSqlServer(sql2.Resource.PrimaryEndpoint, sql2.Resource.PasswordParameter));
+            .WithSqlServer(sql1)
+            .WithSqlServer(sql2));
 
         var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
 
@@ -770,13 +835,40 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
             {
                 if (sqlServerFirst)
                 {
-                    configure.WithSqlServer(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter)
+                    configure.WithSqlServer(sql)
                         .WithSqlServerContainer(container => container.WithImageTag("2019-latest"));
                 }
                 else
                 {
                     configure.WithSqlServerContainer(container => container.WithImageTag("2019-latest"))
-                        .WithSqlServer(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter);
+                        .WithSqlServer(sql);
+                }
+            }));
+
+        Assert.Contains("cannot use both", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithSqlServerConnectionAndWithSqlServerContainer_AreMutuallyExclusive(bool connectionFirst)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql = builder.AddSqlServer("sql");
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            builder.AddAzureServiceBus("sb").RunAsEmulator(configure =>
+            {
+                if (connectionFirst)
+                {
+                    configure.WithSqlServerConnection(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter)
+                        .WithSqlServerContainer(container => container.WithImageTag("2019-latest"));
+                }
+                else
+                {
+                    configure.WithSqlServerContainer(container => container.WithImageTag("2019-latest"))
+                        .WithSqlServerConnection(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter);
                 }
             }));
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -674,12 +674,35 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void WithSqlServerContainer_CustomizesSqlServerContainer()
+    public void AddAzureServiceBusWithEmulator_WaitsForSqlServer()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator();
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+
+        AssertWaitsForHealthy(serviceBus.Resource, sql);
+    }
+
+    [Fact]
+    public void WithSqlServer_WithoutArguments_UsesTheSqlServerResourceCreatedForTheEmulator()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure.WithSqlServer());
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+        Assert.IsType<SqlServerServerResource>(sql);
+    }
+
+    [Fact]
+    public void WithSqlServer_CustomizesSqlServerResource()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
         builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
-            .WithSqlServerContainer(sql => sql
+            .WithSqlServer(sql => sql
                 .WithImageTag("2019-latest")
                 .WithContainerName("custom-sql")));
 
@@ -693,12 +716,12 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void WithSqlServerContainer_SupportsSqlServerIntegrationApis()
+    public void WithSqlServer_SupportsSqlServerIntegrationApis()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
         builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
-            .WithSqlServerContainer(sql => sql.WithHostPort(12345)));
+            .WithSqlServer(sql => sql.WithHostPort(12345)));
 
         var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
         var endpoint = Assert.Single(sql.Annotations.OfType<EndpointAnnotation>());
@@ -706,14 +729,14 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public async Task WithSqlServerContainer_PasswordChangedInCallback_IsUsedByEmulator()
+    public async Task WithSqlServer_PasswordChangedInCallback_IsUsedByEmulator()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var password = builder.AddParameter("sql-password", "p@ssw0rd1");
 
         var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
-            .WithSqlServerContainer(sql => sql.WithPassword(password)));
+            .WithSqlServer(sql => sql.WithPassword(password)));
 
         var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
         AllocateContainerNetworkEndpoint(sql, "sb-mssql.dev.internal", 1433);
@@ -734,6 +757,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
             .WithSqlServer(sql));
 
         Assert.DoesNotContain(builder.Resources, x => x.Name == "sb-mssql");
+        AssertWaitsForHealthy(serviceBus.Resource, sql.Resource);
 
         AllocateContainerNetworkEndpoint(sql.Resource, "sql.dev.internal", 1433);
 
@@ -764,57 +788,34 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public async Task WithSqlServerConnection_UsesProvidedEndpointAndPassword()
+    public async Task WithSqlServer_UsesTheAddressProjectedIntoTheContainerNetwork()
     {
+        // The emulator reaches the SQL Server resource through the emulator container's network, so the
+        // endpoint must resolve to the address the orchestrator projects into that network rather than to
+        // the resource name. That address is the container host address when the SQL Server isn't itself
+        // running in the container network.
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var sql = builder.AddSqlServer("sql");
 
         var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
-            .WithSqlServerConnection(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter));
+            .WithSqlServer(sql));
 
-        Assert.DoesNotContain(builder.Resources, x => x.Name == "sb-mssql");
-
-        AllocateContainerNetworkEndpoint(sql.Resource, "sql.dev.internal", 1433);
-
-        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
-
-        Assert.Equal("Y", env["ACCEPT_EULA"]);
-        Assert.Equal("sql.dev.internal:1433", env["SQL_SERVER"]);
-        Assert.Equal(await sql.Resource.PasswordParameter.GetValueAsync(CancellationToken.None), env["MSSQL_SA_PASSWORD"]);
-    }
-
-    [Fact]
-    public async Task WithSqlServerConnection_HostProcessEndpoint_ResolvesToContainerHostAddress()
-    {
-        // A SQL Server instance that is not a container (e.g. hosted by an executable resource) is not
-        // reachable from the emulator container via its resource name. The endpoint must resolve to the
-        // address the orchestrator projects into the container network (the container host address).
-        using var builder = TestDistributedApplicationBuilder.Create();
-
-        var password = builder.AddParameter("sa-password", "p@ssw0rd1");
-        var sqlHost = builder.AddExecutable("sql-host", "sqlservr", ".")
-            .WithEndpoint(name: "tcp");
-
-        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
-            .WithSqlServerConnection(sqlHost.GetEndpoint("tcp"), password.Resource));
-
-        AllocateContainerNetworkEndpoint(sqlHost.Resource, "host.docker.internal", 52133);
+        AllocateContainerNetworkEndpoint(sql.Resource, "host.docker.internal", 52133);
 
         var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
 
         Assert.Equal("host.docker.internal:52133", env["SQL_SERVER"]);
-        Assert.Equal("p@ssw0rd1", env["MSSQL_SA_PASSWORD"]);
     }
 
     [Fact]
-    public void WithSqlServerContainer_RemovingTcpEndpoint_Throws()
+    public void WithSqlServer_RemovingTcpEndpoint_Throws()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
             builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
-                .WithSqlServerContainer(sql =>
+                .WithSqlServer(sql =>
                 {
                     var endpoint = sql.Resource.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == "tcp");
                     sql.Resource.Annotations.Remove(endpoint);
@@ -824,13 +825,13 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void WithSqlServerContainer_CalledMultipleTimes_AppliesCallbacksInOrder()
+    public void WithSqlServer_CallbackCalledMultipleTimes_AppliesCallbacksInOrder()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
         builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
-            .WithSqlServerContainer(sql => sql.WithImageTag("2019-latest"))
-            .WithSqlServerContainer(sql => sql.WithImageTag("2022-latest")));
+            .WithSqlServer(sql => sql.WithImageTag("2019-latest"))
+            .WithSqlServer(sql => sql.WithImageTag("2022-latest")));
 
         var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
         var imageAnnotation = Assert.Single(sql.Annotations.OfType<ContainerImageAnnotation>());
@@ -856,12 +857,16 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 
         Assert.Equal("sql2.dev.internal:1433", env["SQL_SERVER"]);
         Assert.Equal(await sql2.Resource.PasswordParameter.GetValueAsync(CancellationToken.None), env["MSSQL_SA_PASSWORD"]);
+
+        // The superseded SQL Server resource is no longer waited for either.
+        AssertWaitsForHealthy(serviceBus.Resource, sql2.Resource);
+        Assert.DoesNotContain(serviceBus.Resource.Annotations.OfType<ResourceRelationshipAnnotation>(), r => r.Resource == sql1.Resource);
     }
 
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void WithSqlServerAndWithSqlServerContainer_AreMutuallyExclusive(bool sqlServerFirst)
+    public void WithSqlServer_ExistingResourceAndCallback_AreMutuallyExclusive(bool sqlServerFirst)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
@@ -873,11 +878,11 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                 if (sqlServerFirst)
                 {
                     configure.WithSqlServer(sql)
-                        .WithSqlServerContainer(container => container.WithImageTag("2019-latest"));
+                        .WithSqlServer(emulatorSql => emulatorSql.WithImageTag("2019-latest"));
                 }
                 else
                 {
-                    configure.WithSqlServerContainer(container => container.WithImageTag("2019-latest"))
+                    configure.WithSqlServer(emulatorSql => emulatorSql.WithImageTag("2019-latest"))
                         .WithSqlServer(sql);
                 }
             }));
@@ -888,7 +893,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void WithSqlServerConnectionAndWithSqlServerContainer_AreMutuallyExclusive(bool connectionFirst)
+    public void WithSqlServer_ExistingResourceAndDefault_AreMutuallyExclusive(bool sqlServerFirst)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
@@ -897,15 +902,13 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var exception = Assert.Throws<InvalidOperationException>(() =>
             builder.AddAzureServiceBus("sb").RunAsEmulator(configure =>
             {
-                if (connectionFirst)
+                if (sqlServerFirst)
                 {
-                    configure.WithSqlServerConnection(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter)
-                        .WithSqlServerContainer(container => container.WithImageTag("2019-latest"));
+                    configure.WithSqlServer(sql).WithSqlServer();
                 }
                 else
                 {
-                    configure.WithSqlServerContainer(container => container.WithImageTag("2019-latest"))
-                        .WithSqlServerConnection(sql.Resource.PrimaryEndpoint, sql.Resource.PasswordParameter);
+                    configure.WithSqlServer().WithSqlServer(sql);
                 }
             }));
 
@@ -954,6 +957,13 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 
     // Simulates the orchestrator allocating the resource's 'tcp' endpoint on the container network,
     // which is the network context the emulator resolves its SQL Server endpoint in.
+    private static void AssertWaitsForHealthy(IResource resource, IResource dependency)
+    {
+        var wait = Assert.Single(resource.Annotations.OfType<WaitAnnotation>());
+        Assert.Same(dependency, wait.Resource);
+        Assert.Equal(WaitType.WaitUntilHealthy, wait.WaitType);
+    }
+
     private static void AllocateContainerNetworkEndpoint(IResource resource, string address, int port)
     {
         var endpoint = resource.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == "tcp");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Nodes;
 using System.Reflection;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.ServiceBus;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Aspire.TestUtilities;
 using Azure.Messaging.ServiceBus;
@@ -651,10 +652,324 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         Assert.Throws<InvalidOperationException>(() => serviceBus.RunAsEmulator());
     }
 
+    [Fact]
+    public async Task AddAzureServiceBusWithEmulator_CreatesDefaultSqlServerContainer()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator();
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+        Assert.IsType<SqlServerServerResource>(sql);
+        var imageAnnotation = Assert.Single(sql.Annotations.OfType<ContainerImageAnnotation>());
+        Assert.Equal("mssql/server", imageAnnotation.Image);
+
+        AllocateContainerNetworkEndpoint(sql, "sb-mssql.dev.internal", 1433);
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("Y", env["ACCEPT_EULA"]);
+        Assert.Equal("sb-mssql.dev.internal:1433", env["SQL_SERVER"]);
+        Assert.False(string.IsNullOrEmpty(env["MSSQL_SA_PASSWORD"]));
+    }
+
+    [Fact]
+    public void AddAzureServiceBusWithEmulator_WaitsForSqlServer()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator();
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+
+        AssertWaitsForHealthy(serviceBus.Resource, sql);
+    }
+
+    [Fact]
+    public void WithSqlServer_WithoutArguments_UsesTheSqlServerResourceCreatedForTheEmulator()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure.WithSqlServer());
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+        Assert.IsType<SqlServerServerResource>(sql);
+    }
+
+    [Fact]
+    public void WithSqlServer_CustomizesSqlServerResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServer(sql => sql
+                .WithImageTag("2019-latest")
+                .WithContainerName("custom-sql")));
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+
+        var imageAnnotation = Assert.Single(sql.Annotations.OfType<ContainerImageAnnotation>());
+        Assert.Equal("2019-latest", imageAnnotation.Tag);
+
+        var nameAnnotation = Assert.Single(sql.Annotations.OfType<ContainerNameAnnotation>());
+        Assert.Equal("custom-sql", nameAnnotation.Name);
+    }
+
+    [Fact]
+    public void WithSqlServer_SupportsSqlServerIntegrationApis()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServer(sql => sql.WithHostPort(12345)));
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+        var endpoint = Assert.Single(sql.Annotations.OfType<EndpointAnnotation>());
+        Assert.Equal(12345, endpoint.Port);
+    }
+
+    [Fact]
+    public async Task WithSqlServer_PasswordChangedInCallback_IsUsedByEmulator()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var password = builder.AddParameter("sql-password", "p@ssw0rd1");
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServer(sql => sql.WithPassword(password)));
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+        AllocateContainerNetworkEndpoint(sql, "sb-mssql.dev.internal", 1433);
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("p@ssw0rd1", env["MSSQL_SA_PASSWORD"]);
+    }
+
+    [Fact]
+    public async Task WithSqlServer_ReusesExistingSqlServerResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql = builder.AddSqlServer("sql");
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServer(sql));
+
+        Assert.DoesNotContain(builder.Resources, x => x.Name == "sb-mssql");
+        AssertWaitsForHealthy(serviceBus.Resource, sql.Resource);
+
+        AllocateContainerNetworkEndpoint(sql.Resource, "sql.dev.internal", 1433);
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("Y", env["ACCEPT_EULA"]);
+        Assert.Equal("sql.dev.internal:1433", env["SQL_SERVER"]);
+        Assert.Equal(await sql.Resource.PasswordParameter.GetValueAsync(CancellationToken.None), env["MSSQL_SA_PASSWORD"]);
+    }
+
+    [Fact]
+    public async Task WithSqlServer_PasswordChangedAfterCall_IsUsedByEmulator()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql = builder.AddSqlServer("sql");
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServer(sql));
+
+        sql.WithPassword(builder.AddParameter("new-password", "p@ssw0rd2"));
+
+        AllocateContainerNetworkEndpoint(sql.Resource, "sql.dev.internal", 1433);
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("p@ssw0rd2", env["MSSQL_SA_PASSWORD"]);
+    }
+
+    [Fact]
+    public async Task WithSqlServer_UsesTheAddressProjectedIntoTheContainerNetwork()
+    {
+        // The emulator reaches the SQL Server resource through the emulator container's network, so the
+        // endpoint must resolve to the address the orchestrator projects into that network rather than to
+        // the resource name. That address is the container host address when the SQL Server isn't itself
+        // running in the container network.
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql = builder.AddSqlServer("sql");
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServer(sql));
+
+        AllocateContainerNetworkEndpoint(sql.Resource, "host.docker.internal", 52133);
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("host.docker.internal:52133", env["SQL_SERVER"]);
+    }
+
+    [Fact]
+    public void WithSqlServer_RemovingTcpEndpoint_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+                .WithSqlServer(sql =>
+                {
+                    var endpoint = sql.Resource.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == "tcp");
+                    sql.Resource.Annotations.Remove(endpoint);
+                })));
+
+        Assert.Contains("must keep its 'tcp' endpoint", exception.Message);
+    }
+
+    [Fact]
+    public void WithSqlServer_CallbackCalledMultipleTimes_AppliesCallbacksInOrder()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServer(sql => sql.WithImageTag("2019-latest"))
+            .WithSqlServer(sql => sql.WithImageTag("2022-latest")));
+
+        var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
+        var imageAnnotation = Assert.Single(sql.Annotations.OfType<ContainerImageAnnotation>());
+        Assert.Equal("2022-latest", imageAnnotation.Tag);
+    }
+
+    [Fact]
+    public async Task WithSqlServer_CalledMultipleTimes_LastWins()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql1 = builder.AddSqlServer("sql1");
+        var sql2 = builder.AddSqlServer("sql2");
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithSqlServer(sql1)
+            .WithSqlServer(sql2));
+
+        // Only sql2's endpoint is allocated; resolving successfully also proves sql1 is not consulted.
+        AllocateContainerNetworkEndpoint(sql2.Resource, "sql2.dev.internal", 1433);
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("sql2.dev.internal:1433", env["SQL_SERVER"]);
+        Assert.Equal(await sql2.Resource.PasswordParameter.GetValueAsync(CancellationToken.None), env["MSSQL_SA_PASSWORD"]);
+
+        // The superseded SQL Server resource is no longer waited for either.
+        AssertWaitsForHealthy(serviceBus.Resource, sql2.Resource);
+        Assert.DoesNotContain(serviceBus.Resource.Annotations.OfType<ResourceRelationshipAnnotation>(), r => r.Resource == sql1.Resource);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithSqlServer_ExistingResourceAndCallback_AreMutuallyExclusive(bool sqlServerFirst)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql = builder.AddSqlServer("sql");
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            builder.AddAzureServiceBus("sb").RunAsEmulator(configure =>
+            {
+                if (sqlServerFirst)
+                {
+                    configure.WithSqlServer(sql)
+                        .WithSqlServer(emulatorSql => emulatorSql.WithImageTag("2019-latest"));
+                }
+                else
+                {
+                    configure.WithSqlServer(emulatorSql => emulatorSql.WithImageTag("2019-latest"))
+                        .WithSqlServer(sql);
+                }
+            }));
+
+        Assert.Contains("cannot use both", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithSqlServer_ExistingResourceAndDefault_AreMutuallyExclusive(bool sqlServerFirst)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql = builder.AddSqlServer("sql");
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            builder.AddAzureServiceBus("sb").RunAsEmulator(configure =>
+            {
+                if (sqlServerFirst)
+                {
+                    configure.WithSqlServer(sql).WithSqlServer();
+                }
+                else
+                {
+                    configure.WithSqlServer().WithSqlServer(sql);
+                }
+            }));
+
+        Assert.Contains("cannot use both", exception.Message);
+    }
+
+    [Fact]
+    public async Task AddAzureServiceBusWithEmulator_EnvironmentOverridesInCallbackTakePrecedence()
+    {
+        // Users have historically pointed the emulator at their own SQL Server by overriding the
+        // SQL_SERVER/MSSQL_SA_PASSWORD environment variables in the configuration callback. Such
+        // overrides must keep taking precedence over the values set by RunAsEmulator.
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WithEnvironment("SQL_SERVER", "external-sql:1433"));
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceBus.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("external-sql:1433", env["SQL_SERVER"]);
+    }
+
+    [Fact]
+    public void AddAzureServiceBusWithEmulator_SqlServerContainerIsInModelAfterRunAsEmulatorReturns()
+    {
+        // Users work around the lack of configurability by locating the SQL container in the model
+        // after RunAsEmulator returns (e.g. to rename or remove it). Keep that working.
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzureServiceBus("servicebus").RunAsEmulator(configure => configure.WithLifetime(ContainerLifetime.Persistent));
+
+        var serviceBusSql = builder.Resources.OfType<ContainerResource>().Last(x => x.Name == "servicebus-mssql");
+        serviceBusSql.Annotations.Add(new ContainerNameAnnotation { Name = "my-servicebus-mssql-container" });
+
+        var nameAnnotation = Assert.Single(serviceBusSql.Annotations.OfType<ContainerNameAnnotation>());
+        Assert.Equal("my-servicebus-mssql-container", nameAnnotation.Name);
+
+        Assert.True(builder.Resources.Remove(serviceBusSql));
+    }
+
     private static IResource GetPersistenceReferenceSource(IResource resource)
     {
         var annotation = Assert.Single(resource.Annotations.OfType<PersistenceAnnotation>());
         return Assert.IsAssignableFrom<IResource>(annotation.SourceResource);
+    }
+
+    // Simulates the orchestrator allocating the resource's 'tcp' endpoint on the container network,
+    // which is the network context the emulator resolves its SQL Server endpoint in.
+    private static void AssertWaitsForHealthy(IResource resource, IResource dependency)
+    {
+        var wait = Assert.Single(resource.Annotations.OfType<WaitAnnotation>());
+        Assert.Same(dependency, wait.Resource);
+        Assert.Equal(WaitType.WaitUntilHealthy, wait.WaitType);
+    }
+
+    private static void AllocateContainerNetworkEndpoint(IResource resource, string address, int port)
+    {
+        var endpoint = resource.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == "tcp");
+        endpoint.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(
+            KnownNetworkIdentifiers.DefaultAspireContainerNetwork,
+            new AllocatedEndpoint(endpoint, address, port, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkId: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
     }
 
     private static PersistenceMode ToPersistenceMode(Lifetime lifetime) =>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -660,7 +660,8 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator();
 
         var sql = Assert.Single(builder.Resources, x => x.Name == "sb-mssql");
-        Assert.IsType<SqlServerServerResource>(sql);
+        var sqlServer = Assert.IsType<SqlServerServerResource>(sql);
+        Assert.Equal("sb-sql-pwd", sqlServer.PasswordParameter.Name);
         var imageAnnotation = Assert.Single(sql.Annotations.OfType<ContainerImageAnnotation>());
         Assert.Equal("mssql/server", imageAnnotation.Image);
 
@@ -756,7 +757,9 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
             .WithSqlServer(sql));
 
-        Assert.DoesNotContain(builder.Resources, x => x.Name == "sb-mssql");
+        Assert.Collection(
+            builder.Resources.OfType<SqlServerServerResource>(),
+            resource => Assert.Same(sql.Resource, resource));
         AssertWaitsForHealthy(serviceBus.Resource, sql.Resource);
 
         AllocateContainerNetworkEndpoint(sql.Resource, "sql.dev.internal", 1433);
@@ -821,7 +824,9 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                     sql.Resource.Annotations.Remove(endpoint);
                 })));
 
-        Assert.Contains("must keep its 'tcp' endpoint", exception.Message);
+        Assert.Equal(
+            "The SQL Server resource for the Azure Service Bus emulator must keep its 'tcp' endpoint. Update the 'WithSqlServer' callback so it does not remove or rename the endpoint.",
+            exception.Message);
     }
 
     [Fact]
@@ -860,7 +865,29 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 
         // The superseded SQL Server resource is no longer waited for either.
         AssertWaitsForHealthy(serviceBus.Resource, sql2.Resource);
-        Assert.DoesNotContain(serviceBus.Resource.Annotations.OfType<ResourceRelationshipAnnotation>(), r => r.Resource == sql1.Resource);
+        Assert.Collection(
+            serviceBus.Resource.Annotations.OfType<ResourceRelationshipAnnotation>(),
+            relationship => Assert.Same(sql2.Resource, relationship.Resource));
+    }
+
+    [Fact]
+    public void WithSqlServer_CalledMultipleTimes_PreservesUserAuthoredWait()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql1 = builder.AddSqlServer("sql1");
+        var sql2 = builder.AddSqlServer("sql2");
+
+        var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator(configure => configure
+            .WaitFor(sql1)
+            .WithSqlServer(sql1)
+            .WithSqlServer(sql2));
+
+        var waits = serviceBus.Resource.Annotations.OfType<WaitAnnotation>().ToArray();
+        Assert.Collection(
+            waits,
+            wait => Assert.Same(sql1.Resource, wait.Resource),
+            wait => Assert.Same(sql2.Resource, wait.Resource));
     }
 
     [Theory]
@@ -887,7 +914,9 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                 }
             }));
 
-        Assert.Contains("cannot use both", exception.Message);
+        Assert.Equal(
+            "The Azure Service Bus emulator cannot use both an existing SQL Server resource and a customized built-in SQL Server resource. Remove either the 'WithSqlServer(sqlServer)' call or the 'WithSqlServer(configureSqlServer)' call.",
+            exception.Message);
     }
 
     [Theory]
@@ -912,7 +941,9 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                 }
             }));
 
-        Assert.Contains("cannot use both", exception.Message);
+        Assert.Equal(
+            "The Azure Service Bus emulator cannot use both an existing SQL Server resource and a customized built-in SQL Server resource. Remove either the 'WithSqlServer(sqlServer)' call or the 'WithSqlServer(configureSqlServer)' call.",
+            exception.Message);
     }
 
     [Fact]
@@ -955,8 +986,6 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         return Assert.IsAssignableFrom<IResource>(annotation.SourceResource);
     }
 
-    // Simulates the orchestrator allocating the resource's 'tcp' endpoint on the container network,
-    // which is the network context the emulator resolves its SQL Server endpoint in.
     private static void AssertWaitsForHealthy(IResource resource, IResource dependency)
     {
         var wait = Assert.Single(resource.Annotations.OfType<WaitAnnotation>());
@@ -966,6 +995,8 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 
     private static void AllocateContainerNetworkEndpoint(IResource resource, string address, int port)
     {
+        // Simulates the orchestrator allocating the resource's 'tcp' endpoint on the container network,
+        // which is the network context the emulator resolves its SQL Server endpoint in.
         var endpoint = resource.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == "tcp");
         endpoint.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(
             KnownNetworkIdentifiers.DefaultAspireContainerNetwork,

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/ServiceBusPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/ServiceBusPublicApiTests.cs
@@ -325,7 +325,7 @@ public class ServiceBusPublicApiTests
     public void WithSqlServerContainerShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<AzureServiceBusEmulatorResource> builder = null!;
-        Action<IResourceBuilder<ContainerResource>> configureContainer = (_) => { };
+        Action<IResourceBuilder<SqlServerServerResource>> configureContainer = (_) => { };
 
         var action = () => builder.WithSqlServerContainer(configureContainer);
 
@@ -338,7 +338,7 @@ public class ServiceBusPublicApiTests
     {
         using var testBuilder = TestDistributedApplicationBuilder.Create();
         var builder = testBuilder.AddAzureServiceBus("service-bus");
-        Action<IResourceBuilder<ContainerResource>> configureContainer = null!;
+        Action<IResourceBuilder<SqlServerServerResource>> configureContainer = null!;
 
         var action = () => builder.RunAsEmulator(configure => configure.WithSqlServerContainer(configureContainer));
 
@@ -353,35 +353,61 @@ public class ServiceBusPublicApiTests
         using var testBuilder = TestDistributedApplicationBuilder.Create();
         var sqlServer = testBuilder.AddSqlServer("sql");
 
-        var action = () => builder.WithSqlServer(sqlServer.Resource.PrimaryEndpoint, sqlServer.Resource.PasswordParameter);
+        var action = () => builder.WithSqlServer(sqlServer);
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(builder), exception.ParamName);
     }
 
     [Fact]
-    public void WithSqlServerShouldThrowWhenSqlServerEndpointIsNull()
+    public void WithSqlServerShouldThrowWhenSqlServerIsNull()
+    {
+        using var testBuilder = TestDistributedApplicationBuilder.Create();
+        var builder = testBuilder.AddAzureServiceBus("service-bus");
+        IResourceBuilder<SqlServerServerResource> sqlServer = null!;
+
+        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServer(sqlServer));
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(sqlServer), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithSqlServerConnectionShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<AzureServiceBusEmulatorResource> builder = null!;
+        using var testBuilder = TestDistributedApplicationBuilder.Create();
+        var sqlServer = testBuilder.AddSqlServer("sql");
+
+        var action = () => builder.WithSqlServerConnection(sqlServer.Resource.PrimaryEndpoint, sqlServer.Resource.PasswordParameter);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithSqlServerConnectionShouldThrowWhenSqlServerEndpointIsNull()
     {
         using var testBuilder = TestDistributedApplicationBuilder.Create();
         var builder = testBuilder.AddAzureServiceBus("service-bus");
         var sqlServer = testBuilder.AddSqlServer("sql");
         EndpointReference sqlServerEndpoint = null!;
 
-        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServer(sqlServerEndpoint, sqlServer.Resource.PasswordParameter));
+        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServerConnection(sqlServerEndpoint, sqlServer.Resource.PasswordParameter));
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(sqlServerEndpoint), exception.ParamName);
     }
 
     [Fact]
-    public void WithSqlServerShouldThrowWhenSaPasswordParameterIsNull()
+    public void WithSqlServerConnectionShouldThrowWhenSaPasswordParameterIsNull()
     {
         using var testBuilder = TestDistributedApplicationBuilder.Create();
         var builder = testBuilder.AddAzureServiceBus("service-bus");
         var sqlServer = testBuilder.AddSqlServer("sql");
         ParameterResource saPasswordParameter = null!;
 
-        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServer(sqlServer.Resource.PrimaryEndpoint, saPasswordParameter));
+        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServerConnection(sqlServer.Resource.PrimaryEndpoint, saPasswordParameter));
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(saPasswordParameter), exception.ParamName);

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/ServiceBusPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/ServiceBusPublicApiTests.cs
@@ -320,4 +320,70 @@ public class ServiceBusPublicApiTests
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(builder), exception.ParamName);
     }
+
+    [Fact]
+    public void WithSqlServerContainerShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<AzureServiceBusEmulatorResource> builder = null!;
+        Action<IResourceBuilder<ContainerResource>> configureContainer = (_) => { };
+
+        var action = () => builder.WithSqlServerContainer(configureContainer);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithSqlServerContainerShouldThrowWhenConfigureContainerIsNull()
+    {
+        using var testBuilder = TestDistributedApplicationBuilder.Create();
+        var builder = testBuilder.AddAzureServiceBus("service-bus");
+        Action<IResourceBuilder<ContainerResource>> configureContainer = null!;
+
+        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServerContainer(configureContainer));
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(configureContainer), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithSqlServerShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<AzureServiceBusEmulatorResource> builder = null!;
+        using var testBuilder = TestDistributedApplicationBuilder.Create();
+        var sqlServer = testBuilder.AddSqlServer("sql");
+
+        var action = () => builder.WithSqlServer(sqlServer.Resource.PrimaryEndpoint, sqlServer.Resource.PasswordParameter);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithSqlServerShouldThrowWhenSqlServerEndpointIsNull()
+    {
+        using var testBuilder = TestDistributedApplicationBuilder.Create();
+        var builder = testBuilder.AddAzureServiceBus("service-bus");
+        var sqlServer = testBuilder.AddSqlServer("sql");
+        EndpointReference sqlServerEndpoint = null!;
+
+        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServer(sqlServerEndpoint, sqlServer.Resource.PasswordParameter));
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(sqlServerEndpoint), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithSqlServerShouldThrowWhenSaPasswordParameterIsNull()
+    {
+        using var testBuilder = TestDistributedApplicationBuilder.Create();
+        var builder = testBuilder.AddAzureServiceBus("service-bus");
+        var sqlServer = testBuilder.AddSqlServer("sql");
+        ParameterResource saPasswordParameter = null!;
+
+        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServer(sqlServer.Resource.PrimaryEndpoint, saPasswordParameter));
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(saPasswordParameter), exception.ParamName);
+    }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/ServiceBusPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/ServiceBusPublicApiTests.cs
@@ -322,32 +322,43 @@ public class ServiceBusPublicApiTests
     }
 
     [Fact]
-    public void WithSqlServerContainerShouldThrowWhenBuilderIsNull()
+    public void WithSqlServerShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<AzureServiceBusEmulatorResource> builder = null!;
-        Action<IResourceBuilder<SqlServerServerResource>> configureContainer = (_) => { };
 
-        var action = () => builder.WithSqlServerContainer(configureContainer);
+        var action = () => builder.WithSqlServer();
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(builder), exception.ParamName);
     }
 
     [Fact]
-    public void WithSqlServerContainerShouldThrowWhenConfigureContainerIsNull()
+    public void WithSqlServerWithCallbackShouldThrowWhenBuilderIsNull()
     {
-        using var testBuilder = TestDistributedApplicationBuilder.Create();
-        var builder = testBuilder.AddAzureServiceBus("service-bus");
-        Action<IResourceBuilder<SqlServerServerResource>> configureContainer = null!;
+        IResourceBuilder<AzureServiceBusEmulatorResource> builder = null!;
+        Action<IResourceBuilder<SqlServerServerResource>> configureSqlServer = (_) => { };
 
-        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServerContainer(configureContainer));
+        var action = () => builder.WithSqlServer(configureSqlServer);
 
         var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal(nameof(configureContainer), exception.ParamName);
+        Assert.Equal(nameof(builder), exception.ParamName);
     }
 
     [Fact]
-    public void WithSqlServerShouldThrowWhenBuilderIsNull()
+    public void WithSqlServerShouldThrowWhenConfigureSqlServerIsNull()
+    {
+        using var testBuilder = TestDistributedApplicationBuilder.Create();
+        var builder = testBuilder.AddAzureServiceBus("service-bus");
+        Action<IResourceBuilder<SqlServerServerResource>> configureSqlServer = null!;
+
+        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServer(configureSqlServer));
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(configureSqlServer), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithSqlServerWithResourceShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<AzureServiceBusEmulatorResource> builder = null!;
         using var testBuilder = TestDistributedApplicationBuilder.Create();
@@ -370,46 +381,5 @@ public class ServiceBusPublicApiTests
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(sqlServer), exception.ParamName);
-    }
-
-    [Fact]
-    public void WithSqlServerConnectionShouldThrowWhenBuilderIsNull()
-    {
-        IResourceBuilder<AzureServiceBusEmulatorResource> builder = null!;
-        using var testBuilder = TestDistributedApplicationBuilder.Create();
-        var sqlServer = testBuilder.AddSqlServer("sql");
-
-        var action = () => builder.WithSqlServerConnection(sqlServer.Resource.PrimaryEndpoint, sqlServer.Resource.PasswordParameter);
-
-        var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal(nameof(builder), exception.ParamName);
-    }
-
-    [Fact]
-    public void WithSqlServerConnectionShouldThrowWhenSqlServerEndpointIsNull()
-    {
-        using var testBuilder = TestDistributedApplicationBuilder.Create();
-        var builder = testBuilder.AddAzureServiceBus("service-bus");
-        var sqlServer = testBuilder.AddSqlServer("sql");
-        EndpointReference sqlServerEndpoint = null!;
-
-        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServerConnection(sqlServerEndpoint, sqlServer.Resource.PasswordParameter));
-
-        var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal(nameof(sqlServerEndpoint), exception.ParamName);
-    }
-
-    [Fact]
-    public void WithSqlServerConnectionShouldThrowWhenSaPasswordParameterIsNull()
-    {
-        using var testBuilder = TestDistributedApplicationBuilder.Create();
-        var builder = testBuilder.AddAzureServiceBus("service-bus");
-        var sqlServer = testBuilder.AddSqlServer("sql");
-        ParameterResource saPasswordParameter = null!;
-
-        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServerConnection(sqlServer.Resource.PrimaryEndpoint, saPasswordParameter));
-
-        var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal(nameof(saPasswordParameter), exception.ParamName);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/ServiceBusPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/ServiceBusPublicApiTests.cs
@@ -320,4 +320,66 @@ public class ServiceBusPublicApiTests
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(builder), exception.ParamName);
     }
+
+    [Fact]
+    public void WithSqlServerShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<AzureServiceBusEmulatorResource> builder = null!;
+
+        var action = () => builder.WithSqlServer();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithSqlServerWithCallbackShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<AzureServiceBusEmulatorResource> builder = null!;
+        Action<IResourceBuilder<SqlServerServerResource>> configureSqlServer = (_) => { };
+
+        var action = () => builder.WithSqlServer(configureSqlServer);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithSqlServerShouldThrowWhenConfigureSqlServerIsNull()
+    {
+        using var testBuilder = TestDistributedApplicationBuilder.Create();
+        var builder = testBuilder.AddAzureServiceBus("service-bus");
+        Action<IResourceBuilder<SqlServerServerResource>> configureSqlServer = null!;
+
+        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServer(configureSqlServer));
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(configureSqlServer), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithSqlServerWithResourceShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<AzureServiceBusEmulatorResource> builder = null!;
+        using var testBuilder = TestDistributedApplicationBuilder.Create();
+        var sqlServer = testBuilder.AddSqlServer("sql");
+
+        var action = () => builder.WithSqlServer(sqlServer);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithSqlServerShouldThrowWhenSqlServerIsNull()
+    {
+        using var testBuilder = TestDistributedApplicationBuilder.Create();
+        var builder = testBuilder.AddAzureServiceBus("service-bus");
+        IResourceBuilder<SqlServerServerResource> sqlServer = null!;
+
+        var action = () => builder.RunAsEmulator(configure => configure.WithSqlServer(sqlServer));
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(sqlServer), exception.ParamName);
+    }
 }


### PR DESCRIPTION
## Description

The Azure Service Bus emulator creates a hardcoded companion SQL Server container with no way to customize its image or container name, and no way to reuse an existing SQL Server instance. Users have been working around this by locating the internal `{name}-mssql` resource by naming convention and mutating annotations, or removing it from the model and wiring environment variables by hand (see the workarounds posted in the issue).

This adds three `WithSqlServer` overloads on `IResourceBuilder<AzureServiceBusEmulatorResource>` (shaped around the existing SQL Server integration per review feedback):

```csharp
// Use the SQL Server resource created for the emulator (the default; explicit form)
builder.AddAzureServiceBus("sb").RunAsEmulator(e => e
    .WithSqlServer());

// Customize that SQL Server resource using the regular SQL Server integration APIs
builder.AddAzureServiceBus("sb").RunAsEmulator(e => e
    .WithSqlServer(sql => sql.WithDataVolume().WithContainerName("myproj-sb-sql")));

// Reuse an existing SQL Server resource; no dedicated resource or password parameter is created
var sql = builder.AddSqlServer("sql");
builder.AddAzureServiceBus("sb").RunAsEmulator(e => e
    .WithSqlServer(sql));
```

Implementation notes:

- The default backing store is now created via `AddSqlServer` (keeping the existing `{name}-mssql` resource name), so the SQL Server container defaults are no longer duplicated inside the Service Bus integration and the customization callback gets the full SQL Server integration surface (`WithDataVolume`, `WithHostPort`, `WithPassword`, ...).
- `Aspire.Hosting.Azure.ServiceBus` now references `Aspire.Hosting.SqlServer` so the primary API can be resource-based (`WithSqlServer(IResourceBuilder<SqlServerServerResource>)`). Discussed in review: requested by @davidfowl, dependency approved by @mitchdenny.
- The emulator waits for its SQL Server to become healthy before starting, whether that resource was created for it or passed in. Because `WithSqlServer(sqlServer)` is last-call-wins, a superseded call's wait and relationship annotations are removed.
- `RunAsEmulator` defers creating the emulator's own SQL Server resource until after the configuration callback has run, so passing an existing resource opts out cleanly without add-then-remove.
- The SQL Server the emulator uses is carried on the resource as an internal `SqlServerConnectionAnnotation`; the emulator's environment callback reads it and sets `SQL_SERVER`/`MSSQL_SA_PASSWORD`/`ACCEPT_EULA` as defaults (`TryAdd`), so user-provided overrides win regardless of callback ordering (regression-tested). The password is read lazily, so calling `WithPassword` on the SQL Server resource after `WithSqlServer` is honored.
- `SQL_SERVER` is set from `EndpointProperty.HostAndPort`, resolved in the emulator container's network context, so the emulator gets the address the orchestrator projects into that network rather than `{name}:{targetPort}` (regression-tested).
- The post-`RunAsEmulator` workarounds from the issue thread (looking up/renaming/removing the `{name}-mssql` resource) continue to work (regression-tested).
- Reusing an existing SQL Server resource and customizing the one created for the emulator are mutually exclusive and throw an `InvalidOperationException` at the offending call site. Removing the SQL Server's `tcp` endpoint in a customization callback also fails fast with a targeted message.
- Only `WithSqlServer(IResourceBuilder<SqlServerServerResource>)` is ATS-exported, so TypeScript app hosts customize the backing store by passing their own SQL resource. The other two overloads are `[AspireExportIgnore]`d: the callback shape isn't ATS-compatible, and a second export under the same name would collide on the generated capability id (ASPIREEXPORT007).
- `api/*.cs` baseline files intentionally untouched per contribution guidelines.

Fixes #9279

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
