### PR TITLE
Add Keycloak persistent lifetime coverage

### DIFF
--- a/playground/keycloak/Keycloak.AppHost/Properties/launchSettings.json
+++ b/playground/keycloak/Keycloak.AppHost/Properties/launchSettings.json
@@ -8,7 +8,10 @@
       "applicationUrl": "https://keycloak.dev.localhost:17241;http://keycloak.dev.localhost:15079",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development"
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21241",
+        "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:21242",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22241"
       }
     },
     "http": {
@@ -18,7 +21,11 @@
       "applicationUrl": "http://keycloak.dev.localhost:15079",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development"
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19141",
+        "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:19142",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20141",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {
@@ -29,7 +36,8 @@
       "applicationUrl": "http://keycloak.dev.localhost:16370",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development"
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19141"
       }
     }
   }

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakFunctionalTests.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREPERSISTENCE001 // Resource lifetime APIs are experimental.
+
+using Aspire.Hosting.Utils;
+using Aspire.TestUtilities;
+
+namespace Aspire.Hosting.Keycloak.Tests;
+
+public class KeycloakFunctionalTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    [RequiresFeature(TestFeature.Docker)]
+    public Task Keycloak_WithPersistentLifetime_ReusesContainer()
+    {
+        return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(
+            testOutputHelper,
+            builder => builder.AddKeycloak("resource").WithPersistentLifetime(),
+            "resource",
+            useTestContainerRegistry: true);
+    }
+}


### PR DESCRIPTION
## Description

Keycloak is a container-backed hosting integration, but it was missing coverage in the persistent lifetime container reuse suite. This adds a functional test that uses the shared persistent container helper to verify a persistent Keycloak resource reuses its Docker container across AppHost runs.

While investigating the Keycloak playground, DCP logs showed rebuilds caused by `OTEL_EXPORTER_OTLP_ENDPOINT` changing between launches because the AppHost launch settings did not pin dashboard endpoints. The Keycloak playground now configures stable dashboard OTLP and resource service endpoint URLs for its launch profiles, matching the pattern used by other playground AppHosts.

Validation:

```bash
dotnet test --project tests/Aspire.Hosting.Keycloak.Tests/Aspire.Hosting.Keycloak.Tests.csproj --no-launch-profile -- --filter-method "*.Keycloak_WithPersistentLifetime_ReusesContainer" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No