### PR TITLE
Upgrade Foundry Local to 1.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -108,7 +108,7 @@
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
     <PackageVersion Include="JsonPatch.Net" Version="5.0.2" />
     <PackageVersion Include="Markdig" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
+    <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.1" />

--- a/src/Aspire.Hosting.Foundry/FoundryDeploymentResource.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryDeploymentResource.cs
@@ -36,8 +36,8 @@ public class FoundryDeploymentResource : Resource, IResourceWithParent<FoundryRe
     }
 
     /// <summary>
-    /// This field is used to store the model id that is downloaded by Foundry Local based on the local machine's GPU.
-    /// It is used in the connection string instead of <see cref="ModelName" />.
+    /// This field is used to store the model identifier used by Foundry Local.
+    /// It is used in the connection string instead of <see cref="ModelName"/>.
     /// </summary>
     internal string? ModelId { get; set; }
 

--- a/src/Aspire.Hosting.Foundry/FoundryExtensions.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryExtensions.cs
@@ -11,10 +11,12 @@ using Azure.Provisioning;
 using Azure.Provisioning.CognitiveServices;
 using Azure.Provisioning.Expressions;
 using Azure.Provisioning.Resources;
-using Microsoft.AI.Foundry.Local;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.Threading.Channels;
 using static Azure.Provisioning.Expressions.BicepFunction;
 
 namespace Aspire.Hosting;
@@ -174,9 +176,8 @@ public static class FoundryExtensions
         ThrowIfProjectsConfiguredForLocal(builder, resource);
         resource.Annotations.Add(new EmulatorResourceAnnotation());
 
-        builder.ApplicationBuilder.Services.AddSingleton<FoundryLocalManager>();
-
         builder.WithInitializer();
+        builder.OnResourceStopped(static (_, _, ct) => FoundryLocalService.StopAsync(ct));
 
         foreach (var deployment in resource.Deployments)
         {
@@ -190,11 +191,12 @@ public static class FoundryExtensions
         builder.ApplicationBuilder.Services.AddHealthChecks()
                 .Add(new HealthCheckRegistration(
                     healthCheckKey,
-                    sp => new FoundryLocalHealthCheck(sp.GetRequiredService<FoundryLocalManager>()),
+                    sp => new FoundryLocalHealthCheck(),
                     failureStatus: default,
                     tags: default,
                     timeout: default
                     ));
+        builder.ApplicationBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, FoundryLocalLifecycleService>());
 
         builder.WithHealthCheck(healthCheckKey);
 
@@ -286,10 +288,9 @@ public static class FoundryExtensions
             => Task.Run(async () =>
             {
                 var rns = @event.Services.GetRequiredService<ResourceNotificationService>();
-                var manager = @event.Services.GetRequiredService<FoundryLocalManager>();
                 var logger = @event.Services.GetRequiredService<ResourceLoggerService>().GetLogger(resource);
 
-                resource.ApiKey = manager.ApiKey;
+                resource.ApiKey = FoundryLocalService.ApiKey;
 
                 await rns.PublishUpdateAsync(resource, state => state with
                 {
@@ -298,16 +299,16 @@ public static class FoundryExtensions
 
                 try
                 {
-                    await manager.StartServiceAsync(ct).ConfigureAwait(false);
+                    await FoundryLocalService.StartAsync(logger, ct).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
                     logger.LogInformation("Foundry Local could not be started. Ensure it's installed correctly: https://learn.microsoft.com/azure/ai-foundry/foundry-local/get-started (Error: {Error}).", e.Message);
                 }
 
-                if (manager.IsServiceRunning)
+                if (FoundryLocalService.IsServiceRunning)
                 {
-                    resource.EmulatorServiceUri = manager.Endpoint;
+                    resource.EmulatorServiceUri = FoundryLocalService.Endpoint;
 
                     await rns.PublishUpdateAsync(resource, state => state with
                     {
@@ -340,7 +341,6 @@ public static class FoundryExtensions
             var rns = @event.Services.GetRequiredService<ResourceNotificationService>();
             var loggerService = @event.Services.GetRequiredService<ResourceLoggerService>();
             var logger = loggerService.GetLogger(deployment);
-            var manager = @event.Services.GetRequiredService<FoundryLocalManager>();
             var eventing = @event.Services.GetRequiredService<IDistributedApplicationEventing>();
 
             var model = deployment.ModelName;
@@ -353,67 +353,63 @@ public static class FoundryExtensions
                     Properties = [.. state.Properties, new(CustomResourceKnownProperties.Source, model)]
                 }).ConfigureAwait(false);
 
-                var result = manager.DownloadModelWithProgressAsync(model, ct: ct);
+                var progressChannel = Channel.CreateUnbounded<float>();
+                var downloadTask = DownloadModelAsync();
 
-                await foreach (var progress in result.ConfigureAwait(false))
+                await foreach (var progress in progressChannel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
                 {
-                    if (progress.IsCompleted && progress.ModelInfo is not null)
+                    logger.LogInformation("Downloading model {Model}: {Progress:F2}%", model, progress);
+                    await rns.PublishUpdateAsync(deployment, state => state with
                     {
-                        // Set the model id that was actually downloaded. This is the value that is used in the
-                        // connection string
+                        State = new ResourceStateSnapshot($"Downloading model {model}: {progress:F2}%", KnownResourceStateStyles.Info)
+                    }).ConfigureAwait(false);
+                }
 
-                        deployment.ModelId = progress.ModelInfo.ModelId;
-                        logger.LogInformation("Model {Model} downloaded successfully ({ModelId}).", model, deployment.ModelId);
+                try
+                {
+                    deployment.ModelId = await downloadTask.ConfigureAwait(false);
+                    logger.LogInformation("Model {Model} downloaded successfully ({ModelId}).", model, deployment.ModelId);
 
-                        // Re-publish the connection string since the model id is now known
-                        var connectionStringAvailableEvent = new ConnectionStringAvailableEvent(deployment, @event.Services);
-                        await eventing.PublishAsync(connectionStringAvailableEvent, ct).ConfigureAwait(false);
+                    // Re-publish the connection string since the model id is now known.
+                    var connectionStringAvailableEvent = new ConnectionStringAvailableEvent(deployment, @event.Services);
+                    await eventing.PublishAsync(connectionStringAvailableEvent, ct).ConfigureAwait(false);
 
-                        await rns.PublishUpdateAsync(deployment, state => state with
-                        {
-                            Properties = [.. state.Properties, new(CustomResourceKnownProperties.Source, $"{model} ({deployment.ModelId})")]
-                        }).ConfigureAwait(false);
+                    await rns.PublishUpdateAsync(deployment, state => state with
+                    {
+                        Properties = [.. state.Properties, new(CustomResourceKnownProperties.Source, $"{model} ({deployment.ModelId})")]
+                    }).ConfigureAwait(false);
 
-                        await rns.PublishUpdateAsync(deployment, state => state with
-                        {
-                            State = new ResourceStateSnapshot("Loading model", KnownResourceStateStyles.Info)
-                        }).ConfigureAwait(false);
+                    await rns.PublishUpdateAsync(deployment, state => state with
+                    {
+                        State = new ResourceStateSnapshot("Loading model", KnownResourceStateStyles.Info)
+                    }).ConfigureAwait(false);
 
-                        try
-                        {
-                            _ = await manager.LoadModelAsync(deployment.ModelId, ct: ct).ConfigureAwait(false);
+                    await FoundryLocalService.LoadModelAsync(deployment.ModelId, ct).ConfigureAwait(false);
 
-                            await rns.PublishUpdateAsync(deployment, state => state with
-                            {
-                                State = KnownResourceStates.Running
-                            }).ConfigureAwait(false);
-                        }
-                        catch (Exception e)
-                        {
-                            // LoadModelAsync throws IOE when the model is invalid.
-                            logger.LogInformation("Failed to start {Model}. Error: {Error}", model, e.Message);
+                    await rns.PublishUpdateAsync(deployment, state => state with
+                    {
+                        State = KnownResourceStates.Running
+                    }).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    logger.LogInformation("Failed to start {Model}. Error: {Error}", model, e.Message);
 
-                            await rns.PublishUpdateAsync(deployment, state => state with
-                            {
-                                State = KnownResourceStates.FailedToStart
-                            }).ConfigureAwait(false);
-                        }
+                    await rns.PublishUpdateAsync(deployment, state => state with
+                    {
+                        State = KnownResourceStates.FailedToStart
+                    }).ConfigureAwait(false);
+                }
+
+                async Task<string> DownloadModelAsync()
+                {
+                    try
+                    {
+                        return await FoundryLocalService.DownloadModelAsync(model, progress => progressChannel.Writer.TryWrite(progress), ct).ConfigureAwait(false);
                     }
-                    else if (progress.IsCompleted && !string.IsNullOrEmpty(progress.ErrorMessage))
+                    finally
                     {
-                        logger.LogInformation("Failed to start {Model}. Error: {Error}", model, progress.ErrorMessage);
-                        await rns.PublishUpdateAsync(deployment, state => state with
-                        {
-                            State = KnownResourceStates.FailedToStart
-                        }).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        logger.LogInformation("Downloading model {Model}: {Progress:F2}%", model, progress.Percentage);
-                        await rns.PublishUpdateAsync(deployment, state => state with
-                        {
-                            State = new ResourceStateSnapshot($"Downloading model {model}: {progress.Percentage:F2}%", KnownResourceStateStyles.Info)
-                        }).ConfigureAwait(false);
+                        progressChannel.Writer.TryComplete();
                     }
                 }
             }, ct);
@@ -426,7 +422,7 @@ public static class FoundryExtensions
         builder.ApplicationBuilder.Services.AddHealthChecks()
                 .Add(new HealthCheckRegistration(
                     healthCheckKey,
-                    sp => new LocalModelHealthCheck(modelId: deployment.ModelId, sp.GetRequiredService<FoundryLocalManager>()),
+                    sp => new LocalModelHealthCheck(modelId: deployment.ModelId),
                     failureStatus: default,
                     tags: default,
                     timeout: default

--- a/src/Aspire.Hosting.Foundry/FoundryLocalHealthCheck.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryLocalHealthCheck.cs
@@ -1,16 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AI.Foundry.Local;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Aspire.Hosting.Foundry;
 
-internal sealed class FoundryLocalHealthCheck(FoundryLocalManager manager) : IHealthCheck
+internal sealed class FoundryLocalHealthCheck : IHealthCheck
 {
     public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        if (!manager.IsServiceRunning)
+        if (!FoundryLocalService.IsServiceRunning)
         {
             return Task.FromResult(HealthCheckResult.Unhealthy("Foundry Local not running"));
         }

--- a/src/Aspire.Hosting.Foundry/FoundryLocalService.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryLocalService.cs
@@ -70,7 +70,7 @@ internal static class FoundryLocalService
             return false;
         }
 
-        var result = await RunFoundryCommandAsync(["service", "list"], onOutput: null, cancellationToken).ConfigureAwait(false);
+        var result = await RunFoundryCommandAsync(["service", "ps"], onOutput: null, cancellationToken).ConfigureAwait(false);
 
         return result.Contains(modelId, StringComparison.OrdinalIgnoreCase);
     }

--- a/src/Aspire.Hosting.Foundry/FoundryLocalService.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryLocalService.cs
@@ -42,12 +42,17 @@ internal static class FoundryLocalService
 
     public static async Task<string> DownloadModelAsync(string modelName, Action<float> downloadProgress, CancellationToken cancellationToken)
     {
-        await RunFoundryCommandAsync(
+        var output = await RunFoundryCommandAsync(
             ["model", "download", modelName],
             line => ReportProgress(line, downloadProgress),
             cancellationToken).ConfigureAwait(false);
 
-        return modelName;
+        if (TryParseModelId(output, out var modelId))
+        {
+            return modelId;
+        }
+
+        return await GetModelIdAsync(modelName, cancellationToken).ConfigureAwait(false);
     }
 
     public static async Task LoadModelAsync(string modelId, CancellationToken cancellationToken)
@@ -102,57 +107,70 @@ internal static class FoundryLocalService
             StartInfo = startInfo,
             EnableRaisingEvents = true
         };
+        var ownsProcess = true;
 
-        var endpointSource = new TaskCompletionSource<Uri>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        process.OutputDataReceived += (_, e) =>
+        try
         {
-            if (e.Data is null)
-            {
-                return;
-            }
+            var endpointSource = new TaskCompletionSource<Uri>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            logger.LogInformation("{Output}", e.Data);
-
-            if (TryParseEndpoint(e.Data, out var endpoint))
+            process.OutputDataReceived += (_, e) =>
             {
-                endpointSource.TrySetResult(endpoint);
-            }
-        };
+                if (e.Data is null)
+                {
+                    return;
+                }
 
-        process.ErrorDataReceived += (_, e) =>
-        {
-            if (e.Data is not null)
-            {
                 logger.LogInformation("{Output}", e.Data);
-            }
-        };
 
-        process.Exited += (_, _) =>
-        {
-            if (process.ExitCode != 0)
+                if (TryParseEndpoint(e.Data, out var endpoint))
+                {
+                    endpointSource.TrySetResult(endpoint);
+                }
+            };
+
+            process.ErrorDataReceived += (_, e) =>
             {
-                endpointSource.TrySetException(new InvalidOperationException($"Foundry CLI service exited with code {process.ExitCode}."));
+                if (e.Data is not null)
+                {
+                    logger.LogInformation("{Output}", e.Data);
+                }
+            };
+
+            process.Exited += (_, _) =>
+            {
+                if (process.ExitCode != 0)
+                {
+                    endpointSource.TrySetException(new InvalidOperationException($"Foundry CLI service exited with code {process.ExitCode}."));
+                }
+            };
+
+            if (!process.Start())
+            {
+                throw new InvalidOperationException("Foundry CLI service process could not be started.");
             }
-        };
 
-        if (!process.Start())
-        {
-            throw new InvalidOperationException("Foundry CLI service process could not be started.");
+            using var cancellationRegistration = cancellationToken.Register(static state =>
+            {
+                var (source, foundryProcess) = ((TaskCompletionSource<Uri>, Process))state!;
+                source.TrySetCanceled();
+                KillProcess(foundryProcess);
+            }, (endpointSource, process));
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            Endpoint = await endpointSource.Task.ConfigureAwait(false);
+            s_serviceProcess = process;
+            ownsProcess = false;
         }
-
-        using var cancellationRegistration = cancellationToken.Register(static state =>
+        finally
         {
-            var (source, foundryProcess) = ((TaskCompletionSource<Uri>, Process))state!;
-            source.TrySetCanceled();
-            KillProcess(foundryProcess);
-        }, (endpointSource, process));
-
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-
-        Endpoint = await endpointSource.Task.ConfigureAwait(false);
-        s_serviceProcess = process;
+            if (ownsProcess)
+            {
+                KillProcess(process);
+                process.Dispose();
+            }
+        }
     }
 
     private static async Task<string> RunFoundryCommandAsync(string[] arguments, Action<string>? onOutput, CancellationToken cancellationToken)
@@ -215,6 +233,17 @@ internal static class FoundryLocalService
         return startInfo;
     }
 
+    private static async Task<string> GetModelIdAsync(string modelName, CancellationToken cancellationToken)
+    {
+        var output = await RunFoundryCommandAsync(["model", "info", modelName], onOutput: null, cancellationToken).ConfigureAwait(false);
+        if (TryParseModelId(output, out var modelId))
+        {
+            return modelId;
+        }
+
+        throw new InvalidOperationException($"Foundry CLI did not return a model ID for model '{modelName}'.");
+    }
+
     private static bool TryParseEndpoint(string output, out Uri endpoint)
     {
         // Foundry CLI emits service startup lines like:
@@ -244,6 +273,39 @@ internal static class FoundryLocalService
 
         endpoint = builder.Uri;
         return true;
+    }
+
+    internal static bool TryParseModelId(string output, out string modelId)
+    {
+        // Foundry CLI emits model info as a fixed-width table:
+        //   Alias                          Device     Task           File Size    License      Model ID
+        //   phi-3.5-mini                   GPU        chat           2.16 GB      MIT          Phi-3.5-mini-instruct-generic-gpu:1
+        using var reader = new StringReader(output);
+        string? line;
+        var modelIdStart = -1;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (modelIdStart < 0)
+            {
+                modelIdStart = line.IndexOf("Model ID", StringComparison.Ordinal);
+                continue;
+            }
+
+            if (line.Length <= modelIdStart || line.All(c => c == '-' || char.IsWhiteSpace(c)))
+            {
+                continue;
+            }
+
+            var candidate = line[modelIdStart..].Trim();
+            if (candidate.Length > 0)
+            {
+                modelId = candidate.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)[0];
+                return true;
+            }
+        }
+
+        modelId = string.Empty;
+        return false;
     }
 
     private static void ReportProgress(string output, Action<float> downloadProgress)

--- a/src/Aspire.Hosting.Foundry/FoundryLocalService.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryLocalService.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -13,6 +14,8 @@ internal static class FoundryLocalService
 {
     internal const string ApiKey = "unused";
 
+    private static readonly TimeSpan s_serviceStartTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan s_serviceStopTimeout = TimeSpan.FromSeconds(10);
     private static readonly SemaphoreSlim s_managerLock = new(1, 1);
     private static readonly Regex s_urlRegex = new(@"https?://\S+", RegexOptions.Compiled);
     private static readonly Regex s_progressRegex = new(@"(?<progress>\d+(?:\.\d+)?)\s*%", RegexOptions.Compiled);
@@ -74,29 +77,42 @@ internal static class FoundryLocalService
 
     public static async Task StopAsync(CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
+        Process? process;
 
-        var process = s_serviceProcess;
-        s_serviceProcess = null;
-        Endpoint = null;
+        await s_managerLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            process = s_serviceProcess;
+            s_serviceProcess = null;
+            Endpoint = null;
+        }
+        finally
+        {
+            s_managerLock.Release();
+        }
 
         if (process is null)
         {
             return;
         }
 
+        var stopTimeout = cancellationToken.IsCancellationRequested ? TimeSpan.FromSeconds(2) : s_serviceStopTimeout;
+        using var stopCancellation = new CancellationTokenSource(stopTimeout);
         try
         {
             // The Foundry CLI starts the inference agent as a service process, which can outlive
             // the foreground "foundry service start" process if we only kill the process tree.
-            await RunFoundryCommandAsync(["service", "stop"], onOutput: null, cancellationToken).ConfigureAwait(false);
+            await RunFoundryCommandAsync(["service", "stop"], onOutput: null, stopCancellation.Token).ConfigureAwait(false);
         }
-        finally
+        catch (Exception e) when (e is OperationCanceledException or InvalidOperationException or Win32Exception)
         {
-            KillProcess(process);
-
-            process.Dispose();
+            // Stopping the external Foundry service is best-effort. The tracked foreground
+            // process is still killed and disposed below even if the CLI stop command fails.
         }
+
+        KillProcess(process);
+
+        process.Dispose();
     }
 
     private static async Task StartCliServiceAsync(ILogger logger, CancellationToken cancellationToken)
@@ -138,10 +154,7 @@ internal static class FoundryLocalService
 
             process.Exited += (_, _) =>
             {
-                if (process.ExitCode != 0)
-                {
-                    endpointSource.TrySetException(new InvalidOperationException($"Foundry CLI service exited with code {process.ExitCode}."));
-                }
+                endpointSource.TrySetException(new InvalidOperationException($"Foundry CLI service exited before reporting an endpoint. Exit code: {process.ExitCode}."));
             };
 
             if (!process.Start())
@@ -149,12 +162,22 @@ internal static class FoundryLocalService
                 throw new InvalidOperationException("Foundry CLI service process could not be started.");
             }
 
-            using var cancellationRegistration = cancellationToken.Register(static state =>
+            using var startCancellation = new CancellationTokenSource(s_serviceStartTimeout);
+            using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, startCancellation.Token);
+            using var cancellationRegistration = linkedCancellation.Token.Register(static state =>
             {
-                var (source, foundryProcess) = ((TaskCompletionSource<Uri>, Process))state!;
-                source.TrySetCanceled();
+                var (source, foundryProcess, timeoutToken) = ((TaskCompletionSource<Uri>, Process, CancellationToken))state!;
+                if (timeoutToken.IsCancellationRequested)
+                {
+                    source.TrySetException(new TimeoutException($"Timed out waiting for Foundry CLI service to report an endpoint after {s_serviceStartTimeout}."));
+                }
+                else
+                {
+                    source.TrySetCanceled();
+                }
+
                 KillProcess(foundryProcess);
-            }, (endpointSource, process));
+            }, (endpointSource, process, startCancellation.Token));
 
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
@@ -329,6 +352,10 @@ internal static class FoundryLocalService
         catch (InvalidOperationException)
         {
             // The process can exit between HasExited and Kill.
+        }
+        catch (Win32Exception)
+        {
+            // Cleanup paths can race with process teardown or OS-level process removal.
         }
     }
 

--- a/src/Aspire.Hosting.Foundry/FoundryLocalService.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryLocalService.cs
@@ -1,0 +1,295 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Foundry;
+
+internal static class FoundryLocalService
+{
+    internal const string ApiKey = "unused";
+
+    private static readonly SemaphoreSlim s_managerLock = new(1, 1);
+    private static readonly Regex s_urlRegex = new(@"https?://\S+", RegexOptions.Compiled);
+    private static readonly Regex s_progressRegex = new(@"(?<progress>\d+(?:\.\d+)?)\s*%", RegexOptions.Compiled);
+    private static Process? s_serviceProcess;
+
+    public static bool IsServiceRunning => Endpoint is not null && s_serviceProcess is { HasExited: false };
+
+    public static Uri? Endpoint { get; private set; }
+
+    public static async Task StartAsync(ILogger logger, CancellationToken cancellationToken)
+    {
+        await s_managerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (s_serviceProcess is { HasExited: false })
+            {
+                return;
+            }
+
+            await StartCliServiceAsync(logger, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            s_managerLock.Release();
+        }
+    }
+
+    public static async Task<string> DownloadModelAsync(string modelName, Action<float> downloadProgress, CancellationToken cancellationToken)
+    {
+        await RunFoundryCommandAsync(
+            ["model", "download", modelName],
+            line => ReportProgress(line, downloadProgress),
+            cancellationToken).ConfigureAwait(false);
+
+        return modelName;
+    }
+
+    public static async Task LoadModelAsync(string modelId, CancellationToken cancellationToken)
+    {
+        await RunFoundryCommandAsync(["model", "load", modelId], onOutput: null, cancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task<bool> IsModelLoadedAsync(string modelId, CancellationToken cancellationToken)
+    {
+        if (!IsServiceRunning)
+        {
+            return false;
+        }
+
+        var result = await RunFoundryCommandAsync(["service", "list"], onOutput: null, cancellationToken).ConfigureAwait(false);
+
+        return result.Contains(modelId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static async Task StopAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var process = s_serviceProcess;
+        s_serviceProcess = null;
+        Endpoint = null;
+
+        if (process is null)
+        {
+            return;
+        }
+
+        try
+        {
+            // The Foundry CLI starts the inference agent as a service process, which can outlive
+            // the foreground "foundry service start" process if we only kill the process tree.
+            await RunFoundryCommandAsync(["service", "stop"], onOutput: null, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            KillProcess(process);
+
+            process.Dispose();
+        }
+    }
+
+    private static async Task StartCliServiceAsync(ILogger logger, CancellationToken cancellationToken)
+    {
+        var startInfo = CreateFoundryStartInfo(["service", "start"]);
+        var process = new Process
+        {
+            StartInfo = startInfo,
+            EnableRaisingEvents = true
+        };
+
+        var endpointSource = new TaskCompletionSource<Uri>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is null)
+            {
+                return;
+            }
+
+            logger.LogInformation("{Output}", e.Data);
+
+            if (TryParseEndpoint(e.Data, out var endpoint))
+            {
+                endpointSource.TrySetResult(endpoint);
+            }
+        };
+
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                logger.LogInformation("{Output}", e.Data);
+            }
+        };
+
+        process.Exited += (_, _) =>
+        {
+            if (process.ExitCode != 0)
+            {
+                endpointSource.TrySetException(new InvalidOperationException($"Foundry CLI service exited with code {process.ExitCode}."));
+            }
+        };
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Foundry CLI service process could not be started.");
+        }
+
+        using var cancellationRegistration = cancellationToken.Register(static state =>
+        {
+            var (source, foundryProcess) = ((TaskCompletionSource<Uri>, Process))state!;
+            source.TrySetCanceled();
+            KillProcess(foundryProcess);
+        }, (endpointSource, process));
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        Endpoint = await endpointSource.Task.ConfigureAwait(false);
+        s_serviceProcess = process;
+    }
+
+    private static async Task<string> RunFoundryCommandAsync(string[] arguments, Action<string>? onOutput, CancellationToken cancellationToken)
+    {
+        using var process = new Process
+        {
+            StartInfo = CreateFoundryStartInfo(arguments)
+        };
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException($"Foundry CLI command '{FormatCommand(arguments)}' could not be started.");
+        }
+
+        using var cancellationRegistration = cancellationToken.Register(static state => KillProcess((Process)state!), process);
+
+        // Read both streams concurrently to avoid deadlock when a pipe buffer fills.
+        var outputTask = ReadOutputAsync(process.StandardOutput, onOutput, cancellationToken);
+        var errorTask = ReadOutputAsync(process.StandardError, onOutput, cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        var output = await outputTask.ConfigureAwait(false);
+        var error = await errorTask.ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Foundry CLI command '{FormatCommand(arguments)}' failed with exit code {process.ExitCode}: {error}{output}");
+        }
+
+        return output;
+    }
+
+    private static async Task<string> ReadOutputAsync(StreamReader reader, Action<string>? onOutput, CancellationToken cancellationToken)
+    {
+        var output = new List<string>();
+
+        while (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line)
+        {
+            output.Add(line);
+            onOutput?.Invoke(line);
+        }
+
+        return string.Join(Environment.NewLine, output);
+    }
+
+    private static ProcessStartInfo CreateFoundryStartInfo(string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo("foundry")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return startInfo;
+    }
+
+    private static bool TryParseEndpoint(string output, out Uri endpoint)
+    {
+        // Foundry CLI emits service startup lines like:
+        //   Service is Started on http://127.0.0.1:50920/, PID 78399!
+        // and status lines like:
+        //   Model management service is running on http://127.0.0.1:50920/openai/status
+        var match = s_urlRegex.Match(output);
+        if (!match.Success)
+        {
+            endpoint = null!;
+            return false;
+        }
+
+        var url = match.Value.TrimEnd(',', '.', '!');
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var parsedEndpoint))
+        {
+            endpoint = null!;
+            return false;
+        }
+
+        var builder = new UriBuilder(parsedEndpoint)
+        {
+            Path = string.Empty,
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        endpoint = builder.Uri;
+        return true;
+    }
+
+    private static void ReportProgress(string output, Action<float> downloadProgress)
+    {
+        var match = s_progressRegex.Match(output);
+        if (match.Success && float.TryParse(match.Groups["progress"].Value, CultureInfo.InvariantCulture, out var progress))
+        {
+            downloadProgress(progress);
+        }
+    }
+
+    private static void KillProcess(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // The process can exit between HasExited and Kill.
+        }
+    }
+
+    private static string FormatCommand(string[] arguments)
+    {
+        return $"foundry {string.Join(' ', arguments)}";
+    }
+}
+
+internal sealed class FoundryLocalLifecycleService : IHostedService, IAsyncDisposable
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return FoundryLocalService.StopAsync(cancellationToken);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return new(FoundryLocalService.StopAsync(CancellationToken.None));
+    }
+}

--- a/src/Aspire.Hosting.Foundry/LocalModelHealthCheck.cs
+++ b/src/Aspire.Hosting.Foundry/LocalModelHealthCheck.cs
@@ -1,12 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AI.Foundry.Local;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Aspire.Hosting.Foundry;
 
-internal sealed class LocalModelHealthCheck(string? modelId, FoundryLocalManager manager) : IHealthCheck
+internal sealed class LocalModelHealthCheck(string? modelId) : IHealthCheck
 {
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
@@ -15,9 +14,7 @@ internal sealed class LocalModelHealthCheck(string? modelId, FoundryLocalManager
             return HealthCheckResult.Unhealthy("Model has not been loaded.");
         }
 
-        var loadedModels = await manager.ListLoadedModelsAsync(cancellationToken).ConfigureAwait(false);
-
-        if (!loadedModels.Any(lm => lm.ModelId.Equals(modelId, StringComparison.InvariantCultureIgnoreCase)))
+        if (!await FoundryLocalService.IsModelLoadedAsync(modelId, cancellationToken).ConfigureAwait(false))
         {
             return HealthCheckResult.Unhealthy("Model has not been loaded.");
         }

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
@@ -97,6 +97,32 @@ public class FoundryExtensionsTests
     }
 
     [Fact]
+    public void FoundryLocalService_TryParseModelId_ParsesModelInfoOutput()
+    {
+        var output = """
+            Alias                          Device     Task           File Size    License      Model ID
+            phi-3.5-mini                   GPU        chat           2.16 GB      MIT          Phi-3.5-mini-instruct-generic-gpu:1
+            """;
+
+        Assert.True(FoundryLocalService.TryParseModelId(output, out var modelId));
+        Assert.Equal("Phi-3.5-mini-instruct-generic-gpu:1", modelId);
+    }
+
+    [Fact]
+    public void FoundryLocalService_TryParseModelId_IgnoresDiagnosticOutputBeforeTable()
+    {
+        var output = """
+            [15:12:56 ERR] Exception fetching models from Azure Foundry catalog
+            Model management service is running on http://127.0.0.1:54597/openai/status
+            Alias                          Device     Task           File Size    License      Model ID
+            phi-3.5-mini                   GPU        chat           2.16 GB      MIT          Phi-3.5-mini-instruct-generic-gpu:1
+            """;
+
+        Assert.True(FoundryLocalService.TryParseModelId(output, out var modelId));
+        Assert.Equal("Phi-3.5-mini-instruct-generic-gpu:1", modelId);
+    }
+
+    [Fact]
     public void RunAsFoundryLocal_DeploymentIsMarkedLocal()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -125,8 +151,8 @@ public class FoundryExtensionsTests
 
         Assert.Single(resource.Deployments);
 
-        // NB: The value of the ModelName property is updated with the downloaded model id when the resource is starting.
-        // We are only testing that the value in the ModelName property is referenced in the connection string.
+        // NB: The ModelId property is updated with the downloaded model id when the resource is starting.
+        // We are only testing that the ModelName fallback is referenced in the connection string.
 
         Assert.Equal("{myAIFoundry.connectionString};Model=gpt-4", deployment.Resource.ConnectionStringExpression.ValueExpression);
     }

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
@@ -5,7 +5,6 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.AppContainers;
 using Aspire.Hosting.Foundry;
 using Aspire.Hosting.Utils;
-using Microsoft.AI.Foundry.Local;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -94,9 +93,7 @@ public class FoundryExtensionsTests
         // Wait until it's not in Starting state anymore (started or failed whether the Foundry Local service is setup or not)
         await rns.WaitForResourceAsync(resource.Name, [KnownResourceStates.FailedToStart, KnownResourceStates.Running], cts.Token);
 
-        var foundryManager = app.Services.GetRequiredService<FoundryLocalManager>();
-
-        Assert.Equal(foundryManager.ApiKey, localResource.ApiKey);
+        Assert.Equal(FoundryLocalService.ApiKey, localResource.ApiKey);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Upgrade the Foundry Local integration to `Microsoft.AI.Foundry.Local` 1.1.0 while keeping `RunAsFoundryLocal()` working for local AppHost scenarios. The 1.1.0 package no longer exposes the same manager APIs used by Aspire, and local SDK-based startup failed because the native Foundry Local core was not available from the NuGet package assets.

This change keeps the user-facing AppHost API the same and switches the runtime integration to the installed `foundry` CLI. Aspire now starts the local service with `foundry service start`, discovers the emitted endpoint, downloads and loads models through CLI commands, checks loaded models with `foundry service list`, and stops the service during AppHost shutdown/disposal with `foundry service stop`.

### User-facing usage

The existing C# AppHost usage stays the same:

```csharp
var foundry = builder.AddFoundry("foundry")
                     .RunAsFoundryLocal();

foundry.AddDeployment("phi", "Phi-3.5-mini-instruct-generic-gpu", "1", "Microsoft");
```

Users do not need to pre-start Foundry Local, but the `foundry` CLI must be installed and available on `PATH`.

### Security considerations

This change starts an installed local executable and opens the Foundry Local service listener managed by that executable. Command arguments are passed through `ProcessStartInfo.ArgumentList` instead of shell command strings, and the service is stopped when the AppHost stops or is disposed. Security review is useful to confirm the process-spawning and local-listener behavior is acceptable for this preview integration.

### Validation

- `dotnet test --project tests/Aspire.Hosting.Foundry.Tests/Aspire.Hosting.Foundry.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj --no-launch-profile -- --filter-class "*.FoundryExtensionsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build src/Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.csproj --no-restore /p:SkipNativeBuild=true`
- Local smoke test with a temporary AppHost test confirmed Foundry Local starts, reaches `Running`, and is stopped after AppHost disposal.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No