### PR TITLE
feat(keyvault): Add HealthCheckOptions to AzureSecurityKeyVaultSettings

### DIFF
--- a/src/Components/Aspire.Azure.Security.KeyVault/AzureKeyVaultSecretsComponent.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AzureKeyVaultSecretsComponent.cs
@@ -23,7 +23,7 @@ internal sealed class AzureKeyVaultSecretsComponent : AbstractAzureKeyVaultCompo
         => configuration.Bind(settings);
 
     protected override IHealthCheck CreateHealthCheck(SecretClient client, AzureSecurityKeyVaultSettings settings)
-        => new AzureKeyVaultSecretsHealthCheck(client, new AzureKeyVaultSecretsHealthCheckOptions());
+        => new AzureKeyVaultSecretsHealthCheck(client, settings.HealthCheckOptions);
 
     internal override SecretClient CreateComponentClient(Uri vaultUri, SecretClientOptions options, TokenCredential cred)
         => new(vaultUri, cred, options);

--- a/src/Components/Aspire.Azure.Security.KeyVault/AzureSecurityKeyVaultSettings.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AzureSecurityKeyVaultSettings.cs
@@ -4,6 +4,7 @@
 using Aspire.Azure.Common;
 using Azure.Core;
 using Azure.Security.KeyVault.Secrets;
+using HealthChecks.Azure.KeyVault.Secrets;
 
 namespace Aspire.Azure.Security.KeyVault;
 
@@ -39,6 +40,14 @@ public sealed class AzureSecurityKeyVaultSettings : IConnectionStringSettings
     /// The default value is <see langword="false"/>.
     /// </value>
     public bool DisableTracing { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="AzureKeyVaultSecretsHealthCheckOptions"/> used to configure the Key Vault health check.
+    /// </summary>
+    /// <value>
+    /// The default value is a new instance of <see cref="AzureKeyVaultSecretsHealthCheckOptions"/>.
+    /// </value>
+    public AzureKeyVaultSecretsHealthCheckOptions HealthCheckOptions { get; set; } = new();
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {

--- a/src/Components/Aspire.Azure.Security.KeyVault/AzureSecurityKeyVaultSettings.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AzureSecurityKeyVaultSettings.cs
@@ -8,6 +8,8 @@ using HealthChecks.Azure.KeyVault.Secrets;
 
 namespace Aspire.Azure.Security.KeyVault;
 
+// Temporary CCR App-token retry marker for PR #17949; remove after the billing investigation.
+
 /// <summary>
 /// Provides the client configuration settings for connecting to Azure Key Vault.
 /// </summary>

--- a/src/Components/Aspire.Azure.Security.KeyVault/AzureSecurityKeyVaultSettings.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AzureSecurityKeyVaultSettings.cs
@@ -8,8 +8,6 @@ using HealthChecks.Azure.KeyVault.Secrets;
 
 namespace Aspire.Azure.Security.KeyVault;
 
-// Temporary CCR App-token retry marker for PR #17949; remove after the billing investigation.
-
 /// <summary>
 /// Provides the client configuration settings for connecting to Azure Key Vault.
 /// </summary>

--- a/src/Components/Aspire.Azure.Security.KeyVault/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Security.KeyVault/ConfigurationSchema.json
@@ -128,6 +128,20 @@
                       "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
                       "default": false
                     },
+                    "HealthCheckOptions": {
+                      "type": "object",
+                      "properties": {
+                        "CreateWhenNotFound": {
+                          "type": "boolean",
+                          "description": "A boolean value that indicates whether the secret should be created when it's not found. false by default."
+                        },
+                        "SecretName": {
+                          "type": "string",
+                          "description": "The name of the secret that will be fetched from Azure Key Vault. The default value is \"AzureKeyVaultSecretsHealthCheck\"."
+                        }
+                      },
+                      "description": "Gets or sets the 'HealthChecks.Azure.KeyVault.Secrets.AzureKeyVaultSecretsHealthCheckOptions' used to configure the Key Vault health check."
+                    },
                     "VaultUri": {
                       "type": "string",
                       "format": "uri",


### PR DESCRIPTION
## Description

Adds support for configuring `AzureKeyVaultSecretsHealthCheckOptions` through `AzureSecurityKeyVaultSettings`.

The Key Vault secrets health check now uses the configured `HealthCheckOptions` when creating `AzureKeyVaultSecretsHealthCheck`. This allows users to configure health-check-specific behavior, including the secret name used by the health check and whether the secret should be created when it is not found.

This exposes options that are already supported by `AzureKeyVaultSecretsHealthCheck`, but were not previously configurable through the Aspire Key Vault settings.

Motivation and context:

- Allows applications to use a custom health check secret name instead of the default `AzureKeyVaultSecretsHealthCheck`.
- Allows users to enable `CreateWhenNotFound` when the application has the required Key Vault secret set permissions.
- Avoids forcing all Aspire Key Vault users to use the default health check behavior.
- Aligns the Aspire Key Vault integration with the configuration capabilities of the underlying health check package.

No additional dependencies are required for this change.

Fixes # 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No