### PR TITLE
feat: add aspire doctor check for legacy settings.json

### DIFF
--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -512,6 +512,7 @@ public class Program
         builder.Services.AddSingleton<IEnvironmentCheck, DevCertsCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, ContainerRuntimeCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, DeprecatedAgentConfigCheck>();
+        builder.Services.AddSingleton<IEnvironmentCheck, LegacySettingsCheck>();
         builder.Services.AddSingleton<IEnvironmentChecker, EnvironmentChecker>();
 
         // MCP server transport factory - creates transport only when needed to avoid

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -230,4 +230,10 @@
   <data name="InstallationDiscoveryFailedReason" xml:space="preserve">
     <value>Install discovery failed. See the Aspire CLI logs for details.</value>
   </data>
+  <data name="LegacySettingsDetected" xml:space="preserve">
+    <value>Legacy .aspire/settings.json detected at {0}.</value>
+  </data>
+  <data name="LegacySettingsFix" xml:space="preserve">
+    <value>Run `aspire init` (or any aspire run/add/update command) to migrate to aspire.config.json. The legacy file continues to work - this is informational only.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/EnvironmentCheckResult.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/EnvironmentCheckResult.cs
@@ -88,6 +88,11 @@ internal enum EnvironmentCheckStatus
     Warning,
 
     /// <summary>
+    /// The check completed with informational feedback (non-blocking).
+    /// </summary>
+    Info,
+
+    /// <summary>
     /// The check failed (blocking issue).
     /// </summary>
     Fail
@@ -105,6 +110,7 @@ internal sealed class LowercaseEnumConverter : JsonConverter<EnvironmentCheckSta
         {
             "pass" => EnvironmentCheckStatus.Pass,
             "warning" => EnvironmentCheckStatus.Warning,
+            "info" => EnvironmentCheckStatus.Info,
             "fail" => EnvironmentCheckStatus.Fail,
             _ => throw new JsonException($"Unknown status value: {value}")
         };

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/LegacySettingsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/LegacySettingsCheck.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Cli.Resources;
+
+namespace Aspire.Cli.Utils.EnvironmentChecker;
+
+/// <summary>
+/// Checks for the presence of a legacy .aspire/settings.json file without a modern aspire.config.json.
+/// </summary>
+internal sealed class LegacySettingsCheck : IEnvironmentCheck
+{
+    private readonly CliExecutionContext _executionContext;
+
+    public LegacySettingsCheck(CliExecutionContext executionContext)
+    {
+        ArgumentNullException.ThrowIfNull(executionContext);
+        _executionContext = executionContext;
+    }
+
+    /// <inheritdoc />
+    public int Order => 110; // Run after core checks
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
+    {
+        var results = new List<EnvironmentCheckResult>();
+
+        var configPath = ConfigurationHelper.FindNearestConfigFilePath(_executionContext.WorkingDirectory);
+        if (configPath is not null)
+        {
+            var configFile = new FileInfo(configPath);
+            var legacyRoot = ConfigurationHelper.GetLegacySettingsRootDirectory(configFile);
+
+            if (legacyRoot is not null)
+            {
+                results.Add(new EnvironmentCheckResult
+                {
+                    Category = "aspire",
+                    Name = "legacy-settings-file",
+                    Status = EnvironmentCheckStatus.Info,
+                    Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.LegacySettingsDetected, configPath),
+                    Fix = DoctorCommandStrings.LegacySettingsFix
+                });
+            }
+        }
+
+        return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>(results);
+    }
+}


### PR DESCRIPTION
Fixes #17632

### Description
This PR addresses the missing migration hint in read-only commands for legacy workspaces. It implements a new `LegacySettingsCheck` for `aspire doctor` that detects the presence of a legacy `.aspire/settings.json` file (without an eagerly created `aspire.config.json` sibling) and outputs an informational message prompting the user to migrate by running an active command. 

- Added `EnvironmentCheckStatus.Info` to support non-warning diagnostics.
- Registered `LegacySettingsCheck` into the `IEnvironmentChecker` pipeline.
- Hooked into `ConfigurationHelper.FindNearestConfigFilePath` and `GetLegacySettingsRootDirectory` as directed.

### Testing
- [x] Tested locally using `dotnet build` and `dotnet test`.