### PR TITLE
Ignore hosted agent target port during deployment

### DIFF
--- a/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
@@ -319,6 +319,15 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
                 continue;
             }
 
+            if (IsHostedAgentTargetPortValue(value, hostedAgent))
+            {
+                // Endpoint target-port variables model how a local process or container binds. Foundry
+                // hosted agents own the container port contract during deployment, and their endpoint
+                // resolver intentionally does not support EndpointProperty.TargetPort.
+                logger.LogDebug("Environment variable '{Key}' for resource '{Name}' references the hosted agent target port and will be skipped.", key, resource.Name);
+                continue;
+            }
+
             switch (value)
             {
                 case null:
@@ -339,6 +348,26 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
             }
         }
         return resolvedEnvVars;
+    }
+
+    private static bool IsHostedAgentTargetPortValue(object? value, AzureHostedAgentResource hostedAgent)
+    {
+        return value switch
+        {
+            EndpointReferenceExpression endpointReferenceExpression => IsHostedAgentTargetPortExpression(endpointReferenceExpression, hostedAgent),
+            ReferenceExpression referenceExpression when referenceExpression.IsConditional =>
+                IsHostedAgentTargetPortValue(referenceExpression.Condition, hostedAgent) ||
+                IsHostedAgentTargetPortValue(referenceExpression.WhenTrue, hostedAgent) ||
+                IsHostedAgentTargetPortValue(referenceExpression.WhenFalse, hostedAgent),
+            ReferenceExpression referenceExpression => referenceExpression.ValueProviders.Any(valueProvider => IsHostedAgentTargetPortValue(valueProvider, hostedAgent)),
+            _ => false
+        };
+    }
+
+    private static bool IsHostedAgentTargetPortExpression(EndpointReferenceExpression endpointReferenceExpression, AzureHostedAgentResource hostedAgent)
+    {
+        return endpointReferenceExpression.Property == EndpointProperty.TargetPort &&
+            ReferenceEquals(endpointReferenceExpression.Endpoint.Resource, hostedAgent.Target);
     }
 
     private static async ValueTask<string?> ResolveValueProviderAsync(

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -402,6 +402,8 @@ public static class HostedAgentResourceBuilderExtensions
             throw new InvalidOperationException($"Unable to create hosted agent for resource '{resource.Name}' because it is not a container, executable, or project resource.");
         }
 
+        EnsureDefaultHostedAgentEndpoint(builder, target);
+
         if (target is ProjectResource projectTarget)
         {
             // Foundry hosted agents are containerized and the platform owns the listening port contract.
@@ -459,6 +461,19 @@ public static class HostedAgentResourceBuilderExtensions
 #pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         target.Annotations.Add(new ReferenceRoleAssignmentAnnotation(account, roles));
 #pragma warning restore ASPIREAZURE003
+    }
+
+    private static void EnsureDefaultHostedAgentEndpoint<T>(IResourceBuilder<T> builder, IResourceWithEnvironment target)
+        where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
+    {
+        if (target is not IResourceWithEndpoints targetWithEndpoints ||
+            targetWithEndpoints.Annotations.OfType<EndpointAnnotation>().Any(e => string.Equals(e.Name, "http", StringComparisons.EndpointAnnotationName)))
+        {
+            return;
+        }
+
+        builder.ApplicationBuilder.CreateResourceBuilder(targetWithEndpoints)
+            .WithHttpEndpoint(name: "http", isProxied: true);
     }
 
     private sealed class HostedAgentRunProtocol

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -402,6 +402,16 @@ public static class HostedAgentResourceBuilderExtensions
             throw new InvalidOperationException($"Unable to create hosted agent for resource '{resource.Name}' because it is not a container, executable, or project resource.");
         }
 
+        if (target is ProjectResource projectTarget)
+        {
+            // Foundry hosted agents are containerized and the platform owns the listening port contract.
+            // Keep the user's local endpoint metadata intact, but do not emit project endpoint variables
+            // such as ASPNETCORE_URLS/HTTP_PORTS because they require EndpointProperty.TargetPort, which
+            // Foundry hosted-agent deployment endpoints intentionally do not support.
+            builder.ApplicationBuilder.CreateResourceBuilder(projectTarget)
+                .WithEndpointsInEnvironment(_ => false);
+        }
+
         // The hosted agent wrapper is not the deployed workload. Apply the Foundry
         // reference to the target so its connection annotations flow into the deployment.
         builder.ApplicationBuilder.CreateResourceBuilder(target)

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -132,14 +132,14 @@ public class AzureContainerAppsTests
             .AddProject("project");
 
         // The agent app is deployed to the Foundry project compute environment via AsHostedAgent.
-        var agent = builder.AddProject<Project>("agent", launchProfileName: null)
-            .WithHttpEndpoint()
-            .WithExternalHttpEndpoints();
+        var agent = builder.AddProject<Project>("agent", launchProfileName: null);
         agent.AsHostedAgent(project);
 
         // The web app is deployed to Azure Container Apps and references the Foundry hosted agent.
         // The ACA publisher must delegate endpoint resolution to the Foundry compute environment
         // rather than looking the agent up in its own endpoint map. See issue #17749.
+        // AsHostedAgent supplies the logical "http" endpoint in publish mode when the target app
+        // does not declare one itself. See issue #17904.
         // WithReference(agent) exercises the bare EndpointReference branch; the explicit
         // Property(Url) environment variable exercises the EndpointReferenceExpression branch.
         var web = builder.AddProject<Project>("web", launchProfileName: null)

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -238,7 +238,7 @@ public class HostedAgentExtensionTests
             .AddProject("my-project");
 
         builder.AddProject<Project>("agent", launchProfileName: null)
-            .WithHttpEndpoint(targetPort: 9000)
+            .WithHttpEndpoint(targetPort: 9000, env: "DEFAULT_AD_PORT")
             .AsHostedAgent(project);
 
         using var app = builder.Build();
@@ -257,6 +257,7 @@ public class HostedAgentExtensionTests
         Assert.DoesNotContain("ASPNETCORE_URLS", envVars.Keys);
         Assert.DoesNotContain("HTTP_PORTS", envVars.Keys);
         Assert.DoesNotContain("HTTPS_PORTS", envVars.Keys);
+        Assert.DoesNotContain("DEFAULT_AD_PORT", envVars.Keys);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -231,6 +231,35 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
+    public async Task AsHostedAgent_InPublishMode_IgnoresProjectEndpointTargetPortEnvironment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        builder.AddProject<Project>("agent", launchProfileName: null)
+            .WithHttpEndpoint(targetPort: 9000)
+            .AsHostedAgent(project);
+
+        using var app = builder.Build();
+        var hostedAgent = Assert.Single(builder.Resources.OfType<AzureHostedAgentResource>());
+        var endpoint = Assert.Single(hostedAgent.Target.Annotations.OfType<EndpointAnnotation>());
+        SetFoundryProjectOutputs(project.Resource);
+
+        var envVars = await AzureHostedAgentResource.GetResolvedEnvironmentVariablesAsync(
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
+            hostedAgent,
+            hostedAgent.Target,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        Assert.Equal(9000, endpoint.TargetPort);
+        Assert.DoesNotContain("ASPNETCORE_URLS", envVars.Keys);
+        Assert.DoesNotContain("HTTP_PORTS", envVars.Keys);
+        Assert.DoesNotContain("HTTPS_PORTS", envVars.Keys);
+    }
+
+    [Fact]
     public void AsHostedAgent_WithOptions_AppliesAllPropertiesToConfiguration()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
@@ -447,6 +476,13 @@ public class HostedAgentExtensionTests
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]
     private static extern Task ExecuteBeforeStartHooksAsync(DistributedApplication app, CancellationToken cancellationToken);
+
+    private static void SetFoundryProjectOutputs(AzureCognitiveServicesProjectResource project)
+    {
+        project.Outputs["endpoint"] = "https://account.services.ai.azure.com/api/projects/my-project";
+        project.Outputs["APPLICATION_INSIGHTS_CONNECTION_STRING"] = "";
+        project.ProvisioningTaskCompletionSource?.TrySetResult();
+    }
 
     [Fact]
     public void AsHostedAgent_StampsReferenceRoleAssignmentAnnotationOnTarget_WithAzureAIUserRole()

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -231,6 +231,26 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
+    public void AsHostedAgent_InPublishMode_AddsDefaultHttpEndpointWhenMissing()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        builder.AddProject<Project>("agent", launchProfileName: null)
+            .AsHostedAgent(project);
+
+        builder.Build();
+
+        var hostedAgent = Assert.Single(builder.Resources.OfType<AzureHostedAgentResource>());
+        var endpoint = Assert.Single(hostedAgent.Target.Annotations.OfType<EndpointAnnotation>());
+
+        Assert.Equal("http", endpoint.Name);
+        Assert.Equal("http", endpoint.UriScheme);
+        Assert.Null(endpoint.TargetPort);
+    }
+
+    [Fact]
     public async Task AsHostedAgent_InPublishMode_IgnoresProjectEndpointTargetPortEnvironment()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);


### PR DESCRIPTION
## Description

Foundry hosted agents can use an explicit `targetPort` for local development, but Foundry deployment endpoints only support `Url` and `Scheme`. When a project was configured with `.WithHttpEndpoint(targetPort: ...)` before `.AsHostedAgent(project)`, the publish path tried to emit project endpoint environment variables such as `ASPNETCORE_URLS` and `HTTP_PORTS`, which forced deployment endpoint resolution for unsupported `TargetPort` metadata.

This keeps the local endpoint metadata intact, while disabling project endpoint environment injection for project resources that are converted to Foundry hosted-agent deployment targets. The hosted agent remains containerized for deployment, and Foundry owns the listening port contract there.

### User-facing usage

Existing AppHost code like this can keep using an explicit local target port without causing hosted-agent deployment endpoint resolution to fail:

```csharp
builder.AddProject<Projects.DotNetHostedAgent>("proj-dotnet-hosted-agent")
    .WithHttpEndpoint(targetPort: 9000)
    .WithReference(chat).WaitFor(chat)
    .AsHostedAgent(project);
```

Fixes #17803

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No