### PR TITLE
Fix VS Code AppHost discovery floods

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -353,7 +353,7 @@ export function deactivate() {
 async function tryExecuteCommand(commandName: string, terminalProvider: AspireTerminalProvider, command: (terminalProvider: AspireTerminalProvider) => Promise<void>): Promise<void> {
   try {
     await withCommandTelemetry(commandName, async () => {
-      const cliCheckExcludedCommands: string[] = ["aspire-vscode.settings", "aspire-vscode.configureLaunchJson"];
+      const cliCheckExcludedCommands: string[] = ["aspire-vscode.settings", "aspire-vscode.configureLaunchJson", "aspire-vscode.updateSelf"];
       if (!cliCheckExcludedCommands.includes(commandName)) {
         if (isE2eBridgeEnabled() && process.env.ASPIRE_EXTENSION_E2E_FORCE_CLI_UNAVAILABLE === 'true') {
           vscode.window.showErrorMessage(

--- a/extension/src/test-e2e/packageSurface.e2e.test.ts
+++ b/extension/src/test-e2e/packageSurface.e2e.test.ts
@@ -153,7 +153,6 @@ suite('Aspire package contribution surface E2E', function () {
             'aspire-vscode.publish',
             'aspire-vscode.do',
             'aspire-vscode.update',
-            'aspire-vscode.updateSelf',
             'aspire-vscode.openTerminal',
             'aspire-vscode.openLocalSettings',
             'aspire-vscode.openGlobalSettings',
@@ -164,6 +163,26 @@ suite('Aspire package contribution surface E2E', function () {
             await executeE2eControlCommand({ name: 'executeAspireCommand', commandId });
             await waitForCommandOutcome(commandId, 'canceled', 60000, before);
         }
+    });
+
+    test('routes update self even when the shared CLI availability path would cancel other commands', async () => {
+        await openAspireView();
+        await waitForRepositoryIdle();
+        await setCliUnavailableForE2E(true);
+        await setTerminalCommandExecutionSuppressedForE2E(true);
+
+        const beforeInvocation = getCommandInvocationCount('aspire-vscode.updateSelf');
+        const beforeTerminalCommand = getTerminalCommandCount();
+        await executeE2eControlCommand({ name: 'executeAspireCommand', commandId: 'aspire-vscode.updateSelf' });
+        await waitForCommandOutcome('aspire-vscode.updateSelf', 'success', 60000, beforeInvocation);
+
+        const terminalCommand = await waitForTerminalCommand(
+            event => event.executionSuppressed && event.subcommand === 'update --self',
+            'update self terminal command',
+            60000,
+            beforeTerminalCommand);
+
+        assert.strictEqual(terminalCommand.executionSuppressed, true);
     });
 
     test('routes package terminal and CodeLens commands without executing shell text', async () => {

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -1113,6 +1113,56 @@ suite('AppHostDataRepository', () => {
         }
     });
 
+    test('queues forced workspace discovery refresh without starting overlapping discovery', async () => {
+        const workspaceFolder = {
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
+        const firstDiscovery = createDeferred<CandidateAppHostDisplayInfo[]>();
+        const secondDiscovery = createDeferred<CandidateAppHostDisplayInfo[]>();
+        let firstTokenCancelled = false;
+        const discoverStub = sinon.stub();
+        discoverStub.onFirstCall().callsFake((_folder: vscode.WorkspaceFolder, _forceRefresh?: boolean, cancellationToken?: vscode.CancellationToken) => {
+            cancellationToken?.onCancellationRequested(() => {
+                firstTokenCancelled = true;
+            });
+            return firstDiscovery.promise;
+        });
+        discoverStub.onSecondCall().callsFake((_folder: vscode.WorkspaceFolder, forceRefresh?: boolean) => {
+            assert.strictEqual(forceRefresh, true);
+            return secondDiscovery.promise;
+        });
+        const appHostDiscoveryService = {
+            onDidChangeCandidates: () => ({ dispose: () => { } }),
+            discover: discoverStub,
+            dispose: () => { },
+        };
+        const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
+
+        try {
+            await waitForMicrotasks();
+            assert.strictEqual(discoverStub.callCount, 1);
+
+            repository.refresh();
+            await waitForMicrotasks();
+
+            assert.strictEqual(firstTokenCancelled, false);
+            assert.strictEqual(discoverStub.callCount, 1);
+
+            firstDiscovery.resolve([]);
+            await waitForCondition(() => discoverStub.callCount === 2, 'queued forced workspace discovery did not run');
+            secondDiscovery.resolve([]);
+            await waitForAppHostDiscovery();
+
+            assert.strictEqual(discoverStub.callCount, 2);
+        } finally {
+            repository.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
     test('workspace ps failure clears loading context and shows error welcome', async () => {
         const workspaceFoldersStub = stubWorkspaceFolders([{
             uri: vscode.Uri.file('/workspace'),

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -1163,6 +1163,54 @@ suite('AppHostDataRepository', () => {
         }
     });
 
+    test('does not apply stale in-flight workspace discovery after refresh is queued', async () => {
+        const workspaceFolder = {
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
+        const firstDiscovery = createDeferred<CandidateAppHostDisplayInfo[]>();
+        const secondDiscovery = createDeferred<CandidateAppHostDisplayInfo[]>();
+        const discoverStub = sinon.stub();
+        discoverStub.onFirstCall().returns(firstDiscovery.promise);
+        discoverStub.onSecondCall().returns(secondDiscovery.promise);
+        const appHostDiscoveryService = {
+            onDidChangeCandidates: () => ({ dispose: () => { } }),
+            discover: discoverStub,
+            dispose: () => { },
+        };
+        const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
+
+        try {
+            await waitForMicrotasks();
+            assert.strictEqual(discoverStub.callCount, 1);
+
+            repository.refresh();
+            await waitForMicrotasks();
+            assert.strictEqual(discoverStub.callCount, 1);
+
+            firstDiscovery.resolve([{
+                path: '/workspace/stale/AppHost.csproj',
+                language: 'csharp',
+                status: 'buildable',
+            }]);
+            await waitForCondition(() => discoverStub.callCount === 2, 'queued forced workspace discovery did not run');
+
+            assert.strictEqual(repository.workspaceAppHostPath, undefined);
+
+            secondDiscovery.resolve([{
+                path: '/workspace/current/AppHost.csproj',
+                language: 'csharp',
+                status: 'buildable',
+            }]);
+            await waitForCondition(() => repository.workspaceAppHostPath === '/workspace/current/AppHost.csproj', 'current workspace discovery did not apply');
+        } finally {
+            repository.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
     test('workspace ps failure clears loading context and shows error welcome', async () => {
         const workspaceFoldersStub = stubWorkspaceFolders([{
             uri: vscode.Uri.file('/workspace'),

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -1069,6 +1069,50 @@ suite('AppHostDataRepository', () => {
         }
     });
 
+    test('coalesces workspace discovery change events while discovery is in flight', async () => {
+        const workspaceFolder = {
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
+        const discoveryChanges = new vscode.EventEmitter<vscode.WorkspaceFolder>();
+        const firstDiscovery = createDeferred<CandidateAppHostDisplayInfo[]>();
+        const secondDiscovery = createDeferred<CandidateAppHostDisplayInfo[]>();
+        const discoverStub = sinon.stub();
+        discoverStub.onFirstCall().returns(firstDiscovery.promise);
+        discoverStub.onSecondCall().returns(secondDiscovery.promise);
+        const appHostDiscoveryService = {
+            onDidChangeCandidates: discoveryChanges.event,
+            discover: discoverStub,
+            dispose: () => { },
+        };
+        const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
+
+        try {
+            await waitForMicrotasks();
+            assert.strictEqual(discoverStub.callCount, 1);
+
+            discoveryChanges.fire(workspaceFolder);
+            discoveryChanges.fire(workspaceFolder);
+            discoveryChanges.fire(workspaceFolder);
+            await waitForMicrotasks();
+
+            assert.strictEqual(discoverStub.callCount, 1);
+
+            firstDiscovery.resolve([]);
+            await waitForCondition(() => discoverStub.callCount === 2, 'pending workspace discovery did not run');
+            secondDiscovery.resolve([]);
+            await waitForAppHostDiscovery();
+
+            assert.strictEqual(discoverStub.callCount, 2);
+        } finally {
+            repository.dispose();
+            discoveryChanges.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
     test('workspace ps failure clears loading context and shows error welcome', async () => {
         const workspaceFoldersStub = stubWorkspaceFolders([{
             uri: vscode.Uri.file('/workspace'),

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -141,6 +141,7 @@ suite('AppHost discovery', () => {
 
         test('fires change event and invalidates cache when watched files change', async () => {
             const watcherCallbacks = stubFileSystemWatchers(sandbox);
+            const clock = sandbox.useFakeTimers();
             const spawnStub = sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
                 options?.stdoutCallback?.('[]');
                 options?.exitCallback?.(0);
@@ -158,6 +159,8 @@ suite('AppHost discovery', () => {
                 assert.strictEqual(spawnStub.callCount, 1);
 
                 watcherCallbacks[0]();
+                assert.strictEqual(changedWorkspaceFolder, undefined);
+                await clock.tickAsync(250);
                 assert.strictEqual(changedWorkspaceFolder, workspaceFolder);
 
                 await service.discover(workspaceFolder);
@@ -190,6 +193,8 @@ suite('AppHost discovery', () => {
                 watcherCallbacks[0](vscode.Uri.file(buildPath('workspace', 'AppHost', 'bin', 'Debug', 'Generated.csproj')));
                 assert.strictEqual(changeCount, 0);
                 watcherCallbacks[0](vscode.Uri.file(buildPath('workspace', '.worktrees', 'feature', 'AppHost', 'AppHost.csproj')));
+                assert.strictEqual(changeCount, 0);
+                watcherCallbacks[0](vscode.Uri.file(buildPath('workspace', '.claude', 'worktrees', 'feature', 'AppHost', 'AppHost.csproj')));
                 assert.strictEqual(changeCount, 0);
 
                 await service.discover(workspaceFolder);
@@ -415,12 +420,36 @@ suite('AppHost discovery', () => {
             }
         });
 
-        test('configured AppHost path search excludes git worktree folders', async () => {
-            await findConfiguredAppHostPaths(makeWorkspaceFolder(buildPath('workspace')));
+        test('configured AppHost path search excludes nested worktrees and user excluded folders', async () => {
+            sandbox.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
+                const values: Record<string, Record<string, boolean>> = {
+                    files: {
+                        '**/private-checkouts/**': true,
+                        '**/generated-but-enabled/**': false,
+                    },
+                    search: {
+                        '**/scratch-worktrees/**': true,
+                    },
+                };
 
-            const excludePatterns = findFilesStub.getCalls().map(call => String(call.args[1]));
-            assert.ok(excludePatterns.length > 0);
-            assert.ok(excludePatterns.every(pattern => pattern.includes('**/.worktrees/**')));
+                return {
+                    get: <T>(key: string, defaultValue: T) => key === 'exclude' && section ? values[section] as T : defaultValue,
+                } as vscode.WorkspaceConfiguration;
+            });
+            const cancellationToken = makeCancellationToken();
+
+            await findConfiguredAppHostPaths(makeWorkspaceFolder(buildPath('workspace')), cancellationToken);
+
+            for (const call of findFilesStub.getCalls()) {
+                const excludePattern = String(call.args[1]);
+                assert.ok(excludePattern.includes('**/.worktrees/**'));
+                assert.ok(excludePattern.includes('**/.claude/**'));
+                assert.ok(excludePattern.includes('**/private-checkouts/**'));
+                assert.ok(excludePattern.includes('**/scratch-worktrees/**'));
+                assert.ok(!excludePattern.includes('**/generated-but-enabled/**'));
+                assert.strictEqual(call.args[2], 512);
+                assert.strictEqual(call.args[3], cancellationToken);
+            }
         });
 
         test('selects configured path from recursive config during service discovery', async () => {
@@ -539,6 +568,13 @@ function makeTerminalProvider(): AspireTerminalProvider {
         getAspireCliExecutablePath: async () => 'aspire',
         createEnvironment: () => ({}),
     } as unknown as AspireTerminalProvider;
+}
+
+function makeCancellationToken(): vscode.CancellationToken {
+    return {
+        isCancellationRequested: false,
+        onCancellationRequested: () => ({ dispose: () => { } }),
+    };
 }
 
 async function waitForMicrotasks(): Promise<void> {

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -206,6 +206,43 @@ suite('AppHost discovery', () => {
             }
         });
 
+        test('ignores watched files matched by user exclude patterns', async () => {
+            const watcherCallbacks = stubFileSystemWatchers(sandbox);
+            const clock = sandbox.useFakeTimers();
+            sandbox.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => ({
+                get: () => section === 'files'
+                    ? { '**/private-checkouts/**': true }
+                    : {},
+            } as unknown as vscode.WorkspaceConfiguration));
+            const spawnStub = sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                options?.stdoutCallback?.('[]');
+                options?.exitCallback?.(0);
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider());
+            const workspaceFolder = makeWorkspaceFolder(buildPath('workspace'));
+            let changeCount = 0;
+            const subscription = service.onDidChangeCandidates(() => {
+                changeCount++;
+            });
+
+            try {
+                await service.discover(workspaceFolder);
+                assert.strictEqual(spawnStub.callCount, 1);
+
+                watcherCallbacks[0](vscode.Uri.file(buildPath('workspace', 'private-checkouts', 'feature', 'AppHost', 'AppHost.csproj')));
+                await clock.tickAsync(250);
+
+                assert.strictEqual(changeCount, 0);
+                await service.discover(workspaceFolder);
+                assert.strictEqual(spawnStub.callCount, 1);
+            }
+            finally {
+                subscription.dispose();
+                service.dispose();
+            }
+        });
+
         test('kills in-flight CLI process when disposed', async () => {
             stubFileSystemWatchers(sandbox);
             const childProcess = {

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import * as cliModule from '../debugger/languages/cli';
 import { AppHostDiscoveryService, findCandidateForEditorFile, findConfiguredAppHostPaths, getDebugTargetForCandidate, selectWorkspaceAppHostPath } from '../utils/appHostDiscovery';
 import type { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
+import { appHostDiscoveryFindFilesMaxResults } from '../utils/workspaceFileSearch';
 
 suite('AppHost discovery', () => {
     test('resolves SDK-style C# AppHost source file to discovered project candidate', () => {
@@ -645,6 +646,52 @@ suite('AppHost discovery', () => {
             }
         });
 
+        test('workspace project fallback checks projects beyond bounded file-search batch', async () => {
+            const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-apphost-discovery-'));
+            try {
+                stubFileSystemWatchers(sandbox);
+                const projectPaths = Array.from({ length: appHostDiscoveryFindFilesMaxResults + 1 }, (_, index) => path.join(tempDir, 'Project' + index, 'Project' + index + '.csproj'));
+                const appHostProjectPath = projectPaths[projectPaths.length - 1];
+                for (const projectPath of projectPaths) {
+                    fs.mkdirSync(path.dirname(projectPath), { recursive: true });
+                    fs.writeFileSync(projectPath, projectPath === appHostProjectPath
+                        ? '<Project Sdk="Aspire.AppHost.Sdk/13.5.0" />'
+                        : '<Project Sdk="Microsoft.NET.Sdk" />');
+                }
+                findFilesStub.callsFake(async (include: vscode.GlobPattern, _exclude?: vscode.GlobPattern | null, maxResults?: number) => {
+                    const pattern = typeof include === 'string' ? include : include.pattern;
+                    if (!pattern.endsWith('*.csproj')) {
+                        return [];
+                    }
+
+                    const uris = projectPaths.map(vscode.Uri.file);
+                    return typeof maxResults === 'number' ? uris.slice(0, maxResults) : uris;
+                });
+                sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, args = [], options) => {
+                    options?.stderrCallback?.(`${args.join(' ')} failed`);
+                    options?.exitCallback?.(1);
+                    return { kill: () => { } } as any;
+                });
+                const service = new AppHostDiscoveryService(makeTerminalProvider());
+
+                try {
+                    const result = await service.discover(makeWorkspaceFolder(tempDir));
+
+                    assert.deepStrictEqual(result, [{
+                        path: appHostProjectPath,
+                        language: 'csharp',
+                        status: 'buildable',
+                    }]);
+                }
+                finally {
+                    service.dispose();
+                }
+            }
+            finally {
+                fs.rmSync(tempDir, { recursive: true, force: true });
+            }
+        });
+
         test('configured AppHost path search excludes nested worktrees and user excluded folders', async () => {
             sandbox.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
                 const values: Record<string, Record<string, boolean>> = {
@@ -672,8 +719,31 @@ suite('AppHost discovery', () => {
                 assert.ok(excludePattern.includes('**/private-checkouts/**'));
                 assert.ok(excludePattern.includes('**/scratch-worktrees/**'));
                 assert.ok(!excludePattern.includes('**/generated-but-enabled/**'));
-                assert.strictEqual(call.args[2], 512);
+                assert.strictEqual(call.args[2], appHostDiscoveryFindFilesMaxResults);
                 assert.strictEqual(call.args[3], cancellationToken);
+            }
+        });
+
+        test('service discovery forwards caller cancellation token to configured AppHost path search', async () => {
+            stubFileSystemWatchers(sandbox);
+            sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                options?.stdoutCallback?.('[]');
+                options?.exitCallback?.(0);
+                return { kill: () => { } } as any;
+            });
+            const cancellationToken = makeCancellationToken();
+            const service = new AppHostDiscoveryService(makeTerminalProvider());
+
+            try {
+                await service.discover(makeWorkspaceFolder(buildPath('workspace')), false, cancellationToken);
+
+                assert.strictEqual(findFilesStub.callCount, 2);
+                for (const call of findFilesStub.getCalls()) {
+                    assert.strictEqual(call.args[3], cancellationToken);
+                }
+            }
+            finally {
+                service.dispose();
             }
         });
 

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -243,6 +243,43 @@ suite('AppHost discovery', () => {
             }
         });
 
+        test('ignores watched files matched by bracket user exclude patterns', async () => {
+            const watcherCallbacks = stubFileSystemWatchers(sandbox);
+            const clock = sandbox.useFakeTimers();
+            sandbox.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => ({
+                get: () => section === 'files'
+                    ? { '**/[Pp]rivate-checkouts/**': true }
+                    : {},
+            } as unknown as vscode.WorkspaceConfiguration));
+            const spawnStub = sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                options?.stdoutCallback?.('[]');
+                options?.exitCallback?.(0);
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider());
+            const workspaceFolder = makeWorkspaceFolder(buildPath('workspace'));
+            let changeCount = 0;
+            const subscription = service.onDidChangeCandidates(() => {
+                changeCount++;
+            });
+
+            try {
+                await service.discover(workspaceFolder);
+                assert.strictEqual(spawnStub.callCount, 1);
+
+                watcherCallbacks[0](vscode.Uri.file(buildPath('workspace', 'private-checkouts', 'feature', 'AppHost', 'AppHost.csproj')));
+                await clock.tickAsync(250);
+
+                assert.strictEqual(changeCount, 0);
+                await service.discover(workspaceFolder);
+                assert.strictEqual(spawnStub.callCount, 1);
+            }
+            finally {
+                subscription.dispose();
+                service.dispose();
+            }
+        });
+
         test('kills in-flight CLI process when disposed', async () => {
             stubFileSystemWatchers(sandbox);
             const childProcess = {

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -230,6 +230,54 @@ suite('AppHost discovery', () => {
             assert.strictEqual(childProcess.killed, true);
         });
 
+        test('caller cancellation does not reject shared discovery for other callers', async () => {
+            stubFileSystemWatchers(sandbox);
+            let options: cliModule.SpawnProcessOptions | undefined;
+            const childProcess = {
+                killed: false,
+                kill: sandbox.stub().callsFake(() => {
+                    childProcess.killed = true;
+                    return true;
+                }),
+            };
+            sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, spawnOptions) => {
+                options = spawnOptions;
+                return childProcess as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider());
+            const workspaceFolder = makeWorkspaceFolder(buildPath('workspace'));
+            const cancellationSource = new vscode.CancellationTokenSource();
+
+            try {
+                const cancelledDiscovery = service.discover(workspaceFolder, false, cancellationSource.token);
+                const sharedDiscovery = service.discover(workspaceFolder);
+                await waitForMicrotasks();
+                assert.ok(options);
+
+                cancellationSource.cancel();
+
+                await assert.rejects(cancelledDiscovery, /cancelled/);
+                assert.strictEqual(childProcess.kill.callCount, 0);
+
+                options.stdoutCallback?.(JSON.stringify([{
+                    path: buildPath('workspace', 'AppHost', 'AppHost.csproj'),
+                    language: 'csharp',
+                    status: 'buildable',
+                }]));
+                options.exitCallback?.(0);
+
+                assert.deepStrictEqual(await sharedDiscovery, [{
+                    path: buildPath('workspace', 'AppHost', 'AppHost.csproj'),
+                    language: 'csharp',
+                    status: 'buildable',
+                }]);
+            }
+            finally {
+                cancellationSource.dispose();
+                service.dispose();
+            }
+        });
+
         test('times out hung CLI process and allows retry', async () => {
             stubFileSystemWatchers(sandbox);
             sandbox.stub(vscode.workspace, 'getConfiguration').returns({

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -724,23 +724,64 @@ suite('AppHost discovery', () => {
             }
         });
 
-        test('service discovery forwards caller cancellation token to configured AppHost path search', async () => {
+        test('caller cancellation does not reject shared configured AppHost path search for other callers', async () => {
             stubFileSystemWatchers(sandbox);
             sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
                 options?.stdoutCallback?.('[]');
                 options?.exitCallback?.(0);
                 return { kill: () => { } } as any;
             });
-            const cancellationToken = makeCancellationToken();
+            let resolveFindFiles: ((uris: vscode.Uri[]) => void) | undefined;
+            const findFilesPromise = new Promise<vscode.Uri[]>(resolve => {
+                resolveFindFiles = resolve;
+            });
+            findFilesStub.callsFake(() => findFilesPromise);
+            const cancellationSource = new vscode.CancellationTokenSource();
             const service = new AppHostDiscoveryService(makeTerminalProvider());
+            const workspaceFolder = makeWorkspaceFolder(buildPath('workspace'));
 
             try {
-                await service.discover(makeWorkspaceFolder(buildPath('workspace')), false, cancellationToken);
+                const cancelledDiscovery = service.discover(workspaceFolder, false, cancellationSource.token);
+                const sharedDiscovery = service.discover(workspaceFolder);
+                await waitForMicrotasks();
+                assert.ok(resolveFindFiles);
+
+                cancellationSource.cancel();
+                const cancelledResult = assert.rejects(cancelledDiscovery, /cancelled/);
+                resolveFindFiles([]);
+                await cancelledResult;
+
+                assert.deepStrictEqual(await sharedDiscovery, []);
+                assert.strictEqual(findFilesStub.callCount, 2);
+            }
+            finally {
+                cancellationSource.dispose();
+                service.dispose();
+            }
+        });
+
+        test('service discovery shares configured AppHost path search between concurrent callers', async () => {
+            stubFileSystemWatchers(sandbox);
+            let options: cliModule.SpawnProcessOptions | undefined;
+            sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, spawnOptions) => {
+                options = spawnOptions;
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider());
+            const workspaceFolder = makeWorkspaceFolder(buildPath('workspace'));
+
+            try {
+                const firstDiscovery = service.discover(workspaceFolder);
+                const secondDiscovery = service.discover(workspaceFolder);
+                await waitForMicrotasks();
+                assert.ok(options);
+
+                options.stdoutCallback?.('[]');
+                options.exitCallback?.(0);
+
+                await Promise.all([firstDiscovery, secondDiscovery]);
 
                 assert.strictEqual(findFilesStub.callCount, 2);
-                for (const call of findFilesStub.getCalls()) {
-                    assert.strictEqual(call.args[3], cancellationToken);
-                }
             }
             finally {
                 service.dispose();

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -160,6 +160,9 @@ suite('AppHost discovery', () => {
 
                 watcherCallbacks[0]();
                 assert.strictEqual(changedWorkspaceFolder, undefined);
+                await service.discover(workspaceFolder);
+                assert.strictEqual(spawnStub.callCount, 2);
+
                 await clock.tickAsync(250);
                 assert.strictEqual(changedWorkspaceFolder, workspaceFolder);
 

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -678,7 +678,7 @@ suite('AppHost discovery', () => {
                     const result = await service.discover(makeWorkspaceFolder(tempDir));
 
                     assert.deepStrictEqual(result, [{
-                        path: appHostProjectPath,
+                        path: vscode.Uri.file(appHostProjectPath).fsPath,
                         language: 'csharp',
                         status: 'buildable',
                     }]);

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -278,6 +278,32 @@ suite('AppHost discovery', () => {
             }
         });
 
+        test('already cancelled caller token does not start discovery on cache miss', async () => {
+            stubFileSystemWatchers(sandbox);
+            const spawnStub = sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                options?.stdoutCallback?.('[]');
+                options?.exitCallback?.(0);
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider());
+            const workspaceFolder = makeWorkspaceFolder(buildPath('workspace'));
+            const cancellationSource = new vscode.CancellationTokenSource();
+            cancellationSource.cancel();
+
+            try {
+                await assert.rejects(service.discover(workspaceFolder, false, cancellationSource.token), /cancelled/);
+                assert.strictEqual(spawnStub.callCount, 0);
+
+                const result = await service.discover(workspaceFolder);
+                assert.deepStrictEqual(result, []);
+                assert.strictEqual(spawnStub.callCount, 1);
+            }
+            finally {
+                cancellationSource.dispose();
+                service.dispose();
+            }
+        });
+
         test('times out hung CLI process and allows retry', async () => {
             stubFileSystemWatchers(sandbox);
             sandbox.stub(vscode.workspace, 'getConfiguration').returns({

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -280,6 +280,80 @@ suite('AppHost discovery', () => {
             }
         });
 
+        test('malformed bracket user exclude patterns do not break watcher invalidation', async () => {
+            const watcherCallbacks = stubFileSystemWatchers(sandbox);
+            const clock = sandbox.useFakeTimers();
+            sandbox.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => ({
+                get: () => section === 'files'
+                    ? { '**/[z-a]/**': true }
+                    : {},
+            } as unknown as vscode.WorkspaceConfiguration));
+            const spawnStub = sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                options?.stdoutCallback?.('[]');
+                options?.exitCallback?.(0);
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider());
+            const workspaceFolder = makeWorkspaceFolder(buildPath('workspace'));
+            let changeCount = 0;
+            const subscription = service.onDidChangeCandidates(() => {
+                changeCount++;
+            });
+
+            try {
+                await service.discover(workspaceFolder);
+                assert.strictEqual(spawnStub.callCount, 1);
+
+                watcherCallbacks[0](vscode.Uri.file(buildPath('workspace', 'AppHost', 'AppHost.csproj')));
+                await clock.tickAsync(250);
+
+                assert.strictEqual(changeCount, 1);
+                await service.discover(workspaceFolder);
+                assert.strictEqual(spawnStub.callCount, 2);
+            }
+            finally {
+                subscription.dispose();
+                service.dispose();
+            }
+        });
+
+        test('negated bracket user exclude patterns do not match path separators', async () => {
+            const watcherCallbacks = stubFileSystemWatchers(sandbox);
+            const clock = sandbox.useFakeTimers();
+            sandbox.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => ({
+                get: () => section === 'files'
+                    ? { '**[!x]AppHost.csproj': true }
+                    : {},
+            } as unknown as vscode.WorkspaceConfiguration));
+            const spawnStub = sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                options?.stdoutCallback?.('[]');
+                options?.exitCallback?.(0);
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider());
+            const workspaceFolder = makeWorkspaceFolder(buildPath('workspace'));
+            let changeCount = 0;
+            const subscription = service.onDidChangeCandidates(() => {
+                changeCount++;
+            });
+
+            try {
+                await service.discover(workspaceFolder);
+                assert.strictEqual(spawnStub.callCount, 1);
+
+                watcherCallbacks[0](vscode.Uri.file(buildPath('workspace', 'x', 'AppHost.csproj')));
+                await clock.tickAsync(250);
+
+                assert.strictEqual(changeCount, 1);
+                await service.discover(workspaceFolder);
+                assert.strictEqual(spawnStub.callCount, 2);
+            }
+            finally {
+                subscription.dispose();
+                service.dispose();
+            }
+        });
+
         test('kills in-flight CLI process when disposed', async () => {
             stubFileSystemWatchers(sandbox);
             const childProcess = {

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -196,7 +196,7 @@ suite('AspireTerminalProvider tests', () => {
             }
         });
 
-        test('records suppressed execution mode and does not send command when E2E suppression is enabled', async () => {
+        test('records suppressed execution mode without creating a terminal when E2E suppression is enabled', async () => {
             resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
             const originalEnableBridge = process.env.ASPIRE_EXTENSION_E2E_ENABLE_BRIDGE;
             const originalStateFile = process.env.ASPIRE_EXTENSION_E2E_STATE_FILE;
@@ -233,6 +233,7 @@ suite('AspireTerminalProvider tests', () => {
 
                 assert.strictEqual(executedCommand, undefined);
                 assert.deepStrictEqual(sentTexts, []);
+                assert.strictEqual(getAspireTerminalStub.called, false);
                 assert.deepStrictEqual(terminalEvents.map(event => (event as { executionMode: string }).executionMode), ['suppressed']);
                 assert.deepStrictEqual(terminalEvents.map(event => (event as { executionSuppressed: boolean }).executionSuppressed), [true]);
             }

--- a/extension/src/test/workspace.test.ts
+++ b/extension/src/test/workspace.test.ts
@@ -72,6 +72,7 @@ suite('utils/workspace tests', () => {
         assert.ok(glob.includes('**/.vs/**'), 'Should exclude .vs');
         assert.ok(glob.includes('**/.vscode-test/**'), 'Should exclude .vscode-test');
         assert.ok(glob.includes('**/.worktrees/**'), 'Should exclude git worktrees');
+        assert.ok(glob.includes('**/.claude/**'), 'Should exclude agent worktrees');
         assert.ok(glob.includes('**/.idea/**'), 'Should exclude .idea');
         assert.ok(glob.includes('**/.git/**'), 'Should exclude .git');
     });

--- a/extension/src/test/workspace.test.ts
+++ b/extension/src/test/workspace.test.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { yesLabel } from '../loc/strings';
 import { checkForExistingAppHostPathInWorkspace, getCommonExcludeGlob, findAspireSettingsFiles } from '../utils/workspace';
 import { AppHostDiscoveryService, getWorkspaceAppHostProjectSearchResult } from '../utils/appHostDiscovery';
+import { getAppHostDiscoveryExcludeGlob } from '../utils/workspaceFileSearch';
 
 suite('utils/workspace tests', () => {
     let sandbox: sinon.SinonSandbox;
@@ -75,6 +76,27 @@ suite('utils/workspace tests', () => {
         assert.ok(glob.includes('**/.claude/**'), 'Should exclude agent worktrees');
         assert.ok(glob.includes('**/.idea/**'), 'Should exclude .idea');
         assert.ok(glob.includes('**/.git/**'), 'Should exclude .git');
+    });
+
+    test('getAppHostDiscoveryExcludeGlob skips user patterns that cannot be safely composed', () => {
+        sandbox.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => ({
+            get: () => section === 'files'
+                ? {
+                    '**/safe-generated/**': true,
+                    '**/{generated,tmp}/**': true,
+                }
+                : {
+                    '**/safe-search/**': true,
+                    '**/coverage,dist/**': true,
+                },
+        } as unknown as vscode.WorkspaceConfiguration));
+
+        const glob = getAppHostDiscoveryExcludeGlob();
+
+        assert.ok(glob.includes('**/safe-generated/**'), 'Should include safe files.exclude pattern');
+        assert.ok(glob.includes('**/safe-search/**'), 'Should include safe search.exclude pattern');
+        assert.ok(!glob.includes('**/{generated,tmp}/**'), 'Should skip nested brace pattern');
+        assert.ok(!glob.includes('**/coverage,dist/**'), 'Should skip comma pattern');
     });
 
     test('AppHost selection quick pick shows aspire ls language and status metadata', async () => {

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -139,7 +139,6 @@ export class AspireTerminalProvider implements vscode.Disposable {
             command += ' ' + quotedArgs.join(' ');
         }
 
-        const aspireTerminal = this.getAspireTerminal();
         let logCommand = command;
         if (options?.redactAdditionalArgs && additionalArgs && additionalArgs.length > 0) {
             const logArgs = extensionArgs.map(arg => quoteShellArg(arg));
@@ -147,11 +146,15 @@ export class AspireTerminalProvider implements vscode.Disposable {
             logCommand = `${baseCommand} ${logArgs.join(' ')}`;
         }
         const executionSuppressed = isE2eTerminalCommandExecutionSuppressed();
-        const executionMode = executionSuppressed
-            ? 'suppressed'
-            : aspireTerminal.terminal.shellIntegration
-                ? 'shellIntegration'
-                : 'sendText';
+        let aspireTerminal: AspireTerminal | undefined;
+        let executionMode: AspireTerminalCommandEvent['executionMode'];
+        if (executionSuppressed) {
+            executionMode = 'suppressed';
+        }
+        else {
+            aspireTerminal = this.getAspireTerminal();
+            executionMode = aspireTerminal.terminal.shellIntegration ? 'shellIntegration' : 'sendText';
+        }
         this._onDidSendAspireCommand.fire({
             subcommand,
             commandLine: logCommand,
@@ -163,12 +166,16 @@ export class AspireTerminalProvider implements vscode.Disposable {
         });
         extensionLogOutputChannel.info(`Sending command to Aspire terminal: ${logCommand}`);
 
-        if (showTerminal) {
-            aspireTerminal.terminal.show();
-        }
-
         if (executionSuppressed) {
             return;
+        }
+
+        if (!aspireTerminal) {
+            throw new Error('Aspire terminal was not created for an unsuppressed command.');
+        }
+
+        if (showTerminal) {
+            aspireTerminal.terminal.show();
         }
 
         if (executionMode === 'shellIntegration' && aspireTerminal.terminal.shellIntegration) {

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -55,6 +55,7 @@ export class AppHostDiscoveryService implements vscode.Disposable {
 
     async discover(workspaceFolder: vscode.WorkspaceFolder, forceRefresh = false, cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
         this._throwIfDisposed();
+        throwIfCancellationRequested(cancellationToken);
 
         const key = path.resolve(workspaceFolder.uri.fsPath);
         if (forceRefresh) {

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -69,8 +69,7 @@ export class AppHostDiscoveryService implements vscode.Disposable {
             // The cached discovery promise is shared across extension features. Keep caller
             // cancellation outside the cached operation so one cancelled refresh doesn't reject
             // unrelated callers that are awaiting the same workspace discovery.
-            const discoveryPromise = this._discoverCore(workspaceFolder)
-                .then(candidates => this._includeConfiguredAppHostCandidate(workspaceFolder, candidates));
+            const discoveryPromise = this._discoverCore(workspaceFolder);
             let cachedPromise: Promise<CandidateAppHostDisplayInfo[]>;
             cachedPromise = discoveryPromise.catch(error => {
                 if (this._cache.get(key) === cachedPromise) {
@@ -82,7 +81,8 @@ export class AppHostDiscoveryService implements vscode.Disposable {
             this._cache.set(key, resultPromise);
         }
 
-        return withCancellation(resultPromise, cancellationToken);
+        const candidates = await withCancellation(resultPromise, cancellationToken);
+        return await this._includeConfiguredAppHostCandidate(workspaceFolder, candidates, cancellationToken);
     }
 
     async resolveDebugTarget(filePath: string, workspaceFolder?: vscode.WorkspaceFolder): Promise<string> {
@@ -246,12 +246,14 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         }
     }
 
-    private async _includeConfiguredAppHostCandidate(workspaceFolder: vscode.WorkspaceFolder, candidates: CandidateAppHostDisplayInfo[]): Promise<CandidateAppHostDisplayInfo[]> {
+    private async _includeConfiguredAppHostCandidate(workspaceFolder: vscode.WorkspaceFolder, candidates: CandidateAppHostDisplayInfo[], cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
+        throwIfCancellationRequested(cancellationToken);
         if (candidates.some(candidate => candidate.selected)) {
             return candidates;
         }
 
-        const configuredPaths = await findConfiguredAppHostPaths(workspaceFolder);
+        const configuredPaths = await findConfiguredAppHostPaths(workspaceFolder, cancellationToken);
+        throwIfCancellationRequested(cancellationToken);
         const configuredPath = configuredPaths.find(configuredPath => candidates.some(candidate => isSamePath(candidate.path, configuredPath)))
             ?? configuredPaths[0];
         if (!configuredPath) {
@@ -549,7 +551,10 @@ function parseCandidateOutput(output: string, commandName: string): CandidateApp
 }
 
 async function discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
-    const projectUris = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, '**/*.csproj'), getAppHostDiscoveryExcludeGlob(), appHostDiscoveryFindFilesMaxResults);
+    // This is the final fallback after both CLI discovery paths fail. Do not cap the
+    // project scan here: VS Code returns only the first maxResults matches, which can
+    // hide the only AppHost in a large workspace.
+    const projectUris = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, '**/*.csproj'), getAppHostDiscoveryExcludeGlob());
     const candidates: CandidateAppHostDisplayInfo[] = [];
     for (const uri of projectUris.sort((left, right) => left.fsPath.localeCompare(right.fsPath))) {
         let projectContents: string;

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -65,16 +65,23 @@ export class AppHostDiscoveryService implements vscode.Disposable {
 
         let resultPromise = this._cache.get(key);
         if (!resultPromise) {
-            resultPromise = this._discoverCore(workspaceFolder, cancellationToken)
-                .then(candidates => this._includeConfiguredAppHostCandidate(workspaceFolder, candidates, cancellationToken))
-                .catch(error => {
+            // The cached discovery promise is shared across extension features. Keep caller
+            // cancellation outside the cached operation so one cancelled refresh doesn't reject
+            // unrelated callers that are awaiting the same workspace discovery.
+            const discoveryPromise = this._discoverCore(workspaceFolder)
+                .then(candidates => this._includeConfiguredAppHostCandidate(workspaceFolder, candidates));
+            let cachedPromise: Promise<CandidateAppHostDisplayInfo[]>;
+            cachedPromise = discoveryPromise.catch(error => {
+                if (this._cache.get(key) === cachedPromise) {
                     this._cache.delete(key);
-                    throw error;
-                });
+                }
+                throw error;
+            });
+            resultPromise = cachedPromise;
             this._cache.set(key, resultPromise);
         }
 
-        return resultPromise;
+        return withCancellation(resultPromise, cancellationToken);
     }
 
     async resolveDebugTarget(filePath: string, workspaceFolder?: vscode.WorkspaceFolder): Promise<string> {
@@ -119,27 +126,25 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         this._onDidChangeCandidates.dispose();
     }
 
-    private async _discoverCore(workspaceFolder: vscode.WorkspaceFolder, cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
+    private async _discoverCore(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
         try {
-            const appHosts = await this._discoverWithLs(workspaceFolder, cancellationToken);
+            const appHosts = await this._discoverWithLs(workspaceFolder);
             extensionLogOutputChannel.info(`Discovered ${appHosts.length} AppHost candidate(s) via aspire ls`);
             return appHosts;
         }
         catch (error) {
             this._throwIfDisposed();
-            throwIfCancellationRequested(cancellationToken);
             extensionLogOutputChannel.warn(`aspire ls discovery failed, falling back to aspire extension get-apphosts: ${formatErrorMessage(error)}`);
             try {
-                const appHosts = await this._discoverWithLegacyGetAppHosts(workspaceFolder, cancellationToken);
+                const appHosts = await this._discoverWithLegacyGetAppHosts(workspaceFolder);
                 extensionLogOutputChannel.info(`Discovered ${appHosts.length} AppHost candidate(s) via aspire extension get-apphosts`);
                 return appHosts;
             }
             catch (fallbackError) {
                 this._throwIfDisposed();
-                throwIfCancellationRequested(cancellationToken);
                 let fileFallbackError: unknown;
                 try {
-                    const appHosts = await discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder, cancellationToken);
+                    const appHosts = await discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder);
                     if (appHosts.length > 0) {
                         extensionLogOutputChannel.warn(`CLI AppHost discovery failed; using ${appHosts.length} C# AppHost project candidate(s) found in the workspace.`);
                         return appHosts;
@@ -157,9 +162,8 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         }
     }
 
-    private async _discoverWithLs(workspaceFolder: vscode.WorkspaceFolder, cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
+    private async _discoverWithLs(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
         this._throwIfDisposed();
-        throwIfCancellationRequested(cancellationToken);
 
         const cliPath = await this._terminalProvider.getAspireCliExecutablePath();
         const args = ['ls', '--format', 'json'];
@@ -167,13 +171,12 @@ export class AppHostDiscoveryService implements vscode.Disposable {
             args.push('--cli-wait-for-debugger');
         }
 
-        const output = await this._runCliForStdout(cliPath, args, workspaceFolder.uri.fsPath, cancellationToken);
+        const output = await this._runCliForStdout(cliPath, args, workspaceFolder.uri.fsPath);
         return parseCandidateOutput(output, 'aspire ls');
     }
 
-    private async _discoverWithLegacyGetAppHosts(workspaceFolder: vscode.WorkspaceFolder, cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
+    private async _discoverWithLegacyGetAppHosts(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
         this._throwIfDisposed();
-        throwIfCancellationRequested(cancellationToken);
 
         const cliPath = await this._terminalProvider.getAspireCliExecutablePath();
         const args = ['extension', 'get-apphosts'];
@@ -181,7 +184,7 @@ export class AppHostDiscoveryService implements vscode.Disposable {
             args.push('--cli-wait-for-debugger');
         }
 
-        const output = await this._runCliForStdout(cliPath, args, workspaceFolder.uri.fsPath, cancellationToken);
+        const output = await this._runCliForStdout(cliPath, args, workspaceFolder.uri.fsPath);
         const parsed = parseLegacyGetAppHostsOutput(output);
         return toCandidatesFromLegacySearchResult(parsed);
     }
@@ -241,12 +244,12 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         }
     }
 
-    private async _includeConfiguredAppHostCandidate(workspaceFolder: vscode.WorkspaceFolder, candidates: CandidateAppHostDisplayInfo[], cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
+    private async _includeConfiguredAppHostCandidate(workspaceFolder: vscode.WorkspaceFolder, candidates: CandidateAppHostDisplayInfo[]): Promise<CandidateAppHostDisplayInfo[]> {
         if (candidates.some(candidate => candidate.selected)) {
             return candidates;
         }
 
-        const configuredPaths = await findConfiguredAppHostPaths(workspaceFolder, cancellationToken);
+        const configuredPaths = await findConfiguredAppHostPaths(workspaceFolder);
         const configuredPath = configuredPaths.find(configuredPath => candidates.some(candidate => isSamePath(candidate.path, configuredPath)))
             ?? configuredPaths[0];
         if (!configuredPath) {
@@ -272,17 +275,15 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         ];
     }
 
-    private _runCliForStdout(cliPath: string, args: string[], workingDirectory: string, cancellationToken?: vscode.CancellationToken): Promise<string> {
+    private _runCliForStdout(cliPath: string, args: string[], workingDirectory: string): Promise<string> {
         return new Promise((resolve, reject) => {
             this._throwIfDisposed();
-            throwIfCancellationRequested(cancellationToken);
 
             let stdout = '';
             let stderr = '';
             let settled = false;
             let childProcess: ChildProcessWithoutNullStreams | undefined;
             let timeout: ReturnType<typeof setTimeout> | undefined;
-            let cancellationDisposable: vscode.Disposable | undefined;
             const cancel = (error: Error) => {
                 if (childProcess && !childProcess.killed) {
                     try {
@@ -306,8 +307,6 @@ export class AppHostDiscoveryService implements vscode.Disposable {
                     this._activeCliProcesses.delete(childProcess);
                 }
                 this._cancelActiveCliProcesses.delete(cancel);
-                cancellationDisposable?.dispose();
-                cancellationDisposable = undefined;
             };
             const settle = (complete: () => void) => {
                 if (settled) {
@@ -320,13 +319,6 @@ export class AppHostDiscoveryService implements vscode.Disposable {
             };
 
             this._cancelActiveCliProcesses.add(cancel);
-            cancellationDisposable = cancellationToken?.onCancellationRequested(() => {
-                cancel(new Error('AppHost discovery was cancelled.'));
-            });
-            if (settled) {
-                return;
-            }
-
             try {
                 childProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
                     noExtensionVariables: true,
@@ -554,8 +546,8 @@ function parseCandidateOutput(output: string, commandName: string): CandidateApp
     throw new Error(`${commandName} returned an unexpected output shape.`);
 }
 
-async function discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder: vscode.WorkspaceFolder, cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
-    const projectUris = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, '**/*.csproj'), getAppHostDiscoveryExcludeGlob(), appHostDiscoveryFindFilesMaxResults, cancellationToken);
+async function discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
+    const projectUris = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, '**/*.csproj'), getAppHostDiscoveryExcludeGlob(), appHostDiscoveryFindFilesMaxResults);
     const candidates: CandidateAppHostDisplayInfo[] = [];
     for (const uri of projectUris.sort((left, right) => left.fsPath.localeCompare(right.fsPath))) {
         let projectContents: string;
@@ -622,6 +614,36 @@ function throwIfCancellationRequested(cancellationToken?: vscode.CancellationTok
     if (cancellationToken?.isCancellationRequested) {
         throw new Error('AppHost discovery was cancelled.');
     }
+}
+
+function withCancellation<T>(promise: Promise<T>, cancellationToken?: vscode.CancellationToken): Promise<T> {
+    if (!cancellationToken) {
+        return promise;
+    }
+
+    try {
+        throwIfCancellationRequested(cancellationToken);
+    }
+    catch (error) {
+        return Promise.reject(error);
+    }
+
+    return new Promise<T>((resolve, reject) => {
+        const disposable = cancellationToken.onCancellationRequested(() => {
+            disposable.dispose();
+            reject(new Error('AppHost discovery was cancelled.'));
+        });
+
+        promise.then(
+            value => {
+                disposable.dispose();
+                resolve(value);
+            },
+            error => {
+                disposable.dispose();
+                reject(error);
+            });
+    });
 }
 
 function isLegacyAppHostProjectSearchResult(obj: unknown): obj is LegacyAppHostProjectSearchResult {

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -69,7 +69,8 @@ export class AppHostDiscoveryService implements vscode.Disposable {
             // The cached discovery promise is shared across extension features. Keep caller
             // cancellation outside the cached operation so one cancelled refresh doesn't reject
             // unrelated callers that are awaiting the same workspace discovery.
-            const discoveryPromise = this._discoverCore(workspaceFolder);
+            const discoveryPromise = this._discoverCore(workspaceFolder)
+                .then(candidates => this._includeConfiguredAppHostCandidate(workspaceFolder, candidates));
             let cachedPromise: Promise<CandidateAppHostDisplayInfo[]>;
             cachedPromise = discoveryPromise.catch(error => {
                 if (this._cache.get(key) === cachedPromise) {
@@ -81,8 +82,7 @@ export class AppHostDiscoveryService implements vscode.Disposable {
             this._cache.set(key, resultPromise);
         }
 
-        const candidates = await withCancellation(resultPromise, cancellationToken);
-        return await this._includeConfiguredAppHostCandidate(workspaceFolder, candidates, cancellationToken);
+        return await withCancellation(resultPromise, cancellationToken);
     }
 
     async resolveDebugTarget(filePath: string, workspaceFolder?: vscode.WorkspaceFolder): Promise<string> {
@@ -246,14 +246,12 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         }
     }
 
-    private async _includeConfiguredAppHostCandidate(workspaceFolder: vscode.WorkspaceFolder, candidates: CandidateAppHostDisplayInfo[], cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
-        throwIfCancellationRequested(cancellationToken);
+    private async _includeConfiguredAppHostCandidate(workspaceFolder: vscode.WorkspaceFolder, candidates: CandidateAppHostDisplayInfo[]): Promise<CandidateAppHostDisplayInfo[]> {
         if (candidates.some(candidate => candidate.selected)) {
             return candidates;
         }
 
-        const configuredPaths = await findConfiguredAppHostPaths(workspaceFolder, cancellationToken);
-        throwIfCancellationRequested(cancellationToken);
+        const configuredPaths = await findConfiguredAppHostPaths(workspaceFolder);
         const configuredPath = configuredPaths.find(configuredPath => candidates.some(candidate => isSamePath(candidate.path, configuredPath)))
             ?? configuredPaths[0];
         if (!configuredPath) {

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -205,13 +205,14 @@ export class AppHostDiscoveryService implements vscode.Disposable {
                 clearTimeout(existingTimer);
             }
 
+            this._cache.delete(key);
+
             const timer = setTimeout(() => {
                 this._pendingInvalidationTimers.delete(key);
                 if (this._disposed) {
                     return;
                 }
 
-                this._cache.delete(key);
                 this._onDidChangeCandidates.fire(workspaceFolder);
             }, AppHostDiscoveryService._candidateChangeDebounceMs);
             this._pendingInvalidationTimers.set(key, timer);

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -8,6 +8,7 @@ import { aspireConfigFileName, getAppHostPathFromConfig, readJsonFile } from './
 import { EnvironmentVariables } from './environment';
 import { extensionLogOutputChannel } from './logging';
 import { getAppHostDiscoveryTimeoutMs } from './settings';
+import { appHostDiscoveryFindFilesMaxResults, getAppHostDiscoveryExcludeGlob, isExcludedDiscoveryUri } from './workspaceFileSearch';
 
 // Mirrors the `aspire ls --format json` candidate shape documented in
 // docs/specs/cli-output-formats.md. Older CLI fallback results are adapted into
@@ -37,12 +38,13 @@ interface LegacyAppHostProjectSearchResult {
     all_project_file_candidates: string[];
 }
 
-const discoveryExcludePattern = '{**/artifacts/**,**/[Bb]in/**,**/[Oo]bj/**,**/node_modules/**,**/.git/**,**/.vs/**,**/.vscode-test/**,**/.worktrees/**,**/.idea/**,**/.aspire/modules/**}';
-
 export class AppHostDiscoveryService implements vscode.Disposable {
+    private static readonly _candidateChangeDebounceMs = 250;
+
     private readonly _onDidChangeCandidates = new vscode.EventEmitter<vscode.WorkspaceFolder>();
     private readonly _cache = new Map<string, Promise<CandidateAppHostDisplayInfo[]>>();
     private readonly _watchers = new Map<string, vscode.Disposable[]>();
+    private readonly _pendingInvalidationTimers = new Map<string, ReturnType<typeof setTimeout>>();
     private readonly _activeCliProcesses = new Set<ChildProcessWithoutNullStreams>();
     private readonly _cancelActiveCliProcesses = new Set<(error: Error) => void>();
     private _disposed = false;
@@ -51,7 +53,7 @@ export class AppHostDiscoveryService implements vscode.Disposable {
     constructor(private readonly _terminalProvider: AspireTerminalProvider) {
     }
 
-    async discover(workspaceFolder: vscode.WorkspaceFolder, forceRefresh = false): Promise<CandidateAppHostDisplayInfo[]> {
+    async discover(workspaceFolder: vscode.WorkspaceFolder, forceRefresh = false, cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
         this._throwIfDisposed();
 
         const key = path.resolve(workspaceFolder.uri.fsPath);
@@ -63,8 +65,8 @@ export class AppHostDiscoveryService implements vscode.Disposable {
 
         let resultPromise = this._cache.get(key);
         if (!resultPromise) {
-            resultPromise = this._discoverCore(workspaceFolder)
-                .then(candidates => this._includeConfiguredAppHostCandidate(workspaceFolder, candidates))
+            resultPromise = this._discoverCore(workspaceFolder, cancellationToken)
+                .then(candidates => this._includeConfiguredAppHostCandidate(workspaceFolder, candidates, cancellationToken))
                 .catch(error => {
                     this._cache.delete(key);
                     throw error;
@@ -105,6 +107,10 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         }
         this._watchers.clear();
         this._cache.clear();
+        for (const timer of this._pendingInvalidationTimers.values()) {
+            clearTimeout(timer);
+        }
+        this._pendingInvalidationTimers.clear();
         for (const cancel of [...this._cancelActiveCliProcesses]) {
             cancel(new Error('AppHost discovery service was disposed.'));
         }
@@ -113,25 +119,27 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         this._onDidChangeCandidates.dispose();
     }
 
-    private async _discoverCore(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
+    private async _discoverCore(workspaceFolder: vscode.WorkspaceFolder, cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
         try {
-            const appHosts = await this._discoverWithLs(workspaceFolder);
+            const appHosts = await this._discoverWithLs(workspaceFolder, cancellationToken);
             extensionLogOutputChannel.info(`Discovered ${appHosts.length} AppHost candidate(s) via aspire ls`);
             return appHosts;
         }
         catch (error) {
             this._throwIfDisposed();
+            throwIfCancellationRequested(cancellationToken);
             extensionLogOutputChannel.warn(`aspire ls discovery failed, falling back to aspire extension get-apphosts: ${formatErrorMessage(error)}`);
             try {
-                const appHosts = await this._discoverWithLegacyGetAppHosts(workspaceFolder);
+                const appHosts = await this._discoverWithLegacyGetAppHosts(workspaceFolder, cancellationToken);
                 extensionLogOutputChannel.info(`Discovered ${appHosts.length} AppHost candidate(s) via aspire extension get-apphosts`);
                 return appHosts;
             }
             catch (fallbackError) {
                 this._throwIfDisposed();
+                throwIfCancellationRequested(cancellationToken);
                 let fileFallbackError: unknown;
                 try {
-                    const appHosts = await discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder);
+                    const appHosts = await discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder, cancellationToken);
                     if (appHosts.length > 0) {
                         extensionLogOutputChannel.warn(`CLI AppHost discovery failed; using ${appHosts.length} C# AppHost project candidate(s) found in the workspace.`);
                         return appHosts;
@@ -149,8 +157,9 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         }
     }
 
-    private async _discoverWithLs(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
+    private async _discoverWithLs(workspaceFolder: vscode.WorkspaceFolder, cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
         this._throwIfDisposed();
+        throwIfCancellationRequested(cancellationToken);
 
         const cliPath = await this._terminalProvider.getAspireCliExecutablePath();
         const args = ['ls', '--format', 'json'];
@@ -158,12 +167,13 @@ export class AppHostDiscoveryService implements vscode.Disposable {
             args.push('--cli-wait-for-debugger');
         }
 
-        const output = await this._runCliForStdout(cliPath, args, workspaceFolder.uri.fsPath);
+        const output = await this._runCliForStdout(cliPath, args, workspaceFolder.uri.fsPath, cancellationToken);
         return parseCandidateOutput(output, 'aspire ls');
     }
 
-    private async _discoverWithLegacyGetAppHosts(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
+    private async _discoverWithLegacyGetAppHosts(workspaceFolder: vscode.WorkspaceFolder, cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
         this._throwIfDisposed();
+        throwIfCancellationRequested(cancellationToken);
 
         const cliPath = await this._terminalProvider.getAspireCliExecutablePath();
         const args = ['extension', 'get-apphosts'];
@@ -171,7 +181,7 @@ export class AppHostDiscoveryService implements vscode.Disposable {
             args.push('--cli-wait-for-debugger');
         }
 
-        const output = await this._runCliForStdout(cliPath, args, workspaceFolder.uri.fsPath);
+        const output = await this._runCliForStdout(cliPath, args, workspaceFolder.uri.fsPath, cancellationToken);
         const parsed = parseLegacyGetAppHostsOutput(output);
         return toCandidatesFromLegacySearchResult(parsed);
     }
@@ -186,8 +196,21 @@ export class AppHostDiscoveryService implements vscode.Disposable {
                 return;
             }
 
-            this._cache.delete(key);
-            this._onDidChangeCandidates.fire(workspaceFolder);
+            const existingTimer = this._pendingInvalidationTimers.get(key);
+            if (existingTimer) {
+                clearTimeout(existingTimer);
+            }
+
+            const timer = setTimeout(() => {
+                this._pendingInvalidationTimers.delete(key);
+                if (this._disposed) {
+                    return;
+                }
+
+                this._cache.delete(key);
+                this._onDidChangeCandidates.fire(workspaceFolder);
+            }, AppHostDiscoveryService._candidateChangeDebounceMs);
+            this._pendingInvalidationTimers.set(key, timer);
         };
         const patterns = [
             '**/*.csproj',
@@ -218,12 +241,12 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         }
     }
 
-    private async _includeConfiguredAppHostCandidate(workspaceFolder: vscode.WorkspaceFolder, candidates: CandidateAppHostDisplayInfo[]): Promise<CandidateAppHostDisplayInfo[]> {
+    private async _includeConfiguredAppHostCandidate(workspaceFolder: vscode.WorkspaceFolder, candidates: CandidateAppHostDisplayInfo[], cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
         if (candidates.some(candidate => candidate.selected)) {
             return candidates;
         }
 
-        const configuredPaths = await findConfiguredAppHostPaths(workspaceFolder);
+        const configuredPaths = await findConfiguredAppHostPaths(workspaceFolder, cancellationToken);
         const configuredPath = configuredPaths.find(configuredPath => candidates.some(candidate => isSamePath(candidate.path, configuredPath)))
             ?? configuredPaths[0];
         if (!configuredPath) {
@@ -249,15 +272,17 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         ];
     }
 
-    private _runCliForStdout(cliPath: string, args: string[], workingDirectory: string): Promise<string> {
+    private _runCliForStdout(cliPath: string, args: string[], workingDirectory: string, cancellationToken?: vscode.CancellationToken): Promise<string> {
         return new Promise((resolve, reject) => {
             this._throwIfDisposed();
+            throwIfCancellationRequested(cancellationToken);
 
             let stdout = '';
             let stderr = '';
             let settled = false;
             let childProcess: ChildProcessWithoutNullStreams | undefined;
             let timeout: ReturnType<typeof setTimeout> | undefined;
+            let cancellationDisposable: vscode.Disposable | undefined;
             const cancel = (error: Error) => {
                 if (childProcess && !childProcess.killed) {
                     try {
@@ -281,6 +306,8 @@ export class AppHostDiscoveryService implements vscode.Disposable {
                     this._activeCliProcesses.delete(childProcess);
                 }
                 this._cancelActiveCliProcesses.delete(cancel);
+                cancellationDisposable?.dispose();
+                cancellationDisposable = undefined;
             };
             const settle = (complete: () => void) => {
                 if (settled) {
@@ -293,6 +320,13 @@ export class AppHostDiscoveryService implements vscode.Disposable {
             };
 
             this._cancelActiveCliProcesses.add(cancel);
+            cancellationDisposable = cancellationToken?.onCancellationRequested(() => {
+                cancel(new Error('AppHost discovery was cancelled.'));
+            });
+            if (settled) {
+                return;
+            }
+
             try {
                 childProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
                     noExtensionVariables: true,
@@ -425,13 +459,14 @@ export async function selectWorkspaceAppHostPath(workspaceFolder: vscode.Workspa
     return candidates.length === 1 ? candidates[0].path : undefined;
 }
 
-export async function findConfiguredAppHostPaths(workspaceFolder: vscode.WorkspaceFolder): Promise<string[]> {
+export async function findConfiguredAppHostPaths(workspaceFolder: vscode.WorkspaceFolder, cancellationToken?: vscode.CancellationToken): Promise<string[]> {
     let newConfigFiles: vscode.Uri[];
     let legacySettingsFiles: vscode.Uri[];
     try {
+        const excludePattern = getAppHostDiscoveryExcludeGlob();
         [newConfigFiles, legacySettingsFiles] = await Promise.all([
-            vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, `**/${aspireConfigFileName}`), discoveryExcludePattern),
-            vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, '**/.aspire/settings.json'), discoveryExcludePattern),
+            vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, `**/${aspireConfigFileName}`), excludePattern, appHostDiscoveryFindFilesMaxResults, cancellationToken),
+            vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, '**/.aspire/settings.json'), excludePattern, appHostDiscoveryFindFilesMaxResults, cancellationToken),
         ]);
     }
     catch (error) {
@@ -459,28 +494,6 @@ export async function findConfiguredAppHostPaths(workspaceFolder: vscode.Workspa
     }
 
     return configuredPaths;
-}
-
-function isExcludedDiscoveryUri(workspaceFolder: vscode.WorkspaceFolder, uri: vscode.Uri): boolean {
-    const relativePath = path.relative(workspaceFolder.uri.fsPath, uri.fsPath);
-    if (relativePath === '' || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
-        return true;
-    }
-
-    const segments = relativePath.split(/[\\/]+/);
-    return segments.some((segment, index) => {
-        const lowerSegment = segment.toLowerCase();
-        return lowerSegment === 'artifacts'
-            || lowerSegment === 'bin'
-            || lowerSegment === 'obj'
-            || lowerSegment === 'node_modules'
-            || lowerSegment === '.git'
-            || lowerSegment === '.vs'
-            || lowerSegment === '.vscode-test'
-            || lowerSegment === '.worktrees'
-            || lowerSegment === '.idea'
-            || (lowerSegment === '.aspire' && segments[index + 1]?.toLowerCase() === 'modules');
-    });
 }
 
 function toAppHostCandidate(workspaceFolder: vscode.WorkspaceFolder, candidate: CandidateAppHostDisplayInfo): AppHostCandidate {
@@ -541,8 +554,8 @@ function parseCandidateOutput(output: string, commandName: string): CandidateApp
     throw new Error(`${commandName} returned an unexpected output shape.`);
 }
 
-async function discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
-    const projectUris = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, '**/*.csproj'), discoveryExcludePattern);
+async function discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder: vscode.WorkspaceFolder, cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
+    const projectUris = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, '**/*.csproj'), getAppHostDiscoveryExcludeGlob(), appHostDiscoveryFindFilesMaxResults, cancellationToken);
     const candidates: CandidateAppHostDisplayInfo[] = [];
     for (const uri of projectUris.sort((left, right) => left.fsPath.localeCompare(right.fsPath))) {
         let projectContents: string;
@@ -603,6 +616,12 @@ function isLsCandidate(obj: unknown): obj is CandidateAppHostDisplayInfo {
 
 function formatErrorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
+}
+
+function throwIfCancellationRequested(cancellationToken?: vscode.CancellationToken): void {
+    if (cancellationToken?.isCancellationRequested) {
+        throw new Error('AppHost discovery was cancelled.');
+    }
 }
 
 function isLegacyAppHostProjectSearchResult(obj: unknown): obj is LegacyAppHostProjectSearchResult {

--- a/extension/src/utils/workspace.ts
+++ b/extension/src/utils/workspace.ts
@@ -6,50 +6,9 @@ import { extensionLogOutputChannel } from './logging';
 import { resolveCliPath } from './cliPath';
 import { AppHostDiscoveryService, AppHostProjectSearchResult, formatAppHostLanguage, getWorkspaceAppHostProjectSearchResult } from './appHostDiscovery';
 import type { AppHostCandidate } from './appHostDiscovery';
+import { getCommonExcludeGlob } from './workspaceFileSearch';
 
-/**
- * Common file patterns to exclude from workspace file searches.
- * These patterns match typical build outputs, dependencies, and generated files
- * that should not be searched when looking for Aspire configuration files.
- */
-const commonExcludePatterns = [
-    // Build outputs
-    '**/artifacts/**',
-    '**/[Bb]in/**',
-    '**/[Oo]bj/**',
-    '**/[Dd]ebug/**',
-    '**/[Rr]elease/**',
-    '**/dist/**',
-    '**/out/**',
-    '**/build/**',
-    '**/target/**',
-    '**/publish/**',
-
-    // Dependencies
-    '**/node_modules/**',
-    '**/.venv/**',
-    '**/packages/**',
-
-    // IDE/Tool directories
-    '**/.vs/**',
-    '**/.vscode-test/**',
-    '**/.worktrees/**',
-    '**/.idea/**',
-    '**/.git/**',
-
-    // Generated/Cache
-    '**/.angular/**',
-    '**/.aspire/modules/**',
-    '**/.azurite/**',
-];
-
-/**
- * Returns a glob pattern suitable for use as an exclude pattern in vscode.workspace.findFiles.
- * This excludes common build outputs, dependencies, and generated directories.
- */
-export function getCommonExcludeGlob(): string {
-    return `{${commonExcludePatterns.join(',')}}`;
-}
+export { getCommonExcludeGlob } from './workspaceFileSearch';
 
 /**
  * Searches for Aspire configuration files in the workspace, excluding common build output

--- a/extension/src/utils/workspaceFileSearch.ts
+++ b/extension/src/utils/workspaceFileSearch.ts
@@ -90,9 +90,16 @@ function getEnabledWorkspaceExcludePatterns(): string[] {
 function getEnabledExcludePatterns(excludes: Record<string, unknown>): string[] {
     return Object.entries(excludes)
         .filter(([, value]) => isExcludeEnabled(value))
+        // VS Code's glob parser doesn't support nested brace expressions. Since we combine
+        // patterns into one outer brace group, skip user patterns that would split it incorrectly.
+        .filter(([pattern]) => canComposeIntoBraceGlob(pattern))
         .map(([pattern]) => pattern);
 }
 
 function isExcludeEnabled(value: unknown): boolean {
     return value === true;
+}
+
+function canComposeIntoBraceGlob(pattern: string): boolean {
+    return !/[{},]/.test(pattern);
 }

--- a/extension/src/utils/workspaceFileSearch.ts
+++ b/extension/src/utils/workspaceFileSearch.ts
@@ -1,0 +1,98 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export const appHostDiscoveryFindFilesMaxResults = 512;
+
+interface SegmentExcludeRule {
+    readonly glob: string;
+    readonly segments: readonly string[];
+}
+
+const commonExcludePatterns = [
+    '**/artifacts/**',
+    '**/[Bb]in/**',
+    '**/[Oo]bj/**',
+    '**/[Dd]ebug/**',
+    '**/[Rr]elease/**',
+    '**/dist/**',
+    '**/out/**',
+    '**/build/**',
+    '**/target/**',
+    '**/publish/**',
+    '**/node_modules/**',
+    '**/.venv/**',
+    '**/packages/**',
+    '**/.vs/**',
+    '**/.vscode-test/**',
+    '**/.worktrees/**',
+    '**/.claude/**',
+    '**/.idea/**',
+    '**/.git/**',
+    '**/.angular/**',
+    '**/.aspire/modules/**',
+    '**/.azurite/**',
+];
+
+const appHostDiscoveryExcludeRules: readonly SegmentExcludeRule[] = [
+    { glob: '**/artifacts/**', segments: ['artifacts'] },
+    { glob: '**/[Bb]in/**', segments: ['bin'] },
+    { glob: '**/[Oo]bj/**', segments: ['obj'] },
+    { glob: '**/node_modules/**', segments: ['node_modules'] },
+    { glob: '**/.git/**', segments: ['.git'] },
+    { glob: '**/.vs/**', segments: ['.vs'] },
+    { glob: '**/.vscode-test/**', segments: ['.vscode-test'] },
+    { glob: '**/.worktrees/**', segments: ['.worktrees'] },
+    // Coding agents commonly store full git worktrees under .claude/worktrees. Treat the
+    // whole tool directory as generated workspace state so discovery doesn't recurse into
+    // dozens of nested repo copies and spawn a storm of file-search processes.
+    { glob: '**/.claude/**', segments: ['.claude'] },
+    { glob: '**/.idea/**', segments: ['.idea'] },
+    { glob: '**/.aspire/modules/**', segments: ['.aspire', 'modules'] },
+];
+
+export function getCommonExcludeGlob(): string {
+    return toBraceGlob(commonExcludePatterns);
+}
+
+export function getAppHostDiscoveryExcludeGlob(): string {
+    return toBraceGlob([
+        ...appHostDiscoveryExcludeRules.map(rule => rule.glob),
+        ...getEnabledWorkspaceExcludePatterns(),
+    ]);
+}
+
+export function isExcludedDiscoveryUri(workspaceFolder: vscode.WorkspaceFolder, uri: vscode.Uri): boolean {
+    const relativePath = path.relative(workspaceFolder.uri.fsPath, uri.fsPath);
+    if (relativePath === '' || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+        return true;
+    }
+
+    const segments = relativePath.split(/[\\/]+/).map(segment => segment.toLowerCase());
+    return appHostDiscoveryExcludeRules.some(rule => containsSegments(segments, rule.segments));
+}
+
+function toBraceGlob(patterns: readonly string[]): string {
+    return `{${patterns.join(',')}}`;
+}
+
+function containsSegments(pathSegments: readonly string[], ruleSegments: readonly string[]): boolean {
+    const normalizedRuleSegments = ruleSegments.map(segment => segment.toLowerCase());
+    return pathSegments.some((_, index) => normalizedRuleSegments.every((segment, ruleIndex) => pathSegments[index + ruleIndex] === segment));
+}
+
+function getEnabledWorkspaceExcludePatterns(): string[] {
+    return [
+        ...getEnabledExcludePatterns(vscode.workspace.getConfiguration('files').get<Record<string, unknown>>('exclude', {})),
+        ...getEnabledExcludePatterns(vscode.workspace.getConfiguration('search').get<Record<string, unknown>>('exclude', {})),
+    ];
+}
+
+function getEnabledExcludePatterns(excludes: Record<string, unknown>): string[] {
+    return Object.entries(excludes)
+        .filter(([, value]) => isExcludeEnabled(value))
+        .map(([pattern]) => pattern);
+}
+
+function isExcludeEnabled(value: unknown): boolean {
+    return value === true;
+}

--- a/extension/src/utils/workspaceFileSearch.ts
+++ b/extension/src/utils/workspaceFileSearch.ts
@@ -145,6 +145,15 @@ function safeGlobToRegExp(pattern: string): RegExp {
                 expression += '[^/]*';
                 i++;
             }
+        } else if (char === '[') {
+            const closingBracketIndex = pattern.indexOf(']', i + 1);
+            if (closingBracketIndex > i + 1) {
+                expression += toRegexCharacterClass(pattern.substring(i + 1, closingBracketIndex));
+                i = closingBracketIndex + 1;
+            } else {
+                expression += escapeRegExp(char);
+                i++;
+            }
         } else if (char === '?') {
             expression += '[^/]';
             i++;
@@ -159,4 +168,11 @@ function safeGlobToRegExp(pattern: string): RegExp {
 
 function escapeRegExp(value: string): string {
     return value.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+}
+
+function toRegexCharacterClass(value: string): string {
+    const negated = value[0] === '!' || value[0] === '^';
+    const content = negated ? value.substring(1) : value;
+    const escapedContent = content.replace(/\\/g, '\\\\').replace(/\]/g, '\\]');
+    return `[${negated ? '^' : ''}${escapedContent}]`;
 }

--- a/extension/src/utils/workspaceFileSearch.ts
+++ b/extension/src/utils/workspaceFileSearch.ts
@@ -68,7 +68,12 @@ export function isExcludedDiscoveryUri(workspaceFolder: vscode.WorkspaceFolder, 
     }
 
     const segments = relativePath.split(/[\\/]+/).map(segment => segment.toLowerCase());
-    return appHostDiscoveryExcludeRules.some(rule => containsSegments(segments, rule.segments));
+    if (appHostDiscoveryExcludeRules.some(rule => containsSegments(segments, rule.segments))) {
+        return true;
+    }
+
+    const normalizedRelativePath = relativePath.replace(/\\/g, '/');
+    return getEnabledWorkspaceExcludePatterns().some(pattern => matchesSafeWorkspaceExcludePattern(normalizedRelativePath, pattern));
 }
 
 function toBraceGlob(patterns: readonly string[]): string {
@@ -102,4 +107,56 @@ function isExcludeEnabled(value: unknown): boolean {
 
 function canComposeIntoBraceGlob(pattern: string): boolean {
     return !/[{},]/.test(pattern);
+}
+
+function matchesSafeWorkspaceExcludePattern(relativePath: string, pattern: string): boolean {
+    // User excludes come from VS Code settings, for example:
+    //   "**/private-checkouts/**": true
+    //   "**/private-checkouts": true
+    // The second form excludes the directory in VS Code, so watcher events under that
+    // directory need to match against ancestor paths too.
+    const regex = safeGlobToRegExp(pattern.replace(/\\/g, '/'));
+    return getPathAndAncestorPaths(relativePath).some(candidate => regex.test(candidate));
+}
+
+function getPathAndAncestorPaths(relativePath: string): string[] {
+    const candidates = [relativePath];
+    for (let slashIndex = relativePath.lastIndexOf('/'); slashIndex > 0; slashIndex = relativePath.lastIndexOf('/', slashIndex - 1)) {
+        candidates.push(relativePath.substring(0, slashIndex));
+    }
+
+    return candidates;
+}
+
+function safeGlobToRegExp(pattern: string): RegExp {
+    let expression = '^';
+    for (let i = 0; i < pattern.length;) {
+        const char = pattern[i];
+        if (char === '*') {
+            if (pattern[i + 1] === '*') {
+                if (pattern[i + 2] === '/') {
+                    expression += '(?:.*/)?';
+                    i += 3;
+                } else {
+                    expression += '.*';
+                    i += 2;
+                }
+            } else {
+                expression += '[^/]*';
+                i++;
+            }
+        } else if (char === '?') {
+            expression += '[^/]';
+            i++;
+        } else {
+            expression += escapeRegExp(char);
+            i++;
+        }
+    }
+
+    return new RegExp(`${expression}$`);
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
 }

--- a/extension/src/utils/workspaceFileSearch.ts
+++ b/extension/src/utils/workspaceFileSearch.ts
@@ -116,6 +116,10 @@ function matchesSafeWorkspaceExcludePattern(relativePath: string, pattern: strin
     // The second form excludes the directory in VS Code, so watcher events under that
     // directory need to match against ancestor paths too.
     const regex = safeGlobToRegExp(pattern.replace(/\\/g, '/'));
+    if (regex === null) {
+        return false;
+    }
+
     return getPathAndAncestorPaths(relativePath).some(candidate => regex.test(candidate));
 }
 
@@ -128,7 +132,7 @@ function getPathAndAncestorPaths(relativePath: string): string[] {
     return candidates;
 }
 
-function safeGlobToRegExp(pattern: string): RegExp {
+function safeGlobToRegExp(pattern: string): RegExp | null {
     let expression = '^';
     for (let i = 0; i < pattern.length;) {
         const char = pattern[i];
@@ -163,7 +167,15 @@ function safeGlobToRegExp(pattern: string): RegExp {
         }
     }
 
-    return new RegExp(`${expression}$`);
+    try {
+        return new RegExp(`${expression}$`);
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            return null;
+        }
+
+        throw error;
+    }
 }
 
 function escapeRegExp(value: string): string {
@@ -174,5 +186,5 @@ function toRegexCharacterClass(value: string): string {
     const negated = value[0] === '!' || value[0] === '^';
     const content = negated ? value.substring(1) : value;
     const escapedContent = content.replace(/\\/g, '\\\\').replace(/\]/g, '\\]');
-    return `[${negated ? '^' : ''}${escapedContent}]`;
+    return `[${negated ? '^/' : ''}${escapedContent}]`;
 }

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -178,6 +178,9 @@ export class AppHostDataRepository {
     private _workspaceAppHostDiscoveryComplete = false;
     private _workspaceAppHostDiscoveryUsesWorkspaceRoot = false;
     private _workspaceAppHostDiscoveryVersion = 0;
+    private _workspaceAppHostDiscoveryInProgress = false;
+    private _workspaceAppHostDiscoveryRefreshQueued = false;
+    private _workspaceAppHostDiscoveryCancellationSource: vscode.CancellationTokenSource | undefined;
     private readonly _appHostDiscoveryChangeDisposable: vscode.Disposable;
     private readonly _workspaceFoldersChangeDisposable: vscode.Disposable;
     private readonly _appHostDiscoveryService: AppHostDiscoveryService;
@@ -348,6 +351,7 @@ export class AppHostDataRepository {
         this._stopPolling();
         this._stopDescribeWatch();
         this._stopAllGlobalDescribes();
+        this._cancelWorkspaceAppHostDiscovery();
         this._configChangeDisposable.dispose();
         this._appHostDiscoveryChangeDisposable.dispose();
         this._workspaceFoldersChangeDisposable.dispose();
@@ -413,6 +417,14 @@ export class AppHostDataRepository {
     // ── Workspace app host (from aspire ls) ──
 
     private _fetchWorkspaceAppHost(options?: { forceRefresh?: boolean }): void {
+        if (this._workspaceAppHostDiscoveryInProgress) {
+            this._workspaceAppHostDiscoveryRefreshQueued = true;
+            if (options?.forceRefresh) {
+                this._workspaceAppHostDiscoveryCancellationSource?.cancel();
+            }
+            return;
+        }
+
         const discoveryVersion = ++this._workspaceAppHostDiscoveryVersion;
         const workspaceFolders = vscode.workspace.workspaceFolders;
         if (!workspaceFolders || workspaceFolders.length === 0) {
@@ -429,8 +441,12 @@ export class AppHostDataRepository {
 
         extensionLogOutputChannel.info('Fetching workspace apphost via shared AppHost discovery');
 
-        this._appHostDiscoveryService.discover(rootFolder, options?.forceRefresh).then(appHosts => {
-            if (!this._isCurrentWorkspaceDiscovery(discoveryVersion, rootFolder)) {
+        const cancellationSource = new vscode.CancellationTokenSource();
+        this._workspaceAppHostDiscoveryInProgress = true;
+        this._workspaceAppHostDiscoveryCancellationSource = cancellationSource;
+
+        this._appHostDiscoveryService.discover(rootFolder, options?.forceRefresh, cancellationSource.token).then(appHosts => {
+            if (cancellationSource.token.isCancellationRequested || !this._isCurrentWorkspaceDiscovery(discoveryVersion, rootFolder)) {
                 return;
             }
 
@@ -438,7 +454,7 @@ export class AppHostDataRepository {
             this._workspaceAppHostDiscoveryComplete = true;
             this._handleWorkspaceAppHostCandidates(result.app_host_candidates, result.selected_project_file);
         }).catch(error => {
-            if (!this._isCurrentWorkspaceDiscovery(discoveryVersion, rootFolder)) {
+            if (cancellationSource.token.isCancellationRequested || !this._isCurrentWorkspaceDiscovery(discoveryVersion, rootFolder)) {
                 return;
             }
 
@@ -449,7 +465,27 @@ export class AppHostDataRepository {
             this._setDescribeError(errorFetchingAppHosts(String(error)));
             this._updateWorkspaceContext({ clearLoading: true });
             this._syncPolling();
+        }).finally(() => {
+            cancellationSource.dispose();
+            if (this._workspaceAppHostDiscoveryCancellationSource !== cancellationSource) {
+                return;
+            }
+
+            this._workspaceAppHostDiscoveryCancellationSource = undefined;
+            this._workspaceAppHostDiscoveryInProgress = false;
+            if (this._workspaceAppHostDiscoveryRefreshQueued && !this._disposed) {
+                this._workspaceAppHostDiscoveryRefreshQueued = false;
+                this._fetchWorkspaceAppHost({ forceRefresh: true });
+            }
         });
+    }
+
+    private _cancelWorkspaceAppHostDiscovery(): void {
+        this._workspaceAppHostDiscoveryRefreshQueued = false;
+        this._workspaceAppHostDiscoveryCancellationSource?.cancel();
+        this._workspaceAppHostDiscoveryCancellationSource?.dispose();
+        this._workspaceAppHostDiscoveryCancellationSource = undefined;
+        this._workspaceAppHostDiscoveryInProgress = false;
     }
 
     private _handleWorkspaceAppHostCandidates(appHostCandidates: readonly AppHostCandidate[], selectedAppHostPath: string | null): void {

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -419,9 +419,6 @@ export class AppHostDataRepository {
     private _fetchWorkspaceAppHost(options?: { forceRefresh?: boolean }): void {
         if (this._workspaceAppHostDiscoveryInProgress) {
             this._workspaceAppHostDiscoveryRefreshQueued = true;
-            if (options?.forceRefresh) {
-                this._workspaceAppHostDiscoveryCancellationSource?.cancel();
-            }
             return;
         }
 

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -419,6 +419,9 @@ export class AppHostDataRepository {
     private _fetchWorkspaceAppHost(options?: { forceRefresh?: boolean }): void {
         if (this._workspaceAppHostDiscoveryInProgress) {
             this._workspaceAppHostDiscoveryRefreshQueued = true;
+            // Let the current discovery finish so we don't start overlapping CLI work, but
+            // prevent its now-stale result from briefly restoring old AppHost candidates.
+            this._workspaceAppHostDiscoveryVersion++;
             return;
         }
 


### PR DESCRIPTION
## Description

Fixes a few VS Code extension paths that could make the Aspire panel do too much AppHost discovery work, especially in workspaces with generated folders, nested worktrees, or fast file changes.

The main change is to make AppHost discovery less noisy and less stale:

- apply the same generated-folder excludes to discovery scans and discovery watcher events
- include enabled `files.exclude` / `search.exclude` patterns in AppHost discovery
- debounce discovery watcher invalidations so one file write burst does not fan out into repeated refreshes
- avoid overlapping workspace AppHost discovery runs, and ignore stale results from an older queued refresh
- keep caller cancellation from poisoning the shared discovery cache for unrelated callers
- cap AppHost config-file searches while leaving the final `.csproj` fallback uncapped so a large workspace does not hide the only AppHost

There are two smaller fixes in the same area:

- suppressed E2E terminal commands no longer create an integrated terminal just to record the command
- **Aspire: Update Aspire CLI** skips the shared CLI availability precheck, so the recovery command can still send `aspire update --self` when the current CLI path is missing or broken

### User-facing usage

Users should not need to change settings. Existing `files.exclude` and `search.exclude` entries now also help keep Aspire AppHost discovery out of ignored folders.

When the CLI install is broken, users can still run **Aspire: Update Aspire CLI** and the extension will send:

```bash
aspire update --self
```

## Validation

- `corepack yarn test` — 811 passing, 1 pending
- package-surface E2E shard — 7/7 passing

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
