### PR TITLE
Support command arguments for HTTP commands

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -135,6 +135,9 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
     // Mapping of handle type IDs to XML documentation captured during ATS scanning.
     private readonly Dictionary<string, AtsDocumentationInfo> _handleDocumentationById = new(StringComparer.Ordinal);
 
+    // Mapping of DTO type IDs to DTO metadata for generated argument marshalling.
+    private readonly Dictionary<string, AtsDtoTypeInfo> _dtoTypesById = new(StringComparer.Ordinal);
+
     private static string GetInterfaceName(string className) => className;
 
     private static string GetPromiseInterfaceName(string className) => $"{className}Promise";
@@ -741,26 +744,6 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             : $"{parameterName}: {valueExpression}";
     }
 
-    private static string GetRpcArgumentEntry(AtsParameterInfo param, bool useRegisteredCallback = true)
-    {
-        if (useRegisteredCallback && param.IsCallback)
-        {
-            return $"{param.Name}: {param.Name}Id";
-        }
-
-        return GetRpcArgumentEntry(param.Name, param.Type);
-    }
-
-    private static string GetRpcArgumentExpression(AtsParameterInfo param, bool useRegisteredCallback = true)
-    {
-        if (useRegisteredCallback && param.IsCallback)
-        {
-            return $"{param.Name}Id";
-        }
-
-        return GetRpcArgumentValueExpression(param.Name, param.Type);
-    }
-
     private static string GetRpcArgumentExpression(AtsParameterInfo param, string localParameterName, bool useRegisteredCallback = true)
     {
         if (useRegisteredCallback && param.IsCallback)
@@ -770,6 +753,47 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
         return GetRpcArgumentValueExpression(localParameterName, param.Type);
     }
+
+    private string GetRpcArgumentEntryForParam(AtsParameterInfo param, string localParameterName, bool useRegisteredCallback = true)
+    {
+        if (useRegisteredCallback && param.IsCallback)
+        {
+            return $"{param.Name}: {localParameterName}Id";
+        }
+
+        var valueExpression = GetRpcArgumentExpressionForParam(param, localParameterName, useRegisteredCallback);
+        return valueExpression == param.Name
+            ? param.Name
+            : $"{param.Name}: {valueExpression}";
+    }
+
+    private string GetRpcArgumentExpressionForParam(AtsParameterInfo param, string localParameterName, bool useRegisteredCallback = true)
+    {
+        if (TryGetDtoCallbackProperties(param.Type, out _))
+        {
+            return GetDtoRpcLocalName(localParameterName);
+        }
+
+        return GetRpcArgumentExpression(param, localParameterName, useRegisteredCallback);
+    }
+
+    private bool TryGetDtoCallbackProperties(AtsTypeRef? typeRef, out List<AtsDtoPropertyInfo> callbackProperties)
+    {
+        callbackProperties = [];
+
+        if (typeRef?.Category != AtsTypeCategory.Dto ||
+            !_dtoTypesById.TryGetValue(typeRef.TypeId, out var dtoType))
+        {
+            return false;
+        }
+
+        callbackProperties = dtoType.Properties.Where(static p => p.IsCallback).ToList();
+        return callbackProperties.Count > 0;
+    }
+
+    private static string GetDtoRpcLocalName(string localParameterName) => $"__{localParameterName}ForRpc";
+
+    private static string GetDtoCallbackLocalName(string dtoLocalName, string propertyName) => $"__{dtoLocalName}{propertyName}";
 
     /// <summary>
     /// Gets the TypeId from a capability's return type.
@@ -919,6 +943,12 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         _optionsInterfacesToGenerate.Clear();
         _capabilityOptionsInterfaceMap.Clear();
         _handleDocumentationById.Clear();
+        _dtoTypesById.Clear();
+
+        foreach (var dtoType in dtoTypes)
+        {
+            _dtoTypesById[dtoType.TypeId] = dtoType;
+        }
 
         foreach (var handleType in context.HandleTypes)
         {
@@ -2342,11 +2372,16 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         // Resolve any promise-like handle parameters
         GeneratePromiseResolution(allParams, indent);
 
+        // DTO callback properties are sent over the wire as callback IDs, just like direct
+        // callback parameters. Copy the DTO before replacing function-valued properties so
+        // callers keep their original options object unchanged.
+        GenerateDtoCallbackPropertyMarshalling(requiredParams.Concat(optionalParams), useSafeOptionalLocalNames, indent);
+
         // Build the required args inline
         var requiredArgs = new List<string> { $"{targetParamName}: this._handle" };
         foreach (var param in requiredParams)
         {
-            requiredArgs.Add(GetRpcArgumentEntry(param));
+            requiredArgs.Add(GetRpcArgumentEntryForParam(param, param.Name));
         }
 
         WriteLine($"{indent}const rpcArgs: Record<string, unknown> = {{ {string.Join(", ", requiredArgs)} }};");
@@ -2355,7 +2390,7 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         foreach (var param in optionalParams)
         {
             var localParameterName = useSafeOptionalLocalNames ? GetLocalParameterName(param) : param.Name;
-            var rpcExpression = GetRpcArgumentExpression(param, localParameterName);
+            var rpcExpression = GetRpcArgumentExpressionForParam(param, localParameterName);
             WriteLine($"{indent}if ({localParameterName} !== undefined) rpcArgs.{param.Name} = {rpcExpression};");
         }
     }
@@ -2370,11 +2405,16 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         bool useSafeOptionalLocalNames = false,
         string indent = "        ")
     {
+        // DTO callback properties are sent over the wire as callback IDs, just like direct
+        // callback parameters. Copy the DTO before replacing function-valued properties so
+        // callers keep their original options object unchanged.
+        GenerateDtoCallbackPropertyMarshalling(requiredParams.Concat(optionalParams), useSafeOptionalLocalNames, indent);
+
         // Build the required args inline
         var requiredArgs = new List<string> { $"{targetParamName}: this._handle" };
         foreach (var param in requiredParams)
         {
-            requiredArgs.Add(GetRpcArgumentEntry(param));
+            requiredArgs.Add(GetRpcArgumentEntryForParam(param, param.Name));
         }
 
         WriteLine($"{indent}const rpcArgs: Record<string, unknown> = {{ {string.Join(", ", requiredArgs)} }};");
@@ -2383,10 +2423,73 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         foreach (var param in optionalParams)
         {
             var localParameterName = useSafeOptionalLocalNames ? GetLocalParameterName(param) : param.Name;
-            var rpcExpression = GetRpcArgumentExpression(param, localParameterName);
+            var rpcExpression = GetRpcArgumentExpressionForParam(param, localParameterName);
             WriteLine($"{indent}if ({localParameterName} !== undefined) rpcArgs.{param.Name} = {rpcExpression};");
         }
     }
+
+    private void GenerateDtoCallbackPropertyMarshalling(
+        IEnumerable<AtsParameterInfo> parameters,
+        bool useSafeOptionalLocalNames,
+        string indent,
+        string clientExpression = "this._client")
+    {
+        foreach (var param in parameters)
+        {
+            if (!TryGetDtoCallbackProperties(param.Type, out var callbackProperties))
+            {
+                continue;
+            }
+
+            var localParameterName = useSafeOptionalLocalNames ? GetLocalParameterName(param) : param.Name;
+            var dtoRpcLocalName = GetDtoRpcLocalName(localParameterName);
+            if (param.IsOptional || param.IsNullable)
+            {
+                WriteLine($"{indent}const {dtoRpcLocalName} = {localParameterName} === undefined || {localParameterName} === null ? {localParameterName} : {{ ...{localParameterName} }};");
+                WriteLine($"{indent}if ({dtoRpcLocalName} !== undefined && {dtoRpcLocalName} !== null) {{");
+                GenerateDtoCallbackPropertyAssignments(dtoRpcLocalName, callbackProperties, $"{indent}    ", clientExpression);
+                WriteLine($"{indent}}}");
+            }
+            else
+            {
+                WriteLine($"{indent}const {dtoRpcLocalName} = {localParameterName} === null ? {localParameterName} : {{ ...{localParameterName} }};");
+                WriteLine($"{indent}if ({dtoRpcLocalName} !== null) {{");
+                GenerateDtoCallbackPropertyAssignments(dtoRpcLocalName, callbackProperties, $"{indent}    ", clientExpression);
+                WriteLine($"{indent}}}");
+            }
+        }
+    }
+
+    private void GenerateDtoCallbackPropertyAssignments(
+        string dtoRpcLocalName,
+        IReadOnlyList<AtsDtoPropertyInfo> callbackProperties,
+        string indent,
+        string clientExpression)
+    {
+        var dtoDataLocalName = $"{dtoRpcLocalName}Data";
+        WriteLine($"{indent}const {dtoDataLocalName} = {dtoRpcLocalName} as Record<string, unknown>;");
+
+        foreach (var callbackProperty in callbackProperties)
+        {
+            var propertyName = ToCamelCase(callbackProperty.Name);
+            var callbackLocalName = GetDtoCallbackLocalName(dtoRpcLocalName, callbackProperty.Name);
+            WriteLine($"{indent}const {callbackLocalName} = {dtoRpcLocalName}.{propertyName};");
+            WriteLine($"{indent}if ({callbackLocalName} !== undefined) {{");
+            GenerateCallbackRegistration(CreateCallbackParameter(callbackProperty, callbackLocalName), $"{indent}    ", clientExpression);
+            WriteLine($"{indent}    {dtoDataLocalName}[\"{propertyName}\"] = {callbackLocalName}Id;");
+            WriteLine($"{indent}}}");
+        }
+    }
+
+    private static AtsParameterInfo CreateCallbackParameter(AtsDtoPropertyInfo callbackProperty, string callbackLocalName)
+        => new()
+        {
+            Name = callbackLocalName,
+            Type = callbackProperty.Type,
+            IsCallback = true,
+            CallbackParameters = callbackProperty.CallbackParameters,
+            CallbackReturnType = callbackProperty.CallbackReturnType
+        };
 
     /// <summary>
     /// Generates a thenable wrapper class for a builder that enables fluent chaining.
@@ -2650,13 +2753,14 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
                     WriteLine($"        {param.Name} = isPromiseLike({param.Name}) ? await {param.Name} : {param.Name};");
                 }
             }
+            GenerateDtoCallbackPropertyMarshalling(capability.Parameters, useSafeOptionalLocalNames: false, indent: "        ", clientExpression: "client");
             var requiredArgs = requiredParams
-                .Select(param => GetRpcArgumentEntry(param, useRegisteredCallback: false))
+                .Select(param => GetRpcArgumentEntryForParam(param, param.Name, useRegisteredCallback: false))
                 .ToList();
             WriteLine($"        const rpcArgs: Record<string, unknown> = {{ {string.Join(", ", requiredArgs)} }};");
             foreach (var param in optionalParams)
             {
-                WriteLine($"        if ({param.Name} !== undefined) rpcArgs.{param.Name} = {GetRpcArgumentExpression(param, useRegisteredCallback: false)};");
+                WriteLine($"        if ({param.Name} !== undefined) rpcArgs.{param.Name} = {GetRpcArgumentExpressionForParam(param, param.Name, useRegisteredCallback: false)};");
             }
             WriteLine($"        const handle = await client.invokeCapability<{handleType}>(");
             WriteLine($"            '{capability.CapabilityId}',");
@@ -2685,13 +2789,14 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
                     WriteLine($"    {param.Name} = isPromiseLike({param.Name}) ? await {param.Name} : {param.Name};");
                 }
             }
+            GenerateDtoCallbackPropertyMarshalling(capability.Parameters, useSafeOptionalLocalNames: false, indent: "    ", clientExpression: "client");
             var requiredArgs = requiredParams
-                .Select(param => GetRpcArgumentEntry(param, useRegisteredCallback: false))
+                .Select(param => GetRpcArgumentEntryForParam(param, param.Name, useRegisteredCallback: false))
                 .ToList();
             WriteLine($"    const rpcArgs: Record<string, unknown> = {{ {string.Join(", ", requiredArgs)} }};");
             foreach (var param in optionalParams)
             {
-                WriteLine($"    if ({param.Name} !== undefined) rpcArgs.{param.Name} = {GetRpcArgumentExpression(param, useRegisteredCallback: false)};");
+                WriteLine($"    if ({param.Name} !== undefined) rpcArgs.{param.Name} = {GetRpcArgumentExpressionForParam(param, param.Name, useRegisteredCallback: false)};");
             }
             if (returnType == "void")
             {
@@ -2744,7 +2849,7 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         return $"({paramsString}) => Promise<{returnType}>";
     }
 
-    private void GenerateCallbackRegistration(AtsParameterInfo callbackParam, string indent = "        ")
+    private void GenerateCallbackRegistration(AtsParameterInfo callbackParam, string indent = "        ", string clientExpression = "this._client")
     {
         var callbackParameters = callbackParam.CallbackParameters;
         var isOptional = callbackParam.IsOptional || callbackParam.IsNullable;
@@ -2776,7 +2881,7 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         }
 
         // Generate the callback body
-        GenerateCallbackBody(callbackParam, callbackParameters, indent);
+        GenerateCallbackBody(callbackParam, callbackParameters, indent, clientExpression);
 
         // Close the callback registration
         if (isOptional)
@@ -2792,7 +2897,7 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
     /// <summary>
     /// Generates the body of a callback function.
     /// </summary>
-    private void GenerateCallbackBody(AtsParameterInfo callbackParam, IReadOnlyList<AtsCallbackParameterInfo>? callbackParameters, string indent)
+    private void GenerateCallbackBody(AtsParameterInfo callbackParam, IReadOnlyList<AtsCallbackParameterInfo>? callbackParameters, string indent, string clientExpression)
     {
         var callbackName = callbackParam.Name;
         var bodyIndent = $"{indent}    ";
@@ -2811,7 +2916,7 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         {
             // Single parameter callback
             var cbParam = callbackParameters[0];
-            GenerateCallbackParameterConversion(cbParam, $"{cbParam.Name}Data");
+            GenerateCallbackParameterConversion(cbParam, $"{cbParam.Name}Data", clientExpression, bodyIndent);
 
             WriteLine($"{bodyIndent}{returnPrefix}await {callbackName}({cbParam.Name});");
         }
@@ -2823,7 +2928,7 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
                 var cbParam = callbackParameters[i];
                 var callbackArgName = $"{cbParam.Name}Data";
 
-                GenerateCallbackParameterConversion(cbParam, callbackArgName);
+                GenerateCallbackParameterConversion(cbParam, callbackArgName, clientExpression, bodyIndent);
                 callArgs.Add(cbParam.Name);
             }
 
@@ -2831,14 +2936,14 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         }
     }
 
-    private void GenerateCallbackParameterConversion(AtsCallbackParameterInfo callbackParameter, string callbackArgName)
+    private void GenerateCallbackParameterConversion(AtsCallbackParameterInfo callbackParameter, string callbackArgName, string clientExpression, string indent)
     {
         var tsType = MapTypeRefToTypeScript(callbackParameter.Type);
         var cbTypeId = callbackParameter.Type.TypeId;
 
         if (cbTypeId == AtsConstants.CancellationToken)
         {
-            WriteLine($"            const {callbackParameter.Name} = CancellationToken.fromValue({callbackArgName});");
+            WriteLine($"{indent}const {callbackParameter.Name} = CancellationToken.fromValue({callbackArgName});");
         }
         else if (IsDictionaryType(callbackParameter.Type) && !callbackParameter.Type.IsReadOnly)
         {
@@ -2846,18 +2951,18 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             var valueType = MapTypeRefToTypeScript(callbackParameter.Type.ValueType);
             var handleType = GetHandleTypeName(cbTypeId);
 
-            WriteLine($"            const {callbackParameter.Name}Handle = wrapIfHandle({callbackArgName}) as {handleType};");
-            WriteLine($"            const {callbackParameter.Name} = new AspireDict<{keyType}, {valueType}>({callbackParameter.Name}Handle, this._client, '{cbTypeId}');");
+            WriteLine($"{indent}const {callbackParameter.Name}Handle = wrapIfHandle({callbackArgName}) as {handleType};");
+            WriteLine($"{indent}const {callbackParameter.Name} = new AspireDict<{keyType}, {valueType}>({callbackParameter.Name}Handle, {clientExpression}, '{cbTypeId}');");
         }
         else if (_wrapperClassNames.TryGetValue(cbTypeId, out var wrapperClassName))
         {
             var handleType = GetHandleTypeName(cbTypeId);
-            WriteLine($"            const {callbackParameter.Name}Handle = wrapIfHandle({callbackArgName}) as {handleType};");
-            WriteLine($"            const {callbackParameter.Name} = new {GetImplementationClassName(wrapperClassName)}({callbackParameter.Name}Handle, this._client);");
+            WriteLine($"{indent}const {callbackParameter.Name}Handle = wrapIfHandle({callbackArgName}) as {handleType};");
+            WriteLine($"{indent}const {callbackParameter.Name} = new {GetImplementationClassName(wrapperClassName)}({callbackParameter.Name}Handle, {clientExpression});");
         }
         else
         {
-            WriteLine($"            const {callbackParameter.Name} = wrapIfHandle({callbackArgName}) as {tsType};");
+            WriteLine($"{indent}const {callbackParameter.Name} = wrapIfHandle({callbackArgName}) as {tsType};");
         }
     }
 

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -769,7 +769,7 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
     private string GetRpcArgumentExpressionForParam(AtsParameterInfo param, string localParameterName, bool useRegisteredCallback = true)
     {
-        if (TryGetDtoCallbackProperties(param.Type, out _))
+        if (TryGetDtoCallbackMarshallingProperties(param.Type, out _))
         {
             return GetDtoRpcLocalName(localParameterName);
         }
@@ -777,9 +777,9 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         return GetRpcArgumentExpression(param, localParameterName, useRegisteredCallback);
     }
 
-    private bool TryGetDtoCallbackProperties(AtsTypeRef? typeRef, out List<AtsDtoPropertyInfo> callbackProperties)
+    private bool TryGetDtoCallbackMarshallingProperties(AtsTypeRef? typeRef, out List<AtsDtoPropertyInfo> marshallingProperties)
     {
-        callbackProperties = [];
+        marshallingProperties = [];
 
         if (typeRef?.Category != AtsTypeCategory.Dto ||
             !_dtoTypesById.TryGetValue(typeRef.TypeId, out var dtoType))
@@ -787,8 +787,35 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             return false;
         }
 
-        callbackProperties = dtoType.Properties.Where(static p => p.IsCallback).ToList();
-        return callbackProperties.Count > 0;
+        marshallingProperties = dtoType.Properties
+            .Where(p => p.IsCallback || RequiresDtoCallbackMarshalling(p.Type))
+            .ToList();
+
+        return marshallingProperties.Count > 0;
+    }
+
+    private bool RequiresDtoCallbackMarshalling(AtsTypeRef? typeRef, HashSet<string>? visitedDtoTypeIds = null)
+    {
+        if (typeRef?.Category != AtsTypeCategory.Dto ||
+            !_dtoTypesById.TryGetValue(typeRef.TypeId, out var dtoType))
+        {
+            return false;
+        }
+
+        visitedDtoTypeIds ??= new(StringComparer.Ordinal);
+        if (!visitedDtoTypeIds.Add(typeRef.TypeId))
+        {
+            return false;
+        }
+
+        try
+        {
+            return dtoType.Properties.Any(p => p.IsCallback || RequiresDtoCallbackMarshalling(p.Type, visitedDtoTypeIds));
+        }
+        finally
+        {
+            visitedDtoTypeIds.Remove(typeRef.TypeId);
+        }
     }
 
     private static string GetDtoRpcLocalName(string localParameterName) => $"__{localParameterName}ForRpc";
@@ -2436,25 +2463,31 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
     {
         foreach (var param in parameters)
         {
-            if (!TryGetDtoCallbackProperties(param.Type, out var callbackProperties))
+            if (!TryGetDtoCallbackMarshallingProperties(param.Type, out var marshallingProperties))
+            {
+                continue;
+            }
+
+            if (param.Type is not { TypeId: var dtoTypeId })
             {
                 continue;
             }
 
             var localParameterName = useSafeOptionalLocalNames ? GetLocalParameterName(param) : param.Name;
             var dtoRpcLocalName = GetDtoRpcLocalName(localParameterName);
+            var visitedDtoTypeIds = new HashSet<string>(StringComparer.Ordinal) { dtoTypeId };
             if (param.IsOptional || param.IsNullable)
             {
                 WriteLine($"{indent}const {dtoRpcLocalName} = {localParameterName} === undefined || {localParameterName} === null ? {localParameterName} : {{ ...{localParameterName} }};");
                 WriteLine($"{indent}if ({dtoRpcLocalName} !== undefined && {dtoRpcLocalName} !== null) {{");
-                GenerateDtoCallbackPropertyAssignments(dtoRpcLocalName, callbackProperties, $"{indent}    ", clientExpression);
+                GenerateDtoCallbackPropertyAssignments(dtoRpcLocalName, marshallingProperties, visitedDtoTypeIds, $"{indent}    ", clientExpression);
                 WriteLine($"{indent}}}");
             }
             else
             {
                 WriteLine($"{indent}const {dtoRpcLocalName} = {localParameterName} === null ? {localParameterName} : {{ ...{localParameterName} }};");
                 WriteLine($"{indent}if ({dtoRpcLocalName} !== null) {{");
-                GenerateDtoCallbackPropertyAssignments(dtoRpcLocalName, callbackProperties, $"{indent}    ", clientExpression);
+                GenerateDtoCallbackPropertyAssignments(dtoRpcLocalName, marshallingProperties, visitedDtoTypeIds, $"{indent}    ", clientExpression);
                 WriteLine($"{indent}}}");
             }
         }
@@ -2462,22 +2495,66 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
     private void GenerateDtoCallbackPropertyAssignments(
         string dtoRpcLocalName,
-        IReadOnlyList<AtsDtoPropertyInfo> callbackProperties,
+        IReadOnlyList<AtsDtoPropertyInfo> marshallingProperties,
+        HashSet<string> visitedDtoTypeIds,
         string indent,
         string clientExpression)
     {
         var dtoDataLocalName = $"{dtoRpcLocalName}Data";
         WriteLine($"{indent}const {dtoDataLocalName} = {dtoRpcLocalName} as Record<string, unknown>;");
 
-        foreach (var callbackProperty in callbackProperties)
+        foreach (var marshallingProperty in marshallingProperties)
         {
-            var propertyName = ToCamelCase(callbackProperty.Name);
-            var callbackLocalName = GetDtoCallbackLocalName(dtoRpcLocalName, callbackProperty.Name);
-            WriteLine($"{indent}const {callbackLocalName} = {dtoRpcLocalName}.{propertyName};");
-            WriteLine($"{indent}if ({callbackLocalName} !== undefined) {{");
-            GenerateCallbackRegistration(CreateCallbackParameter(callbackProperty, callbackLocalName), $"{indent}    ", clientExpression);
-            WriteLine($"{indent}    {dtoDataLocalName}[\"{propertyName}\"] = {callbackLocalName}Id;");
+            if (marshallingProperty.IsCallback)
+            {
+                var propertyName = ToCamelCase(marshallingProperty.Name);
+                var callbackLocalName = GetDtoCallbackLocalName(dtoRpcLocalName, marshallingProperty.Name);
+                WriteLine($"{indent}const {callbackLocalName} = {dtoRpcLocalName}.{propertyName};");
+                WriteLine($"{indent}if ({callbackLocalName} !== undefined) {{");
+                GenerateCallbackRegistration(CreateCallbackParameter(marshallingProperty, callbackLocalName), $"{indent}    ", clientExpression);
+                WriteLine($"{indent}    {dtoDataLocalName}[\"{propertyName}\"] = {callbackLocalName}Id;");
+                WriteLine($"{indent}}}");
+                continue;
+            }
+
+            GenerateNestedDtoCallbackPropertyAssignments(dtoRpcLocalName, dtoDataLocalName, marshallingProperty, visitedDtoTypeIds, indent, clientExpression);
+        }
+    }
+
+    private void GenerateNestedDtoCallbackPropertyAssignments(
+        string dtoRpcLocalName,
+        string dtoDataLocalName,
+        AtsDtoPropertyInfo dtoProperty,
+        HashSet<string> visitedDtoTypeIds,
+        string indent,
+        string clientExpression)
+    {
+        if (!TryGetDtoCallbackMarshallingProperties(dtoProperty.Type, out var nestedMarshallingProperties))
+        {
+            return;
+        }
+
+        var propertyName = ToCamelCase(dtoProperty.Name);
+        var dtoPropertyLocalName = GetDtoCallbackLocalName(dtoRpcLocalName, dtoProperty.Name);
+        var nestedDtoRpcLocalName = $"{dtoPropertyLocalName}ForRpc";
+
+        if (!visitedDtoTypeIds.Add(dtoProperty.Type.TypeId))
+        {
+            return;
+        }
+
+        try
+        {
+            WriteLine($"{indent}const {dtoPropertyLocalName} = {dtoRpcLocalName}.{propertyName};");
+            WriteLine($"{indent}if ({dtoPropertyLocalName} !== undefined && {dtoPropertyLocalName} !== null) {{");
+            WriteLine($"{indent}    const {nestedDtoRpcLocalName} = {{ ...{dtoPropertyLocalName} }};");
+            GenerateDtoCallbackPropertyAssignments(nestedDtoRpcLocalName, nestedMarshallingProperties, visitedDtoTypeIds, $"{indent}    ", clientExpression);
+            WriteLine($"{indent}    {dtoDataLocalName}[\"{propertyName}\"] = {nestedDtoRpcLocalName};");
             WriteLine($"{indent}}}");
+        }
+        finally
+        {
+            visitedDtoTypeIds.Remove(dtoProperty.Type.TypeId);
         }
     }
 
@@ -2486,6 +2563,8 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         {
             Name = callbackLocalName,
             Type = callbackProperty.Type,
+            IsOptional = callbackProperty.IsOptional,
+            IsNullable = callbackProperty.Type.IsNullable == true,
             IsCallback = true,
             CallbackParameters = callbackProperty.CallbackParameters,
             CallbackReturnType = callbackProperty.CallbackReturnType

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -201,6 +201,7 @@ public static class HostedAgentResourceBuilderExtensions
                 path: protocol.Path,
                 displayName: "Send Message",
                 endpointName: "http",
+                commandName: "send-message",
                 commandOptions: new()
                 {
                     Method = HttpMethod.Post,

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -6,7 +6,6 @@ using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Foundry;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting;
 
@@ -208,24 +207,34 @@ public static class HostedAgentResourceBuilderExtensions
                     IconName = "ChatSparkle",
                     IconVariant = IconVariant.Regular,
                     IsHighlighted = true,
-                    PrepareRequest = async ctx =>
-                    {
-                        var interactionService = ctx.ServiceProvider.GetRequiredService<IInteractionService>();
-                        var result = await interactionService.PromptInputAsync(
-                            title: protocol.PromptTitle,
-                            message: "Enter a message to send to the agent.",
-                            inputLabel: "Message",
-                            placeHolder: "I would like to know the weather today.",
-                            cancellationToken: ctx.CancellationToken
-                        ).ConfigureAwait(true);
-                        if (result.Canceled || string.IsNullOrWhiteSpace(result.Data.Value))
+                    Arguments =
+                    [
+                        new InteractionInput
                         {
-                            ctx.HttpClient.CancelPendingRequests();
-                            throw new OperationCanceledException("User canceled the input prompt.");
+                            Name = "message",
+                            InputType = InputType.Text,
+                            Label = "Message",
+                            Required = true,
+                            Placeholder = "I would like to know the weather today.",
+                            Description = "Enter a message to send to the agent."
                         }
+                    ],
+                    ValidateArguments = ctx =>
+                    {
+                        var message = ctx.Inputs["message"];
+                        if (string.IsNullOrWhiteSpace(message.Value))
+                        {
+                            ctx.AddValidationError(message, "Message is required.");
+                        }
+
+                        return Task.CompletedTask;
+                    },
+                    PrepareRequest = ctx =>
+                    {
+                        var input = ctx.Arguments.GetString("message")!;
                         var request = ctx.Request;
-                        var input = result.Data.Value;
                         request.Content = protocol.CreateRequestContent(input);
+                        return Task.CompletedTask;
                     },
                     GetCommandResult = async ctx =>
                     {

--- a/src/Aspire.Hosting/ApplicationModel/HttpCommandContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HttpCommandContext.cs
@@ -3,6 +3,8 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
+#pragma warning disable ASPIREINTERACTION001 // HTTP command arguments intentionally reuse the experimental interaction input model.
+
 /// <summary>
 /// Context passed to callback to configure <see cref="HttpRequestMessage"/> when using
 /// <see cref="ResourceBuilderExtensions.WithHttpCommand{TResource}(IResourceBuilder{TResource}, string, string, string?, string?, HttpCommandOptions?)"/>
@@ -36,9 +38,48 @@ public sealed class HttpCommandRequestContext
     public required HttpClient HttpClient { get; init; }
 
     /// <summary>
+    /// Gets the invocation arguments supplied by the client when the command is executed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The collection contains the arguments described by the command's <see cref="CommandOptions.Arguments"/> with their
+    /// submitted values populated. CLI positional arguments are mapped by declaration order. Dashboard, MCP, and other
+    /// named-payload clients are mapped by <see cref="InteractionInput.Name"/>.
+    /// </para>
+    /// </remarks>
+    public InteractionInputCollection Arguments { get; init; } = new([]);
+
+    /// <summary>
     /// The HTTP request message.
     /// </summary>
     public required HttpRequestMessage Request { get; init; }
+}
+
+/// <summary>
+/// Provides context for HTTP command prepare-request callbacks in polyglot app hosts.
+/// </summary>
+[AspireExport(ExposeProperties = true)]
+internal sealed class HttpCommandPrepareRequestContext
+{
+    /// <summary>
+    /// The name of the resource the command was configured on.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>
+    /// The endpoint the request is targeting.
+    /// </summary>
+    public required EndpointReference Endpoint { get; init; }
+
+    /// <summary>
+    /// The cancellation token.
+    /// </summary>
+    public required CancellationToken CancellationToken { get; init; }
+
+    /// <summary>
+    /// Gets the invocation arguments supplied by the client when the command is executed.
+    /// </summary>
+    public required InteractionInputCollection Arguments { get; init; }
 }
 
 /// <summary>
@@ -74,7 +115,21 @@ public sealed class HttpCommandResultContext
     public required HttpClient HttpClient { get; init; }
 
     /// <summary>
+    /// Gets the invocation arguments supplied by the client when the command is executed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The collection contains the arguments described by the command's <see cref="CommandOptions.Arguments"/> with their
+    /// submitted values populated. CLI positional arguments are mapped by declaration order. Dashboard, MCP, and other
+    /// named-payload clients are mapped by <see cref="InteractionInput.Name"/>.
+    /// </para>
+    /// </remarks>
+    public InteractionInputCollection Arguments { get; init; } = new([]);
+
+    /// <summary>
     /// The HTTP response message.
     /// </summary>
     public required HttpResponseMessage Response { get; init; }
 }
+
+#pragma warning restore ASPIREINTERACTION001

--- a/src/Aspire.Hosting/ApplicationModel/HttpCommandOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HttpCommandOptions.cs
@@ -77,7 +77,7 @@ internal sealed class HttpCommandExportOptions
     /// <summary>
     /// Optional command configuration.
     /// </summary>
-    public CommandOptions? CommandOptions { get; set; }
+    public CommandOptions? CommandOptions { get; init; }
 
     /// <summary>
     /// Optional description of the command, to be shown in the UI.
@@ -122,7 +122,7 @@ internal sealed class HttpCommandExportOptions
     /// <summary>
     /// Gets or sets a callback to be invoked to configure the request before it is sent.
     /// </summary>
-    public Func<HttpCommandPrepareRequestContext, Task<HttpCommandRequestExportData>>? PrepareRequest { get; set; }
+    public Func<HttpCommandPrepareRequestContext, Task<HttpCommandRequestExportData>>? PrepareRequest { get; init; }
 
     /// <summary>
     /// Gets or sets how the HTTP response content should be returned as command result data.

--- a/src/Aspire.Hosting/ApplicationModel/HttpCommandOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HttpCommandOptions.cs
@@ -75,6 +75,11 @@ public class HttpCommandOptions : CommandOptions
 internal sealed class HttpCommandExportOptions
 {
     /// <summary>
+    /// Optional command configuration.
+    /// </summary>
+    public CommandOptions? CommandOptions { get; set; }
+
+    /// <summary>
     /// Optional description of the command, to be shown in the UI.
     /// </summary>
     public string? Description { get; set; }
@@ -115,7 +120,39 @@ internal sealed class HttpCommandExportOptions
     public string? MethodName { get; set; }
 
     /// <summary>
+    /// Gets or sets a callback to be invoked to configure the request before it is sent.
+    /// </summary>
+    public Func<HttpCommandPrepareRequestContext, Task<HttpCommandRequestExportData>>? PrepareRequest { get; set; }
+
+    /// <summary>
     /// Gets or sets how the HTTP response content should be returned as command result data.
     /// </summary>
     public HttpCommandResultMode ResultMode { get; set; }
+}
+
+/// <summary>
+/// ATS-friendly request data returned from HTTP command prepare-request callbacks.
+/// </summary>
+[AspireDto]
+internal sealed class HttpCommandRequestExportData
+{
+    /// <summary>
+    /// Gets or sets the HTTP method name to use when sending the request.
+    /// </summary>
+    public string? MethodName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the request headers.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Headers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the request content.
+    /// </summary>
+    public string? Content { get; set; }
+
+    /// <summary>
+    /// Gets or sets the request content type.
+    /// </summary>
+    public string? ContentType { get; set; }
 }

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -9,6 +9,7 @@ using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Ats;
@@ -3015,6 +3016,24 @@ public static class ResourceBuilderExtensions
     }
 #pragma warning restore ASPIREINTERACTION001
 
+    private static void ApplyCommandOptions(CommandOptions target, CommandOptions source)
+    {
+#pragma warning disable ASPIREINTERACTION001 // Exported command options intentionally reuse command argument metadata.
+#pragma warning disable CS0618 // Parameter is obsolete but still flowed for command option compatibility.
+        target.Description = source.Description;
+        target.Parameter = source.Parameter;
+        target.Arguments = source.Arguments;
+        target.ValidateArguments = source.ValidateArguments;
+        target.Visibility = source.Visibility;
+        target.ConfirmationMessage = source.ConfirmationMessage;
+        target.IconName = source.IconName;
+        target.IconVariant = source.IconVariant;
+        target.IsHighlighted = source.IsHighlighted;
+        target.UpdateState = source.UpdateState;
+#pragma warning restore CS0618
+#pragma warning restore ASPIREINTERACTION001
+    }
+
     #pragma warning disable ASPIREPROCESSCOMMAND001 // Process command APIs are experimental.
 
     /// <summary>
@@ -3297,20 +3316,7 @@ public static class ResourceBuilderExtensions
 
         if (exportOptions.CommandOptions is { } commonOptions)
         {
-#pragma warning disable ASPIREINTERACTION001 // Process command exports reuse command argument metadata.
-#pragma warning disable CS0618 // Parameter is obsolete but still flowed for command option compatibility.
-            commandOptions.Description = commonOptions.Description;
-            commandOptions.Parameter = commonOptions.Parameter;
-            commandOptions.Arguments = commonOptions.Arguments;
-            commandOptions.ValidateArguments = commonOptions.ValidateArguments;
-            commandOptions.Visibility = commonOptions.Visibility;
-            commandOptions.ConfirmationMessage = commonOptions.ConfirmationMessage;
-            commandOptions.IconName = commonOptions.IconName;
-            commandOptions.IconVariant = commonOptions.IconVariant;
-            commandOptions.IsHighlighted = commonOptions.IsHighlighted;
-            commandOptions.UpdateState = commonOptions.UpdateState;
-#pragma warning restore CS0618
-#pragma warning restore ASPIREINTERACTION001
+            ApplyCommandOptions(commandOptions, commonOptions);
         }
 
         if (exportOptions.MaxOutputLineCount is { } maxOutputLineCount)
@@ -3710,6 +3716,7 @@ public static class ResourceBuilderExtensions
                         Endpoint = endpoint,
                         CancellationToken = context.CancellationToken,
                         HttpClient = httpClient,
+                        Arguments = context.Arguments,
                         Request = request
                     };
                     await commandOptions.PrepareRequest(requestContext).ConfigureAwait(false);
@@ -3727,6 +3734,7 @@ public static class ResourceBuilderExtensions
                             Endpoint = endpoint,
                             CancellationToken = context.CancellationToken,
                             HttpClient = httpClient,
+                            Arguments = context.Arguments,
                             Response = response
                         };
                         return await commandOptions.GetCommandResult(resultContext).ConfigureAwait(false);
@@ -3772,16 +3780,74 @@ public static class ResourceBuilderExtensions
             return null;
         }
 
-        return new HttpCommandOptions
+        var commandOptions = new HttpCommandOptions();
+        if (exportOptions.CommandOptions is { } commonOptions)
         {
-            Description = exportOptions.Description,
-            ConfirmationMessage = exportOptions.ConfirmationMessage,
-            IconName = exportOptions.IconName,
-            IconVariant = exportOptions.IconVariant,
-            IsHighlighted = exportOptions.IsHighlighted,
-            Method = !string.IsNullOrWhiteSpace(exportOptions.MethodName) ? new HttpMethod(exportOptions.MethodName) : null,
-            ResultMode = exportOptions.ResultMode
-        };
+            ApplyCommandOptions(commandOptions, commonOptions);
+        }
+
+        commandOptions.Description = exportOptions.Description ?? commandOptions.Description;
+        commandOptions.ConfirmationMessage = exportOptions.ConfirmationMessage ?? commandOptions.ConfirmationMessage;
+        commandOptions.IconName = exportOptions.IconName ?? commandOptions.IconName;
+        commandOptions.IconVariant = exportOptions.IconVariant ?? commandOptions.IconVariant;
+        commandOptions.IsHighlighted = exportOptions.IsHighlighted || commandOptions.IsHighlighted;
+        commandOptions.Method = !string.IsNullOrWhiteSpace(exportOptions.MethodName) ? new HttpMethod(exportOptions.MethodName) : null;
+        commandOptions.ResultMode = exportOptions.ResultMode;
+        if (exportOptions.PrepareRequest is { } prepareRequest)
+        {
+            commandOptions.PrepareRequest = async context =>
+            {
+                var requestData = await prepareRequest(new HttpCommandPrepareRequestContext
+                {
+                    ResourceName = context.ResourceName,
+                    Endpoint = context.Endpoint,
+                    CancellationToken = context.CancellationToken,
+                    Arguments = context.Arguments
+                }).ConfigureAwait(false);
+
+                ApplyHttpCommandRequestExportData(context.Request, requestData);
+            };
+        }
+
+        return commandOptions;
+    }
+
+    private static void ApplyHttpCommandRequestExportData(HttpRequestMessage request, HttpCommandRequestExportData requestData)
+    {
+        if (requestData is null)
+        {
+            throw new InvalidOperationException("The HTTP command prepare-request callback returned null.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(requestData.MethodName))
+        {
+            request.Method = new HttpMethod(requestData.MethodName);
+        }
+
+        if (requestData.Content is not null)
+        {
+            request.Content = !string.IsNullOrWhiteSpace(requestData.ContentType)
+                ? new StringContent(requestData.Content, Encoding.UTF8, requestData.ContentType)
+                : new StringContent(requestData.Content, Encoding.UTF8);
+        }
+        else if (!string.IsNullOrWhiteSpace(requestData.ContentType))
+        {
+            throw new InvalidOperationException("HTTP command request content type cannot be specified without request content.");
+        }
+
+        if (requestData.Headers is null)
+        {
+            return;
+        }
+
+        foreach (var (name, value) in requestData.Headers)
+        {
+            if (!request.Headers.TryAddWithoutValidation(name, value) &&
+                request.Content?.Headers.TryAddWithoutValidation(name, value) != true)
+            {
+                throw new InvalidOperationException($"HTTP command request header '{name}' could not be applied.");
+            }
+        }
     }
 
     internal static async Task<ExecuteCommandResult> GetDefaultHttpCommandResultAsync(HttpResponseMessage response, HttpCommandOptions commandOptions, CancellationToken cancellationToken)

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -502,6 +502,7 @@ func (d *CommandOptions) ToMap() map[string]any {
 
 // HttpCommandExportOptions represents HttpCommandExportOptions.
 type HttpCommandExportOptions struct {
+	CommandOptions *CommandOptions `json:"CommandOptions,omitempty"`
 	Description string `json:"Description,omitempty"`
 	ConfirmationMessage string `json:"ConfirmationMessage,omitempty"`
 	IconName string `json:"IconName,omitempty"`
@@ -510,12 +511,14 @@ type HttpCommandExportOptions struct {
 	CommandName string `json:"CommandName,omitempty"`
 	EndpointName string `json:"EndpointName,omitempty"`
 	MethodName string `json:"MethodName,omitempty"`
+	PrepareRequest func(...any) any `json:"PrepareRequest,omitempty"`
 	ResultMode HttpCommandResultMode `json:"ResultMode,omitempty"`
 }
 
 // ToMap converts the DTO to a map for JSON serialization.
 func (d *HttpCommandExportOptions) ToMap() map[string]any {
 	m := map[string]any{}
+	if d.CommandOptions != nil { m["CommandOptions"] = serializeValue(d.CommandOptions) }
 	m["Description"] = serializeValue(d.Description)
 	m["ConfirmationMessage"] = serializeValue(d.ConfirmationMessage)
 	m["IconName"] = serializeValue(d.IconName)
@@ -524,7 +527,26 @@ func (d *HttpCommandExportOptions) ToMap() map[string]any {
 	m["CommandName"] = serializeValue(d.CommandName)
 	m["EndpointName"] = serializeValue(d.EndpointName)
 	m["MethodName"] = serializeValue(d.MethodName)
+	if d.PrepareRequest != nil { m["PrepareRequest"] = serializeValue(d.PrepareRequest) }
 	m["ResultMode"] = serializeValue(d.ResultMode)
+	return m
+}
+
+// HttpCommandRequestExportData represents HttpCommandRequestExportData.
+type HttpCommandRequestExportData struct {
+	MethodName string `json:"MethodName,omitempty"`
+	Headers map[string]string `json:"Headers,omitempty"`
+	Content string `json:"Content,omitempty"`
+	ContentType string `json:"ContentType,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *HttpCommandRequestExportData) ToMap() map[string]any {
+	m := map[string]any{}
+	m["MethodName"] = serializeValue(d.MethodName)
+	if d.Headers != nil { m["Headers"] = serializeValue(d.Headers) }
+	m["Content"] = serializeValue(d.Content)
+	m["ContentType"] = serializeValue(d.ContentType)
 	return m
 }
 
@@ -15576,6 +15598,94 @@ func (s *hostEnvironment) SetEnvironmentName(value string) HostEnvironment {
 	return s
 }
 
+// HttpCommandPrepareRequestContext is the public interface for handle type HttpCommandPrepareRequestContext.
+type HttpCommandPrepareRequestContext interface {
+	handleReference
+	Arguments() InteractionInputCollection
+	CancellationToken() (*CancellationToken, error)
+	Endpoint() EndpointReference
+	ResourceName() (string, error)
+	Err() error
+}
+
+// httpCommandPrepareRequestContext is the unexported impl of HttpCommandPrepareRequestContext.
+type httpCommandPrepareRequestContext struct {
+	*resourceBuilderBase
+}
+
+// newHttpCommandPrepareRequestContextFromHandle wraps an existing handle as HttpCommandPrepareRequestContext.
+func newHttpCommandPrepareRequestContextFromHandle(h *handle, c *client) HttpCommandPrepareRequestContext {
+	return &httpCommandPrepareRequestContext{resourceBuilderBase: newResourceBuilderBase(h, c)}
+}
+
+// Arguments gets the invocation arguments supplied by the client when the command is executed.
+func (s *httpCommandPrepareRequestContext) Arguments() InteractionInputCollection {
+	if s.err != nil { return &interactionInputCollection{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.arguments", reqArgs)
+	if err != nil {
+		return &interactionInputCollection{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.arguments returned unexpected type %T", result)
+		return &interactionInputCollection{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &interactionInputCollection{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// CancellationToken the cancellation token.
+func (s *httpCommandPrepareRequestContext) CancellationToken() (*CancellationToken, error) {
+	if s.err != nil { var zero *CancellationToken; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.cancellationToken", reqArgs)
+	if err != nil {
+		var zero *CancellationToken
+		return zero, err
+	}
+	return decodeAs[*CancellationToken](result)
+}
+
+// Endpoint the endpoint the request is targeting.
+func (s *httpCommandPrepareRequestContext) Endpoint() EndpointReference {
+	if s.err != nil { return &endpointReference{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.endpoint", reqArgs)
+	if err != nil {
+		return &endpointReference{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.endpoint returned unexpected type %T", result)
+		return &endpointReference{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &endpointReference{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// ResourceName the name of the resource the command was configured on.
+func (s *httpCommandPrepareRequestContext) ResourceName() (string, error) {
+	if s.err != nil { var zero string; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.resourceName", reqArgs)
+	if err != nil {
+		var zero string
+		return zero, err
+	}
+	return decodeAs[string](result)
+}
+
 // IComputeResource is the public interface for handle type IComputeResource.
 type IComputeResource interface {
 	handleReference
@@ -26477,6 +26587,9 @@ func registerWrappers(c *client) {
 	})
 	c.registerHandleWrapper("Microsoft.Extensions.Hosting.Abstractions/Microsoft.Extensions.Hosting.IHostEnvironment", func(h *handle, c *client) any {
 		return newHostEnvironmentFromHandle(h, c)
+	})
+	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpCommandPrepareRequestContext", func(h *handle, c *client) any {
+		return newHttpCommandPrepareRequestContextFromHandle(h, c)
 	})
 	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IComputeResource", func(h *handle, c *client) any {
 		return newIComputeResourceFromHandle(h, c)

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1386,6 +1386,7 @@ public class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext", (h, c) -> new EndpointUpdateContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext", (h, c) -> new EnvironmentCallbackContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentEditor", (h, c) -> new EnvironmentEditor(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpCommandPrepareRequestContext", (h, c) -> new HttpCommandPrepareRequestContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExpressionValue", (h, c) -> new IExpressionValue(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent", (h, c) -> new InitializeResourceEvent(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.LogFacade", (h, c) -> new LogFacade(h, c));
@@ -12280,6 +12281,7 @@ import java.util.function.*;
 
 /** HttpCommandExportOptions DTO. */
 public class HttpCommandExportOptions implements JsonSerializable {
+    private CommandOptions commandOptions;
     private String description;
     private String confirmationMessage;
     private String iconName;
@@ -12288,8 +12290,11 @@ public class HttpCommandExportOptions implements JsonSerializable {
     private String commandName;
     private String endpointName;
     private String methodName;
+    private Object prepareRequest;
     private HttpCommandResultMode resultMode;
 
+    public CommandOptions getCommandOptions() { return commandOptions; }
+    public void setCommandOptions(CommandOptions value) { this.commandOptions = value; }
     public String getDescription() { return description; }
     public void setDescription(String value) { this.description = value; }
     public String getConfirmationMessage() { return confirmationMessage; }
@@ -12306,12 +12311,16 @@ public class HttpCommandExportOptions implements JsonSerializable {
     public void setEndpointName(String value) { this.endpointName = value; }
     public String getMethodName() { return methodName; }
     public void setMethodName(String value) { this.methodName = value; }
+    public Object getPrepareRequest() { return prepareRequest; }
+    public void setPrepareRequest(Object value) { this.prepareRequest = value; }
     public HttpCommandResultMode getResultMode() { return resultMode; }
     public void setResultMode(HttpCommandResultMode value) { this.resultMode = value; }
 
     @SuppressWarnings("unchecked")
     public static HttpCommandExportOptions fromMap(Map<String, Object> map) {
         var value = new HttpCommandExportOptions();
+        var commandOptionsValue = map.get("CommandOptions");
+        value.setCommandOptions(commandOptionsValue == null ? null : CommandOptions.fromMap((Map<String, Object>) commandOptionsValue));
         var descriptionValue = map.get("Description");
         value.setDescription(descriptionValue == null ? null : (String) descriptionValue);
         var confirmationMessageValue = map.get("ConfirmationMessage");
@@ -12328,6 +12337,8 @@ public class HttpCommandExportOptions implements JsonSerializable {
         value.setEndpointName(endpointNameValue == null ? null : (String) endpointNameValue);
         var methodNameValue = map.get("MethodName");
         value.setMethodName(methodNameValue == null ? null : (String) methodNameValue);
+        var prepareRequestValue = map.get("PrepareRequest");
+        value.setPrepareRequest(prepareRequestValue);
         var resultModeValue = map.get("ResultMode");
         value.setResultMode(HttpCommandResultMode.fromValue((String) resultModeValue));
         return value;
@@ -12335,6 +12346,7 @@ public class HttpCommandExportOptions implements JsonSerializable {
 
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
+        map.put("CommandOptions", AspireClient.serializeValue(commandOptions));
         map.put("Description", AspireClient.serializeValue(description));
         map.put("ConfirmationMessage", AspireClient.serializeValue(confirmationMessage));
         map.put("IconName", AspireClient.serializeValue(iconName));
@@ -12343,7 +12355,104 @@ public class HttpCommandExportOptions implements JsonSerializable {
         map.put("CommandName", AspireClient.serializeValue(commandName));
         map.put("EndpointName", AspireClient.serializeValue(endpointName));
         map.put("MethodName", AspireClient.serializeValue(methodName));
+        map.put("PrepareRequest", AspireClient.serializeValue(prepareRequest));
         map.put("ResultMode", AspireClient.serializeValue(resultMode));
+        return map;
+    }
+}
+
+// ===== HttpCommandPrepareRequestContext.java =====
+// HttpCommandPrepareRequestContext.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpCommandPrepareRequestContext. */
+public class HttpCommandPrepareRequestContext extends HandleWrapperBase {
+    HttpCommandPrepareRequestContext(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** The name of the resource the command was configured on. */
+    public String resourceName() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.resourceName", reqArgs);
+        return (String) result;
+    }
+
+    /** The endpoint the request is targeting. */
+    public EndpointReference endpoint() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.endpoint", reqArgs);
+        return (EndpointReference) result;
+    }
+
+    /** The cancellation token. */
+    public CancellationToken cancellationToken() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.cancellationToken", reqArgs);
+        return (CancellationToken) result;
+    }
+
+    /** Gets the invocation arguments supplied by the client when the command is executed. */
+    public InteractionInputCollection arguments() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.arguments", reqArgs);
+        return (InteractionInputCollection) result;
+    }
+
+}
+
+// ===== HttpCommandRequestExportData.java =====
+// HttpCommandRequestExportData.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** HttpCommandRequestExportData DTO. */
+public class HttpCommandRequestExportData implements JsonSerializable {
+    private String methodName;
+    private Map<String, String> headers;
+    private String content;
+    private String contentType;
+
+    public String getMethodName() { return methodName; }
+    public void setMethodName(String value) { this.methodName = value; }
+    public Map<String, String> getHeaders() { return headers; }
+    public void setHeaders(Map<String, String> value) { this.headers = value; }
+    public String getContent() { return content; }
+    public void setContent(String value) { this.content = value; }
+    public String getContentType() { return contentType; }
+    public void setContentType(String value) { this.contentType = value; }
+
+    @SuppressWarnings("unchecked")
+    public static HttpCommandRequestExportData fromMap(Map<String, Object> map) {
+        var value = new HttpCommandRequestExportData();
+        var methodNameValue = map.get("MethodName");
+        value.setMethodName(methodNameValue == null ? null : (String) methodNameValue);
+        var headersValue = map.get("Headers");
+        value.setHeaders(headersValue == null ? null : (Map<String, String>) headersValue);
+        var contentValue = map.get("Content");
+        value.setContent(contentValue == null ? null : (String) contentValue);
+        var contentTypeValue = map.get("ContentType");
+        value.setContentType(contentTypeValue == null ? null : (String) contentTypeValue);
+        return value;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("MethodName", AspireClient.serializeValue(methodName));
+        map.put("Headers", AspireClient.serializeValue(headers));
+        map.put("Content", AspireClient.serializeValue(content));
+        map.put("ContentType", AspireClient.serializeValue(contentType));
         return map;
     }
 }
@@ -25887,6 +25996,8 @@ public final class WithVolumeOptions {
 .aspire/modules/HandleWrapperBase.java
 .aspire/modules/HealthStatus.java
 .aspire/modules/HttpCommandExportOptions.java
+.aspire/modules/HttpCommandPrepareRequestContext.java
+.aspire/modules/HttpCommandRequestExportData.java
 .aspire/modules/HttpCommandResultMode.java
 .aspire/modules/HttpsCertificateExecutionConfigurationContext.java
 .aspire/modules/HttpsCertificateExecutionConfigurationExportData.java

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1805,6 +1805,7 @@ class GenerateParameterDefault(typing.TypedDict, total=False):
     MinSpecial: int
 
 class HttpCommandExportOptions(typing.TypedDict, total=False):
+    CommandOptions: CommandOptions
     Description: str | None
     ConfirmationMessage: str | None
     IconName: str | None
@@ -1813,7 +1814,14 @@ class HttpCommandExportOptions(typing.TypedDict, total=False):
     CommandName: str | None
     EndpointName: str | None
     MethodName: str | None
+    PrepareRequest: typing.Callable
     ResultMode: HttpCommandResultMode
+
+class HttpCommandRequestExportData(typing.TypedDict, total=False):
+    MethodName: str | None
+    Headers: typing.Mapping[str, str]
+    Content: str | None
+    ContentType: str | None
 
 class HttpsCertificateExecutionConfigurationContext(typing.TypedDict, total=False):
     CertificatePath: ReferenceExpression
@@ -4798,6 +4806,57 @@ class ExecuteCommandContext:
         """Gets the invocation arguments supplied by the client when the command is executed."""
         result = self._client.invoke_capability(
             'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.arguments',
+            {'context': self._handle}
+        )
+        return typing.cast(InteractionInputCollection, result)
+
+
+class HttpCommandPrepareRequestContext:
+    """Type class for HttpCommandPrepareRequestContext."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"HttpCommandPrepareRequestContext(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    @_cached_property
+    def resource_name(self) -> str:
+        """The name of the resource the command was configured on."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.resourceName',
+            {'context': self._handle}
+        )
+        return typing.cast(str, result)
+
+    @_cached_property
+    def endpoint(self) -> EndpointReference:
+        """The endpoint the request is targeting."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.endpoint',
+            {'context': self._handle}
+        )
+        return typing.cast(EndpointReference, result)
+
+    def cancel(self) -> None:
+        """Cancel the operation."""
+        token: CancellationToken = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.cancellationToken',
+            {'context': self._handle}
+        )
+        token.cancel()
+
+    @_cached_property
+    def arguments(self) -> InteractionInputCollection:
+        """Gets the invocation arguments supplied by the client when the command is executed."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.arguments',
             {'context': self._handle}
         )
         return typing.cast(InteractionInputCollection, result)
@@ -11534,6 +11593,7 @@ _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.Environ
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentEditor", EnvironmentEditor)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext", EventingSubscriberRegistrationContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext", ExecuteCommandContext)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpCommandPrepareRequestContext", HttpCommandPrepareRequestContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent", InitializeResourceEvent)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.InputsDialogValidationContext", InputsDialogValidationContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.InteractionInputCollection", InteractionInputCollection)

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -963,6 +963,8 @@ impl CommandOptions {
 /// HttpCommandExportOptions
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HttpCommandExportOptions {
+    #[serde(rename = "CommandOptions", skip_serializing_if = "Option::is_none")]
+    pub command_options: Option<CommandOptions>,
     #[serde(rename = "Description")]
     pub description: String,
     #[serde(rename = "ConfirmationMessage")]
@@ -979,6 +981,8 @@ pub struct HttpCommandExportOptions {
     pub endpoint_name: String,
     #[serde(rename = "MethodName")]
     pub method_name: String,
+    #[serde(rename = "PrepareRequest", skip_serializing_if = "Option::is_none")]
+    pub prepare_request: Option<Value>,
     #[serde(rename = "ResultMode")]
     pub result_mode: HttpCommandResultMode,
 }
@@ -986,6 +990,9 @@ pub struct HttpCommandExportOptions {
 impl HttpCommandExportOptions {
     pub fn to_map(&self) -> HashMap<String, Value> {
         let mut map = HashMap::new();
+        if let Some(ref v) = self.command_options {
+            map.insert("CommandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
         map.insert("Description".to_string(), serde_json::to_value(&self.description).unwrap_or(Value::Null));
         map.insert("ConfirmationMessage".to_string(), serde_json::to_value(&self.confirmation_message).unwrap_or(Value::Null));
         map.insert("IconName".to_string(), serde_json::to_value(&self.icon_name).unwrap_or(Value::Null));
@@ -996,7 +1003,34 @@ impl HttpCommandExportOptions {
         map.insert("CommandName".to_string(), serde_json::to_value(&self.command_name).unwrap_or(Value::Null));
         map.insert("EndpointName".to_string(), serde_json::to_value(&self.endpoint_name).unwrap_or(Value::Null));
         map.insert("MethodName".to_string(), serde_json::to_value(&self.method_name).unwrap_or(Value::Null));
+        if let Some(ref v) = self.prepare_request {
+            map.insert("PrepareRequest".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
         map.insert("ResultMode".to_string(), serde_json::to_value(&self.result_mode).unwrap_or(Value::Null));
+        map
+    }
+}
+
+/// HttpCommandRequestExportData
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HttpCommandRequestExportData {
+    #[serde(rename = "MethodName")]
+    pub method_name: String,
+    #[serde(rename = "Headers")]
+    pub headers: HashMap<String, String>,
+    #[serde(rename = "Content")]
+    pub content: String,
+    #[serde(rename = "ContentType")]
+    pub content_type: String,
+}
+
+impl HttpCommandRequestExportData {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("MethodName".to_string(), serde_json::to_value(&self.method_name).unwrap_or(Value::Null));
+        map.insert("Headers".to_string(), serde_json::to_value(&self.headers).unwrap_or(Value::Null));
+        map.insert("Content".to_string(), serde_json::to_value(&self.content).unwrap_or(Value::Null));
+        map.insert("ContentType".to_string(), serde_json::to_value(&self.content_type).unwrap_or(Value::Null));
         map
     }
 }
@@ -9566,6 +9600,67 @@ impl ExternalServiceResource {
         let result = self.client.invoke_capability("Aspire.Hosting.CodeGeneration.Rust.Tests/withMergeRouteMiddleware", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpCommandPrepareRequestContext
+pub struct HttpCommandPrepareRequestContext {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for HttpCommandPrepareRequestContext {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl HttpCommandPrepareRequestContext {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// The name of the resource the command was configured on.
+    pub fn resource_name(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.resourceName", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// The endpoint the request is targeting.
+    pub fn endpoint(&self) -> Result<EndpointReference, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.endpoint", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EndpointReference::new(handle, self.client.clone()))
+    }
+
+    /// The cancellation token.
+    pub fn cancellation_token(&self) -> Result<CancellationToken, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.cancellationToken", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(CancellationToken::new(handle, self.client.clone()))
+    }
+
+    /// Gets the invocation arguments supplied by the client when the command is executed.
+    pub fn arguments(&self) -> Result<InteractionInputCollection, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.arguments", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(InteractionInputCollection::new(handle, self.client.clone()))
     }
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -1034,6 +1034,22 @@ public class AtsTypeScriptCodeGeneratorTests
     }
 
     [Fact]
+    public void GenerateDistributedApplication_WithDtoCallbackOptions_MarshalsNestedCallbackProperties()
+    {
+        var atsContext = CreateContextFromBothAssemblies();
+
+        var files = _generator.GenerateDistributedApplication(atsContext);
+        var aspireTs = files["aspire.mts"];
+
+        Assert.Contains("const ____optionsForRpcPrepareRequestId = ____optionsForRpcPrepareRequest ? registerCallback", aspireTs);
+        Assert.Contains("const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;", aspireTs);
+        Assert.Contains("const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };", aspireTs);
+        Assert.Contains("const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback", aspireTs);
+        Assert.Contains("const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback", aspireTs);
+        Assert.Contains("__optionsForRpcData[\"commandOptions\"] = ____optionsForRpcCommandOptionsForRpc;", aspireTs);
+    }
+
+    [Fact]
     public void Scanner_AzureProvisioningCallbacks_ExposeTypedCustomizationProperties()
     {
         var capabilities = ScanCapabilitiesFromAzureAssemblies();

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -188,6 +188,9 @@ type ExecutableResourceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Applicatio
 /** Context for {@link ResourceCommandAnnotation.ExecuteCommand}. */
 type ExecuteCommandContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext'>;
 
+/** Provides context for HTTP command prepare-request callbacks in polyglot app hosts. */
+type HttpCommandPrepareRequestContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpCommandPrepareRequestContext'>;
+
 /**
  * Represents a store for managing files in the Aspire hosting environment that can be reused across runs.
  *
@@ -817,6 +820,8 @@ export interface GenerateParameterDefault {
 
 /** ATS-friendly configuration for resource HTTP commands. */
 export interface HttpCommandExportOptions {
+    /** Optional command configuration. */
+    commandOptions?: CommandOptions;
     /** Optional description of the command, to be shown in the UI. */
     description?: string | null;
     /** When a confirmation message is specified, the UI will prompt with an OK/Cancel dialog before starting the command. */
@@ -833,8 +838,22 @@ export interface HttpCommandExportOptions {
     endpointName?: string | null;
     /** Gets or sets the HTTP method name to use when sending the request. */
     methodName?: string | null;
+    /** Gets or sets a callback to be invoked to configure the request before it is sent. */
+    prepareRequest?: (arg: HttpCommandPrepareRequestContext) => Promise<HttpCommandRequestExportData>;
     /** Gets or sets how the HTTP response content should be returned as command result data. */
     resultMode?: HttpCommandResultMode;
+}
+
+/** ATS-friendly request data returned from HTTP command prepare-request callbacks. */
+export interface HttpCommandRequestExportData {
+    /** Gets or sets the HTTP method name to use when sending the request. */
+    methodName?: string | null;
+    /** Gets or sets the request headers. */
+    headers?: Record<string, string>;
+    /** Gets or sets the request content. */
+    content?: string | null;
+    /** Gets or sets the request content type. */
+    contentType?: string | null;
 }
 
 /** Configuration context for server authentication certificate configuration. */
@@ -5036,6 +5055,113 @@ class ExecuteCommandContextPromiseImpl implements ExecuteCommandContextPromise {
 
     logger(): LoggerPromise {
         return new LoggerPromiseImpl(this._promise.then(obj => obj.logger()), this._client, false);
+    }
+
+    arguments(): Promise<InteractionInputCollection> {
+        return this._promise.then(obj => obj.arguments());
+    }
+
+}
+
+// ============================================================================
+// HttpCommandPrepareRequestContext
+// ============================================================================
+
+/** Provides context for HTTP command prepare-request callbacks in polyglot app hosts. */
+export interface HttpCommandPrepareRequestContext {
+    toJSON(): MarshalledHandle;
+    /** The name of the resource the command was configured on. */
+    resourceName(): Promise<string>;
+    /** The endpoint the request is targeting. */
+    endpoint(): EndpointReferencePromise;
+    /** The cancellation token. */
+    cancellationToken(): Promise<CancellationToken>;
+    /** Gets the invocation arguments supplied by the client when the command is executed. */
+    arguments(): Promise<InteractionInputCollection>;
+}
+
+export interface HttpCommandPrepareRequestContextPromise extends PromiseLike<HttpCommandPrepareRequestContext> {
+    /** The name of the resource the command was configured on. */
+    resourceName(): Promise<string>;
+    /** The endpoint the request is targeting. */
+    endpoint(): EndpointReferencePromise;
+    /** The cancellation token. */
+    cancellationToken(): Promise<CancellationToken>;
+    /** Gets the invocation arguments supplied by the client when the command is executed. */
+    arguments(): Promise<InteractionInputCollection>;
+}
+
+// ============================================================================
+// HttpCommandPrepareRequestContextImpl
+// ============================================================================
+
+/** Provides context for HTTP command prepare-request callbacks in polyglot app hosts. */
+class HttpCommandPrepareRequestContextImpl implements HttpCommandPrepareRequestContext {
+    constructor(private _handle: HttpCommandPrepareRequestContextHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    async resourceName(): Promise<string> {
+        return await this._client.invokeCapability<string>(
+            'Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.resourceName',
+            { context: this._handle }
+        );
+    }
+
+    endpoint(): EndpointReferencePromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<EndpointReferenceHandle>(
+                'Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.endpoint',
+                { context: this._handle }
+            );
+            return new EndpointReferenceImpl(handle, this._client);
+        })();
+        return new EndpointReferencePromiseImpl(promise, this._client, false);
+    }
+
+    async cancellationToken(): Promise<CancellationToken> {
+        const result = await this._client.invokeCapability<string | null>(
+            'Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.cancellationToken',
+            { context: this._handle }
+        );
+        return CancellationToken.fromValue(result);
+    }
+
+    async arguments(): Promise<InteractionInputCollection> {
+        return await this._client.invokeCapability<InteractionInputCollection>(
+            'Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.arguments',
+            { context: this._handle }
+        );
+    }
+
+}
+
+/**
+ * Thenable wrapper for HttpCommandPrepareRequestContext that enables fluent chaining.
+ */
+class HttpCommandPrepareRequestContextPromiseImpl implements HttpCommandPrepareRequestContextPromise {
+    constructor(private _promise: Promise<HttpCommandPrepareRequestContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = HttpCommandPrepareRequestContext, TResult2 = never>(
+        onfulfilled?: ((value: HttpCommandPrepareRequestContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resourceName(): Promise<string> {
+        return this._promise.then(obj => obj.resourceName());
+    }
+
+    endpoint(): EndpointReferencePromise {
+        return new EndpointReferencePromiseImpl(this._promise.then(obj => obj.endpoint()), this._client, false);
+    }
+
+    cancellationToken(): Promise<CancellationToken> {
+        return this._promise.then(obj => obj.cancellationToken());
     }
 
     arguments(): Promise<InteractionInputCollection> {
@@ -12559,8 +12685,30 @@ class ContainerRegistryResourceImpl extends ResourceBuilderBase<ContainerRegistr
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await executeCommand(arg);
         });
+        const __commandOptionsForRpc = commandOptions === undefined || commandOptions === null ? commandOptions : { ...commandOptions };
+        if (__commandOptionsForRpc !== undefined && __commandOptionsForRpc !== null) {
+            const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
+            const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
+            if (____commandOptionsForRpcValidateArguments !== undefined) {
+                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                    const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                    await ____commandOptionsForRpcValidateArguments(arg);
+                });
+                __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
+            }
+            const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
+            if (____commandOptionsForRpcUpdateState !== undefined) {
+                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                    const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                    return await ____commandOptionsForRpcUpdateState(arg);
+                });
+                __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, displayName, executeCommand: executeCommandId };
-        if (commandOptions !== undefined) rpcArgs.commandOptions = commandOptions;
+        if (commandOptions !== undefined) rpcArgs.commandOptions = __commandOptionsForRpc;
         const result = await this._client.invokeCapability<ContainerRegistryResourceHandle>(
             'Aspire.Hosting/withCommand',
             rpcArgs
@@ -16354,8 +16502,30 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await executeCommand(arg);
         });
+        const __commandOptionsForRpc = commandOptions === undefined || commandOptions === null ? commandOptions : { ...commandOptions };
+        if (__commandOptionsForRpc !== undefined && __commandOptionsForRpc !== null) {
+            const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
+            const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
+            if (____commandOptionsForRpcValidateArguments !== undefined) {
+                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                    const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                    await ____commandOptionsForRpcValidateArguments(arg);
+                });
+                __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
+            }
+            const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
+            if (____commandOptionsForRpcUpdateState !== undefined) {
+                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                    const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                    return await ____commandOptionsForRpcUpdateState(arg);
+                });
+                __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, displayName, executeCommand: executeCommandId };
-        if (commandOptions !== undefined) rpcArgs.commandOptions = commandOptions;
+        if (commandOptions !== undefined) rpcArgs.commandOptions = __commandOptionsForRpc;
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting/withCommand',
             rpcArgs
@@ -16421,8 +16591,21 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
 
     /** @internal */
     private async _withHttpCommandInternal(path: string, displayName: string, options?: HttpCommandExportOptions): Promise<ContainerResource> {
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
+            if (____optionsForRpcPrepareRequest !== undefined) {
+                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
+                    const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcPrepareRequest(arg);
+                });
+                __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, path, displayName };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting/withHttpCommand',
             rpcArgs
@@ -19977,8 +20160,30 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await executeCommand(arg);
         });
+        const __commandOptionsForRpc = commandOptions === undefined || commandOptions === null ? commandOptions : { ...commandOptions };
+        if (__commandOptionsForRpc !== undefined && __commandOptionsForRpc !== null) {
+            const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
+            const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
+            if (____commandOptionsForRpcValidateArguments !== undefined) {
+                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                    const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                    await ____commandOptionsForRpcValidateArguments(arg);
+                });
+                __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
+            }
+            const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
+            if (____commandOptionsForRpcUpdateState !== undefined) {
+                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                    const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                    return await ____commandOptionsForRpcUpdateState(arg);
+                });
+                __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, displayName, executeCommand: executeCommandId };
-        if (commandOptions !== undefined) rpcArgs.commandOptions = commandOptions;
+        if (commandOptions !== undefined) rpcArgs.commandOptions = __commandOptionsForRpc;
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
             'Aspire.Hosting/withCommand',
             rpcArgs
@@ -20044,8 +20249,21 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
 
     /** @internal */
     private async _withHttpCommandInternal(path: string, displayName: string, options?: HttpCommandExportOptions): Promise<CSharpAppResource> {
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
+            if (____optionsForRpcPrepareRequest !== undefined) {
+                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
+                    const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcPrepareRequest(arg);
+                });
+                __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, path, displayName };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
             'Aspire.Hosting/withHttpCommand',
             rpcArgs
@@ -23647,8 +23865,30 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await executeCommand(arg);
         });
+        const __commandOptionsForRpc = commandOptions === undefined || commandOptions === null ? commandOptions : { ...commandOptions };
+        if (__commandOptionsForRpc !== undefined && __commandOptionsForRpc !== null) {
+            const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
+            const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
+            if (____commandOptionsForRpcValidateArguments !== undefined) {
+                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                    const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                    await ____commandOptionsForRpcValidateArguments(arg);
+                });
+                __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
+            }
+            const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
+            if (____commandOptionsForRpcUpdateState !== undefined) {
+                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                    const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                    return await ____commandOptionsForRpcUpdateState(arg);
+                });
+                __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, displayName, executeCommand: executeCommandId };
-        if (commandOptions !== undefined) rpcArgs.commandOptions = commandOptions;
+        if (commandOptions !== undefined) rpcArgs.commandOptions = __commandOptionsForRpc;
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
             'Aspire.Hosting/withCommand',
             rpcArgs
@@ -23714,8 +23954,21 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
 
     /** @internal */
     private async _withHttpCommandInternal(path: string, displayName: string, options?: HttpCommandExportOptions): Promise<DotnetToolResource> {
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
+            if (____optionsForRpcPrepareRequest !== undefined) {
+                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
+                    const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcPrepareRequest(arg);
+                });
+                __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, path, displayName };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
             'Aspire.Hosting/withHttpCommand',
             rpcArgs
@@ -27174,8 +27427,30 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await executeCommand(arg);
         });
+        const __commandOptionsForRpc = commandOptions === undefined || commandOptions === null ? commandOptions : { ...commandOptions };
+        if (__commandOptionsForRpc !== undefined && __commandOptionsForRpc !== null) {
+            const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
+            const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
+            if (____commandOptionsForRpcValidateArguments !== undefined) {
+                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                    const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                    await ____commandOptionsForRpcValidateArguments(arg);
+                });
+                __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
+            }
+            const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
+            if (____commandOptionsForRpcUpdateState !== undefined) {
+                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                    const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                    return await ____commandOptionsForRpcUpdateState(arg);
+                });
+                __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, displayName, executeCommand: executeCommandId };
-        if (commandOptions !== undefined) rpcArgs.commandOptions = commandOptions;
+        if (commandOptions !== undefined) rpcArgs.commandOptions = __commandOptionsForRpc;
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting/withCommand',
             rpcArgs
@@ -27241,8 +27516,21 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
 
     /** @internal */
     private async _withHttpCommandInternal(path: string, displayName: string, options?: HttpCommandExportOptions): Promise<ExecutableResource> {
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
+            if (____optionsForRpcPrepareRequest !== undefined) {
+                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
+                    const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcPrepareRequest(arg);
+                });
+                __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, path, displayName };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting/withHttpCommand',
             rpcArgs
@@ -29555,8 +29843,30 @@ class ExternalServiceResourceImpl extends ResourceBuilderBase<ExternalServiceRes
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await executeCommand(arg);
         });
+        const __commandOptionsForRpc = commandOptions === undefined || commandOptions === null ? commandOptions : { ...commandOptions };
+        if (__commandOptionsForRpc !== undefined && __commandOptionsForRpc !== null) {
+            const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
+            const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
+            if (____commandOptionsForRpcValidateArguments !== undefined) {
+                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                    const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                    await ____commandOptionsForRpcValidateArguments(arg);
+                });
+                __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
+            }
+            const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
+            if (____commandOptionsForRpcUpdateState !== undefined) {
+                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                    const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                    return await ____commandOptionsForRpcUpdateState(arg);
+                });
+                __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, displayName, executeCommand: executeCommandId };
-        if (commandOptions !== undefined) rpcArgs.commandOptions = commandOptions;
+        if (commandOptions !== undefined) rpcArgs.commandOptions = __commandOptionsForRpc;
         const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
             'Aspire.Hosting/withCommand',
             rpcArgs
@@ -31497,8 +31807,30 @@ class ParameterResourceImpl extends ResourceBuilderBase<ParameterResourceHandle>
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await executeCommand(arg);
         });
+        const __commandOptionsForRpc = commandOptions === undefined || commandOptions === null ? commandOptions : { ...commandOptions };
+        if (__commandOptionsForRpc !== undefined && __commandOptionsForRpc !== null) {
+            const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
+            const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
+            if (____commandOptionsForRpcValidateArguments !== undefined) {
+                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                    const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                    await ____commandOptionsForRpcValidateArguments(arg);
+                });
+                __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
+            }
+            const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
+            if (____commandOptionsForRpcUpdateState !== undefined) {
+                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                    const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                    return await ____commandOptionsForRpcUpdateState(arg);
+                });
+                __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, displayName, executeCommand: executeCommandId };
-        if (commandOptions !== undefined) rpcArgs.commandOptions = commandOptions;
+        if (commandOptions !== undefined) rpcArgs.commandOptions = __commandOptionsForRpc;
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting/withCommand',
             rpcArgs
@@ -34549,8 +34881,30 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await executeCommand(arg);
         });
+        const __commandOptionsForRpc = commandOptions === undefined || commandOptions === null ? commandOptions : { ...commandOptions };
+        if (__commandOptionsForRpc !== undefined && __commandOptionsForRpc !== null) {
+            const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
+            const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
+            if (____commandOptionsForRpcValidateArguments !== undefined) {
+                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                    const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                    await ____commandOptionsForRpcValidateArguments(arg);
+                });
+                __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
+            }
+            const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
+            if (____commandOptionsForRpcUpdateState !== undefined) {
+                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                    const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                    return await ____commandOptionsForRpcUpdateState(arg);
+                });
+                __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, displayName, executeCommand: executeCommandId };
-        if (commandOptions !== undefined) rpcArgs.commandOptions = commandOptions;
+        if (commandOptions !== undefined) rpcArgs.commandOptions = __commandOptionsForRpc;
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting/withCommand',
             rpcArgs
@@ -34616,8 +34970,21 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
 
     /** @internal */
     private async _withHttpCommandInternal(path: string, displayName: string, options?: HttpCommandExportOptions): Promise<ProjectResource> {
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
+            if (____optionsForRpcPrepareRequest !== undefined) {
+                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
+                    const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcPrepareRequest(arg);
+                });
+                __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, path, displayName };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting/withHttpCommand',
             rpcArgs
@@ -38824,8 +39191,30 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await executeCommand(arg);
         });
+        const __commandOptionsForRpc = commandOptions === undefined || commandOptions === null ? commandOptions : { ...commandOptions };
+        if (__commandOptionsForRpc !== undefined && __commandOptionsForRpc !== null) {
+            const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
+            const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
+            if (____commandOptionsForRpcValidateArguments !== undefined) {
+                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                    const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                    await ____commandOptionsForRpcValidateArguments(arg);
+                });
+                __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
+            }
+            const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
+            if (____commandOptionsForRpcUpdateState !== undefined) {
+                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                    const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                    return await ____commandOptionsForRpcUpdateState(arg);
+                });
+                __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, displayName, executeCommand: executeCommandId };
-        if (commandOptions !== undefined) rpcArgs.commandOptions = commandOptions;
+        if (commandOptions !== undefined) rpcArgs.commandOptions = __commandOptionsForRpc;
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
             'Aspire.Hosting/withCommand',
             rpcArgs
@@ -38891,8 +39280,21 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
 
     /** @internal */
     private async _withHttpCommandInternal(path: string, displayName: string, options?: HttpCommandExportOptions): Promise<TestDatabaseResource> {
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
+            if (____optionsForRpcPrepareRequest !== undefined) {
+                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
+                    const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcPrepareRequest(arg);
+                });
+                __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, path, displayName };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
             'Aspire.Hosting/withHttpCommand',
             rpcArgs
@@ -43362,8 +43764,30 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await executeCommand(arg);
         });
+        const __commandOptionsForRpc = commandOptions === undefined || commandOptions === null ? commandOptions : { ...commandOptions };
+        if (__commandOptionsForRpc !== undefined && __commandOptionsForRpc !== null) {
+            const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
+            const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
+            if (____commandOptionsForRpcValidateArguments !== undefined) {
+                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                    const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                    await ____commandOptionsForRpcValidateArguments(arg);
+                });
+                __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
+            }
+            const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
+            if (____commandOptionsForRpcUpdateState !== undefined) {
+                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                    const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                    return await ____commandOptionsForRpcUpdateState(arg);
+                });
+                __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, displayName, executeCommand: executeCommandId };
-        if (commandOptions !== undefined) rpcArgs.commandOptions = commandOptions;
+        if (commandOptions !== undefined) rpcArgs.commandOptions = __commandOptionsForRpc;
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withCommand',
             rpcArgs
@@ -43429,8 +43853,21 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
 
     /** @internal */
     private async _withHttpCommandInternal(path: string, displayName: string, options?: HttpCommandExportOptions): Promise<TestRedisResource> {
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
+            if (____optionsForRpcPrepareRequest !== undefined) {
+                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
+                    const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcPrepareRequest(arg);
+                });
+                __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, path, displayName };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withHttpCommand',
             rpcArgs
@@ -48011,8 +48448,30 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await executeCommand(arg);
         });
+        const __commandOptionsForRpc = commandOptions === undefined || commandOptions === null ? commandOptions : { ...commandOptions };
+        if (__commandOptionsForRpc !== undefined && __commandOptionsForRpc !== null) {
+            const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
+            const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
+            if (____commandOptionsForRpcValidateArguments !== undefined) {
+                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                    const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                    await ____commandOptionsForRpcValidateArguments(arg);
+                });
+                __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
+            }
+            const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
+            if (____commandOptionsForRpcUpdateState !== undefined) {
+                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                    const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                    return await ____commandOptionsForRpcUpdateState(arg);
+                });
+                __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, displayName, executeCommand: executeCommandId };
-        if (commandOptions !== undefined) rpcArgs.commandOptions = commandOptions;
+        if (commandOptions !== undefined) rpcArgs.commandOptions = __commandOptionsForRpc;
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
             'Aspire.Hosting/withCommand',
             rpcArgs
@@ -48078,8 +48537,21 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
 
     /** @internal */
     private async _withHttpCommandInternal(path: string, displayName: string, options?: HttpCommandExportOptions): Promise<TestVaultResource> {
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
+            if (____optionsForRpcPrepareRequest !== undefined) {
+                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
+                    const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcPrepareRequest(arg);
+                });
+                __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, path, displayName };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
             'Aspire.Hosting/withHttpCommand',
             rpcArgs
@@ -50801,8 +51273,30 @@ class ResourceImpl extends ResourceBuilderBase<IResourceHandle> implements Resou
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await executeCommand(arg);
         });
+        const __commandOptionsForRpc = commandOptions === undefined || commandOptions === null ? commandOptions : { ...commandOptions };
+        if (__commandOptionsForRpc !== undefined && __commandOptionsForRpc !== null) {
+            const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
+            const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
+            if (____commandOptionsForRpcValidateArguments !== undefined) {
+                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                    const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                    await ____commandOptionsForRpcValidateArguments(arg);
+                });
+                __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
+            }
+            const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
+            if (____commandOptionsForRpcUpdateState !== undefined) {
+                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                    const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                    return await ____commandOptionsForRpcUpdateState(arg);
+                });
+                __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, displayName, executeCommand: executeCommandId };
-        if (commandOptions !== undefined) rpcArgs.commandOptions = commandOptions;
+        if (commandOptions !== undefined) rpcArgs.commandOptions = __commandOptionsForRpc;
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting/withCommand',
             rpcArgs
@@ -52762,8 +53256,21 @@ class ResourceWithEndpointsImpl extends ResourceBuilderBase<IResourceWithEndpoin
 
     /** @internal */
     private async _withHttpCommandInternal(path: string, displayName: string, options?: HttpCommandExportOptions): Promise<ResourceWithEndpoints> {
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
+            if (____optionsForRpcPrepareRequest !== undefined) {
+                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
+                    const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcPrepareRequest(arg);
+                });
+                __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, path, displayName };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<IResourceWithEndpointsHandle>(
             'Aspire.Hosting/withHttpCommand',
             rpcArgs
@@ -53764,6 +54271,7 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.Environmen
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentEditor', (handle, client) => new EnvironmentEditorImpl(handle as EnvironmentEditorHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext', (handle, client) => new EventingSubscriberRegistrationContextImpl(handle as EventingSubscriberRegistrationContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext', (handle, client) => new ExecuteCommandContextImpl(handle as ExecuteCommandContextHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpCommandPrepareRequestContext', (handle, client) => new HttpCommandPrepareRequestContextImpl(handle as HttpCommandPrepareRequestContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent', (handle, client) => new InitializeResourceEventImpl(handle as InitializeResourceEventHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.InputsDialogValidationContext', (handle, client) => new InputsDialogValidationContextImpl(handle as InputsDialogValidationContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.LogFacade', (handle, client) => new LogFacadeImpl(handle as LogFacadeHandle, client));

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -12690,20 +12690,20 @@ class ContainerRegistryResourceImpl extends ResourceBuilderBase<ContainerRegistr
             const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
             const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
             if (____commandOptionsForRpcValidateArguments !== undefined) {
-                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcValidateArgumentsId = ____commandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
                     const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
                     await ____commandOptionsForRpcValidateArguments(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
             }
             const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
             if (____commandOptionsForRpcUpdateState !== undefined) {
-                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcUpdateStateId = ____commandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
                     const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
                     return await ____commandOptionsForRpcUpdateState(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
             }
         }
@@ -12735,7 +12735,35 @@ class ContainerRegistryResourceImpl extends ResourceBuilderBase<ContainerRegistr
 
     /** @internal */
     private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<ContainerRegistryResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const __optionsForRpc = options === null ? options : { ...options };
+        if (__optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options: __optionsForRpc };
         const result = await this._client.invokeCapability<ContainerRegistryResourceHandle>(
             'Aspire.Hosting/withProcessCommand',
             rpcArgs
@@ -12755,8 +12783,36 @@ class ContainerRegistryResourceImpl extends ResourceBuilderBase<ContainerRegistr
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await createProcessSpec(arg);
         });
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, createProcessSpec: createProcessSpecId };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<ContainerRegistryResourceHandle>(
             'Aspire.Hosting/withProcessCommandFactory',
             rpcArgs
@@ -16507,20 +16563,20 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
             const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
             const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
             if (____commandOptionsForRpcValidateArguments !== undefined) {
-                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcValidateArgumentsId = ____commandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
                     const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
                     await ____commandOptionsForRpcValidateArguments(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
             }
             const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
             if (____commandOptionsForRpcUpdateState !== undefined) {
-                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcUpdateStateId = ____commandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
                     const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
                     return await ____commandOptionsForRpcUpdateState(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
             }
         }
@@ -16552,7 +16608,35 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
 
     /** @internal */
     private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<ContainerResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const __optionsForRpc = options === null ? options : { ...options };
+        if (__optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options: __optionsForRpc };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting/withProcessCommand',
             rpcArgs
@@ -16572,8 +16656,36 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await createProcessSpec(arg);
         });
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, createProcessSpec: createProcessSpecId };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting/withProcessCommandFactory',
             rpcArgs
@@ -16594,13 +16706,37 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
         const __optionsForRpc = options === undefined || options === null ? options : { ...options };
         if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
             const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
             if (____optionsForRpcPrepareRequest !== undefined) {
-                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                const ____optionsForRpcPrepareRequestId = ____optionsForRpcPrepareRequest ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
                     const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
                     return await ____optionsForRpcPrepareRequest(arg);
-                });
+                }) : undefined;
                 __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
             }
         }
@@ -20165,20 +20301,20 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
             const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
             const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
             if (____commandOptionsForRpcValidateArguments !== undefined) {
-                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcValidateArgumentsId = ____commandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
                     const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
                     await ____commandOptionsForRpcValidateArguments(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
             }
             const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
             if (____commandOptionsForRpcUpdateState !== undefined) {
-                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcUpdateStateId = ____commandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
                     const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
                     return await ____commandOptionsForRpcUpdateState(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
             }
         }
@@ -20210,7 +20346,35 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
 
     /** @internal */
     private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<CSharpAppResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const __optionsForRpc = options === null ? options : { ...options };
+        if (__optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options: __optionsForRpc };
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
             'Aspire.Hosting/withProcessCommand',
             rpcArgs
@@ -20230,8 +20394,36 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await createProcessSpec(arg);
         });
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, createProcessSpec: createProcessSpecId };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
             'Aspire.Hosting/withProcessCommandFactory',
             rpcArgs
@@ -20252,13 +20444,37 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
         const __optionsForRpc = options === undefined || options === null ? options : { ...options };
         if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
             const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
             if (____optionsForRpcPrepareRequest !== undefined) {
-                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                const ____optionsForRpcPrepareRequestId = ____optionsForRpcPrepareRequest ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
                     const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
                     return await ____optionsForRpcPrepareRequest(arg);
-                });
+                }) : undefined;
                 __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
             }
         }
@@ -23870,20 +24086,20 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
             const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
             const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
             if (____commandOptionsForRpcValidateArguments !== undefined) {
-                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcValidateArgumentsId = ____commandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
                     const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
                     await ____commandOptionsForRpcValidateArguments(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
             }
             const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
             if (____commandOptionsForRpcUpdateState !== undefined) {
-                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcUpdateStateId = ____commandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
                     const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
                     return await ____commandOptionsForRpcUpdateState(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
             }
         }
@@ -23915,7 +24131,35 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
 
     /** @internal */
     private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<DotnetToolResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const __optionsForRpc = options === null ? options : { ...options };
+        if (__optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options: __optionsForRpc };
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
             'Aspire.Hosting/withProcessCommand',
             rpcArgs
@@ -23935,8 +24179,36 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await createProcessSpec(arg);
         });
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, createProcessSpec: createProcessSpecId };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
             'Aspire.Hosting/withProcessCommandFactory',
             rpcArgs
@@ -23957,13 +24229,37 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
         const __optionsForRpc = options === undefined || options === null ? options : { ...options };
         if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
             const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
             if (____optionsForRpcPrepareRequest !== undefined) {
-                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                const ____optionsForRpcPrepareRequestId = ____optionsForRpcPrepareRequest ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
                     const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
                     return await ____optionsForRpcPrepareRequest(arg);
-                });
+                }) : undefined;
                 __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
             }
         }
@@ -27432,20 +27728,20 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
             const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
             const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
             if (____commandOptionsForRpcValidateArguments !== undefined) {
-                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcValidateArgumentsId = ____commandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
                     const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
                     await ____commandOptionsForRpcValidateArguments(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
             }
             const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
             if (____commandOptionsForRpcUpdateState !== undefined) {
-                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcUpdateStateId = ____commandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
                     const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
                     return await ____commandOptionsForRpcUpdateState(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
             }
         }
@@ -27477,7 +27773,35 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
 
     /** @internal */
     private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<ExecutableResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const __optionsForRpc = options === null ? options : { ...options };
+        if (__optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options: __optionsForRpc };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting/withProcessCommand',
             rpcArgs
@@ -27497,8 +27821,36 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await createProcessSpec(arg);
         });
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, createProcessSpec: createProcessSpecId };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting/withProcessCommandFactory',
             rpcArgs
@@ -27519,13 +27871,37 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
         const __optionsForRpc = options === undefined || options === null ? options : { ...options };
         if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
             const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
             if (____optionsForRpcPrepareRequest !== undefined) {
-                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                const ____optionsForRpcPrepareRequestId = ____optionsForRpcPrepareRequest ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
                     const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
                     return await ____optionsForRpcPrepareRequest(arg);
-                });
+                }) : undefined;
                 __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
             }
         }
@@ -29848,20 +30224,20 @@ class ExternalServiceResourceImpl extends ResourceBuilderBase<ExternalServiceRes
             const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
             const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
             if (____commandOptionsForRpcValidateArguments !== undefined) {
-                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcValidateArgumentsId = ____commandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
                     const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
                     await ____commandOptionsForRpcValidateArguments(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
             }
             const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
             if (____commandOptionsForRpcUpdateState !== undefined) {
-                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcUpdateStateId = ____commandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
                     const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
                     return await ____commandOptionsForRpcUpdateState(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
             }
         }
@@ -29893,7 +30269,35 @@ class ExternalServiceResourceImpl extends ResourceBuilderBase<ExternalServiceRes
 
     /** @internal */
     private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<ExternalServiceResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const __optionsForRpc = options === null ? options : { ...options };
+        if (__optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options: __optionsForRpc };
         const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
             'Aspire.Hosting/withProcessCommand',
             rpcArgs
@@ -29913,8 +30317,36 @@ class ExternalServiceResourceImpl extends ResourceBuilderBase<ExternalServiceRes
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await createProcessSpec(arg);
         });
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, createProcessSpec: createProcessSpecId };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
             'Aspire.Hosting/withProcessCommandFactory',
             rpcArgs
@@ -31812,20 +32244,20 @@ class ParameterResourceImpl extends ResourceBuilderBase<ParameterResourceHandle>
             const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
             const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
             if (____commandOptionsForRpcValidateArguments !== undefined) {
-                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcValidateArgumentsId = ____commandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
                     const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
                     await ____commandOptionsForRpcValidateArguments(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
             }
             const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
             if (____commandOptionsForRpcUpdateState !== undefined) {
-                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcUpdateStateId = ____commandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
                     const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
                     return await ____commandOptionsForRpcUpdateState(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
             }
         }
@@ -31857,7 +32289,35 @@ class ParameterResourceImpl extends ResourceBuilderBase<ParameterResourceHandle>
 
     /** @internal */
     private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<ParameterResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const __optionsForRpc = options === null ? options : { ...options };
+        if (__optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options: __optionsForRpc };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting/withProcessCommand',
             rpcArgs
@@ -31877,8 +32337,36 @@ class ParameterResourceImpl extends ResourceBuilderBase<ParameterResourceHandle>
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await createProcessSpec(arg);
         });
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, createProcessSpec: createProcessSpecId };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting/withProcessCommandFactory',
             rpcArgs
@@ -34886,20 +35374,20 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
             const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
             const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
             if (____commandOptionsForRpcValidateArguments !== undefined) {
-                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcValidateArgumentsId = ____commandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
                     const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
                     await ____commandOptionsForRpcValidateArguments(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
             }
             const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
             if (____commandOptionsForRpcUpdateState !== undefined) {
-                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcUpdateStateId = ____commandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
                     const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
                     return await ____commandOptionsForRpcUpdateState(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
             }
         }
@@ -34931,7 +35419,35 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
 
     /** @internal */
     private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<ProjectResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const __optionsForRpc = options === null ? options : { ...options };
+        if (__optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options: __optionsForRpc };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting/withProcessCommand',
             rpcArgs
@@ -34951,8 +35467,36 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await createProcessSpec(arg);
         });
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, createProcessSpec: createProcessSpecId };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting/withProcessCommandFactory',
             rpcArgs
@@ -34973,13 +35517,37 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
         const __optionsForRpc = options === undefined || options === null ? options : { ...options };
         if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
             const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
             if (____optionsForRpcPrepareRequest !== undefined) {
-                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                const ____optionsForRpcPrepareRequestId = ____optionsForRpcPrepareRequest ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
                     const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
                     return await ____optionsForRpcPrepareRequest(arg);
-                });
+                }) : undefined;
                 __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
             }
         }
@@ -39196,20 +39764,20 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
             const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
             const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
             if (____commandOptionsForRpcValidateArguments !== undefined) {
-                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcValidateArgumentsId = ____commandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
                     const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
                     await ____commandOptionsForRpcValidateArguments(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
             }
             const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
             if (____commandOptionsForRpcUpdateState !== undefined) {
-                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcUpdateStateId = ____commandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
                     const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
                     return await ____commandOptionsForRpcUpdateState(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
             }
         }
@@ -39241,7 +39809,35 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
 
     /** @internal */
     private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<TestDatabaseResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const __optionsForRpc = options === null ? options : { ...options };
+        if (__optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options: __optionsForRpc };
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
             'Aspire.Hosting/withProcessCommand',
             rpcArgs
@@ -39261,8 +39857,36 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await createProcessSpec(arg);
         });
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, createProcessSpec: createProcessSpecId };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
             'Aspire.Hosting/withProcessCommandFactory',
             rpcArgs
@@ -39283,13 +39907,37 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
         const __optionsForRpc = options === undefined || options === null ? options : { ...options };
         if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
             const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
             if (____optionsForRpcPrepareRequest !== undefined) {
-                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                const ____optionsForRpcPrepareRequestId = ____optionsForRpcPrepareRequest ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
                     const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
                     return await ____optionsForRpcPrepareRequest(arg);
-                });
+                }) : undefined;
                 __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
             }
         }
@@ -43769,20 +44417,20 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
             const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
             const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
             if (____commandOptionsForRpcValidateArguments !== undefined) {
-                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcValidateArgumentsId = ____commandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
                     const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
                     await ____commandOptionsForRpcValidateArguments(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
             }
             const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
             if (____commandOptionsForRpcUpdateState !== undefined) {
-                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcUpdateStateId = ____commandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
                     const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
                     return await ____commandOptionsForRpcUpdateState(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
             }
         }
@@ -43814,7 +44462,35 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
 
     /** @internal */
     private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<TestRedisResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const __optionsForRpc = options === null ? options : { ...options };
+        if (__optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options: __optionsForRpc };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withProcessCommand',
             rpcArgs
@@ -43834,8 +44510,36 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await createProcessSpec(arg);
         });
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, createProcessSpec: createProcessSpecId };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withProcessCommandFactory',
             rpcArgs
@@ -43856,13 +44560,37 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
         const __optionsForRpc = options === undefined || options === null ? options : { ...options };
         if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
             const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
             if (____optionsForRpcPrepareRequest !== undefined) {
-                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                const ____optionsForRpcPrepareRequestId = ____optionsForRpcPrepareRequest ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
                     const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
                     return await ____optionsForRpcPrepareRequest(arg);
-                });
+                }) : undefined;
                 __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
             }
         }
@@ -48453,20 +49181,20 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
             const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
             const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
             if (____commandOptionsForRpcValidateArguments !== undefined) {
-                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcValidateArgumentsId = ____commandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
                     const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
                     await ____commandOptionsForRpcValidateArguments(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
             }
             const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
             if (____commandOptionsForRpcUpdateState !== undefined) {
-                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcUpdateStateId = ____commandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
                     const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
                     return await ____commandOptionsForRpcUpdateState(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
             }
         }
@@ -48498,7 +49226,35 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
 
     /** @internal */
     private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<TestVaultResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const __optionsForRpc = options === null ? options : { ...options };
+        if (__optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options: __optionsForRpc };
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
             'Aspire.Hosting/withProcessCommand',
             rpcArgs
@@ -48518,8 +49274,36 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await createProcessSpec(arg);
         });
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, createProcessSpec: createProcessSpecId };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
             'Aspire.Hosting/withProcessCommandFactory',
             rpcArgs
@@ -48540,13 +49324,37 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
         const __optionsForRpc = options === undefined || options === null ? options : { ...options };
         if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
             const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
             if (____optionsForRpcPrepareRequest !== undefined) {
-                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                const ____optionsForRpcPrepareRequestId = ____optionsForRpcPrepareRequest ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
                     const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
                     return await ____optionsForRpcPrepareRequest(arg);
-                });
+                }) : undefined;
                 __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
             }
         }
@@ -51278,20 +52086,20 @@ class ResourceImpl extends ResourceBuilderBase<IResourceHandle> implements Resou
             const __commandOptionsForRpcData = __commandOptionsForRpc as Record<string, unknown>;
             const ____commandOptionsForRpcValidateArguments = __commandOptionsForRpc.validateArguments;
             if (____commandOptionsForRpcValidateArguments !== undefined) {
-                const ____commandOptionsForRpcValidateArgumentsId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcValidateArgumentsId = ____commandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
                     const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
                     await ____commandOptionsForRpcValidateArguments(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["validateArguments"] = ____commandOptionsForRpcValidateArgumentsId;
             }
             const ____commandOptionsForRpcUpdateState = __commandOptionsForRpc.updateState;
             if (____commandOptionsForRpcUpdateState !== undefined) {
-                const ____commandOptionsForRpcUpdateStateId = registerCallback(async (argData: unknown) => {
+                const ____commandOptionsForRpcUpdateStateId = ____commandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
                     const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
                     return await ____commandOptionsForRpcUpdateState(arg);
-                });
+                }) : undefined;
                 __commandOptionsForRpcData["updateState"] = ____commandOptionsForRpcUpdateStateId;
             }
         }
@@ -51323,7 +52131,35 @@ class ResourceImpl extends ResourceBuilderBase<IResourceHandle> implements Resou
 
     /** @internal */
     private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<Resource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const __optionsForRpc = options === null ? options : { ...options };
+        if (__optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options: __optionsForRpc };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting/withProcessCommand',
             rpcArgs
@@ -51343,8 +52179,36 @@ class ResourceImpl extends ResourceBuilderBase<IResourceHandle> implements Resou
             const arg = new ExecuteCommandContextImpl(argHandle, this._client);
             return await createProcessSpec(arg);
         });
+        const __optionsForRpc = options === undefined || options === null ? options : { ...options };
+        if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
+            const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
+        }
         const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, createProcessSpec: createProcessSpecId };
-        if (options !== undefined) rpcArgs.options = options;
+        if (options !== undefined) rpcArgs.options = __optionsForRpc;
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting/withProcessCommandFactory',
             rpcArgs
@@ -53259,13 +54123,37 @@ class ResourceWithEndpointsImpl extends ResourceBuilderBase<IResourceWithEndpoin
         const __optionsForRpc = options === undefined || options === null ? options : { ...options };
         if (__optionsForRpc !== undefined && __optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
+            if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
+                const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
+                const ____optionsForRpcCommandOptionsForRpcData = ____optionsForRpcCommandOptionsForRpc as Record<string, unknown>;
+                const ______optionsForRpcCommandOptionsForRpcValidateArguments = ____optionsForRpcCommandOptionsForRpc.validateArguments;
+                if (______optionsForRpcCommandOptionsForRpcValidateArguments !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as InputsDialogValidationContextHandle;
+                        const arg = new InputsDialogValidationContextImpl(argHandle, this._client);
+                        await ______optionsForRpcCommandOptionsForRpcValidateArguments(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["validateArguments"] = ______optionsForRpcCommandOptionsForRpcValidateArgumentsId;
+                }
+                const ______optionsForRpcCommandOptionsForRpcUpdateState = ____optionsForRpcCommandOptionsForRpc.updateState;
+                if (______optionsForRpcCommandOptionsForRpcUpdateState !== undefined) {
+                    const ______optionsForRpcCommandOptionsForRpcUpdateStateId = ______optionsForRpcCommandOptionsForRpcUpdateState ? registerCallback(async (argData: unknown) => {
+                        const argHandle = wrapIfHandle(argData) as UpdateCommandStateContextHandle;
+                        const arg = new UpdateCommandStateContextImpl(argHandle, this._client);
+                        return await ______optionsForRpcCommandOptionsForRpcUpdateState(arg);
+                    }) : undefined;
+                    ____optionsForRpcCommandOptionsForRpcData["updateState"] = ______optionsForRpcCommandOptionsForRpcUpdateStateId;
+                }
+                __optionsForRpcData["commandOptions"] = ____optionsForRpcCommandOptionsForRpc;
+            }
             const ____optionsForRpcPrepareRequest = __optionsForRpc.prepareRequest;
             if (____optionsForRpcPrepareRequest !== undefined) {
-                const ____optionsForRpcPrepareRequestId = registerCallback(async (argData: unknown) => {
+                const ____optionsForRpcPrepareRequestId = ____optionsForRpcPrepareRequest ? registerCallback(async (argData: unknown) => {
                     const argHandle = wrapIfHandle(argData) as HttpCommandPrepareRequestContextHandle;
                     const arg = new HttpCommandPrepareRequestContextImpl(argHandle, this._client);
                     return await ____optionsForRpcPrepareRequest(arg);
-                });
+                }) : undefined;
                 __optionsForRpcData["prepareRequest"] = ____optionsForRpcPrepareRequestId;
             }
         }

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIRECOMPUTE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREINTERACTION001 // InteractionInput is used to describe resource command arguments.
 
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
@@ -81,6 +82,41 @@ public class HostedAgentExtensionTests
         Assert.Equal("ChatSparkle", command.IconName);
         Assert.Equal(IconVariant.Regular, command.IconVariant);
         Assert.True(command.IsHighlighted);
+        var argument = Assert.Single(command.Arguments);
+        Assert.Equal("message", argument.Name);
+        Assert.Equal(InputType.Text, argument.InputType);
+        Assert.Equal("Message", argument.Label);
+        Assert.True(argument.Required);
+        Assert.NotNull(command.ValidateArguments);
+    }
+
+    [Fact]
+    public async Task AsHostedAgent_InRunMode_SendMessageCommandRejectsWhitespaceMessage()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.AddPythonApp("agent", "./app.py", "main:app")
+            .AsHostedAgent();
+
+        using var app = builder.Build();
+
+        var resource = builder.Resources.Single(r => r.Name == "agent");
+        var command = Assert.Single(resource.Annotations.OfType<ResourceCommandAnnotation>());
+        Assert.NotNull(command.ValidateArguments);
+        var arguments = new InteractionInputCollection(
+        [
+            new InteractionInput
+            {
+                Name = "message",
+                InputType = InputType.Text,
+                Value = "   "
+            }
+        ]);
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource, command.Name, arguments);
+
+        Assert.False(result.Success);
+        Assert.Equal("Command argument validation failed.", result.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -78,7 +78,7 @@ public class HostedAgentExtensionTests
         var resource = builder.Resources.Single(r => r.Name == "agent");
         var command = Assert.Single(resource.Annotations.OfType<ResourceCommandAnnotation>());
         Assert.Equal("Send Message", command.DisplayName);
-        Assert.EndsWith("-/responses", command.Name);
+        Assert.Equal("send-message", command.Name);
         Assert.Equal("ChatSparkle", command.IconName);
         Assert.Equal(IconVariant.Regular, command.IconVariant);
         Assert.True(command.IsHighlighted);
@@ -136,7 +136,7 @@ public class HostedAgentExtensionTests
 
         var resource = builder.Resources.Single(r => r.Name == "agent");
         var command = Assert.Single(resource.Annotations.OfType<ResourceCommandAnnotation>());
-        Assert.EndsWith("-/invocations", command.Name);
+        Assert.Equal("send-message", command.Name);
 
         var urlsCallback = Assert.Single(resource.Annotations.OfType<ResourceUrlsCallbackAnnotation>());
         var url = new ResourceUrlAnnotation

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -364,13 +364,15 @@ public class AtsCapabilityScannerTests
 
         var dto = Assert.Single(result.DtoTypes, d => d.TypeId == AtsTypeMapping.DeriveTypeId(typeof(HttpCommandExportOptions)));
         Assert.Equal(nameof(HttpCommandExportOptions), dto.Name);
-        Assert.Contains(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.CommandOptions));
+        var commandOptionsProperty = Assert.Single(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.CommandOptions));
+        Assert.True(commandOptionsProperty.IsOptional);
         Assert.Contains(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.CommandName));
         Assert.Contains(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.EndpointName));
         Assert.Contains(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.MethodName));
         Assert.Contains(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.ResultMode));
         var prepareRequestProperty = Assert.Single(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.PrepareRequest));
         Assert.True(prepareRequestProperty.IsCallback);
+        Assert.True(prepareRequestProperty.IsOptional);
 
         var callbackParameter = Assert.Single(prepareRequestProperty.CallbackParameters!);
         Assert.Equal(AtsTypeMapping.DeriveTypeId(typeof(HttpCommandPrepareRequestContext)), callbackParameter.Type.TypeId);

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -364,16 +364,35 @@ public class AtsCapabilityScannerTests
 
         var dto = Assert.Single(result.DtoTypes, d => d.TypeId == AtsTypeMapping.DeriveTypeId(typeof(HttpCommandExportOptions)));
         Assert.Equal(nameof(HttpCommandExportOptions), dto.Name);
+        Assert.Contains(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.CommandOptions));
         Assert.Contains(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.CommandName));
         Assert.Contains(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.EndpointName));
         Assert.Contains(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.MethodName));
         Assert.Contains(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.ResultMode));
+        var prepareRequestProperty = Assert.Single(dto.Properties, p => p.Name == nameof(HttpCommandExportOptions.PrepareRequest));
+        Assert.True(prepareRequestProperty.IsCallback);
+
+        var callbackParameter = Assert.Single(prepareRequestProperty.CallbackParameters!);
+        Assert.Equal(AtsTypeMapping.DeriveTypeId(typeof(HttpCommandPrepareRequestContext)), callbackParameter.Type.TypeId);
+        Assert.Equal(AtsTypeCategory.Handle, callbackParameter.Type.Category);
+        Assert.Equal(AtsTypeMapping.DeriveTypeId(typeof(HttpCommandRequestExportData)), prepareRequestProperty.CallbackReturnType?.TypeId);
+        Assert.Equal(AtsTypeCategory.Dto, prepareRequestProperty.CallbackReturnType?.Category);
+
         Assert.DoesNotContain(dto.Properties, p => p.Name == "Parameter");
         Assert.DoesNotContain(dto.Properties, p => p.Name == nameof(HttpCommandOptions.HttpClientName));
-        Assert.DoesNotContain(dto.Properties, p => p.Name == nameof(HttpCommandOptions.PrepareRequest));
         Assert.DoesNotContain(dto.Properties, p => p.Name == nameof(HttpCommandOptions.Method));
         Assert.DoesNotContain(dto.Properties, p => p.Name == nameof(HttpCommandOptions.EndpointSelector));
         Assert.DoesNotContain(dto.Properties, p => p.Name == nameof(HttpCommandOptions.GetCommandResult));
+
+        Assert.DoesNotContain(result.Capabilities,
+            c => c.CapabilityId == "Aspire.Hosting/withHttpCommandPrepareRequest");
+
+        var requestDataDto = Assert.Single(result.DtoTypes, d => d.TypeId == AtsTypeMapping.DeriveTypeId(typeof(HttpCommandRequestExportData)));
+        Assert.Equal(nameof(HttpCommandRequestExportData), requestDataDto.Name);
+        Assert.Contains(requestDataDto.Properties, p => p.Name == nameof(HttpCommandRequestExportData.MethodName));
+        Assert.Contains(requestDataDto.Properties, p => p.Name == nameof(HttpCommandRequestExportData.Headers));
+        Assert.Contains(requestDataDto.Properties, p => p.Name == nameof(HttpCommandRequestExportData.Content));
+        Assert.Contains(requestDataDto.Properties, p => p.Name == nameof(HttpCommandRequestExportData.ContentType));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -12,6 +12,8 @@ using Microsoft.Extensions.Http.Resilience;
 
 namespace Aspire.Hosting.Tests;
 
+#pragma warning disable ASPIREINTERACTION001 // InteractionInput is used to describe resource command arguments.
+
 [Trait("Partition", "6")]
 public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
 {
@@ -218,6 +220,152 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void WithHttpCommandExport_CopiesCommonCommandOptions()
+    {
+        using var builder = CreateTestDistributedApplicationBuilder();
+        var resourceBuilder = builder.AddResource(new CustomResource("name"))
+            .WithHttpEndpoint()
+            .WithHttpCommandExport("/some-path", "Do The Thing", new HttpCommandExportOptions
+            {
+                CommandOptions = new CommandOptions
+                {
+                    Description = "Command description",
+                    ConfirmationMessage = "Are you sure?",
+                    IconName = "DatabaseLightning",
+                    IconVariant = IconVariant.Filled,
+                    IsHighlighted = true,
+                    Visibility = ResourceCommandVisibility.Api,
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "message",
+                            InputType = InputType.Text,
+                            Required = true
+                        }
+                    ]
+                }
+            });
+
+        var command = resourceBuilder.Resource.Annotations.OfType<ResourceCommandAnnotation>().Single();
+        var argument = Assert.Single(command.Arguments);
+
+        Assert.Equal("Do The Thing", command.DisplayName);
+        Assert.Equal("Command description", command.DisplayDescription);
+        Assert.Equal("Are you sure?", command.ConfirmationMessage);
+        Assert.Equal("DatabaseLightning", command.IconName);
+        Assert.Equal(IconVariant.Filled, command.IconVariant);
+        Assert.True(command.IsHighlighted);
+        Assert.Equal(ResourceCommandVisibility.Api, command.Visibility);
+        Assert.Equal("message", argument.Name);
+        Assert.True(argument.Required);
+    }
+
+    [Fact]
+    public void WithHttpCommandExport_PrefersTopLevelOptionsOverCommonCommandOptions()
+    {
+        using var builder = CreateTestDistributedApplicationBuilder();
+        var resourceBuilder = builder.AddResource(new CustomResource("name"))
+            .WithHttpEndpoint()
+            .WithHttpCommandExport("/some-path", "Do The Thing", new HttpCommandExportOptions
+            {
+                Description = "Top-level description",
+                ConfirmationMessage = "Top-level confirmation",
+                IconName = "TopLevelIcon",
+                IconVariant = IconVariant.Filled,
+                IsHighlighted = true,
+                CommandOptions = new CommandOptions
+                {
+                    Description = "Common description",
+                    ConfirmationMessage = "Common confirmation",
+                    IconName = "CommonIcon",
+                    IconVariant = IconVariant.Regular
+                }
+            });
+
+        var command = resourceBuilder.Resource.Annotations.OfType<ResourceCommandAnnotation>().Single();
+
+        Assert.Equal("Top-level description", command.DisplayDescription);
+        Assert.Equal("Top-level confirmation", command.ConfirmationMessage);
+        Assert.Equal("TopLevelIcon", command.IconName);
+        Assert.Equal(IconVariant.Filled, command.IconVariant);
+        Assert.True(command.IsHighlighted);
+    }
+
+    [Fact]
+    public async Task WithHttpCommandExport_UsesPrepareRequestCallbackProperty()
+    {
+        using var builder = CreateTestDistributedApplicationBuilder();
+
+        var fakeHandler = new FakeHttpMessageHandler(HttpStatusCode.OK, "ok", "text/plain");
+        builder.Services.AddHttpClient(string.Empty)
+            .ConfigurePrimaryHttpMessageHandler(() => fakeHandler);
+
+        InteractionInputCollection? prepareArguments = null;
+        var service = CreateResourceWithAllocatedEndpoint(builder, "service");
+        service.WithHttpCommandExport(
+            "/send",
+            "Send Message",
+            new HttpCommandExportOptions
+            {
+                MethodName = "POST",
+                CommandName = "mycommand",
+                PrepareRequest = context =>
+                {
+                    prepareArguments = context.Arguments;
+                    var message = context.Arguments.GetString("message")!;
+
+                    return Task.FromResult(new HttpCommandRequestExportData
+                    {
+                        MethodName = "PUT",
+                        Content = message,
+                        ContentType = "text/plain",
+                        Headers = new Dictionary<string, string>
+                        {
+                            ["X-Message"] = message
+                        }
+                    });
+                },
+                CommandOptions = new CommandOptions
+                {
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "message",
+                            InputType = InputType.Text,
+                            Required = true
+                        }
+                    ]
+                }
+            });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        await MoveResourceToRunningStateAsync(app, service.Resource);
+
+        var arguments = new InteractionInputCollection(
+        [
+            new InteractionInput
+            {
+                Name = "message",
+                InputType = InputType.Text,
+                Value = "hello-from-ts-prepare-request"
+            }
+        ]);
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(service.Resource, "mycommand", arguments).DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal("hello-from-ts-prepare-request", prepareArguments?.GetString("message"));
+        Assert.Equal(HttpMethod.Put, fakeHandler.RequestMethod);
+        Assert.Equal("hello-from-ts-prepare-request", fakeHandler.RequestContent);
+        Assert.Equal("hello-from-ts-prepare-request", fakeHandler.RequestHeader);
+        Assert.Equal("text/plain", fakeHandler.RequestContentType);
+    }
+
+    [Fact]
     public void WithHttpCommand_AddsResourceCommandAnnotations_WithUniqueCommandNames()
     {
         // Arrange
@@ -343,10 +491,22 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     private sealed class FakeHttpMessageHandler(HttpStatusCode statusCode, string? responseBody = null, string? mediaType = null) : HttpMessageHandler
     {
         public bool Called { get; private set; }
+        public HttpMethod? RequestMethod { get; private set; }
+        public string? RequestContent { get; private set; }
+        public string? RequestContentType { get; private set; }
+        public string? RequestHeader { get; private set; }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             Called = true;
+            RequestMethod = request.Method;
+            RequestContent = request.Content is not null
+                ? await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false)
+                : null;
+            RequestContentType = request.Content?.Headers.ContentType?.MediaType;
+            RequestHeader = request.Headers.TryGetValues("X-Message", out var values)
+                ? Assert.Single(values)
+                : null;
 
             var response = new HttpResponseMessage(statusCode);
             if (responseBody is not null)
@@ -356,7 +516,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
                     : new StringContent(responseBody);
             }
 
-            return Task.FromResult(response);
+            return response;
         }
     }
 
@@ -490,6 +650,72 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
         Assert.True(callbackCalled);
         Assert.False(result.Success);
         Assert.Equal("A test error message", result.Message);
+    }
+
+    [Fact]
+    public async Task WithHttpCommand_PassesArgumentsToRequestAndResultCallbacks()
+    {
+        using var builder = CreateTestDistributedApplicationBuilder();
+
+        var fakeHandler = new FakeHttpMessageHandler(HttpStatusCode.OK, "ok", "text/plain");
+        builder.Services.AddHttpClient("commandclient")
+            .ConfigurePrimaryHttpMessageHandler(() => fakeHandler);
+
+        InteractionInputCollection? prepareArguments = null;
+        InteractionInputCollection? resultArguments = null;
+        var service = CreateResourceWithAllocatedEndpoint(builder, "service");
+        service.WithHttpCommand("/send", "Send Message",
+            commandName: "mycommand",
+            commandOptions: new()
+            {
+                HttpClientName = "commandclient",
+                Arguments =
+                [
+                    new InteractionInput
+                    {
+                        Name = "message",
+                        InputType = InputType.Text,
+                        Required = true
+                    }
+                ],
+                PrepareRequest = requestContext =>
+                {
+                    prepareArguments = requestContext.Arguments;
+                    var message = requestContext.Arguments.GetString("message")!;
+                    requestContext.Request.Headers.Add("X-Message", message);
+                    requestContext.Request.Content = new StringContent(message, Encoding.UTF8, "text/plain");
+                    return Task.CompletedTask;
+                },
+                GetCommandResult = resultContext =>
+                {
+                    resultArguments = resultContext.Arguments;
+                    return Task.FromResult(CommandResults.Success(resultContext.Arguments.GetString("message")!));
+                }
+            });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        await MoveResourceToRunningStateAsync(app, service.Resource);
+
+        var arguments = new InteractionInputCollection(
+        [
+            new InteractionInput
+            {
+                Name = "message",
+                InputType = InputType.Text,
+                Value = "hello-from-argument"
+            }
+        ]);
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(service.Resource, "mycommand", arguments).DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal("hello-from-argument", result.Message);
+        Assert.Equal("hello-from-argument", prepareArguments?.GetString("message"));
+        Assert.Equal("hello-from-argument", resultArguments?.GetString("message"));
+        Assert.Equal("hello-from-argument", fakeHandler.RequestContent);
+        Assert.Equal("hello-from-argument", fakeHandler.RequestHeader);
     }
 
     [Fact]
@@ -787,3 +1013,5 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
 
     }
 }
+
+#pragma warning restore ASPIREINTERACTION001

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
@@ -773,7 +773,31 @@ await container.withProcessCommand("node-stdin", "Node stdin", {
 
 // withHttpCommand
 await container.withHttpCommand("/health", "Health Check");
-await container.withHttpCommand("/api/reset", "Reset", { methodName: "POST", confirmationMessage: "Are you sure?" });
+await container.withHttpCommand("/api/reset", "Reset", {
+    methodName: "POST",
+    prepareRequest: async (context) => {
+        const args = await context.arguments();
+        const message = await args.requiredValue("message");
+
+        return {
+            content: JSON.stringify({ message }),
+            contentType: "application/json",
+            headers: {
+                "X-Message": message,
+            },
+        };
+    },
+    commandOptions: {
+        arguments: [
+            {
+                name: "message",
+                inputType: InputType.Text,
+                required: true,
+            },
+        ],
+    },
+    confirmationMessage: "Are you sure?",
+});
 
 const app = await builder.build();
 await app.run();


### PR DESCRIPTION
## Description

HTTP resource commands should support the same command argument flow as process commands, including from TypeScript AppHosts and CLI invocation. This change flows declared command arguments into HTTP command prepare/result contexts, exports the HTTP command option shape through ATS, and updates the Foundry hosted-agent command to declare its `message` argument and use the stable `send-message` command name.

The TypeScript generator now handles DTO callback properties generically. That lets `prepareRequest` live directly on `HttpCommandExportOptions`, preserves optional callback metadata so omitted callbacks do not call `registerCallback`, and recursively marshals nested DTO callbacks such as `commandOptions.validateArguments` and `commandOptions.updateState` before JSON-RPC serialization. The generated Go, Java, Python, Rust, and TypeScript snapshots were updated for the new HTTP command DTO surface.

### User-facing usage

C# HTTP command callbacks can read declared command arguments:

```csharp
resource.WithHttpCommand("/api/reset", "Reset message", commandOptions: new()
{
    Arguments =
    [
        new InteractionInput
        {
            Name = "message",
            InputType = InputType.Text,
            Required = true
        }
    ],
    PrepareRequest = ctx =>
    {
        var message = ctx.Arguments.GetString("message");
        ctx.Request.Content = JsonContent.Create(new { message });
        return Task.CompletedTask;
    }
});
```

TypeScript AppHosts can use the same shape through `withHttpCommand` options:

```typescript
await api.withHttpCommand("/api/reset", "Reset message", {
  commandOptions: {
    arguments: [
      {
        name: "message",
        inputType: InputType.Text,
        required: true,
      },
    ],
  },
  prepareRequest: async (context) => {
    const args = await context.arguments();
    const message = await args.requiredValue("message");
    return {
      methodName: "POST",
      contentType: "application/json",
      content: JSON.stringify({ message }),
    };
  },
});
```

CLI callers can invoke the command with the declared named option:

```bash
aspire resource api reset-message --message hello-from-ts-e2e
```

Foundry hosted-agent resources now expose their Send Message command with a stable friendly command name:

```bash
aspire resource agent send-message --message "hello from foundry"
```

Validation:
- `./restore.sh`
- `./build.sh --build /p:SkipNativeBuild=true`
- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.WithHttpCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.WithProcessCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.Foundry.Tests/Aspire.Hosting.Foundry.Tests.csproj --no-launch-profile -- --filter-class "*.HostedAgentExtensionTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.RemoteHost.Tests/Aspire.Hosting.RemoteHost.Tests.csproj --no-launch-profile -- --filter-class "*.AtsCapabilityScannerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.CodeGeneration.Go.Tests/Aspire.Hosting.CodeGeneration.Go.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.CodeGeneration.Java.Tests/Aspire.Hosting.CodeGeneration.Java.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.Python.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Aspire.Hosting.CodeGeneration.Rust.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `npm test --prefix tests/Aspire.Hosting.CodeGeneration.TypeScript.JsTests`
- `npm run build` in `tests/PolyglotAppHosts/Aspire.Hosting/TypeScript`
- Local TypeScript API compatibility repro for `Aspire.Hosting` reported no undeclared breaks.

Fixes #17648

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No