### PR TITLE
Harden VS Code terminal commands against shell injection

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -64,6 +64,9 @@
     <trans-unit id="aspire-vscode.strings.aspireTerminalName">
       <source xml:lang="en">Aspire terminal</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.terminalCommandArgumentControlCharacters">
+      <source xml:lang="en">Aspire terminal command arguments cannot contain control characters.</source>
+    </trans-unit>
     <trans-unit id="extension.debug.defaultConfiguration.name">
       <source xml:lang="en">Aspire: Launch default AppHost</source>
     </trans-unit>

--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -67,6 +67,9 @@
     <trans-unit id="aspire-vscode.strings.terminalCommandArgumentControlCharacters">
       <source xml:lang="en">Aspire terminal command arguments cannot contain control characters.</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.terminalCommandUnsafeLiteral">
+      <source xml:lang="en">Aspire terminal command syntax can only contain command names and flags.</source>
+    </trans-unit>
     <trans-unit id="extension.debug.defaultConfiguration.name">
       <source xml:lang="en">Aspire: Launch default AppHost</source>
     </trans-unit>

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -65,6 +65,7 @@
 	"aspire-vscode.strings.aspireCliVersion": "Aspire CLI Version: {0}.",
 	"aspire-vscode.strings.requiredCapability": "Required capability: {0}.",
 	"aspire-vscode.strings.aspireTerminalName": "Aspire terminal",
+	"aspire-vscode.strings.terminalCommandArgumentControlCharacters": "Aspire terminal command arguments cannot contain control characters.",
 	"aspire-vscode.strings.rpcServerError": "RPC server error: {0}.",
 	"aspire-vscode.strings.aspireOutputChannelName": "Aspire Extension",
 	"aspire-vscode.strings.fieldRequired": "This field is required.",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -66,6 +66,7 @@
 	"aspire-vscode.strings.requiredCapability": "Required capability: {0}.",
 	"aspire-vscode.strings.aspireTerminalName": "Aspire terminal",
 	"aspire-vscode.strings.terminalCommandArgumentControlCharacters": "Aspire terminal command arguments cannot contain control characters.",
+	"aspire-vscode.strings.terminalCommandUnsafeLiteral": "Aspire terminal command syntax can only contain command names and flags.",
 	"aspire-vscode.strings.rpcServerError": "RPC server error: {0}.",
 	"aspire-vscode.strings.aspireOutputChannelName": "Aspire Extension",
 	"aspire-vscode.strings.fieldRequired": "This field is required.",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -20,7 +20,7 @@ import { AspireExtensionContext } from './AspireExtensionContext';
 import AspireRpcServer, { RpcServerConnectionInfo } from './server/AspireRpcServer';
 import AspireDcpServer from './dcp/AspireDcpServer';
 import { configureLaunchJsonCommand } from './commands/configureLaunchJson';
-import { AspireTerminalProvider, AspireTerminalCommandEvent, quoteShellArg } from './utils/AspireTerminalProvider';
+import { AspireTerminalProvider, AspireTerminalCommandEvent, shellArg } from './utils/AspireTerminalProvider';
 import { MessageConnection } from 'vscode-jsonrpc';
 import { openTerminalCommand } from './commands/openTerminal';
 import { updateCommand, updateSelfCommand } from './commands/update';
@@ -235,18 +235,15 @@ export async function activate(context: vscode.ExtensionContext) {
       return;
     }
 
-    let command = `resource ${quoteShellArg(resourceName)} ${quoteShellArg(action)}`;
-    if (appHostPath) {
-      command += ` --apphost ${quoteShellArg(appHostPath)}`;
-    }
+    const command = appHostPath
+      ? ['resource', shellArg(resourceName), shellArg(action), '--apphost', shellArg(appHostPath)]
+      : ['resource', shellArg(resourceName), shellArg(action)];
     terminalProvider.sendAspireCommandToAspireTerminal(command, true, commandArguments.args, { redactAdditionalArgs: commandArguments.containsSecret });
   });
   const codeLensViewLogsRegistration = registerInstrumentedCommand('aspire-vscode.codeLensViewLogs', 'codelens', (resourceName: string, appHostPath: string) => {
-    let command = `logs ${quoteShellArg(resourceName)}`;
-    if (appHostPath) {
-      command += ` --apphost ${quoteShellArg(appHostPath)}`;
-    }
-    command += ' --follow';
+    const command = appHostPath
+      ? ['logs', shellArg(resourceName), '--apphost', shellArg(appHostPath), '--follow']
+      : ['logs', shellArg(resourceName), '--follow'];
     terminalProvider.sendAspireCommandToAspireTerminal(command);
   });
   const codeLensRevealResourceRegistration = registerInstrumentedCommand('aspire-vscode.codeLensRevealResource', 'codelens', (resourceName: string, appHostPath?: string) => {

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -21,6 +21,7 @@ export const aspireCliVersion = (version: string) => vscode.l10n.t('Aspire CLI V
 export const requiredCapability = (capability: string) => vscode.l10n.t('Required capability: {0}.', capability);
 export const aspireTerminalName = vscode.l10n.t('Aspire terminal');
 export const terminalCommandArgumentControlCharacters = vscode.l10n.t('Aspire terminal command arguments cannot contain control characters.');
+export const terminalCommandUnsafeLiteral = vscode.l10n.t('Aspire terminal command syntax can only contain command names and flags.');
 export const aspireOutputChannelName = vscode.l10n.t('Aspire Extension');
 export const fieldRequired = vscode.l10n.t('This field is required.');
 export const runProject = (projectName: string) => vscode.l10n.t('Run {0}', projectName);

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -20,6 +20,7 @@ export const aspireHostingSdkVersion = (version: string) => vscode.l10n.t('Aspir
 export const aspireCliVersion = (version: string) => vscode.l10n.t('Aspire CLI Version: {0}.', version);
 export const requiredCapability = (capability: string) => vscode.l10n.t('Required capability: {0}.', capability);
 export const aspireTerminalName = vscode.l10n.t('Aspire terminal');
+export const terminalCommandArgumentControlCharacters = vscode.l10n.t('Aspire terminal command arguments cannot contain control characters.');
 export const aspireOutputChannelName = vscode.l10n.t('Aspire Extension');
 export const fieldRequired = vscode.l10n.t('This field is required.');
 export const runProject = (projectName: string) => vscode.l10n.t('Run {0}', projectName);

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -15,6 +15,7 @@ import { ResourceState, HealthStatus, StateStyle } from '../editor/resourceConst
 import type { AspireSubcommand } from '../utils/AspireTerminalProvider';
 import { AspireTerminalProvider, shellArg } from '../utils/AspireTerminalProvider';
 import { AppHostLaunchService } from '../services/AppHostLaunchService';
+import { terminalCommandArgumentControlCharacters } from '../loc/strings';
 
 function makeResource(overrides: Partial<ResourceJson> = {}): ResourceJson {
     const base: ResourceJson = {
@@ -496,6 +497,46 @@ suite('AspireAppHostTreeProvider', () => {
 
             await provider.restartResource(resourceItem as any);
             proof.run(commandLines[2], ['resource', resourceName, 'restart', '--apphost', appHostPath]);
+        }
+        finally {
+            provider.dispose();
+            proofTerminalProvider.dispose();
+            proof.dispose();
+        }
+    });
+
+    test('workspace tree terminal actions reject control characters before terminal input', async () => {
+        const proof = createShellProof();
+        const commandLines: string[] = [];
+        const proofTerminalProvider = makeProofTerminalProvider(sandbox, proof, commandLines);
+        const appHostPath = path.join(proof.directory, 'workspace') + `\x03\ntouch ${proof.appHostMarkerPath}\n#`;
+        const resourceName = `cache\x03\ntouch ${proof.resourceMarkerPath}\n#`;
+        const resource = makeResource({ name: resourceName, displayName: resourceName });
+        const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
+        const repository = {
+            viewMode: 'workspace' as ViewMode,
+            appHosts: [],
+            workspaceResources: [resource],
+            workspaceAppHost: makeAppHost({ appHostPath, resources: [resource] }),
+            workspaceAppHostPath: appHostPath,
+            workspaceAppHostCandidatePaths: [appHostPath],
+            workspaceAppHostName: 'AppHost.csproj',
+            workspaceAppHostDescription: undefined,
+            onDidChangeData,
+        } as unknown as AppHostDataRepository;
+        const provider = new AspireAppHostTreeProvider(repository, proofTerminalProvider.terminalProvider, makeLaunchService());
+
+        try {
+            const [workspaceItem] = provider.getChildren();
+            const [resourceItem] = provider.getChildren(workspaceItem);
+
+            await assert.rejects(() => provider.stopAppHost(workspaceItem as any), { message: terminalCommandArgumentControlCharacters });
+            await assert.rejects(() => provider.viewResourceLogs(resourceItem as any), { message: terminalCommandArgumentControlCharacters });
+            await assert.rejects(() => provider.restartResource(resourceItem as any), { message: terminalCommandArgumentControlCharacters });
+
+            assert.deepStrictEqual(commandLines, []);
+            assert.strictEqual(fs.existsSync(proof.appHostMarkerPath), false, 'AppHost control-character payload should not execute');
+            assert.strictEqual(fs.existsSync(proof.resourceMarkerPath), false, 'resource control-character payload should not execute');
         }
         finally {
             provider.dispose();

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -1,15 +1,19 @@
 import * as assert from 'assert';
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as cliModule from '../debugger/languages/cli';
+import * as cliPathModule from '../utils/cliPath';
 import * as configInfoProvider from '../utils/configInfoProvider';
 import { AppHostDataRepository, shortenPath, shortenPaths } from '../views/AppHostDataRepository';
 import { AspireAppHostTreeProvider, getResourceContextValue, getResourceIcon, getResourceCommandIcon, resolveAppHostSourcePath, buildResourceDescription } from '../views/AspireAppHostTreeProvider';
 import type { AppHostDisplayInfo, ResourceJson, ViewMode } from '../views/AppHostDataRepository';
 import { ResourceState, HealthStatus, StateStyle } from '../editor/resourceConstants';
-import type { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
-import { quoteShellArg } from '../utils/AspireTerminalProvider';
+import type { AspireSubcommand } from '../utils/AspireTerminalProvider';
+import { AspireTerminalProvider, shellArg } from '../utils/AspireTerminalProvider';
 import { AppHostLaunchService } from '../services/AppHostLaunchService';
 
 function makeResource(overrides: Partial<ResourceJson> = {}): ResourceJson {
@@ -114,6 +118,75 @@ function makeWorkspaceTreeProvider(workspaceAppHostDescription: string): AspireA
     } as unknown as AppHostDataRepository;
 
     return new AspireAppHostTreeProvider(repository, makeTerminalProvider(), makeLaunchService());
+}
+
+interface ShellProof {
+    readonly directory: string;
+    readonly cliPath: string;
+    readonly appHostMarkerPath: string;
+    readonly resourceMarkerPath: string;
+    run(commandLine: string, expectedArgs: readonly string[]): void;
+    dispose(): void;
+}
+
+function createShellProof(): ShellProof {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-tree-rce-proof-'));
+    const cliPath = path.join(directory, 'aspire');
+    const argvPath = path.join(directory, 'argv.txt');
+    const appHostMarkerPath = path.join(directory, 'apphost-pwned');
+    const resourceMarkerPath = path.join(directory, 'resource-pwned');
+
+    fs.writeFileSync(cliPath, '#!/bin/sh\nprintf "%s\\n" "$@" > "$PROOF_ARGV"\n');
+    fs.chmodSync(cliPath, 0o700);
+
+    return {
+        directory,
+        cliPath,
+        appHostMarkerPath,
+        resourceMarkerPath,
+        run(commandLine: string, expectedArgs: readonly string[]): void {
+            childProcess.execFileSync('/bin/sh', ['-c', commandLine], {
+                env: { ...process.env, PROOF_ARGV: argvPath },
+                stdio: 'ignore',
+            });
+
+            const actualArgs = fs.readFileSync(argvPath, 'utf8').trimEnd().split('\n');
+            assert.deepStrictEqual(actualArgs, expectedArgs);
+            assert.strictEqual(fs.existsSync(appHostMarkerPath), false, 'AppHost path payload should not execute');
+            assert.strictEqual(fs.existsSync(resourceMarkerPath), false, 'resource payload should not execute');
+        },
+        dispose(): void {
+            fs.rmSync(directory, { recursive: true, force: true });
+        },
+    };
+}
+
+function makeProofTerminalProvider(sandbox: sinon.SinonSandbox, proof: ShellProof, commandLines: string[]): { terminalProvider: AspireTerminalProvider; dispose: () => void } {
+    const subscriptions: vscode.Disposable[] = [];
+    const terminalProvider = new AspireTerminalProvider(subscriptions);
+    sandbox.stub(cliPathModule, 'resolveCliPath').resolves({ cliPath: proof.cliPath, available: true, source: 'configured' });
+    sandbox.stub(terminalProvider, 'isCliDebugLoggingEnabled').returns(false);
+    sandbox.stub(terminalProvider, 'getAspireTerminal').returns({
+        terminal: {
+            shellIntegration: {
+                executeCommand: (commandLine: string) => {
+                    commandLines.push(commandLine);
+                    return {} as vscode.TerminalShellExecution;
+                }
+            },
+            sendText: () => assert.fail('expected shell integration to execute the command'),
+            show: () => { }
+        } as unknown as vscode.Terminal,
+        dispose: () => { },
+    });
+
+    return {
+        terminalProvider,
+        dispose: () => {
+            terminalProvider.dispose();
+            subscriptions.forEach(subscription => subscription.dispose());
+        },
+    };
 }
 
 async function flushPromises(): Promise<void> {
@@ -287,7 +360,7 @@ suite('AspireAppHostTreeProvider', () => {
     });
 
     test('global AppHost shows stopping state immediately after stop command', () => {
-        const commands: string[] = [];
+        const commands: AspireSubcommand[] = [];
         const appHostPath = path.resolve('workspace', 'apps', 'Store', 'AppHost.csproj');
         const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
         const repository = {
@@ -303,7 +376,7 @@ suite('AspireAppHostTreeProvider', () => {
         const terminalProvider = {
             getAspireCliExecutablePath: async () => 'aspire',
             createEnvironment: () => ({}),
-            sendAspireCommandToAspireTerminal: (command: string) => commands.push(command),
+            sendAspireCommandToAspireTerminal: (command: AspireSubcommand) => commands.push(command),
         } as unknown as AspireTerminalProvider;
         const provider = new AspireAppHostTreeProvider(repository, terminalProvider, makeLaunchService());
         const [item] = provider.getChildren();
@@ -314,12 +387,12 @@ suite('AspireAppHostTreeProvider', () => {
         assert.strictEqual(stoppingItem.contextValue, 'appHost:stopping');
         assert.strictEqual(stoppingItem.description, 'Stopping...');
         assert.strictEqual((stoppingItem.iconPath as vscode.ThemeIcon).id, 'loading~spin');
-        assert.deepStrictEqual(commands, [`stop --apphost ${quoteShellArg(appHostPath)}`]);
+        assert.deepStrictEqual(commands, [['stop', '--apphost', shellArg(appHostPath)]]);
         provider.dispose();
     });
 
     test('workspace AppHost shows stopping state immediately after stop command', () => {
-        const commands: string[] = [];
+        const commands: AspireSubcommand[] = [];
         const appHostPath = path.resolve('workspace', 'apps', 'Store', 'AppHost.csproj');
         const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
         const repository = {
@@ -336,7 +409,7 @@ suite('AspireAppHostTreeProvider', () => {
         const terminalProvider = {
             getAspireCliExecutablePath: async () => 'aspire',
             createEnvironment: () => ({}),
-            sendAspireCommandToAspireTerminal: (command: string) => commands.push(command),
+            sendAspireCommandToAspireTerminal: (command: AspireSubcommand) => commands.push(command),
         } as unknown as AspireTerminalProvider;
         const provider = new AspireAppHostTreeProvider(repository, terminalProvider, makeLaunchService());
         const [item] = provider.getChildren();
@@ -347,12 +420,12 @@ suite('AspireAppHostTreeProvider', () => {
         assert.strictEqual(stoppingItem.contextValue, 'workspaceResources:stopping');
         assert.strictEqual(stoppingItem.description, 'Stopping...');
         assert.strictEqual((stoppingItem.iconPath as vscode.ThemeIcon).id, 'loading~spin');
-        assert.deepStrictEqual(commands, [`stop --apphost ${quoteShellArg(appHostPath)}`]);
+        assert.deepStrictEqual(commands, [['stop', '--apphost', shellArg(appHostPath)]]);
         provider.dispose();
     });
 
     test('workspace AppHost candidate shows stopping state immediately after stop command', () => {
-        const commands: string[] = [];
+        const commands: AspireSubcommand[] = [];
         const appHostPath = path.resolve('workspace', 'apps', 'Store', 'AppHost.csproj');
         const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
         const repository = {
@@ -369,7 +442,7 @@ suite('AspireAppHostTreeProvider', () => {
         const terminalProvider = {
             getAspireCliExecutablePath: async () => 'aspire',
             createEnvironment: () => ({}),
-            sendAspireCommandToAspireTerminal: (command: string) => commands.push(command),
+            sendAspireCommandToAspireTerminal: (command: AspireSubcommand) => commands.push(command),
         } as unknown as AspireTerminalProvider;
         const provider = new AspireAppHostTreeProvider(repository, terminalProvider, makeLaunchService());
         const [groupItem] = provider.getChildren();
@@ -382,8 +455,53 @@ suite('AspireAppHostTreeProvider', () => {
         assert.strictEqual(stoppingItem.contextValue, 'workspaceAppHostStopping');
         assert.strictEqual(stoppingItem.description, 'Stopping...');
         assert.strictEqual((stoppingItem.iconPath as vscode.ThemeIcon).id, 'loading~spin');
-        assert.deepStrictEqual(commands, [`stop --apphost ${quoteShellArg(appHostPath)}`]);
+        assert.deepStrictEqual(commands, [['stop', '--apphost', shellArg(appHostPath)]]);
         provider.dispose();
+    });
+
+    test('workspace tree terminal actions pass hostile paths as inert shell arguments', async function () {
+        if (process.platform === 'win32') {
+            this.skip();
+        }
+
+        const proof = createShellProof();
+        const commandLines: string[] = [];
+        const proofTerminalProvider = makeProofTerminalProvider(sandbox, proof, commandLines);
+        const appHostPath = path.join(proof.directory, 'workspace') + `'; touch ${proof.appHostMarkerPath} #/$(whoami)/"bad"/AppHost.csproj`;
+        const resourceName = `cache'; touch ${proof.resourceMarkerPath} #`;
+        const resource = makeResource({ name: resourceName, displayName: resourceName });
+        const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
+        const repository = {
+            viewMode: 'workspace' as ViewMode,
+            appHosts: [],
+            workspaceResources: [resource],
+            workspaceAppHost: makeAppHost({ appHostPath, resources: [resource] }),
+            workspaceAppHostPath: appHostPath,
+            workspaceAppHostCandidatePaths: [appHostPath],
+            workspaceAppHostName: 'AppHost.csproj',
+            workspaceAppHostDescription: undefined,
+            onDidChangeData,
+        } as unknown as AppHostDataRepository;
+        const provider = new AspireAppHostTreeProvider(repository, proofTerminalProvider.terminalProvider, makeLaunchService());
+
+        try {
+            const [workspaceItem] = provider.getChildren();
+            const [resourceItem] = provider.getChildren(workspaceItem);
+
+            await provider.stopAppHost(workspaceItem as any);
+            proof.run(commandLines[0], ['stop', '--apphost', appHostPath]);
+
+            await provider.viewResourceLogs(resourceItem as any);
+            proof.run(commandLines[1], ['logs', resourceName, '--apphost', appHostPath]);
+
+            await provider.restartResource(resourceItem as any);
+            proof.run(commandLines[2], ['resource', resourceName, 'restart', '--apphost', appHostPath]);
+        }
+        finally {
+            provider.dispose();
+            proofTerminalProvider.dispose();
+            proof.dispose();
+        }
     });
 
     test('stopping state clears when AppHost leaves the running list', () => {
@@ -571,11 +689,11 @@ suite('AspireAppHostTreeProvider', () => {
     });
 
     test('legacy command item without state executes from context menu', async () => {
-        const sentCommands: string[] = [];
+        const sentCommands: AspireSubcommand[] = [];
         const terminalProvider = {
             getAspireCliExecutablePath: async () => 'aspire',
             createEnvironment: () => ({}),
-            sendAspireCommandToAspireTerminal: (command: string) => sentCommands.push(command),
+            sendAspireCommandToAspireTerminal: (command: AspireSubcommand) => sentCommands.push(command),
         } as unknown as AspireTerminalProvider;
         const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
         const repository = {
@@ -604,7 +722,7 @@ suite('AspireAppHostTreeProvider', () => {
         await provider.executeResourceCommandItem(commandItem as any);
 
         assert.strictEqual(infoStub.called, false);
-        assert.deepStrictEqual(sentCommands, [`resource ${quoteShellArg('my-service')} ${quoteShellArg('$(legacy)')} --apphost ${quoteShellArg('/test/AppHost.csproj')}`]);
+        assert.deepStrictEqual(sentCommands, [['resource', shellArg('my-service'), shellArg('$(legacy)'), '--apphost', shellArg('/test/AppHost.csproj')]]);
     });
 
     test('resource with commands is expandable even without URLs, health checks, or child resources', () => {
@@ -1478,7 +1596,7 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
     });
 
     test('workspace resource commands use the AppHost that owns the resource', () => {
-        const commands: string[] = [];
+        const commands: AspireSubcommand[] = [];
         const selectedHostPath = '/repo/apps/Store/AppHost.csproj';
         const otherHostPath = '/repo/samples/Store/AppHost.csproj';
         const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
@@ -1499,7 +1617,7 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         const terminalProvider = {
             getAspireCliExecutablePath: async () => 'aspire',
             createEnvironment: () => ({}),
-            sendAspireCommandToAspireTerminal: (command: string) => commands.push(command),
+            sendAspireCommandToAspireTerminal: (command: AspireSubcommand) => commands.push(command),
         } as unknown as AspireTerminalProvider;
         const provider = new AspireAppHostTreeProvider(repository, terminalProvider, makeLaunchService());
 
@@ -1512,14 +1630,14 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         provider.restartResource(resourceItem as any);
 
         assert.deepStrictEqual(commands, [
-            `logs ${quoteShellArg('cache')} --apphost ${quoteShellArg(otherHostPath)}`,
-            `resource ${quoteShellArg('cache-b')} ${quoteShellArg('restart')} --apphost ${quoteShellArg(otherHostPath)}`,
+            ['logs', shellArg('cache'), '--apphost', shellArg(otherHostPath)],
+            ['resource', shellArg('cache-b'), shellArg('restart'), '--apphost', shellArg(otherHostPath)],
         ]);
         provider.dispose();
     });
 
     test('workspace resource commands use the running AppHost path when no workspace AppHost is selected', () => {
-        const commands: string[] = [];
+        const commands: AspireSubcommand[] = [];
         const runningHostPath = '/repo/apps/Store/AppHost.csproj';
         const idleHostPath = '/repo/samples/Store/AppHost.csproj';
         const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
@@ -1539,7 +1657,7 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         const terminalProvider = {
             getAspireCliExecutablePath: async () => 'aspire',
             createEnvironment: () => ({}),
-            sendAspireCommandToAspireTerminal: (command: string) => commands.push(command),
+            sendAspireCommandToAspireTerminal: (command: AspireSubcommand) => commands.push(command),
         } as unknown as AspireTerminalProvider;
         const provider = new AspireAppHostTreeProvider(repository, terminalProvider, makeLaunchService());
 
@@ -1551,8 +1669,8 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         provider.restartResource(resourceItem as any);
 
         assert.deepStrictEqual(commands, [
-            `logs ${quoteShellArg('cache')} --apphost ${quoteShellArg(runningHostPath)}`,
-            `resource ${quoteShellArg('cache')} ${quoteShellArg('restart')} --apphost ${quoteShellArg(runningHostPath)}`,
+            ['logs', shellArg('cache'), '--apphost', shellArg(runningHostPath)],
+            ['resource', shellArg('cache'), shellArg('restart'), '--apphost', shellArg(runningHostPath)],
         ]);
         provider.dispose();
     });

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -127,6 +127,7 @@ interface ShellProof {
     readonly appHostMarkerPath: string;
     readonly resourceMarkerPath: string;
     run(commandLine: string, expectedArgs: readonly string[]): void;
+    runPowerShell(commandLine: string, expectedArgs: readonly string[], shellPath: string): void;
     dispose(): void;
 }
 
@@ -156,10 +157,41 @@ function createShellProof(): ShellProof {
             assert.strictEqual(fs.existsSync(appHostMarkerPath), false, 'AppHost path payload should not execute');
             assert.strictEqual(fs.existsSync(resourceMarkerPath), false, 'resource payload should not execute');
         },
+        runPowerShell(commandLine: string, expectedArgs: readonly string[], shellPath: string): void {
+            childProcess.execFileSync(shellPath, ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', commandLine], {
+                env: { ...process.env, PROOF_ARGV: argvPath },
+                stdio: 'ignore',
+            });
+
+            const actualArgs = fs.readFileSync(argvPath, 'utf8').trimEnd().split('\n');
+            assert.deepStrictEqual(actualArgs, expectedArgs);
+            assert.strictEqual(fs.existsSync(appHostMarkerPath), false, 'AppHost path payload should not execute');
+            assert.strictEqual(fs.existsSync(resourceMarkerPath), false, 'resource payload should not execute');
+        },
         dispose(): void {
             fs.rmSync(directory, { recursive: true, force: true });
         },
     };
+}
+
+function getPowerShellForShellProof(): string | undefined {
+    if (process.platform === 'win32') {
+        // The proof CLI is a shebang script so PowerShell invokes it as a native
+        // command on Unix hosts. Windows coverage would need a compiled shim to
+        // exercise the same native-executable boundary.
+        return undefined;
+    }
+
+    for (const candidate of ['pwsh', 'pwsh.exe']) {
+        const result = childProcess.spawnSync(candidate, ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', '$PSVersionTable.PSVersion.Major'], {
+            stdio: 'ignore',
+        });
+        if (result.status === 0 && result.error === undefined) {
+            return candidate;
+        }
+    }
+
+    return undefined;
 }
 
 function makeProofTerminalProvider(sandbox: sinon.SinonSandbox, proof: ShellProof, commandLines: string[]): { terminalProvider: AspireTerminalProvider; dispose: () => void } {
@@ -499,6 +531,54 @@ suite('AspireAppHostTreeProvider', () => {
             proof.run(commandLines[2], ['resource', resourceName, 'restart', '--apphost', appHostPath]);
         }
         finally {
+            provider.dispose();
+            proofTerminalProvider.dispose();
+            proof.dispose();
+        }
+    });
+
+    test('workspace tree terminal actions pass hostile paths as inert PowerShell arguments', async function () {
+        const powerShellPath = getPowerShellForShellProof();
+        if (powerShellPath === undefined) {
+            this.skip();
+        }
+
+        const platformStub = sandbox.stub(process, 'platform').value('win32');
+        const proof = createShellProof();
+        const commandLines: string[] = [];
+        const proofTerminalProvider = makeProofTerminalProvider(sandbox, proof, commandLines);
+        const appHostPath = path.join(proof.directory, 'workspace') + `"\u201C; touch ${proof.appHostMarkerPath} #/$(whoami)/\`whoami\`/AppHost.csproj`;
+        const resourceName = `cache"\u201C; touch ${proof.resourceMarkerPath} # $(whoami) \`whoami\``;
+        const resource = makeResource({ name: resourceName, displayName: resourceName });
+        const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
+        const repository = {
+            viewMode: 'workspace' as ViewMode,
+            appHosts: [],
+            workspaceResources: [resource],
+            workspaceAppHost: makeAppHost({ appHostPath, resources: [resource] }),
+            workspaceAppHostPath: appHostPath,
+            workspaceAppHostCandidatePaths: [appHostPath],
+            workspaceAppHostName: 'AppHost.csproj',
+            workspaceAppHostDescription: undefined,
+            onDidChangeData,
+        } as unknown as AppHostDataRepository;
+        const provider = new AspireAppHostTreeProvider(repository, proofTerminalProvider.terminalProvider, makeLaunchService());
+
+        try {
+            const [workspaceItem] = provider.getChildren();
+            const [resourceItem] = provider.getChildren(workspaceItem);
+
+            await provider.stopAppHost(workspaceItem as any);
+            proof.runPowerShell(commandLines[0], ['stop', '--apphost', appHostPath], powerShellPath);
+
+            await provider.viewResourceLogs(resourceItem as any);
+            proof.runPowerShell(commandLines[1], ['logs', resourceName, '--apphost', appHostPath], powerShellPath);
+
+            await provider.restartResource(resourceItem as any);
+            proof.runPowerShell(commandLines[2], ['resource', resourceName, 'restart', '--apphost', appHostPath], powerShellPath);
+        }
+        finally {
+            platformStub.restore();
             provider.dispose();
             proofTerminalProvider.dispose();
             proof.dispose();

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -5,6 +5,7 @@ import { AspireTerminalProvider, quoteShellArg, shellArg } from '../utils/Aspire
 import * as cliPathModule from '../utils/cliPath';
 import { EnvironmentVariables } from '../utils/environment';
 import { extensionLogOutputChannel } from '../utils/logging';
+import { terminalCommandArgumentControlCharacters } from '../loc/strings';
 
 suite('AspireTerminalProvider tests', () => {
     let terminalProvider: AspireTerminalProvider;
@@ -240,6 +241,24 @@ suite('AspireTerminalProvider tests', () => {
                     : `aspire ${expectedSubcommand}`;
                 assert.strictEqual(executedCommand, expectedCommand);
                 assert.strictEqual(executedCommand.includes(`--apphost ${appHostPath}`), false);
+            }
+            finally {
+                getAspireTerminalStub.restore();
+            }
+        });
+
+        test('rejects terminal control characters before falling back to sendText', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').throws(new Error('Terminal should not be created'));
+
+            try {
+                await assert.rejects(
+                    () => terminalProvider.sendAspireCommandToAspireTerminal(['stop', '--apphost', shellArg('/workspace/AppHost.csproj\x03\necho pwned')]),
+                    { message: terminalCommandArgumentControlCharacters });
+                await assert.rejects(
+                    () => terminalProvider.sendAspireCommandToAspireTerminal('resource "web" "restart"', true, ['--', 'safe\r\necho pwned']),
+                    { message: terminalCommandArgumentControlCharacters });
+                assert.strictEqual(getAspireTerminalStub.called, false);
             }
             finally {
                 getAspireTerminalStub.restore();
@@ -486,7 +505,6 @@ suite('AspireTerminalProvider tests', () => {
                 { name: 'backslash followed by quote', input: 'a\\"b', expected: '"a\\`"b"' },
                 { name: 'pipe and chaining', input: 'a | b; c && d', expected: '"a | b; c && d"' },
                 { name: 'redirection', input: '> out.txt < in.txt', expected: '"> out.txt < in.txt"' },
-                { name: 'newline', input: 'line1\nline2', expected: '"line1\nline2"' },
                 { name: 'mixed dollar quote backtick', input: '`$x"y"`', expected: '"```$x`"y`"``"' },
                 { name: 'attempted PowerShell break-out', input: '"; Remove-Item C:\\ -Recurse #', expected: '"`"; Remove-Item C:\\ -Recurse #"' },
                 { name: 'subshell with backticks and dollar', input: '`echo $(rm -rf /)`', expected: '"``echo `$(rm -rf /)``"' },
@@ -514,7 +532,6 @@ suite('AspireTerminalProvider tests', () => {
                 { name: 'glob characters', input: '* ? [a-z]', expected: `'* ? [a-z]'` },
                 { name: 'pipe and chaining', input: 'a | b; c && d', expected: `'a | b; c && d'` },
                 { name: 'redirection', input: '> out.txt < in.txt', expected: `'> out.txt < in.txt'` },
-                { name: 'newline', input: 'line1\nline2', expected: `'line1\nline2'` },
                 { name: 'attempted bash break-out', input: `'; rm -rf / #`, expected: `''"'"'; rm -rf / #'` },
                 { name: 'backslash', input: 'a\\b', expected: `'a\\b'` },
                 { name: 'empty string', input: '', expected: `''` },
@@ -529,6 +546,15 @@ suite('AspireTerminalProvider tests', () => {
             test('darwin uses identical posix quoting', () => {
                 assert.strictEqual(quoteShellArg(`it's fine`, 'darwin'), `'it'"'"'s fine'`);
             });
+        });
+
+        test('rejects terminal control characters on every platform', () => {
+            const cases = ['line1\nline2', 'line1\rline2', 'prefix\x03suffix', 'prefix\x1bsuffix', 'prefix\x7fsuffix'];
+
+            for (const value of cases) {
+                assert.throws(() => quoteShellArg(value, 'linux'), { message: terminalCommandArgumentControlCharacters });
+                assert.throws(() => quoteShellArg(value, 'win32'), { message: terminalCommandArgumentControlCharacters });
+            }
         });
     });
 });

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -5,7 +5,7 @@ import { AspireTerminalProvider, quoteShellArg, shellArg } from '../utils/Aspire
 import * as cliPathModule from '../utils/cliPath';
 import { EnvironmentVariables } from '../utils/environment';
 import { extensionLogOutputChannel } from '../utils/logging';
-import { terminalCommandArgumentControlCharacters } from '../loc/strings';
+import { terminalCommandArgumentControlCharacters, terminalCommandUnsafeLiteral } from '../loc/strings';
 
 suite('AspireTerminalProvider tests', () => {
     let terminalProvider: AspireTerminalProvider;
@@ -70,8 +70,13 @@ suite('AspireTerminalProvider tests', () => {
     }
 
     suite('getAspireTerminal', () => {
-        test('creates Windows terminal with PowerShell so Windows quoting matches the shell', () => {
+        test('creates Windows terminal with PowerShell 7 when it is available', () => {
             const platformStub = sinon.stub(process, 'platform').value('win32');
+            let probeCount = 0;
+            terminalProvider = new AspireTerminalProvider(subscriptions, () => {
+                probeCount++;
+                return true;
+            });
             const createEnvironmentStub = sinon.stub(terminalProvider, 'createEnvironment').returns({});
             const terminal = {
                 dispose: () => { }
@@ -83,7 +88,35 @@ suite('AspireTerminalProvider tests', () => {
 
                 assert.strictEqual(result.terminal, terminal);
                 assert.strictEqual(createTerminalStub.calledOnce, true);
+                assert.strictEqual((createTerminalStub.firstCall.args[0] as vscode.TerminalOptions).shellPath, 'pwsh.exe');
+                assert.strictEqual(probeCount, 1);
+            }
+            finally {
+                terminalProvider.dispose();
+                createTerminalStub.restore();
+                createEnvironmentStub.restore();
+                platformStub.restore();
+            }
+        });
+
+        test('falls back to Windows PowerShell when PowerShell 7 is unavailable', () => {
+            const platformStub = sinon.stub(process, 'platform').value('win32');
+            let probeCount = 0;
+            terminalProvider = new AspireTerminalProvider(subscriptions, () => {
+                probeCount++;
+                return false;
+            });
+            const createEnvironmentStub = sinon.stub(terminalProvider, 'createEnvironment').returns({});
+            const terminal = {
+                dispose: () => { }
+            } as unknown as vscode.Terminal;
+            const createTerminalStub = sinon.stub(vscode.window, 'createTerminal').returns(terminal);
+
+            try {
+                terminalProvider.getAspireTerminal(true);
+                assert.strictEqual(createTerminalStub.calledOnce, true);
                 assert.strictEqual((createTerminalStub.firstCall.args[0] as vscode.TerminalOptions).shellPath, 'powershell.exe');
+                assert.strictEqual(probeCount, 1);
             }
             finally {
                 terminalProvider.dispose();
@@ -258,6 +291,58 @@ suite('AspireTerminalProvider tests', () => {
                 await assert.rejects(
                     () => terminalProvider.sendAspireCommandToAspireTerminal('resource "web" "restart"', true, ['--', 'safe\r\necho pwned']),
                     { message: terminalCommandArgumentControlCharacters });
+                assert.strictEqual(getAspireTerminalStub.called, false);
+            }
+            finally {
+                getAspireTerminalStub.restore();
+            }
+        });
+
+        test('allows tabs inside quoted structured arguments', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            const appHostPath = '/workspace/apps/Store\tTabbed/AppHost.csproj';
+            let executedCommand: string | undefined;
+            const terminal = {
+                shellIntegration: {
+                    executeCommand: (commandLine: string) => {
+                        executedCommand = commandLine;
+                        return {} as vscode.TerminalShellExecution;
+                    }
+                },
+                sendText: () => { },
+                show: () => { }
+            } as unknown as vscode.Terminal;
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').returns({
+                terminal,
+                dispose: () => { }
+            });
+
+            try {
+                await terminalProvider.sendAspireCommandToAspireTerminal(['stop', '--apphost', shellArg(appHostPath)]);
+
+                const expectedSubcommand = `stop --apphost ${quoteShellArg(appHostPath)}`;
+                const expectedCommand = process.platform === 'win32'
+                    ? `& "aspire" ${expectedSubcommand}`
+                    : `aspire ${expectedSubcommand}`;
+                assert.strictEqual(executedCommand, expectedCommand);
+            }
+            finally {
+                getAspireTerminalStub.restore();
+            }
+        });
+
+        test('rejects unsafe bare structured subcommand literals before creating a terminal', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').throws(new Error('Terminal should not be created'));
+            const unsafeLiterals = ['resource; touch /tmp/pwned', '$(whoami)', '`whoami`', '--apphost=/tmp/AppHost.csproj', 'logs --follow'];
+
+            try {
+                for (const unsafeLiteral of unsafeLiterals) {
+                    await assert.rejects(
+                        () => terminalProvider.sendAspireCommandToAspireTerminal(['resource', unsafeLiteral, shellArg('web')]),
+                        { message: terminalCommandUnsafeLiteral });
+                }
+
                 assert.strictEqual(getAspireTerminalStub.called, false);
             }
             finally {
@@ -505,8 +590,11 @@ suite('AspireTerminalProvider tests', () => {
                 { name: 'backslash followed by quote', input: 'a\\"b', expected: '"a\\`"b"' },
                 { name: 'pipe and chaining', input: 'a | b; c && d', expected: '"a | b; c && d"' },
                 { name: 'redirection', input: '> out.txt < in.txt', expected: '"> out.txt < in.txt"' },
+                { name: 'tab', input: 'hello\tworld', expected: '"hello\tworld"' },
                 { name: 'mixed dollar quote backtick', input: '`$x"y"`', expected: '"```$x`"y`"``"' },
                 { name: 'attempted PowerShell break-out', input: '"; Remove-Item C:\\ -Recurse #', expected: '"`"; Remove-Item C:\\ -Recurse #"' },
+                { name: 'attempted smart double quote break-out', input: 'safe\u201C; Remove-Item C:\\ -Recurse #', expected: '"safe`\u201C; Remove-Item C:\\ -Recurse #"' },
+                { name: 'attempted smart single quote break-out', input: 'safe\u2018; Remove-Item C:\\ -Recurse #', expected: '"safe`\u2018; Remove-Item C:\\ -Recurse #"' },
                 { name: 'subshell with backticks and dollar', input: '`echo $(rm -rf /)`', expected: '"``echo `$(rm -rf /)``"' },
                 { name: 'empty string', input: '', expected: '""' },
                 { name: 'only special characters', input: '`$"', expected: '"```$`""' },
@@ -532,6 +620,7 @@ suite('AspireTerminalProvider tests', () => {
                 { name: 'glob characters', input: '* ? [a-z]', expected: `'* ? [a-z]'` },
                 { name: 'pipe and chaining', input: 'a | b; c && d', expected: `'a | b; c && d'` },
                 { name: 'redirection', input: '> out.txt < in.txt', expected: `'> out.txt < in.txt'` },
+                { name: 'tab', input: 'hello\tworld', expected: `'hello\tworld'` },
                 { name: 'attempted bash break-out', input: `'; rm -rf / #`, expected: `''"'"'; rm -rf / #'` },
                 { name: 'backslash', input: 'a\\b', expected: `'a\\b'` },
                 { name: 'empty string', input: '', expected: `''` },

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -68,6 +68,53 @@ suite('AspireTerminalProvider tests', () => {
         process.env[name] = value;
     }
 
+    suite('getAspireTerminal', () => {
+        test('creates Windows terminal with PowerShell so Windows quoting matches the shell', () => {
+            const platformStub = sinon.stub(process, 'platform').value('win32');
+            const createEnvironmentStub = sinon.stub(terminalProvider, 'createEnvironment').returns({});
+            const terminal = {
+                dispose: () => { }
+            } as unknown as vscode.Terminal;
+            const createTerminalStub = sinon.stub(vscode.window, 'createTerminal').returns(terminal);
+
+            try {
+                const result = terminalProvider.getAspireTerminal(true);
+
+                assert.strictEqual(result.terminal, terminal);
+                assert.strictEqual(createTerminalStub.calledOnce, true);
+                assert.strictEqual((createTerminalStub.firstCall.args[0] as vscode.TerminalOptions).shellPath, 'powershell.exe');
+            }
+            finally {
+                terminalProvider.dispose();
+                createTerminalStub.restore();
+                createEnvironmentStub.restore();
+                platformStub.restore();
+            }
+        });
+
+        test('uses default terminal profile on non-Windows hosts', () => {
+            const platformStub = sinon.stub(process, 'platform').value('darwin');
+            const createEnvironmentStub = sinon.stub(terminalProvider, 'createEnvironment').returns({});
+            const terminal = {
+                dispose: () => { }
+            } as unknown as vscode.Terminal;
+            const createTerminalStub = sinon.stub(vscode.window, 'createTerminal').returns(terminal);
+
+            try {
+                terminalProvider.getAspireTerminal(true);
+
+                assert.strictEqual(createTerminalStub.calledOnce, true);
+                assert.strictEqual((createTerminalStub.firstCall.args[0] as vscode.TerminalOptions).shellPath, undefined);
+            }
+            finally {
+                terminalProvider.dispose();
+                createTerminalStub.restore();
+                createEnvironmentStub.restore();
+                platformStub.restore();
+            }
+        });
+    });
+
     suite('sendAspireCommandToAspireTerminal', () => {
         const expectedCommand = process.platform === 'win32' ? '& "aspire" logs' : 'aspire logs';
         let originalStopOnEntry: string | undefined;

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
-import { AspireTerminalProvider, quoteShellArg } from '../utils/AspireTerminalProvider';
+import { AspireTerminalProvider, quoteShellArg, shellArg } from '../utils/AspireTerminalProvider';
 import * as cliPathModule from '../utils/cliPath';
 import { EnvironmentVariables } from '../utils/environment';
 import { extensionLogOutputChannel } from '../utils/logging';
@@ -161,6 +161,40 @@ suite('AspireTerminalProvider tests', () => {
             }
             finally {
                 platformStub.restore();
+                getAspireTerminalStub.restore();
+            }
+        });
+
+        test('quotes structured subcommand arguments with shell metacharacters', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            const appHostPath = `/workspace/'; touch /tmp/aspire-rce #/$(whoami)/"bad"/AppHost.csproj`;
+            let executedCommand: string | undefined;
+            const terminal = {
+                shellIntegration: {
+                    executeCommand: (commandLine: string) => {
+                        executedCommand = commandLine;
+                        return {} as vscode.TerminalShellExecution;
+                    }
+                },
+                sendText: () => { },
+                show: () => { }
+            } as unknown as vscode.Terminal;
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').returns({
+                terminal,
+                dispose: () => { }
+            });
+
+            try {
+                await terminalProvider.sendAspireCommandToAspireTerminal(['stop', '--apphost', shellArg(appHostPath)]);
+
+                const expectedSubcommand = `stop --apphost ${quoteShellArg(appHostPath)}`;
+                const expectedCommand = process.platform === 'win32'
+                    ? `& "aspire" ${expectedSubcommand}`
+                    : `aspire ${expectedSubcommand}`;
+                assert.strictEqual(executedCommand, expectedCommand);
+                assert.strictEqual(executedCommand.includes(`--apphost ${appHostPath}`), false);
+            }
+            finally {
                 getAspireTerminalStub.restore();
             }
         });

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { aspireTerminalName, dcpServerNotInitialized, rpcServerNotInitialized } from '../loc/strings';
+import { aspireTerminalName, dcpServerNotInitialized, rpcServerNotInitialized, terminalCommandArgumentControlCharacters } from '../loc/strings';
 import { extensionLogOutputChannel } from './logging';
 import { RpcServerConnectionInfo } from '../server/AspireRpcServer';
 import { DcpServerConnectionInfo } from '../dcp/types';
@@ -60,6 +60,8 @@ export interface AspireTerminalCommandEvent {
  * branches regardless of the host OS.
  */
 export function quoteShellArg(arg: string, platform: NodeJS.Platform = process.platform): string {
+    assertNoTerminalControlCharacters(arg);
+
     if (platform === 'win32') {
         // Order matters: escape backticks first so that the backticks we
         // introduce when escaping " and $ are not themselves re-escaped.
@@ -119,6 +121,7 @@ export class AspireTerminalProvider implements vscode.Disposable {
     async sendAspireCommandToAspireTerminal(subcommand: AspireSubcommand, showTerminal: boolean = true, additionalArgs?: string[], options?: SendAspireCommandOptions) {
         const cliPath = await this.getAspireCliExecutablePath();
         const subcommandLine = formatSubcommand(subcommand);
+        assertNoTerminalControlCharacters(cliPath);
 
         // On Windows, use & to execute paths, especially those with special characters
         // On Unix, just use the path directly
@@ -149,6 +152,7 @@ export class AspireTerminalProvider implements vscode.Disposable {
             const quotedArgs = cliArgs.map(arg => quoteShellArg(arg));
             command += ' ' + quotedArgs.join(' ');
         }
+        assertNoTerminalControlCharacters(command);
 
         const aspireTerminal = this.getAspireTerminal();
         let logCommand = command;
@@ -340,6 +344,16 @@ function isE2eTerminalCommandExecutionSuppressed(): boolean {
         !!process.env.ASPIRE_EXTENSION_E2E_STATE_FILE &&
         !!process.env.ASPIRE_EXTENSION_E2E_CONTROL_FILE &&
         process.env.ASPIRE_EXTENSION_E2E_SUPPRESS_TERMINAL_COMMAND_EXECUTION === 'true';
+}
+
+function assertNoTerminalControlCharacters(value: string): void {
+    // Shell quoting protects shell metacharacters after the command reaches the
+    // shell. C0 controls are terminal input first: in sendText fallback, ETX can
+    // abort the current line and CR/LF can submit following text as another
+    // command before shell parsing can make those bytes inert.
+    if (/[\x00-\x1F\x7F]/.test(value)) {
+        throw new Error(terminalCommandArgumentControlCharacters);
+    }
 }
 
 function formatSubcommand(subcommand: AspireSubcommand): string {

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
-import { aspireTerminalName, dcpServerNotInitialized, rpcServerNotInitialized, terminalCommandArgumentControlCharacters } from '../loc/strings';
+import * as childProcess from 'child_process';
+import { aspireTerminalName, dcpServerNotInitialized, rpcServerNotInitialized, terminalCommandArgumentControlCharacters, terminalCommandUnsafeLiteral } from '../loc/strings';
 import { extensionLogOutputChannel } from './logging';
 import { RpcServerConnectionInfo } from '../server/AspireRpcServer';
 import { DcpServerConnectionInfo } from '../dcp/types';
@@ -23,8 +24,9 @@ export interface SendAspireCommandOptions {
     redactAdditionalArgs?: boolean;
 }
 
-// String parts are fixed CLI syntax. ShellArg parts are workspace/user data that
-// must be shell-quoted at the terminal boundary before interpolation.
+// String parts are fixed CLI syntax and are validated before interpolation.
+// ShellArg parts are workspace/user data that must be shell-quoted at the
+// terminal boundary.
 export interface ShellArg {
     readonly quote: true;
     readonly value: string;
@@ -45,10 +47,13 @@ export interface AspireTerminalCommandEvent {
 /**
  * Quotes a single argument for safe interpolation into a shell command line.
  *
- * Windows: The output targets the PowerShell terminal created by
- * getAspireTerminal(). The argument is wrapped in double quotes and the
- * interpolation-significant characters (backtick, double quote, dollar sign)
- * are backtick-escaped.
+ * Windows: The output targets the PowerShell terminal created by getAspireTerminal().
+ * The terminal prefers PowerShell 7 (pwsh.exe) and falls back to Windows PowerShell
+ * (powershell.exe). The argument is wrapped in double quotes and the
+ * interpolation-significant characters (backtick, PowerShell quote delimiters,
+ * dollar sign) are backtick-escaped, which both shells use for expandable
+ * strings. PowerShell treats smart quotes as quote delimiters too:
+ * https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_quoting_rules
  *
  * Unix: The output uses POSIX single-quote quoting, which is interpreted the
  * same way by bash, zsh, dash, sh, and fish. Embedded single quotes are split
@@ -63,9 +68,8 @@ export function quoteShellArg(arg: string, platform: NodeJS.Platform = process.p
     assertNoTerminalControlCharacters(arg);
 
     if (platform === 'win32') {
-        // Order matters: escape backticks first so that the backticks we
-        // introduce when escaping " and $ are not themselves re-escaped.
-        return `"${arg.replace(/`/g, '``').replace(/"/g, '`"').replace(/\$/g, '`$')}"`;
+        const escaped = arg.replace(/[`"$\u2018\u2019\u201C\u201D]/g, value => value === '`' ? '``' : '`' + value);
+        return `"${escaped}"`;
     }
 
     return `'${arg.replace(/'/g, "'\"'\"'")}'`;
@@ -79,11 +83,15 @@ export class AspireTerminalProvider implements vscode.Disposable {
     private _terminalByDebugSessionId: Map<string | null, AspireTerminal> = new Map();
     private _rpcServerConnectionInfo?: RpcServerConnectionInfo;
     private _dcpServerConnectionInfo?: DcpServerConnectionInfo;
+    private _windowsPowerShellPath?: string;
 
     private readonly _onDidSendAspireCommand = new vscode.EventEmitter<AspireTerminalCommandEvent>();
     readonly onDidSendAspireCommand = this._onDidSendAspireCommand.event;
 
-    constructor(subscriptions: vscode.Disposable[]) {
+    constructor(
+        subscriptions: vscode.Disposable[],
+        private readonly _isPowerShell7Available = isPowerShell7Available,
+    ) {
         subscriptions.push(vscode.window.onDidCloseTerminal(closedTerminal => {
             for (const [debugSessionId, terminal] of this._terminalByDebugSessionId.entries()) {
                 if (terminal.terminal === closedTerminal) {
@@ -217,11 +225,10 @@ export class AspireTerminalProvider implements vscode.Disposable {
             env: this.createEnvironment(),
         };
         if (process.platform === 'win32') {
-            // quoteShellArg uses PowerShell escaping on Windows. Do not rely on
-            // the user's default terminal profile because cmd.exe treats
-            // backticks as ordinary characters and would make quoted values
-            // containing " shell-sensitive again.
-            terminalOptions.shellPath = 'powershell.exe';
+            // quoteShellArg uses PowerShell escaping on Windows. Do not rely on the
+            // user's default terminal profile because cmd.exe treats backticks as
+            // ordinary characters and would make quoted values containing " shell-sensitive again.
+            terminalOptions.shellPath = this.getWindowsPowerShellPath();
         }
 
         const terminal = vscode.window.createTerminal(terminalOptions);
@@ -337,6 +344,27 @@ export class AspireTerminalProvider implements vscode.Disposable {
     isDebugConfigEnvironmentLoggingEnabled(): boolean {
         return vscode.workspace.getConfiguration('aspire').get<boolean>('enableDebugConfigEnvironmentLogging', false);
     }
+
+    private getWindowsPowerShellPath(): string {
+        if (this._windowsPowerShellPath !== undefined) {
+            return this._windowsPowerShellPath;
+        }
+
+        this._windowsPowerShellPath = this._isPowerShell7Available()
+            ? 'pwsh.exe'
+            : 'powershell.exe';
+
+        return this._windowsPowerShellPath;
+    }
+}
+
+function isPowerShell7Available(): boolean {
+    const result = childProcess.spawnSync('pwsh.exe', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', '$PSVersionTable.PSVersion.Major'], {
+        stdio: 'ignore',
+        windowsHide: true,
+    });
+
+    return result.status === 0 && result.error === undefined;
 }
 
 function isE2eTerminalCommandExecutionSuppressed(): boolean {
@@ -350,10 +378,19 @@ function assertNoTerminalControlCharacters(value: string): void {
     // Shell quoting protects shell metacharacters after the command reaches the
     // shell. C0 controls are terminal input first: in sendText fallback, ETX can
     // abort the current line and CR/LF can submit following text as another
-    // command before shell parsing can make those bytes inert.
-    if (/[\x00-\x1F\x7F]/.test(value)) {
+    // command before shell parsing can make those bytes inert. Tab is allowed
+    // because shells treat it as ordinary whitespace inside quotes.
+    if (/[\x00-\x08\x0A-\x1F\x7F]/.test(value)) {
         throw new Error(terminalCommandArgumentControlCharacters);
     }
+}
+
+function validateLiteralSubcommandPart(value: string): string {
+    if (!/^-{0,2}[A-Za-z0-9][-A-Za-z0-9]*$/.test(value)) {
+        throw new Error(terminalCommandUnsafeLiteral);
+    }
+
+    return value;
 }
 
 function formatSubcommand(subcommand: AspireSubcommand): string {
@@ -361,5 +398,5 @@ function formatSubcommand(subcommand: AspireSubcommand): string {
         return subcommand;
     }
 
-    return subcommand.map(part => typeof part === 'string' ? part : quoteShellArg(part.value)).join(' ');
+    return subcommand.map(part => typeof part === 'string' ? validateLiteralSubcommandPart(part) : quoteShellArg(part.value)).join(' ');
 }

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -45,13 +45,10 @@ export interface AspireTerminalCommandEvent {
 /**
  * Quotes a single argument for safe interpolation into a shell command line.
  *
- * Windows: The output targets PowerShell (powershell.exe / pwsh.exe), which is
- * VS Code's default integrated terminal on Windows. The argument is wrapped in
- * double quotes and the interpolation-significant characters (backtick, double
- * quote, dollar sign) are backtick-escaped. This form is NOT safe for cmd.exe;
- * users who have configured cmd.exe as their default terminal may see
- * unexpected behavior. End-to-end coverage through a real child process is
- * out of scope for this helper.
+ * Windows: The output targets the PowerShell terminal created by
+ * getAspireTerminal(). The argument is wrapped in double quotes and the
+ * interpolation-significant characters (backtick, double quote, dollar sign)
+ * are backtick-escaped.
  *
  * Unix: The output uses POSIX single-quote quoting, which is interpreted the
  * same way by bash, zsh, dash, sh, and fish. Embedded single quotes are split
@@ -211,10 +208,19 @@ export class AspireTerminalProvider implements vscode.Disposable {
         }
 
         extensionLogOutputChannel.info(`Creating new Aspire terminal`);
-        const terminal = vscode.window.createTerminal({
+        const terminalOptions: vscode.TerminalOptions = {
             name: terminalName,
             env: this.createEnvironment(),
-        });
+        };
+        if (process.platform === 'win32') {
+            // quoteShellArg uses PowerShell escaping on Windows. Do not rely on
+            // the user's default terminal profile because cmd.exe treats
+            // backticks as ordinary characters and would make quoted values
+            // containing " shell-sensitive again.
+            terminalOptions.shellPath = 'powershell.exe';
+        }
+
+        const terminal = vscode.window.createTerminal(terminalOptions);
 
         const aspireTerminal: AspireTerminal = {
             terminal,

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -23,6 +23,15 @@ export interface SendAspireCommandOptions {
     redactAdditionalArgs?: boolean;
 }
 
+// String parts are fixed CLI syntax. ShellArg parts are workspace/user data that
+// must be shell-quoted at the terminal boundary before interpolation.
+export interface ShellArg {
+    readonly quote: true;
+    readonly value: string;
+}
+
+export type AspireSubcommand = string | readonly (string | ShellArg)[];
+
 export interface AspireTerminalCommandEvent {
     subcommand: string;
     commandLine: string;
@@ -61,6 +70,10 @@ export function quoteShellArg(arg: string, platform: NodeJS.Platform = process.p
     }
 
     return `'${arg.replace(/'/g, "'\"'\"'")}'`;
+}
+
+export function shellArg(value: string): ShellArg {
+    return { quote: true, value };
 }
 
 export class AspireTerminalProvider implements vscode.Disposable {
@@ -106,18 +119,19 @@ export class AspireTerminalProvider implements vscode.Disposable {
         this._dcpServerConnectionInfo = value;
     }
 
-    async sendAspireCommandToAspireTerminal(subcommand: string, showTerminal: boolean = true, additionalArgs?: string[], options?: SendAspireCommandOptions) {
+    async sendAspireCommandToAspireTerminal(subcommand: AspireSubcommand, showTerminal: boolean = true, additionalArgs?: string[], options?: SendAspireCommandOptions) {
         const cliPath = await this.getAspireCliExecutablePath();
+        const subcommandLine = formatSubcommand(subcommand);
 
         // On Windows, use & to execute paths, especially those with special characters
         // On Unix, just use the path directly
         let command: string;
         if (process.platform === 'win32') {
-            command = `& ${quoteShellArg(cliPath)} ${subcommand}`;
+            command = `& ${quoteShellArg(cliPath)} ${subcommandLine}`;
         } else {
             // For Unix-like systems, quote only if needed
             const quotedPath = /[\s"'`$!*?()&|<>;]/.test(cliPath) ? `'${cliPath.replace(/'/g, `'\"'\"'`)}'` : cliPath;
-            command = `${quotedPath} ${subcommand}`;
+            command = `${quotedPath} ${subcommandLine}`;
         }
         const baseCommand = command;
 
@@ -153,7 +167,7 @@ export class AspireTerminalProvider implements vscode.Disposable {
                 ? 'shellIntegration'
                 : 'sendText';
         this._onDidSendAspireCommand.fire({
-            subcommand,
+            subcommand: subcommandLine,
             commandLine: logCommand,
             showTerminal,
             additionalArgs: options?.redactAdditionalArgs ? undefined : cliArgs,
@@ -320,4 +334,12 @@ function isE2eTerminalCommandExecutionSuppressed(): boolean {
         !!process.env.ASPIRE_EXTENSION_E2E_STATE_FILE &&
         !!process.env.ASPIRE_EXTENSION_E2E_CONTROL_FILE &&
         process.env.ASPIRE_EXTENSION_E2E_SUPPRESS_TERMINAL_COMMAND_EXECUTION === 'true';
+}
+
+function formatSubcommand(subcommand: AspireSubcommand): string {
+    if (typeof subcommand === 'string') {
+        return subcommand;
+    }
+
+    return subcommand.map(part => typeof part === 'string' ? part : quoteShellArg(part.value)).join(' ');
 }

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { AspireTerminalProvider, quoteShellArg } from '../utils/AspireTerminalProvider';
+import { AspireTerminalProvider, shellArg } from '../utils/AspireTerminalProvider';
 import { ResourceState, HealthStatus, StateStyle } from '../editor/resourceConstants';
 import {
     pidDescription,
@@ -1249,7 +1249,7 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
         this._trackStoppingAppHost(appHostPath);
         this._onDidChangeTreeData.fire();
         try {
-            await this._terminalProvider.sendAspireCommandToAspireTerminal(`stop --apphost ${quoteShellArg(appHostPath)}`);
+            await this._terminalProvider.sendAspireCommandToAspireTerminal(['stop', '--apphost', shellArg(appHostPath)]);
         } catch (err) {
             const stoppingKey = this._findStoppingAppHostKey(appHostPath);
             if (stoppingKey) {
@@ -1300,18 +1300,19 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
     async viewResourceLogs(element: ResourceItem): Promise<void> {
         // aspire logs accepts the resource display name, not the internal name
         const resourceName = element.resource.displayName ?? element.resource.name;
-        const resourceNameArg = quoteShellArg(resourceName);
         if (this._repository.viewMode === 'workspace') {
             const appHostPath = this._getAppHostPathForResource(element);
-            const appHostFlag = appHostPath ? ` --apphost ${quoteShellArg(appHostPath)}` : '';
-            await this._terminalProvider.sendAspireCommandToAspireTerminal(`logs ${resourceNameArg}${appHostFlag}`);
+            const command = appHostPath
+                ? ['logs', shellArg(resourceName), '--apphost', shellArg(appHostPath)]
+                : ['logs', shellArg(resourceName)];
+            await this._terminalProvider.sendAspireCommandToAspireTerminal(command);
             return;
         }
         const appHost = this._findAppHostForResource(element);
         if (!appHost) {
             return;
         }
-        await this._terminalProvider.sendAspireCommandToAspireTerminal(`logs ${resourceNameArg} --apphost ${quoteShellArg(appHost.appHostPath)}`);
+        await this._terminalProvider.sendAspireCommandToAspireTerminal(['logs', shellArg(resourceName), '--apphost', shellArg(appHost.appHostPath)]);
     }
 
     async executeResourceCommand(element: ResourceItem): Promise<void> {
@@ -1440,13 +1441,12 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
     }
 
     private async _runResourceCommand(element: ResourceItem, commandName: string, additionalArgs?: string[], redactAdditionalArgs = false): Promise<void> {
-        const resourceNameArg = quoteShellArg(element.resource.name);
-        const commandNameArg = quoteShellArg(commandName);
-
         if (this._repository.viewMode === 'workspace') {
             const appHostPath = this._getAppHostPathForResource(element);
-            const appHostFlag = appHostPath ? ` --apphost ${quoteShellArg(appHostPath)}` : '';
-            await this._terminalProvider.sendAspireCommandToAspireTerminal(`resource ${resourceNameArg} ${commandNameArg}${appHostFlag}`, true, additionalArgs, { redactAdditionalArgs });
+            const command = appHostPath
+                ? ['resource', shellArg(element.resource.name), shellArg(commandName), '--apphost', shellArg(appHostPath)]
+                : ['resource', shellArg(element.resource.name), shellArg(commandName)];
+            await this._terminalProvider.sendAspireCommandToAspireTerminal(command, true, additionalArgs, { redactAdditionalArgs });
             return;
         }
 
@@ -1454,7 +1454,7 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
         if (!appHost) {
             return;
         }
-        await this._terminalProvider.sendAspireCommandToAspireTerminal(`resource ${resourceNameArg} ${commandNameArg} --apphost ${quoteShellArg(appHost.appHostPath)}`, true, additionalArgs, { redactAdditionalArgs });
+        await this._terminalProvider.sendAspireCommandToAspireTerminal(['resource', shellArg(element.resource.name), shellArg(commandName), '--apphost', shellArg(appHost.appHostPath)], true, additionalArgs, { redactAdditionalArgs });
     }
 
     private async _loadResourceCommandArguments(element: ResourceItem, commandName: string, values: readonly ResourceCommandArgumentValue[]): Promise<ResourceCommandArgumentInputJson[] | undefined> {


### PR DESCRIPTION
## Description

Harden the VS Code extension terminal command path used by AppHost tree actions. The tree-provider paths I traced were already manually quoting AppHost/resource values, but the terminal provider API still accepted pre-built shell fragments. This moves those values to structured shell args so workspace paths, resource names, and command names are quoted at the terminal boundary.

The AppHost tree now uses structured arguments for:

- stopping a workspace/global AppHost
- viewing resource logs
- running resource lifecycle commands

This also forces the extension-owned Aspire terminal to PowerShell on Windows, because the Windows quoting path is PowerShell-style and should not be sent to a user-configured `cmd.exe` terminal. It also rejects C0/DEL control characters before terminal input, so `sendText` fallback cannot be bypassed with Enter/Ctrl-C/escape-style payloads.

### Security considerations

This change affects generated integrated-terminal commands and shell escaping. Security review is useful because the code intentionally treats workspace/AppHost paths and resource names as untrusted shell argument values, quotes them at the terminal boundary, and preserves the existing string-command path for fixed CLI syntax.

Validation includes actual scenario proof: the test drives the real `AspireAppHostTreeProvider` actions for workspace Stop AppHost, View Resource Logs, and Restart Resource through the real `AspireTerminalProvider`, executes the generated command via `/bin/sh` against a fake `aspire`, and verifies hostile `touch ...` payloads stay as argv values without creating marker files. A second scenario verifies control-character payloads are rejected before any terminal command is sent.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
