### PR TITLE
Show extension compatibility error for empty running AppHost describe

### DIFF
--- a/.agents/skills/vscode-extension/SKILL.md
+++ b/.agents/skills/vscode-extension/SKILL.md
@@ -150,11 +150,13 @@ pointing the `Aspire Cli Executable Path` setting at your locally built `aspire`
 
 When opening a PR for a user-visible VS Code extension change, include proof in the PR body. Prefer
 before/after screenshots for changed UI, notifications, tree views, browser flows, or error states.
-Include a short video or recording when the behavior is interactive, timing-sensitive, or difficult
-to understand from static images. If screenshots or video are not appropriate, say why and include
-the closest useful evidence instead, such as focused test output, E2E state files, logs, or command
-output. Redact tokens, secrets, local usernames, private paths, private URLs, and any other sensitive
-details before putting evidence in a public PR body.
+If you include a before screenshot, include an actual after screenshot of the changed state too;
+focused tests, E2E state files, logs, or command output can support the after case, but they are not
+a substitute for the after visual. Include a short video or recording when the behavior is
+interactive, timing-sensitive, or difficult to understand from static images. If screenshots or video
+are not appropriate, say why and include the closest useful evidence instead. Redact tokens, secrets,
+local usernames, private paths, private URLs, and any other sensitive details before putting evidence
+in a public PR body.
 
 ## Gotchas
 

--- a/.agents/skills/vscode-extension/SKILL.md
+++ b/.agents/skills/vscode-extension/SKILL.md
@@ -146,6 +146,16 @@ not yet clear. If that exploration reproduces the issue, convert the scenario in
 fixing the bug unless there is a strong, explicit reason not to. You can test a custom CLI build by
 pointing the `Aspire Cli Executable Path` setting at your locally built `aspire`.
 
+## Pull request evidence
+
+When opening a PR for a user-visible VS Code extension change, include proof in the PR body. Prefer
+before/after screenshots for changed UI, notifications, tree views, browser flows, or error states.
+Include a short video or recording when the behavior is interactive, timing-sensitive, or difficult
+to understand from static images. If screenshots or video are not appropriate, say why and include
+the closest useful evidence instead, such as focused test output, E2E state files, logs, or command
+output. Redact tokens, secrets, local usernames, private paths, private URLs, and any other sensitive
+details before putting evidence in a public PR body.
+
 ## Gotchas
 
 - Do not modify `package.json` / `yarn.lock` / `package-lock.json` unless explicitly asked; when you

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -1686,6 +1686,68 @@ suite('AppHostDataRepository', () => {
         }
     });
 
+    test('workspace describe reports compatibility error when running AppHost returns no data successfully', async () => {
+        const workspaceFoldersStub = stubWorkspaceFolders([{
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        }]);
+        let getAppHostsLineCallback: ((line: string) => void) | undefined;
+        let psOptions: any;
+        const describeOptions: any[] = [];
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ls') {
+                getAppHostsLineCallback = createLsLineCallback(options);
+            }
+            if (args[0] === 'describe') {
+                describeOptions.push(options);
+            }
+            if (args[0] === 'ps') {
+                psOptions = options;
+            }
+            return new TestChildProcess();
+        });
+
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        try {
+            repository.activate();
+            repository.setPanelVisible(true);
+            await waitForMicrotasks();
+
+            assert.ok(getAppHostsLineCallback);
+            getAppHostsLineCallback(JSON.stringify({
+                selected_project_file: '/workspace/labs/ops/apphost.cs',
+                all_project_file_candidates: ['/workspace/labs/ops/apphost.cs'],
+            }));
+            await waitForAppHostDiscovery();
+
+            assert.strictEqual(describeOptions.length, 1);
+            describeOptions[0].exitCallback(0);
+            assert.strictEqual(repository.hasError, false);
+
+            assert.ok(psOptions);
+            psOptions.lineCallback(JSON.stringify([
+                {
+                    appHostPath: '/workspace/labs/ops/apphost.cs',
+                    appHostPid: 125881,
+                },
+            ]));
+            await waitForMicrotasks();
+
+            assert.strictEqual(repository.workspaceAppHost?.appHostPid, 125881);
+            assert.strictEqual(describeOptions.length, 2);
+
+            describeOptions[1].exitCallback(0);
+
+            assert.strictEqual(repository.hasError, true);
+            assert.ok(repository.errorMessage?.includes('Aspire.Hosting 13.2.0'), repository.errorMessage);
+        } finally {
+            repository.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
     test('late close from stopped describe watch does not orphan replacement watch', async () => {
         const firstChildProcess = new TestChildProcess();
         const secondChildProcess = new TestChildProcess();

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -768,7 +768,10 @@ export class AppHostDataRepository {
             return aspireCliDescribeNotSupported(aspireDescribeMinimumVersion);
         }
 
-        if (exitCode !== 0 && this._workspaceAppHostPath) {
+        // A clean exit before `ps` observes the AppHost can happen while the app is still starting.
+        // Once `ps` reports the workspace AppHost as running, an empty describe stream means the
+        // AppHost cannot serve workspace resources even if the CLI process exits successfully.
+        if (this._workspaceAppHostPath && (exitCode !== 0 || this._workspaceAppHost !== undefined)) {
             return appHostDescribeMayNotBeSupported(aspireDescribeMinimumVersion);
         }
 


### PR DESCRIPTION
## Description

The VS Code extension could leave the Aspire tree in a confusing state when a workspace AppHost was running but `aspire describe --follow` exited successfully without returning resource data. In the reported case (#17906), the AppHost was an older Aspire.Hosting 13.1.0 app, the dashboard startup had already failed, and the extension still had enough state from `aspire ps` to know the workspace AppHost was running.

This keeps the existing startup grace period: an empty successful `describe` before `ps` sees the AppHost still does not show a compatibility error. Once `ps` has reported the selected workspace AppHost as running, a subsequent empty successful `describe` now surfaces the existing Aspire.Hosting 13.2.0+ compatibility message instead of silently showing no resources.

Also updates the VS Code extension skill so future user-visible extension PRs include useful proof in the PR body: before/after screenshots when UI changes, video when interaction/timing matters, and sanitized logs/test output when screenshots are not appropriate.

### User-facing usage

Before: the issue report shows the dashboard browser timing out after startup failure, while the extension state did not clearly explain why workspace resources were unavailable.

![Before: Simple Browser timeout from issue #17906](https://github.com/user-attachments/assets/5c7b36f2-e657-43d8-9063-39e51ff9391d)

After: the extension reports the existing compatibility message once the AppHost is known to be running but cannot provide workspace resource data.

![After: Aspire view shows workspace resource compatibility guidance](https://raw.githubusercontent.com/adamint/aspire/adamint/pr-17925-artifacts/pr-artifacts/17925-after-aspire-view.png)

The focused regression test below covers the state-machine path behind this visual state.

### Proof

```text
$ cd /tmp/aspire-wt/17906/extension
$ corepack yarn run test --grep AppHostDataRepository
...
  AppHostDataRepository
    ✔ workspace ps start restarts describe after earlier empty describe exit
    ✔ workspace describe reports compatibility error when running AppHost returns no data successfully
...
  58 passing (176ms)
```

Reviewed with:

- `code-review` skill loaded and applied to the branch diff
- `code-review` agent: no significant issues found after re-review
- `reviewing-aspire-architecture` agent: no findings after redaction guidance was added

Fixes #17906

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No


