### PR TITLE
Harden Foundry model generation

### DIFF
--- a/src/Aspire.Hosting.Foundry/FoundryModel.Generated.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryModel.Generated.cs
@@ -49,6 +49,12 @@ public partial class FoundryModel
         public static readonly FoundryModel ClaudeOpus47 = new() { Name = "claude-opus-4-7", Version = "1", Format = "Anthropic" };
 
         /// <summary>
+        /// Claude Opus 4.8 is our most intelligent Opus model and the best generally available model for coding and agents, with deeper reasoning for enterprise workflows.
+        /// </summary>
+        [AspireValue("FoundryModels")]
+        public static readonly FoundryModel ClaudeOpus48 = new() { Name = "claude-opus-4-8", Version = "1", Format = "Anthropic" };
+
+        /// <summary>
         /// Claude Sonnet 4.5 is Anthropic's most capable model for complex agents and an industry leader for coding and computer use.
         /// </summary>
         [AspireValue("FoundryModels")]
@@ -103,18 +109,6 @@ public partial class FoundryModel
         public static readonly FoundryModel CohereCommandA = new() { Name = "cohere-command-a", Version = "4", Format = "Cohere" };
 
         /// <summary>
-        /// Command R is a scalable generative model targeting RAG and Tool Use to enable production-scale AI for enterprise.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel CohereCommandR082024 = new() { Name = "Cohere-command-r-08-2024", Version = "1", Format = "Cohere" };
-
-        /// <summary>
-        /// Command R+ is a state-of-the-art RAG-optimized model designed to tackle enterprise-grade workloads.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel CohereCommandRPlus082024 = new() { Name = "Cohere-command-r-plus-08-2024", Version = "1", Format = "Cohere" };
-
-        /// <summary>
         /// Cohere Embed English is the market's leading text representation model used for semantic search, retrieval-augmented generation (RAG), classification, and clustering.
         /// </summary>
         [AspireValue("FoundryModels")]
@@ -161,12 +155,6 @@ public partial class FoundryModel
         /// </summary>
         [AspireValue("FoundryModels")]
         public static readonly FoundryModel DeepSeekR10528 = new() { Name = "DeepSeek-R1-0528", Version = "1", Format = "DeepSeek" };
-
-        /// <summary>
-        /// A strong Mixture-of-Experts (MoE) language model with 671B total parameters with 37B activated for each token.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel DeepSeekV3 = new() { Name = "DeepSeek-V3", Version = "1", Format = "DeepSeek" };
 
         /// <summary>
         /// DeepSeek-V3-0324 demonstrates notable improvements over its predecessor, DeepSeek-V3, in several key aspects, including enhanced reasoning, improved function calling, and superior code generation capabilities.
@@ -1351,16 +1339,16 @@ public partial class FoundryModel
         public static readonly FoundryModel AzureTranslatorTextTranslation = new() { Name = "Azure-Translator-Text-translation", Version = "1", Format = "Microsoft" };
 
         /// <summary>
-        /// MAI-DS-R1 is a DeepSeek-R1 reasoning model that has been post-trained by the Microsoft AI team to fill in information gaps in the previous version of the model and improve its harm protections while maintaining R1 reasoning capabilities.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel MaiDSR1 = new() { Name = "MAI-DS-R1", Version = "1", Format = "Microsoft" };
-
-        /// <summary>
         /// MAI-Transcribe-1 is an ASR model built to deliver high quality batch transcription whenever the user speaks. It is designed to achieve high accuracy across 25 languages and to adapt seamlessly to diverse accents, dialects, and regional speech patterns.
         /// </summary>
         [AspireValue("FoundryModels")]
         public static readonly FoundryModel MaiTranscribe1 = new() { Name = "MAI-Transcribe-1", Version = "2026-01-23", Format = "Microsoft" };
+
+        /// <summary>
+        /// MAI-Transcribe-1.5 is the second iteration of Microsoft's best-in-class speech-to-text model family. It delivers consistently strong transcription accuracy across 43 languages, accents, speaking styles, and noisy environments, with faster inference and now
+        /// </summary>
+        [AspireValue("FoundryModels")]
+        public static readonly FoundryModel MaiTranscribe15 = new() { Name = "MAI-Transcribe-1.5", Version = "2026-06-02", Format = "Microsoft" };
 
         /// <summary>
         /// MAI-Voice-1 is a text-to-speech (TTS) model that generates high-quality single-speaker speech and, soon, multi-speaker speech for public preview. It produces audio that strictly follows the input transcript and supports per-turn emotion control as well as
@@ -1369,40 +1357,16 @@ public partial class FoundryModel
         public static readonly FoundryModel MaiVoice1 = new() { Name = "MAI-Voice-1", Version = "2025-12-18", Format = "Microsoft" };
 
         /// <summary>
+        /// MAI-Voice-2 is a prompted text-to-speech (TTS) model that generates high-fidelity, natural, and expressive speech across 10+ languages. It captures human-like intonation, rhythm, and emotional nuance for engaging conversational experiences.
+        /// </summary>
+        [AspireValue("FoundryModels")]
+        public static readonly FoundryModel MaiVoice2 = new() { Name = "MAI-Voice-2", Version = "2026-06-02", Format = "Microsoft" };
+
+        /// <summary>
         /// Model router is a deployable AI model that is trained to select the most suitable large language model (LLM) for a given prompt.
         /// </summary>
         [AspireValue("FoundryModels")]
         public static readonly FoundryModel ModelRouter = new() { Name = "model-router", Version = "2025-11-18", Format = "Microsoft" };
-
-        /// <summary>
-        /// Same Phi-3-medium model, but with a larger context size for RAG or few shot prompting.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Phi3Medium128kInstruct = new() { Name = "Phi-3-medium-128k-instruct", Version = "7", Format = "Microsoft" };
-
-        /// <summary>
-        /// A 14B parameters model, proves better quality than Phi-3-mini, with a focus on high-quality, reasoning-dense data.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Phi3Medium4kInstruct = new() { Name = "Phi-3-medium-4k-instruct", Version = "6", Format = "Microsoft" };
-
-        /// <summary>
-        /// Same Phi-3-mini model, but with a larger context size for RAG or few shot prompting.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Phi3Mini128kInstruct = new() { Name = "Phi-3-mini-128k-instruct", Version = "13", Format = "Microsoft" };
-
-        /// <summary>
-        /// Tiniest member of the Phi-3 family. Optimized for both quality and low latency.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Phi3Mini4kInstruct = new() { Name = "Phi-3-mini-4k-instruct", Version = "15", Format = "Microsoft" };
-
-        /// <summary>
-        /// Same Phi-3-small model, but with a larger context size for RAG or few shot prompting.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Phi3Small128kInstruct = new() { Name = "Phi-3-small-128k-instruct", Version = "5", Format = "Microsoft" };
 
         /// <summary>
         /// A 7B parameters model, proves better quality than Phi-3-mini, with a focus on high-quality, reasoning-dense data.
@@ -1830,24 +1794,6 @@ public partial class FoundryModel
         public static readonly FoundryModel Phi3Vision128kInstruct = new() { Name = "Phi-3-vision-128k-instruct", Version = "2", Format = "Microsoft" };
 
         /// <summary>
-        /// Refresh of Phi-3-mini model.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Phi35MiniInstruct = new() { Name = "Phi-3.5-mini-instruct", Version = "6", Format = "Microsoft" };
-
-        /// <summary>
-        /// A new mixture of experts model
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Phi35MoEInstruct = new() { Name = "Phi-3.5-MoE-instruct", Version = "5", Format = "Microsoft" };
-
-        /// <summary>
-        /// Refresh of Phi-3-vision model.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Phi35VisionInstruct = new() { Name = "Phi-3.5-vision-instruct", Version = "2", Format = "Microsoft" };
-
-        /// <summary>
         /// Phi-4 14B, a highly capable model for low latency scenarios.
         /// </summary>
         [AspireValue("FoundryModels")]
@@ -1942,127 +1888,6 @@ public partial class FoundryModel
         /// </summary>
         [AspireValue("FoundryModels")]
         public static readonly FoundryModel ComputerUsePreview = new() { Name = "computer-use-preview", Version = "2025-03-11", Format = "OpenAI" };
-
-        /// <summary>
-        ///   <para>
-        ///     <b>Direct from Azure models</b>
-        ///   </para>
-        ///   <para>Direct from Azure models are a select portfolio curated for their market-differentiated capabilities:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>Secure and managed by Microsoft: Purchase and manage models directly through Azure with a single license, consistent support, and no third-party dependencies, backed by Azure's enterprise-grade infrastructure.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Streamlined operations: Benefit from unified billing, governance, and seamless PTU portability across models hosted on Azure - all part of Microsoft Foundry.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Future-ready flexibility: Access the latest models as they become available, and easily test, deploy, or switch between them within Microsoft Foundry; reducing integration effort.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Cost control and optimization: Scale on demand with pay-as-you-go flexibility or reserve PTUs for predictable performance and savings.</para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        ///   <para>Learn more about <see href="https://aka.ms/DirectfromAzure">Direct from Azure models</see>.</para>
-        ///   <para>
-        ///     <b>Key capabilities</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>About this model</b>
-        ///   </para>
-        ///   <para>DALL-E 3 generates images from text prompts that are provided by the user.</para>
-        ///   <para>
-        ///     <b>Key model capabilities</b>
-        ///   </para>
-        ///   <para>The image generation API creates an image from a text prompt. It does not edit existing images or create variations.</para>
-        ///   <para>
-        ///     <b>Use cases</b>
-        ///   </para>
-        ///   <para>See Responsible AI for additional considerations for responsible use.</para>
-        ///   <para>
-        ///     <b>Key use cases</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Out of scope use cases</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Pricing</b>
-        ///   </para>
-        ///   <para>Pricing is based on a number of factors, including deployment type and tokens used. <see href="https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/?msockid=1775f99b2f8e614e1ba1eb792e496067">See pricing details here.</see></para>
-        ///   <para>
-        ///     <b>Technical specs</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Training cut-off date</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Training time</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Input formats</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Output formats</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Supported languages</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Sample JSON response</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Model architecture</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Long context</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Optimizing model performance</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Additional assets</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Training disclosure</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>Training, testing and validation</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Distribution</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>Distribution channels</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>More information</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel DallE3 = new() { Name = "dall-e-3", Version = "3.0", Format = "OpenAI" };
 
         /// <summary>
         ///   <para>
@@ -2219,127 +2044,6 @@ public partial class FoundryModel
         ///   <para>
         ///     <b>About this model</b>
         ///   </para>
-        ///   <para>The gpt-35-turbo is a language model designed for conversational interfaces that has been optimized for chat using the Chat Completions API.</para>
-        ///   <para>
-        ///     <b>Key model capabilities</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Use cases</b>
-        ///   </para>
-        ///   <para>See Responsible AI for additional considerations for responsible use.</para>
-        ///   <para>
-        ///     <b>Key use cases</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Out of scope use cases</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Pricing</b>
-        ///   </para>
-        ///   <para>Pricing is based on a number of factors, including deployment type and tokens used. <see href="https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/?msockid=1775f99b2f8e614e1ba1eb792e496067">See pricing details here.</see></para>
-        ///   <para>
-        ///     <b>Technical specs</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Training cut-off date</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Training time</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Input formats</b>
-        ///   </para>
-        ///   <para>The model expects a prompt string formatted in a specific chat-like transcript format.</para>
-        ///   <para>
-        ///     <b>Output formats</b>
-        ///   </para>
-        ///   <para>The model returns a completion that represents a model-written message in the chat.</para>
-        ///   <para>
-        ///     <b>Supported languages</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Sample JSON response</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Model architecture</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Long context</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Optimizing model performance</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Additional assets</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Training disclosure</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>Training, testing and validation</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Distribution</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>Distribution channels</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>More information</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Gpt35Turbo = new() { Name = "gpt-35-turbo", Version = "0125", Format = "OpenAI" };
-
-        /// <summary>
-        ///   <para>
-        ///     <b>Direct from Azure models</b>
-        ///   </para>
-        ///   <para>Direct from Azure models are a select portfolio curated for their market-differentiated capabilities:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>Secure and managed by Microsoft: Purchase and manage models directly through Azure with a single license, consistent support, and no third-party dependencies, backed by Azure's enterprise-grade infrastructure.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Streamlined operations: Benefit from unified billing, governance, and seamless PTU portability across models hosted on Azure - all part of Microsoft Foundry.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Future-ready flexibility: Access the latest models as they become available, and easily test, deploy, or switch between them within Microsoft Foundry; reducing integration effort.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Cost control and optimization: Scale on demand with pay-as-you-go flexibility or reserve PTUs for predictable performance and savings.</para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        ///   <para>Learn more about <see href="https://aka.ms/DirectfromAzure">Direct from Azure models</see>.</para>
-        ///   <para>
-        ///     <b>Key capabilities</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>About this model</b>
-        ///   </para>
         ///   <para>gpt-3.5 models can understand and generate natural language or code.</para>
         ///   <para>
         ///     <b>Key model capabilities</b>
@@ -2455,498 +2159,6 @@ public partial class FoundryModel
         public static readonly FoundryModel Gpt35Turbo16k = new() { Name = "gpt-35-turbo-16k", Version = "0613", Format = "OpenAI" };
 
         /// <summary>
-        ///   <para>
-        ///     <b>Direct from Azure models</b>
-        ///   </para>
-        ///   <para>Direct from Azure models are a select portfolio curated for their market-differentiated capabilities:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>Secure and managed by Microsoft: Purchase and manage models directly through Azure with a single license, consistent support, and no third-party dependencies, backed by Azure's enterprise-grade infrastructure.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Streamlined operations: Benefit from unified billing, governance, and seamless PTU portability across models hosted on Azure - all part of Microsoft Foundry.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Future-ready flexibility: Access the latest models as they become available, and easily test, deploy, or switch between them within Microsoft Foundry; reducing integration effort.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Cost control and optimization: Scale on demand with pay-as-you-go flexibility or reserve PTUs for predictable performance and savings.</para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        ///   <para>Learn more about <see href="https://aka.ms/DirectfromAzure">Direct from Azure models</see>.</para>
-        ///   <para>
-        ///     <b>Key capabilities</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>About this model</b>
-        ///   </para>
-        ///   <para>gpt-3.5 models can understand and generate natural language or code.</para>
-        ///   <para>
-        ///     <b>Key model capabilities</b>
-        ///   </para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>Understand and generate natural language</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Generate code</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Chat optimized interactions</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Traditional completions tasks</para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        ///   <para>
-        ///     <b>Use cases</b>
-        ///   </para>
-        ///   <para>See Responsible AI for additional considerations for responsible use.</para>
-        ///   <para>
-        ///     <b>Key use cases</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Out of scope use cases</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Pricing</b>
-        ///   </para>
-        ///   <para>Pricing is based on a number of factors, including deployment type and tokens used. <see href="https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/?msockid=1775f99b2f8e614e1ba1eb792e496067">See pricing details here.</see></para>
-        ///   <para>
-        ///     <b>Technical specs</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Training cut-off date</b>
-        ///   </para>
-        ///   <para>Sep 2021</para>
-        ///   <para>
-        ///     <b>Training time</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Input formats</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Output formats</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Supported languages</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Sample JSON response</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Model architecture</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Long context</b>
-        ///   </para>
-        ///   <para>You can see the token context length supported by each model in the model summary table.</para>
-        ///   <para>Model ID</para>
-        ///   <para>Model Availability</para>
-        ///   <para>Max Request (tokens)</para>
-        ///   <para>Training Data (up to)</para>
-        ///   <para>gpt-35-turbo<i>1</i>1 (0301)</para>
-        ///   <para>East US, France Central, South Central US, UK South, West Europe</para>
-        ///   <para>4,096</para>
-        ///   <para>Sep 2021</para>
-        ///   <para>gpt-35-turbo (0613)</para>
-        ///   <para>Australia East, Canada East, East US, East US 2, France Central, Japan East, North Central US, Sweden Central, Switzerland North, UK South</para>
-        ///   <para>4,096</para>
-        ///   <para>Sep 2021</para>
-        ///   <para>gpt-35-turbo-16k (0613)</para>
-        ///   <para>Australia East, Canada East, East US, East US 2, France Central, Japan East, North Central US, Sweden Central, Switzerland North, UK South</para>
-        ///   <para>16,384</para>
-        ///   <para>Sep 2021</para>
-        ///   <para>gpt-35-turbo-instruct (0914)</para>
-        ///   <para>East US, Sweden Central</para>
-        ///   <para>4,097</para>
-        ///   <para>Sep 2021</para>
-        ///   <para>gpt-35-turbo (1106)</para>
-        ///   <para>Australia East, Canada East, France Central, South India, Sweden Central, UK South, West US</para>
-        ///   <para>Input: 16,385 Output: 4,096</para>
-        ///   <para>Sep 2021</para>
-        ///   <para>
-        ///     <i>1</i>1 This model will accept requests &gt; 4,096 tokens. It is not recommended to exceed the 4,096 input token limit as the newer version of the model are capped at 4,096 tokens. If you encounter issues when exceeding 4,096 input tokens with this model this configuration is not officially supported.</para>
-        ///   <para>
-        ///     <b>Optimizing model performance</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Additional assets</b>
-        ///   </para>
-        ///   <para>To learn more about how to interact with GPT-3.5 Turbo and the Chat Completions API check out our <see href="https://learn.microsoft.com/azure/ai-services/openai/how-to/chatgpt?tabs=python&amp;pivots=programming-language-chat-completions">in-depth how-to.</see>in-depth how-to.</para>
-        ///   <para>
-        ///     <b>Training disclosure</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>Training, testing and validation</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Distribution</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>Distribution channels</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>More information</b>
-        ///   </para>
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Gpt35TurboInstruct = new() { Name = "gpt-35-turbo-instruct", Version = "0914", Format = "OpenAI" };
-
-        /// <summary>
-        ///   <para>
-        ///     <b>Direct from Azure models</b>
-        ///   </para>
-        ///   <para>Direct from Azure models are a select portfolio curated for their market-differentiated capabilities:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>Secure and managed by Microsoft: Purchase and manage models directly through Azure with a single license, consistent support, and no third-party dependencies, backed by Azure's enterprise-grade infrastructure.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Streamlined operations: Benefit from unified billing, governance, and seamless PTU portability across models hosted on Azure - all part of Microsoft Foundry.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Future-ready flexibility: Access the latest models as they become available, and easily test, deploy, or switch between them within Microsoft Foundry; reducing integration effort.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Cost control and optimization: Scale on demand with pay-as-you-go flexibility or reserve PTUs for predictable performance and savings.</para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        ///   <para>Learn more about <see href="https://aka.ms/DirectfromAzure">Direct from Azure models</see>.</para>
-        ///   <para>
-        ///     <b>Key capabilities</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>About this model</b>
-        ///   </para>
-        ///   <para>gpt-4 is a large multimodal model that can solve complex problems with greater accuracy than any of our previous models, thanks to its extensive general knowledge and advanced reasoning capabilities.</para>
-        ///   <para>
-        ///     <b>Key model capabilities</b>
-        ///   </para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-turbo-2024-04-09:</b> This is the GPT-4 Turbo with Vision GA model. It can return up to 4,096 output tokens.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-1106-preview (GPT-4 Turbo):</b> The latest gpt-4 model with improved instruction following, JSON mode, reproducible outputs, parallel function calling, and more. It returns a maximum of 4,096 output tokens.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-vision Preview (GPT-4 Turbo with vision):</b> This multimodal AI model enables users to direct the model to analyze image inputs they provide, along with all the other capabilities of GPT-4 Turbo. It can return up to 4,096 output tokens.</para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        ///   <para>
-        ///     <b>Use cases</b>
-        ///   </para>
-        ///   <para>See Responsible AI for additional considerations for responsible use.</para>
-        ///   <para>
-        ///     <b>Key use cases</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Out of scope use cases</b>
-        ///   </para>
-        ///   <para>Please note that AzureML Studio only supports the deployment of the gpt-4-0314 model version and AI Studio supports the deployment of all the model versions listed below. This preview model is not yet suited for production traffic. As a preview model version, it is not yet suitable for production traffic. This model version will be retired no earlier than July 5, 2024.</para>
-        ///   <para>
-        ///     <b>Pricing</b>
-        ///   </para>
-        ///   <para>Pricing is based on a number of factors, including deployment type and tokens used. <see href="https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/?msockid=1775f99b2f8e614e1ba1eb792e496067">See pricing details here.</see></para>
-        ///   <para>
-        ///     <b>Technical specs</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Training cut-off date</b>
-        ///   </para>
-        ///   <para>gpt-4 provides a wide range of model versions to fit your business needs:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-turbo-2024-04-09:</b> The training data is current up to December 2023.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-1106-preview (GPT-4 Turbo):</b> Training Data: Up to April 2023.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-vision Preview (GPT-4 Turbo with vision):</b> Training data is current up to April 2023.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-0613:</b> Training data up to September 2021.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-0314:</b> Training data up to September 2021.</para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        ///   <para>
-        ///     <b>Training time</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Input formats</b>
-        ///   </para>
-        ///   <para>gpt-4 is a large multimodal model that accepts text or image inputs.</para>
-        ///   <para>
-        ///     <b>Output formats</b>
-        ///   </para>
-        ///   <para>gpt-4 outputs text.</para>
-        ///   <para>
-        ///     <b>Supported languages</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Sample JSON response</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Model architecture</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Long context</b>
-        ///   </para>
-        ///   <para>gpt-4 provides different context window sizes across model versions:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-turbo-2024-04-09:</b> The context window is 128,000 tokens.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-1106-preview (GPT-4 Turbo):</b> Context window: 128,000 tokens.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-vision Preview (GPT-4 Turbo with vision):</b> The context window is 128,000 tokens.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-0613:</b> gpt-4 model with a context window of 8,192 tokens.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>gpt-4-0314:</b> gpt-4 legacy model with a context window of 8,192 tokens.</para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        ///   <para>
-        ///     <b>Optimizing model performance</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Additional assets</b>
-        ///   </para>
-        ///   <para>Learn more at https://learn.microsoft.com/azure/cognitive-services/openai/concepts/models</para>
-        ///   <para>
-        ///     <b>Training disclosure</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>Training, testing and validation</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Distribution</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>Distribution channels</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>More information</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Gpt4 = new() { Name = "gpt-4", Version = "turbo-2024-04-09", Format = "OpenAI" };
-
-        /// <summary>
-        ///   <para>
-        ///     <b>Direct from Azure models</b>
-        ///   </para>
-        ///   <para>Direct from Azure models are a select portfolio curated for their market-differentiated capabilities:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>Secure and managed by Microsoft: Purchase and manage models directly through Azure with a single license, consistent support, and no third-party dependencies, backed by Azure's enterprise-grade infrastructure.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Streamlined operations: Benefit from unified billing, governance, and seamless PTU portability across models hosted on Azure - all part of Microsoft Foundry.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Future-ready flexibility: Access the latest models as they become available, and easily test, deploy, or switch between them within Microsoft Foundry; reducing integration effort.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Cost control and optimization: Scale on demand with pay-as-you-go flexibility or reserve PTUs for predictable performance and savings.</para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        ///   <para>Learn more about <see href="https://aka.ms/DirectfromAzure">Direct from Azure models</see>.</para>
-        ///   <para>
-        ///     <b>Key capabilities</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>About this model</b>
-        ///   </para>
-        ///   <para>gpt-4 can solve difficult problems with greater accuracy than any of the previous OpenAI models. Like gpt-35-turbo, gpt-4 is optimized for chat but works well for traditional completions tasks.</para>
-        ///   <para>
-        ///     <b>Key model capabilities</b>
-        ///   </para>
-        ///   <para>gpt-4 can solve difficult problems with greater accuracy than any of the previous OpenAI models. Like gpt-35-turbo, gpt-4 is optimized for chat but works well for traditional completions tasks.</para>
-        ///   <para>
-        ///     <b>Use cases</b>
-        ///   </para>
-        ///   <para>See Responsible AI for additional considerations for responsible use.</para>
-        ///   <para>
-        ///     <b>Key use cases</b>
-        ///   </para>
-        ///   <para>gpt-4 is optimized for chat but works well for traditional completions tasks.</para>
-        ///   <para>
-        ///     <b>Out of scope use cases</b>
-        ///   </para>
-        ///   <para>this model can be deployed for inference, but cannot be finetuned.</para>
-        ///   <para>
-        ///     <b>Pricing</b>
-        ///   </para>
-        ///   <para>Pricing is based on a number of factors, including deployment type and tokens used. <see href="https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/?msockid=1775f99b2f8e614e1ba1eb792e496067">See pricing details here.</see></para>
-        ///   <para>
-        ///     <b>Technical specs</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Training cut-off date</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Training time</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Input formats</b>
-        ///   </para>
-        ///   <para>The gpt-4 supports 8192 max input tokens and the gpt-4-32k supports up to 32,768 tokens.</para>
-        ///   <para>
-        ///     <b>Output formats</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Supported languages</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Sample JSON response</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Model architecture</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Long context</b>
-        ///   </para>
-        ///   <para>The gpt-4 supports 8192 max input tokens and the gpt-4-32k supports up to 32,768 tokens.</para>
-        ///   <para>
-        ///     <b>Optimizing model performance</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Additional assets</b>
-        ///   </para>
-        ///   <para>Learn more at https://learn.microsoft.com/azure/cognitive-services/openai/concepts/models</para>
-        ///   <para>
-        ///     <b>Training disclosure</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>Training, testing and validation</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Distribution</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>Distribution channels</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>More information</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Gpt432k = new() { Name = "gpt-4-32k", Version = "0613", Format = "OpenAI" };
-
-        /// <summary>
         /// gpt-4.1 outperforms gpt-4o across the board, with major gains in coding, instruction following, and long-context understanding
         /// </summary>
         [AspireValue("FoundryModels")]
@@ -2965,40 +2177,16 @@ public partial class FoundryModel
         public static readonly FoundryModel Gpt41Nano = new() { Name = "gpt-4.1-nano", Version = "2025-04-14", Format = "OpenAI" };
 
         /// <summary>
-        /// the largest and strongest general purpose model in the gpt model family up to date, best suited for diverse text and image tasks.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Gpt45Preview = new() { Name = "gpt-4.5-preview", Version = "2025-02-27", Format = "OpenAI" };
-
-        /// <summary>
         /// OpenAI's most advanced multimodal model in the gpt-4o family. Can handle both text and image inputs.
         /// </summary>
         [AspireValue("FoundryModels")]
         public static readonly FoundryModel Gpt4o = new() { Name = "gpt-4o", Version = "2024-11-20", Format = "OpenAI" };
 
         /// <summary>
-        /// Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Gpt4oAudioPreview = new() { Name = "gpt-4o-audio-preview", Version = "2024-12-17", Format = "OpenAI" };
-
-        /// <summary>
         /// An affordable, efficient AI solution for diverse text and image tasks.
         /// </summary>
         [AspireValue("FoundryModels")]
         public static readonly FoundryModel Gpt4oMini = new() { Name = "gpt-4o-mini", Version = "2024-07-18", Format = "OpenAI" };
-
-        /// <summary>
-        /// Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Gpt4oMiniAudioPreview = new() { Name = "gpt-4o-mini-audio-preview", Version = "2024-12-17", Format = "OpenAI" };
-
-        /// <summary>
-        /// Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Gpt4oMiniRealtimePreview = new() { Name = "gpt-4o-mini-realtime-preview", Version = "2024-12-17", Format = "OpenAI" };
 
         /// <summary>
         /// A highly efficient and cost effective speech-to-text solution that deliverables reliable and accurate transcripts.
@@ -3011,180 +2199,6 @@ public partial class FoundryModel
         /// </summary>
         [AspireValue("FoundryModels")]
         public static readonly FoundryModel Gpt4oMiniTts = new() { Name = "gpt-4o-mini-tts", Version = "2025-12-15", Format = "OpenAI" };
-
-        /// <summary>
-        ///   <para>
-        ///     <b>Direct from Azure models</b>
-        ///   </para>
-        ///   <para>Direct from Azure models are a select portfolio curated for their market-differentiated capabilities:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>Secure and managed by Microsoft: Purchase and manage models directly through Azure with a single license, consistent support, and no third-party dependencies, backed by Azure's enterprise-grade infrastructure.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Streamlined operations: Benefit from unified billing, governance, and seamless PTU portability across models hosted on Azure - all part of Microsoft Foundry.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Future-ready flexibility: Access the latest models as they become available, and easily test, deploy, or switch between them within Microsoft Foundry; reducing integration effort.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>Cost control and optimization: Scale on demand with pay-as-you-go flexibility or reserve PTUs for predictable performance and savings.</para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        ///   <para>Learn more about <see href="https://aka.ms/DirectfromAzure">Direct from Azure models</see>.</para>
-        ///   <para>
-        ///     <b>Key capabilities</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>About this model</b>
-        ///   </para>
-        ///   <para>Introducing our new multimodal AI model, which now supports both text and audio modalities.</para>
-        ///   <para>
-        ///     <b>Key model capabilities</b>
-        ///   </para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>Enhanced customer service:</b> By integrating audio inputs, gpt-4o-realtime-preview enables more dynamic and comprehensive customer support interactions.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>Content innovation:</b> Use gpt-4o-realtime-preview's generative capabilities to create engaging and diverse audio content, catering to a broad range of consumer preferences.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>Real-time translation:</b> Leverage gpt-4o-realtime-preview's capability to provide accurate and immediate translations, facilitating seamless communication across different languages</para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        ///   <para>
-        ///     <b>Use cases</b>
-        ///   </para>
-        ///   <para>See Responsible AI for additional considerations for responsible use.</para>
-        ///   <para>
-        ///     <b>Key use cases</b>
-        ///   </para>
-        ///   <para>The introduction of gpt-4o-realtime-preview opens numerous possibilities for businesses in various sectors: Enhanced customer service, content innovation, and real-time translation capabilities facilitate seamless communication across different languages.</para>
-        ///   <para>
-        ///     <b>Out of scope use cases</b>
-        ///   </para>
-        ///   <para>Currently, the gpt-4o-realtime-preview model focuses on text and audio and does not support existing gpt-4o features such as image modality and structured outputs. For many tasks, the generally available gpt-4o models may still be more suitable.</para>
-        ///   <para>IMPORTANT: At this time, gpt-4o-realtime-preview usage limits are suitable for test and development. To prevent abuse and preserve service integrity, rate limits will be adjusted as needed.</para>
-        ///   <para>IMPORTANT: The system stores your prompts and completions as described in the "Data Use and Access for Abuse Monitoring" section of the service-specific Product Terms for Azure OpenAI Service, except that the Limited Exception does not apply. Abuse monitoring will be turned on for use of the GPT-4o-realtime-preview API even for customers who otherwise are approved for modified abuse monitoring.</para>
-        ///   <para>
-        ///     <b>Pricing</b>
-        ///   </para>
-        ///   <para>Pricing is based on a number of factors, including deployment type and tokens used. <see href="https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/?msockid=1775f99b2f8e614e1ba1eb792e496067">See pricing details here.</see></para>
-        ///   <para>
-        ///     <b>Technical specs</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Training cut-off date</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Training time</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Input formats</b>
-        ///   </para>
-        ///   <para>Currently, the gpt-4o-realtime-preview model focuses on text and audio and does not support existing gpt-4o features such as image modality and structured outputs.</para>
-        ///   <para>
-        ///     <b>Output formats</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Supported languages</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Sample JSON response</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Model architecture</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Long context</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Optimizing model performance</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>Additional assets</b>
-        ///   </para>
-        ///   <para>The following documents are applicable:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <see href="https://learn.microsoft.com/legal/cognitive-services/openai/overview">Overview of Responsible AI practices for Azure OpenAI models</see>
-        ///         </para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <see href="https://learn.microsoft.com/legal/cognitive-services/openai/transparency-note">Transparency Note for Azure OpenAI Service</see>
-        ///         </para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        ///   <para>
-        ///     <b>Training disclosure</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>Training, testing and validation</b>
-        ///   </para>
-        ///   <para>GPT-4o-realtime-preview has safety built-in by design across modalities, through techniques such as filtering training data and refining the model's behavior through post-training.</para>
-        ///   <para>
-        ///     <b>Distribution</b>
-        ///   </para>
-        ///   <para>
-        ///     <b>Distribution channels</b>
-        ///   </para>
-        ///   <para>The provider has not supplied this information.</para>
-        ///   <para>
-        ///     <b>More information</b>
-        ///   </para>
-        ///   <para>We've evaluated GPT-4o-realtime-preview according to our <see href="https://openai.com/safety/">Preparedness Framework</see> and in line with our <see href="https://openai.com/index/moving-ai-governance-forward/">voluntary commitments</see>. Our evaluations of cybersecurity, CBRN, persuasion, and model autonomy show that GPT-4o-realtime-preview does not score above Medium risk in any of these categories. This assessment involved running a suite of automated and human evaluations throughout the model training process. We tested both pre-safety-mitigation and post-safety-mitigation versions of the model, using custom fine-tuning and prompts, to better elicit model capabilities.</para>
-        ///   <para>GPT-4o-realtime-preview has also undergone extensive external red teaming with 70+ <see href="https://openai.com/index/red-teaming-network/">external experts</see> in domains such as social psychology, bias and fairness, and misinformation to identify risks that are introduced or amplified by the newly added modalities. We used these learnings to build out our safety interventions in order to improve the safety of interacting with GPT-4o-realtime-preview. We will continue to mitigate new risks as they're discovered.</para>
-        ///   <para>Model Versions:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>2024-12-17:</b> Updating the gpt-4o-realtime-preview model with improvements in voice quality and input reliability. As this is a preview version, it is designed for testing and feedback purposes and is not yet optimized for production traffic.</para>
-        ///       </description>
-        ///     </item>
-        ///     <item>
-        ///       <description>
-        ///         <para>
-        ///           <b>2024-10-01:</b> Introducing our new multimodal AI model, which now supports both text and audio modalities. As this is a preview version, it is designed for testing and feedback purposes and is not yet optimized for production traffic.</para>
-        ///       </description>
-        ///     </item>
-        ///   </list>
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Gpt4oRealtimePreview = new() { Name = "gpt-4o-realtime-preview", Version = "2024-12-17", Format = "OpenAI" };
 
         /// <summary>
         /// A cutting-edge speech-to-text solution that deliverables reliable and accurate transcripts.
@@ -3313,7 +2327,7 @@ public partial class FoundryModel
         public static readonly FoundryModel Gpt54Nano = new() { Name = "gpt-5.4-nano", Version = "2026-03-17", Format = "OpenAI" };
 
         /// <summary>
-        /// GPT‑5.4-Pro is OpenAI’s most capable frontier model, built to deliver faster, more reliable results for complex professional work.
+        /// GPT‑5.4-Pro is OpenAI's most capable frontier model, built to deliver faster, more reliable results for complex professional work.
         /// </summary>
         [AspireValue("FoundryModels")]
         public static readonly FoundryModel Gpt54Pro = new() { Name = "gpt-5.4-pro", Version = "2026-03-05", Format = "OpenAI" };
@@ -3346,7 +2360,7 @@ public partial class FoundryModel
         /// gpt-chat-latest (preview) is an advanced, natural, multimodal, and context-aware conversations for enterprise applications.
         /// </summary>
         [AspireValue("FoundryModels")]
-        public static readonly FoundryModel GptChatLatest = new() { Name = "gpt-chat-latest", Version = "2026-05-05", Format = "OpenAI" };
+        public static readonly FoundryModel GptChatLatest = new() { Name = "gpt-chat-latest", Version = "2026-05-28", Format = "OpenAI" };
 
         /// <summary>
         /// An efficient AI solution for diverse text and image tasks, including text to image, image to image, inpainting, and prompt transformation.
@@ -3377,6 +2391,12 @@ public partial class FoundryModel
         /// </summary>
         [AspireValue("FoundryModels")]
         public static readonly FoundryModel GptOss120b = new() { Name = "gpt-oss-120b", Version = "4", Format = "OpenAI" };
+
+        /// <summary>
+        /// Push the open model frontier with GPT-OSS models, released under the permissive Apache 2.0 license, allowing anyone to use, modify, and deploy them freely.
+        /// </summary>
+        [AspireValue("FoundryModels")]
+        public static readonly FoundryModel GptOss20b = new() { Name = "gpt-oss-20b", Version = "11", Format = "OpenAI" };
 
         /// <summary>
         /// A new S2S (speech to speech) model with improved instruction following.
@@ -3421,18 +2441,6 @@ public partial class FoundryModel
         public static readonly FoundryModel O1 = new() { Name = "o1", Version = "2024-12-17", Format = "OpenAI" };
 
         /// <summary>
-        /// Smaller, faster, and 80% cheaper than o1-preview, performs well at code generation and small context operations.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel O1Mini = new() { Name = "o1-mini", Version = "2024-09-12", Format = "OpenAI" };
-
-        /// <summary>
-        /// Focused on advanced reasoning and solving complex problems, including math and science tasks. Ideal for applications that require deep contextual understanding and agentic workflows.
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel O1Preview = new() { Name = "o1-preview", Version = "1", Format = "OpenAI" };
-
-        /// <summary>
         /// o3 includes significant improvements on quality and safety while supporting the existing features of o1 and delivering comparable or better performance.
         /// </summary>
         [AspireValue("FoundryModels")]
@@ -3461,12 +2469,6 @@ public partial class FoundryModel
         /// </summary>
         [AspireValue("FoundryModels")]
         public static readonly FoundryModel O4Mini = new() { Name = "o4-mini", Version = "2025-04-16", Format = "OpenAI" };
-
-        /// <summary>
-        /// An efficient AI solution to generate videos
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Sora = new() { Name = "sora", Version = "2025-05-02", Format = "OpenAI" };
 
         /// <summary>
         /// Text-embedding-3 series models are the latest and most capable embedding model from OpenAI.
@@ -4549,18 +3551,6 @@ public partial class FoundryModel
         /// </summary>
         [AspireValue("FoundryModels")]
         public static readonly FoundryModel Grok420Reasoning = new() { Name = "grok-4-20-reasoning", Version = "1", Format = "xAI" };
-
-        /// <summary>
-        /// Grok 4 Fast is an efficiency-focused large language model developed by xAI, pre-trained on general-purpose data and post-trained on task demonstrations and tool use, with built-in safety features including refusal behaviors, a fixed system prompt enforcing
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Grok4FastNonReasoning = new() { Name = "grok-4-fast-non-reasoning", Version = "1", Format = "xAI" };
-
-        /// <summary>
-        /// Grok 4 Fast is an efficiency-focused large language model developed by xAI, pre-trained on general-purpose data and post-trained on task demonstrations and tool use, with built-in safety features including refusal behaviors, a fixed system prompt enforcing
-        /// </summary>
-        [AspireValue("FoundryModels")]
-        public static readonly FoundryModel Grok4FastReasoning = new() { Name = "grok-4-fast-reasoning", Version = "1", Format = "xAI" };
 
         /// <summary>
         /// Grok 4.3 is the latest model from xAI, with advanced reasoning, productivity, and multi-agent capabilities, enabling it to achieve state-of-the-art performance across challenging academic and industry benchmarks.

--- a/src/Aspire.Hosting.Foundry/FoundryModel.Local.Generated.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryModel.Local.Generated.cs
@@ -199,6 +199,62 @@ public partial class FoundryModel
         public static readonly FoundryModel GptOss20b = new() { Name = "gpt-oss-20b", Version = "1", Format = "Microsoft" };
 
         /// <summary>
+        ///   <para>This model is an optimized version of Ministral-3-3B-Instruct-2512 for local inference. This optimized model is published here in ONNX format to run on CUDA-capable GPU devices, with the precision best suited to this target.</para>
+        ///   <para>
+        ///     <b>ONNX Models</b>
+        ///   </para>
+        ///   <para>Here are some of the optimized configurations we have added:</para>
+        ///   <list type="number">
+        ///     <item>
+        ///       <description>
+        ///         <para>ONNX model for CUDA GPU using RTN quantization.</para>
+        ///       </description>
+        ///     </item>
+        ///   </list>
+        ///   <para>
+        ///     <b>Model Description</b>
+        ///   </para>
+        ///   <list type="bullet">
+        ///     <item>
+        ///       <description>
+        ///         <para>
+        ///           <b>Developed by:</b> Microsoft</para>
+        ///       </description>
+        ///     </item>
+        ///     <item>
+        ///       <description>
+        ///         <para>
+        ///           <b>Model type:</b> ONNX</para>
+        ///       </description>
+        ///     </item>
+        ///     <item>
+        ///       <description>
+        ///         <para>
+        ///           <b>License:</b> apache-2.0</para>
+        ///       </description>
+        ///     </item>
+        ///     <item>
+        ///       <description>
+        ///         <para>
+        ///           <b>Model Description:</b> This is a conversion of Ministral-3-3B-Instruct-2512 for local inference.</para>
+        ///       </description>
+        ///     </item>
+        ///     <item>
+        ///       <description>
+        ///         <para>
+        ///           <b>Disclaimer:</b> Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.</para>
+        ///       </description>
+        ///     </item>
+        ///   </list>
+        ///   <para>
+        ///     <b>Base Model Information</b>
+        ///   </para>
+        ///   <para>See Hugging Face model <see href="https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512">Ministral-3-3B-Instruct-2512</see> for details.</para>
+        /// </summary>
+        [AspireValue("FoundryModels")]
+        public static readonly FoundryModel Ministral33bInstruct2512 = new() { Name = "ministral-3-3b-instruct-2512", Version = "1", Format = "Microsoft" };
+
+        /// <summary>
         ///   <para>This model is an optimized version of Mistral-7B-Instruct-v0.2 to enable local inference on Intel GPUs.</para>
         ///   <para>
         ///     <b>Model Description</b>

--- a/src/Aspire.Hosting.Foundry/tools/GenModel.cs
+++ b/src/Aspire.Hosting.Foundry/tools/GenModel.cs
@@ -27,10 +27,18 @@ if (models.Count == 0)
     throw new InvalidOperationException("The Microsoft Foundry model catalog returned no models. Refusing to overwrite the generated model descriptors with an empty catalog.");
 }
 
+var descriptorModels = isFoundryLocal
+    ? GetLocalDescriptorModels(models)
+    : GetDistinctHostedModels(models).ToList();
+if (descriptorModels.Count == 0)
+{
+    throw new InvalidOperationException("The Microsoft Foundry model catalog produced no model descriptors after filtering. Refusing to overwrite the generated model descriptors with an empty catalog.");
+}
+
 // Generate C# extension methods for the models
 var generatedCode = isFoundryLocal
-    ? GenerateLocalCode("Aspire.Hosting.Foundry", models)
-    : GenerateHostedCode("Aspire.Hosting.Foundry", models);
+    ? GenerateLocalCode("Aspire.Hosting.Foundry", descriptorModels)
+    : GenerateHostedCode("Aspire.Hosting.Foundry", descriptorModels);
 
 // Write the generated code to a file
 var filename = isFoundryLocal
@@ -64,8 +72,7 @@ string GenerateHostedCode(string csNamespace, List<ModelEntity> models)
     sb.AppendLine("public partial class FoundryModel");
     sb.AppendLine("{");
 
-    // Group models by publisher (only include models that are visible and have names & publishers)
-    var modelsByPublisher = GetDistinctHostedModels(models)
+    var modelsByPublisher = models
         .GroupBy(m => m.Annotations!.SystemCatalogData!.Publisher!)
         .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase);
 
@@ -140,6 +147,22 @@ static bool IsAllUppercaseAscii(string value)
     return value.Any(char.IsAsciiLetter) && !value.Any(char.IsAsciiLetterLower);
 }
 
+static List<ModelEntity> GetLocalDescriptorModels(IEnumerable<ModelEntity> models)
+{
+    return models
+        .Where(m => m.Annotations?.SystemCatalogData?.Publisher != null &&
+                    m.Annotations?.Name != null &&
+                    m.Annotations?.Tags?.ContainsKey("alias") is true &&
+                    IsVisible(m.Annotations?.InvisibleUntil))
+        .GroupBy(m => m.Annotations!.SystemCatalogData!.Publisher!)
+        .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+        .SelectMany(publisherGroup => publisherGroup
+            .GroupBy(m => m.Annotations!.Tags!["alias"])
+            .Select(g => g.First())
+            .OrderBy(m => m.Annotations!.Name, StringComparer.OrdinalIgnoreCase))
+        .ToList();
+}
+
 string GenerateLocalCode(string csNamespace, List<ModelEntity> models)
 {
     var sb = new StringBuilder();
@@ -154,11 +177,7 @@ string GenerateLocalCode(string csNamespace, List<ModelEntity> models)
     sb.AppendLine("public partial class FoundryModel");
     sb.AppendLine("{");
 
-    // Group models by publisher (only include models that are visible and have names & publishers)
     var modelsByPublisher = models
-        .Where(m => m.Annotations?.SystemCatalogData?.Publisher != null &&
-                    m.Annotations?.Name != null &&
-                    IsVisible(m.Annotations?.InvisibleUntil))
         .GroupBy(m => m.Annotations!.SystemCatalogData!.Publisher!)
         .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase);
 
@@ -171,9 +190,7 @@ string GenerateLocalCode(string csNamespace, List<ModelEntity> models)
     foreach (var publisherGroup in modelsByPublisher)
     {
         var firstMethod = true;
-        foreach (var model in publisherGroup
-            .GroupBy(m => m.Annotations!.Tags!["alias"])
-            .Select(x => x.First()).OrderBy(m => m.Annotations!.Name, StringComparer.OrdinalIgnoreCase))
+        foreach (var model in publisherGroup.OrderBy(m => m.Annotations!.Name, StringComparer.OrdinalIgnoreCase))
         {
             var modelName = model.Annotations!.Tags!["alias"];
             var descriptorName = ToPascalCase(modelName); // Reuse method name logic for descriptor property name

--- a/src/Aspire.Hosting.Foundry/tools/GenModel.cs
+++ b/src/Aspire.Hosting.Foundry/tools/GenModel.cs
@@ -703,6 +703,7 @@ public class ModelClient : IDisposable
     private const int MaxRequestAttempts = 6;
     private const int PageSize = 200;
     private const int ResponseSnippetLength = 2000;
+    private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(30);
 
     private readonly HttpClient _httpClient;
     private readonly HttpClientHandler _handler;
@@ -742,6 +743,8 @@ public class ModelClient : IDisposable
                 throw new InvalidOperationException($"The Microsoft Foundry model catalog response did not contain an indexEntitiesResponse.value array. Response: {GetResponseSnippet(pageResponse)}");
             }
 
+            ValidateSuccessfulCatalogResponse(apiResponse, pageResponse);
+
             foreach (var model in pageModels)
             {
                 allModels.Add(model);
@@ -760,8 +763,7 @@ public class ModelClient : IDisposable
                 // Check for infinite loop (same token repeated)
                 if (continuationToken == previousToken)
                 {
-                    Console.WriteLine("WARNING: Same continuation token received twice. Breaking to prevent infinite loop.");
-                    continuationToken = null;
+                    throw new InvalidOperationException($"The Microsoft Foundry model catalog returned the same continuation token twice. Refusing to overwrite the generated model descriptors with a partial catalog. Response: {GetResponseSnippet(pageResponse)}");
                 }
             }
 
@@ -971,12 +973,22 @@ public class ModelClient : IDisposable
             return AddRetryBuffer(bodyDelay, attempt);
         }
 
-        return TimeSpan.FromSeconds(Math.Min(30, Math.Pow(2, attempt)));
+        return ClampRetryDelay(TimeSpan.FromSeconds(Math.Pow(2, attempt)));
     }
 
     private static TimeSpan AddRetryBuffer(TimeSpan delay, int attempt)
     {
-        return delay + TimeSpan.FromSeconds(Math.Min(attempt, 5));
+        if (delay >= MaxRetryDelay)
+        {
+            return MaxRetryDelay;
+        }
+
+        return ClampRetryDelay(delay + TimeSpan.FromSeconds(Math.Min(attempt, 5)));
+    }
+
+    private static TimeSpan ClampRetryDelay(TimeSpan delay)
+    {
+        return delay <= MaxRetryDelay ? delay : MaxRetryDelay;
     }
 
     private static TimeSpan? TryGetRetryAfterFromBody(string content)
@@ -1007,6 +1019,51 @@ public class ModelClient : IDisposable
         return sanitized.Length <= ResponseSnippetLength
             ? sanitized
             : sanitized[..ResponseSnippetLength] + "...";
+    }
+
+    private static void ValidateSuccessfulCatalogResponse(ApiResponse apiResponse, string pageResponse)
+    {
+        var partialFailureFields = new List<string>();
+
+        AddPopulatedJsonField(partialFailureFields, "regionalErrors", apiResponse.RegionalErrors);
+        AddPopulatedJsonField(partialFailureFields, "resourceSkipReasons", apiResponse.ResourceSkipReasons);
+        AddPopulatedJsonField(partialFailureFields, "shardErrors", apiResponse.ShardErrors);
+
+        if (apiResponse.NumberOfResourcesNotIncludedInSearch > 0)
+        {
+            partialFailureFields.Add("numberOfResourcesNotIncludedInSearch");
+        }
+
+        if (partialFailureFields.Count > 0)
+        {
+            throw new InvalidOperationException($"The Microsoft Foundry model catalog response included partial failure data in {string.Join(", ", partialFailureFields)}. Refusing to overwrite the generated model descriptors with a partial catalog. Response: {GetResponseSnippet(pageResponse)}");
+        }
+    }
+
+    private static void AddPopulatedJsonField(List<string> partialFailureFields, string fieldName, object? value)
+    {
+        if (value is JsonElement element && IsPopulatedJsonElement(element))
+        {
+            partialFailureFields.Add(fieldName);
+        }
+        else if (value is not null)
+        {
+            partialFailureFields.Add(fieldName);
+        }
+    }
+
+    private static bool IsPopulatedJsonElement(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => element.EnumerateObject().Any(),
+            JsonValueKind.Array => element.EnumerateArray().Any(),
+            JsonValueKind.String => !string.IsNullOrEmpty(element.GetString()),
+            JsonValueKind.Number => true,
+            JsonValueKind.True => true,
+            JsonValueKind.False => true,
+            _ => false
+        };
     }
 }
 

--- a/src/Aspire.Hosting.Foundry/tools/GenModel.cs
+++ b/src/Aspire.Hosting.Foundry/tools/GenModel.cs
@@ -21,11 +21,16 @@ var isFoundryLocal = args.Contains("--local");
 
 using var mc = new ModelClient(isFoundryLocal);
 var allModelsResponse = await mc.GetAllModelsAsync().ConfigureAwait(false);
+var models = allModelsResponse.Entities ?? [];
+if (models.Count == 0)
+{
+    throw new InvalidOperationException("The Microsoft Foundry model catalog returned no models. Refusing to overwrite the generated model descriptors with an empty catalog.");
+}
 
 // Generate C# extension methods for the models
 var generatedCode = isFoundryLocal
-    ? GenerateLocalCode("Aspire.Hosting.Foundry", allModelsResponse.Entities ?? [])
-    : GenerateHostedCode("Aspire.Hosting.Foundry", allModelsResponse.Entities ?? []);
+    ? GenerateLocalCode("Aspire.Hosting.Foundry", models)
+    : GenerateHostedCode("Aspire.Hosting.Foundry", models);
 
 // Write the generated code to a file
 var filename = isFoundryLocal
@@ -695,6 +700,10 @@ public partial class ModelClassGenerator
 
 public class ModelClient : IDisposable
 {
+    private const int MaxRequestAttempts = 6;
+    private const int PageSize = 200;
+    private const int ResponseSnippetLength = 2000;
+
     private readonly HttpClient _httpClient;
     private readonly HttpClientHandler _handler;
     private readonly bool _isFoundryLocal;
@@ -726,22 +735,19 @@ public class ModelClient : IDisposable
 
             var pageResponse = await GetModelsAsync(continuationToken).ConfigureAwait(false);
 
-            // Deserialize the response using our models
             var apiResponse = JsonSerializer.Deserialize<ApiResponse>(pageResponse);
 
-            if (apiResponse?.IndexEntitiesResponse?.Value != null)
+            if (apiResponse?.IndexEntitiesResponse?.Value is not { } pageModels)
             {
-                foreach (var model in apiResponse.IndexEntitiesResponse.Value)
-                {
-                    allModels.Add(model);
-                }
+                throw new InvalidOperationException($"The Microsoft Foundry model catalog response did not contain an indexEntitiesResponse.value array. Response: {GetResponseSnippet(pageResponse)}");
+            }
 
-                Console.WriteLine($"Fetched page with {apiResponse.IndexEntitiesResponse.Value.Count} models. Total so far: {allModels.Count}");
-            }
-            else
+            foreach (var model in pageModels)
             {
-                Console.WriteLine("No models found in this page response.");
+                allModels.Add(model);
             }
+
+            Console.WriteLine($"Fetched page with {pageModels.Count} models. Total so far: {allModels.Count}");
 
             // Check if there's a continuation token for the next page
             previousToken = continuationToken;
@@ -780,12 +786,7 @@ public class ModelClient : IDisposable
     {
         var url = "https://ai.azure.com/api/eastus/ux/v1.0/entities/crossRegion";
 
-        var request = new HttpRequestMessage(HttpMethod.Post, url);
-
-        request.Headers.Add("User-Agent", "AzureAiStudio");
-
-        // Build the JSON payload with optional continuation token
-        var basePayload = """
+        var basePayload = $$"""
         {
             "resourceIds": [
                 {"resourceId": "azure-openai", "entityContainerType": "Registry"},
@@ -835,7 +836,7 @@ public class ModelClient : IDisposable
                 ],
                 "freeTextSearch": "",
                 "order": [{"field": "properties/name", "direction": "Asc"}],
-                "pageSize": 30,
+                "pageSize": {{PageSize}},
                 "facets": [ ],
                 "includeTotalResultCount": true,
                 "searchBuilder": "AppendPrefix"
@@ -861,7 +862,7 @@ public class ModelClient : IDisposable
                         ],
                         "freeTextSearch": "",
                         "order": [{"field": "properties/name", "direction": "Asc"}],
-                        "pageSize": 30,
+                        "pageSize": {{PageSize}},
                         "facets": [ ],
                         "includeTotalResultCount": true,
                         "searchBuilder": "AppendPrefix"
@@ -885,13 +886,31 @@ public class ModelClient : IDisposable
             jsonContent = basePayload;
         }
 
-        request.Content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
+        for (var attempt = 1; attempt <= MaxRequestAttempts; attempt++)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, url);
+            request.Headers.Add("User-Agent", "AzureAiStudio");
+            request.Content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
-        var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+            using var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
+            {
+                return content;
+            }
 
-        // Handle decompression automatically
-        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        return content;
+            if (IsTransientStatusCode(response.StatusCode) && attempt < MaxRequestAttempts)
+            {
+                var delay = GetRetryDelay(response, content, attempt);
+                Console.WriteLine($"Microsoft Foundry model catalog request failed with HTTP {(int)response.StatusCode} ({response.StatusCode}). Retrying in {delay.TotalSeconds:N0}s (attempt {attempt + 1}/{MaxRequestAttempts}).");
+                await Task.Delay(delay).ConfigureAwait(false);
+                continue;
+            }
+
+            throw new HttpRequestException($"Microsoft Foundry model catalog request failed with HTTP {(int)response.StatusCode} ({response.StatusCode}). Response: {GetResponseSnippet(content)}", inner: null, response.StatusCode);
+        }
+
+        throw new InvalidOperationException("The Microsoft Foundry model catalog request loop completed without returning or throwing.");
     }
 
     public void Dispose()
@@ -924,6 +943,70 @@ public class ModelClient : IDisposable
                 }
             }
         }
+    }
+
+    private static bool IsTransientStatusCode(HttpStatusCode statusCode)
+    {
+        return statusCode == HttpStatusCode.TooManyRequests || (int)statusCode >= 500;
+    }
+
+    private static TimeSpan GetRetryDelay(HttpResponseMessage response, string content, int attempt)
+    {
+        if (response.Headers.RetryAfter?.Delta is { } delta && delta > TimeSpan.Zero)
+        {
+            return AddRetryBuffer(delta, attempt);
+        }
+
+        if (response.Headers.RetryAfter?.Date is { } date)
+        {
+            var dateDelta = date - DateTimeOffset.UtcNow;
+            if (dateDelta > TimeSpan.Zero)
+            {
+                return AddRetryBuffer(dateDelta, attempt);
+            }
+        }
+
+        if (TryGetRetryAfterFromBody(content) is { } bodyDelay)
+        {
+            return AddRetryBuffer(bodyDelay, attempt);
+        }
+
+        return TimeSpan.FromSeconds(Math.Min(30, Math.Pow(2, attempt)));
+    }
+
+    private static TimeSpan AddRetryBuffer(TimeSpan delay, int attempt)
+    {
+        return delay + TimeSpan.FromSeconds(Math.Min(attempt, 5));
+    }
+
+    private static TimeSpan? TryGetRetryAfterFromBody(string content)
+    {
+        try
+        {
+            var retryAfterValue = JsonNode.Parse(content)?["error"]?["messageParameters"]?["retryAfter"]?.ToString();
+            if (int.TryParse(retryAfterValue, CultureInfo.InvariantCulture, out var retryAfterSeconds) && retryAfterSeconds > 0)
+            {
+                return TimeSpan.FromSeconds(retryAfterSeconds);
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return null;
+    }
+
+    private static string GetResponseSnippet(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return "<empty>";
+        }
+
+        var sanitized = content.ReplaceLineEndings(" ").Trim();
+        return sanitized.Length <= ResponseSnippetLength
+            ? sanitized
+            : sanitized[..ResponseSnippetLength] + "...";
     }
 }
 


### PR DESCRIPTION
## Description

The scheduled Microsoft Foundry model update workflow could overwrite the generated descriptors with an empty catalog when the public Foundry catalog endpoint returned a transient error response. The endpoint still returns model data, but it frequently returns HTTP 429 first, and the generator previously treated that error JSON as a successful response with no models.

This hardens the generator by retrying transient HTTP failures, increasing the page size to reduce request count, failing fast when the response shape is invalid, and refusing to write generated descriptors when the resolved catalog is empty. The hosted and Foundry Local descriptor files were regenerated from the current live catalog after the retry handling was added.

Validation:

- Ran `./restore.sh`
- Ran `dotnet run GenModel.cs --local` from `src/Aspire.Hosting.Foundry/tools`
- Ran `dotnet run GenModel.cs` from `src/Aspire.Hosting.Foundry/tools`
- Ran `dotnet build src/Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.csproj --no-restore`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No