### PR TITLE
Unblock WinGet Manifest job on locked-down 1ES agents; update manifest tags

### DIFF
--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -367,7 +367,6 @@ extends:
                 artifactVersion: $(aspireArtifactVersion)
                 channel: $(installerChannel)
                 archiveRoot: $(Pipeline.Workspace)/native-archives
-                skipUrlValidation: true
 
           - job: Homebrew
             displayName: Homebrew Cask

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -104,13 +104,6 @@ variables:
     - name: _Sign
       value: true
 
-  # Packages are published only on internal, non-PR builds on publishing branches.
-  # Feature branches and PR builds don't have Maestro default channels so archive
-  # URLs won't be valid. The branch set lives in common-variables.yml as
-  # _IsProductionBranch.
-  - name: _PackagesPublished
-    value: ${{ and(ne(variables['_RunAsPublic'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['_IsProductionBranch'], 'true')) }}
-
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -507,7 +500,6 @@ extends:
                 artifactVersion: $(aspireArtifactVersion)
                 channel: $(installerChannel)
                 archiveRoot: $(Pipeline.Workspace)/native-archives
-                skipUrlValidation: ${{ ne(variables['_PackagesPublished'], 'true') }}
 
           - job: Homebrew
             displayName: Homebrew Cask

--- a/eng/pipelines/common-variables.yml
+++ b/eng/pipelines/common-variables.yml
@@ -55,8 +55,6 @@ variables:
 
   # Single source of truth for "this build is on a branch where Aspire signs,
   # publishes archives to ci.dot.net, and submits to upstream installer
-  # repositories." Composed into _PackagesPublished (which adds non-PR/internal
-  # checks) and consumed directly by publish-winget.yml to guard upstream
-  # submission.
+  # repositories." Consumed by publish-winget.yml to guard upstream submission.
   - name: _IsProductionBranch
     value: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/')) }}

--- a/eng/pipelines/templates/prepare-winget-manifest.yml
+++ b/eng/pipelines/templates/prepare-winget-manifest.yml
@@ -10,11 +10,6 @@ parameters:
   - name: archiveRoot
     type: string
     default: ''
-  - name: skipUrlValidation
-    type: boolean
-    default: false
-  # runInstallTest is derived from skipUrlValidation (they are logical inverses).
-  # Callers should only set skipUrlValidation; install tests run when URLs are valid.
 
 steps:
   - pwsh: |
@@ -56,32 +51,31 @@ steps:
     displayName: 🟣Set version ${{ parameters.version }}
 
   - pwsh: |
-      $repoName = 'dotnet-public'
-      $repoUri = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json'
-
-      Write-Host "Ensuring PSResource repository '$repoName' is registered..."
-      $existingRepo = Get-PSResourceRepository -Name $repoName -ErrorAction SilentlyContinue
-      if ($null -eq $existingRepo) {
-        Register-PSResourceRepository -Name $repoName -Uri $repoUri -Trusted
+      # Probe-only: do not attempt to install/repair winget here. The 1ES `1es-windows-2022`
+      # pool blocks outbound access to cdn.winget.microsoft.com, so
+      # `Repair-WinGetPackageManager` fails with "An attempt was made to access a socket in a
+      # way forbidden by its access permissions. (cdn.winget.microsoft.com:443)".
+      #
+      # `prepare-manifest-artifact.ps1` only needs winget when ValidationMode is `Full`
+      # (install/uninstall round-trip) or `Offline` (best-effort `winget validate`); in
+      # Offline mode it tolerates winget being missing and still produces the manifest
+      # artifact. This pipeline hardcodes Offline (see the Prepare step below), so
+      # probing for a pre-installed winget on the image is sufficient and avoids the
+      # blocked CDN path entirely.
+      #
+      # Manifest validation is intentionally delegated to upstream microsoft/winget-pkgs
+      # CI; see eng/winget/README.md "Validation model" for what upstream checks.
+      $winget = Get-Command winget -ErrorAction SilentlyContinue
+      if ($winget) {
+        Write-Host "winget already on PATH at $($winget.Source):"
+        winget --version
       } else {
-        Write-Host "PSResource repository '$repoName' is already registered. Skipping registration."
+        Write-Host "##[warning]winget was not found on PATH. Offline validation will skip the winget validate step (see prepare-manifest-artifact.ps1)."
       }
-
-      Write-Host "Installing Microsoft.WinGet.Client from $repoName feed..."
-      Install-PSResource -Name Microsoft.WinGet.Client -Repository $repoName -TrustRepository
-      Write-Host "Microsoft.WinGet.Client installed. Listing installed version:"
-      Get-Module -ListAvailable Microsoft.WinGet.Client | Select-Object Name, Version | Format-Table
-
-      Write-Host "Installing WinGet..."
-      Repair-WinGetPackageManager -Latest -Force -AllUsers
-
-      Write-Host "winget installed:"
-      winget --version
-    displayName: 🟣Install winget CLI
+    displayName: 🟣Probe winget CLI
 
   - pwsh: |
       $ErrorActionPreference = 'Stop'
-      $validationMode = if ('${{ parameters.skipUrlValidation }}' -eq 'true') { 'Offline' } else { 'Full' }
 
       $args = @{
         Version = '$(CliVersion)'
@@ -89,7 +83,13 @@ steps:
         Channel = '${{ parameters.channel }}'
         TemplateDir = '$(Build.SourcesDirectory)/eng/winget/$(WinGetTemplateDir)'
         OutputPath = '$(Build.StagingDirectory)/winget-manifests'
-        ValidationMode = $validationMode
+        # Hardcoded Offline: Full mode requires winget.exe on the agent, which
+        # is not present on 1ES `1es-windows-2022` and cannot be installed
+        # (see the Probe step above). prepare-manifest-artifact.ps1 still accepts
+        # ValidationMode for local/dogfood callers running on a machine with
+        # winget installed. Manifest validation is delegated to upstream
+        # microsoft/winget-pkgs CI — see eng/winget/README.md "Validation model".
+        ValidationMode = 'Offline'
       }
 
       if (-not [string]::IsNullOrWhiteSpace('${{ parameters.archiveRoot }}')) {

--- a/eng/winget/README.md
+++ b/eng/winget/README.md
@@ -56,6 +56,47 @@ Where arch is `x64` or `arm64`.
 
 Publishing submits a PR to `microsoft/winget-pkgs` using `wingetcreate submit`.
 
+## Validation model
+
+Aspire CI relies on the upstream
+[`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs)
+validation pipeline for comprehensive manifest validation. That pipeline
+runs on every submitted PR (see the
+[validation failure guide](https://github.com/microsoft/winget-pkgs/blob/master/doc/ValidationFailureGuide.md))
+and checks:
+
+- **Schema validation** (what `winget validate --manifest` does) — missing
+  required fields, type errors, deprecated schema versions, directory
+  layout, regex constraints like `InstallerUrl ^https?://`.
+- **Binary scanning** of the actual installer through multiple antivirus
+  engines.
+- **URL accessibility + Microsoft Defender SmartScreen reputation** for every
+  `InstallerUrl`.
+- **SHA256 hash verification** — downloads the installer and compares it
+  to the manifest `InstallerSha256`.
+- **Install/uninstall round-trip** in a clean VM, including verification of
+  `AppsAndFeaturesEntries`.
+
+On the Aspire side, `prepare-manifest-artifact.ps1` runs `winget validate
+--manifest` opportunistically — whenever `winget.exe` is available on the
+agent — as a fast local schema check. That covers the GitHub Actions
+`windows-latest` runner used by
+`.github/workflows/prepare-installer-artifacts.yml` (winget is
+pre-installed there). It does **not** cover the official 1ES
+`1es-windows-2022` pool used by the release pipeline: winget is not
+pre-installed there and the agent cannot reach
+`cdn.winget.microsoft.com` to install it (see
+`eng/pipelines/templates/prepare-winget-manifest.yml`), so on that pool
+the script skips local validate and the upstream-CI checks are the only
+ones that run. No Aspire pipeline runs the install/uninstall round-trip
+on the build agent; that is delegated to upstream CI on every submission.
+
+Other Microsoft repos publishing to WinGet (`microsoft/PowerToys`,
+`microsoft/terminal`, `microsoft/winget-create`) follow the same pattern
+of relying on upstream CI for the install/uninstall round-trip.
+
+## Local dogfood
+
 To dogfood a GitHub Actions artifact locally, download the `winget-manifests-prerelease`
 artifact and the `cli-native-archives-win-*` artifacts into the same parent directory, then run:
 

--- a/eng/winget/README.md
+++ b/eng/winget/README.md
@@ -88,8 +88,17 @@ pre-installed there and the agent cannot reach
 `cdn.winget.microsoft.com` to install it (see
 `eng/pipelines/templates/prepare-winget-manifest.yml`), so on that pool
 the script skips local validate and the upstream-CI checks are the only
-ones that run. No Aspire pipeline runs the install/uninstall round-trip
-on the build agent; that is delegated to upstream CI on every submission.
+ones that run.
+
+The same `.github/workflows/prepare-installer-artifacts.yml` job goes a
+step further on every PR: after generating the manifest it runs
+`eng/winget/dogfood.ps1 -Force` (real `winget install --manifest` from
+the freshly built archive) and a smoke test (`aspire new` + restore)
+against the installed shim. That catches manifest issues `winget
+validate` does not — installer SHA mismatches, broken `InstallerSwitches`,
+missing `Commands`. It does not exercise uninstall, so the full
+install/uninstall round-trip stays delegated to upstream CI on every
+submission.
 
 Other Microsoft repos publishing to WinGet (`microsoft/PowerToys`,
 `microsoft/terminal`, `microsoft/winget-create`) follow the same pattern

--- a/eng/winget/microsoft.aspire/Aspire.locale.en-US.yaml.template
+++ b/eng/winget/microsoft.aspire/Aspire.locale.en-US.yaml.template
@@ -19,7 +19,8 @@ Description: >
   Aspire applications. It provides commands for project scaffolding, local development,
   and deployment of cloud-native distributed applications.
 Tags:
-- dotnet
+- csharp
+- typescript
 - aspire
 - cloud-native
 - distributed-systems


### PR DESCRIPTION
Ports the `release/13.4` WinGet manifest fixes (#17860, #17863) to `main` so the next time the WinGet Manifest job runs from a `main`-derived branch the same fixes are in place.

## 1. Unblock WinGet Manifest job on locked-down 1ES agents (from #17860)

The `🟣Install winget CLI` step on the WinGet Manifest job was failing on the 1ES `1es-windows-2022` pool with:

```
An attempt was made to access a socket in a way forbidden by its access permissions. (cdn.winget.microsoft.com:443)
```

The step ran `Repair-WinGetPackageManager -Latest -Force -AllUsers` to (re)install the winget CLI, which downloads the Microsoft.DesktopAppInstaller MSIX from `cdn.winget.microsoft.com`. That CDN is not reachable from the locked-down 1ES pool, so the PowerShell step exits 1, `🟣Prepare WinGet manifests` is skipped, and `🔒 🟣Publish WinGet manifests` then fails because the manifest directory was never produced. The whole job aborted before any manifests reached the artifact share. This is the failure on `release/13.4` builds 2989641, 2989822, 2990382, 2990509, 2990688.

**Fix:** Replace the install/repair step with a probe-only step that records whether winget happens to be pre-installed on the image, and hardcode the downstream `prepare-manifest-artifact.ps1` call to `Offline` `ValidationMode`. The script tolerates a missing winget in `Offline` mode (logs a warning, still produces the manifest artifact) but hard-fails in `Full` mode — and `Full` mode is unreachable on this pool because winget cannot be installed. Drop the `skipUrlValidation` template parameter, the only callers (`azure-pipelines.yml`, `azure-pipelines-unofficial.yml`), and the `_PackagesPublished` variable composed only to feed it.

Manifest validation is intentionally delegated to upstream `microsoft/winget-pkgs` CI — see the new "Validation model" section in `eng/winget/README.md` for what upstream checks (schema, binary AV scan, URL + SmartScreen, SHA256, install/uninstall in a clean VM). This matches the pattern used by every other Microsoft repo publishing to WinGet (PowerToys, terminal, winget-create itself, which also runs on the same 1ES `windows-2022` pool and likewise does not invoke winget in CI).

End-to-end probe + prepare + publish path validated on internal build 2990922 (a sibling branch that exercised the WinGet Manifest job via a stage-condition override). Real-prod validation occurs when this lands and the stage condition naturally includes it.

## 2. Update WinGet manifest tags (from #17863)

The WinGet package template still categorized the Aspire CLI with the `dotnet` tag. Replace that tag with `csharp` and `typescript` so the package metadata better matches supported Aspire application languages.

Refs #17860, #17863.
