### PR TITLE
fix(cli): detect winget install of aspire.exe so bundle stays in the winget package dir

### DIFF
--- a/.github/workflows/prepare-installer-artifacts.yml
+++ b/.github/workflows/prepare-installer-artifacts.yml
@@ -77,6 +77,40 @@ jobs:
           $env:PATH = "$env:LOCALAPPDATA\Microsoft\WinGet\Links;" + $env:PATH
           & "$env:GITHUB_WORKSPACE/eng/scripts/smoke-installed-cli.ps1"
 
+      - name: Verify winget install detection (route + sidecar + bundle location)
+        if: ${{ inputs.installer == 'winget' }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # The smoke test alone passes even when the bundle ends up in the wrong place,
+          # because `aspire new` + `aspire restore` work from the ~/.aspire fallback layout
+          # too. This step asserts the route-detection chain itself (registry probe →
+          # sidecar → ComputeDefaultExtractDir → bundle colocation) actually fires for
+          # the shape winget ships our manifest as, so silent regressions are caught
+          # before they ship.
+          $env:PATH = "$env:LOCALAPPDATA\Microsoft\WinGet\Links;" + $env:PATH
+
+          # Parse PackageVersion from the staged installer manifest so the verify
+          # script can confirm `aspire doctor` reports the version this job built,
+          # not a leftover machine-wide install on a self-hosted runner.
+          $manifestDir = "$env:GITHUB_WORKSPACE/artifacts/installers/winget-manifests"
+          $installerManifests = @(Get-ChildItem -Path $manifestDir -File -Filter "*.installer.yaml")
+          if ($installerManifests.Count -ne 1) {
+            throw "Expected exactly one *.installer.yaml under $manifestDir, found $($installerManifests.Count)."
+          }
+          $expectedVersion = $null
+          foreach ($line in Get-Content -LiteralPath $installerManifests[0].FullName) {
+            if ($line -match '^\s*PackageVersion:\s*"?([^"]+)"?\s*$') {
+              $expectedVersion = $Matches[1]
+              break
+            }
+          }
+          if (-not $expectedVersion) {
+            throw "Could not read PackageVersion from $($installerManifests[0].FullName)."
+          }
+          Write-Host "Verifying installed CLI reports PackageVersion '$expectedVersion'."
+          & "$env:GITHUB_WORKSPACE/eng/scripts/verify-winget-install-detection.ps1" -ExpectedVersion $expectedVersion
+
       - name: Smoke test installed CLI (aspire new + restore)
         if: ${{ inputs.installer == 'homebrew' }}
         shell: bash

--- a/eng/scripts/verify-winget-install-detection.ps1
+++ b/eng/scripts/verify-winget-install-detection.ps1
@@ -1,0 +1,172 @@
+<#
+.SYNOPSIS
+    Verifies an already-installed Aspire CLI looks like a winget install end-to-end.
+
+.DESCRIPTION
+    Run AFTER 'winget install --manifest ...' has placed the CLI on PATH and AFTER
+    at least one CLI command has been invoked (so the first-run probe and the
+    bundle extraction have both had a chance to run). Asserts:
+
+      1. 'aspire doctor --format json --self' reports the running install with
+         route == "winget". This is the highest-signal assertion: the route is
+         only "winget" when WindowsRegistryReader matched a winget ARP entry and
+         WingetFirstRunProbe stamped {"source":"winget"} into the sidecar.
+
+      2. The .aspire-install.json sidecar exists next to the resolved binary
+         (or the resolved-target binary if it's a symlink) with source=winget.
+
+      3. The Aspire bundle was extracted under the winget install location, NOT
+         under $HOME\.aspire — i.e. the route-driven extract-dir logic in
+         BundleService.ComputeDefaultExtractDir picked the winget colocation
+         branch instead of the sidecar-less fallback.
+
+    Any failed assertion exits non-zero with a diagnostic dump so the CI log
+    captures both the JSON and the surrounding filesystem state. This script
+    guards specifically against silent regressions in winget-install detection:
+    the smoke test alone passes even when the bundle ends up in the wrong place,
+    because aspire new + restore work fine from the $HOME fallback layout too.
+
+.PARAMETER ExpectedVersion
+    Optional. When supplied, also asserts installations[0].version contains the
+    expected version string. Useful for confirming the PR build (not a stale
+    machine-wide install) is the one that produced the report.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$ExpectedVersion
+)
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+function Resolve-AspireBinary {
+    $cmd = Get-Command aspire -ErrorAction SilentlyContinue
+    if (-not $cmd) {
+        throw "'aspire' is not on PATH. Did the winget install step run?"
+    }
+    # Follow one level of symlink/junction so we land on the real exe winget
+    # extracted, not the alias winget may have layered in WinGet\Links. Use
+    # Get-Item -Force to resolve reparse points without throwing on plain files.
+    $item = Get-Item -LiteralPath $cmd.Source -Force
+    if ($item.Target) {
+        $real = $item.Target | Select-Object -First 1
+        if (-not [System.IO.Path]::IsPathRooted($real)) {
+            $real = Join-Path (Split-Path $cmd.Source -Parent) $real
+        }
+        return [System.IO.Path]::GetFullPath($real)
+    }
+    return [System.IO.Path]::GetFullPath($cmd.Source)
+}
+
+function Get-DoctorSelfJson {
+    Write-Host "Running: aspire doctor --format json --self"
+    $raw = aspire doctor --format json --self
+    if ($LASTEXITCODE -ne 0) {
+        throw "aspire doctor --format json --self exited $LASTEXITCODE; output: $raw"
+    }
+    try {
+        return $raw | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        throw "Failed to parse aspire doctor JSON output. Raw output:`n$raw"
+    }
+}
+
+function Format-Object($obj) {
+    return ($obj | ConvertTo-Json -Depth 8)
+}
+
+$failures = New-Object System.Collections.Generic.List[string]
+$report = [ordered]@{}
+
+$realBinary = Resolve-AspireBinary
+$binaryDir = Split-Path $realBinary -Parent
+$report['ResolvedBinary'] = $realBinary
+$report['BinaryDirectory'] = $binaryDir
+
+$doctor = Get-DoctorSelfJson
+$report['DoctorJson'] = $doctor
+
+$installs = $doctor.installations
+if (-not $installs -or $installs.Count -eq 0) {
+    $failures.Add("aspire doctor --self returned no installations entry.")
+}
+else {
+    $self = $installs[0]
+    $report['SelfInstallation'] = $self
+
+    if ($self.route -ne 'winget') {
+        $failures.Add("Expected installations[0].route == 'winget', got '$($self.route)'. This means WindowsRegistryReader did not match the winget ARP entry and the sidecar was never stamped.")
+    }
+
+    if ($ExpectedVersion -and $self.version -notlike "*$ExpectedVersion*") {
+        $failures.Add("Expected installations[0].version to contain '$ExpectedVersion', got '$($self.version)'. The reporting CLI may not be the freshly-installed one.")
+    }
+}
+
+# Sidecar assertion. The probe writes {"source":"winget"} into a file named
+# .aspire-install.json beside the binary. If route reported winget but this file
+# is missing, the probe took a non-canonical write path and we need to know.
+$sidecarPath = Join-Path $binaryDir '.aspire-install.json'
+$report['SidecarPath'] = $sidecarPath
+$report['SidecarExists'] = Test-Path -LiteralPath $sidecarPath -PathType Leaf
+if (-not $report['SidecarExists']) {
+    $failures.Add("Expected sidecar file '$sidecarPath' to exist after first run, but it was not found.")
+}
+else {
+    $sidecarText = Get-Content -LiteralPath $sidecarPath -Raw
+    $report['SidecarContent'] = $sidecarText
+    try {
+        $sidecar = $sidecarText | ConvertFrom-Json -ErrorAction Stop
+        if ($sidecar.source -ne 'winget') {
+            $failures.Add("Sidecar source field expected 'winget', got '$($sidecar.source)'.")
+        }
+    }
+    catch {
+        $failures.Add("Sidecar at '$sidecarPath' is not valid JSON: $sidecarText")
+    }
+}
+
+# Bundle-location assertion. After ComputeDefaultExtractDir picks the winget
+# colocation branch, the bundle/ link (or directory) lives alongside the binary.
+# If it instead lives under $HOME\.aspire, the route detection silently fell
+# back even if route happens to be reported correctly through a different path.
+$wingetBundleDir = Join-Path $binaryDir 'bundle'
+$report['ExpectedBundleDir'] = $wingetBundleDir
+$report['ExpectedBundleDirExists'] = Test-Path -LiteralPath $wingetBundleDir
+$aspireHomeBundleDir = Join-Path $env:USERPROFILE '.aspire\bundle'
+$report['FallbackBundleDir'] = $aspireHomeBundleDir
+$report['FallbackBundleDirExists'] = Test-Path -LiteralPath $aspireHomeBundleDir
+
+if (-not $report['ExpectedBundleDirExists']) {
+    $failures.Add("Expected the Aspire bundle to be extracted under the winget install directory at '$wingetBundleDir', but that directory does not exist. Fallback location '$aspireHomeBundleDir' exists: $($report['FallbackBundleDirExists']).")
+}
+
+# A bundle under $HOME\.aspire after a winget install means BundleService
+# colocation did not select the winget branch. Even if the winget directory
+# also exists (e.g. from a previous run), the fallback being populated
+# indicates the route detection regressed.
+if ($report['FallbackBundleDirExists']) {
+    $failures.Add("Fallback bundle directory '$aspireHomeBundleDir' must not exist after a winget install; BundleService should colocate the bundle under '$wingetBundleDir'. Its presence indicates winget install detection regressed.")
+}
+
+Write-Host ''
+Write-Host '=== verify-winget-install-detection report ==='
+Write-Host (Format-Object $report)
+
+if ($failures.Count -gt 0) {
+    Write-Host ''
+    Write-Host '=== Failures ==='
+    # $ErrorActionPreference is 'Stop' for this script; Write-Error would
+    # throw on the first failure and abort the loop, surfacing only one
+    # failure to the operator. Use Write-Host so every failure is printed
+    # before the explicit `exit 1` returns the non-zero status to CI.
+    foreach ($f in $failures) {
+        Write-Host -ForegroundColor Red $f
+    }
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'All winget install-detection assertions passed.'

--- a/eng/scripts/verify-winget-install-detection.ps1
+++ b/eng/scripts/verify-winget-install-detection.ps1
@@ -3,9 +3,10 @@
     Verifies an already-installed Aspire CLI looks like a winget install end-to-end.
 
 .DESCRIPTION
-    Run AFTER 'winget install --manifest ...' has placed the CLI on PATH and AFTER
-    at least one CLI command has been invoked (so the first-run probe and the
-    bundle extraction have both had a chance to run). Asserts:
+    Run AFTER 'winget install --manifest ...' has placed the CLI on PATH. The
+    script primes the first-run probe and bundle extraction itself by invoking
+    'aspire doctor' before its assertions, so no separate CLI command needs to
+    be run by the caller. Asserts:
 
       1. 'aspire doctor --format json --self' reports the running install with
          route == "winget". This is the highest-signal assertion: the route is
@@ -73,6 +74,20 @@ function Get-DoctorSelfJson {
     }
 }
 
+function Invoke-DoctorPriming {
+    # Belt-and-suspenders against future regressions where the --self fast-path
+    # diverges from the discovery path and the first-run probe (which writes the
+    # sidecar) and bundle extraction stop firing on `aspire doctor --self`. A
+    # plain `aspire doctor` runs both unambiguously. Output is discarded; non-zero
+    # exit is treated as a hard failure because every subsequent assertion in
+    # this script depends on the probe + extract having run.
+    Write-Host "Priming: aspire doctor"
+    $primingOutput = aspire doctor 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Priming 'aspire doctor' exited $LASTEXITCODE; output: $primingOutput"
+    }
+}
+
 function Format-Object($obj) {
     return ($obj | ConvertTo-Json -Depth 8)
 }
@@ -84,6 +99,8 @@ $realBinary = Resolve-AspireBinary
 $binaryDir = Split-Path $realBinary -Parent
 $report['ResolvedBinary'] = $realBinary
 $report['BinaryDirectory'] = $binaryDir
+
+Invoke-DoctorPriming
 
 $doctor = Get-DoctorSelfJson
 $report['DoctorJson'] = $doctor

--- a/eng/scripts/verify-winget-install-detection.ps1
+++ b/eng/scripts/verify-winget-install-detection.ps1
@@ -78,13 +78,34 @@ function Invoke-DoctorPriming {
     # Belt-and-suspenders against future regressions where the --self fast-path
     # diverges from the discovery path and the first-run probe (which writes the
     # sidecar) and bundle extraction stop firing on `aspire doctor --self`. A
-    # plain `aspire doctor` runs both unambiguously. Output is discarded; non-zero
-    # exit is treated as a hard failure because every subsequent assertion in
-    # this script depends on the probe + extract having run.
+    # plain `aspire doctor` runs both unambiguously.
+    #
+    # The exit code is intentionally NOT treated as a failure. `aspire doctor`
+    # runs environment checks (dev certs, container runtime, .NET SDK, etc.)
+    # and exits 1 when any of them report Fail. Those checks are unrelated to
+    # install-route detection, and the route-detection side effects we care
+    # about — the first-run probe writing the sidecar and BundleService
+    # extracting under the winget directory — run BEFORE any environment
+    # check, so a Fail there does not invalidate priming. The subsequent
+    # assertions in this script (route, sidecar, bundle colocation) are the
+    # authoritative signal.
+    #
+    # We capture stdout + stderr and always echo them to the CI log so that
+    # if priming does behave unexpectedly, the operator can see what doctor
+    # reported instead of a bare non-zero exit. PSNativeCommandUseErrorActionPreference
+    # is disabled inside the script block so a non-zero exit from aspire.exe
+    # does not throw before we get to print the output.
     Write-Host "Priming: aspire doctor"
-    $primingOutput = aspire doctor 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        throw "Priming 'aspire doctor' exited $LASTEXITCODE; output: $primingOutput"
+    $primingOutput = & {
+        $PSNativeCommandUseErrorActionPreference = $false
+        aspire doctor 2>&1
+    }
+    $primingExit = $LASTEXITCODE
+    Write-Host "Priming 'aspire doctor' exit code: $primingExit"
+    if ($primingOutput) {
+        Write-Host '--- Priming output (begin) ---'
+        $primingOutput | ForEach-Object { Write-Host $_ }
+        Write-Host '--- Priming output (end) ---'
     }
 }
 

--- a/src/Aspire.Cli/Acquisition/IWindowsRegistryReader.cs
+++ b/src/Aspire.Cli/Acquisition/IWindowsRegistryReader.cs
@@ -17,11 +17,13 @@ internal interface IWindowsRegistryReader
     /// <summary>
     /// Returns <see langword="true"/> when an entry under
     /// <c>HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall</c> (or the
-    /// 64-bit HKLM hive) carries
-    /// <c>WinGetPackageIdentifier == "Microsoft.Aspire"</c> and a
-    /// <c>PortableTargetFullPath</c> that matches the supplied
-    /// <paramref name="processPath"/> (canonicalized and compared
-    /// case-insensitively).
+    /// 64-bit HKLM hive) carries <c>WinGetPackageIdentifier == "Microsoft.Aspire"</c>,
+    /// <c>WinGetInstallerType == "portable"</c>, and either a <c>TargetFullPath</c>
+    /// that resolves to <paramref name="processPath"/> (single-file portable) or
+    /// an <c>InstallLocation</c> directory that contains it (archive/zip
+    /// portable, the shape Aspire actually ships). See
+    /// <see cref="WingetAspireEntryMatcher"/> for the matching contract and the
+    /// winget-cli sources behind it.
     /// </summary>
     bool HasWingetAspireUninstallEntry(string processPath);
 }
@@ -33,9 +35,6 @@ internal interface IWindowsRegistryReader
 internal sealed class WindowsRegistryReader : IWindowsRegistryReader
 {
     private const string UninstallSubKey = @"Software\Microsoft\Windows\CurrentVersion\Uninstall";
-    private const string PackageIdentifierValueName = "WinGetPackageIdentifier";
-    private const string AspirePackageIdentifier = "Microsoft.Aspire";
-    private const string PortableTargetValueName = "PortableTargetFullPath";
 
     public bool HasWingetAspireUninstallEntry(string processPath)
     {
@@ -65,6 +64,9 @@ internal sealed class WindowsRegistryReader : IWindowsRegistryReader
     {
         try
         {
+            // Winget always writes to the 64-bit registry view (winget-cli:
+            // src/AppInstallerCommonCore/PortableARPEntry.cpp uses
+            // KEY_WOW64_64KEY for both HKCU and machine x64 scopes).
             using var baseKey = RegistryKey.OpenBaseKey(hive, RegistryView.Registry64);
             using var uninstall = baseKey.OpenSubKey(UninstallSubKey, writable: false);
             if (uninstall is null)
@@ -80,29 +82,21 @@ internal sealed class WindowsRegistryReader : IWindowsRegistryReader
                     continue;
                 }
 
-                if (entry.GetValue(PackageIdentifierValueName) is not string identifier
-                    || !string.Equals(identifier, AspirePackageIdentifier, StringComparison.Ordinal))
+                // Read the identifier first and short-circuit on non-Aspire entries
+                // before incurring three more RegQueryValueEx calls per subkey.
+                // Uninstall has hundreds of subkeys on a typical machine and this
+                // probe runs on every CLI invocation that lacks the sidecar.
+                var identifier = entry.GetValue(WingetAspireEntryMatcher.PackageIdentifierValueName) as string;
+                if (!WingetAspireEntryMatcher.HasAspirePackageIdentifier(identifier))
                 {
                     continue;
                 }
 
-                if (entry.GetValue(PortableTargetValueName) is not string portableTarget
-                    || string.IsNullOrEmpty(portableTarget))
-                {
-                    continue;
-                }
+                var installerType = entry.GetValue(WingetAspireEntryMatcher.InstallerTypeValueName) as string;
+                var targetFullPath = entry.GetValue(WingetAspireEntryMatcher.TargetFullPathValueName) as string;
+                var installLocation = entry.GetValue(WingetAspireEntryMatcher.InstallLocationValueName) as string;
 
-                string canonicalTarget;
-                try
-                {
-                    canonicalTarget = Path.GetFullPath(portableTarget);
-                }
-                catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
-                {
-                    continue;
-                }
-
-                if (string.Equals(canonicalTarget, canonicalProcessPath, StringComparison.OrdinalIgnoreCase))
+                if (WingetAspireEntryMatcher.Matches(canonicalProcessPath, identifier, installerType, targetFullPath, installLocation))
                 {
                     return true;
                 }
@@ -116,6 +110,149 @@ internal sealed class WindowsRegistryReader : IWindowsRegistryReader
         }
 
         return false;
+    }
+}
+
+/// <summary>
+/// Pure matcher that decides whether a single uninstall-registry entry
+/// represents the winget portable install that placed the running CLI binary.
+/// Pulled out of <see cref="WindowsRegistryReader"/> so the matching rules can
+/// be unit-tested on every platform without touching the Windows registry.
+/// </summary>
+/// <remarks>
+/// Two registry shapes are accepted, both confirmed against the winget-cli
+/// source at <see href="https://github.com/microsoft/winget-cli/blob/master/src/AppInstallerCommonCore/PortableARPEntry.cpp"/>:
+/// <list type="number">
+/// <item>
+/// <description>
+/// Single-file portable: winget writes the <c>TargetFullPath</c> value (note
+/// the C++ enum identifier is <c>PortableTargetFullPath</c> but the actual
+/// registry string is just <c>"TargetFullPath"</c> — see
+/// <c>PortableARPEntry.cpp</c> <c>s_PortableTargetFullPath = L"TargetFullPath"</c>)
+/// to the full path of the installed exe.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// Archive portable (<c>InstallerType: zip</c> + <c>NestedInstallerType: portable</c>,
+/// the shape <c>eng/winget/microsoft.aspire/Aspire.installer.yaml.template</c>
+/// declares): winget extracts the archive and skips per-file ARP writes
+/// (<c>PortableInstaller::InstallFile</c> guards
+/// <c>CommitToARPEntry(PortableTargetFullPath)</c> behind <c>!RecordToIndex</c>,
+/// and <c>PortableFlow::GetDesiredStateForPortableInstall</c> sets
+/// <c>RecordToIndex = true</c> for any directory extraction). The only
+/// always-written pointer is <c>InstallLocation</c>, the extraction directory
+/// the running binary lives inside.
+/// </description>
+/// </item>
+/// </list>
+/// </remarks>
+internal static class WingetAspireEntryMatcher
+{
+    internal const string PackageIdentifierValueName = "WinGetPackageIdentifier";
+    internal const string InstallerTypeValueName = "WinGetInstallerType";
+    internal const string TargetFullPathValueName = "TargetFullPath";
+    internal const string InstallLocationValueName = "InstallLocation";
+
+    internal const string AspirePackageIdentifier = "Microsoft.Aspire";
+    internal const string PortableInstallerType = "portable";
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="packageIdentifier"/>
+    /// matches the Aspire winget package identifier. Exposed so callers that
+    /// iterate registry subkeys can short-circuit non-Aspire entries before
+    /// reading the other matcher inputs.
+    /// </summary>
+    public static bool HasAspirePackageIdentifier(string? packageIdentifier)
+        => string.Equals(packageIdentifier, AspirePackageIdentifier, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the supplied registry-entry values
+    /// identify a winget portable install of the Aspire CLI that placed
+    /// <paramref name="canonicalProcessPath"/>. The caller is responsible for
+    /// canonicalizing <paramref name="canonicalProcessPath"/> via
+    /// <see cref="Path.GetFullPath(string)"/> before calling.
+    /// </summary>
+    public static bool Matches(
+        string canonicalProcessPath,
+        string? packageIdentifier,
+        string? installerType,
+        string? targetFullPath,
+        string? installLocation)
+    {
+        if (string.IsNullOrEmpty(canonicalProcessPath))
+        {
+            return false;
+        }
+
+        if (!HasAspirePackageIdentifier(packageIdentifier))
+        {
+            return false;
+        }
+
+        // WinGetInstallerType filters out any future non-portable Aspire winget
+        // installer (e.g. MSI) so this probe stays narrowly scoped to the
+        // portable shapes it knows how to reason about. Empty/missing values
+        // are tolerated for backward compat with older winget builds that may
+        // not have written the field on every entry.
+        if (!string.IsNullOrEmpty(installerType)
+            && !string.Equals(installerType, PortableInstallerType, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(targetFullPath)
+            && TryCanonicalize(targetFullPath) is string canonicalTarget
+            && string.Equals(canonicalTarget, canonicalProcessPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrEmpty(installLocation)
+            && TryCanonicalize(installLocation) is string canonicalInstallDir
+            && IsProcessUnderDirectory(canonicalProcessPath, canonicalInstallDir))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string? TryCanonicalize(string path)
+    {
+        try
+        {
+            return Path.GetFullPath(path);
+        }
+        catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsProcessUnderDirectory(string canonicalProcessPath, string canonicalDirectory)
+    {
+        // Trim a single trailing separator so "C:\\Foo\\" and "C:\\Foo" behave
+        // the same. The separator boundary check below prevents "C:\\Foo" from
+        // falsely matching "C:\\FooBar\\aspire.exe".
+        var directory = canonicalDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (directory.Length == 0)
+        {
+            return false;
+        }
+
+        if (canonicalProcessPath.Length <= directory.Length + 1)
+        {
+            return false;
+        }
+
+        if (!canonicalProcessPath.StartsWith(directory, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var nextChar = canonicalProcessPath[directory.Length];
+        return nextChar == Path.DirectorySeparatorChar || nextChar == Path.AltDirectorySeparatorChar;
     }
 }
 

--- a/src/Aspire.Cli/Acquisition/WingetFirstRunProbe.cs
+++ b/src/Aspire.Cli/Acquisition/WingetFirstRunProbe.cs
@@ -62,7 +62,17 @@ internal sealed class WingetFirstRunProbe
         }
 
         var sidecarPath = Path.Combine(binaryDir, InstallSidecarReader.SidecarFileName);
-        if (File.Exists(sidecarPath))
+        // Self-heal: skip only when the sidecar exists AND its `source` field
+        // parses cleanly. A malformed/truncated/oversized/empty sidecar (mid-write
+        // crash, manual edit, source string missing, etc.) counts as "needs
+        // overwrite" — fall through so the probe can re-stamp the canonical
+        // {"source":"winget"} payload below if the registry still claims this
+        // binary as winget. Sidecars whose `source` is a non-winget string
+        // (e.g. {"source":"script"} from a different install route) parse as
+        // non-null and are still skipped — the probe never clobbers a foreign
+        // route's sidecar, only a corrupt one.
+        var sidecarExists = File.Exists(sidecarPath);
+        if (sidecarExists && InstallSidecarReader.ReadSourceField(sidecarPath) is not null)
         {
             return;
         }
@@ -72,10 +82,14 @@ internal sealed class WingetFirstRunProbe
             return;
         }
 
-        TryWriteSidecarAtomically(binaryDir, sidecarPath);
+        // overwriteIfCorrupt: only true on the self-heal branch (the corrupt
+        // sidecar already exists). For the cold-start branch (no sidecar yet)
+        // we keep overwrite:false so two racing probes don't clobber a sidecar
+        // that just got written by a different install-route's atomic writer.
+        TryWriteSidecarAtomically(binaryDir, sidecarPath, overwriteIfCorrupt: sidecarExists);
     }
 
-    private void TryWriteSidecarAtomically(string binaryDir, string sidecarPath)
+    private void TryWriteSidecarAtomically(string binaryDir, string sidecarPath, bool overwriteIfCorrupt)
     {
         var tempPath = Path.Combine(binaryDir, $"{InstallSidecarReader.SidecarFileName}.{Guid.NewGuid():N}.tmp");
 
@@ -91,7 +105,7 @@ internal sealed class WingetFirstRunProbe
 
         try
         {
-            File.Move(tempPath, sidecarPath, overwrite: false);
+            File.Move(tempPath, sidecarPath, overwrite: overwriteIfCorrupt);
             _logger.LogDebug("Winget first-run probe wrote sidecar at {Path}.", sidecarPath);
         }
         catch (Exception ex)

--- a/src/Aspire.Cli/Acquisition/WingetFirstRunProbe.cs
+++ b/src/Aspire.Cli/Acquisition/WingetFirstRunProbe.cs
@@ -27,12 +27,35 @@ internal sealed class WingetFirstRunProbe
     }
 
     /// <summary>
-    /// Writes <c>&lt;binaryDir&gt;/.aspire-install.json</c> when the running
-    /// process is a winget portable install AND no sidecar exists yet.
-    /// Idempotent: any second call is a no-op.
+    /// Writes <c>&lt;binaryDir&gt;/.aspire-install.json</c> next to
+    /// <paramref name="realProcessPath"/> when that path identifies a winget
+    /// portable install AND no sidecar exists yet. Idempotent: any second
+    /// call is a no-op.
     /// </summary>
-    public void Run(string binaryDir)
+    /// <param name="realProcessPath">
+    /// The fully-resolved path to the running CLI binary, after symlink
+    /// resolution via
+    /// <see cref="Utils.CliPathHelper.ResolveSymlinkOrOriginalPath(string, ILogger?)"/>.
+    /// Callers must pass the resolved path, not the raw
+    /// <see cref="Environment.ProcessPath"/>: winget portable installs expose the
+    /// CLI through a command-alias symlink under
+    /// <c>%LOCALAPPDATA%\Microsoft\WinGet\Links\aspire.exe</c>, and the
+    /// registry matcher's <c>InstallLocation</c> containment check requires
+    /// the resolved path so that the link-path location does not falsely
+    /// look outside the package's install directory. Both call sites that
+    /// previously read <see cref="Environment.ProcessPath"/> directly inside
+    /// this method instead resolve once at the caller and pass the result
+    /// through, which also ensures the sidecar is stamped next to the real
+    /// binary rather than next to the link.
+    /// </param>
+    public void Run(string realProcessPath)
     {
+        if (string.IsNullOrEmpty(realProcessPath))
+        {
+            return;
+        }
+
+        var binaryDir = Path.GetDirectoryName(realProcessPath);
         if (string.IsNullOrEmpty(binaryDir))
         {
             return;
@@ -44,13 +67,7 @@ internal sealed class WingetFirstRunProbe
             return;
         }
 
-        var processPath = Environment.ProcessPath;
-        if (string.IsNullOrEmpty(processPath))
-        {
-            return;
-        }
-
-        if (!_registry.HasWingetAspireUninstallEntry(processPath))
+        if (!_registry.HasWingetAspireUninstallEntry(realProcessPath))
         {
             return;
         }

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -195,13 +195,17 @@ internal sealed class BundleService(
         // The winget portable installer has no post-install hook, so the CLI
         // self-stamps the install-route sidecar on first run. No-op on
         // non-Windows and once the sidecar already exists.
+        //
+        // The probe needs the symlink-resolved real binary path so the
+        // matcher's InstallLocation containment check succeeds when the CLI
+        // is launched via the winget command-alias symlink under
+        // %LOCALAPPDATA%\Microsoft\WinGet\Links — see WingetFirstRunProbe.Run.
         if (wingetFirstRunProbe is not null && OperatingSystem.IsWindows())
         {
             var realBinaryPath = CliPathHelper.ResolveSymlinkOrOriginalPath(processPath, logger);
-            var binaryDir = Path.GetDirectoryName(realBinaryPath);
-            if (!string.IsNullOrEmpty(binaryDir))
+            if (!string.IsNullOrEmpty(realBinaryPath))
             {
-                wingetFirstRunProbe.Run(binaryDir);
+                wingetFirstRunProbe.Run(realBinaryPath);
             }
         }
 

--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -63,7 +63,7 @@ internal sealed class DoctorCommand : BaseCommand
 
         if (selfOnly)
         {
-            var self = InstallationInfoOutput.DescribeSelfSafely(_installationDiscovery, _logger);
+            var self = InstallationInfoOutput.DescribeSelfSafely(_installationDiscovery, _wingetFirstRunProbe, _logger);
             if (format == OutputFormat.Json)
             {
                 OutputJson([], self);

--- a/src/Aspire.Cli/Commands/InstallationInfoOutput.cs
+++ b/src/Aspire.Cli/Commands/InstallationInfoOutput.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Acquisition;
 using Aspire.Cli.Resources;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
@@ -18,7 +19,7 @@ internal static class InstallationInfoOutput
     {
         try
         {
-            RunWingetFirstRunProbe(wingetFirstRunProbe);
+            RunWingetFirstRunProbe(wingetFirstRunProbe, logger);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -63,22 +64,28 @@ internal static class InstallationInfoOutput
         }
     }
 
-    public static void RunWingetFirstRunProbe(WingetFirstRunProbe wingetFirstRunProbe)
+    public static void RunWingetFirstRunProbe(WingetFirstRunProbe wingetFirstRunProbe, ILogger? logger = null)
     {
         // Give a never-run winget install a chance to stamp its sidecar before
         // we read it. The probe writes nothing on non-Windows hosts or when the
         // running binary isn't a winget portable install, so this is a cheap
         // no-op in the common case.
+        //
+        // Pass the symlink-resolved real process path: winget exposes the CLI
+        // via a command-alias symlink under %LOCALAPPDATA%\Microsoft\WinGet\Links,
+        // and the registry probe's InstallLocation containment check needs the
+        // resolved path. Resolving here also ensures the sidecar is written next
+        // to the real binary rather than in the Links directory.
         var processPath = Environment.ProcessPath;
         if (string.IsNullOrEmpty(processPath))
         {
             return;
         }
 
-        var binaryDir = Path.GetDirectoryName(processPath);
-        if (!string.IsNullOrEmpty(binaryDir))
+        var realProcessPath = CliPathHelper.ResolveSymlinkOrOriginalPath(processPath, logger);
+        if (!string.IsNullOrEmpty(realProcessPath))
         {
-            wingetFirstRunProbe.Run(binaryDir);
+            wingetFirstRunProbe.Run(realProcessPath);
         }
     }
 

--- a/src/Aspire.Cli/Commands/InstallationInfoOutput.cs
+++ b/src/Aspire.Cli/Commands/InstallationInfoOutput.cs
@@ -44,8 +44,26 @@ internal static class InstallationInfoOutput
         }
     }
 
-    public static IReadOnlyList<InstallationInfo> DescribeSelfSafely(IInstallationDiscovery discovery, ILogger logger)
+    public static IReadOnlyList<InstallationInfo> DescribeSelfSafely(
+        IInstallationDiscovery discovery,
+        WingetFirstRunProbe wingetFirstRunProbe,
+        ILogger logger)
     {
+        // Mirror DiscoverAllSafelyAsync: even on the `--self` fast-path the probe
+        // must run before discovery reads the install sidecar, otherwise a fresh
+        // winget install reports route=null until some other command (a plain
+        // `aspire doctor` without --self, `aspire restore`, etc.) happens to
+        // run the probe. The PR's verify-winget-install-detection.ps1 calls
+        // `aspire doctor --format json --self` and depends on this priming.
+        try
+        {
+            RunWingetFirstRunProbe(wingetFirstRunProbe, logger);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "Could not run the winget first-run install sidecar probe before doctor self-probe describe.");
+        }
+
         try
         {
             return [discovery.DescribeSelf()];

--- a/tests/Aspire.Acquisition.Tests/Scripts/Common/LoopbackHttpFileServer.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/Common/LoopbackHttpFileServer.cs
@@ -1,0 +1,229 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Sockets;
+
+namespace Aspire.Acquisition.Tests.Scripts;
+
+/// <summary>
+/// Minimal loopback HTTP file server for tests that need a real TCP endpoint —
+/// e.g. piping a script into <c>bash</c>/<c>iex</c> via <c>curl</c>/<c>irm</c>,
+/// or pointing <c>winget install</c> at an <c>InstallerUrl</c> that WinINet's
+/// <c>InternetOpenUrl</c> can fetch (it supports http/https/ftp/gopher only —
+/// not <c>file://</c>). The ASP.NET Core <c>TestServer</c>
+/// (<c>Microsoft.AspNetCore.TestHost</c>) is in-memory only and would not
+/// satisfy either scenario.
+/// </summary>
+/// <remarks>
+/// Loopback HTTP prefixes (<c>http://127.0.0.1:port/</c> and
+/// <c>http://localhost:port/</c>) do not require admin / <c>netsh urlacl</c>
+/// reservation on Windows — that restriction only applies to non-loopback
+/// prefixes. See <c>eng/winget/dogfood.ps1</c>
+/// <c>Start-LocalArchiveServer</c> for the same rationale used in dogfood.
+/// </remarks>
+internal sealed class LoopbackHttpFileServer : IDisposable
+{
+    private readonly HttpListener _listener;
+    private readonly CancellationTokenSource _cts;
+    private readonly Task _loop;
+
+    /// <summary>
+    /// Base URL with no trailing slash, e.g. <c>http://127.0.0.1:50123</c>.
+    /// Callers append <c>/&lt;filename&gt;</c> to request a mapped file.
+    /// </summary>
+    public string BaseUrl { get; }
+
+    private LoopbackHttpFileServer(
+        HttpListener listener,
+        string baseUrl,
+        IReadOnlyDictionary<string, string> fileMap,
+        string contentType)
+    {
+        _listener = listener;
+        BaseUrl = baseUrl;
+        _cts = new CancellationTokenSource();
+        _loop = Task.Run(() => ServeAsync(fileMap, contentType, _cts.Token));
+    }
+
+    /// <summary>
+    /// Starts a loopback HTTP server that serves the values of
+    /// <paramref name="fileMap"/> by file name. Lookup is case-insensitive
+    /// regardless of the dictionary's own comparer because Windows file paths
+    /// are case-insensitive and Linux/macOS scripts requesting these test
+    /// URLs do not vary case at the test sites.
+    /// </summary>
+    /// <param name="fileMap">
+    /// Map from request file name (the last path segment) to absolute file
+    /// path on disk. Files are read fresh on each request, so callers can
+    /// rewrite a backing file between requests in the same test.
+    /// </param>
+    /// <param name="contentType">
+    /// The <c>Content-Type</c> header to send on every 200 response.
+    /// </param>
+    /// <param name="host">
+    /// Host part of the URL prefix. Use <c>127.0.0.1</c> when the consumer
+    /// is sensitive to IPv4 vs IPv6 resolution of <c>localhost</c> (e.g.
+    /// Windows' WinINet); use <c>localhost</c> when the URL string itself
+    /// is asserted by tests.
+    /// </param>
+    public static LoopbackHttpFileServer Start(
+        IReadOnlyDictionary<string, string> fileMap,
+        string contentType,
+        string host = "127.0.0.1")
+    {
+        ArgumentNullException.ThrowIfNull(fileMap);
+        ArgumentException.ThrowIfNullOrEmpty(contentType);
+        ArgumentException.ThrowIfNullOrEmpty(host);
+
+        // Wrap the caller's map in a case-insensitive view so we don't depend
+        // on the caller's comparer choice.
+        var caseInsensitiveMap = new Dictionary<string, string>(fileMap, StringComparer.OrdinalIgnoreCase);
+
+        // Retry binding to avoid TOCTOU: another process can grab the probed
+        // port between TcpListener releasing it and HttpListener.Start binding
+        // to it. Both existing call sites in this project hit this and need
+        // the retry.
+        const int maxAttempts = 5;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            var port = GetFreeLoopbackPort();
+            var prefix = $"http://{host}:{port}/";
+            var listener = new HttpListener();
+            listener.Prefixes.Add(prefix);
+            try
+            {
+                listener.Start();
+                // BaseUrl without trailing slash; callers append "/<file>".
+                var baseUrl = $"http://{host}:{port}";
+                return new LoopbackHttpFileServer(listener, baseUrl, caseInsensitiveMap, contentType);
+            }
+            catch (HttpListenerException) when (attempt < maxAttempts)
+            {
+                listener.Close();
+            }
+        }
+
+        throw new InvalidOperationException($"Could not bind a loopback HttpListener after {maxAttempts} attempts.");
+    }
+
+    private async Task ServeAsync(
+        IReadOnlyDictionary<string, string> fileMap,
+        string contentType,
+        CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested && _listener.IsListening)
+        {
+            HttpListenerContext context;
+            try
+            {
+                context = await _listener.GetContextAsync().WaitAsync(ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (HttpListenerException)
+            {
+                return;
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+
+            try
+            {
+                // Strip the leading '/' and any subdirectories; only the file
+                // name is significant for lookup. URL-decode so spaces/escapes
+                // in archive names round-trip.
+                var name = Path.GetFileName(Uri.UnescapeDataString(context.Request.Url!.AbsolutePath));
+                if (fileMap.TryGetValue(name, out var filePath) && File.Exists(filePath))
+                {
+                    var bytes = await File.ReadAllBytesAsync(filePath, ct);
+                    context.Response.ContentType = contentType;
+                    context.Response.ContentLength64 = bytes.LongLength;
+                    await context.Response.OutputStream.WriteAsync(bytes, ct);
+                }
+                else
+                {
+                    context.Response.StatusCode = 404;
+                }
+            }
+            catch
+            {
+                // Never let a single bad request kill the listen loop.
+                try
+                {
+                    context.Response.StatusCode = 500;
+                }
+                catch
+                {
+                    // Response may already be in an unwritable state.
+                }
+            }
+            finally
+            {
+                try
+                {
+                    context.Response.Close();
+                }
+                catch
+                {
+                    // Best-effort close; nothing actionable here.
+                }
+            }
+        }
+    }
+
+    private static int GetFreeLoopbackPort()
+    {
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        try
+        {
+            return ((IPEndPoint)probe.LocalEndpoint).Port;
+        }
+        finally
+        {
+            probe.Stop();
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            _cts.Cancel();
+        }
+        catch
+        {
+            // Already canceled / disposed.
+        }
+        try
+        {
+            _listener.Stop();
+        }
+        catch
+        {
+            // Listener may already be torn down; the loop's catch blocks handle that.
+        }
+        try
+        {
+            _loop.Wait(TimeSpan.FromSeconds(2));
+        }
+        catch
+        {
+            // Loop exited via exception path or didn't observe cancel in time; nothing to recover.
+        }
+        try
+        {
+            _listener.Close();
+        }
+        catch
+        {
+            // Already closed.
+        }
+        _cts.Dispose();
+    }
+}

--- a/tests/Aspire.Acquisition.Tests/Scripts/Common/ScriptHostFixture.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/Common/ScriptHostFixture.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net;
 using Aspire.Templates.Tests;
 using Xunit;
 
@@ -14,188 +13,57 @@ namespace Aspire.Acquisition.Tests.Scripts;
 /// </summary>
 public sealed class ScriptHostFixture : IAsyncLifetime
 {
-    private HttpListener? _listener;
-    private CancellationTokenSource? _cts;
-    private Task? _serverTask;
-    private string? _scriptsDirectory;
-
-    /// <summary>
-    /// Gets the TCP port the HTTP server is listening on.
-    /// </summary>
-    public int Port { get; private set; }
+    private LoopbackHttpFileServer? _server;
 
     /// <summary>
     /// Gets the base URL for the HTTP server (e.g., <c>http://localhost:12345</c>).
     /// </summary>
-    public string BaseUrl => $"http://localhost:{Port}";
+    public string BaseUrl => _server?.BaseUrl ?? throw new InvalidOperationException("Server not started.");
 
     public async ValueTask InitializeAsync()
     {
-        // Resolve the scripts directory from the repo root
+        // Resolve the scripts directory from the repo root.
         var repoRoot = TestUtils.FindRepoRoot()?.FullName
             ?? throw new InvalidOperationException("Could not find repository root");
-        _scriptsDirectory = Path.Combine(repoRoot, "eng", "scripts");
+        var scriptsDirectory = Path.Combine(repoRoot, "eng", "scripts");
 
-        if (!Directory.Exists(_scriptsDirectory))
+        if (!Directory.Exists(scriptsDirectory))
         {
-            throw new DirectoryNotFoundException($"Scripts directory not found: {_scriptsDirectory}");
+            throw new DirectoryNotFoundException($"Scripts directory not found: {scriptsDirectory}");
         }
 
-        // Retry binding to avoid TOCTOU port races: another process can claim the
-        // probed port between TcpListener.Stop() and HttpListener.Start().
-        const int maxRetries = 5;
-        for (var attempt = 0; attempt < maxRetries; attempt++)
-        {
-            // Find a free port by binding to port 0
-            using (var portFinder = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0))
-            {
-                portFinder.Start();
-                Port = ((IPEndPoint)portFinder.LocalEndpoint).Port;
-                portFinder.Stop();
-            }
+        // Snapshot the script files at startup. Files are re-read on each
+        // request by the loopback server, so edits during a test still take
+        // effect; only file *additions* would require a fixture restart, and
+        // these tests don't add scripts at runtime.
+        var fileMap = Directory.EnumerateFiles(scriptsDirectory)
+            .ToDictionary(p => Path.GetFileName(p)!, p => p, StringComparer.OrdinalIgnoreCase);
 
-            _cts = new CancellationTokenSource();
-            _listener = new HttpListener();
-            _listener.Prefixes.Add($"http://localhost:{Port}/");
+        // The piped-install tests embed BaseUrl into shell snippets executed by
+        // bash/pwsh; keep the URL host as "localhost" to preserve existing
+        // call-site URLs verbatim. Content type matches raw.githubusercontent.com
+        // (text/plain) so curl/irm don't apply any transformation a real install
+        // wouldn't see.
+        _server = LoopbackHttpFileServer.Start(
+            fileMap,
+            contentType: "text/plain; charset=utf-8",
+            host: "localhost");
 
-            try
-            {
-                _listener.Start();
-                break;
-            }
-            catch (HttpListenerException) when (attempt < maxRetries - 1)
-            {
-                _listener.Close();
-                _cts.Dispose();
-                _listener = null;
-                _cts = null;
-            }
-        }
-
-        _serverTask = Task.Run(() => ServeAsync(_cts!.Token));
-
-        // Verify the server is reachable
+        // Verify the server is reachable on the documented entry-point script
+        // before any test runs; surfaces port-bind races and the rare case
+        // where the scripts directory is unreadable.
         using var client = new HttpClient();
         using var response = await client.GetAsync($"{BaseUrl}/get-aspire-cli.sh");
         if (!response.IsSuccessStatusCode)
         {
             throw new InvalidOperationException($"Script host failed to start: HTTP {response.StatusCode}");
         }
-
-        await Task.CompletedTask;
     }
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        _cts?.Cancel();
-
-        try
-        {
-            _listener?.Stop();
-        }
-        catch (ObjectDisposedException)
-        {
-            // Already disposed
-        }
-        catch (HttpListenerException)
-        {
-            // The listener may already be torn down while another process has reused the probed port.
-        }
-
-        if (_serverTask is not null)
-        {
-            try
-            {
-                await _serverTask.WaitAsync(TimeSpan.FromSeconds(5));
-            }
-            catch (TimeoutException)
-            {
-                // Server didn't stop in time — ignore
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected
-            }
-        }
-
-        try
-        {
-            _listener?.Close();
-        }
-        catch (ObjectDisposedException)
-        {
-            // Already disposed
-        }
-        catch (HttpListenerException)
-        {
-            // Closing only releases cleanup state; the server loop has already been canceled.
-        }
-
-        _cts?.Dispose();
-    }
-
-    private async Task ServeAsync(CancellationToken cancellationToken)
-    {
-        while (!cancellationToken.IsCancellationRequested && _listener?.IsListening == true)
-        {
-            HttpListenerContext ctx;
-            try
-            {
-                ctx = await _listener.GetContextAsync().WaitAsync(cancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-            catch (ObjectDisposedException)
-            {
-                break;
-            }
-            catch (HttpListenerException)
-            {
-                break;
-            }
-
-            try
-            {
-                await HandleRequestAsync(ctx);
-            }
-            catch
-            {
-                // Don't let a single request crash the server
-            }
-        }
-    }
-
-    private async Task HandleRequestAsync(HttpListenerContext ctx)
-    {
-        var requestPath = ctx.Request.Url?.AbsolutePath.TrimStart('/');
-
-        if (string.IsNullOrEmpty(requestPath) || _scriptsDirectory is null)
-        {
-            ctx.Response.StatusCode = 404;
-            ctx.Response.Close();
-            return;
-        }
-
-        // Prevent directory traversal
-        var safeName = Path.GetFileName(requestPath);
-        var filePath = Path.Combine(_scriptsDirectory, safeName);
-
-        if (!File.Exists(filePath))
-        {
-            ctx.Response.StatusCode = 404;
-            ctx.Response.Close();
-            return;
-        }
-
-        var content = await File.ReadAllBytesAsync(filePath);
-
-        // Serve as text/plain — this matches what raw.githubusercontent.com does
-        ctx.Response.ContentType = "text/plain; charset=utf-8";
-        ctx.Response.ContentLength64 = content.Length;
-        ctx.Response.StatusCode = 200;
-        await ctx.Response.OutputStream.WriteAsync(content);
-        ctx.Response.Close();
+        _server?.Dispose();
+        _server = null;
+        return ValueTask.CompletedTask;
     }
 }

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptInstallerModeTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptInstallerModeTests.cs
@@ -746,6 +746,17 @@ public class PRScriptInstallerModeTests(ITestOutputHelper testOutput)
         Assert.DoesNotContain(new string('0', 64), installerManifest);
         Assert.DoesNotContain("${", installerManifest);
 
+        // The installer shape is load-bearing for self-extract detection at runtime: the
+        // WingetFirstRunProbe identifies an Aspire winget install via the InstallLocation
+        // ARP value, which winget only writes for an InstallerType: zip + NestedInstallerType:
+        // portable manifest. Switching to InstallerType: portable directly, removing
+        // NestedInstallerType, or moving aspire.exe out of NestedInstallerFiles would change
+        // the registry shape and silently break install detection. See WingetAspireEntryMatcher.
+        Assert.Contains("InstallerType: zip", installerManifest);
+        Assert.Contains("NestedInstallerType: portable", installerManifest);
+        Assert.Contains("NestedInstallerFiles:", installerManifest);
+        Assert.Contains("RelativeFilePath: aspire.exe", installerManifest);
+
         var localeManifest = await File.ReadAllTextAsync(Path.Combine(outputDir, "Microsoft.Aspire.locale.en-US.yaml"));
         Assert.Contains("For testing builds only. Prerelease package in stable manifest.", localeManifest);
         Assert.True(File.Exists(Path.Combine(outputDir, "Microsoft.Aspire.yaml")));

--- a/tests/Aspire.Acquisition.Tests/Scripts/WinGetRegistryShapeTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/WinGetRegistryShapeTests.cs
@@ -4,7 +4,6 @@
 #if NET
 using System.Diagnostics;
 using System.IO.Compression;
-using System.Net;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
@@ -109,10 +108,12 @@ public sealed class WinGetRegistryShapeTests(ITestOutputHelper testOutput)
         // InternetOpenUrl(), which only supports http/https/ftp (not file://). See
         // Start-LocalArchiveServer in eng/winget/dogfood.ps1 for the same workaround.
         // Loopback prefixes don't require admin / netsh urlacl reservation.
-        using var server = LoopbackArchiveServer.Start(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            [archiveName] = archivePath,
-        });
+        using var server = LoopbackHttpFileServer.Start(
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [archiveName] = archivePath,
+            },
+            contentType: "application/octet-stream");
         _testOutput.WriteLine($"loopback: {server.BaseUrl}");
 
         // PackageLocale is required by the singleton schema's top-level "required" array; the
@@ -142,7 +143,7 @@ public sealed class WinGetRegistryShapeTests(ITestOutputHelper testOutput)
             UpgradeBehavior: uninstallPrevious
             Installers:
             - Architecture: {{(RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "arm64" : "x64")}}
-              InstallerUrl: {{server.BaseUrl}}{{archiveName}}
+              InstallerUrl: {{server.BaseUrl}}/{{archiveName}}
               InstallerSha256: {{archiveSha256.ToUpperInvariant()}}
             ManifestType: singleton
             ManifestVersion: 1.6.0
@@ -335,118 +336,6 @@ public sealed class WinGetRegistryShapeTests(ITestOutputHelper testOutput)
     }
 
     private sealed record ProcessResult(int ExitCode, string Stdout, string Stderr);
-
-    private sealed class LoopbackArchiveServer : IDisposable
-    {
-        private readonly HttpListener _listener;
-        private readonly CancellationTokenSource _cts;
-        private readonly Task _loop;
-
-        public string BaseUrl { get; }
-
-        private LoopbackArchiveServer(HttpListener listener, string baseUrl, IReadOnlyDictionary<string, string> fileMap)
-        {
-            _listener = listener;
-            BaseUrl = baseUrl;
-            _cts = new CancellationTokenSource();
-            _loop = Task.Run(() => ServeAsync(fileMap, _cts.Token));
-        }
-
-        public static LoopbackArchiveServer Start(IReadOnlyDictionary<string, string> fileMap)
-        {
-            // Pick a free loopback port. Loopback bindings don't require admin / netsh urlacl
-            // — that restriction only applies to non-loopback prefixes. See dogfood.ps1
-            // Start-LocalArchiveServer for the same rationale.
-            for (var attempt = 1; attempt <= 5; attempt++)
-            {
-                var port = GetFreeLoopbackPort();
-                var prefix = $"http://127.0.0.1:{port}/";
-                var listener = new HttpListener();
-                listener.Prefixes.Add(prefix);
-                try
-                {
-                    listener.Start();
-                    return new LoopbackArchiveServer(listener, prefix, fileMap);
-                }
-                catch (HttpListenerException) when (attempt < 5)
-                {
-                    // The port may have been grabbed between GetFreeLoopbackPort releasing
-                    // the TcpListener and HttpListener.Start binding it. Retry with a fresh
-                    // port.
-                    listener.Close();
-                }
-            }
-
-            throw new InvalidOperationException("Could not bind a loopback HttpListener after 5 attempts.");
-        }
-
-        private async Task ServeAsync(IReadOnlyDictionary<string, string> fileMap, CancellationToken ct)
-        {
-            while (!ct.IsCancellationRequested && _listener.IsListening)
-            {
-                HttpListenerContext context;
-                try
-                {
-                    context = await _listener.GetContextAsync();
-                }
-                catch (HttpListenerException)
-                {
-                    return;
-                }
-                catch (ObjectDisposedException)
-                {
-                    return;
-                }
-
-                try
-                {
-                    var name = Path.GetFileName(Uri.UnescapeDataString(context.Request.Url!.AbsolutePath));
-                    if (fileMap.TryGetValue(name, out var filePath) && File.Exists(filePath))
-                    {
-                        var bytes = await File.ReadAllBytesAsync(filePath, ct);
-                        context.Response.ContentType = "application/octet-stream";
-                        context.Response.ContentLength64 = bytes.LongLength;
-                        await context.Response.OutputStream.WriteAsync(bytes, ct);
-                    }
-                    else
-                    {
-                        context.Response.StatusCode = 404;
-                    }
-                }
-                catch
-                {
-                    try { context.Response.StatusCode = 500; } catch { }
-                }
-                finally
-                {
-                    try { context.Response.Close(); } catch { }
-                }
-            }
-        }
-
-        private static int GetFreeLoopbackPort()
-        {
-            var tcp = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-            tcp.Start();
-            try
-            {
-                return ((System.Net.IPEndPoint)tcp.LocalEndpoint).Port;
-            }
-            finally
-            {
-                tcp.Stop();
-            }
-        }
-
-        public void Dispose()
-        {
-            try { _cts.Cancel(); } catch { }
-            try { _listener.Stop(); } catch { }
-            try { _loop.Wait(TimeSpan.FromSeconds(2)); } catch { }
-            try { _listener.Close(); } catch { }
-            _cts.Dispose();
-        }
-    }
 }
 
 /// <summary>

--- a/tests/Aspire.Acquisition.Tests/Scripts/WinGetRegistryShapeTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/WinGetRegistryShapeTests.cs
@@ -1,0 +1,459 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.Text;
+using Aspire.TestUtilities;
+using Microsoft.DotNet.XUnitExtensions;
+using Microsoft.Win32;
+using Xunit;
+
+namespace Aspire.Acquisition.Tests.Scripts;
+
+/// <summary>
+/// Verifies the actual ARP registry shape that real winget writes when installing a
+/// zip+portable package, so that drift in winget's wire format (key names, value types,
+/// which fields are present) is caught before it silently breaks the install-detection
+/// matcher in <c>Aspire.Cli.Acquisition.WingetAspireEntryMatcher</c>.
+///
+/// Why this exists: the unit tests for the matcher are agnostic to wire names (they call
+/// <c>Matches(...)</c> with strings directly), and the HKCU integration tests in
+/// Aspire.Cli.Tests write the values they expect to read — both are self-referential.
+/// This test goes through real <c>winget install</c> against a synthetic
+/// zip+portable manifest and asserts the actual values winget writes, so changes in
+/// the winget wire format are caught here rather than in a customer's self-extract bug
+/// report.
+///
+/// Tradeoff: a real <c>winget install</c>/uninstall cycle takes ~10–30s and mutates user
+/// state (registry, PATH, %LOCALAPPDATA%\Microsoft\WinGet\Packages). Cleanup runs in
+/// <c>finally</c> via <c>winget uninstall --id &lt;unique-id&gt; --silent</c>, and the
+/// package identifier is suffixed with a per-run GUID so a crashed run still leaves
+/// identifiable, grep-able state.
+///
+/// Loud-fail rather than silent-skip: on Windows we deliberately do not use
+/// <c>[RequiresTools]</c>. If winget is missing on a Windows test host the test throws
+/// with an actionable message so we can see in CI logs that we're not silently
+/// skipping the only test that exercises real winget against the matcher.
+/// </summary>
+[Collection(nameof(WinGetRegistryShapeTestCollection))]
+[SupportedOSPlatform("windows")]
+public sealed class WinGetRegistryShapeTests(ITestOutputHelper testOutput)
+{
+    private readonly ITestOutputHelper _testOutput = testOutput;
+
+    [Fact]
+    [SkipOnPlatform(TestPlatforms.Linux | TestPlatforms.OSX | TestPlatforms.FreeBSD, "winget is Windows-only.")]
+    public async Task WinGet_Install_Of_PortableZip_Writes_ARP_Values_Matcher_Reads()
+    {
+        // Loud-fail (not skip) if winget isn't on PATH on a Windows host. GitHub-hosted
+        // windows-latest (windows-2022) images ship App Installer / winget pre-installed
+        // since mid-2023, so absence is a CI-image regression we want to surface, not hide.
+        var wingetPath = LocateWinGetOrThrow();
+        _testOutput.WriteLine($"winget: {wingetPath}");
+
+        // Local manifest install is an opt-in winget feature. dogfood.ps1 and
+        // prepare-manifest-artifact.ps1 both flip this on the same way. Toggling the
+        // setting requires admin on a first-time machine. GH Actions windows-latest
+        // runners are admin by default; developer machines often are not. If we are
+        // not admin AND the setting isn't already enabled, the install would later
+        // fail with the cryptic 0x8a150004 "Opening manifest failed" — skip with an
+        // actionable message instead so the failure is recognisable and avoidable.
+        var enable = await RunAsync(wingetPath, ["settings", "--enable", "LocalManifestFiles"], allowFailure: true);
+        if (enable.ExitCode != 0)
+        {
+            _testOutput.WriteLine($"winget settings --enable LocalManifestFiles failed (exit {enable.ExitCode}).");
+            _testOutput.WriteLine($"stdout: {enable.Stdout}");
+            _testOutput.WriteLine($"stderr: {enable.Stderr}");
+
+            if (!IsCurrentProcessElevated())
+            {
+                Assert.Skip(
+                    "This test requires winget LocalManifestFiles to be enabled. Toggling that setting needs an " +
+                    "elevated shell on first use. Either rerun the test from an elevated PowerShell, or enable the " +
+                    "setting once (admin) with: winget settings --enable LocalManifestFiles. CI hosts run elevated " +
+                    "so this skip never fires there.");
+            }
+
+            // Elevated but still failed — that's a real environment issue (winget too
+            // old, App Installer not present, etc.). Fall through to the install
+            // attempt below, which surfaces the underlying 0x8a150004 as a loud
+            // failure with full context.
+        }
+
+        var packageSuffix = Guid.NewGuid().ToString("N")[..8];
+        var packageId = $"AspireTest.WinGetShape.{packageSuffix}";
+        var packageVersion = "0.0.1";
+        var commandAlias = $"aspiretest-winget-shape-{packageSuffix}".ToLowerInvariant();
+        var archiveName = $"aspiretest-winget-shape-{packageSuffix}.zip";
+
+        using var env = new TestEnvironment();
+        var stageDir = Path.Combine(env.TempDirectory, "stage");
+        var manifestDir = Path.Combine(stageDir, "manifest");
+        var archiveDir = Path.Combine(stageDir, "archive");
+        Directory.CreateDirectory(manifestDir);
+        Directory.CreateDirectory(archiveDir);
+
+        var archivePath = Path.Combine(archiveDir, archiveName);
+        await WriteSyntheticZipAsync(archivePath, payloadName: "aspire.exe", payloadContent: $"stub-{packageSuffix}");
+        var archiveSha256 = await ComputeSha256HexAsync(archivePath);
+        _testOutput.WriteLine($"archive: {archivePath} sha256={archiveSha256}");
+
+        // Loopback HttpListener — winget downloads InstallerUrl via WinINet's
+        // InternetOpenUrl(), which only supports http/https/ftp (not file://). See
+        // Start-LocalArchiveServer in eng/winget/dogfood.ps1 for the same workaround.
+        // Loopback prefixes don't require admin / netsh urlacl reservation.
+        using var server = LoopbackArchiveServer.Start(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [archiveName] = archivePath,
+        });
+        _testOutput.WriteLine($"loopback: {server.BaseUrl}");
+
+        // PackageLocale is required by the singleton schema's top-level "required" array; the
+        // multi-file shape (used by the real Aspire manifest) carries it in a separate
+        // *.locale.<tag>.yaml so it's easy to forget on a hand-rolled singleton. Without it,
+        // winget rejects the manifest with 0x8A150004 "Opening manifest failed" before any
+        // install/download attempt — see
+        // https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.singleton.1.6.0.json
+        var manifestYaml = $$"""
+            # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
+            PackageIdentifier: {{packageId}}
+            PackageVersion: {{packageVersion}}
+            PackageLocale: en-US
+            PackageName: Aspire WinGet Shape Test {{packageSuffix}}
+            Publisher: AspireTest
+            License: MIT
+            ShortDescription: Synthetic package used to snapshot the ARP registry shape that winget writes for zip+portable installs.
+            InstallerType: zip
+            NestedInstallerType: portable
+            NestedInstallerFiles:
+            - RelativeFilePath: aspire.exe
+              PortableCommandAlias: {{commandAlias}}
+            Commands:
+            - {{commandAlias}}
+            InstallModes:
+            - silent
+            UpgradeBehavior: uninstallPrevious
+            Installers:
+            - Architecture: {{(RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "arm64" : "x64")}}
+              InstallerUrl: {{server.BaseUrl}}{{archiveName}}
+              InstallerSha256: {{archiveSha256.ToUpperInvariant()}}
+            ManifestType: singleton
+            ManifestVersion: 1.6.0
+            """;
+        var manifestPath = Path.Combine(manifestDir, $"{packageId}.yaml");
+        await File.WriteAllTextAsync(manifestPath, manifestYaml);
+        _testOutput.WriteLine($"manifest: {manifestPath}");
+
+        try
+        {
+            // --disable-interactivity: belt-and-suspenders alongside --accept-*-agreements.
+            // If a future winget adds a new prompt type, this still fails fast instead of
+            // hanging this test process (which has no stdin).
+            var install = await RunAsync(wingetPath,
+                ["install", "--manifest", manifestPath, "--silent", "--accept-package-agreements", "--accept-source-agreements", "--disable-interactivity"],
+                allowFailure: true);
+            if (install.ExitCode != 0)
+            {
+                // 0x8a150004 is APPINSTALLER_CLI_ERROR_MANIFEST_FAILED — typically because
+                // LocalManifestFiles is not enabled in winget settings (which requires admin
+                // to enable on first use).
+                var hint = unchecked((int)0x8a150004) == install.ExitCode
+                    ? " Likely cause: LocalManifestFiles is not enabled in winget settings. " +
+                      "Run elevated: 'winget settings --enable LocalManifestFiles'. " +
+                      "On GH Actions windows-latest this should already be admin-runnable."
+                    : string.Empty;
+                Assert.Fail($"winget install failed (exit 0x{install.ExitCode:x8}).{hint}\nstdout:\n{install.Stdout}\nstderr:\n{install.Stderr}");
+            }
+
+            // The ARP subkey for a locally-installed singleton package is named
+            // "<PackageIdentifier>_<scope-suffix>" under
+            // HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall. The exact suffix
+            // depends on winget's source bookkeeping for local installs, so enumerate.
+            var (subkeyName, snapshot) = ReadAspireTestArpEntry(packageId);
+            _testOutput.WriteLine($"ARP subkey: {subkeyName}");
+            foreach (var kvp in snapshot)
+            {
+                _testOutput.WriteLine($"  {kvp.Key} = ({kvp.Value?.GetType().Name ?? "null"}) {kvp.Value}");
+            }
+
+            // The wire-name + presence + type contract that
+            // WingetAspireEntryMatcher.Matches() depends on. If any of these assertions
+            // start failing, winget changed its ARP wire format and the matcher needs
+            // to be updated in lockstep.
+            Assert.Equal(packageId, Assert.IsType<string>(snapshot["WinGetPackageIdentifier"]));
+            Assert.Equal("portable", Assert.IsType<string>(snapshot["WinGetInstallerType"]));
+            var installLocation = Assert.IsType<string>(snapshot["InstallLocation"]);
+            Assert.False(string.IsNullOrWhiteSpace(installLocation), "InstallLocation must be a non-empty string.");
+            Assert.True(Directory.Exists(installLocation), $"InstallLocation '{installLocation}' must point at an extant directory.");
+
+            // The aspire.exe extracted from the zip lives directly under InstallLocation
+            // (NestedInstallerFiles[].RelativeFilePath relative to extraction root) —
+            // this is exactly the "binary colocated with InstallLocation" relationship
+            // that WingetAspireEntryMatcher.IsProcessUnderDirectory relies on.
+            var extractedAspireExe = Path.Combine(installLocation, "aspire.exe");
+            Assert.True(File.Exists(extractedAspireExe), $"Expected extracted payload at '{extractedAspireExe}'.");
+        }
+        finally
+        {
+            try
+            {
+                // --accept-source-agreements + --disable-interactivity: the uninstall path
+                // touches winget's configured sources (e.g. msstore) which can otherwise
+                // prompt for a one-time source agreement. There is no stdin in this test
+                // process, so any prompt fails with 0x8A150042 "Error reading input in
+                // prompt" and leaves the package half-uninstalled. Pass both so cleanup
+                // is fully non-interactive.
+                var uninstall = await RunAsync(wingetPath, ["uninstall", "--id", packageId, "--silent", "--accept-source-agreements", "--disable-interactivity"], allowFailure: true);
+                _testOutput.WriteLine($"winget uninstall exit={uninstall.ExitCode}");
+                if (uninstall.ExitCode != 0)
+                {
+                    _testOutput.WriteLine($"uninstall stdout:\n{uninstall.Stdout}\nstderr:\n{uninstall.Stderr}");
+                }
+            }
+            catch (Exception ex)
+            {
+                _testOutput.WriteLine($"winget uninstall threw: {ex}");
+            }
+        }
+    }
+
+    private static bool IsCurrentProcessElevated()
+    {
+        try
+        {
+            using var identity = WindowsIdentity.GetCurrent();
+            return new WindowsPrincipal(identity).IsInRole(WindowsBuiltInRole.Administrator);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string LocateWinGetOrThrow()
+    {
+        var winget = Environment.GetEnvironmentVariable("PATH")
+            ?.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Select(dir => Path.Combine(dir, "winget.exe"))
+            .FirstOrDefault(File.Exists);
+
+        if (winget is null)
+        {
+            throw new InvalidOperationException(
+                "winget.exe was not found on PATH. GitHub-hosted windows-latest runner images " +
+                "ship App Installer / winget pre-installed; if running locally, install 'App Installer' " +
+                "from the Microsoft Store. We intentionally do not [RequiresTools(\"winget\")] here so " +
+                "that an image regression surfaces as a loud failure rather than a silent skip.");
+        }
+
+        return winget;
+    }
+
+    private static async Task WriteSyntheticZipAsync(string path, string payloadName, string payloadContent)
+    {
+        await using var fs = File.Create(path);
+        using var archive = new ZipArchive(fs, ZipArchiveMode.Create);
+        var entry = archive.CreateEntry(payloadName, CompressionLevel.NoCompression);
+        await using var s = entry.Open();
+        await s.WriteAsync(Encoding.UTF8.GetBytes(payloadContent));
+    }
+
+    private static async Task<string> ComputeSha256HexAsync(string path)
+    {
+        await using var fs = File.OpenRead(path);
+        var hash = await SHA256.HashDataAsync(fs);
+        return Convert.ToHexString(hash);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static (string SubkeyName, Dictionary<string, object?> Values) ReadAspireTestArpEntry(string packageId)
+    {
+        const string ArpPath = @"Software\Microsoft\Windows\CurrentVersion\Uninstall";
+        using var arp = Registry.CurrentUser.OpenSubKey(ArpPath)
+            ?? throw new InvalidOperationException($"HKCU\\{ArpPath} does not exist.");
+
+        // Locally-installed packages get a subkey name "<PackageIdentifier>_<scope-suffix>"
+        // — match by prefix so we don't have to hardcode the suffix shape.
+        var match = arp.GetSubKeyNames().FirstOrDefault(name => name.StartsWith(packageId, StringComparison.OrdinalIgnoreCase));
+        if (match is null)
+        {
+            var sample = string.Join(", ", arp.GetSubKeyNames().Where(n => n.Contains("AspireTest", StringComparison.OrdinalIgnoreCase)));
+            throw new InvalidOperationException(
+                $"No ARP subkey starting with '{packageId}' under HKCU\\{ArpPath}. " +
+                $"AspireTest-related subkeys present: [{sample}].");
+        }
+
+        using var entry = arp.OpenSubKey(match)
+            ?? throw new InvalidOperationException($"Failed to open HKCU\\{ArpPath}\\{match} for reading.");
+
+        var values = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var name in entry.GetValueNames())
+        {
+            values[name] = entry.GetValue(name);
+        }
+
+        return (match, values);
+    }
+
+    private async Task<ProcessResult> RunAsync(string fileName, IReadOnlyList<string> args, bool allowFailure = false)
+    {
+        var psi = new ProcessStartInfo(fileName)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var arg in args)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        _testOutput.WriteLine($"> {fileName} {string.Join(' ', args)}");
+
+        using var proc = Process.Start(psi)!;
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        await proc.WaitForExitAsync();
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        if (!allowFailure && proc.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"'{fileName} {string.Join(' ', args)}' failed with exit code {proc.ExitCode}.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        }
+
+        return new ProcessResult(proc.ExitCode, stdout, stderr);
+    }
+
+    private sealed record ProcessResult(int ExitCode, string Stdout, string Stderr);
+
+    private sealed class LoopbackArchiveServer : IDisposable
+    {
+        private readonly HttpListener _listener;
+        private readonly CancellationTokenSource _cts;
+        private readonly Task _loop;
+
+        public string BaseUrl { get; }
+
+        private LoopbackArchiveServer(HttpListener listener, string baseUrl, IReadOnlyDictionary<string, string> fileMap)
+        {
+            _listener = listener;
+            BaseUrl = baseUrl;
+            _cts = new CancellationTokenSource();
+            _loop = Task.Run(() => ServeAsync(fileMap, _cts.Token));
+        }
+
+        public static LoopbackArchiveServer Start(IReadOnlyDictionary<string, string> fileMap)
+        {
+            // Pick a free loopback port. Loopback bindings don't require admin / netsh urlacl
+            // — that restriction only applies to non-loopback prefixes. See dogfood.ps1
+            // Start-LocalArchiveServer for the same rationale.
+            for (var attempt = 1; attempt <= 5; attempt++)
+            {
+                var port = GetFreeLoopbackPort();
+                var prefix = $"http://127.0.0.1:{port}/";
+                var listener = new HttpListener();
+                listener.Prefixes.Add(prefix);
+                try
+                {
+                    listener.Start();
+                    return new LoopbackArchiveServer(listener, prefix, fileMap);
+                }
+                catch (HttpListenerException) when (attempt < 5)
+                {
+                    // The port may have been grabbed between GetFreeLoopbackPort releasing
+                    // the TcpListener and HttpListener.Start binding it. Retry with a fresh
+                    // port.
+                    listener.Close();
+                }
+            }
+
+            throw new InvalidOperationException("Could not bind a loopback HttpListener after 5 attempts.");
+        }
+
+        private async Task ServeAsync(IReadOnlyDictionary<string, string> fileMap, CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested && _listener.IsListening)
+            {
+                HttpListenerContext context;
+                try
+                {
+                    context = await _listener.GetContextAsync();
+                }
+                catch (HttpListenerException)
+                {
+                    return;
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+
+                try
+                {
+                    var name = Path.GetFileName(Uri.UnescapeDataString(context.Request.Url!.AbsolutePath));
+                    if (fileMap.TryGetValue(name, out var filePath) && File.Exists(filePath))
+                    {
+                        var bytes = await File.ReadAllBytesAsync(filePath, ct);
+                        context.Response.ContentType = "application/octet-stream";
+                        context.Response.ContentLength64 = bytes.LongLength;
+                        await context.Response.OutputStream.WriteAsync(bytes, ct);
+                    }
+                    else
+                    {
+                        context.Response.StatusCode = 404;
+                    }
+                }
+                catch
+                {
+                    try { context.Response.StatusCode = 500; } catch { }
+                }
+                finally
+                {
+                    try { context.Response.Close(); } catch { }
+                }
+            }
+        }
+
+        private static int GetFreeLoopbackPort()
+        {
+            var tcp = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            tcp.Start();
+            try
+            {
+                return ((System.Net.IPEndPoint)tcp.LocalEndpoint).Port;
+            }
+            finally
+            {
+                tcp.Stop();
+            }
+        }
+
+        public void Dispose()
+        {
+            try { _cts.Cancel(); } catch { }
+            try { _listener.Stop(); } catch { }
+            try { _loop.Wait(TimeSpan.FromSeconds(2)); } catch { }
+            try { _listener.Close(); } catch { }
+            _cts.Dispose();
+        }
+    }
+}
+
+/// <summary>
+/// Forces all real-winget tests to run serially. Real <c>winget install</c>/uninstall
+/// mutates a single process-wide settings store and the per-user PATH; parallel runs
+/// can race or trip winget's internal mutex.
+/// </summary>
+[CollectionDefinition(nameof(WinGetRegistryShapeTestCollection), DisableParallelization = true)]
+public sealed class WinGetRegistryShapeTestCollection;
+#endif

--- a/tests/Aspire.Cli.Tests/Acquisition/WindowsRegistryReaderIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/WindowsRegistryReaderIntegrationTests.cs
@@ -1,0 +1,295 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Versioning;
+using Aspire.Cli.Acquisition;
+using Microsoft.Win32;
+
+namespace Aspire.Cli.Tests.Acquisition;
+
+/// <summary>
+/// Windows-only integration tests for <see cref="WindowsRegistryReader"/> that
+/// write a real-shaped winget Add/Remove Programs entry to <c>HKCU</c> and walk
+/// the live registry, then clean up.
+///
+/// These complement <see cref="WingetAspireEntryMatcherTests"/>: the matcher
+/// tests cover the pure predicate, but they cannot catch a regression that
+/// flips one of the registry value-name constants
+/// (<c>WingetAspireEntryMatcher.TargetFullPathValueName</c>,
+/// <c>InstallLocationValueName</c>, <c>PackageIdentifierValueName</c>,
+/// <c>InstallerTypeValueName</c>) to the wrong wire string — exactly the class
+/// of bug that shipped (<c>"PortableTargetFullPath"</c> when winget actually
+/// writes <c>"TargetFullPath"</c>).
+///
+/// Tests use a unique GUID-suffixed subkey under
+/// <c>HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall</c>, plus
+/// process paths under a fresh temp directory, so they cannot collide with or
+/// be confused by a real Aspire winget install that may exist on the host. The
+/// matcher iterates all subkeys and matches purely on values, so the subkey
+/// name only affects cleanup precision.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public class WindowsRegistryReaderIntegrationTests
+{
+    private const string UninstallSubKey = @"Software\Microsoft\Windows\CurrentVersion\Uninstall";
+    private const string TestSubKeyPrefix = "Microsoft.Aspire_AspireCliTests_";
+
+    static WindowsRegistryReaderIntegrationTests()
+    {
+        // Purge any subkeys leaked by crashed prior runs before any test
+        // creates a new entry. Without this, the orphans accumulate in
+        // HKCU\...\Uninstall and show up in Settings -> Apps as
+        // "Aspire CLI (...test) 0.0.0" entries on developer machines. Each
+        // entry's unique GUID-suffixed name makes the prefix scan safe.
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
+        {
+            using var baseKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry64);
+            using var uninstall = baseKey.OpenSubKey(UninstallSubKey, writable: true);
+            if (uninstall is null)
+            {
+                return;
+            }
+
+            foreach (var name in uninstall.GetSubKeyNames())
+            {
+                if (name.StartsWith(TestSubKeyPrefix, StringComparison.Ordinal))
+                {
+                    try
+                    {
+                        uninstall.DeleteSubKeyTree(name, throwOnMissingSubKey: false);
+                    }
+                    catch
+                    {
+                        // Best-effort: one stuck orphan must not block the
+                        // rest of the reaping pass or the test run.
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Reaping is best-effort; the per-test Dispose still runs.
+        }
+    }
+
+    [Fact]
+    public void HasWingetAspireUninstallEntry_ArchivePortableShape_MatchesViaInstallLocation()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Real-registry test is Windows-only.");
+
+        using var workspace = new TestTempDirectory();
+        var installDir = Path.Combine(workspace.Path, "WinGet", "Packages", "Microsoft.Aspire_TestSource");
+        Directory.CreateDirectory(installDir);
+        var processPath = Path.Combine(installDir, "aspire.exe");
+
+        using var entry = TestUninstallEntry.CreatePortableArchiveShape(installDir);
+
+        var reader = new WindowsRegistryReader();
+
+        Assert.True(reader.HasWingetAspireUninstallEntry(processPath),
+            "Reader must match the archive-portable shape via InstallLocation (the shape Aspire's winget manifest produces).");
+    }
+
+    [Fact]
+    public void HasWingetAspireUninstallEntry_SingleFilePortableShape_MatchesViaTargetFullPath()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Real-registry test is Windows-only.");
+
+        using var workspace = new TestTempDirectory();
+        var installDir = Path.Combine(workspace.Path, "WinGet", "Packages", "Microsoft.Aspire_SingleFile");
+        Directory.CreateDirectory(installDir);
+        var processPath = Path.Combine(installDir, "aspire.exe");
+
+        using var entry = TestUninstallEntry.CreatePortableSingleFileShape(processPath);
+
+        var reader = new WindowsRegistryReader();
+
+        Assert.True(reader.HasWingetAspireUninstallEntry(processPath),
+            "Reader must match the single-file portable shape via TargetFullPath.");
+    }
+
+    [Fact]
+    public void HasWingetAspireUninstallEntry_WrongPackageIdentifier_DoesNotMatch()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Real-registry test is Windows-only.");
+
+        using var workspace = new TestTempDirectory();
+        var installDir = Path.Combine(workspace.Path, "Other.Package");
+        Directory.CreateDirectory(installDir);
+        var processPath = Path.Combine(installDir, "aspire.exe");
+
+        using var entry = TestUninstallEntry.Create(values: new()
+        {
+            ["WinGetPackageIdentifier"] = "Microsoft.NotAspire",
+            ["WinGetInstallerType"] = "portable",
+            ["InstallLocation"] = installDir,
+        });
+
+        var reader = new WindowsRegistryReader();
+
+        Assert.False(reader.HasWingetAspireUninstallEntry(processPath),
+            "Reader must not match entries whose WinGetPackageIdentifier is not Microsoft.Aspire.");
+    }
+
+    [Fact]
+    public void HasWingetAspireUninstallEntry_NonPortableInstallerType_DoesNotMatch()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Real-registry test is Windows-only.");
+
+        using var workspace = new TestTempDirectory();
+        var installDir = Path.Combine(workspace.Path, "MsiInstall");
+        Directory.CreateDirectory(installDir);
+        var processPath = Path.Combine(installDir, "aspire.exe");
+
+        using var entry = TestUninstallEntry.Create(values: new()
+        {
+            ["WinGetPackageIdentifier"] = "Microsoft.Aspire",
+            ["WinGetInstallerType"] = "msi",
+            ["InstallLocation"] = installDir,
+        });
+
+        var reader = new WindowsRegistryReader();
+
+        Assert.False(reader.HasWingetAspireUninstallEntry(processPath),
+            "Reader must reject non-portable installer types so a hypothetical future MSI install is not silently treated as portable.");
+    }
+
+    [Fact]
+    public void HasWingetAspireUninstallEntry_AspireEntryButPathOutsideInstallDir_DoesNotMatch()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Real-registry test is Windows-only.");
+
+        using var workspace = new TestTempDirectory();
+        var installDir = Path.Combine(workspace.Path, "real-winget-dir");
+        Directory.CreateDirectory(installDir);
+        // Process lives somewhere else entirely.
+        var unrelatedProcessPath = Path.Combine(workspace.Path, "elsewhere", "aspire.exe");
+
+        using var entry = TestUninstallEntry.CreatePortableArchiveShape(installDir);
+
+        var reader = new WindowsRegistryReader();
+
+        Assert.False(reader.HasWingetAspireUninstallEntry(unrelatedProcessPath),
+            "Reader must not match when the running process path is not inside the winget InstallLocation, even when an Aspire entry exists.");
+    }
+
+    [Fact]
+    public void HasWingetAspireUninstallEntry_AspireEntryWithNoPathEvidence_DoesNotMatch()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Real-registry test is Windows-only.");
+
+        using var workspace = new TestTempDirectory();
+        var processPath = Path.Combine(workspace.Path, "aspire.exe");
+
+        using var entry = TestUninstallEntry.Create(values: new()
+        {
+            ["WinGetPackageIdentifier"] = "Microsoft.Aspire",
+            ["WinGetInstallerType"] = "portable",
+            // No InstallLocation, no TargetFullPath: no way to attribute the path.
+            ["DisplayName"] = "Aspire CLI (no path)",
+        });
+
+        var reader = new WindowsRegistryReader();
+
+        Assert.False(reader.HasWingetAspireUninstallEntry(processPath),
+            "Reader must require at least one path-evidence value (TargetFullPath or InstallLocation) before claiming an entry owns the running process.");
+    }
+
+    /// <summary>
+    /// IDisposable wrapper that creates a uniquely-named subkey under
+    /// HKCU\...\Uninstall, populates it with the supplied values using the
+    /// exact wire names winget writes, and deletes the subkey on dispose.
+    /// Writing to HKCU does not require elevation.
+    /// </summary>
+    private sealed class TestUninstallEntry : IDisposable
+    {
+        private readonly string _subKeyName;
+
+        private TestUninstallEntry(string subKeyName)
+        {
+            _subKeyName = subKeyName;
+        }
+
+        public static TestUninstallEntry Create(Dictionary<string, string> values)
+        {
+            // Unique per-test subkey so concurrent test runs and any real Aspire
+            // winget install on the machine cannot interfere with cleanup. The
+            // reader matches on values, not names, so this naming is purely a
+            // cleanup-precision concern.
+            var subKeyName = $"{TestSubKeyPrefix}{Guid.NewGuid():N}";
+            using var baseKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry64);
+            // HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall is created lazily
+            // and may not exist on a fresh user profile (observed on a GitHub Actions
+            // windows-latest runneradmin profile where nothing had yet registered a
+            // user-scope ARP entry). CreateSubKey opens-if-exists / creates-if-missing,
+            // and HKCU writes do not require elevation.
+            using var uninstall = baseKey.CreateSubKey(UninstallSubKey, writable: true)
+                ?? throw new InvalidOperationException($"HKCU\\{UninstallSubKey} could not be opened or created for write.");
+            using var entry = uninstall.CreateSubKey(subKeyName, writable: true);
+            foreach (var (name, value) in values)
+            {
+                entry.SetValue(name, value, RegistryValueKind.String);
+            }
+            return new TestUninstallEntry(subKeyName);
+        }
+
+        /// <summary>
+        /// Mirrors what winget actually writes for an archive/zip portable
+        /// install (the shape Aspire's manifest produces). No TargetFullPath
+        /// is written for this shape; InstallLocation is the only path
+        /// pointer. Live registry verified on a current Aspire winget install.
+        /// </summary>
+        public static TestUninstallEntry CreatePortableArchiveShape(string installLocation)
+            => Create(new Dictionary<string, string>
+            {
+                ["WinGetPackageIdentifier"] = "Microsoft.Aspire",
+                ["WinGetSourceIdentifier"] = "Microsoft.Winget.Source_8wekyb3d8bbwe",
+                ["WinGetInstallerType"] = "portable",
+                ["InstallLocation"] = installLocation,
+                ["InstallDirectoryAddedToPath"] = "1",
+                ["DisplayName"] = "Aspire CLI (archive portable, test)",
+                ["DisplayVersion"] = "0.0.0",
+                ["Publisher"] = "Microsoft Corporation",
+            });
+
+        /// <summary>
+        /// Mirrors what winget writes for a single-file portable install: the
+        /// TargetFullPath value (registry wire name <c>TargetFullPath</c> —
+        /// note the C++ enum identifier <c>PortableTargetFullPath</c> maps to
+        /// this wire string — see winget-cli
+        /// <c>src/AppInstallerCommonCore/PortableARPEntry.cpp</c>).
+        /// </summary>
+        public static TestUninstallEntry CreatePortableSingleFileShape(string targetFullPath)
+            => Create(new Dictionary<string, string>
+            {
+                ["WinGetPackageIdentifier"] = "Microsoft.Aspire",
+                ["WinGetSourceIdentifier"] = "Microsoft.Winget.Source_8wekyb3d8bbwe",
+                ["WinGetInstallerType"] = "portable",
+                ["TargetFullPath"] = targetFullPath,
+                ["DisplayName"] = "Aspire CLI (single-file portable, test)",
+                ["DisplayVersion"] = "0.0.0",
+                ["Publisher"] = "Microsoft Corporation",
+            });
+
+        public void Dispose()
+        {
+            try
+            {
+                using var baseKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry64);
+                using var uninstall = baseKey.OpenSubKey(UninstallSubKey, writable: true);
+                uninstall?.DeleteSubKeyTree(_subKeyName, throwOnMissingSubKey: false);
+            }
+            catch
+            {
+                // Best-effort cleanup. A leaked subkey under HKCU is named with
+                // a unique guid prefix so it is grep-able and safe to clean by
+                // hand if needed.
+            }
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Acquisition/WingetAspireEntryMatcherTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/WingetAspireEntryMatcherTests.cs
@@ -1,0 +1,255 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Acquisition;
+
+namespace Aspire.Cli.Tests.Acquisition;
+
+public class WingetAspireEntryMatcherTests
+{
+    // Archive (zip + NestedInstallerType: portable) shape — the layout Aspire actually
+    // ships. winget writes InstallLocation + (often) InstallDirectoryAddedToPath=1 and
+    // omits TargetFullPath entirely because the per-file ARP writes in
+    // PortableInstaller::InstallFile are gated behind !RecordToIndex, and
+    // GetDesiredStateForPortableInstall always sets RecordToIndex=true when winget
+    // extracts a directory. Verified against winget-cli sources cited on
+    // WingetAspireEntryMatcher.
+
+    [Fact]
+    public void Matches_ArchiveShape_ProcessAtInstallRoot_Matches()
+    {
+        var installDir = MakePath("C:", "Users", "u", "AppData", "Local", "Microsoft", "WinGet", "Packages", "Microsoft.Aspire_Microsoft.Winget.Source_8wekyb3d8bbwe");
+        var processPath = Path.Combine(installDir, "aspire.exe");
+
+        Assert.True(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: processPath,
+            packageIdentifier: "Microsoft.Aspire",
+            installerType: "portable",
+            targetFullPath: null,
+            installLocation: installDir));
+    }
+
+    [Fact]
+    public void Matches_ArchiveShape_ProcessInSubdirOfInstallLocation_Matches()
+    {
+        // Future-proofing: if a winget manifest ever declares
+        // NestedInstallerFiles[].RelativeFilePath: bin/aspire.exe, the binary will
+        // live in a subdirectory of InstallLocation. Containment matching covers it.
+        var installDir = MakePath("C:", "ProgramData", "WinGet", "Microsoft.Aspire");
+        var processPath = MakePath("C:", "ProgramData", "WinGet", "Microsoft.Aspire", "bin", "aspire.exe");
+
+        Assert.True(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: processPath,
+            packageIdentifier: "Microsoft.Aspire",
+            installerType: "portable",
+            targetFullPath: null,
+            installLocation: installDir));
+    }
+
+    [Fact]
+    public void Matches_ArchiveShape_TrailingSeparatorOnInstallLocation_Matches()
+    {
+        var installDir = MakePath("C:", "tmp", "winget", "aspire") + Path.DirectorySeparatorChar;
+        var processPath = MakePath("C:", "tmp", "winget", "aspire", "aspire.exe");
+
+        Assert.True(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: processPath,
+            packageIdentifier: "Microsoft.Aspire",
+            installerType: "portable",
+            targetFullPath: null,
+            installLocation: installDir));
+    }
+
+    [Fact]
+    public void Matches_SingleFileShape_TargetFullPathExactMatch_Matches()
+    {
+        // Single-file portable: winget writes TargetFullPath (NOT
+        // "PortableTargetFullPath" — the C++ enum identifier is misleading; the wire
+        // name in winget-cli/PortableARPEntry.cpp is L"TargetFullPath"). Some future
+        // Aspire installer shape could land here.
+        var processPath = MakePath("C:", "Users", "u", "WinGet", "Links", "aspire.exe");
+
+        Assert.True(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: processPath,
+            packageIdentifier: "Microsoft.Aspire",
+            installerType: "portable",
+            targetFullPath: processPath,
+            installLocation: null));
+    }
+
+    [Fact]
+    public void Matches_SingleFileShape_TargetFullPathCaseInsensitive_Matches()
+    {
+        // Windows paths compare case-insensitively. Drive letter casing differs.
+        var processPath = MakePath("C:", "Users", "U", "WinGet", "Links", "aspire.exe");
+        var targetFullPath = MakePath("c:", "users", "u", "winget", "links", "aspire.exe");
+
+        Assert.True(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: processPath,
+            packageIdentifier: "Microsoft.Aspire",
+            installerType: "portable",
+            targetFullPath: targetFullPath,
+            installLocation: null));
+    }
+
+    [Fact]
+    public void Matches_PrefixCollision_DoesNotFalselyMatch()
+    {
+        // C:\Foo is not a prefix of C:\FooBar — the separator boundary in
+        // IsProcessUnderDirectory must reject this.
+        var installDir = MakePath("C:", "Foo");
+        var processPath = MakePath("C:", "FooBar", "aspire.exe");
+
+        Assert.False(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: processPath,
+            packageIdentifier: "Microsoft.Aspire",
+            installerType: "portable",
+            targetFullPath: null,
+            installLocation: installDir));
+    }
+
+    [Fact]
+    public void Matches_NonAspirePackage_DoesNotMatch()
+    {
+        var installDir = MakePath("C:", "tmp", "winget", "other");
+        var processPath = Path.Combine(installDir, "aspire.exe");
+
+        Assert.False(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: processPath,
+            packageIdentifier: "Some.Other.Package",
+            installerType: "portable",
+            targetFullPath: null,
+            installLocation: installDir));
+    }
+
+    [Fact]
+    public void Matches_AspirePackageIdentifierIsCaseSensitive()
+    {
+        // The C++ enum and the manifest both use PascalCase "Microsoft.Aspire" — match it ordinal-exact
+        // to guard against a future package id collision under different casing.
+        var installDir = MakePath("C:", "tmp", "winget", "aspire");
+        var processPath = Path.Combine(installDir, "aspire.exe");
+
+        Assert.False(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: processPath,
+            packageIdentifier: "microsoft.aspire",
+            installerType: "portable",
+            targetFullPath: null,
+            installLocation: installDir));
+    }
+
+    [Fact]
+    public void Matches_NonPortableInstallerType_BlocksMatch()
+    {
+        // Defense in depth: if Aspire ever ships an MSI manifest under the same
+        // package id, the probe must not claim it as a portable install.
+        var installDir = MakePath("C:", "tmp", "winget", "aspire-msi");
+        var processPath = Path.Combine(installDir, "aspire.exe");
+
+        Assert.False(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: processPath,
+            packageIdentifier: "Microsoft.Aspire",
+            installerType: "msi",
+            targetFullPath: null,
+            installLocation: installDir));
+    }
+
+    [Fact]
+    public void Matches_EmptyInstallerType_TreatedAsAcceptableForBackCompat()
+    {
+        // Older winget builds may not have written WinGetInstallerType on every
+        // entry. The matcher tolerates an empty value rather than excluding the
+        // entry outright, so the package-identifier gate remains the primary filter.
+        var installDir = MakePath("C:", "tmp", "winget", "aspire");
+        var processPath = Path.Combine(installDir, "aspire.exe");
+
+        Assert.True(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: processPath,
+            packageIdentifier: "Microsoft.Aspire",
+            installerType: null,
+            targetFullPath: null,
+            installLocation: installDir));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Matches_EmptyProcessPath_DoesNotMatch(string? processPath)
+    {
+        Assert.False(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: processPath!,
+            packageIdentifier: "Microsoft.Aspire",
+            installerType: "portable",
+            targetFullPath: null,
+            installLocation: MakePath("C:", "tmp")));
+    }
+
+    [Fact]
+    public void Matches_BothPathValuesEmpty_DoesNotMatch()
+    {
+        // Identifier and installer type are correct, but no pointer to where the
+        // binary lives — nothing to match against.
+        Assert.False(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: MakePath("C:", "anywhere", "aspire.exe"),
+            packageIdentifier: "Microsoft.Aspire",
+            installerType: "portable",
+            targetFullPath: null,
+            installLocation: null));
+    }
+
+    [Fact]
+    public void Matches_TargetFullPathMismatch_FallsBackToInstallLocation()
+    {
+        // Both shapes coexist in the registry: TargetFullPath points elsewhere
+        // (e.g. stale write from an earlier install), but InstallLocation still
+        // contains the running binary. Containment match must still fire.
+        var installDir = MakePath("C:", "tmp", "winget", "aspire");
+        var processPath = Path.Combine(installDir, "aspire.exe");
+        var staleTarget = MakePath("C:", "Old", "Path", "aspire.exe");
+
+        Assert.True(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: processPath,
+            packageIdentifier: "Microsoft.Aspire",
+            installerType: "portable",
+            targetFullPath: staleTarget,
+            installLocation: installDir));
+    }
+
+    [Fact]
+    public void Matches_ProcessPathEqualsInstallLocation_DoesNotMatch()
+    {
+        // A directory path equal to InstallLocation is not a binary inside it.
+        var installDir = MakePath("C:", "tmp", "winget", "aspire");
+
+        Assert.False(WingetAspireEntryMatcher.Matches(
+            canonicalProcessPath: installDir,
+            packageIdentifier: "Microsoft.Aspire",
+            installerType: "portable",
+            targetFullPath: null,
+            installLocation: installDir));
+    }
+
+    // Path-construction helper that produces an absolute, OS-appropriate path
+    // on every platform the test suite runs on. Tests below run on Linux/macOS CI
+    // too, where Windows drive-letter paths aren't valid roots; Path.Combine with
+    // a leading "/" segment yields a clean absolute path on Unix.
+    private static string MakePath(params string[] segments)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return Path.Combine(segments);
+        }
+
+        // On Unix, drop "C:" style roots and synthesize an absolute path under /.
+        var unixSegments = new List<string> { "/" };
+        foreach (var segment in segments)
+        {
+            if (segment.EndsWith(':'))
+            {
+                continue;
+            }
+            unixSegments.Add(segment.TrimEnd('\\', '/'));
+        }
+        return Path.GetFullPath(Path.Combine([.. unixSegments]));
+    }
+}

--- a/tests/Aspire.Cli.Tests/Acquisition/WingetRegistryProbeTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/WingetRegistryProbeTests.cs
@@ -18,9 +18,10 @@ public class WingetRegistryProbeTests
     public void Run_WritesSidecarOnlyWhenRegistryClaimsAspire(bool registryClaim, bool expectSidecar)
     {
         using var workspace = new TestTempDirectory();
+        var realProcessPath = Path.Combine(workspace.Path, "aspire.exe");
         var probe = new WingetFirstRunProbe(new FakeWindowsRegistryReader(claim: registryClaim), NullLogger<WingetFirstRunProbe>.Instance);
 
-        probe.Run(workspace.Path);
+        probe.Run(realProcessPath);
 
         var sidecarPath = Path.Combine(workspace.Path, SidecarFileName);
         Assert.Equal(expectSidecar, File.Exists(sidecarPath));
@@ -41,6 +42,7 @@ public class WingetRegistryProbeTests
     public void Run_IsIdempotent_OnSecondRun()
     {
         using var workspace = new TestTempDirectory();
+        var realProcessPath = Path.Combine(workspace.Path, "aspire.exe");
         var sidecarPath = Path.Combine(workspace.Path, SidecarFileName);
         // Pre-seed with a distinctive payload no real producer would write.
         // The probe's contract is "do not touch an existing sidecar"; if it
@@ -54,7 +56,7 @@ public class WingetRegistryProbeTests
         // Even with the registry asserting winget, an existing sidecar must
         // not be touched.
         var probe = new WingetFirstRunProbe(new FakeWindowsRegistryReader(claim: true), NullLogger<WingetFirstRunProbe>.Instance);
-        probe.Run(workspace.Path);
+        probe.Run(realProcessPath);
 
         Assert.Equal(preSeededContent, File.ReadAllText(sidecarPath));
     }
@@ -63,6 +65,7 @@ public class WingetRegistryProbeTests
     public async Task Run_ConcurrentInvocations_ProduceSingleValidSidecar()
     {
         using var workspace = new TestTempDirectory();
+        var realProcessPath = Path.Combine(workspace.Path, "aspire.exe");
         var probe = new WingetFirstRunProbe(new FakeWindowsRegistryReader(claim: true), NullLogger<WingetFirstRunProbe>.Instance);
         var errors = new ConcurrentBag<Exception>();
 
@@ -73,7 +76,7 @@ public class WingetRegistryProbeTests
             {
                 try
                 {
-                    probe.Run(workspace.Path);
+                    probe.Run(realProcessPath);
                 }
                 catch (Exception ex)
                 {
@@ -97,9 +100,77 @@ public class WingetRegistryProbeTests
         Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
         Assert.Equal("winget", doc.RootElement.GetProperty("source").GetString());
     }
+
+    [Fact]
+    public void Run_ForwardsRealProcessPathToRegistryReader()
+    {
+        // Regression: the probe previously re-read Environment.ProcessPath
+        // internally, which on Windows can yield the winget command-alias
+        // symlink path under %LOCALAPPDATA%\Microsoft\WinGet\Links rather
+        // than the resolved binary path under %LOCALAPPDATA%\Microsoft\WinGet\Packages.
+        // The matcher's InstallLocation containment check then misses, the
+        // sidecar is never written, and the bundle ends up under ~/.aspire
+        // — the exact regression the probe exists to prevent. Locking in the
+        // pass-through contract here ensures any future "convenience" change
+        // that re-introduces a raw Environment.ProcessPath read fails this test.
+        using var workspace = new TestTempDirectory();
+        var realProcessPath = Path.Combine(workspace.Path, "aspire.exe");
+        var reader = new RecordingFakeRegistryReader(claim: true);
+        var probe = new WingetFirstRunProbe(reader, NullLogger<WingetFirstRunProbe>.Instance);
+
+        probe.Run(realProcessPath);
+
+        Assert.Equal(realProcessPath, reader.LastQueriedPath);
+        Assert.Equal(1, reader.QueryCount);
+    }
+
+    [Fact]
+    public void Run_WritesSidecarNextToRealProcessPath_NotElsewhere()
+    {
+        // Companion to Run_ForwardsRealProcessPathToRegistryReader: the
+        // sidecar location is derived from the path argument, so a caller
+        // that passes a resolved path also gets the sidecar in the right
+        // (resolved) directory.
+        using var workspace = new TestTempDirectory();
+        var realBinaryDir = Path.Combine(workspace.Path, "package-dir");
+        Directory.CreateDirectory(realBinaryDir);
+        var realProcessPath = Path.Combine(realBinaryDir, "aspire.exe");
+
+        var probe = new WingetFirstRunProbe(new FakeWindowsRegistryReader(claim: true), NullLogger<WingetFirstRunProbe>.Instance);
+        probe.Run(realProcessPath);
+
+        Assert.True(File.Exists(Path.Combine(realBinaryDir, SidecarFileName)));
+        Assert.False(File.Exists(Path.Combine(workspace.Path, SidecarFileName)));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Run_EmptyOrNullPath_IsNoOp(string? path)
+    {
+        var reader = new RecordingFakeRegistryReader(claim: true);
+        var probe = new WingetFirstRunProbe(reader, NullLogger<WingetFirstRunProbe>.Instance);
+
+        probe.Run(path!);
+
+        Assert.Equal(0, reader.QueryCount);
+    }
 }
 
 file sealed class FakeWindowsRegistryReader(bool claim) : IWindowsRegistryReader
 {
     public bool HasWingetAspireUninstallEntry(string processPath) => claim;
+}
+
+file sealed class RecordingFakeRegistryReader(bool claim) : IWindowsRegistryReader
+{
+    public string? LastQueriedPath { get; private set; }
+    public int QueryCount { get; private set; }
+
+    public bool HasWingetAspireUninstallEntry(string processPath)
+    {
+        LastQueriedPath = processPath;
+        QueryCount++;
+        return claim;
+    }
 }

--- a/tests/Aspire.Cli.Tests/Acquisition/WingetRegistryProbeTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/WingetRegistryProbeTests.cs
@@ -47,20 +47,78 @@ public class WingetRegistryProbeTests
         var realProcessPath = Path.Combine(workspace.Path, "aspire.exe");
         var sidecarPath = Path.Combine(workspace.Path, SidecarFileName);
         // Pre-seed with a distinctive payload no real producer would write.
-        // The probe's contract is "do not touch an existing sidecar"; if it
-        // ever rewrites unconditionally, this distinctive payload would be
-        // overwritten with the probe's canonical {"source":"winget"} content
-        // and the assertion below would fail — independent of any filesystem
+        // The probe's contract is "do not touch a parseable sidecar even if
+        // its source string is unrecognized"; if it ever rewrites
+        // unconditionally, this distinctive payload would be overwritten
+        // with the probe's canonical {"source":"winget"} content and the
+        // assertion below would fail — independent of any filesystem
         // timestamp resolution.
+        //
+        // Corrupt-sidecar self-heal is covered separately in
+        // Run_OverwritesMalformedSidecar_WhenRegistryClaimsAspire below.
         const string preSeededContent = "{\"source\":\"winget-pre-seeded\"}";
         File.WriteAllText(sidecarPath, preSeededContent);
 
-        // Even with the registry asserting winget, an existing sidecar must
-        // not be touched.
+        // Even with the registry asserting winget, a parseable existing
+        // sidecar must not be touched.
         var probe = new WingetFirstRunProbe(new FakeWindowsRegistryReader(claim: true), NullLogger<WingetFirstRunProbe>.Instance);
         probe.Run(realProcessPath);
 
         Assert.Equal(preSeededContent, File.ReadAllText(sidecarPath));
+    }
+
+    [Theory]
+    // Malformed JSON: never parses, the probe's old File.Exists guard
+    // skipped it and left the install permanently un-identified.
+    [InlineData("this is not json {{{ broken")]
+    // Empty object: parseable JSON but no `source` field. The reader's
+    // ReadSourceField returns null for this shape, so the probe treats it
+    // as "needs overwrite" too.
+    [InlineData("{}")]
+    // Truncated mid-write: representative of a crash during atomic-rename
+    // or a partial copy. JsonDocument.Parse throws JsonException.
+    [InlineData("{\"sour")]
+    public void Run_OverwritesMalformedSidecar_WhenRegistryClaimsAspire(string corruptContent)
+    {
+        // Regression: the probe used to early-return on File.Exists with no
+        // validation, so a corrupted .aspire-install.json (truncated write,
+        // crashed mid-rename, manual edit) wedged the install permanently
+        // — every subsequent `aspire` invocation saw `route` as null and
+        // BundleService fell back to the sidecar-less default. Self-heal
+        // is cheap (one JsonDocument.Parse per cold start when the sidecar
+        // exists) and bounds the worst-case corruption window to a single
+        // CLI invocation.
+        using var workspace = new TestTempDirectory();
+        var realProcessPath = Path.Combine(workspace.Path, "aspire.exe");
+        var sidecarPath = Path.Combine(workspace.Path, SidecarFileName);
+        File.WriteAllText(sidecarPath, corruptContent);
+
+        var probe = new WingetFirstRunProbe(new FakeWindowsRegistryReader(claim: true), NullLogger<WingetFirstRunProbe>.Instance);
+        probe.Run(realProcessPath);
+
+        using var doc = JsonDocument.Parse(File.ReadAllBytes(sidecarPath));
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+        Assert.Equal("winget", doc.RootElement.GetProperty("source").GetString());
+    }
+
+    [Fact]
+    public void Run_DoesNotOverwriteForeignSidecar_EvenWhenRegistryClaimsAspire()
+    {
+        // Sibling guarantee to Run_OverwritesMalformedSidecar_*: if a sidecar
+        // is parseable and its `source` field is a non-empty string (any
+        // string — "script", "brew", "pr", an unknown future route, etc.),
+        // the probe must NOT clobber it. The probe owns only the winget
+        // detection lane; other install routes write their own sidecars.
+        using var workspace = new TestTempDirectory();
+        var realProcessPath = Path.Combine(workspace.Path, "aspire.exe");
+        var sidecarPath = Path.Combine(workspace.Path, SidecarFileName);
+        const string scriptSidecar = "{\"source\":\"script\"}";
+        File.WriteAllText(sidecarPath, scriptSidecar);
+
+        var probe = new WingetFirstRunProbe(new FakeWindowsRegistryReader(claim: true), NullLogger<WingetFirstRunProbe>.Instance);
+        probe.Run(realProcessPath);
+
+        Assert.Equal(scriptSidecar, File.ReadAllText(sidecarPath));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Acquisition/WingetRegistryProbeTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/WingetRegistryProbeTests.cs
@@ -4,6 +4,8 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using Aspire.Cli.Acquisition;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Acquisition;
@@ -154,6 +156,40 @@ public class WingetRegistryProbeTests
         probe.Run(path!);
 
         Assert.Equal(0, reader.QueryCount);
+    }
+
+    [Fact]
+    public void DescribeSelfSafely_RunsWingetFirstRunProbe()
+    {
+        // Regression: previously DoctorCommand's --self fast-path called
+        // DescribeSelfSafely without the probe, so a fresh winget install
+        // reported route=null until some other CLI command (a plain
+        // `aspire doctor` without --self, `aspire restore`, etc.) happened
+        // to invoke the probe. The PR's verify-winget-install-detection.ps1
+        // calls `aspire doctor --format json --self` and silently failed
+        // on assertion #1 (route == "winget") on a fresh install. Locking
+        // in the priming contract here prevents the --self path from
+        // diverging from the discovery path again.
+        var reader = new RecordingFakeRegistryReader(claim: false);
+        var probe = new WingetFirstRunProbe(reader, NullLogger<WingetFirstRunProbe>.Instance);
+        var discovery = new FakeInstallationDiscovery(self: new InstallationInfo
+        {
+            Path = "/fake/aspire",
+            Version = "0.0.0-test",
+            Status = InstallationInfoStatus.Ok,
+            PathStatus = InstallationPathStatus.Active,
+        });
+
+        var result = InstallationInfoOutput.DescribeSelfSafely(discovery, probe, NullLogger.Instance);
+
+        Assert.Single(result);
+        // The probe always queries the registry reader exactly once when the
+        // sidecar is missing — there is no OS guard inside the probe itself;
+        // the platform short-circuit lives in the real WindowsRegistryReader.
+        // The fake reader is happy to be queried on any OS, so the assertion
+        // is platform-agnostic: a single query proves DescribeSelfSafely
+        // invoked the probe rather than skipping it.
+        Assert.Equal(1, reader.QueryCount);
     }
 }
 

--- a/tests/Aspire.Cli.Tests/Acquisition/cleanup-test-arp-entries.ps1
+++ b/tests/Aspire.Cli.Tests/Acquisition/cleanup-test-arp-entries.ps1
@@ -1,0 +1,74 @@
+#!/usr/bin/env pwsh
+#requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Removes leaked Aspire CLI test entries from the per-user Add/Remove
+    Programs (ARP) list.
+
+.DESCRIPTION
+    WindowsRegistryReaderIntegrationTests writes a uniquely-named subkey
+    under HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall to
+    exercise the real registry path. A crashed test run can leave subkeys
+    behind, which then show up in Settings -> Apps as
+    "Aspire CLI (... test) 0.0.0" entries on developer machines. This
+    script removes every subkey whose name starts with the test prefix
+    "Microsoft.Aspire_AspireCliTests_".
+
+    Writing to HKCU does not require elevation, so this script does not
+    require an administrator shell.
+
+.PARAMETER WhatIf
+    Show which subkeys would be deleted without modifying the registry.
+
+.EXAMPLE
+    pwsh eng/scripts/cleanup-test-arp-entries.ps1
+
+.EXAMPLE
+    pwsh eng/scripts/cleanup-test-arp-entries.ps1 -WhatIf
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows -and $PSVersionTable.PSEdition -ne 'Desktop') {
+    Write-Host 'This script only runs on Windows.'
+    exit 0
+}
+
+$uninstallPath = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
+$prefix = 'Microsoft.Aspire_AspireCliTests_'
+
+if (-not (Test-Path -LiteralPath $uninstallPath)) {
+    Write-Host "Uninstall key not found at $uninstallPath; nothing to do."
+    exit 0
+}
+
+$matches = Get-ChildItem -LiteralPath $uninstallPath |
+    Where-Object { $_.PSChildName.StartsWith($prefix, [System.StringComparison]::Ordinal) }
+
+if (-not $matches) {
+    Write-Host "No leaked Aspire CLI test ARP entries found under $uninstallPath."
+    exit 0
+}
+
+$removed = 0
+$failed = 0
+foreach ($entry in $matches) {
+    if ($PSCmdlet.ShouldProcess($entry.PSPath, 'Remove leaked test ARP entry')) {
+        try {
+            Remove-Item -LiteralPath $entry.PSPath -Recurse -Force
+            $removed++
+        }
+        catch {
+            Write-Warning "Failed to remove '$($entry.PSChildName)': $_"
+            $failed++
+        }
+    }
+}
+
+Write-Host "Removed $removed leaked Aspire CLI test ARP entries from $uninstallPath. Failed: $failed."
+if ($failed -gt 0) {
+    exit 1
+}


### PR DESCRIPTION
**Symptom.** `winget install Microsoft.Aspire` produces an install that doesn't recognise itself as a winget install. `aspire doctor --format json` reports `installations[0]` without a `route` field; the install bundle extracts to `~/.aspire/bundle` instead of colocating with the binary under `%LOCALAPPDATA%\Microsoft\WinGet\Packages\Microsoft.Aspire_*\`. The pre-existing CI smoke step passed regardless of where the bundle landed, which is why this slipped through.

**Root cause.** Five independent bugs in the winget → ARP → sidecar → bundle chain, all only visible from a real winget install:

1. `WindowsRegistryReader` looked up the registry value `"PortableTargetFullPath"`, but winget writes that value under the wire name `"TargetFullPath"`. The C++ identifier `PortableTargetFullPath` in `winget-cli/src/AppInstallerCommonCore/PortableARPEntry.cpp` maps to that wire string.

2. Even with the correct wire name, the Aspire manifest (`InstallerType: zip` + `NestedInstallerType: portable` + multiple files in the archive) hits winget's `PortableInstaller::InstallFile` `!RecordToIndex` branch, which skips the per-file `TargetFullPath` ARP write entirely. The only path evidence in ARP is the `InstallLocation` directory.

3. The first-run probe re-read `Environment.ProcessPath` internally, which on Windows returns the winget command-alias symlink path under `%LOCALAPPDATA%\Microsoft\WinGet\Links\aspire.exe` rather than the resolved binary under `WinGet\Packages\`. The matcher's `InstallLocation` containment check then missed.

4. `aspire doctor --format json --self` skipped the probe entirely. `DescribeSelfSafely` didn't take the probe and went straight to `discovery.DescribeSelf()`, which reads a sidecar the probe never had a chance to stamp.

5. The probe's idempotency guard was `File.Exists(sidecarPath) → return`. A malformed `.aspire-install.json` (mid-write crash, manual edit, truncated atomic-rename, oversized payload, valid JSON missing the `source` field) wedged route detection permanently — every subsequent `aspire` invocation read the sidecar as `Invalid` and fell back to the sidecar-less default extract dir.

The live ARP shape a current winget install produces:

```
HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\
    Microsoft.Aspire_Microsoft.Winget.Source_8wekyb3d8bbwe
        WinGetPackageIdentifier      = Microsoft.Aspire
        WinGetInstallerType          = portable
        InstallLocation              = C:\Users\<user>\AppData\Local\Microsoft\WinGet\Packages\Microsoft.Aspire_Microsoft.Winget.Source_8wekyb3d8bbwe
        InstallDirectoryAddedToPath  = 1
        (no TargetFullPath, no PortableTargetFullPath, no SymlinkFullPath)
```

**The fix.**

`WindowsRegistryReader` is split into a thin walker plus a pure static `WingetAspireEntryMatcher`. The matcher reads the registry value at wire name `TargetFullPath`; falls back to `InstallLocation`-containment when `TargetFullPath` is absent (the zip+portable case); gates on `WinGetInstallerType == "portable"` permissively (tolerates null/empty for older winget builds, rejects `"msi"`/`"exe"`/etc.); and short-circuits on `WinGetPackageIdentifier` first inside the walk loop — `HKCU\...\Uninstall` has hundreds of subkeys on a typical machine and this probe runs on every CLI invocation without a sidecar. `InstallLocation` containment uses case-insensitive Ordinal compare with a trailing-separator-aware boundary so `C:\Foo` doesn't match `C:\FooBar\aspire.exe`.

`WingetFirstRunProbe` takes a symlink-resolved real process path from both call sites (resolved via `CliPathHelper.ResolveSymlinkOrOriginalPath`). The sidecar stamps next to the real binary, not next to the alias link.

`InstallationInfoOutput.DescribeSelfSafely` now takes and invokes the probe before reading the sidecar, mirroring `DiscoverAllSafelyAsync`. `aspire doctor --self` primes its own state.

The probe's idempotency guard now consults `InstallSidecarReader.ReadSourceField` instead of `File.Exists`: it skips only when the sidecar exists AND its `source` field parses cleanly. Malformed/oversized/empty-object sidecars fall through to the re-stamp path; a parseable foreign-route sidecar (`{"source":"script"}`, `{"source":"brew"}`, etc.) is preserved verbatim. The atomic rename gains an `overwriteIfCorrupt` flag so cold-start writes still use `overwrite: false` (concurrent-writer safety) while self-heal writes use `overwrite: true`.

A new `eng/scripts/verify-winget-install-detection.ps1` is wired into `prepare-installer-artifacts.yml` to assert end-to-end on the freshly-installed CLI:

1. `aspire doctor --format json` reports `installations[].route == "winget"`.
2. The `.aspire-install.json` sidecar exists next to the binary with `source=winget`.
3. The bundle directory lives under the winget install location, not `~/.aspire/`.
4. The fallback `~/.aspire/bundle` does NOT exist (catches regressions that populate both locations and would otherwise pass on positive-existence assertions alone).

The script primes the probe and bundle extraction itself by running `aspire doctor` before its assertions, so no separate CLI invocation by the workflow is needed. It runs with `-ExpectedVersion` parsed from the staged manifest's `PackageVersion`, so a self-hosted runner with a pre-existing machine-wide `aspire` on PATH can't silently pass with the wrong binary.

**Test layering.** Four levels guard against winget's wire format and the chain itself drifting:

- `WingetAspireEntryMatcherTests` — 15 cross-platform unit cases over both portable shapes, separator boundary, case sensitivity, null/empty inputs, and the `TargetFullPath`-stale → `InstallLocation`-fallback path. Wire-name agnostic (calls `Matches(...)` with strings directly).
- `WindowsRegistryReaderIntegrationTests` — 6 Windows-only cases write synthetic ARP entries to HKCU under unique GUID-suffixed subkeys and run the real reader. Verified to catch a `"TargetFullPath"` → `"PortableTargetFullPath"` regression and an `"InstallLocation"` rename regression when the constants are flipped.
- `WinGetRegistryShapeTests` — 1 Windows-only case builds a synthetic zip+portable manifest, serves it over a loopback `HttpListener` (winget's `WinINet` rejects `file://`), runs real `winget install`/`uninstall`, and asserts on the actual ARP values winget writes. The only layer that catches winget changing its wire format.
- `WingetRegistryProbeTests` — probe-level guards: `Run_ForwardsRealProcessPathToRegistryReader` (recording fake reader; fails if the probe re-introduces an internal `Environment.ProcessPath` read), `Run_WritesSidecarNextToRealProcessPath_NotElsewhere`, `DescribeSelfSafely_RunsWingetFirstRunProbe`, `Run_OverwritesMalformedSidecar_WhenRegistryClaimsAspire` (Theory over raw garbage, empty object, truncated JSON), `Run_DoesNotOverwriteForeignSidecar_EvenWhenRegistryClaimsAspire`.

The Aspire manifest shape the matcher depends on (`InstallerType: zip` + `NestedInstallerType: portable` + `NestedInstallerFiles: aspire.exe`) is asserted statically in `PRScriptInstallerModeTests`, so a manifest-template change that switches install shape is caught at inner-loop test time.

**Call-outs.**

- The verify script's failure-dump loop uses `Write-Host -ForegroundColor Red` rather than `Write-Error`: under `$ErrorActionPreference='Stop'`, `Write-Error` is terminating, so the first failed iteration would have aborted the loop and lost the diagnostic dump before `exit 1`.
- `WindowsRegistryReaderIntegrationTests` reaps orphan `Microsoft.Aspire_AspireCliTests_*` subkeys from `HKCU\...\Uninstall` on first use, so a crashed prior run does not leave "Aspire CLI (... test) 0.0.0" entries in Settings → Apps on developer machines. `tests/Aspire.Cli.Tests/Acquisition/cleanup-test-arp-entries.ps1` lets devs purge a polluted machine by hand. `TestUninstallEntry.Create` uses `CreateSubKey` rather than `OpenSubKey` so a fresh user profile where `HKCU\...\Uninstall` doesn't yet exist (e.g. a clean GH Actions runner) doesn't fail with a misleading "not writable" error.
- `WinGetRegistryShapeTests` probes elevation up-front via `WindowsPrincipal`. When the test isn't running elevated and `LocalManifestFiles` isn't already on, it skips with an actionable message instead of failing later with the cryptic `0x8a150004 "Opening manifest failed"`. Loud-fail on elevated CI runners is preserved. The synthetic singleton manifest carries `PackageLocale: en-US` because the singleton schema's top-level `required` array lists it — easy to forget on a hand-rolled singleton, and missing it produces the same `0x8a150004`. The finally-block uninstall passes `--accept-source-agreements --disable-interactivity` so cleanup doesn't trip on the msstore source-agreement prompt.

Out of scope: the winget manifest could set `ArchiveBinariesDependOnPath: true` to nudge winget toward an alias/symlink layout, which would make the path more obvious — separate change. Cross-route install/update/uninstall integration tests (mixing winget + script + dotnet-tool) are tracked in #17916. `winget uninstall` failing on dogfood `LocalManifestFiles` installs is tracked in #17944.

**Verified end-to-end** on Windows against a real `winget install Microsoft.Aspire`: before the fix `installations[0]` has no `route` field and the bundle extracts to `~/.aspire/bundle`; after the fix `installations[0].route == "winget"`, the `{"source":"winget"}` sidecar is stamped next to the winget `aspire.exe` (both when the CLI is launched directly and through the `WinGet\Links` alias), bundle extraction colocates with the binary, and corrupting the sidecar to garbage self-heals on the next invocation. The `Prepare WinGet manifests` CI job exercises the full chain on `windows-latest` every PR.

Fixes #17909.
