### PR TITLE
Update hosting READMEs for polyglot AppHosts

### DIFF
--- a/.github/instructions/hosting-readme.instructions.md
+++ b/.github/instructions/hosting-readme.instructions.md
@@ -137,7 +137,7 @@ See [Local Azure Provisioning](https://aspire.dev/integrations/cloud/azure/local
 ```markdown
 ## Additional documentation
 
-https://aspire.dev/integrations/gallery/?search=hosting
+https://aspire.dev/integrations/
 {Links to relevant Microsoft Learn documentation}
 {Links to technology-specific documentation}
 ```
@@ -145,7 +145,7 @@ https://aspire.dev/integrations/gallery/?search=hosting
 **Guidelines:**
 
 - Include links to relevant aspire.dev documentation
-- Include `https://aspire.dev/integrations/gallery/?search=hosting`
+- Include `https://aspire.dev/integrations/`
 - Include links to official technology documentation
 - Use the format: `https://aspire.dev/...`
 - For multiple links, use a bulleted list with `*` prefix (hosting READMEs) or separate lines (simpler hosting READMEs)
@@ -223,7 +223,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
-https://aspire.dev/integrations/gallery/?search=hosting
+https://aspire.dev/integrations/
 https://www.postgresql.org/docs/
 
 ## Feedback & contributing
@@ -271,7 +271,7 @@ When reviewing or creating a hosting integration README.md:
 - [ ] Usage example shows `Add{Technology}` method with `WithReference` pattern
 - [ ] Usage example includes C# and TypeScript AppHost samples when the API is exported for TypeScript
 - [ ] Usage example uses appropriate variable names and resource names
-- [ ] "Additional documentation" section includes `https://aspire.dev/integrations/gallery/?search=hosting`
+- [ ] "Additional documentation" section includes `https://aspire.dev/integrations/`
 - [ ] "Feedback & contributing" section is present at the end
 - [ ] Trademark notices are included if applicable
 - [ ] No consuming-app setup or dependency-injection details

--- a/.github/instructions/hosting-readme.instructions.md
+++ b/.github/instructions/hosting-readme.instructions.md
@@ -137,6 +137,7 @@ See [Local Azure Provisioning](https://aspire.dev/integrations/cloud/azure/local
 ```markdown
 ## Additional documentation
 
+https://aspire.dev/integrations/gallery/?search=hosting
 {Links to relevant Microsoft Learn documentation}
 {Links to technology-specific documentation}
 ```
@@ -144,6 +145,7 @@ See [Local Azure Provisioning](https://aspire.dev/integrations/cloud/azure/local
 **Guidelines:**
 
 - Include links to relevant aspire.dev documentation
+- Include `https://aspire.dev/integrations/gallery/?search=hosting`
 - Include links to official technology documentation
 - Use the format: `https://aspire.dev/...`
 - For multiple links, use a bulleted list with `*` prefix (hosting READMEs) or separate lines (simpler hosting READMEs)
@@ -221,6 +223,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
+https://aspire.dev/integrations/gallery/?search=hosting
 https://www.postgresql.org/docs/
 
 ## Feedback & contributing
@@ -268,7 +271,7 @@ When reviewing or creating a hosting integration README.md:
 - [ ] Usage example shows `Add{Technology}` method with `WithReference` pattern
 - [ ] Usage example includes C# and TypeScript AppHost samples when the API is exported for TypeScript
 - [ ] Usage example uses appropriate variable names and resource names
-- [ ] "Additional documentation" section includes relevant aspire.dev links
+- [ ] "Additional documentation" section includes `https://aspire.dev/integrations/gallery/?search=hosting`
 - [ ] "Feedback & contributing" section is present at the end
 - [ ] Trademark notices are included if applicable
 - [ ] No consuming-app setup or dependency-injection details

--- a/.github/instructions/hosting-readme.instructions.md
+++ b/.github/instructions/hosting-readme.instructions.md
@@ -19,14 +19,14 @@ All hosting integration README.md files should follow this structure:
 ```markdown
 # {Technology} hosting integration
 
-Use the Aspire {Technology} hosting integration to model, configure, and orchestrate {a/an} {Technology} {resource type} in an Aspire solution.
+Use this integration to model, configure, and orchestrate {a/an} {Technology} {resource type} in an Aspire solution.
 ```
 
 **Guidelines:**
 
 - Title format: `# {Technology} hosting integration`
 - Do not use "library", "package", or "component" in the title
-- Start description with "Use the Aspire {Technology} hosting integration to..."
+- Start description with "Use this integration to..."
 - Be specific about what type of resource is being configured (e.g., "a SQL Server database resource", "a MongoDB resource", "Azure CosmosDB")
 
 ### 2. Getting Started Section
@@ -187,7 +187,7 @@ Here's a complete example for a hosting integration:
 ````markdown
 # PostgreSQL hosting integration
 
-Use the Aspire PostgreSQL hosting integration to model, configure, and orchestrate a PostgreSQL database in an Aspire solution.
+Use this integration to model, configure, and orchestrate a PostgreSQL resource in an Aspire solution.
 
 ## Getting started
 
@@ -266,7 +266,7 @@ Update hosting integration README.md files when:
 When reviewing or creating a hosting integration README.md:
 
 - [ ] Title follows the format: `# {Technology} hosting integration`
-- [ ] Description starts with "Use the Aspire {Technology} hosting integration to..."
+- [ ] Description starts with "Use this integration to..."
 - [ ] Installation section uses `aspire add` with the correct integration ID in a `bash` code block
 - [ ] Usage example shows `Add{Technology}` method with `WithReference` pattern
 - [ ] Usage example includes C# and TypeScript AppHost samples when the API is exported for TypeScript

--- a/.github/instructions/hosting-readme.instructions.md
+++ b/.github/instructions/hosting-readme.instructions.md
@@ -2,13 +2,13 @@
 applyTo: "src/Aspire.Hosting*/README.md"
 ---
 
-# README.md Instructions for Hosting Integration Packages
+# README.md Instructions for Hosting Integration READMEs
 
-This document provides guidelines for writing and maintaining README.md files for Aspire hosting integration packages located under `src/Aspire.Hosting*/README.md`.
+This document provides guidelines for writing and maintaining README.md files for Aspire hosting integrations located under `src/Aspire.Hosting*/README.md`.
 
 ## Purpose
 
-Hosting integration packages provide extension methods and resource definitions for the Aspire AppHost. They enable developers to configure and orchestrate infrastructure resources (databases, message queues, caches, cloud services, etc.) in their distributed applications. The README.md files help developers understand how to add and configure these resources in their AppHost project.
+Hosting integrations model infrastructure resources (databases, message queues, caches, cloud services, and more) in an Aspire AppHost. The README.md files help developers add and configure those resources from an AppHost written in C# or TypeScript.
 
 ## Standard Structure
 
@@ -17,16 +17,16 @@ All hosting integration README.md files should follow this structure:
 ### 1. Title and Description
 
 ```markdown
-# Aspire.Hosting.{Technology} library
+# {Technology} hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure {a/an} {Technology} {resource type}.
+Use the Aspire {Technology} hosting integration to model, configure, and orchestrate {a/an} {Technology} {resource type} in an Aspire solution.
 ```
 
 **Guidelines:**
 
-- Title format: `# Aspire.Hosting.{Technology} library`
-- Use "library" (not "package" or "component")
-- Start description with "Provides extension methods and resource definitions for an Aspire AppHost to configure..."
+- Title format: `# {Technology} hosting integration`
+- Do not use "library", "package", or "component" in the title
+- Start description with "Use the Aspire {Technology} hosting integration to..."
 - Be specific about what type of resource is being configured (e.g., "a SQL Server database resource", "a MongoDB resource", "Azure CosmosDB")
 
 ### 2. Getting Started Section
@@ -38,43 +38,56 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 {List any prerequisites such as Azure subscription, if applicable}
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire {Technology} Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.{Technology}` integration with the Aspire CLI:
 
-\```dotnetcli
-dotnet add package Aspire.Hosting.{Technology}
+\```bash
+aspire add Aspire.Hosting.{Technology}
 \```
 ````
 
 **Guidelines:**
 
 - Include a "Prerequisites" subsection only if there are specific requirements (e.g., Azure subscription for Azure resources)
-- Installation command should be in a `dotnetcli` code block
-- Use consistent phrasing: "In your AppHost project, install the Aspire {Technology} Hosting library with [NuGet](https://www.nuget.org):"
+- Installation command should be in a `bash` code block
+- Use consistent phrasing: "From your AppHost directory, add the `Aspire.Hosting.{Technology}` integration with the Aspire CLI:"
+- Use the exact integration ID with `aspire add` so the command works without relying on fuzzy matching or interactive selection
 
 ### 3. Usage Example
 
 ````markdown
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add {a/an} {Technology} resource and consume the connection using the following methods:
+Then, in the AppHost, add {a/an} {Technology} resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 \```csharp
 var {resourceName} = builder.Add{Technology}("{name}"){.AddDatabase("dbname") if applicable};
 
 var myService = builder.AddProject<Projects.MyService>()
-.WithReference({resourceName});
+                       .WithReference({resourceName});
+\```
+
+**TypeScript**
+
+\```typescript
+const {resourceName} = await builder.add{Technology}("{name}"){.addDatabase("dbname") if applicable};
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+    .withReference({resourceName});
 \```
 ````
 
 **Guidelines:**
 
-- Start with "Then, in the _AppHost.cs_ file of `AppHost`, add..."
+- Start with "Then, in the AppHost, add..."
 - Show the minimal working example
 - Use descriptive variable names that match the technology (e.g., `redis`, `postgres`, `sql`, `mongodb`)
 - Include chained methods like `.AddDatabase()` when applicable
-- Show the `WithReference` pattern to demonstrate resource consumption
+- Show the `WithReference` pattern to demonstrate resource references
+- Include both C# and TypeScript AppHost samples when the APIs are exported for TypeScript. Do not invent TypeScript examples for advanced or C#-only APIs.
 - Keep examples simple and focused on the most common use case
 
 ### 4. Additional Sections (Optional)
@@ -86,7 +99,7 @@ For Azure services that support emulators:
 ````markdown
 ### Emulator usage
 
-Aspire supports the usage of the {Azure Service} emulator. To use the emulator, add the following to your AppHost project:
+Aspire supports the usage of the {Azure Service} emulator. To use the emulator, add the following to your AppHost:
 
 \```csharp
 // AppHost
@@ -105,8 +118,15 @@ For Azure resources:
 
 Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. The Aspire dashboard will prompt you to set these values if they are not already
-configured. See [Local Azure Provisioning](https://aspire.dev/integrations/cloud/azure/local-provisioning/) for more details.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
+
+\```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
+\```
+
+See [Local Azure Provisioning](https://aspire.dev/integrations/cloud/azure/local-provisioning/) for more details.
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
 > can be configured for the provisioned resources.
@@ -123,7 +143,7 @@ configured. See [Local Azure Provisioning](https://aspire.dev/integrations/cloud
 
 **Guidelines:**
 
-- Include links to aspire.dev documentation for the component
+- Include links to relevant aspire.dev documentation
 - Include links to official technology documentation
 - Use the format: `https://aspire.dev/...`
 - For multiple links, use a bulleted list with `*` prefix (hosting READMEs) or separate lines (simpler hosting READMEs)
@@ -163,35 +183,45 @@ _{Trademark notice text}_
 Here's a complete example for a hosting integration:
 
 ````markdown
-# Aspire.Hosting.PostgreSQL library
+# PostgreSQL hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a PostgreSQL resource.
+Use the Aspire PostgreSQL hosting integration to model, configure, and orchestrate a PostgreSQL database in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire PostgreSQL Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.PostgreSQL` integration with the Aspire CLI:
 
-\```dotnetcli
-dotnet add package Aspire.Hosting.PostgreSQL
+\```bash
+aspire add Aspire.Hosting.PostgreSQL
 \```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a PostgreSQL resource and consume the connection using the following methods:
+Then, in the AppHost, add a PostgreSQL resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 \```csharp
 var db = builder.AddPostgres("pgsql").AddDatabase("mydb");
 
 var myService = builder.AddProject<Projects.MyService>()
-.WithReference(db);
+                       .WithReference(db);
+\```
+
+**TypeScript**
+
+\```typescript
+const db = await builder.addPostgres("pgsql").addDatabase("mydb");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+    .withReference(db);
 \```
 
 ## Additional documentation
 
-https://aspire.dev/integrations/databases/postgres-client/
-https://aspire.dev/integrations/databases/postgresql-extensions/
+https://www.postgresql.org/docs/
 
 ## Feedback & contributing
 
@@ -204,17 +234,17 @@ _*Postgres*, *PostgreSQL* and the *Slonik Logo* are trademarks or registered tra
 
 1. **Keep it simple**: Hosting READMEs should be concise and focused on the AppHost usage pattern
 2. **Be consistent**: Use the same structure, phrasing, and formatting across all hosting integration READMEs
-3. **Focus on the AppHost**: The primary audience is developers configuring their AppHost project
+3. **Focus on the AppHost**: The primary audience is developers configuring their AppHost model
 4. **Minimal examples**: Show the simplest working example; don't overwhelm with options
-5. **Clear resource flow**: Demonstrate the pattern of adding a resource and referencing it in a project
+5. **Clear resource flow**: Demonstrate the pattern of adding a resource and referencing it from another resource
 6. **Link to detailed docs**: Use the "Additional documentation" section for deeper dive content
 
 ## Common Mistakes to Avoid
 
-- ❌ Don't include detailed configuration options (these belong in client integration READMEs)
-- ❌ Don't explain DI container registration (that's for client integrations)
+- ❌ Don't include consuming-app setup; hosting READMEs should focus on the AppHost resource model
+- ❌ Don't explain dependency-injection registration; that belongs in consuming-app docs
 - ❌ Don't include health check, telemetry, or observability details in hosting READMEs
-- ❌ Don't use "component" or "package" in titles - always use "library"
+- ❌ Don't use "library", "package", or "component" in titles
 - ❌ Don't omit the `WithReference` pattern in examples
 - ❌ Don't forget trademark notices when applicable
 
@@ -232,13 +262,14 @@ Update hosting integration README.md files when:
 
 When reviewing or creating a hosting integration README.md:
 
-- [ ] Title follows the format: `# Aspire.Hosting.{Technology} library`
-- [ ] Description starts with "Provides extension methods and resource definitions..."
-- [ ] Installation section uses correct package name and `dotnetcli` code block
+- [ ] Title follows the format: `# {Technology} hosting integration`
+- [ ] Description starts with "Use the Aspire {Technology} hosting integration to..."
+- [ ] Installation section uses `aspire add` with the correct integration ID in a `bash` code block
 - [ ] Usage example shows `Add{Technology}` method with `WithReference` pattern
+- [ ] Usage example includes C# and TypeScript AppHost samples when the API is exported for TypeScript
 - [ ] Usage example uses appropriate variable names and resource names
 - [ ] "Additional documentation" section includes relevant aspire.dev links
 - [ ] "Feedback & contributing" section is present at the end
 - [ ] Trademark notices are included if applicable
-- [ ] No configuration details that belong in client integration READMEs
+- [ ] No consuming-app setup or dependency-injection details
 - [ ] Consistent formatting and style with other hosting integration READMEs

--- a/.github/instructions/hosting-readme.instructions.md
+++ b/.github/instructions/hosting-readme.instructions.md
@@ -137,7 +137,7 @@ See [Local Azure Provisioning](https://aspire.dev/integrations/cloud/azure/local
 ```markdown
 ## Additional documentation
 
-https://aspire.dev/integrations/
+https://aspire.dev/integrations/gallery/
 {Links to relevant Microsoft Learn documentation}
 {Links to technology-specific documentation}
 ```
@@ -145,7 +145,7 @@ https://aspire.dev/integrations/
 **Guidelines:**
 
 - Include links to relevant aspire.dev documentation
-- Include `https://aspire.dev/integrations/`
+- Include `https://aspire.dev/integrations/gallery/`
 - Include links to official technology documentation
 - Use the format: `https://aspire.dev/...`
 - For multiple links, use a bulleted list with `*` prefix (hosting READMEs) or separate lines (simpler hosting READMEs)
@@ -223,7 +223,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
-https://aspire.dev/integrations/
+https://aspire.dev/integrations/gallery/
 https://www.postgresql.org/docs/
 
 ## Feedback & contributing
@@ -271,7 +271,7 @@ When reviewing or creating a hosting integration README.md:
 - [ ] Usage example shows `Add{Technology}` method with `WithReference` pattern
 - [ ] Usage example includes C# and TypeScript AppHost samples when the API is exported for TypeScript
 - [ ] Usage example uses appropriate variable names and resource names
-- [ ] "Additional documentation" section includes `https://aspire.dev/integrations/`
+- [ ] "Additional documentation" section includes `https://aspire.dev/integrations/gallery/`
 - [ ] "Feedback & contributing" section is present at the end
 - [ ] Trademark notices are included if applicable
 - [ ] No consuming-app setup or dependency-injection details

--- a/.github/instructions/hosting-readme.instructions.md
+++ b/.github/instructions/hosting-readme.instructions.md
@@ -138,6 +138,7 @@ See [Local Azure Provisioning](https://aspire.dev/integrations/cloud/azure/local
 ## Additional documentation
 
 https://aspire.dev/integrations/gallery/
+{Specific hosting integration docs URL from aspire docs search, when available}
 {Links to relevant Microsoft Learn documentation}
 {Links to technology-specific documentation}
 ```
@@ -146,6 +147,7 @@ https://aspire.dev/integrations/gallery/
 
 - Include links to relevant aspire.dev documentation
 - Include `https://aspire.dev/integrations/gallery/`
+- Use `aspire docs search "{Technology}"` to find and include the specific hosting integration docs page when one exists
 - Include links to official technology documentation
 - Use the format: `https://aspire.dev/...`
 - For multiple links, use a bulleted list with `*` prefix (hosting READMEs) or separate lines (simpler hosting READMEs)
@@ -224,6 +226,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 ## Additional documentation
 
 https://aspire.dev/integrations/gallery/
+https://aspire.dev/integrations/databases/postgres/postgres-host/
 https://www.postgresql.org/docs/
 
 ## Feedback & contributing
@@ -272,6 +275,7 @@ When reviewing or creating a hosting integration README.md:
 - [ ] Usage example includes C# and TypeScript AppHost samples when the API is exported for TypeScript
 - [ ] Usage example uses appropriate variable names and resource names
 - [ ] "Additional documentation" section includes `https://aspire.dev/integrations/gallery/`
+- [ ] "Additional documentation" section links to the specific hosting integration docs page found with `aspire docs search` when one exists
 - [ ] "Feedback & contributing" section is present at the end
 - [ ] Trademark notices are included if applicable
 - [ ] No consuming-app setup or dependency-injection details

--- a/src/Aspire.Hosting.Azure.AppConfiguration/README.md
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.AppConfiguration library
+# Azure App Configuration hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure App Configuration.
+Use this integration to model, configure, and orchestrate Azure App Configuration in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Azure App Configuration Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.AppConfiguration` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.AppConfiguration
+```bash
+aspire add Aspire.Hosting.Azure.AppConfiguration
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,13 +33,24 @@ automatically.
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add an App Configuration connection and consume the connection using the following methods:
+In the AppHost, add an App Configuration connection and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var appConfig = builder.AddAzureAppConfiguration("config");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(appConfig);
+```
+
+**TypeScript**
+
+```typescript
+const appConfig = await builder.addAzureAppConfiguration("config");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(appConfig);
 ```
 
 > NOTE: Consider setting the name of your resource to something other than "config" or "appconfig". Even though during deployment a random suffix will be added it is still possible to get a name collision.

--- a/src/Aspire.Hosting.Azure.AppConfiguration/README.md
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/README.md
@@ -57,6 +57,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/azure-app-configuration/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.AppConfiguration/README.md
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/README.md
@@ -57,7 +57,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/azure-app-configuration/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.AppConfiguration/README.md
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/README.md
@@ -58,6 +58,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-app-configuration/azure-app-configuration-host/
 * https://learn.microsoft.com/azure/azure-app-configuration/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.AppConfiguration/README.md
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/README.md
@@ -57,7 +57,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/azure-app-configuration/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.AppService/README.md
+++ b/src/Aspire.Hosting.Azure.AppService/README.md
@@ -116,7 +116,7 @@ var appServiceEnvironment = builder.AddAzureAppServiceEnvironment("env")
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/app-service/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.AppService/README.md
+++ b/src/Aspire.Hosting.Azure.AppService/README.md
@@ -116,6 +116,7 @@ var appServiceEnvironment = builder.AddAzureAppServiceEnvironment("env")
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/app-service/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.AppService/README.md
+++ b/src/Aspire.Hosting.Azure.AppService/README.md
@@ -117,6 +117,7 @@ var appServiceEnvironment = builder.AddAzureAppServiceEnvironment("env")
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-app-service/azure-app-service-host/
 * https://learn.microsoft.com/azure/app-service/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.AppService/README.md
+++ b/src/Aspire.Hosting.Azure.AppService/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.AppService library
+# Azure App Service hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure App Service for the compute resources (like project).
+Use this integration to model, configure, and orchestrate Azure App Service for compute resources in an Aspire solution.
 
 ## Getting started
 
@@ -8,17 +8,17 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription (requires Owner access to the target subscription for role assignments)
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Azure App Service Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.AppService` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.AppService
+```bash
+aspire add Aspire.Hosting.Azure.AppService
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add an Azure App Service Environment and publish your project as an Azure App Service Web App:
+In the AppHost, add an Azure App Service Environment and publish a compute resource as an Azure App Service Web App:
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -49,10 +49,10 @@ When deploying to Azure App Service, the following constraints apply:
 
 ### Publishing compute resources to Azure App Service
 
-The `PublishAsAzureAppServiceWebsite` extension method is used to configure a compute resource (such as a project) to be published as an Azure App Service Web App when deploying to Azure. This method allows you to customize the App Service Web App configuration using the Azure Provisioning SDK.
+The `PublishAsAzureAppServiceWebsite` extension method configures a compute resource to be published as an Azure App Service Web App when deploying to Azure. This method allows you to customize the App Service Web App configuration using the Azure Provisioning SDK.
 
 ```csharp
-builder.AddProject<Projects.MyApi>("api")
+builder.AddProject<Projects.Api>("api")
     .WithHttpEndpoint(targetPort: 8080)
     .WithExternalHttpEndpoints()
     .WithHealthProbe(ProbeType.Liveness, "/health")

--- a/src/Aspire.Hosting.Azure.AppService/README.md
+++ b/src/Aspire.Hosting.Azure.AppService/README.md
@@ -116,7 +116,7 @@ var appServiceEnvironment = builder.AddAzureAppServiceEnvironment("env")
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/app-service/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/README.md
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/README.md
@@ -56,6 +56,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-application-insights/
 * https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/README.md
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.ApplicationInsights library
+# Azure Application Insights hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure Application Insights.
+Use this integration to model, configure, and orchestrate Azure Application Insights in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Azure Application Insights Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.ApplicationInsights` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.ApplicationInsights
+```bash
+aspire add Aspire.Hosting.Azure.ApplicationInsights
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,13 +33,24 @@ automatically.
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add an Application Insights connection and consume the connection using the following methods:
+In the AppHost, add an Application Insights connection and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var appInsights = builder.AddAzureApplicationInsights("appInsights");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(appInsights);
+```
+
+**TypeScript**
+
+```typescript
+const appInsights = await builder.addAzureApplicationInsights("appInsights");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(appInsights);
 ```
 
 ## Additional documentation

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/README.md
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/README.md
@@ -55,7 +55,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/README.md
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/README.md
@@ -55,6 +55,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/README.md
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/README.md
@@ -55,7 +55,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.CognitiveServices/README.md
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.CognitiveServices library
+# Azure OpenAI hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure OpenAI.
+Use this integration to model, configure, and orchestrate Azure OpenAI in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Azure Hosting Cognitive Services library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.CognitiveServices` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.CognitiveServices
+```bash
+aspire add Aspire.Hosting.Azure.CognitiveServices
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,7 +33,9 @@ automatically.
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add an Azure OpenAI service and consume the connection using the following methods:
+In the AppHost, add an Azure OpenAI service and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var openai = builder.AddAzureOpenAI("openai");
@@ -47,10 +44,13 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(openai);
 ```
 
-The `WithReference` method passes that connection information into a connection string named `openai` in the `MyService` project. In the _Program.cs_ file of `MyService`, the connection can be consumed using the client library [Aspire.Azure.AI.OpenAI](https://www.nuget.org/packages/Aspire.Azure.AI.OpenAI):
+**TypeScript**
 
-```csharp
-builder.AddAzureOpenAIClient("openai");
+```typescript
+const openai = await builder.addAzureOpenAI("openai");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(openai);
 ```
 
 ## Connection Properties
@@ -77,8 +77,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://learn.microsoft.com/dotnet/api/overview/azure/ai.openai-readme
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/azure/ai-services/openai/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.CognitiveServices/README.md
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/README.md
@@ -78,6 +78,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-openai/azure-openai-host/
 * https://learn.microsoft.com/azure/ai-services/openai/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.CognitiveServices/README.md
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/README.md
@@ -77,6 +77,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/ai-services/openai/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.CognitiveServices/README.md
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/README.md
@@ -77,7 +77,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/ai-services/openai/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.CognitiveServices/README.md
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/README.md
@@ -77,7 +77,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/ai-services/openai/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.CosmosDB/README.md
+++ b/src/Aspire.Hosting.Azure.CosmosDB/README.md
@@ -87,7 +87,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/cosmos-db/nosql/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.CosmosDB/README.md
+++ b/src/Aspire.Hosting.Azure.CosmosDB/README.md
@@ -87,6 +87,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/cosmos-db/nosql/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.CosmosDB/README.md
+++ b/src/Aspire.Hosting.Azure.CosmosDB/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.Cosmos library
+# Azure Cosmos DB hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure CosmosDB.
+Use this integration to model, configure, and orchestrate Azure CosmosDB in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Azure Cosmos DB Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.CosmosDB` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.CosmosDB
+```bash
+aspire add Aspire.Hosting.Azure.CosmosDB
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,7 +33,9 @@ automatically.
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Cosmos DB connection and consume the connection using the following methods:
+In the AppHost, add a Cosmos DB connection and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var cosmosdb = builder.AddAzureCosmosDB("cdb").AddCosmosDatabase("cosmosdb");
@@ -47,26 +44,13 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(cosmosdb);
 ```
 
-The `WithReference` method passes that connection information into a connection string named `cosmosdb` in the `MyService` project. In the _Program.cs_ file of `MyService`, the connection can be consumed using the client library [Aspire.Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Aspire.Microsoft.Azure.Cosmos):
+**TypeScript**
 
-```csharp
-builder.AddAzureCosmosClient("cosmosdb");
-```
+```typescript
+const cosmosdb = await builder.addAzureCosmosDB("cdb").addCosmosDatabase("cosmosdb");
 
-### Emulator usage
-
-Aspire supports the usage of the Azure Cosmos DB emulator to use the emulator, add the following to your AppHost project:
-
-```csharp
-// AppHost
-var cosmosdb = builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
-```
-
-When the AppHost starts up a local container running the Azure CosmosDB will also be started:
-
-```csharp
-// Service code
-builder.AddAzureCosmosClient("cosmos");
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(cosmosdb);
 ```
 
 ## Connection Properties
@@ -103,8 +87,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://learn.microsoft.com/azure/cosmos-db/nosql/sdk-dotnet-v3
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/azure/cosmos-db/nosql/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.CosmosDB/README.md
+++ b/src/Aspire.Hosting.Azure.CosmosDB/README.md
@@ -87,7 +87,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/cosmos-db/nosql/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.CosmosDB/README.md
+++ b/src/Aspire.Hosting.Azure.CosmosDB/README.md
@@ -88,6 +88,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-cosmos-db/azure-cosmos-db-host/
 * https://learn.microsoft.com/azure/cosmos-db/nosql/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.EventHubs/README.md
+++ b/src/Aspire.Hosting.Azure.EventHubs/README.md
@@ -88,6 +88,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/event-hubs/event-hubs-about
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.EventHubs/README.md
+++ b/src/Aspire.Hosting.Azure.EventHubs/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.EventHubs library
+# Azure Event Hubs hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure Event Hubs.
+Use this integration to model, configure, and orchestrate Azure Event Hubs in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-Install the Aspire Azure Event Hubs Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.EventHubs` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.EventHubs
+```bash
+aspire add Aspire.Hosting.Azure.EventHubs
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,7 +33,9 @@ automatically.
 
 ## Usage example
 
-In the _AppHost.cs_ file of `AppHost`, add an Event Hubs connection and consume the connection using the following methods:
+In the AppHost, add an Event Hubs connection and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var eventHubs = builder.AddAzureEventHubs("eh");
@@ -47,10 +44,13 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(eventHubs);
 ```
 
-The `WithReference` method passes that connection information into a connection string named `eh` in the `MyService` project. In the _Program.cs_ file of `MyService`, the connection can be consumed using the client library [Aspire.Azure.Messaging.EventHubs](https://www.nuget.org/packages/Aspire.Azure.Messaging.EventHubs):
+**TypeScript**
 
-```csharp
-builder.AddAzureEventProcessorClient("eh");
+```typescript
+const eventHubs = await builder.addAzureEventHubs("eh");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(eventHubs);
 ```
 
 ## Connection Properties
@@ -88,8 +88,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Microsoft.Azure.EventHubs/README.md
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/azure/event-hubs/event-hubs-about
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.EventHubs/README.md
+++ b/src/Aspire.Hosting.Azure.EventHubs/README.md
@@ -88,7 +88,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/event-hubs/event-hubs-about
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.EventHubs/README.md
+++ b/src/Aspire.Hosting.Azure.EventHubs/README.md
@@ -88,7 +88,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/event-hubs/event-hubs-about
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.EventHubs/README.md
+++ b/src/Aspire.Hosting.Azure.EventHubs/README.md
@@ -89,6 +89,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-event-hubs/azure-event-hubs-host/
 * https://learn.microsoft.com/azure/event-hubs/event-hubs-about
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.FrontDoor/README.md
+++ b/src/Aspire.Hosting.Azure.FrontDoor/README.md
@@ -42,6 +42,7 @@ const frontDoor = await builder.addAzureFrontDoor("frontdoor")
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/frontdoor/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.FrontDoor/README.md
+++ b/src/Aspire.Hosting.Azure.FrontDoor/README.md
@@ -43,6 +43,7 @@ const frontDoor = await builder.addAzureFrontDoor("frontdoor")
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-front-door/
 * https://learn.microsoft.com/azure/frontdoor/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.FrontDoor/README.md
+++ b/src/Aspire.Hosting.Azure.FrontDoor/README.md
@@ -42,7 +42,7 @@ const frontDoor = await builder.addAzureFrontDoor("frontdoor")
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/frontdoor/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.FrontDoor/README.md
+++ b/src/Aspire.Hosting.Azure.FrontDoor/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.FrontDoor library
+# Azure Front Door hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure an Azure Front Door resource.
+Use this integration to model, configure, and orchestrate an Azure Front Door resource in an Aspire solution.
 
 ## Getting started
 
@@ -8,15 +8,9 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - An Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the `Aspire.Hosting.Azure.FrontDoor` library via NuGet:
-
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.FrontDoor
-```
-
-Or using the Aspire CLI:
+From your AppHost directory, add the `Aspire.Hosting.Azure.FrontDoor` integration with the Aspire CLI:
 
 ```bash
 aspire add Aspire.Hosting.Azure.FrontDoor
@@ -24,7 +18,9 @@ aspire add Aspire.Hosting.Azure.FrontDoor
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add an Azure Front Door resource and configure origins using the following methods:
+In the AppHost, add an Azure Front Door resource and configure origins with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var api = builder.AddProject<Projects.Api>("api")
@@ -32,6 +28,16 @@ var api = builder.AddProject<Projects.Api>("api")
 
 var frontDoor = builder.AddAzureFrontDoor("frontdoor")
     .WithOrigin(api);
+```
+
+**TypeScript**
+
+```typescript
+const api = await builder.addNodeApp("api", "../api", "server.js")
+    .withExternalHttpEndpoints();
+
+const frontDoor = await builder.addAzureFrontDoor("frontdoor")
+    .withOrigin(api);
 ```
 
 ## Additional documentation

--- a/src/Aspire.Hosting.Azure.FrontDoor/README.md
+++ b/src/Aspire.Hosting.Azure.FrontDoor/README.md
@@ -42,7 +42,7 @@ const frontDoor = await builder.addAzureFrontDoor("frontdoor")
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/frontdoor/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Functions/README.md
+++ b/src/Aspire.Hosting.Azure.Functions/README.md
@@ -115,7 +115,7 @@ var taskHub = scheduler.AddTaskHub("taskhub").WithTaskHubName(taskHubName);
 ```
 ## Additional documentation
 
-- https://aspire.dev/integrations/gallery/?search=hosting
+- https://aspire.dev/integrations/
 - https://learn.microsoft.com/azure/azure-functions
 - https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler
 

--- a/src/Aspire.Hosting.Azure.Functions/README.md
+++ b/src/Aspire.Hosting.Azure.Functions/README.md
@@ -1,31 +1,27 @@
-# Aspire.Hosting.Azure.Functions library
+# Azure Functions hosting integration
 
-Provides methods to the Aspire hosting model for Azure functions.
+Use this integration to model, configure, and orchestrate Azure Functions projects in an Aspire solution.
 
 ## Getting started
 
 ### Prerequisites
 
 * An Aspire project based on the starter template.
-* A .NET-based Azure Functions worker project.
+* An Azure Functions app project.
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Azure Functions Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.Functions` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.Functions
+```bash
+aspire add Aspire.Hosting.Azure.Functions
 ```
 
 ## Usage example
 
-Add a reference to the .NET-based Azure Functions project in your `AppHost` project.
+In the AppHost, use `AddAzureFunctionsProject` to configure the Functions app resource. C# AppHosts use the generated project metadata type; TypeScript AppHosts point at the Functions app directory.
 
-```dotnetcli
-dotnet add reference ..\Company.FunctionApp\Company.FunctionApp.csproj
-```
-
-In the _AppHost.cs_ file of `AppHost`, use the `AddAzureFunctionsProject` to configure the Functions project resource.
+**C#**
 
 ```csharp
 using Aspire.Hosting;
@@ -47,11 +43,29 @@ var app = builder.Build();
 app.Run();
 ```
 
+**TypeScript**
+
+```typescript
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const storage = await builder.addAzureStorage("storage").runAsEmulator();
+const queue = await storage.addQueues("queue");
+const blob = await storage.addBlobs("blob");
+
+await builder.addAzureFunctionsProject("my-functions-project", "../Company.FunctionApp")
+    .withReference(queue)
+    .withReference(blob);
+
+await builder.build().run();
+```
+
 ## Durable Task Scheduler (Durable Functions)
 
-The Azure Functions hosting library also provides resource APIs for using the Durable Task Scheduler (DTS) with Durable Functions.
+The Azure Functions hosting integration also provides resource APIs for using the Durable Task Scheduler (DTS) with Durable Functions.
 
-In the _AppHost.cs_ file of `AppHost`, add a Scheduler resource, create one or more Task Hubs, and pass the connection string and hub name to your Functions project:
+In the AppHost, add a Scheduler resource, create one or more Task Hubs, and pass the connection string and hub name to your Functions app resource:
 
 ```csharp
 using Aspire.Hosting;

--- a/src/Aspire.Hosting.Azure.Functions/README.md
+++ b/src/Aspire.Hosting.Azure.Functions/README.md
@@ -115,6 +115,7 @@ var taskHub = scheduler.AddTaskHub("taskhub").WithTaskHubName(taskHubName);
 ```
 ## Additional documentation
 
+- https://aspire.dev/integrations/gallery/?search=hosting
 - https://learn.microsoft.com/azure/azure-functions
 - https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler
 

--- a/src/Aspire.Hosting.Azure.Functions/README.md
+++ b/src/Aspire.Hosting.Azure.Functions/README.md
@@ -115,7 +115,7 @@ var taskHub = scheduler.AddTaskHub("taskhub").WithTaskHubName(taskHubName);
 ```
 ## Additional documentation
 
-- https://aspire.dev/integrations/
+- https://aspire.dev/integrations/gallery/
 - https://learn.microsoft.com/azure/azure-functions
 - https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler
 

--- a/src/Aspire.Hosting.Azure.Functions/README.md
+++ b/src/Aspire.Hosting.Azure.Functions/README.md
@@ -116,6 +116,7 @@ var taskHub = scheduler.AddTaskHub("taskhub").WithTaskHubName(taskHubName);
 ## Additional documentation
 
 - https://aspire.dev/integrations/gallery/
+- https://aspire.dev/integrations/cloud/azure/azure-functions/azure-functions-host/
 - https://learn.microsoft.com/azure/azure-functions
 - https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler
 

--- a/src/Aspire.Hosting.Azure.KeyVault/README.md
+++ b/src/Aspire.Hosting.Azure.KeyVault/README.md
@@ -96,7 +96,7 @@ builder.AddProject<Projects.MyApp>("myapp")
 
 ## Additional documentation
 
-https://aspire.dev/integrations/gallery/?search=hosting
+https://aspire.dev/integrations/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.KeyVault/README.md
+++ b/src/Aspire.Hosting.Azure.KeyVault/README.md
@@ -93,3 +93,11 @@ var keyVault = builder.AddAzureKeyVault("mykeyvault", (_, construct, kv) => {
 builder.AddProject<Projects.MyApp>("myapp")
        .WithReference(keyVault);
 ```
+
+## Additional documentation
+
+https://aspire.dev/integrations/gallery/?search=hosting
+
+## Feedback & contributing
+
+https://github.com/microsoft/aspire

--- a/src/Aspire.Hosting.Azure.KeyVault/README.md
+++ b/src/Aspire.Hosting.Azure.KeyVault/README.md
@@ -1,8 +1,6 @@
-# Azure Key Vault extensions library for Aspire application model
+# Azure Key Vault hosting integration
 
-Azure Key Vault is a cloud service that provides a secure storage of secrets, such as passwords and database connection strings.
-
-The Azure Key Vault extensions library allows you to extend the Aspire application model to support to provisioning Key Vaults as part of application development and testing.
+Use this integration to model, configure, and provision Azure Key Vault resources in an Aspire solution.
 
 ## Getting started
 
@@ -11,29 +9,24 @@ The Azure Key Vault extensions library allows you to extend the Aspire applicati
 * Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 * An Aspire project based on the starter template.
  
-### Install the package
+### Add the integration
 
-Install the Azure Key Vault extensions library for Aspire application model with [NuGet](https://www.nuget.org/packages/Aspire.Hosting.Azure.KeyVault):
+From your AppHost directory, add the `Aspire.Hosting.Azure.KeyVault` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.KeyVault
+```bash
+aspire add Aspire.Hosting.Azure.KeyVault
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -41,9 +34,11 @@ automatically.
 
 ## Usage examples
 
-### Adding a Key Vault resource to the Aspire application model
+### Adding a Key Vault resource to the AppHost model
 
-In order to provision a Key Vault resource as part of an Aspire application you need to add the resource via the `IDistributedApplicationBuilder` interface. The `builder.AddAzureKeyVault(...)` extension method is used to register a Key Vault resource with the application model. Then use the `WithReference` extension method on a resource to inject the necessary connection string information for accessing Key Vault into the application that depends on it.
+Add a Key Vault resource in the AppHost, then reference it from another resource with `WithReference`.
+
+**C#**
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -54,7 +49,18 @@ builder.AddProject<Projects.MyApp>("myapp")
        .WithReference(keyVault);
 ```
 
-Inside the the implementation of the application that depends on Key Vault (MyApp in this case) add the `Aspire.Azure.Security.KeyVault` package and follow the instructions in that package README to use the connection string that was injected by the code above.
+**TypeScript**
+
+```typescript
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const keyVault = await builder.addAzureKeyVault("mykeyvault");
+
+await builder.addNodeApp("myapp", "../my-app", "server.js")
+    .withReference(keyVault);
+```
 
 ## Connection Properties
 

--- a/src/Aspire.Hosting.Azure.KeyVault/README.md
+++ b/src/Aspire.Hosting.Azure.KeyVault/README.md
@@ -97,6 +97,7 @@ builder.AddProject<Projects.MyApp>("myapp")
 ## Additional documentation
 
 https://aspire.dev/integrations/gallery/
+https://aspire.dev/integrations/cloud/azure/azure-key-vault/azure-key-vault-host/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.KeyVault/README.md
+++ b/src/Aspire.Hosting.Azure.KeyVault/README.md
@@ -96,7 +96,7 @@ builder.AddProject<Projects.MyApp>("myapp")
 
 ## Additional documentation
 
-https://aspire.dev/integrations/
+https://aspire.dev/integrations/gallery/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.Kubernetes/README.md
+++ b/src/Aspire.Hosting.Azure.Kubernetes/README.md
@@ -43,7 +43,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/aks/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Kubernetes/README.md
+++ b/src/Aspire.Hosting.Azure.Kubernetes/README.md
@@ -44,6 +44,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/aks/
 * https://learn.microsoft.com/azure/aks/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Kubernetes/README.md
+++ b/src/Aspire.Hosting.Azure.Kubernetes/README.md
@@ -43,6 +43,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/aks/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Kubernetes/README.md
+++ b/src/Aspire.Hosting.Azure.Kubernetes/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.Kubernetes library
+# Azure Kubernetes Service hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure an Azure Kubernetes Service (AKS) environment.
+Use this integration to model, configure, and orchestrate an Azure Kubernetes Service (AKS) environment in an Aspire solution.
 
 ## Getting started
 
@@ -11,23 +11,34 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 Aspire shells out to `helm upgrade --install` to deploy the generated chart and any `AddHelmChart(...)` releases, and validates the Helm version up front so missing or older installs produce a clear actionable error instead of cryptic flag failures.
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Azure Kubernetes Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.Kubernetes` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.Kubernetes
+```bash
+aspire add Aspire.Hosting.Azure.Kubernetes
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add an AKS environment and deploy services to it:
+In the AppHost, add an AKS environment and deploy services to it:
+
+**C#**
 
 ```csharp
 var aks = builder.AddAzureKubernetesEnvironment("aks");
 
 var myService = builder.AddProject<Projects.MyService>()
     .WithComputeEnvironment(aks);
+```
+
+**TypeScript**
+
+```typescript
+const aks = await builder.addAzureKubernetesEnvironment("aks");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+    .withComputeEnvironment(aks);
 ```
 
 ## Additional documentation

--- a/src/Aspire.Hosting.Azure.Kubernetes/README.md
+++ b/src/Aspire.Hosting.Azure.Kubernetes/README.md
@@ -43,7 +43,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/aks/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Kusto/README.md
+++ b/src/Aspire.Hosting.Azure.Kusto/README.md
@@ -59,7 +59,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/en-us/kusto/
 * https://learn.microsoft.com/en-us/kusto/api/
 * https://learn.microsoft.com/en-us/azure/data-explorer/kusto-emulator-overview

--- a/src/Aspire.Hosting.Azure.Kusto/README.md
+++ b/src/Aspire.Hosting.Azure.Kusto/README.md
@@ -59,6 +59,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/en-us/kusto/
 * https://learn.microsoft.com/en-us/kusto/api/
 * https://learn.microsoft.com/en-us/azure/data-explorer/kusto-emulator-overview

--- a/src/Aspire.Hosting.Azure.Kusto/README.md
+++ b/src/Aspire.Hosting.Azure.Kusto/README.md
@@ -60,6 +60,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-data-explorer/
 * https://learn.microsoft.com/en-us/kusto/
 * https://learn.microsoft.com/en-us/kusto/api/
 * https://learn.microsoft.com/en-us/azure/data-explorer/kusto-emulator-overview

--- a/src/Aspire.Hosting.Azure.Kusto/README.md
+++ b/src/Aspire.Hosting.Azure.Kusto/README.md
@@ -1,20 +1,22 @@
-# Aspire.Hosting.Azure.Kusto library
+# Azure Data Explorer hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a Kusto resource.
+Use this integration to model, configure, and orchestrate a Kusto resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Azure Kusto Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.Kusto` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.Kusto
+```bash
+aspire add Aspire.Hosting.Azure.Kusto
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Kusto resource and consume the connection using the following method:
+In the AppHost, add a Kusto resource and reference it from another resource:
+
+**C#**
 
 ```csharp
 var db = builder.AddAzureKustoCluster("kusto")
@@ -23,6 +25,17 @@ var db = builder.AddAzureKustoCluster("kusto")
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(db);
+```
+
+**TypeScript**
+
+```typescript
+const db = await builder.addAzureKustoCluster("kusto")
+                .runAsEmulator()
+                .addReadWriteDatabase("mydb");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(db);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.Azure.Kusto/README.md
+++ b/src/Aspire.Hosting.Azure.Kusto/README.md
@@ -59,7 +59,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/en-us/kusto/
 * https://learn.microsoft.com/en-us/kusto/api/
 * https://learn.microsoft.com/en-us/azure/data-explorer/kusto-emulator-overview

--- a/src/Aspire.Hosting.Azure.Network/README.md
+++ b/src/Aspire.Hosting.Azure.Network/README.md
@@ -183,6 +183,7 @@ storage.ConfigureInfrastructure(infra =>
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-virtual-network/
 * https://learn.microsoft.com/azure/virtual-network/
 * https://learn.microsoft.com/azure/nat-gateway/
 * https://learn.microsoft.com/azure/private-link/

--- a/src/Aspire.Hosting.Azure.Network/README.md
+++ b/src/Aspire.Hosting.Azure.Network/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.Network library
+# Azure networking integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure Virtual Networks, Subnets, NAT Gateways, Public IP Addresses, Network Security Groups, Network Security Perimeters, and Private Endpoints.
+Use this integration to model, configure, and orchestrate Azure Virtual Networks, Subnets, NAT Gateways, Public IP Addresses, Network Security Groups, Network Security Perimeters, and Private Endpoints in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-Install the Aspire Azure Virtual Network Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.Network` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.Network
+```bash
+aspire add Aspire.Hosting.Azure.Network
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -40,10 +35,18 @@ automatically.
 
 ### Adding a Virtual Network
 
-In the _AppHost.cs_ file of `AppHost`, add a Virtual Network using the following method:
+In the AppHost, add a Virtual Network using the following method:
+
+**C#**
 
 ```csharp
 var vnet = builder.AddAzureVirtualNetwork("vnet");
+```
+
+**TypeScript**
+
+```typescript
+const vnet = await builder.addAzureVirtualNetwork("vnet");
 ```
 
 By default, the virtual network will use the address prefix `10.0.0.0/16`. You can specify a custom address prefix:

--- a/src/Aspire.Hosting.Azure.Network/README.md
+++ b/src/Aspire.Hosting.Azure.Network/README.md
@@ -182,7 +182,7 @@ storage.ConfigureInfrastructure(infra =>
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/virtual-network/
 * https://learn.microsoft.com/azure/nat-gateway/
 * https://learn.microsoft.com/azure/private-link/

--- a/src/Aspire.Hosting.Azure.Network/README.md
+++ b/src/Aspire.Hosting.Azure.Network/README.md
@@ -182,6 +182,7 @@ storage.ConfigureInfrastructure(infra =>
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/virtual-network/
 * https://learn.microsoft.com/azure/nat-gateway/
 * https://learn.microsoft.com/azure/private-link/

--- a/src/Aspire.Hosting.Azure.Network/README.md
+++ b/src/Aspire.Hosting.Azure.Network/README.md
@@ -182,7 +182,7 @@ storage.ConfigureInfrastructure(infra =>
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/virtual-network/
 * https://learn.microsoft.com/azure/nat-gateway/
 * https://learn.microsoft.com/azure/private-link/

--- a/src/Aspire.Hosting.Azure.OperationalInsights/README.md
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/README.md
@@ -48,7 +48,7 @@ var myService = builder.AddProject<Projects.MyService>()
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/azure-monitor/logs/log-analytics-workspace-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.OperationalInsights/README.md
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/README.md
@@ -48,6 +48,7 @@ var myService = builder.AddProject<Projects.MyService>()
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/azure-monitor/logs/log-analytics-workspace-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.OperationalInsights/README.md
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/README.md
@@ -48,7 +48,7 @@ var myService = builder.AddProject<Projects.MyService>()
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/azure-monitor/logs/log-analytics-workspace-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.OperationalInsights/README.md
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.OperationalInsights library
+# Azure Log Analytics hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure Log Analytics.
+Use this integration to model, configure, and orchestrate Azure Log Analytics in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-Install the Aspire Azure Operational Insights Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.OperationalInsights` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.OperationalInsights
+```bash
+aspire add Aspire.Hosting.Azure.OperationalInsights
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,7 +33,7 @@ automatically.
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add an Azure Log Analytics workspace and pass the workspace ID via an environment variable:
+In the AppHost, add an Azure Log Analytics workspace and pass the workspace ID via an environment variable:
 
 ```csharp
 var laws = builder.AddAzureLogAnalyticsWorkspace("laws");

--- a/src/Aspire.Hosting.Azure.OperationalInsights/README.md
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/README.md
@@ -49,6 +49,7 @@ var myService = builder.AddProject<Projects.MyService>()
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-log-analytics/
 * https://learn.microsoft.com/azure/azure-monitor/logs/log-analytics-workspace-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.PostgreSQL/README.md
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/README.md
@@ -86,7 +86,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/postgresql/flexible-server/overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.PostgreSQL/README.md
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/README.md
@@ -86,7 +86,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/postgresql/flexible-server/overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.PostgreSQL/README.md
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.PostgreSQL library
+# Azure Database for PostgreSQL hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure Database for PostgreSQL.
+Use this integration to model, configure, and orchestrate Azure Database for PostgreSQL in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Azure PostgreSQL Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.PostgreSQL` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.PostgreSQL
+```bash
+aspire add Aspire.Hosting.Azure.PostgreSQL
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,7 +33,9 @@ automatically.
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, register a Postgres database and consume the connection using the following methods:
+In the AppHost, register a Postgres database and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var postgresdb = builder.AddAzurePostgresFlexibleServer("pg")
@@ -48,10 +45,14 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(postgresdb);
 ```
 
-The `WithReference` method configures a connection in the `MyService` project named `postgresdb`. By default, `AddAzurePostgresFlexibleServer` configures [Microsoft Entra ID](https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-azure-ad-authentication) authentication. This requires changes to applications that need to connect to these resources. In the _Program.cs_ file of `MyService`, the database connection can be consumed using the client library [Aspire.Azure.Npgsql](https://www.nuget.org/packages/Aspire.Azure.Npgsql) or [Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL](https://www.nuget.org/packages/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL):
+**TypeScript**
 
-```csharp
-builder.AddAzureNpgsqlDataSource("postgresdb");
+```typescript
+const postgresdb = await builder.addAzurePostgresFlexibleServer("pg")
+                        .addDatabase("postgresdb");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(postgresdb);
 ```
 
 ## Connection Properties
@@ -85,8 +86,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://www.npgsql.org/doc/basic-usage.html
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/azure/postgresql/flexible-server/overview
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.PostgreSQL/README.md
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/README.md
@@ -87,6 +87,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-postgresql/azure-postgresql-host/
 * https://learn.microsoft.com/azure/postgresql/flexible-server/overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.PostgreSQL/README.md
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/README.md
@@ -86,6 +86,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/postgresql/flexible-server/overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Redis/README.md
+++ b/src/Aspire.Hosting.Azure.Redis/README.md
@@ -72,7 +72,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/azure-cache-for-redis/cache-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Redis/README.md
+++ b/src/Aspire.Hosting.Azure.Redis/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.Redis library
+# Azure Cache for Redis hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure Managed Redis.
+Use this integration to model, configure, and orchestrate Azure Managed Redis in an Aspire solution.
 
 > **Note**: The `AddAzureRedis` method is obsolete. Use `AddAzureManagedRedis` instead, which provisions Azure Managed Redis. Azure Cache for Redis announced its [retirement timeline](https://learn.microsoft.com/azure/azure-cache-for-redis/retirement-faq).
 
@@ -10,29 +10,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the `Aspire.Hosting.Azure.Redis` library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.Redis` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.Redis
+```bash
+aspire add Aspire.Hosting.Azure.Redis
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -40,7 +35,9 @@ automatically.
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, register an Azure Managed Redis resource using the following methods:
+In the AppHost, register an Azure Managed Redis resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var redis = builder.AddAzureManagedRedis("cache");
@@ -49,11 +46,13 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(redis);
 ```
 
-The `WithReference` method configures a connection in the `MyService` project named `cache`. By default, `AddAzureManagedRedis` configures [Microsoft Entra ID](https://learn.microsoft.com/azure/redis/entra-for-authentication) authentication. This requires changes to applications that need to connect to these resources. In the _Program.cs_ file of `MyService`, the redis connection can be consumed using the client library [Aspire.Microsoft.Azure.StackExchangeRedis](https://www.nuget.org/packages/Aspire.Microsoft.Azure.StackExchangeRedis):
+**TypeScript**
 
-```csharp
-builder.AddRedisClientBuilder("cache")
-       .WithAzureAuthentication();
+```typescript
+const redis = await builder.addAzureManagedRedis("cache");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(redis);
 ```
 
 ## Connection Properties
@@ -73,8 +72,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://stackexchange.github.io/StackExchange.Redis/Basics
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/azure/azure-cache-for-redis/cache-overview
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.Redis/README.md
+++ b/src/Aspire.Hosting.Azure.Redis/README.md
@@ -72,6 +72,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/azure-cache-for-redis/cache-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Redis/README.md
+++ b/src/Aspire.Hosting.Azure.Redis/README.md
@@ -73,6 +73,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-cache-redis/azure-cache-redis-host/
 * https://learn.microsoft.com/azure/azure-cache-for-redis/cache-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Redis/README.md
+++ b/src/Aspire.Hosting.Azure.Redis/README.md
@@ -72,7 +72,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/azure-cache-for-redis/cache-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Search/README.md
+++ b/src/Aspire.Hosting.Azure.Search/README.md
@@ -66,6 +66,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-ai-search/azure-ai-search-host/
 * https://learn.microsoft.com/azure/search/search-what-is-azure-search
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Search/README.md
+++ b/src/Aspire.Hosting.Azure.Search/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.Search library
+# Azure AI Search hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure AI Search Service.
+Use this integration to model, configure, and orchestrate Azure AI Search Service in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-Install the Aspire Azure AI Search Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.Search` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.Search
+```bash
+aspire add Aspire.Hosting.Azure.Search
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,7 +33,9 @@ automatically.
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add an Azure AI Search service and consume the connection using the following methods:
+In the AppHost, add an Azure AI Search service and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var search = builder.AddAzureSearch("search");
@@ -47,10 +44,13 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(search);
 ```
 
-The `WithReference` method passes that connection information into a connection string named `search` in the `MyService` project. In the _Program.cs_ file of `MyService`, the connection can be consumed using the client library [Aspire.Azure.Search.Documents](https://www.nuget.org/packages/Aspire.Azure.Search.Documents):
+**TypeScript**
 
-```csharp
-builder.AddAzureSearchClient("search");
+```typescript
+const search = await builder.addAzureSearch("search");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(search);
 ```
 
 ## Connection Properties
@@ -65,8 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://learn.microsoft.com/azure/search/search-howto-dotnet-sdk
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/azure/search/search-what-is-azure-search
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.Search/README.md
+++ b/src/Aspire.Hosting.Azure.Search/README.md
@@ -65,7 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/search/search-what-is-azure-search
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Search/README.md
+++ b/src/Aspire.Hosting.Azure.Search/README.md
@@ -65,7 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/search/search-what-is-azure-search
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Search/README.md
+++ b/src/Aspire.Hosting.Azure.Search/README.md
@@ -65,6 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/search/search-what-is-azure-search
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.ServiceBus/README.md
+++ b/src/Aspire.Hosting.Azure.ServiceBus/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.ServiceBus library
+# Azure Service Bus hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure Service Bus.
+Use this integration to model, configure, and orchestrate Azure Service Bus in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-Install the Aspire Azure Service Bus Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.ServiceBus` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.ServiceBus
+```bash
+aspire add Aspire.Hosting.Azure.ServiceBus
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,7 +33,9 @@ automatically.
 
 ## Usage example
 
-In the _AppHost.cs_ file of `AppHost`, add a Service Bus connection and consume the connection using the following methods:
+In the AppHost, add a Service Bus connection and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var serviceBus = builder.AddAzureServiceBus("sb");
@@ -47,10 +44,13 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(serviceBus);
 ```
 
-The `WithReference` method passes that connection information into a connection string named `sb` in the `MyService` project. In the _Program.cs_ file of `MyService`, the connection can be consumed using the client library [Aspire.Azure.Messaging.ServiceBus](https://www.nuget.org/packages/Aspire.Azure.Messaging.ServiceBus):
+**TypeScript**
 
-```csharp
-builder.AddAzureServiceBusClient("sb");
+```typescript
+const serviceBus = await builder.addAzureServiceBus("sb");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(serviceBus);
 ```
 
 ## Connection Properties
@@ -97,8 +97,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.ServiceBus/README.md
+++ b/src/Aspire.Hosting.Azure.ServiceBus/README.md
@@ -97,6 +97,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.ServiceBus/README.md
+++ b/src/Aspire.Hosting.Azure.ServiceBus/README.md
@@ -98,6 +98,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-service-bus/azure-service-bus-host/
 * https://learn.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.ServiceBus/README.md
+++ b/src/Aspire.Hosting.Azure.ServiceBus/README.md
@@ -97,7 +97,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.ServiceBus/README.md
+++ b/src/Aspire.Hosting.Azure.ServiceBus/README.md
@@ -97,7 +97,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.SignalR/README.md
+++ b/src/Aspire.Hosting.Azure.SignalR/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.SignalR library
+# Azure SignalR Service hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure SignalR.
+Use this integration to model, configure, and orchestrate Azure SignalR in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-Install the Aspire Azure SignalR Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.SignalR` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.SignalR
+```bash
+aspire add Aspire.Hosting.Azure.SignalR
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,7 +33,9 @@ automatically.
 
 ## Usage example
 
-In the _AppHost.cs_ file of `AppHost`, add a SignalR connection and consume the connection using the following methods:
+In the AppHost, add a SignalR connection and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var signalR = builder.AddAzureSignalR("sr");
@@ -47,11 +44,13 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(signalR);
 ```
 
-The `WithReference` method configures a connection in the `MyService` project named `sr`. In the _Program.cs_ file of `MyService`, the Azure SignalR connection can be consumed using the client library [Microsoft.Azure.SignalR](https://www.nuget.org/packages/Microsoft.Azure.SignalR):
+**TypeScript**
 
-```csharp
-builder.Services.AddSignalR()
-    .AddNamedAzureSignalR("sr");
+```typescript
+const signalR = await builder.addAzureSignalR("sr");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(signalR);
 ```
 
 ## Connection Properties
@@ -66,7 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/azure/azure-signalr/signalr-overview
 * https://aspire.dev/integrations/cloud/azure/azure-signalr/
 * https://learn.microsoft.com/azure/azure-signalr/signalr-overview
 

--- a/src/Aspire.Hosting.Azure.SignalR/README.md
+++ b/src/Aspire.Hosting.Azure.SignalR/README.md
@@ -65,7 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/azure-signalr/signalr-overview
 * https://aspire.dev/integrations/cloud/azure/azure-signalr/
 * https://learn.microsoft.com/azure/azure-signalr/signalr-overview

--- a/src/Aspire.Hosting.Azure.SignalR/README.md
+++ b/src/Aspire.Hosting.Azure.SignalR/README.md
@@ -65,6 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/azure-signalr/signalr-overview
 * https://aspire.dev/integrations/cloud/azure/azure-signalr/
 * https://learn.microsoft.com/azure/azure-signalr/signalr-overview

--- a/src/Aspire.Hosting.Azure.SignalR/README.md
+++ b/src/Aspire.Hosting.Azure.SignalR/README.md
@@ -65,7 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/azure-signalr/signalr-overview
 * https://aspire.dev/integrations/cloud/azure/azure-signalr/
 * https://learn.microsoft.com/azure/azure-signalr/signalr-overview

--- a/src/Aspire.Hosting.Azure.SignalR/README.md
+++ b/src/Aspire.Hosting.Azure.SignalR/README.md
@@ -68,7 +68,6 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 * https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/azure-signalr/signalr-overview
 * https://aspire.dev/integrations/cloud/azure/azure-signalr/
-* https://learn.microsoft.com/azure/azure-signalr/signalr-overview
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.SignalR/README.md
+++ b/src/Aspire.Hosting.Azure.SignalR/README.md
@@ -66,8 +66,8 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-signalr/azure-signalr-host/
 * https://learn.microsoft.com/azure/azure-signalr/signalr-overview
-* https://aspire.dev/integrations/cloud/azure/azure-signalr/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.Sql/README.md
+++ b/src/Aspire.Hosting.Azure.Sql/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.Sql library
+# Azure SQL Database hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure SQL DB.
+Use this integration to model, configure, and orchestrate Azure SQL DB in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-Install the Aspire Azure SQL Server Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.Sql` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.Sql
+```bash
+aspire add Aspire.Hosting.Azure.Sql
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,7 +33,9 @@ automatically.
 
 ## Usage example
 
-In the _AppHost.cs_ file of `AppHost`, register a SqlServer database and consume the connection using the following methods:
+In the AppHost, register a SqlServer database and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var sql = builder.AddAzureSqlServer("sql")
@@ -48,10 +45,14 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(sql);
 ```
 
-The `WithReference` method configures a connection in the `MyService` project named `sqldata`. In the _Program.cs_ file of `MyService`, the sql connection can be consumed using the client library [Aspire.Microsoft.Data.SqlClient](https://www.nuget.org/packages/Aspire.Microsoft.Data.SqlClient):
+**TypeScript**
 
-```csharp
-builder.AddSqlServerClient("sqldata");
+```typescript
+const sql = await builder.addAzureSqlServer("sql")
+                 .addDatabase("sqldata");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(sql);
 ```
 
 ## Connection Properties
@@ -115,9 +116,7 @@ var sqlSrv = builder.AddAzureSqlServer("sqlsrv")
 
 ## Additional documentation
 
-* https://learn.microsoft.com/dotnet/framework/data/adonet/sql/
-* https://learn.microsoft.com/dotnet/api/system.data.sqlclient.sqlconnection
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/azure/azure-sql/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.Sql/README.md
+++ b/src/Aspire.Hosting.Azure.Sql/README.md
@@ -116,7 +116,7 @@ var sqlSrv = builder.AddAzureSqlServer("sqlsrv")
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/azure-sql/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Sql/README.md
+++ b/src/Aspire.Hosting.Azure.Sql/README.md
@@ -116,6 +116,7 @@ var sqlSrv = builder.AddAzureSqlServer("sqlsrv")
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/azure-sql/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Sql/README.md
+++ b/src/Aspire.Hosting.Azure.Sql/README.md
@@ -117,6 +117,7 @@ var sqlSrv = builder.AddAzureSqlServer("sqlsrv")
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-sql-database/azure-sql-database-host/
 * https://learn.microsoft.com/azure/azure-sql/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Sql/README.md
+++ b/src/Aspire.Hosting.Azure.Sql/README.md
@@ -116,7 +116,7 @@ var sqlSrv = builder.AddAzureSqlServer("sqlsrv")
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/azure-sql/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Storage/README.md
+++ b/src/Aspire.Hosting.Azure.Storage/README.md
@@ -176,7 +176,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/storage/common/storage-introduction
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Storage/README.md
+++ b/src/Aspire.Hosting.Azure.Storage/README.md
@@ -176,6 +176,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/storage/common/storage-introduction
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Storage/README.md
+++ b/src/Aspire.Hosting.Azure.Storage/README.md
@@ -176,7 +176,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/storage/common/storage-introduction
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Storage/README.md
+++ b/src/Aspire.Hosting.Azure.Storage/README.md
@@ -177,6 +177,9 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-storage-blobs/azure-storage-blobs-host/
+* https://aspire.dev/integrations/cloud/azure/azure-storage-queues/azure-storage-queues-host/
+* https://aspire.dev/integrations/cloud/azure/azure-storage-tables/azure-storage-tables-host/
 * https://learn.microsoft.com/azure/storage/common/storage-introduction
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.Storage/README.md
+++ b/src/Aspire.Hosting.Azure.Storage/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.Storage library
+# Azure Storage hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure Storage.
+Use this integration to model, configure, and orchestrate Azure Storage in an Aspire solution.
 
 ## Getting started
 
@@ -8,29 +8,24 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-Install the Aspire Azure Storage Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.Storage` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.Storage
+```bash
+aspire add Aspire.Hosting.Azure.Storage
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,7 +33,9 @@ automatically.
 
 ## Usage example
 
-In the _AppHost.cs_ file of `AppHost`, add a Blob (can use tables or queues also) Storage connection and consume the connection using the following methods:
+In the AppHost, add a Blob (can use tables or queues also) Storage connection and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var blobs = builder.AddAzureStorage("storage").AddBlobs("blobs");
@@ -47,10 +44,13 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(blobs);
 ```
 
-The `WithReference` method passes that connection information into a connection string named `blobs` in the `MyService` project. In the _Program.cs_ file of `MyService`, the connection can be consumed using the client library [Aspire.Azure.Storage.Blobs](https://www.nuget.org/packages/Aspire.Azure.Storage.Blobs):
+**TypeScript**
 
-```csharp
-builder.AddAzureBlobServiceClient("blobs");
+```typescript
+const blobs = await builder.addAzureStorage("storage").addBlobs("blobs");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(blobs);
 ```
 
 ## Creating and using blob containers and queues directly
@@ -64,20 +64,12 @@ var storage = builder.AddAzureStorage("storage");
 var container = storage.AddBlobContainer("my-container");
 ```
 
-You can then pass the container reference to a project:
+The container reference can be passed to another resource:
 
 ```csharp
 builder.AddProject<Projects.MyService>()
        .WithReference(container);
 ```
-
-In your service, consume the container using:
-
-```csharp
-builder.AddAzureBlobContainerClient("my-container");
-```
-
-This will register a singleton of type `BlobContainerClient`.
 
 ### Adding a queue
 
@@ -86,22 +78,14 @@ var storage = builder.AddAzureStorage("storage");
 var queue = storage.AddQueue("my-queue");
 ```
 
-Pass the queue reference to a project:
+The queue reference can be passed to another resource:
 
 ```csharp
 builder.AddProject<Projects.MyService>()
        .WithReference(queue);
 ```
 
-In your service, consume the queue using:
-
-```csharp
-builder.AddAzureQueue("my-queue");
-```
-
-This will register a singleton of type `QueueClient`.
-
-This approach allows you to define and use specific blob containers and queues as first-class resources in your Aspire application model.
+This approach allows you to define and reference specific blob containers and queues as first-class resources in your AppHost model.
 
 ## Creating and using data lake
 ```csharp
@@ -110,17 +94,10 @@ var dataLake = storage.AddDataLake("data-lake");
 var fileSystem = storage.AddDataLakeFileSystem("data-lake-file-system");
 ```
 
-You can then pass the references to a project:
+The references can be passed to a project:
 
 ```csharp
 api.WithReference(dataLake).WithReference(fileSystem);
-```
-
-In your service, consume the services using:
-
-```csharp
-builder.AddAzureDataLakeServiceClient("data-lake");
-builder.AddAzureDataLakeFileSystemClient("data-lake-file-system");
 ```
 
 ## Connection Properties
@@ -199,8 +176,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Azure.Storage.Blobs/README.md
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/azure/storage/common/storage-introduction
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.WebPubSub/README.md
+++ b/src/Aspire.Hosting.Azure.WebPubSub/README.md
@@ -51,6 +51,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-web-pubsub/azure-web-pubsub-host/
 * https://learn.microsoft.com/azure/azure-web-pubsub/overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.WebPubSub/README.md
+++ b/src/Aspire.Hosting.Azure.WebPubSub/README.md
@@ -50,7 +50,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/azure-web-pubsub/overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.WebPubSub/README.md
+++ b/src/Aspire.Hosting.Azure.WebPubSub/README.md
@@ -50,7 +50,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/azure-web-pubsub/overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure.WebPubSub/README.md
+++ b/src/Aspire.Hosting.Azure.WebPubSub/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Azure.WebPubSub library
+# Azure Web PubSub hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Azure Web PubSub.
+Use this integration to model, configure, and orchestrate Azure Web PubSub in an Aspire solution.
 
 ## Getting started
 
@@ -8,23 +8,34 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-Install the Aspire Azure Web PubSub Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure.WebPubSub` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure.WebPubSub
+```bash
+aspire add Aspire.Hosting.Azure.WebPubSub
 ```
 
 ## Usage example
 
-In the _AppHost.cs_ file of `AppHost`, add a WebPubSub connection and consume the connection using the following methods:
+In the AppHost, add a WebPubSub connection and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var wps = builder.AddAzureWebPubSub("wps1");
 
 var web = builder.AddProject<Projects.WebPubSubWeb>("webfrontend")
                        .WithReference(wps);
+```
+
+**TypeScript**
+
+```typescript
+const wps = await builder.addAzureWebPubSub("wps1");
+
+const web = await builder.addNodeApp("webfrontend", "../web-frontend", "server.js")
+                       .withReference(wps);
 ```
 
 ## Connection Properties
@@ -39,7 +50,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/azure/azure-web-pubsub/overview
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.WebPubSub/README.md
+++ b/src/Aspire.Hosting.Azure.WebPubSub/README.md
@@ -50,6 +50,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/azure-web-pubsub/overview
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Azure/README.md
+++ b/src/Aspire.Hosting.Azure/README.md
@@ -51,6 +51,7 @@ const bicepResource = await builder.addBicepTemplate("bicep", "template.bicep")
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://aspire.dev/integrations/cloud/azure/overview/
 * https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
 

--- a/src/Aspire.Hosting.Azure/README.md
+++ b/src/Aspire.Hosting.Azure/README.md
@@ -51,7 +51,7 @@ const bicepResource = await builder.addBicepTemplate("bicep", "template.bicep")
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://aspire.dev/integrations/cloud/azure/overview/
 * https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
 

--- a/src/Aspire.Hosting.Azure/README.md
+++ b/src/Aspire.Hosting.Azure/README.md
@@ -1,4 +1,4 @@
-# Aspire.Hosting.Azure library
+# Azure provisioning integration
 
 Provides core extensions to the Aspire hosting model for Azure services.
 
@@ -8,29 +8,24 @@ Provides core extensions to the Aspire hosting model for Azure services.
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Azure Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Azure` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Azure
+```bash
+aspire add Aspire.Hosting.Azure
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 > NOTE: Developers must have Owner access to the target subscription so that role assignments
@@ -38,13 +33,20 @@ automatically.
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a resource based on a Bicep template:
+In the AppHost, add a resource based on a Bicep template:
+
+**C#**
 
 ```csharp
 var bicepResource = builder.AddBicepTemplate("bicep", "template.bicep")
                            .WithParameter("parametername", "parametervalue");
-});
+```
 
+**TypeScript**
+
+```typescript
+const bicepResource = await builder.addBicepTemplate("bicep", "template.bicep")
+                           .withParameter("parametername", "parametervalue");
 ```
 
 ## Additional documentation

--- a/src/Aspire.Hosting.Azure/README.md
+++ b/src/Aspire.Hosting.Azure/README.md
@@ -51,7 +51,7 @@ const bicepResource = await builder.addBicepTemplate("bicep", "template.bicep")
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://aspire.dev/integrations/cloud/azure/overview/
 * https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
 

--- a/src/Aspire.Hosting.DevTunnels/README.md
+++ b/src/Aspire.Hosting.DevTunnels/README.md
@@ -236,7 +236,7 @@ The logging helps you verify that your tunnel configuration is working as expect
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * [Aspire documentation](https://aspire.dev/integrations/devtools/dev-tunnels/)
 * [Dev tunnels service](https://learn.microsoft.com/azure/developer/dev-tunnels/overview)
 * [Dev tunnels FAQ](https://learn.microsoft.com/azure/developer/dev-tunnels/faq)

--- a/src/Aspire.Hosting.DevTunnels/README.md
+++ b/src/Aspire.Hosting.DevTunnels/README.md
@@ -1,4 +1,4 @@
-# Aspire.Hosting.DevTunnels library
+# Dev tunnels hosting integration
 
 Provides extension methods and resource definitions for an Aspire AppHost to expose local application endpoints publicly via a secure [dev tunnel](https://learn.microsoft.com/azure/developer/dev-tunnels/overview).  
 Dev tunnels are useful for:
@@ -12,18 +12,12 @@ Dev tunnels are useful for:
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the `Aspire.Hosting.DevTunnels` library via NuGet:
-
-```dotnetcli
-dotnet add package Aspire.Hosting.DevTunnels
-```
-
-Or using the Aspire CLI:
+From your AppHost directory, add the `Aspire.Hosting.DevTunnels` integration with the Aspire CLI:
 
 ```bash
-aspire add devtunnels
+aspire add Aspire.Hosting.DevTunnels
 ```
 
 ### Install the devtunnel CLI
@@ -36,6 +30,8 @@ Before you create a dev tunnel, you first need to download and install the devtu
 
 ### Expose all endpoints on a project
 
+**C#**
+
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -45,6 +41,21 @@ var tunnel = builder.AddDevTunnel("mytunnel")
                     .WithReference(web);
 
 builder.Build().Run();
+```
+
+**TypeScript**
+
+```typescript
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const web = await builder.addNodeApp("web", "../web", "server.js");
+
+const tunnel = await builder.addDevTunnel("mytunnel")
+                    .withReference(web);
+
+await builder.build().run();
 ```
 
 ### Enable anonymous (public) access
@@ -69,7 +80,7 @@ var tunnel = builder.AddDevTunnel("apitunnel")
 You can control anonymous access at the port (endpoint) level using the overload of `WithReference` that accepts a `bool allowAnonymous` parameter:
 
 ```csharp
-var api = builder.AddProject<Projects.ApiService>("api");
+var api = builder.AddProject<Projects.Api>("api");
 
 var tunnel = builder.AddDevTunnel("mixedaccess")
                     .WithReference(api.GetEndpoint("public"), allowAnonymous: true)

--- a/src/Aspire.Hosting.DevTunnels/README.md
+++ b/src/Aspire.Hosting.DevTunnels/README.md
@@ -236,7 +236,7 @@ The logging helps you verify that your tunnel configuration is working as expect
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * [Aspire documentation](https://aspire.dev/integrations/devtools/dev-tunnels/)
 * [Dev tunnels service](https://learn.microsoft.com/azure/developer/dev-tunnels/overview)
 * [Dev tunnels FAQ](https://learn.microsoft.com/azure/developer/dev-tunnels/faq)

--- a/src/Aspire.Hosting.DevTunnels/README.md
+++ b/src/Aspire.Hosting.DevTunnels/README.md
@@ -236,6 +236,7 @@ The logging helps you verify that your tunnel configuration is working as expect
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * [Aspire documentation](https://aspire.dev/integrations/devtools/dev-tunnels/)
 * [Dev tunnels service](https://learn.microsoft.com/azure/developer/dev-tunnels/overview)
 * [Dev tunnels FAQ](https://learn.microsoft.com/azure/developer/dev-tunnels/faq)

--- a/src/Aspire.Hosting.DevTunnels/README.md
+++ b/src/Aspire.Hosting.DevTunnels/README.md
@@ -237,7 +237,7 @@ The logging helps you verify that your tunnel configuration is working as expect
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
-* [Aspire documentation](https://aspire.dev/integrations/devtools/dev-tunnels/)
+* https://aspire.dev/integrations/devtools/dev-tunnels/
 * [Dev tunnels service](https://learn.microsoft.com/azure/developer/dev-tunnels/overview)
 * [Dev tunnels FAQ](https://learn.microsoft.com/azure/developer/dev-tunnels/faq)
 

--- a/src/Aspire.Hosting.Docker/README.md
+++ b/src/Aspire.Hosting.Docker/README.md
@@ -34,7 +34,7 @@ aspire publish -o docker-compose-artifacts
 
 ## Additional documentation
 
-https://aspire.dev/integrations/
+https://aspire.dev/integrations/gallery/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Docker/README.md
+++ b/src/Aspire.Hosting.Docker/README.md
@@ -1,23 +1,31 @@
-# Aspire.Hosting.Docker library
+# Docker hosting integration
 
 Provides publishing extensions to Aspire for Docker Compose.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Docker Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Docker` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Docker
+```bash
+aspire add Aspire.Hosting.Docker
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add the environment:
+In the AppHost, add the environment:
+
+**C#**
 
 ```csharp
 builder.AddDockerComposeEnvironment("compose");
+```
+
+**TypeScript**
+
+```typescript
+await builder.addDockerComposeEnvironment("compose");
 ```
 
 ```shell

--- a/src/Aspire.Hosting.Docker/README.md
+++ b/src/Aspire.Hosting.Docker/README.md
@@ -32,6 +32,10 @@ await builder.addDockerComposeEnvironment("compose");
 aspire publish -o docker-compose-artifacts
 ```
 
+## Additional documentation
+
+https://aspire.dev/integrations/gallery/?search=hosting
+
 ## Feedback & contributing
 
 https://github.com/microsoft/aspire

--- a/src/Aspire.Hosting.Docker/README.md
+++ b/src/Aspire.Hosting.Docker/README.md
@@ -34,7 +34,7 @@ aspire publish -o docker-compose-artifacts
 
 ## Additional documentation
 
-https://aspire.dev/integrations/gallery/?search=hosting
+https://aspire.dev/integrations/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Docker/README.md
+++ b/src/Aspire.Hosting.Docker/README.md
@@ -35,6 +35,7 @@ aspire publish -o docker-compose-artifacts
 ## Additional documentation
 
 https://aspire.dev/integrations/gallery/
+https://aspire.dev/integrations/compute/docker/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.EntityFrameworkCore/README.md
+++ b/src/Aspire.Hosting.EntityFrameworkCore/README.md
@@ -248,7 +248,7 @@ Similarly you can use `PublishAsMigrationScript()` if you also want a raw SQL sc
 
 ## Additional documentation
 
-https://aspire.dev/integrations/gallery/?search=hosting
+https://aspire.dev/integrations/
 https://learn.microsoft.com/ef/core/managing-schemas/migrations/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.EntityFrameworkCore/README.md
+++ b/src/Aspire.Hosting.EntityFrameworkCore/README.md
@@ -248,7 +248,7 @@ Similarly you can use `PublishAsMigrationScript()` if you also want a raw SQL sc
 
 ## Additional documentation
 
-https://aspire.dev/integrations/
+https://aspire.dev/integrations/gallery/
 https://learn.microsoft.com/ef/core/managing-schemas/migrations/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.EntityFrameworkCore/README.md
+++ b/src/Aspire.Hosting.EntityFrameworkCore/README.md
@@ -249,6 +249,7 @@ Similarly you can use `PublishAsMigrationScript()` if you also want a raw SQL sc
 ## Additional documentation
 
 https://aspire.dev/integrations/gallery/
+https://aspire.dev/integrations/databases/efcore/migrations/
 https://learn.microsoft.com/ef/core/managing-schemas/migrations/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.EntityFrameworkCore/README.md
+++ b/src/Aspire.Hosting.EntityFrameworkCore/README.md
@@ -1,38 +1,41 @@
-# Aspire.Hosting.EntityFrameworkCore library
+# Entity Framework Core hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Entity Framework Core migration management.
+Use this integration to model, configure, and orchestrate Entity Framework Core migration management in an Aspire solution.
 
 ## Getting started
 
 ### Prerequisites
 
-The target project must reference `Microsoft.EntityFrameworkCore.Design`. Add the following to your project file:
+The target project must expose EF Core design-time services so migration commands can create design-time `DbContext` instances.
 
-```xml
-<ItemGroup>
-  <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="x.y.z" />
-</ItemGroup>
-```
+### Add the integration
 
-Note: Using `dotnet add package` will add the reference with `PrivateAssets="All"` which may not work correctly with the migration commands.
+From your AppHost directory, add the `Aspire.Hosting.EntityFrameworkCore` integration with the Aspire CLI:
 
-### Install the package
-
-In your AppHost project, install the Aspire EntityFrameworkCore Hosting library with [NuGet](https://www.nuget.org):
-
-```dotnetcli
-dotnet add package Aspire.Hosting.EntityFrameworkCore
+```bash
+aspire add Aspire.Hosting.EntityFrameworkCore
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add EF migrations to a project resource:
+In the AppHost, add EF migrations to a project resource:
+
+**C#**
 
 ```csharp
 var api = builder.AddProject<Projects.Api>("api");
 
 // Add EF migrations for a specific DbContext
 var apiMigrations = api.AddEFMigrations("api-migrations", "MyApp.Data.MyDbContext");
+```
+
+**TypeScript**
+
+```typescript
+const api = await builder.addProject("api", "../Api");
+
+// Add EF migrations for a specific DbContext
+const apiMigrations = await api.addEFMigrations("api-migrations", "MyApp.Data.MyDbContext");
 ```
 
 ### Resource Commands
@@ -48,20 +51,20 @@ When `AddEFMigrations` is called, the migration resource appears in the Aspire D
 | Remove Migration | Remove the last migration |
 | Get Database Status | Show the current migration status |
 
-> **Note:** After adding or removing a migration, all commands are disabled until the target project is recompiled. This prevents executing commands against stale assemblies.
+> **Note:** After adding or removing a migration, all commands are disabled until the target app is rebuilt. This prevents executing commands against stale assemblies.
 
-### Automatic Tool Installation
+### Automatic tool installation
 
-The `dotnet-ef` tool is automatically downloaded and executed using `dotnet tool exec` when commands are run. You don't need to install it globally or in a local tool manifest.
+The EF migration command-line tool is downloaded and executed on demand when commands run. You don't need to install it globally.
 
-### Configuring the dotnet-ef Tool
+### Configuring the migration tool
 
-You can customize the `dotnet-ef` tool version, NuGet sources, or allow prerelease versions:
+You can customize the migration tool version, package sources, or allow prerelease versions:
 
 ```csharp
 var api = builder.AddProject<Projects.Api>("api");
 
-// Use a specific version of dotnet-ef
+// Use a specific migration tool version
 var apiMigrations = api.AddEFMigrations("api-migrations", "MyApp.Data.MyDbContext",
     configureToolResource: tool =>
     {
@@ -75,12 +78,11 @@ var apiMigrations = api.AddEFMigrations("api-migrations", "MyApp.Data.MyDbContex
         tool.WithToolPrerelease();
     });
 
-// Use a custom NuGet source
+// Use a custom package source
 var apiMigrations = api.AddEFMigrations("api-migrations", "MyApp.Data.MyDbContext",
     configureToolResource: tool =>
     {
-        tool.WithToolSource("https://api.nuget.org/v3/index.json")
-            .WithToolSource("https://my-feed.example.com/v3/index.json");
+        tool.WithToolSource("https://my-feed.example.com/v3/index.json");
     });
 ```
 
@@ -124,13 +126,8 @@ When migrations are in a different project than the startup project, use `WithMi
 ```csharp
 var startup = builder.AddProject<Projects.Api>("api");
 
-// Using a project metadata type (recommended)
 var apiMigrations = startup.AddEFMigrations("api-migrations", "MyApp.Data.MyDbContext")
     .WithMigrationsProject<Projects.Data>();
-
-// Or using a project path
-var apiMigrations = startup.AddEFMigrations("api-migrations", "MyApp.Data.MyDbContext")
-    .WithMigrationsProject("../MyApp.Data/MyApp.Data.csproj");
 ```
 
 ### Multiple DbContexts
@@ -177,8 +174,7 @@ var apiMigrations = api.AddEFMigrations("api-migrations", "MyApp.Data.MyDbContex
     .PublishAsMigrationBundle(publishContainer: true);
 ```
 
-- The generated `Dockerfile` uses `mcr.microsoft.com/dotnet/runtime:10.0` (or
-  `mcr.microsoft.com/dotnet/runtime-deps:10.0` when `selfContained: true`).
+- The generated `Dockerfile` uses the runtime image selected by the integration for the configured target runtime.
 - The `targetRuntime` argument defaults to `linux-x64` when `publishContainer: true`; override it
   explicitly to publish for a different architecture (e.g., `linux-arm64`).
 - The container reads its connection string from the standard environment variable that aspire wires
@@ -245,17 +241,15 @@ does not add any compute resource to the deployment manifest. Execute the bundle
 for your deployment flow:
 
 ```bash
-./<publish-output>/efmigrations/api-migrations --connection "$CONNECTION_STRING" --verbove
+./<publish-output>/efmigrations/api-migrations --connection "$CONNECTION_STRING" --verbose
 ```
 
 Similarly you can use `PublishAsMigrationScript()` if you also want a raw SQL script produced.
 
 ## Additional documentation
 
-<!-- TODO: Update this to the EntityFrameworkCore-specific page once published, https://github.com/microsoft/aspire.dev/issues/536 -->
-https://learn.microsoft.com/dotnet/aspire/
 https://learn.microsoft.com/ef/core/managing-schemas/migrations/
 
 ## Feedback & contributing
 
-https://github.com/dotnet/aspire
+https://github.com/microsoft/aspire

--- a/src/Aspire.Hosting.EntityFrameworkCore/README.md
+++ b/src/Aspire.Hosting.EntityFrameworkCore/README.md
@@ -248,6 +248,7 @@ Similarly you can use `PublishAsMigrationScript()` if you also want a raw SQL sc
 
 ## Additional documentation
 
+https://aspire.dev/integrations/gallery/?search=hosting
 https://learn.microsoft.com/ef/core/managing-schemas/migrations/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -219,7 +219,7 @@ var agent2 = project.AddPromptAgent(chat, "agent-2").WithTool(codeInterp);
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://learn.microsoft.com/azure/ai-foundry/what-is-azure-ai-foundry
 * https://learn.microsoft.com/azure/ai-foundry/foundry-local/
 

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -1,4 +1,4 @@
-# Azure AI Foundry hosting integration
+# Microsoft Foundry hosting integration
 
 Use this integration to model, configure, and orchestrate Microsoft Foundry in an Aspire solution.
 

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -219,7 +219,7 @@ var agent2 = project.AddPromptAgent(chat, "agent-2").WithTool(codeInterp);
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://learn.microsoft.com/azure/ai-foundry/what-is-azure-ai-foundry
 * https://learn.microsoft.com/azure/ai-foundry/foundry-local/
 

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -219,6 +219,7 @@ var agent2 = project.AddPromptAgent(chat, "agent-2").WithTool(codeInterp);
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://learn.microsoft.com/azure/ai-foundry/what-is-azure-ai-foundry
 * https://learn.microsoft.com/azure/ai-foundry/foundry-local/
 

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -220,6 +220,7 @@ var agent2 = project.AddPromptAgent(chat, "agent-2").WithTool(codeInterp);
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host/
 * https://learn.microsoft.com/azure/ai-foundry/what-is-azure-ai-foundry
 * https://learn.microsoft.com/azure/ai-foundry/foundry-local/
 

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Foundry library
+# Azure AI Foundry hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Microsoft Foundry.
+Use this integration to model, configure, and orchestrate Microsoft Foundry in an Aspire solution.
 
 ## Getting started
 
@@ -8,34 +8,31 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Microsoft Foundry Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Foundry` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Foundry
+```bash
+aspire add Aspire.Hosting.Foundry
 ```
 
 ## Configure Azure Provisioning for local development
 
-Adding Azure resources to the Aspire application model will automatically enable development-time provisioning
+Adding Azure resources to the AppHost model will automatically enable development-time provisioning
 for Azure resources so that you don't need to configure them manually. Provisioning requires a number of settings
-to be available via .NET configuration. Set these values in user secrets in order to allow resources to be configured
-automatically.
+to be available via AppHost configuration. From your AppHost directory, set these values with `aspire secret set`:
 
-```json
-{
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
-}
+```bash
+aspire secret set Azure:SubscriptionId "<your subscription id>"
+aspire secret set Azure:ResourceGroupPrefix "<prefix for the resource group>"
+aspire secret set Azure:Location "<azure location>"
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Microsoft Foundry deployment and consume the connection using the following methods:
+In the AppHost, add a Microsoft Foundry deployment and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var chat = builder.AddFoundry("foundry")
@@ -45,51 +42,15 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(chat);
 ```
 
-The `WithReference` method passes that connection information into a connection string named `chat` in the `MyService` project.
+**TypeScript**
 
-### Configuring deployment rate limits
+```typescript
+const chat = await builder.addFoundry("foundry")
+                  .addDeployment("chat", "Phi-4", "1", "Microsoft");
 
-The `SkuCapacity` property controls the rate limit in thousands of tokens per minute (TPM). For example, a value of `10` means 10,000 TPM. The default is `1` (1,000 TPM). Use `WithProperties` to configure it:
-
-```csharp
-var chat = builder.AddFoundry("foundry")
-                  .AddDeployment("chat", "gpt-4", "1", "OpenAI")
-                  .WithProperties(d => d.SkuCapacity = 10);
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(chat);
 ```
-
-See the [Azure AI quota management](https://learn.microsoft.com/azure/ai-foundry/openai/how-to/quota) documentation for available quota limits per model and region.
-
-In the _Program.cs_ file of `MyService`, the connection can be consumed using a client library like [Aspire.Azure.AI.Inference](https://www.nuget.org/packages/Aspire.Azure.AI.Inference) or [Aspire.OpenAI](https://www.nuget.org/packages/Aspire.OpenAI) if the model is compatible with the OpenAI API:
-
-Note: The `format` parameter of the `AddDeployment()` method can be found in the Microsoft Foundry portal in the details
-page of the model, right after the `Quick facts` text.
-
-#### Inference client usage
-```csharp
-builder.AddAzureChatCompletionsClient("chat")
-       .AddChatClient();
-```
-
-#### OpenAI client usage
-```csharp
-builder.AddOpenAIClient("chat")
-       .AddChatClient();
-```
-
-### Emulator usage
-
-Aspire supports the usage of Foundry Local. Add the following to your AppHost project:
-
-```csharp
-// AppHost
-var chat = builder.AddFoundry("foundry")
-                  .RunAsFoundryLocal()
-                  .AddDeployment("chat", "phi-3.5-mini", "1", "Microsoft");
-```
-
-When the AppHost starts up, the local Foundry service will also be started.
-
-This requires the local machine to have [Foundry Local](https://learn.microsoft.com/azure/ai-foundry/foundry-local/get-started) installed and running.
 
 ## Connection Properties
 
@@ -260,7 +221,6 @@ var agent2 = project.AddPromptAgent(chat, "agent-2").WithTool(codeInterp);
 
 * https://learn.microsoft.com/azure/ai-foundry/what-is-azure-ai-foundry
 * https://learn.microsoft.com/azure/ai-foundry/foundry-local/
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Garnet/README.md
+++ b/src/Aspire.Hosting.Garnet/README.md
@@ -53,7 +53,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://github.com/microsoft/garnet/blob/main/README.md
 * https://microsoft.github.io/garnet/
 

--- a/src/Aspire.Hosting.Garnet/README.md
+++ b/src/Aspire.Hosting.Garnet/README.md
@@ -53,6 +53,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://github.com/microsoft/garnet/blob/main/README.md
 * https://microsoft.github.io/garnet/
 

--- a/src/Aspire.Hosting.Garnet/README.md
+++ b/src/Aspire.Hosting.Garnet/README.md
@@ -1,20 +1,22 @@
-# Aspire.Hosting.Garnet library
+# Garnet hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a Garnet cache resource.
+Use this integration to model, configure, and orchestrate a Garnet cache resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Garnet Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Garnet` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Garnet
+```bash
+aspire add Aspire.Hosting.Garnet
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Garnet resource and consume the connection using the following methods:
+In the AppHost, add a Garnet resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var garnet = builder.AddGarnet("cache");
@@ -23,10 +25,13 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(garnet);
 ```
 
-The `WithReference` method configures a connection in the `MyService` project named `cache`. In the _Program.cs_ file of `MyService`, the redis connection can be consumed using the client library [Aspire.StackExchange.Redis](https://www.nuget.org/packages/Aspire.StackExchange.Redis):
+**TypeScript**
 
-```csharp
-builder.AddRedisClient("cache");
+```typescript
+const garnet = await builder.addGarnet("cache");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(garnet);
 ```
 
 ## Connection Properties
@@ -49,8 +54,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://github.com/microsoft/garnet/blob/main/README.md
-* https://stackexchange.github.io/StackExchange.Redis/Basics
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://microsoft.github.io/garnet/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Garnet/README.md
+++ b/src/Aspire.Hosting.Garnet/README.md
@@ -53,7 +53,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://github.com/microsoft/garnet/blob/main/README.md
 * https://microsoft.github.io/garnet/
 

--- a/src/Aspire.Hosting.Garnet/README.md
+++ b/src/Aspire.Hosting.Garnet/README.md
@@ -54,6 +54,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/caching/garnet/garnet-host/
 * https://github.com/microsoft/garnet/blob/main/README.md
 * https://microsoft.github.io/garnet/
 

--- a/src/Aspire.Hosting.GitHub.Models/README.md
+++ b/src/Aspire.Hosting.GitHub.Models/README.md
@@ -104,6 +104,7 @@ Check the [GitHub Models documentation](https://docs.github.com/en/github-models
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/ai/github-models/github-models-host/
 * https://docs.github.com/en/github-models
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.GitHub.Models/README.md
+++ b/src/Aspire.Hosting.GitHub.Models/README.md
@@ -103,7 +103,7 @@ Check the [GitHub Models documentation](https://docs.github.com/en/github-models
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://docs.github.com/en/github-models
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.GitHub.Models/README.md
+++ b/src/Aspire.Hosting.GitHub.Models/README.md
@@ -103,7 +103,7 @@ Check the [GitHub Models documentation](https://docs.github.com/en/github-models
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://docs.github.com/en/github-models
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.GitHub.Models/README.md
+++ b/src/Aspire.Hosting.GitHub.Models/README.md
@@ -103,6 +103,7 @@ Check the [GitHub Models documentation](https://docs.github.com/en/github-models
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://docs.github.com/en/github-models
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.GitHub.Models/README.md
+++ b/src/Aspire.Hosting.GitHub.Models/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.GitHub.Models library
+# GitHub Models hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure GitHub Models.
+Use this integration to model, configure, and orchestrate GitHub Models in an Aspire solution.
 
 ## Getting started
 
@@ -9,17 +9,19 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 - GitHub account with access to GitHub Models
 - GitHub [personal access token](https://docs.github.com/en/github-models/use-github-models/prototyping-with-ai-models#experimenting-with-ai-models-using-the-api) with appropriate permissions (`models: read`)
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire GitHub Models Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.GitHub.Models` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.GitHub.Models
+```bash
+aspire add Aspire.Hosting.GitHub.Models
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a GitHub Model resource and consume the connection using the following methods:
+In the AppHost, add a GitHub Model resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -30,14 +32,17 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(chat);
 ```
 
-The `WithReference` method passes that connection information into a connection string named `chat` in the `MyService` project.
+**TypeScript**
 
-In the _Program.cs_ file of `MyService`, the connection can be consumed using a client library like [Aspire.Azure.AI.Inference](https://www.nuget.org/packages/Aspire.Azure.AI.Inference):
+```typescript
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
-#### Inference client usage
-```csharp
-builder.AddAzureChatCompletionsClient("chat")
-       .AddChatClient();
+const builder = await createBuilder();
+
+const chat = await builder.addGitHubModelById("chat", "openai/gpt-4o-mini");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(chat);
 ```
 
 ## Configuration
@@ -48,15 +53,10 @@ The GitHub Model resource can be configured with the following options:
 
 The API key can be set as a configuration value using the default name `{resource_name}-gh-apikey` or the `GITHUB_TOKEN` environment variable.
 
-Then in user secrets:
+From your AppHost directory, set the parameter value with `aspire secret set`:
 
-```json
-{
-    "Parameters": 
-    {
-        "chat-gh-apikey": "YOUR_GITHUB_TOKEN_HERE"
-    }
-}
+```bash
+aspire secret set Parameters:chat-gh-apikey "YOUR_GITHUB_TOKEN_HERE"
 ```
 
 Furthermore, the API key can be configured using a custom parameter:
@@ -67,15 +67,10 @@ var chat = builder.AddGitHubModel("chat", "openai/gpt-4o-mini")
                   .WithApiKey(apiKey);
 ```
 
-Then in user secrets:
+From your AppHost directory, set the custom parameter value with `aspire secret set`:
 
-```json
-{
-    "Parameters": 
-    {
-        "my-api-key": "YOUR_GITHUB_TOKEN_HERE"
-    }
-}
+```bash
+aspire secret set Parameters:my-api-key "YOUR_GITHUB_TOKEN_HERE"
 ```
 
 ## Connection Properties
@@ -109,7 +104,6 @@ Check the [GitHub Models documentation](https://docs.github.com/en/github-models
 ## Additional documentation
 
 * https://docs.github.com/en/github-models
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Go/README.md
+++ b/src/Aspire.Hosting.Go/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.Go library
+# Go app hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure Go applications.
+Use this integration to model, configure, and orchestrate Go applications in an Aspire solution.
 
 ## Getting started
 
@@ -9,17 +9,19 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 The **Go toolchain** (`go`) must be available on the PATH of the machine running the AppHost.
 For GoLand remote debugging, [Delve](https://github.com/go-delve/delve) (`dlv`) must also be on the PATH.
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Go library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Go` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Go
+```bash
+aspire add Aspire.Hosting.Go
 ```
 
 ## Usage example
 
-In the _AppHost.cs_ file of `AppHost`, add a Go application resource:
+In the AppHost, add a Go application resource:
+
+**C#**
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -30,6 +32,21 @@ var api = builder.AddGoApp("api", "../go-api")
     .WithOtlpExporter();
 
 builder.Build().Run();
+```
+
+**TypeScript**
+
+```typescript
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const api = await builder.addGoApp("api", "../go-api")
+    .withHttpEndpoint({ port: 8080 })
+    .withExternalHttpEndpoints()
+    .withOtlpExporter();
+
+await builder.build().run();
 ```
 
 The method executes the package as `go run .` from the directory containing `go.mod`.
@@ -103,9 +120,9 @@ See the [JetBrains docs](https://www.jetbrains.com/help/go/attach-to-running-go-
 
 ## Additional documentation
 
-- [.NET Aspire documentation](https://learn.microsoft.com/dotnet/aspire)
+- [Aspire documentation](https://aspire.dev/)
 - [Delve debugger](https://github.com/go-delve/delve)
 
 ## Feedback & contributing
 
-https://github.com/dotnet/aspire
+https://github.com/microsoft/aspire

--- a/src/Aspire.Hosting.Go/README.md
+++ b/src/Aspire.Hosting.Go/README.md
@@ -120,7 +120,7 @@ See the [JetBrains docs](https://www.jetbrains.com/help/go/attach-to-running-go-
 
 ## Additional documentation
 
-- https://aspire.dev/integrations/gallery/?search=hosting
+- https://aspire.dev/integrations/
 - [Aspire documentation](https://aspire.dev/)
 - [Delve debugger](https://github.com/go-delve/delve)
 

--- a/src/Aspire.Hosting.Go/README.md
+++ b/src/Aspire.Hosting.Go/README.md
@@ -121,6 +121,7 @@ See the [JetBrains docs](https://www.jetbrains.com/help/go/attach-to-running-go-
 ## Additional documentation
 
 - https://aspire.dev/integrations/gallery/
+- https://aspire.dev/integrations/frameworks/go/go-host/
 - [Aspire documentation](https://aspire.dev/)
 - [Delve debugger](https://github.com/go-delve/delve)
 

--- a/src/Aspire.Hosting.Go/README.md
+++ b/src/Aspire.Hosting.Go/README.md
@@ -120,6 +120,7 @@ See the [JetBrains docs](https://www.jetbrains.com/help/go/attach-to-running-go-
 
 ## Additional documentation
 
+- https://aspire.dev/integrations/gallery/?search=hosting
 - [Aspire documentation](https://aspire.dev/)
 - [Delve debugger](https://github.com/go-delve/delve)
 

--- a/src/Aspire.Hosting.Go/README.md
+++ b/src/Aspire.Hosting.Go/README.md
@@ -120,7 +120,7 @@ See the [JetBrains docs](https://www.jetbrains.com/help/go/attach-to-running-go-
 
 ## Additional documentation
 
-- https://aspire.dev/integrations/
+- https://aspire.dev/integrations/gallery/
 - [Aspire documentation](https://aspire.dev/)
 - [Delve debugger](https://github.com/go-delve/delve)
 

--- a/src/Aspire.Hosting.JavaScript/README.md
+++ b/src/Aspire.Hosting.JavaScript/README.md
@@ -39,6 +39,7 @@ await builder.build().run();
 ```
 
 ## Additional documentation
+https://aspire.dev/integrations/gallery/?search=hosting
 https://github.com/microsoft/aspire-samples/tree/main/samples/aspire-with-javascript
 https://github.com/microsoft/aspire-samples/tree/main/samples/aspire-with-node
 

--- a/src/Aspire.Hosting.JavaScript/README.md
+++ b/src/Aspire.Hosting.JavaScript/README.md
@@ -39,7 +39,9 @@ await builder.build().run();
 ```
 
 ## Additional documentation
+
 https://aspire.dev/integrations/gallery/
+https://aspire.dev/integrations/frameworks/javascript/
 https://github.com/microsoft/aspire-samples/tree/main/samples/aspire-with-javascript
 https://github.com/microsoft/aspire-samples/tree/main/samples/aspire-with-node
 

--- a/src/Aspire.Hosting.JavaScript/README.md
+++ b/src/Aspire.Hosting.JavaScript/README.md
@@ -39,7 +39,7 @@ await builder.build().run();
 ```
 
 ## Additional documentation
-https://aspire.dev/integrations/gallery/?search=hosting
+https://aspire.dev/integrations/
 https://github.com/microsoft/aspire-samples/tree/main/samples/aspire-with-javascript
 https://github.com/microsoft/aspire-samples/tree/main/samples/aspire-with-node
 

--- a/src/Aspire.Hosting.JavaScript/README.md
+++ b/src/Aspire.Hosting.JavaScript/README.md
@@ -1,20 +1,22 @@
-# Aspire.Hosting.JavaScript library
+# JavaScript app hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure JavaScript projects.
+Use this integration to model, configure, and orchestrate JavaScript projects in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire JavaScript library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.JavaScript` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.JavaScript
+```bash
+aspire add Aspire.Hosting.JavaScript
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Or resource and consume the connection using the following methods:
+In the AppHost, add a JavaScript app resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -22,6 +24,18 @@ var builder = DistributedApplication.CreateBuilder(args);
 builder.AddJavaScriptApp("frontend", "../frontend", "app.js");
 
 builder.Build().Run();
+```
+
+**TypeScript**
+
+```typescript
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+await builder.addJavaScriptApp("frontend", "../frontend", "app.js");
+
+await builder.build().run();
 ```
 
 ## Additional documentation

--- a/src/Aspire.Hosting.JavaScript/README.md
+++ b/src/Aspire.Hosting.JavaScript/README.md
@@ -39,7 +39,7 @@ await builder.build().run();
 ```
 
 ## Additional documentation
-https://aspire.dev/integrations/
+https://aspire.dev/integrations/gallery/
 https://github.com/microsoft/aspire-samples/tree/main/samples/aspire-with-javascript
 https://github.com/microsoft/aspire-samples/tree/main/samples/aspire-with-node
 

--- a/src/Aspire.Hosting.Kafka/README.md
+++ b/src/Aspire.Hosting.Kafka/README.md
@@ -51,7 +51,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://aspire.dev/integrations/messaging/apache-kafka/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Kafka/README.md
+++ b/src/Aspire.Hosting.Kafka/README.md
@@ -51,6 +51,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://aspire.dev/integrations/messaging/apache-kafka/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Kafka/README.md
+++ b/src/Aspire.Hosting.Kafka/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.Kafka library
+# Apache Kafka hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a Kafka resource.
+Use this integration to model, configure, and orchestrate a Kafka resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Kafka Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Kafka` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Kafka
+```bash
+aspire add Aspire.Hosting.Kafka
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Kafka resource and consume the connection using the following methods:
+In the AppHost, add a Kafka resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var kafka = builder.AddKafka("messaging");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(kafka);
+```
+
+**TypeScript**
+
+```typescript
+const kafka = await builder.addKafka("messaging");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(kafka);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.Kafka/README.md
+++ b/src/Aspire.Hosting.Kafka/README.md
@@ -52,7 +52,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
-* https://aspire.dev/integrations/messaging/apache-kafka/
+* https://aspire.dev/integrations/messaging/apache-kafka/apache-kafka-host/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Kafka/README.md
+++ b/src/Aspire.Hosting.Kafka/README.md
@@ -51,7 +51,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://aspire.dev/integrations/messaging/apache-kafka/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Keycloak/README.md
+++ b/src/Aspire.Hosting.Keycloak/README.md
@@ -38,7 +38,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
-https://aspire.dev/integrations/
+https://aspire.dev/integrations/gallery/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Keycloak/README.md
+++ b/src/Aspire.Hosting.Keycloak/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.Keycloak library
+# Keycloak hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a Keycloak resource.
+Use this integration to model, configure, and orchestrate a Keycloak resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Keycloak Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Keycloak` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Keycloak
+```bash
+aspire add Aspire.Hosting.Keycloak
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Keycloak resource and enable service discovery using the following methods:
+In the AppHost, add a Keycloak resource and enable service discovery with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var keycloak = builder.AddKeycloak("keycloak", 8080);
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(keycloak);
+```
+
+**TypeScript**
+
+```typescript
+const keycloak = await builder.addKeycloak("keycloak", 8080);
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(keycloak);
 ```
 
 **Recommendation:** For local development use a stable port for the Keycloak resource (8080 in the example above). It can be any port, but it should be stable to avoid issues with browser cookies that will persist OIDC tokens (which include the authority URL, with port) beyond the lifetime of the AppHost.

--- a/src/Aspire.Hosting.Keycloak/README.md
+++ b/src/Aspire.Hosting.Keycloak/README.md
@@ -36,6 +36,10 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 **Recommendation:** For local development use a stable port for the Keycloak resource (8080 in the example above). It can be any port, but it should be stable to avoid issues with browser cookies that will persist OIDC tokens (which include the authority URL, with port) beyond the lifetime of the AppHost.
 
+## Additional documentation
+
+https://aspire.dev/integrations/gallery/?search=hosting
+
 ## Feedback & contributing
 
 https://github.com/microsoft/aspire

--- a/src/Aspire.Hosting.Keycloak/README.md
+++ b/src/Aspire.Hosting.Keycloak/README.md
@@ -39,6 +39,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 ## Additional documentation
 
 https://aspire.dev/integrations/gallery/
+https://aspire.dev/integrations/security/keycloak/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Keycloak/README.md
+++ b/src/Aspire.Hosting.Keycloak/README.md
@@ -38,7 +38,7 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 ## Additional documentation
 
-https://aspire.dev/integrations/gallery/?search=hosting
+https://aspire.dev/integrations/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Kubernetes/README.md
+++ b/src/Aspire.Hosting.Kubernetes/README.md
@@ -1,4 +1,4 @@
-# Aspire.Hosting.Kubernetes library
+# Kubernetes hosting integration
 
 Provides publishing extensions to Aspire for Kubernetes.
 
@@ -10,20 +10,28 @@ Provides publishing extensions to Aspire for Kubernetes.
 
 Aspire shells out to `helm upgrade --install` to deploy the generated chart and validates the Helm version up front, so missing or older installs produce a clear actionable error instead of cryptic flag failures.
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Kubernetes Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Kubernetes` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Kubernetes
+```bash
+aspire add Aspire.Hosting.Kubernetes
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add the environment:
+In the AppHost, add the environment:
+
+**C#**
 
 ```csharp
 builder.AddKubernetesEnvironment("k8s");
+```
+
+**TypeScript**
+
+```typescript
+await builder.addKubernetesEnvironment("k8s");
 ```
 
 ```shell

--- a/src/Aspire.Hosting.Kubernetes/README.md
+++ b/src/Aspire.Hosting.Kubernetes/README.md
@@ -41,6 +41,7 @@ aspire publish -o k8s-artifacts
 ## Additional documentation
 
 https://aspire.dev/integrations/gallery/
+https://aspire.dev/integrations/compute/kubernetes/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Kubernetes/README.md
+++ b/src/Aspire.Hosting.Kubernetes/README.md
@@ -38,6 +38,10 @@ await builder.addKubernetesEnvironment("k8s");
 aspire publish -o k8s-artifacts
 ```
 
+## Additional documentation
+
+https://aspire.dev/integrations/gallery/?search=hosting
+
 ## Feedback & contributing
 
 https://github.com/microsoft/aspire

--- a/src/Aspire.Hosting.Kubernetes/README.md
+++ b/src/Aspire.Hosting.Kubernetes/README.md
@@ -40,7 +40,7 @@ aspire publish -o k8s-artifacts
 
 ## Additional documentation
 
-https://aspire.dev/integrations/
+https://aspire.dev/integrations/gallery/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Kubernetes/README.md
+++ b/src/Aspire.Hosting.Kubernetes/README.md
@@ -40,7 +40,7 @@ aspire publish -o k8s-artifacts
 
 ## Additional documentation
 
-https://aspire.dev/integrations/gallery/?search=hosting
+https://aspire.dev/integrations/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Milvus/README.md
+++ b/src/Aspire.Hosting.Milvus/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.Milvus library
+# Milvus hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a Milvus vector database resource.
+Use this integration to model, configure, and orchestrate a Milvus vector database resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Milvus Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Milvus` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Milvus
+```bash
+aspire add Aspire.Hosting.Milvus
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Milvus resource and consume the connection using the following methods:
+In the AppHost, add a Milvus resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var milvus = builder.AddMilvus("milvus");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(milvus);
+```
+
+**TypeScript**
+
+```typescript
+const milvus = await builder.addMilvus("milvus");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(milvus);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.Milvus/README.md
+++ b/src/Aspire.Hosting.Milvus/README.md
@@ -61,7 +61,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://milvus.io/docs
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Milvus/README.md
+++ b/src/Aspire.Hosting.Milvus/README.md
@@ -62,6 +62,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/databases/milvus/milvus-host/
 * https://milvus.io/docs
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Milvus/README.md
+++ b/src/Aspire.Hosting.Milvus/README.md
@@ -61,6 +61,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://milvus.io/docs
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Milvus/README.md
+++ b/src/Aspire.Hosting.Milvus/README.md
@@ -61,7 +61,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://milvus.io/docs
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.MongoDB/README.md
+++ b/src/Aspire.Hosting.MongoDB/README.md
@@ -64,7 +64,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://aspire.dev/integrations/databases/mongodb/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.MongoDB/README.md
+++ b/src/Aspire.Hosting.MongoDB/README.md
@@ -65,7 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
-* https://aspire.dev/integrations/databases/mongodb/
+* https://aspire.dev/integrations/databases/mongodb/mongodb-host/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.MongoDB/README.md
+++ b/src/Aspire.Hosting.MongoDB/README.md
@@ -64,7 +64,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://aspire.dev/integrations/databases/mongodb/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.MongoDB/README.md
+++ b/src/Aspire.Hosting.MongoDB/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.MongoDB library
+# MongoDB hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a MongoDB resource.
+Use this integration to model, configure, and orchestrate a MongoDB resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire MongoDB Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.MongoDB` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.MongoDB
+```bash
+aspire add Aspire.Hosting.MongoDB
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a MongoDB resource and consume the connection using the following methods:
+In the AppHost, add a MongoDB resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var db = builder.AddMongoDB("mongodb").AddDatabase("mydb");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(db);
+```
+
+**TypeScript**
+
+```typescript
+const db = await builder.addMongoDB("mongodb").addDatabase("mydb");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(db);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.MongoDB/README.md
+++ b/src/Aspire.Hosting.MongoDB/README.md
@@ -64,6 +64,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://aspire.dev/integrations/databases/mongodb/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.MySql/README.md
+++ b/src/Aspire.Hosting.MySql/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.MySql library
+# MySQL hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a MySQL resource.
+Use this integration to model, configure, and orchestrate a MySQL resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire MySQL Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.MySql` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.MySql
+```bash
+aspire add Aspire.Hosting.MySql
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a MySQL resource and consume the connection using the following methods:
+In the AppHost, add a MySQL resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var db = builder.AddMySql("mysql").AddDatabase("mydb");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(db);
+```
+
+**TypeScript**
+
+```typescript
+const db = await builder.addMySql("mysql").addDatabase("mydb");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(db);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.MySql/README.md
+++ b/src/Aspire.Hosting.MySql/README.md
@@ -65,6 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://aspire.dev/integrations/databases/mysql/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.MySql/README.md
+++ b/src/Aspire.Hosting.MySql/README.md
@@ -65,7 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://aspire.dev/integrations/databases/mysql/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.MySql/README.md
+++ b/src/Aspire.Hosting.MySql/README.md
@@ -65,7 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://aspire.dev/integrations/databases/mysql/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.MySql/README.md
+++ b/src/Aspire.Hosting.MySql/README.md
@@ -66,7 +66,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
-* https://aspire.dev/integrations/databases/mysql/
+* https://aspire.dev/integrations/databases/mysql/mysql-host/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Nats/README.md
+++ b/src/Aspire.Hosting.Nats/README.md
@@ -54,7 +54,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://aspire.dev/integrations/messaging/nats/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Nats/README.md
+++ b/src/Aspire.Hosting.Nats/README.md
@@ -55,7 +55,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
-* https://aspire.dev/integrations/messaging/nats/
+* https://aspire.dev/integrations/messaging/nats/nats-host/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Nats/README.md
+++ b/src/Aspire.Hosting.Nats/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.NATS library
+# NATS hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a NATS resource.
+Use this integration to model, configure, and orchestrate a NATS resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire NATS Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Nats` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Nats
+```bash
+aspire add Aspire.Hosting.Nats
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a NATS resource and consume the connection using the following methods:
+In the AppHost, add a NATS resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var nats = builder.AddNats("nats");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(nats);
+```
+
+**TypeScript**
+
+```typescript
+const nats = await builder.addNats("nats");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(nats);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.Nats/README.md
+++ b/src/Aspire.Hosting.Nats/README.md
@@ -54,6 +54,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://aspire.dev/integrations/messaging/nats/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Nats/README.md
+++ b/src/Aspire.Hosting.Nats/README.md
@@ -54,7 +54,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://aspire.dev/integrations/messaging/nats/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.OpenAI/README.md
+++ b/src/Aspire.Hosting.OpenAI/README.md
@@ -133,6 +133,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://platform.openai.com/docs/models
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.OpenAI/README.md
+++ b/src/Aspire.Hosting.OpenAI/README.md
@@ -134,6 +134,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/ai/openai/openai-host/
 * https://platform.openai.com/docs/models
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.OpenAI/README.md
+++ b/src/Aspire.Hosting.OpenAI/README.md
@@ -133,7 +133,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://platform.openai.com/docs/models
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.OpenAI/README.md
+++ b/src/Aspire.Hosting.OpenAI/README.md
@@ -133,7 +133,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://platform.openai.com/docs/models
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.OpenAI/README.md
+++ b/src/Aspire.Hosting.OpenAI/README.md
@@ -1,6 +1,6 @@
-# Aspire.Hosting.OpenAI library
+# OpenAI hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure OpenAI resources and models.
+Use this integration to model, configure, and orchestrate OpenAI resources and models in an Aspire solution.
 
 ## Getting started
 
@@ -9,17 +9,19 @@ Provides extension methods and resource definitions for an Aspire AppHost to con
 - An OpenAI account with access to the OpenAI API
 - OpenAI [API key](https://platform.openai.com/api-keys)
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire OpenAI Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.OpenAI` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.OpenAI
+```bash
+aspire add Aspire.Hosting.OpenAI
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add an OpenAI resource and one or more model resources, and consume connections as needed:
+In the AppHost, add an OpenAI resource and one or more model resources, then reference them from other resources as needed:
+
+**C#**
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -31,21 +33,18 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(chat);
 ```
 
-The `WithReference` method passes that connection information into a connection string named `chat` in the `MyService` project. Multiple models can share the same OpenAI API key via the parent `OpenAIResource`.
+**TypeScript**
 
-In the _Program.cs_ file of `MyService`, the connection can be consumed using the client library [Aspire.OpenAI](https://www.nuget.org/packages/Aspire.OpenAI):
+```typescript
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
-#### OpenAI client usage
+const builder = await createBuilder();
 
-```csharp
-builder.AddOpenAIClient("chat");
-```
+const openai = await builder.addOpenAI("openai");
+const chat = await openai.addModel("chat", "gpt-4o-mini");
 
-When no model resources are defined, clients can be created with the OpenAI resource only:
-
-```csharp
-builder.AddOpenAIClient("openai")
-       .AddChatClient("gpt-4o-mini");
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(chat);
 ```
 
 ## Configuration
@@ -56,15 +55,10 @@ The OpenAI resources can be configured with the following options:
 
 The API key is configured on the parent OpenAI resource via a parameter named `{resource_name}-openai-apikey` or the `OPENAI_API_KEY` environment variable.
 
-Then in user secrets:
+From your AppHost directory, set the parameter value with `aspire secret set`:
 
-```json
-{
-    "Parameters": 
-    {
-        "openai-openai-apikey": "YOUR_OPENAI_API_KEY_HERE"
-    }
-}
+```bash
+aspire secret set Parameters:openai-openai-apikey "YOUR_OPENAI_API_KEY_HERE"
 ```
 
 You can replace the parent API key with a custom parameter on the parent resource:
@@ -78,16 +72,11 @@ var chat = openai.AddModel("chat", "gpt-4o-mini");
 var embeddings = openai.AddModel("embeddings", "text-embedding-3-small");
 ```
 
-Then in user secrets:
+From your AppHost directory, set the custom parameter values with `aspire secret set`:
 
-```json
-{
-    "Parameters": 
-    {
-        "my-api-key": "YOUR_OPENAI_API_KEY_HERE",
-        "alt-key": "ANOTHER_OPENAI_API_KEY"
-    }
-}
+```bash
+aspire secret set Parameters:my-api-key "YOUR_OPENAI_API_KEY_HERE"
+aspire secret set Parameters:alt-key "ANOTHER_OPENAI_API_KEY"
 ```
 
 ## Available Models
@@ -145,7 +134,6 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://platform.openai.com/docs/models
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Oracle/README.md
+++ b/src/Aspire.Hosting.Oracle/README.md
@@ -66,7 +66,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 https://aspire.dev/integrations/gallery/
-https://aspire.dev/integrations/databases/oracle/
+https://aspire.dev/integrations/databases/efcore/oracle/oracle-host/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Oracle/README.md
+++ b/src/Aspire.Hosting.Oracle/README.md
@@ -65,6 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+https://aspire.dev/integrations/gallery/?search=hosting
 https://aspire.dev/integrations/databases/oracle/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Oracle/README.md
+++ b/src/Aspire.Hosting.Oracle/README.md
@@ -65,7 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-https://aspire.dev/integrations/gallery/?search=hosting
+https://aspire.dev/integrations/
 https://aspire.dev/integrations/databases/oracle/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Oracle/README.md
+++ b/src/Aspire.Hosting.Oracle/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.Oracle library
+# Oracle Database hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure an Oracle database resource.
+Use this integration to model, configure, and orchestrate an Oracle database resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire PostgreSQL Oracle library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Oracle` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Oracle
+```bash
+aspire add Aspire.Hosting.Oracle
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Oracle database resource and consume the connection using the following methods:
+In the AppHost, add an Oracle database resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var db = builder.AddOracle("oracle").AddDatabase("mydb");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(db);
+```
+
+**TypeScript**
+
+```typescript
+const db = await builder.addOracle("oracle").addDatabase("mydb");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(db);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.Oracle/README.md
+++ b/src/Aspire.Hosting.Oracle/README.md
@@ -65,7 +65,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-https://aspire.dev/integrations/
+https://aspire.dev/integrations/gallery/
 https://aspire.dev/integrations/databases/oracle/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Orleans/README.md
+++ b/src/Aspire.Hosting.Orleans/README.md
@@ -54,7 +54,7 @@ await builder.addNodeApp("frontend", "../orleans-frontend", "server.js")
 
 ## Additional documentation
 
-https://aspire.dev/integrations/gallery/?search=hosting
+https://aspire.dev/integrations/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Orleans/README.md
+++ b/src/Aspire.Hosting.Orleans/README.md
@@ -55,6 +55,7 @@ await builder.addNodeApp("frontend", "../orleans-frontend", "server.js")
 ## Additional documentation
 
 https://aspire.dev/integrations/gallery/
+https://aspire.dev/integrations/frameworks/orleans/
 https://learn.microsoft.com/dotnet/orleans/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Orleans/README.md
+++ b/src/Aspire.Hosting.Orleans/README.md
@@ -1,20 +1,22 @@
-# Aspire.Hosting.Orleans library
+# Orleans hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure an Orleans cluster.
+Use this integration to model, configure, and orchestrate an Orleans cluster in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Orleans library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Orleans` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Orleans
+```bash
+aspire add Aspire.Hosting.Orleans
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Or resource and consume the connection using the following methods:
+In the AppHost, add an Orleans cluster resource and reference it from other resources with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var storage = builder.AddAzureStorage("storage").RunAsEmulator();
@@ -32,8 +34,23 @@ builder.AddProject<Projects.OrleansClient>("frontend")
        .WithReference(orleans.AsClient());
 ```
 
-## Additional documentation
-https://learn.microsoft.com/dotnet/orleans/
+**TypeScript**
+
+```typescript
+const storage = await builder.addAzureStorage("storage").runAsEmulator();
+const clusteringTable = await storage.addTables("clustering");
+const grainStorage = await storage.addBlobs("grainstate");
+
+const orleans = await builder.addOrleans("my-app")
+                     .withClustering(clusteringTable)
+                     .withGrainStorage("Default", grainStorage);
+
+await builder.addNodeApp("silo", "../orleans-silo", "server.js")
+    .withReference(orleans);
+
+await builder.addNodeApp("frontend", "../orleans-frontend", "server.js")
+    .withReference(orleans.asClient());
+```
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Orleans/README.md
+++ b/src/Aspire.Hosting.Orleans/README.md
@@ -54,7 +54,7 @@ await builder.addNodeApp("frontend", "../orleans-frontend", "server.js")
 
 ## Additional documentation
 
-https://aspire.dev/integrations/
+https://aspire.dev/integrations/gallery/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Orleans/README.md
+++ b/src/Aspire.Hosting.Orleans/README.md
@@ -52,6 +52,10 @@ await builder.addNodeApp("frontend", "../orleans-frontend", "server.js")
     .withReference(orleans.asClient());
 ```
 
+## Additional documentation
+
+https://aspire.dev/integrations/gallery/?search=hosting
+
 ## Feedback & contributing
 
 https://github.com/microsoft/aspire

--- a/src/Aspire.Hosting.Orleans/README.md
+++ b/src/Aspire.Hosting.Orleans/README.md
@@ -55,6 +55,7 @@ await builder.addNodeApp("frontend", "../orleans-frontend", "server.js")
 ## Additional documentation
 
 https://aspire.dev/integrations/gallery/
+https://learn.microsoft.com/dotnet/orleans/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.PostgreSQL/README.md
+++ b/src/Aspire.Hosting.PostgreSQL/README.md
@@ -78,6 +78,7 @@ for database exploration, query execution, index tuning, and health checks.
 
 ## Additional documentation
 
+https://aspire.dev/integrations/gallery/?search=hosting
 https://aspire.dev/integrations/databases/postgres/postgres-get-started/
 https://aspire.dev/integrations/databases/efcore/postgresql/
 

--- a/src/Aspire.Hosting.PostgreSQL/README.md
+++ b/src/Aspire.Hosting.PostgreSQL/README.md
@@ -78,7 +78,7 @@ for database exploration, query execution, index tuning, and health checks.
 
 ## Additional documentation
 
-https://aspire.dev/integrations/gallery/?search=hosting
+https://aspire.dev/integrations/
 https://aspire.dev/integrations/databases/postgres/postgres-get-started/
 https://aspire.dev/integrations/databases/efcore/postgresql/
 

--- a/src/Aspire.Hosting.PostgreSQL/README.md
+++ b/src/Aspire.Hosting.PostgreSQL/README.md
@@ -78,7 +78,7 @@ for database exploration, query execution, index tuning, and health checks.
 
 ## Additional documentation
 
-https://aspire.dev/integrations/
+https://aspire.dev/integrations/gallery/
 https://aspire.dev/integrations/databases/postgres/postgres-get-started/
 https://aspire.dev/integrations/databases/efcore/postgresql/
 

--- a/src/Aspire.Hosting.PostgreSQL/README.md
+++ b/src/Aspire.Hosting.PostgreSQL/README.md
@@ -79,8 +79,7 @@ for database exploration, query execution, index tuning, and health checks.
 ## Additional documentation
 
 https://aspire.dev/integrations/gallery/
-https://aspire.dev/integrations/databases/postgres/postgres-get-started/
-https://aspire.dev/integrations/databases/efcore/postgresql/
+https://aspire.dev/integrations/databases/postgres/postgres-host/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.PostgreSQL/README.md
+++ b/src/Aspire.Hosting.PostgreSQL/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.PostgreSQL library
+# PostgreSQL hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a PostgreSQL resource.
+Use this integration to model, configure, and orchestrate a PostgreSQL resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire PostgreSQL Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.PostgreSQL` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.PostgreSQL
+```bash
+aspire add Aspire.Hosting.PostgreSQL
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a PostgreSQL resource and consume the connection using the following methods:
+In the AppHost, add a PostgreSQL resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var db = builder.AddPostgres("pgsql").AddDatabase("mydb");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(db);
+```
+
+**TypeScript**
+
+```typescript
+const db = await builder.addPostgres("pgsql").addDatabase("mydb");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(db);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.Qdrant/README.md
+++ b/src/Aspire.Hosting.Qdrant/README.md
@@ -57,6 +57,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/databases/qdrant/qdrant-host/
 * https://qdrant.tech/documentation
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Qdrant/README.md
+++ b/src/Aspire.Hosting.Qdrant/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.Qdrant library
+# Qdrant hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a Qdrant vector database resource.
+Use this integration to model, configure, and orchestrate a Qdrant vector database resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Qdrant Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Qdrant` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Qdrant
+```bash
+aspire add Aspire.Hosting.Qdrant
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Qdrant resource and consume the connection using the following methods:
+In the AppHost, add a Qdrant resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var qdrant = builder.AddQdrant("qdrant");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(qdrant);
+```
+
+**TypeScript**
+
+```typescript
+const qdrant = await builder.addQdrant("qdrant");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(qdrant);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.Qdrant/README.md
+++ b/src/Aspire.Hosting.Qdrant/README.md
@@ -56,7 +56,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://qdrant.tech/documentation
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Qdrant/README.md
+++ b/src/Aspire.Hosting.Qdrant/README.md
@@ -56,6 +56,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://qdrant.tech/documentation
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Qdrant/README.md
+++ b/src/Aspire.Hosting.Qdrant/README.md
@@ -56,7 +56,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://qdrant.tech/documentation
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.RabbitMQ/README.md
+++ b/src/Aspire.Hosting.RabbitMQ/README.md
@@ -55,7 +55,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
-* https://aspire.dev/integrations/messaging/rabbitmq/
+* https://aspire.dev/integrations/messaging/rabbitmq/rabbitmq-host/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.RabbitMQ/README.md
+++ b/src/Aspire.Hosting.RabbitMQ/README.md
@@ -54,7 +54,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://aspire.dev/integrations/messaging/rabbitmq/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.RabbitMQ/README.md
+++ b/src/Aspire.Hosting.RabbitMQ/README.md
@@ -54,7 +54,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://aspire.dev/integrations/messaging/rabbitmq/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.RabbitMQ/README.md
+++ b/src/Aspire.Hosting.RabbitMQ/README.md
@@ -54,6 +54,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://aspire.dev/integrations/messaging/rabbitmq/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.RabbitMQ/README.md
+++ b/src/Aspire.Hosting.RabbitMQ/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.RabbitMQ library
+# RabbitMQ hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a RabbitMQ resource.
+Use this integration to model, configure, and orchestrate a RabbitMQ resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire RabbitMQ Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.RabbitMQ` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.RabbitMQ
+```bash
+aspire add Aspire.Hosting.RabbitMQ
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a RabbitMQ resource and consume the connection using the following methods:
+In the AppHost, add a RabbitMQ resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var rmq = builder.AddRabbitMQ("rmq");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(rmq);
+```
+
+**TypeScript**
+
+```typescript
+const rmq = await builder.addRabbitMQ("rmq");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(rmq);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.Redis/README.md
+++ b/src/Aspire.Hosting.Redis/README.md
@@ -54,9 +54,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
-* https://aspire.dev/integrations/caching/redis/
-* https://aspire.dev/integrations/caching/redis-output/
-* https://aspire.dev/integrations/caching/redis-distributed/
+* https://aspire.dev/integrations/caching/redis/redis-host/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Redis/README.md
+++ b/src/Aspire.Hosting.Redis/README.md
@@ -53,6 +53,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://aspire.dev/integrations/caching/redis/
 * https://aspire.dev/integrations/caching/redis-output/
 * https://aspire.dev/integrations/caching/redis-distributed/

--- a/src/Aspire.Hosting.Redis/README.md
+++ b/src/Aspire.Hosting.Redis/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.Redis library
+# Redis hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a Redis resource.
+Use this integration to model, configure, and orchestrate a Redis resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Redis Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Redis` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Redis
+```bash
+aspire add Aspire.Hosting.Redis
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Redis resource and consume the connection using the following methods:
+In the AppHost, add a Redis resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var redis = builder.AddRedis("redis");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(redis);
+```
+
+**TypeScript**
+
+```typescript
+const redis = await builder.addRedis("redis");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(redis);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.Redis/README.md
+++ b/src/Aspire.Hosting.Redis/README.md
@@ -53,7 +53,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://aspire.dev/integrations/caching/redis/
 * https://aspire.dev/integrations/caching/redis-output/
 * https://aspire.dev/integrations/caching/redis-distributed/

--- a/src/Aspire.Hosting.Redis/README.md
+++ b/src/Aspire.Hosting.Redis/README.md
@@ -53,7 +53,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://aspire.dev/integrations/caching/redis/
 * https://aspire.dev/integrations/caching/redis-output/
 * https://aspire.dev/integrations/caching/redis-distributed/

--- a/src/Aspire.Hosting.Seq/README.md
+++ b/src/Aspire.Hosting.Seq/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.Seq library
+# Seq hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a Seq resource.
+Use this integration to model, configure, and orchestrate a Seq resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Seq Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Seq` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Seq
+```bash
+aspire add Aspire.Hosting.Seq
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Seq resource and consume the connection using the following methods:
+In the AppHost, add a Seq resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var seq = builder.AddSeq("seq");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(seq);
+```
+
+**TypeScript**
+
+```typescript
+const seq = await builder.addSeq("seq");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(seq);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.Seq/README.md
+++ b/src/Aspire.Hosting.Seq/README.md
@@ -52,7 +52,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://aspire.dev/integrations/observability/seq/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Seq/README.md
+++ b/src/Aspire.Hosting.Seq/README.md
@@ -53,7 +53,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
-* https://aspire.dev/integrations/observability/seq/
+* https://aspire.dev/integrations/observability/seq/seq-host/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Seq/README.md
+++ b/src/Aspire.Hosting.Seq/README.md
@@ -52,6 +52,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://aspire.dev/integrations/observability/seq/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Seq/README.md
+++ b/src/Aspire.Hosting.Seq/README.md
@@ -52,7 +52,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://aspire.dev/integrations/observability/seq/
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.SqlServer/README.md
+++ b/src/Aspire.Hosting.SqlServer/README.md
@@ -64,9 +64,9 @@ The SQL Server database resource inherits all properties from its parent `SqlSer
 Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `db1` becomes `DB1_URI`.
 
 ## Additional documentation
+
 https://aspire.dev/integrations/gallery/
-https://aspire.dev/integrations/databases/sql-server/
-https://aspire.dev/integrations/databases/efcore/sql-server/
+https://aspire.dev/integrations/databases/sql-server/sql-server-host/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.SqlServer/README.md
+++ b/src/Aspire.Hosting.SqlServer/README.md
@@ -64,6 +64,7 @@ The SQL Server database resource inherits all properties from its parent `SqlSer
 Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `db1` becomes `DB1_URI`.
 
 ## Additional documentation
+https://aspire.dev/integrations/gallery/?search=hosting
 https://aspire.dev/integrations/databases/sql-server/
 https://aspire.dev/integrations/databases/efcore/sql-server/
 

--- a/src/Aspire.Hosting.SqlServer/README.md
+++ b/src/Aspire.Hosting.SqlServer/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.SqlServer library
+# SQL Server hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a SQL Server database resource.
+Use this integration to model, configure, and orchestrate a SQL Server database resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire SQL Server Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.SqlServer` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.SqlServer
+```bash
+aspire add Aspire.Hosting.SqlServer
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a SQL Server resource and consume the connection using the following methods:
+In the AppHost, add a SQL Server resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
-var db = builder.AddSqlServer("sql").AddDatabase("db")
+var db = builder.AddSqlServer("sql").AddDatabase("db");
 
 var myService = builder.AddProject<Projects.MyService>()
    .WithReference(db);
+```
+
+**TypeScript**
+
+```typescript
+const db = await builder.addSqlServer("sql").addDatabase("db");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+   .withReference(db);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.SqlServer/README.md
+++ b/src/Aspire.Hosting.SqlServer/README.md
@@ -64,7 +64,7 @@ The SQL Server database resource inherits all properties from its parent `SqlSer
 Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `db1` becomes `DB1_URI`.
 
 ## Additional documentation
-https://aspire.dev/integrations/
+https://aspire.dev/integrations/gallery/
 https://aspire.dev/integrations/databases/sql-server/
 https://aspire.dev/integrations/databases/efcore/sql-server/
 

--- a/src/Aspire.Hosting.SqlServer/README.md
+++ b/src/Aspire.Hosting.SqlServer/README.md
@@ -64,7 +64,7 @@ The SQL Server database resource inherits all properties from its parent `SqlSer
 Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `db1` becomes `DB1_URI`.
 
 ## Additional documentation
-https://aspire.dev/integrations/gallery/?search=hosting
+https://aspire.dev/integrations/
 https://aspire.dev/integrations/databases/sql-server/
 https://aspire.dev/integrations/databases/efcore/sql-server/
 

--- a/src/Aspire.Hosting.Valkey/README.md
+++ b/src/Aspire.Hosting.Valkey/README.md
@@ -54,6 +54,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/caching/valkey/valkey-host/
 * https://valkey.io
 * https://github.com/valkey-io/valkey/blob/unstable/README.md
 * https://valkey.io/docs/

--- a/src/Aspire.Hosting.Valkey/README.md
+++ b/src/Aspire.Hosting.Valkey/README.md
@@ -53,6 +53,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * https://valkey.io
 * https://github.com/valkey-io/valkey/blob/unstable/README.md
 * https://valkey.io/docs/

--- a/src/Aspire.Hosting.Valkey/README.md
+++ b/src/Aspire.Hosting.Valkey/README.md
@@ -1,26 +1,37 @@
-# Aspire.Hosting.Valkey library
+# Valkey hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a Valkey cache resource.
+Use this integration to model, configure, and orchestrate a Valkey cache resource in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire Valkey Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Valkey` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Valkey
+```bash
+aspire add Aspire.Hosting.Valkey
 ```
 
 ## Usage example
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a Valkey resource and consume the connection using the following methods:
+In the AppHost, add a Valkey resource and reference it from another resource with either C# or TypeScript:
+
+**C#**
 
 ```csharp
 var valkey = builder.AddValkey("cache");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(valkey);
+```
+
+**TypeScript**
+
+```typescript
+const valkey = await builder.addValkey("cache");
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(valkey);
 ```
 
 ## Connection Properties
@@ -44,8 +55,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 * https://valkey.io
 * https://github.com/valkey-io/valkey/blob/unstable/README.md
-* https://stackexchange.github.io/StackExchange.Redis/Basics
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+* https://valkey.io/docs/
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Valkey/README.md
+++ b/src/Aspire.Hosting.Valkey/README.md
@@ -53,7 +53,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * https://valkey.io
 * https://github.com/valkey-io/valkey/blob/unstable/README.md
 * https://valkey.io/docs/

--- a/src/Aspire.Hosting.Valkey/README.md
+++ b/src/Aspire.Hosting.Valkey/README.md
@@ -53,7 +53,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * https://valkey.io
 * https://github.com/valkey-io/valkey/blob/unstable/README.md
 * https://valkey.io/docs/

--- a/src/Aspire.Hosting.Yarp/README.md
+++ b/src/Aspire.Hosting.Yarp/README.md
@@ -180,6 +180,7 @@ builder.AddYarp("gateway")
 
 ## Additional documentation
 
+* https://aspire.dev/integrations/gallery/?search=hosting
 * [YARP documentation](https://microsoft.github.io/reverse-proxy/)
 * [Aspire documentation](https://aspire.dev/)
 * [YARP integration in Aspire](https://aspire.dev/integrations/reverse-proxies/yarp/)

--- a/src/Aspire.Hosting.Yarp/README.md
+++ b/src/Aspire.Hosting.Yarp/README.md
@@ -180,7 +180,7 @@ builder.AddYarp("gateway")
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/gallery/?search=hosting
+* https://aspire.dev/integrations/
 * [YARP documentation](https://microsoft.github.io/reverse-proxy/)
 * [Aspire documentation](https://aspire.dev/)
 * [YARP integration in Aspire](https://aspire.dev/integrations/reverse-proxies/yarp/)

--- a/src/Aspire.Hosting.Yarp/README.md
+++ b/src/Aspire.Hosting.Yarp/README.md
@@ -1,15 +1,15 @@
-# Aspire.Hosting.Yarp library
+# YARP hosting integration
 
-Provides extension methods and resource definitions for an Aspire AppHost to configure a YARP reverse proxy instance.
+Use this integration to model, configure, and orchestrate a YARP reverse proxy instance in an Aspire solution.
 
 ## Getting started
 
-### Install the package
+### Add the integration
 
-In your AppHost project, install the Aspire YARP Hosting library with [NuGet](https://www.nuget.org):
+From your AppHost directory, add the `Aspire.Hosting.Yarp` integration with the Aspire CLI:
 
-```dotnetcli
-dotnet add package Aspire.Hosting.Yarp
+```bash
+aspire add Aspire.Hosting.Yarp
 ```
 
 ## Usage examples
@@ -64,15 +64,18 @@ YARP can serve static files alongside proxied routes. There are two approaches:
 builder.AddYarp("static")
        .WithStaticFiles("../static");
 ```
-This will copy files into the container use container files in run mode, and use a bind mount in publish mode.
+This bind mounts files in run mode and copies them into the generated container image in publish mode.
 
 #### Copy files via Docker
 
-You can also use a docker file to copy static assets into the yarp container: e.g.
+You can also use a Dockerfile to copy static assets into the YARP container. Pass the YARP base image used by your deployment as `YARP_BASE_IMAGE` when building the image:
 ```C#
+var yarpBaseImage = builder.AddParameter("yarp-base-image");
+
 builder.AddYarp("frontend")
        .WithStaticFiles()
-       .WithDockerFile("../npmapp");
+       .WithDockerfile("../npmapp")
+       .WithBuildArg("YARP_BASE_IMAGE", yarpBaseImage);
 ```
 
 ```Dockerfile
@@ -83,8 +86,9 @@ COPY . .
 RUN npm install
 RUN npm run build
 
-# Stage 2: Copy static files to YARP container
-FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4 AS yarp
+# Stage 2: Copy static files into the YARP base image used by your deployment
+ARG YARP_BASE_IMAGE
+FROM ${YARP_BASE_IMAGE} AS yarp
 WORKDIR /app
 COPY --from=builder /app/dist ./wwwroot
 ```

--- a/src/Aspire.Hosting.Yarp/README.md
+++ b/src/Aspire.Hosting.Yarp/README.md
@@ -181,9 +181,9 @@ builder.AddYarp("gateway")
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/
+* https://aspire.dev/integrations/reverse-proxies/yarp/
 * [YARP documentation](https://microsoft.github.io/reverse-proxy/)
 * [Aspire documentation](https://aspire.dev/)
-* [YARP integration in Aspire](https://aspire.dev/integrations/reverse-proxies/yarp/)
 * [Service Discovery in Aspire](https://aspire.dev/fundamentals/service-discovery/)
 
 ## Feedback & contributing

--- a/src/Aspire.Hosting.Yarp/README.md
+++ b/src/Aspire.Hosting.Yarp/README.md
@@ -180,7 +180,7 @@ builder.AddYarp("gateway")
 
 ## Additional documentation
 
-* https://aspire.dev/integrations/
+* https://aspire.dev/integrations/gallery/
 * [YARP documentation](https://microsoft.github.io/reverse-proxy/)
 * [Aspire documentation](https://aspire.dev/)
 * [YARP integration in Aspire](https://aspire.dev/integrations/reverse-proxies/yarp/)


### PR DESCRIPTION
## Description

Hosting integration READMEs currently read like NuGet package docs, which makes TypeScript and other AppHost users look like second-class consumers. This updates the hosting integration README guidance and integration READMEs to focus on Aspire CLI and AppHost modeling instead of client registration.

- Replaces package install snippets in hosting integration READMEs with `aspire add`.
- Updates usage examples to show C# and TypeScript AppHost patterns, using `AddProject<Projects.*>()` for C# app resources and `addNodeApp(...)` for TypeScript app resources where a consumer resource is needed.
- Removes client integration setup, dependency-injection, and user-secrets wording from hosting docs, and switches Azure configuration examples to `aspire secret set`.
- Keeps client integration READMEs unchanged.

Validation:

- Validated TypeScript method names with `aspire docs api search --language typescript`.
- Ran focused scans for package-manager/client setup leftovers.
- Checked markdown fences and diff whitespace.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No