### PR TITLE
Fix release npm validation artifact downloads

### DIFF
--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -355,17 +355,44 @@ extends:
                     **/microsoft-aspire-cli*.tgz
                     **/microsoft-aspire-cli*.tgz.sig
 
-                - download: aspire-build
+                - task: DownloadBuildArtifacts@1
                   displayName: 'Download npm validation summary from Source Build (win-x64)'
-                  artifact: $(NPM_VALIDATION_SUMMARY_WIN_X64_ARTIFACT)
+                  inputs:
+                    buildType: specific
+                    project: internal
+                    pipeline: microsoft-aspire
+                    buildVersionToDownload: specific
+                    buildId: $(resources.pipeline.aspire-build.runID)
+                    downloadType: single
+                    artifactName: $(NPM_VALIDATION_SUMMARY_WIN_X64_ARTIFACT)
+                    downloadPath: '$(Pipeline.Workspace)/aspire-build'
+                    checkDownloadedFiles: true
 
-                - download: aspire-build
+                - task: DownloadBuildArtifacts@1
                   displayName: 'Download npm validation summary from Source Build (linux-x64)'
-                  artifact: $(NPM_VALIDATION_SUMMARY_LINUX_X64_ARTIFACT)
+                  inputs:
+                    buildType: specific
+                    project: internal
+                    pipeline: microsoft-aspire
+                    buildVersionToDownload: specific
+                    buildId: $(resources.pipeline.aspire-build.runID)
+                    downloadType: single
+                    artifactName: $(NPM_VALIDATION_SUMMARY_LINUX_X64_ARTIFACT)
+                    downloadPath: '$(Pipeline.Workspace)/aspire-build'
+                    checkDownloadedFiles: true
 
-                - download: aspire-build
+                - task: DownloadBuildArtifacts@1
                   displayName: 'Download npm validation summary from Source Build (macOS)'
-                  artifact: $(NPM_VALIDATION_SUMMARY_OSX_ARTIFACT)
+                  inputs:
+                    buildType: specific
+                    project: internal
+                    pipeline: microsoft-aspire
+                    buildVersionToDownload: specific
+                    buildId: $(resources.pipeline.aspire-build.runID)
+                    downloadType: single
+                    artifactName: $(NPM_VALIDATION_SUMMARY_OSX_ARTIFACT)
+                    downloadPath: '$(Pipeline.Workspace)/aspire-build'
+                    checkDownloadedFiles: true
 
               - ${{ if eq(parameters.SkipWinGetPublish, false) }}:
                 - download: aspire-build

--- a/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
@@ -196,9 +196,13 @@ public sealed class NpmCliPackageTests
         Assert.DoesNotContain("artifact: npm-validation-summary-win-x64", releasePipeline);
         Assert.DoesNotContain("artifact: npm-validation-summary-linux-x64", releasePipeline);
         Assert.DoesNotContain("artifact: npm-validation-summary-osx", releasePipeline);
-        Assert.Contains("$(NPM_VALIDATION_SUMMARY_WIN_X64_ARTIFACT)", releasePipeline);
-        Assert.Contains("$(NPM_VALIDATION_SUMMARY_LINUX_X64_ARTIFACT)", releasePipeline);
-        Assert.Contains("$(NPM_VALIDATION_SUMMARY_OSX_ARTIFACT)", releasePipeline);
+        Assert.DoesNotContain("artifact: $(NPM_VALIDATION_SUMMARY", releasePipeline);
+        Assert.Equal(3, CountOccurrences(releasePipeline, "task: DownloadBuildArtifacts@1"));
+        Assert.Equal(3, CountOccurrences(releasePipeline, "buildId: $(resources.pipeline.aspire-build.runID)"));
+        Assert.Equal(3, CountOccurrences(releasePipeline, "downloadPath: '$(Pipeline.Workspace)/aspire-build'"));
+        Assert.Contains("artifactName: $(NPM_VALIDATION_SUMMARY_WIN_X64_ARTIFACT)", releasePipeline);
+        Assert.Contains("artifactName: $(NPM_VALIDATION_SUMMARY_LINUX_X64_ARTIFACT)", releasePipeline);
+        Assert.Contains("artifactName: $(NPM_VALIDATION_SUMMARY_OSX_ARTIFACT)", releasePipeline);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Fixes the release/13.4 NuGet release pipeline failure in the Prepare Artifacts stage.

The source build publishes the npm validation summaries as classic build/container artifacts via `1ES.PublishBuildArtifacts@1`, but the release pipeline used the `download: aspire-build` shorthand with variable artifact names. That resolved to the pipeline-artifact download path and failed while trying to parse container artifact metadata like `#/73727037/npm-validation-summary-win-x64` as a pipeline-artifact hash.

This changes those three npm validation summary downloads to explicit `DownloadBuildArtifacts@1` tasks against the selected `aspire-build` resource build, while keeping the downloaded layout under `$(Pipeline.Workspace)/aspire-build` for the existing prepare step.

Validation:
- `./restore.sh --disable-build-servers`
- `dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- --filter-method "*.NpmCliPackageTests.NpmInstallValidationJobsUseExplicitJobsSharedStepsTemplateAndCentralArtifactNames" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` failed before the YAML fix and passed after
- `git diff --check`
- `dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- --filter-class "*.NpmCliPackageTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
