### PR TITLE
Stream AppHost discovery in VS Code extension

### DIFF
--- a/docs/specs/cli-output-formats.md
+++ b/docs/specs/cli-output-formats.md
@@ -38,6 +38,7 @@ By default, the command outputs a human-readable table. Use `--format json` for 
 ```
 
 Use `--format json --stream` to receive discovery results as NDJSON, with one complete AppHost candidate object per line. `--stream` is valid only with `--format json`.
+Tooling such as the VS Code extension consumes this stream incrementally, so each line must remain a complete candidate object.
 
 ```json
 {"path":"/path/to/MyApp.AppHost/MyApp.AppHost.csproj","language":"C#","status":"buildable"}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -45,6 +45,7 @@ import { AppHostDiscoveryService } from './utils/appHostDiscovery';
 import { AppHostLaunchRequestedEvent, AppHostLaunchService } from './services/AppHostLaunchService';
 import type { AspireAppHostState, AspireDebugConsoleOutputEvent, AspireExtensionApi, AspireExtensionE2ECommandInvocation, AspireExtensionE2EControlCommand, AspireExtensionE2EControlPayload, AspireExtensionE2EControlStatus, AspireExtensionE2EDebugConsoleOutput, AspireExtensionE2EDebugLaunch, AspireExtensionE2ETerminalCommand, AspireExtensionStateSnapshot, AspireResourceCommandState, AspireResourceState, AspireResourceUrlState, WaitForStateOptions } from './types/extensionApi';
 import { AppHostsViewTelemetry } from './views/AppHostsViewTelemetry';
+import { ConfigInfoProvider } from './utils/configInfoProvider';
 
 let aspireExtensionContext = new AspireExtensionContext();
 let atomicWriteSequence = 0;
@@ -78,7 +79,8 @@ export async function activate(context: vscode.ExtensionContext) {
   terminalProvider.dcpServerConnectionInfo = dcpServer.connectionInfo;
   terminalProvider.closeAllOpenAspireTerminals();
 
-  const appHostDiscoveryService = new AppHostDiscoveryService(terminalProvider);
+  const configInfoProvider = new ConfigInfoProvider(terminalProvider);
+  const appHostDiscoveryService = new AppHostDiscoveryService(terminalProvider, configInfoProvider);
   context.subscriptions.push(appHostDiscoveryService);
 
   // Meaningful-engagement reporter must outlive every command callback so it
@@ -151,7 +153,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const verifyCliInstalledRegistration = registerInstrumentedCommand('aspire-vscode.verifyCliInstalled', 'walkthrough', verifyCliInstalledCommand);
 
   // Aspire panel - running app hosts tree view
-  const dataRepository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService);
+  const dataRepository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService, configInfoProvider);
   const appHostTreeProvider = new AspireAppHostTreeProvider(dataRepository, terminalProvider, appHostLaunchService, context.globalState);
   const appHostTreeView = vscode.window.createTreeView('aspire-vscode.appHosts', {
     treeDataProvider: appHostTreeProvider,

--- a/extension/src/test-e2e/discoveryConfiguration.e2e.test.ts
+++ b/extension/src/test-e2e/discoveryConfiguration.e2e.test.ts
@@ -1,9 +1,10 @@
 import * as assert from 'assert';
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { getCommandInvocationCount, isSamePath, waitForCommandOutcome, waitForExtensionState, waitForRepositoryIdle, waitForSelectedWorkspaceAppHost, waitForWorkspaceAppHost } from './helpers/assertions';
-import { createAdditionalAppHostCandidate, executeE2eControlCommand, removeAdditionalAppHostCandidate, removeLegacyAspireSettings, removeWorkspaceAppHostConfig, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, stopPrimaryAppHostIfRunning, writeLegacyAspireSettings, writeWorkspaceAppHostConfig, writeWorkspaceAppHostConfigRaw } from './helpers/fixtures';
-import { getPrimaryAppHostProjectPath, getRunRoot, getWorkspaceRoot } from './helpers/paths';
+import { getCommandInvocationCount, isSamePath, waitForCommandOutcome, waitForExtensionState, waitForNoRunningAppHost, waitForRepositoryIdle, waitForSelectedWorkspaceAppHost, waitForWorkspaceAppHost } from './helpers/assertions';
+import { createAdditionalAppHostCandidate, executeE2eControlCommand, removeAdditionalAppHostCandidate, removeLegacyAspireSettings, removeWorkspaceAppHostConfig, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, stopPrimaryAppHostIfRunning, writeLegacyAspireSettings, writeSlowAppHostDiscoveryCliWrapper, writeWorkspaceAppHostConfig, writeWorkspaceAppHostConfigRaw, writeWorkspaceCliPath } from './helpers/fixtures';
+import { getCliPath, getPrimaryAppHostProjectPath, getRunRoot, getWorkspaceRoot } from './helpers/paths';
 import { openAspireView, waitForWorkbenchText } from './helpers/vscode';
 
 suite('Aspire workspace discovery and configuration E2E', function () {
@@ -172,7 +173,98 @@ suite('Aspire workspace discovery and configuration E2E', function () {
             }
         }
     });
+
+    test('shows running workspace AppHosts while discovery is still pending', async () => {
+        await openAspireView();
+        await waitForRepositoryIdle();
+        await waitForSelectedWorkspaceAppHost();
+        await stopPrimaryAppHostIfRunning();
+        await waitForNoRunningAppHost();
+
+        const wrapperPath = writeSlowAppHostDiscoveryCliWrapper(60000);
+        await writeWorkspaceCliPath(wrapperPath);
+
+        const refreshBefore = getCommandInvocationCount('aspire-vscode.refreshAppHosts');
+        await executeE2eControlCommand({ name: 'refreshAppHosts' }, { waitFor: 'started' });
+        await waitForCommandOutcome('aspire-vscode.refreshAppHosts', 'success', 60000, refreshBefore);
+        await waitForExtensionState(
+            file => !file.state.isWorkspaceAppHostDiscoveryComplete
+                && file.state.workspaceAppHostCandidatePaths.length === 0
+                && file.state.appHosts.length === 0,
+            'slow workspace discovery to remain pending without AppHost candidates',
+            30000);
+
+        const appHostProcessOutput: string[] = [];
+        const appHostProcess = startPrimaryAppHost(appHostProcessOutput);
+        try {
+            await waitForAppHostRunReady(appHostProcessOutput);
+            const psRefreshBefore = getCommandInvocationCount('aspire-vscode.refreshAppHosts');
+            await executeE2eControlCommand({ name: 'refreshAppHosts' }, { waitFor: 'started' });
+            await waitForCommandOutcome('aspire-vscode.refreshAppHosts', 'success', 60000, psRefreshBefore);
+
+            const appHostPath = getPrimaryAppHostProjectPath();
+            const runningDuringDiscovery = await waitForExtensionState(
+                file => !file.state.isWorkspaceAppHostDiscoveryComplete
+                    && file.state.workspaceAppHostCandidatePaths.length === 0
+                    && file.state.appHosts.some(appHost => isSamePath(appHost.appHostPath, appHostPath))
+                    && file.state.workspaceAppHost !== undefined
+                    && isSamePath(file.state.workspaceAppHost.appHostPath, appHostPath)
+                    && !file.state.isRepositoryLoading,
+                'running workspace AppHost from ps while workspace discovery is pending',
+                120000);
+
+            assert.ok(runningDuringDiscovery.state.appHosts.some(appHost => isSamePath(appHost.appHostPath, appHostPath)));
+        } catch (error) {
+            throw new Error(`Running AppHost was not shown before slow discovery completed. AppHost output:\n${appHostProcessOutput.join('')}`, { cause: error });
+        } finally {
+            await restoreWorkspaceCliPath();
+            terminateAppHostProcess(appHostProcess);
+        }
+    });
 });
+
+function startPrimaryAppHost(output: string[]): ChildProcessWithoutNullStreams {
+    const child = spawn(getCliPath(), ['run', '--apphost', getPrimaryAppHostProjectPath(), '--nologo'], {
+        cwd: getWorkspaceRoot(),
+        env: process.env,
+    });
+
+    child.stdout.on('data', chunk => recordProcessOutput(output, chunk));
+    child.stderr.on('data', chunk => recordProcessOutput(output, chunk));
+
+    return child;
+}
+
+function terminateAppHostProcess(child: ChildProcessWithoutNullStreams): void {
+    if (!child.killed) {
+        child.kill('SIGTERM');
+    }
+}
+
+async function waitForAppHostRunReady(output: string[], timeoutMs = 60000): Promise<void> {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+        const text = output.join('');
+        if (text.includes('Press CTRL+C') || text.includes('Presione CTRL+C')) {
+            return;
+        }
+
+        await delay(250);
+    }
+
+    throw new Error(`Timed out waiting for AppHost to start. Output:\n${output.join('')}`);
+}
+
+function recordProcessOutput(output: string[], chunk: Buffer): void {
+    output.push(chunk.toString());
+    while (output.join('').length > 8000) {
+        output.shift();
+    }
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 function getHiddenAppHostDirectory(appHostDirectory: string): string {
     const runRoot = getRunRoot();

--- a/extension/src/test-e2e/discoveryConfiguration.e2e.test.ts
+++ b/extension/src/test-e2e/discoveryConfiguration.e2e.test.ts
@@ -3,12 +3,13 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getCommandInvocationCount, isSamePath, waitForCommandOutcome, waitForExtensionState, waitForNoRunningAppHost, waitForRepositoryIdle, waitForSelectedWorkspaceAppHost, waitForWorkspaceAppHost } from './helpers/assertions';
-import { createAdditionalAppHostCandidate, executeE2eControlCommand, removeAdditionalAppHostCandidate, removeLegacyAspireSettings, removeWorkspaceAppHostConfig, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, stopPrimaryAppHostIfRunning, writeLegacyAspireSettings, writeSlowAppHostDiscoveryCliWrapper, writeWorkspaceAppHostConfig, writeWorkspaceAppHostConfigRaw, writeWorkspaceCliPath } from './helpers/fixtures';
+import { createAdditionalAppHostCandidate, executeE2eControlCommand, removeAdditionalAppHostCandidate, removeLegacyAspireSettings, removeWorkspaceAppHostConfig, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, stopPrimaryAppHostIfRunning, writeLegacyAspireSettings, writeSlowAppHostDiscoveryCliWrapper, writeStreamingAppHostDiscoveryCliWrapper, writeWorkspaceAppHostConfig, writeWorkspaceAppHostConfigRaw, writeWorkspaceCliPath } from './helpers/fixtures';
 import { getCliPath, getPrimaryAppHostProjectPath, getRunRoot, getWorkspaceRoot } from './helpers/paths';
-import { openAspireView, waitForWorkbenchText } from './helpers/vscode';
+import { terminateProcessTree } from './helpers/process';
+import { openAspireView, waitForTreeItem, waitForTreeItemDescription, waitForWorkbenchText } from './helpers/vscode';
 
 suite('Aspire workspace discovery and configuration E2E', function () {
-    this.timeout(180000);
+    this.timeout(300000);
 
     teardown(async () => {
         await runE2eTeardown([
@@ -218,7 +219,63 @@ suite('Aspire workspace discovery and configuration E2E', function () {
             throw new Error(`Running AppHost was not shown before slow discovery completed. AppHost output:\n${appHostProcessOutput.join('')}`, { cause: error });
         } finally {
             await restoreWorkspaceCliPath();
-            terminateAppHostProcess(appHostProcess);
+            await terminateAppHostProcess(appHostProcess, appHostProcessOutput);
+        }
+    });
+
+    test('streams workspace AppHost candidates before discovery completes', async () => {
+        await openAspireView();
+        await waitForRepositoryIdle();
+        await waitForSelectedWorkspaceAppHost();
+        await stopPrimaryAppHostIfRunning();
+        await waitForNoRunningAppHost();
+
+        const wrapperPath = writeStreamingAppHostDiscoveryCliWrapper(180000);
+        await writeWorkspaceCliPath(wrapperPath);
+
+        const refreshBefore = getCommandInvocationCount('aspire-vscode.refreshAppHosts');
+        await executeE2eControlCommand({ name: 'refreshAppHosts' }, { waitFor: 'started' });
+        await waitForCommandOutcome('aspire-vscode.refreshAppHosts', 'success', 60000, refreshBefore);
+
+        const appHostPath = getPrimaryAppHostProjectPath();
+        const streamedCandidate = await waitForExtensionState(
+            file => !file.state.isWorkspaceAppHostDiscoveryComplete
+                && file.state.workspaceAppHostCandidatePaths.some(candidate => isSamePath(candidate, appHostPath))
+                && !file.state.isRepositoryLoading,
+            'streamed workspace AppHost candidate before discovery completed',
+            60000);
+        assert.ok(streamedCandidate.state.workspaceAppHostCandidatePaths.some(candidate => isSamePath(candidate, appHostPath)));
+
+        let section = await openAspireView();
+        const workspaceGroup = await waitForTreeItem(section, 'Workspace AppHosts', 60000);
+        await workspaceGroup.expand();
+        const idleItem = await waitForTreeItem(section, path.basename(appHostPath), 60000);
+        assert.strictEqual(await idleItem.getLabel(), path.basename(appHostPath));
+
+        const appHostProcessOutput: string[] = [];
+        const appHostProcess = startPrimaryAppHost(appHostProcessOutput);
+        try {
+            await waitForAppHostRunReady(appHostProcessOutput);
+
+            const runningDuringDiscovery = await waitForExtensionState(
+                file => !file.state.isWorkspaceAppHostDiscoveryComplete
+                    && file.state.workspaceAppHostCandidatePaths.some(candidate => isSamePath(candidate, appHostPath))
+                    && file.state.appHosts.some(appHost => isSamePath(appHost.appHostPath, appHostPath))
+                    && file.state.workspaceAppHost !== undefined
+                    && isSamePath(file.state.workspaceAppHost.appHostPath, appHostPath)
+                    && !file.state.isRepositoryLoading,
+                'running workspace AppHost while streamed discovery is pending',
+                120000);
+            assert.ok(runningDuringDiscovery.state.appHosts.some(appHost => isSamePath(appHost.appHostPath, appHostPath)));
+
+            section = await openAspireView();
+            const runningItem = await waitForTreeItemDescription(section, path.basename(appHostPath), '(0 resources)', 60000);
+            assert.strictEqual(await runningItem.getLabel(), path.basename(appHostPath));
+        } catch (error) {
+            throw new Error(`Streamed discovery did not show the running AppHost before completion. AppHost output:\n${appHostProcessOutput.join('')}`, { cause: error });
+        } finally {
+            await restoreWorkspaceCliPath();
+            await terminateAppHostProcess(appHostProcess, appHostProcessOutput);
         }
     });
 });
@@ -227,6 +284,7 @@ function startPrimaryAppHost(output: string[]): ChildProcessWithoutNullStreams {
     const child = spawn(getCliPath(), ['run', '--apphost', getPrimaryAppHostProjectPath(), '--nologo'], {
         cwd: getWorkspaceRoot(),
         env: process.env,
+        detached: process.platform !== 'win32',
     });
 
     child.stdout.on('data', chunk => recordProcessOutput(output, chunk));
@@ -235,17 +293,64 @@ function startPrimaryAppHost(output: string[]): ChildProcessWithoutNullStreams {
     return child;
 }
 
-function terminateAppHostProcess(child: ChildProcessWithoutNullStreams): void {
-    if (!child.killed) {
-        child.kill('SIGTERM');
+async function terminateAppHostProcess(child: ChildProcessWithoutNullStreams, output: readonly string[]): Promise<void> {
+    const failures: unknown[] = [];
+
+    try {
+        if (child.exitCode === null && child.signalCode === null) {
+            terminateProcessTree(child.pid, 'SIGTERM');
+        }
+
+        await waitForProcessExit(child, 15000);
+    } catch (error) {
+        failures.push(error);
+    }
+
+    try {
+        const refreshBefore = getCommandInvocationCount('aspire-vscode.refreshAppHosts');
+        await executeE2eControlCommand({ name: 'refreshAppHosts' }, { waitFor: 'started' });
+        await waitForCommandOutcome('aspire-vscode.refreshAppHosts', 'success', 60000, refreshBefore);
+        await waitForNoRunningAppHost(60000);
+        await waitForRepositoryIdle(120000);
+    } catch (error) {
+        failures.push(error);
+    }
+
+    if (failures.length > 0) {
+        throw new AggregateError(failures, `Failed to clean up AppHost process ${child.pid ?? '<unknown>'}. AppHost output:\n${output.join('')}`);
     }
 }
 
-async function waitForAppHostRunReady(output: string[], timeoutMs = 60000): Promise<void> {
+function waitForProcessExit(child: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<void> {
+    if (child.exitCode !== null || child.signalCode !== null) {
+        return Promise.resolve();
+    }
+
+    return new Promise((resolve, reject) => {
+        let forceKillTimeout: NodeJS.Timeout | undefined;
+        const timeout = setTimeout(() => {
+            terminateProcessTree(child.pid, 'SIGKILL');
+            forceKillTimeout = setTimeout(() => {
+                reject(new Error(`Timed out waiting for AppHost process ${child.pid ?? '<unknown>'} to exit.`));
+            }, 5000);
+        }, timeoutMs);
+
+        child.once('close', () => {
+            clearTimeout(timeout);
+            if (forceKillTimeout) {
+                clearTimeout(forceKillTimeout);
+            }
+
+            resolve();
+        });
+    });
+}
+
+async function waitForAppHostRunReady(output: string[], timeoutMs = 120000): Promise<void> {
     const startedAt = Date.now();
     while (Date.now() - startedAt < timeoutMs) {
-        const text = output.join('');
-        if (text.includes('Press CTRL+C') || text.includes('Presione CTRL+C')) {
+        const text = stripAnsi(output.join(''));
+        if (text.includes('CTRL+C')) {
             return;
         }
 
@@ -260,6 +365,10 @@ function recordProcessOutput(output: string[], chunk: Buffer): void {
     while (output.join('').length > 8000) {
         output.shift();
     }
+}
+
+function stripAnsi(value: string): string {
+    return value.replace(/\x1b\[[0-9;]*m/g, '');
 }
 
 function delay(ms: number): Promise<void> {

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -165,6 +165,12 @@ export function writeConfigInfoUnsupportedCliWrapper(name = 'aspire-no-config-in
     });
 }
 
+export function writeSlowAppHostDiscoveryCliWrapper(delayMs: number, name = 'aspire-slow-ls'): string {
+    return writeCliWrapper(name, {
+        lsDelayMs: delayMs,
+    });
+}
+
 export async function restoreWorkspaceCliPath(): Promise<void> {
     await writeWorkspaceCliPath(getCliPath());
 }
@@ -324,7 +330,7 @@ function getLegacyAspireSettingsPath(): string {
 
 function writeCliWrapper(
     name: string,
-    options: { configInfoJson?: unknown; configInfoExitCode?: number; configInfoStderr?: string },
+    options: { configInfoJson?: unknown; configInfoExitCode?: number; configInfoStderr?: string; lsDelayMs?: number },
 ): string {
     const wrapperDirectory = path.join(getWorkspaceRoot(), '.e2e-cli-wrappers');
     fs.mkdirSync(wrapperDirectory, { recursive: true });
@@ -340,12 +346,16 @@ if (args.includes('--include-disabled-commands')) {
   process.exit(123);
 }
 
-if (args.length === 3 && args[0] === 'config' && args[1] === 'info' && args[2] === '--json') {
+if (args.includes('config') && args.includes('info') && args.includes('--json')) {
 ${options.configInfoJson === undefined
         ? `  console.error(${JSON.stringify(options.configInfoStderr ?? 'config info is not available')});
   process.exit(${options.configInfoExitCode ?? 1});`
         : `  console.log(${JSON.stringify(JSON.stringify(options.configInfoJson))});
   process.exit(0);`}
+}
+
+if (args.includes('ls') && ${options.lsDelayMs ?? 0} > 0) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ${options.lsDelayMs ?? 0});
 }
 
 const result = spawnSync(realCli, args, {

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -35,7 +35,7 @@ export async function writeWorkspaceCliPath(cliPath: string): Promise<void> {
     settings['aspire.aspireCliExecutablePath'] = cliPath;
     fs.writeFileSync(settingsPath, JSON.stringify(settings, undefined, 2));
 
-    await applyE2eControl({ aspireCliExecutablePath: cliPath });
+    await applyE2eControl({ aspireCliExecutablePath: cliPath, e2eCliExecutablePath: cliPath });
 }
 
 export async function setE2eCliPathForE2E(cliPath: string | undefined): Promise<void> {

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { AspireExtensionE2EControlCommand, AspireExtensionE2EControlStatus } from '../../types/extensionApi';
 import { applyE2eControl, isSamePath, readStateFile, waitForExtensionState, waitForNoRunningAppHost } from './assertions';
+import { describeIncludeDisabledCommandsCapability, lsJsonStreamCapability } from '../../types/configInfo';
 import { getCliPath, getPrimaryAppHostProjectPath, getRepoRoot, getWorkspaceRoot } from './paths';
 import { runProcess, terminateProcessTree } from './process';
 
@@ -171,6 +172,21 @@ export function writeSlowAppHostDiscoveryCliWrapper(delayMs: number, name = 'asp
     });
 }
 
+export function writeStreamingAppHostDiscoveryCliWrapper(completionDelayMs: number, name = 'aspire-streaming-ls'): string {
+    return writeCliWrapper(name, {
+        configInfoJson: {
+            localSettingsPath: path.join(getWorkspaceRoot(), 'aspire.config.json'),
+            globalSettingsPath: path.join(getWorkspaceRoot(), 'global-aspire.config.json'),
+            availableFeatures: [],
+            localSettingsSchema: { properties: [] },
+            globalSettingsSchema: { properties: [] },
+            capabilities: [describeIncludeDisabledCommandsCapability, lsJsonStreamCapability],
+        },
+        lsStreamCompletionDelayMs: completionDelayMs,
+        rejectIncludeDisabledCommands: false,
+    });
+}
+
 export async function restoreWorkspaceCliPath(): Promise<void> {
     await writeWorkspaceCliPath(getCliPath());
 }
@@ -330,7 +346,7 @@ function getLegacyAspireSettingsPath(): string {
 
 function writeCliWrapper(
     name: string,
-    options: { configInfoJson?: unknown; configInfoExitCode?: number; configInfoStderr?: string; lsDelayMs?: number },
+    options: { configInfoJson?: unknown; configInfoExitCode?: number; configInfoStderr?: string; lsDelayMs?: number; lsStreamCompletionDelayMs?: number; rejectIncludeDisabledCommands?: boolean },
 ): string {
     const wrapperDirectory = path.join(getWorkspaceRoot(), '.e2e-cli-wrappers');
     fs.mkdirSync(wrapperDirectory, { recursive: true });
@@ -341,7 +357,7 @@ const { spawnSync } = require('child_process');
 const realCli = ${JSON.stringify(getCliPath())};
 const args = process.argv.slice(2);
 
-if (args.includes('--include-disabled-commands')) {
+if (${options.rejectIncludeDisabledCommands ?? true} && args.includes('--include-disabled-commands')) {
   console.error('simulated old CLI does not support --include-disabled-commands');
   process.exit(123);
 }
@@ -356,6 +372,35 @@ ${options.configInfoJson === undefined
 
 if (args.includes('ls') && ${options.lsDelayMs ?? 0} > 0) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ${options.lsDelayMs ?? 0});
+}
+
+function sleep(ms) {
+  if (ms > 0) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  }
+}
+
+if (args.includes('ls') && args.includes('--stream') && ${options.lsStreamCompletionDelayMs ?? 0} > 0) {
+  const result = spawnSync(realCli, args, {
+    cwd: process.cwd(),
+    env: process.env,
+    encoding: 'utf8',
+    shell: false,
+  });
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  if (result.error) {
+    console.error(result.error.stack || result.error.message);
+    process.exit(1);
+  }
+
+  sleep(${options.lsStreamCompletionDelayMs ?? 0});
+  process.exit(result.status ?? (result.signal ? 1 : 0));
 }
 
 const result = spawnSync(realCli, args, {

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -8,7 +8,7 @@ import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
 import { AppHostDataRepository } from '../views/AppHostDataRepository';
 import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
-import type { AppHostDiscoveryService, CandidateAppHostDisplayInfo } from '../utils/appHostDiscovery';
+import type { AppHostDiscoveryService, AppHostDiscoverySnapshot, CandidateAppHostDisplayInfo } from '../utils/appHostDiscovery';
 import * as cliModule from '../debugger/languages/cli';
 import * as configInfoProvider from '../utils/configInfoProvider';
 import { describeIncludeDisabledCommandsCapability, lsJsonStreamCapability } from '../types/configInfo';
@@ -45,6 +45,20 @@ function createLsLineCallback(options: any): (line: string) => void {
         options?.stdoutCallback?.(line);
         options?.exitCallback?.(0);
     };
+}
+
+function createDeferredDiscoveryService(): { appHostDiscoveryService: AppHostDiscoveryService; discovery: { promise: Promise<AppHostDiscoverySnapshot>; resolve: (snapshot: AppHostDiscoverySnapshot) => void } } {
+    const discovery = createDeferred<AppHostDiscoverySnapshot>();
+    const appHostDiscoveryService = {
+        onDidChangeCandidates: () => ({ dispose: () => { } }),
+        discover: async () => (await discovery.promise).candidates,
+        discoverStream: async function* () {
+            yield await discovery.promise;
+        },
+        dispose: () => { },
+    } as unknown as AppHostDiscoveryService;
+
+    return { appHostDiscoveryService, discovery };
 }
 
 suite('AppHostDataRepository', () => {
@@ -210,11 +224,12 @@ suite('AppHostDataRepository', () => {
 
     test('describe watch does not report compatibility error when workspace AppHost returns no data successfully', async () => {
         let getAppHostsLineCallback: ((line: string) => void) | undefined;
-        spawnStub.onFirstCall().callsFake((_terminalProvider, _command, _args, options) => {
-            getAppHostsLineCallback = createLsLineCallback(options);
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ls') {
+                getAppHostsLineCallback = createLsLineCallback(options);
+            }
             return new TestChildProcess();
         });
-        spawnStub.onSecondCall().returns(new TestChildProcess());
         const workspaceFoldersStub = stubWorkspaceFolders([{
             uri: vscode.Uri.file('/workspace'),
             name: 'workspace',
@@ -228,14 +243,16 @@ suite('AppHostDataRepository', () => {
             await waitForAppHostDiscovery();
             assert.ok(getAppHostsLineCallback);
 
-            getAppHostsLineCallback(JSON.stringify({
-                selected_project_file: '/workspace/apps/Store/AppHost.csproj',
-                all_project_file_candidates: [
-                    '/workspace/apps/Store/AppHost.csproj',
-                ],
-            }));
+            getAppHostsLineCallback(JSON.stringify([{
+                path: '/workspace/apps/Store/AppHost.csproj',
+                language: 'csharp',
+                status: 'buildable',
+            }]));
             await waitForAppHostDiscovery();
 
+            await waitForCondition(
+                () => spawnStub.getCalls().some(call => (call.args[2] as string[] | undefined)?.[0] === 'describe'),
+                'describe watch did not start');
             const describeCall = spawnStub.getCalls().find(call => (call.args[2] as string[])[0] === 'describe');
             assert.ok(describeCall);
             const exitCallback = describeCall.args[3].exitCallback;
@@ -251,11 +268,12 @@ suite('AppHostDataRepository', () => {
 
     test('describe watch reports minimum AppHost version when workspace AppHost exits without unsupported command output', async () => {
         let getAppHostsLineCallback: ((line: string) => void) | undefined;
-        spawnStub.onFirstCall().callsFake((_terminalProvider, _command, _args, options) => {
-            getAppHostsLineCallback = createLsLineCallback(options);
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ls') {
+                getAppHostsLineCallback = createLsLineCallback(options);
+            }
             return new TestChildProcess();
         });
-        spawnStub.onSecondCall().returns(new TestChildProcess());
         const workspaceFoldersStub = stubWorkspaceFolders([{
             uri: vscode.Uri.file('/workspace'),
             name: 'workspace',
@@ -269,14 +287,16 @@ suite('AppHostDataRepository', () => {
             await waitForAppHostDiscovery();
             assert.ok(getAppHostsLineCallback);
 
-            getAppHostsLineCallback(JSON.stringify({
-                selected_project_file: '/workspace/apps/Store/AppHost.csproj',
-                all_project_file_candidates: [
-                    '/workspace/apps/Store/AppHost.csproj',
-                ],
-            }));
+            getAppHostsLineCallback(JSON.stringify([{
+                path: '/workspace/apps/Store/AppHost.csproj',
+                language: 'csharp',
+                status: 'buildable',
+            }]));
             await waitForAppHostDiscovery();
 
+            await waitForCondition(
+                () => spawnStub.getCalls().some(call => (call.args[2] as string[] | undefined)?.[0] === 'describe'),
+                'describe watch did not start');
             const describeCall = spawnStub.getCalls().find(call => (call.args[2] as string[])[0] === 'describe');
             assert.ok(describeCall);
             const exitCallback = describeCall.args[3].exitCallback;
@@ -311,11 +331,16 @@ suite('AppHostDataRepository', () => {
         let getAppHostsLineCallback: ((line: string) => void) | undefined;
         const getAppHostsProcess = new TestChildProcess();
         const psProcess = new TestChildProcess();
-        spawnStub.onFirstCall().callsFake((_terminalProvider, _command, _args, options) => {
-            getAppHostsLineCallback = createLsLineCallback(options);
-            return getAppHostsProcess;
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ls') {
+                getAppHostsLineCallback = createLsLineCallback(options);
+                return getAppHostsProcess;
+            }
+            if (args[0] === 'ps') {
+                return psProcess;
+            }
+            return new TestChildProcess();
         });
-        spawnStub.onSecondCall().returns(psProcess);
         const workspaceFoldersStub = stubWorkspaceFolders([{
             uri: vscode.Uri.file('/workspace'),
             name: 'workspace',
@@ -329,14 +354,16 @@ suite('AppHostDataRepository', () => {
             await waitForAppHostDiscovery();
             assert.ok(getAppHostsLineCallback);
 
-            getAppHostsLineCallback(JSON.stringify({
-                selected_project_file: '/workspace/apps/Store/AppHost.csproj',
-                all_project_file_candidates: [
-                    '/workspace/apps/Store/AppHost.csproj',
-                ],
-            }));
+            getAppHostsLineCallback(JSON.stringify([{
+                path: '/workspace/apps/Store/AppHost.csproj',
+                language: 'csharp',
+                status: 'buildable',
+            }]));
             await waitForAppHostDiscovery();
 
+            await waitForCondition(
+                () => spawnStub.getCalls().some(call => (call.args[2] as string[] | undefined)?.[0] === 'describe'),
+                'describe watch did not start');
             const describeCall = spawnStub.getCalls().find(call => (call.args[2] as string[])[0] === 'describe');
             assert.ok(describeCall);
             const describeErrorCallback = describeCall.args[3].errorCallback;
@@ -404,13 +431,13 @@ suite('AppHostDataRepository', () => {
             }));
             await waitForAppHostDiscovery();
 
-            const psFollowCall = spawnStub.getCalls().find(call => call.args[2][0] === 'ps');
+            const psFollowCall = spawnStub.getCalls().filter(call => call.args[2][0] === 'ps' && typeof call.args[3].lineCallback === 'function').at(-1);
             assert.ok(psFollowCall);
             const psFollowOptions = psFollowCall.args[3];
             psFollowOptions.exitCallback(1);
-            await waitForAppHostDiscovery();
+            await waitForCondition(() => spawnStub.getCalls().filter(call => call.args[2][0] === 'ps').some(call => typeof call.args[3].stderrCallback === 'function'), 'ps fallback did not start');
 
-            const psFallbackCall = spawnStub.getCalls().filter(call => call.args[2][0] === 'ps').at(-1);
+            const psFallbackCall = spawnStub.getCalls().filter(call => call.args[2][0] === 'ps').find(call => typeof call.args[3].stderrCallback === 'function');
             assert.ok(psFallbackCall);
             const psFallbackOptions = psFallbackCall.args[3];
             psFallbackOptions.stderrCallback('ps failed');
@@ -440,12 +467,19 @@ suite('AppHostDataRepository', () => {
         const getAppHostsProcess = new TestChildProcess();
         const describeProcess = new TestChildProcess();
         const psProcess = new TestChildProcess();
-        spawnStub.onFirstCall().callsFake((_terminalProvider, _command, _args, options) => {
-            getAppHostsLineCallback = createLsLineCallback(options);
-            return getAppHostsProcess;
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            switch (args[0]) {
+                case 'ls':
+                    getAppHostsLineCallback = createLsLineCallback(options);
+                    return getAppHostsProcess;
+                case 'describe':
+                    return describeProcess;
+                case 'ps':
+                    return psProcess;
+                default:
+                    return new TestChildProcess();
+            }
         });
-        spawnStub.onSecondCall().returns(describeProcess);
-        spawnStub.onThirdCall().returns(psProcess);
         const workspaceFoldersStub = stubWorkspaceFolders([{
             uri: vscode.Uri.file('/workspace'),
             name: 'workspace',
@@ -482,12 +516,19 @@ suite('AppHostDataRepository', () => {
         const getAppHostsProcess = new TestChildProcess();
         const describeProcess = new TestChildProcess();
         const psProcess = new TestChildProcess();
-        spawnStub.onFirstCall().callsFake((_terminalProvider, _command, _args, options) => {
-            getAppHostsLineCallback = createLsLineCallback(options);
-            return getAppHostsProcess;
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            switch (args[0]) {
+                case 'ls':
+                    getAppHostsLineCallback = createLsLineCallback(options);
+                    return getAppHostsProcess;
+                case 'describe':
+                    return describeProcess;
+                case 'ps':
+                    return psProcess;
+                default:
+                    return new TestChildProcess();
+            }
         });
-        spawnStub.onSecondCall().returns(describeProcess);
-        spawnStub.onThirdCall().returns(psProcess);
         const workspaceFoldersStub = stubWorkspaceFolders([{
             uri: vscode.Uri.file('/workspace'),
             name: 'workspace',
@@ -931,8 +972,10 @@ suite('AppHostDataRepository', () => {
         }]);
         const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves(undefined);
         let getAppHostsLineCallback: ((line: string) => void) | undefined;
-        spawnStub.onFirstCall().callsFake((_terminalProvider, _command, _args, options) => {
-            getAppHostsLineCallback = createLsLineCallback(options);
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ls') {
+                getAppHostsLineCallback = createLsLineCallback(options);
+            }
             return new TestChildProcess();
         });
         const repository = new AppHostDataRepository(terminalProvider);
@@ -946,6 +989,10 @@ suite('AppHostDataRepository', () => {
             getAppHostsLineCallback(JSON.stringify([]));
             await waitForAppHostDiscovery();
 
+            await waitForCondition(
+                () => executeCommandStub.getCalls().some(call =>
+                    call.args[0] === 'setContext' && call.args[1] === 'aspire.loading' && call.args[2] === false),
+                'workspace loading context did not clear');
             const loadingContextCalls = executeCommandStub.getCalls().filter(call =>
                 call.args[0] === 'setContext' && call.args[1] === 'aspire.loading');
             assert.strictEqual(loadingContextCalls.at(-1)?.args[2], false);
@@ -968,8 +1015,10 @@ suite('AppHostDataRepository', () => {
         }]);
         const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand').resolves(undefined);
         let getAppHostsLineCallback: ((line: string) => void) | undefined;
-        spawnStub.onFirstCall().callsFake((_terminalProvider, _command, _args, options) => {
-            getAppHostsLineCallback = createLsLineCallback(options);
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ls') {
+                getAppHostsLineCallback = createLsLineCallback(options);
+            }
             return new TestChildProcess();
         });
         const repository = new AppHostDataRepository(terminalProvider);
@@ -990,6 +1039,10 @@ suite('AppHostDataRepository', () => {
             ]));
             await waitForAppHostDiscovery();
 
+            await waitForCondition(
+                () => executeCommandStub.getCalls().some(call =>
+                    call.args[0] === 'setContext' && call.args[1] === 'aspire.loading' && call.args[2] === false),
+                'workspace loading context did not clear');
             const loadingContextCalls = executeCommandStub.getCalls().filter(call =>
                 call.args[0] === 'setContext' && call.args[1] === 'aspire.loading');
             assert.strictEqual(loadingContextCalls.at(-1)?.args[2], false);
@@ -1127,6 +1180,166 @@ suite('AppHostDataRepository', () => {
         }
     });
 
+    test('workspace ps shows running AppHosts before workspace discovery completes', async () => {
+        const workspaceFolder = {
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
+        const { appHostDiscoveryService, discovery } = createDeferredDiscoveryService();
+        let psOptions: any;
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ps') {
+                psOptions = options;
+            }
+            return new TestChildProcess();
+        });
+        const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
+
+        try {
+            repository.activate();
+            repository.setPanelVisible(true);
+            await waitForCondition(() => psOptions !== undefined, 'workspace ps watch did not start before discovery completed');
+
+            psOptions.lineCallback(JSON.stringify([
+                {
+                    appHostPath: '/workspace/apps/Store/AppHost.csproj',
+                    appHostPid: 125881,
+                    dashboardUrl: 'https://localhost:17193/login?t=061212',
+                },
+            ]));
+
+            assert.strictEqual(repository.isWorkspaceAppHostDiscoveryComplete, false);
+            assert.strictEqual(repository.appHosts.length, 1);
+            assert.strictEqual(repository.appHosts[0].appHostPath, '/workspace/apps/Store/AppHost.csproj');
+            assert.strictEqual(repository.workspaceAppHost?.appHostPid, 125881);
+            assert.strictEqual(repository.isLoading, false);
+
+            discovery.resolve({
+                candidates: [{
+                    path: '/workspace/apps/Store/AppHost.csproj',
+                    language: 'csharp',
+                    status: 'buildable',
+                }],
+                isComplete: true,
+            });
+            await waitForCondition(() => repository.isWorkspaceAppHostDiscoveryComplete, 'workspace discovery did not complete');
+
+            assert.deepStrictEqual(repository.workspaceAppHostCandidatePaths, [
+                '/workspace/apps/Store/AppHost.csproj',
+            ]);
+            assert.strictEqual(repository.appHosts.length, 1);
+        } finally {
+            repository.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
+    test('refresh restarts workspace ps follow while workspace discovery is pending', async () => {
+        const workspaceFolder = {
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
+        const { appHostDiscoveryService } = createDeferredDiscoveryService();
+        const psProcesses: TestChildProcess[] = [];
+        spawnStub.callsFake((_terminalProvider, _command, args) => {
+            const process = new TestChildProcess();
+            if (args[0] === 'ps') {
+                psProcesses.push(process);
+            }
+
+            return process;
+        });
+        const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
+
+        try {
+            repository.activate();
+            repository.setPanelVisible(true);
+            await waitForCondition(() => psProcesses.length === 1, 'workspace ps follow did not start before discovery completed');
+
+            repository.refresh();
+            await waitForCondition(() => psProcesses.length === 2, 'workspace ps follow did not restart on refresh');
+
+            assert.strictEqual(psProcesses[0].killed, true);
+            assert.deepStrictEqual(
+                spawnStub.getCalls()
+                    .map(call => call.args[2])
+                    .filter(args => args[0] === 'ps'),
+                [
+                    ['ps', '--follow', '--format', 'json'],
+                    ['ps', '--follow', '--format', 'json'],
+                ]);
+        } finally {
+            repository.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
+    test('workspace ps keeps all running AppHosts while streamed discovery is incomplete', async () => {
+        const workspaceFolder = {
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
+        const finalDiscovery = createDeferred<AppHostDiscoverySnapshot>();
+        const appHostDiscoveryService = {
+            onDidChangeCandidates: () => ({ dispose: () => { } }),
+            discover: async () => (await finalDiscovery.promise).candidates,
+            discoverStream: async function* () {
+                yield {
+                    candidates: [{
+                        path: '/workspace/apps/Store/AppHost.csproj',
+                        language: 'csharp',
+                        status: 'buildable',
+                    }],
+                    isComplete: false,
+                };
+                yield await finalDiscovery.promise;
+            },
+            dispose: () => { },
+        } as unknown as AppHostDiscoveryService;
+        let psOptions: any;
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ps') {
+                psOptions = options;
+            }
+            return new TestChildProcess();
+        });
+        const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService);
+
+        try {
+            repository.activate();
+            repository.setPanelVisible(true);
+            await waitForCondition(() => repository.workspaceAppHostCandidatePaths.length === 1, 'streamed workspace candidate did not appear');
+            await waitForCondition(() => psOptions !== undefined, 'workspace ps watch did not start before discovery completed');
+
+            psOptions.lineCallback(JSON.stringify([
+                {
+                    appHostPath: '/workspace/apps/Store/AppHost.csproj',
+                    appHostPid: 125881,
+                },
+                {
+                    appHostPath: '/workspace/samples/Store/AppHost.csproj',
+                    appHostPid: 125882,
+                },
+            ]));
+
+            assert.strictEqual(repository.isWorkspaceAppHostDiscoveryComplete, false);
+            assert.deepStrictEqual(repository.appHosts.map(appHost => appHost.appHostPath), [
+                '/workspace/apps/Store/AppHost.csproj',
+                '/workspace/samples/Store/AppHost.csproj',
+            ]);
+        } finally {
+            finalDiscovery.resolve({ candidates: [], isComplete: true });
+            repository.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
     test('coalesces workspace discovery change events while discovery is in flight', async () => {
         const workspaceFolder = {
             uri: vscode.Uri.file('/workspace'),
@@ -1135,35 +1348,40 @@ suite('AppHostDataRepository', () => {
         };
         const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
         const discoveryChanges = new vscode.EventEmitter<vscode.WorkspaceFolder>();
-        const firstDiscovery = createDeferred<CandidateAppHostDisplayInfo[]>();
-        const secondDiscovery = createDeferred<CandidateAppHostDisplayInfo[]>();
-        const discoverStub = sinon.stub();
-        discoverStub.onFirstCall().returns(firstDiscovery.promise);
-        discoverStub.onSecondCall().returns(secondDiscovery.promise);
+        const firstDiscovery = createDeferred<AppHostDiscoverySnapshot>();
+        const secondDiscovery = createDeferred<AppHostDiscoverySnapshot>();
+        const discoverStreamStub = sinon.stub();
+        discoverStreamStub.onFirstCall().callsFake(async function* () {
+            yield await firstDiscovery.promise;
+        });
+        discoverStreamStub.onSecondCall().callsFake(async function* () {
+            yield await secondDiscovery.promise;
+        });
         const appHostDiscoveryService = {
             onDidChangeCandidates: discoveryChanges.event,
-            discover: discoverStub,
+            discover: async () => [],
+            discoverStream: discoverStreamStub,
             dispose: () => { },
         };
         const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
 
         try {
             await waitForMicrotasks();
-            assert.strictEqual(discoverStub.callCount, 1);
+            assert.strictEqual(discoverStreamStub.callCount, 1);
 
             discoveryChanges.fire(workspaceFolder);
             discoveryChanges.fire(workspaceFolder);
             discoveryChanges.fire(workspaceFolder);
             await waitForMicrotasks();
 
-            assert.strictEqual(discoverStub.callCount, 1);
+            assert.strictEqual(discoverStreamStub.callCount, 1);
 
-            firstDiscovery.resolve([]);
-            await waitForCondition(() => discoverStub.callCount === 2, 'pending workspace discovery did not run');
-            secondDiscovery.resolve([]);
+            firstDiscovery.resolve({ candidates: [], isComplete: true });
+            await waitForCondition(() => discoverStreamStub.callCount === 2, 'pending workspace discovery did not run');
+            secondDiscovery.resolve({ candidates: [], isComplete: true });
             await waitForAppHostDiscovery();
 
-            assert.strictEqual(discoverStub.callCount, 2);
+            assert.strictEqual(discoverStreamStub.callCount, 2);
         } finally {
             repository.dispose();
             discoveryChanges.dispose();
@@ -1178,43 +1396,155 @@ suite('AppHostDataRepository', () => {
             index: 0,
         };
         const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
-        const firstDiscovery = createDeferred<CandidateAppHostDisplayInfo[]>();
-        const secondDiscovery = createDeferred<CandidateAppHostDisplayInfo[]>();
+        const firstDiscovery = createDeferred<AppHostDiscoverySnapshot>();
+        const secondDiscovery = createDeferred<AppHostDiscoverySnapshot>();
         let firstTokenCancelled = false;
-        const discoverStub = sinon.stub();
-        discoverStub.onFirstCall().callsFake((_folder: vscode.WorkspaceFolder, _forceRefresh?: boolean, cancellationToken?: vscode.CancellationToken) => {
+        const discoverStreamStub = sinon.stub();
+        discoverStreamStub.onFirstCall().callsFake(async function* (_folder: vscode.WorkspaceFolder, _forceRefresh?: boolean, cancellationToken?: vscode.CancellationToken) {
             cancellationToken?.onCancellationRequested(() => {
                 firstTokenCancelled = true;
             });
-            return firstDiscovery.promise;
+            yield await firstDiscovery.promise;
         });
-        discoverStub.onSecondCall().callsFake((_folder: vscode.WorkspaceFolder, forceRefresh?: boolean) => {
+        discoverStreamStub.onSecondCall().callsFake(async function* (_folder: vscode.WorkspaceFolder, forceRefresh?: boolean) {
             assert.strictEqual(forceRefresh, true);
-            return secondDiscovery.promise;
+            yield await secondDiscovery.promise;
         });
         const appHostDiscoveryService = {
             onDidChangeCandidates: () => ({ dispose: () => { } }),
-            discover: discoverStub,
+            discover: async () => [],
+            discoverStream: discoverStreamStub,
             dispose: () => { },
         };
         const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
 
         try {
             await waitForMicrotasks();
-            assert.strictEqual(discoverStub.callCount, 1);
+            assert.strictEqual(discoverStreamStub.callCount, 1);
 
             repository.refresh();
             await waitForMicrotasks();
 
             assert.strictEqual(firstTokenCancelled, false);
-            assert.strictEqual(discoverStub.callCount, 1);
+            assert.strictEqual(discoverStreamStub.callCount, 1);
 
-            firstDiscovery.resolve([]);
-            await waitForCondition(() => discoverStub.callCount === 2, 'queued forced workspace discovery did not run');
-            secondDiscovery.resolve([]);
+            firstDiscovery.resolve({ candidates: [], isComplete: true });
+            await waitForCondition(() => discoverStreamStub.callCount === 2, 'queued forced workspace discovery did not run');
+            secondDiscovery.resolve({ candidates: [], isComplete: true });
             await waitForAppHostDiscovery();
 
-            assert.strictEqual(discoverStub.callCount, 2);
+            assert.strictEqual(discoverStreamStub.callCount, 2);
+        } finally {
+            repository.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
+    test('workspace ps ignores running AppHosts outside workspace before discovery completes', async () => {
+        const workspaceFolder = {
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
+        const { appHostDiscoveryService } = createDeferredDiscoveryService();
+        let psOptions: any;
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ps') {
+                psOptions = options;
+            }
+            return new TestChildProcess();
+        });
+        const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
+
+        try {
+            repository.activate();
+            repository.setPanelVisible(true);
+            await waitForCondition(() => psOptions !== undefined, 'workspace ps watch did not start before discovery completed');
+
+            psOptions.lineCallback(JSON.stringify([
+                {
+                    appHostPath: '/other/apps/Store/AppHost.csproj',
+                    appHostPid: 125881,
+                    dashboardUrl: 'https://localhost:17193/login?t=061212',
+                },
+            ]));
+
+            assert.strictEqual(repository.isWorkspaceAppHostDiscoveryComplete, false);
+            assert.strictEqual(repository.appHosts.length, 0);
+            assert.strictEqual(repository.workspaceAppHost, undefined);
+        } finally {
+            repository.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
+    test('workspace ps empty snapshot keeps loading while workspace discovery is pending', async () => {
+        const workspaceFolder = {
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
+        const { appHostDiscoveryService } = createDeferredDiscoveryService();
+        let psOptions: any;
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ps') {
+                psOptions = options;
+            }
+            return new TestChildProcess();
+        });
+        const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
+
+        try {
+            repository.activate();
+            repository.setPanelVisible(true);
+            await waitForCondition(() => psOptions !== undefined, 'workspace ps watch did not start before discovery completed');
+
+            psOptions.lineCallback(JSON.stringify([]));
+
+            assert.strictEqual(repository.isWorkspaceAppHostDiscoveryComplete, false);
+            assert.strictEqual(repository.isLoading, true);
+        } finally {
+            repository.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
+    test('workspace ps stops after discovery completes with no buildable AppHosts', async () => {
+        const workspaceFolder = {
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
+        const { appHostDiscoveryService, discovery } = createDeferredDiscoveryService();
+        let psProcess: TestChildProcess | undefined;
+        spawnStub.callsFake((_terminalProvider, _command, args) => {
+            const process = new TestChildProcess();
+            if (args[0] === 'ps') {
+                psProcess = process;
+            }
+            return process;
+        });
+        const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
+
+        try {
+            repository.activate();
+            repository.setPanelVisible(true);
+            await waitForCondition(() => psProcess !== undefined, 'workspace ps watch did not start before discovery completed');
+
+            discovery.resolve({
+                candidates: [{
+                    path: '/workspace/apps/Store/Store.csproj',
+                    language: 'csharp',
+                    status: 'possibly-unbuildable',
+                }],
+                isComplete: true,
+            });
+            await waitForCondition(() => repository.isWorkspaceAppHostDiscoveryComplete, 'workspace discovery did not complete');
+
+            assert.strictEqual(psProcess?.killed, true);
         } finally {
             repository.dispose();
             workspaceFoldersStub.restore();
@@ -1228,40 +1558,51 @@ suite('AppHostDataRepository', () => {
             index: 0,
         };
         const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
-        const firstDiscovery = createDeferred<CandidateAppHostDisplayInfo[]>();
-        const secondDiscovery = createDeferred<CandidateAppHostDisplayInfo[]>();
-        const discoverStub = sinon.stub();
-        discoverStub.onFirstCall().returns(firstDiscovery.promise);
-        discoverStub.onSecondCall().returns(secondDiscovery.promise);
+        const firstDiscovery = createDeferred<AppHostDiscoverySnapshot>();
+        const secondDiscovery = createDeferred<AppHostDiscoverySnapshot>();
+        const discoverStreamStub = sinon.stub();
+        discoverStreamStub.onFirstCall().callsFake(async function* () {
+            yield await firstDiscovery.promise;
+        });
+        discoverStreamStub.onSecondCall().callsFake(async function* () {
+            yield await secondDiscovery.promise;
+        });
         const appHostDiscoveryService = {
             onDidChangeCandidates: () => ({ dispose: () => { } }),
-            discover: discoverStub,
+            discover: async () => [],
+            discoverStream: discoverStreamStub,
             dispose: () => { },
         };
         const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
 
         try {
             await waitForMicrotasks();
-            assert.strictEqual(discoverStub.callCount, 1);
+            assert.strictEqual(discoverStreamStub.callCount, 1);
 
             repository.refresh();
             await waitForMicrotasks();
-            assert.strictEqual(discoverStub.callCount, 1);
+            assert.strictEqual(discoverStreamStub.callCount, 1);
 
-            firstDiscovery.resolve([{
-                path: '/workspace/stale/AppHost.csproj',
-                language: 'csharp',
-                status: 'buildable',
-            }]);
-            await waitForCondition(() => discoverStub.callCount === 2, 'queued forced workspace discovery did not run');
+            firstDiscovery.resolve({
+                candidates: [{
+                    path: '/workspace/stale/AppHost.csproj',
+                    language: 'csharp',
+                    status: 'buildable',
+                }],
+                isComplete: true,
+            });
+            await waitForCondition(() => discoverStreamStub.callCount === 2, 'queued forced workspace discovery did not run');
 
             assert.strictEqual(repository.workspaceAppHostPath, undefined);
 
-            secondDiscovery.resolve([{
-                path: '/workspace/current/AppHost.csproj',
-                language: 'csharp',
-                status: 'buildable',
-            }]);
+            secondDiscovery.resolve({
+                candidates: [{
+                    path: '/workspace/current/AppHost.csproj',
+                    language: 'csharp',
+                    status: 'buildable',
+                }],
+                isComplete: true,
+            });
             await waitForCondition(() => repository.workspaceAppHostPath === '/workspace/current/AppHost.csproj', 'current workspace discovery did not apply');
         } finally {
             repository.dispose();
@@ -1314,13 +1655,13 @@ suite('AppHostDataRepository', () => {
             }));
             await waitForAppHostDiscovery();
 
-            const psFollowCall = spawnStub.getCalls().find(call => (call.args[2] as string[])[0] === 'ps');
+            const psFollowCall = spawnStub.getCalls().filter(call => (call.args[2] as string[])[0] === 'ps' && typeof call.args[3].lineCallback === 'function').at(-1);
             assert.ok(psFollowCall);
             const psFollowOptions = psFollowCall.args[3];
             psFollowOptions.exitCallback(1);
-            await waitForAppHostDiscovery();
+            await waitForCondition(() => spawnStub.getCalls().filter(call => (call.args[2] as string[])[0] === 'ps').some(call => typeof call.args[3].stderrCallback === 'function'), 'ps fallback did not start');
 
-            const psFallbackCall = spawnStub.getCalls().filter(call => (call.args[2] as string[])[0] === 'ps')[1];
+            const psFallbackCall = spawnStub.getCalls().filter(call => (call.args[2] as string[])[0] === 'ps').find(call => typeof call.args[3].stderrCallback === 'function');
             assert.ok(psFallbackCall);
             const psFallbackOptions = psFallbackCall.args[3];
             psFallbackOptions.stderrCallback('ps failed');

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -11,7 +11,7 @@ import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 import type { AppHostDiscoveryService, CandidateAppHostDisplayInfo } from '../utils/appHostDiscovery';
 import * as cliModule from '../debugger/languages/cli';
 import * as configInfoProvider from '../utils/configInfoProvider';
-import { describeIncludeDisabledCommandsCapability } from '../types/configInfo';
+import { describeIncludeDisabledCommandsCapability, lsJsonStreamCapability } from '../types/configInfo';
 
 class TestChildProcess extends EventEmitter {
     stdout = new PassThrough();
@@ -1004,6 +1004,61 @@ suite('AppHostDataRepository', () => {
         }
     });
 
+    test('workspace discovery applies streamed AppHost candidates before completion', async () => {
+        getConfigInfoStub.resolves({
+            capabilities: [describeIncludeDisabledCommandsCapability, lsJsonStreamCapability],
+        } as any);
+        const workspaceFoldersStub = stubWorkspaceFolders([{
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        }]);
+        let lsOptions: any;
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ls') {
+                lsOptions = options;
+            }
+            return new TestChildProcess();
+        });
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        try {
+            repository.activate();
+            repository.setPanelVisible(true);
+            await waitForCondition(() => lsOptions !== undefined, 'streaming aspire ls did not start');
+
+            lsOptions.lineCallback(JSON.stringify({
+                path: '/workspace/apps/Store/AppHost.csproj',
+                language: 'csharp',
+                status: 'buildable',
+            }));
+            await waitForAppHostDiscovery();
+
+            assert.strictEqual(repository.isWorkspaceAppHostDiscoveryComplete, false);
+            assert.strictEqual(repository.isLoading, false);
+            assert.deepStrictEqual(repository.workspaceAppHostCandidatePaths, [
+                '/workspace/apps/Store/AppHost.csproj',
+            ]);
+            assert.strictEqual(repository.workspaceAppHostPath, undefined);
+
+            lsOptions.lineCallback(JSON.stringify({
+                path: '/workspace/samples/Store/AppHost.csproj',
+                language: 'csharp',
+                status: 'buildable',
+            }));
+            lsOptions.exitCallback(0);
+            await waitForCondition(() => repository.isWorkspaceAppHostDiscoveryComplete, 'streaming aspire ls did not complete');
+
+            assert.deepStrictEqual(repository.workspaceAppHostCandidatePaths, [
+                '/workspace/apps/Store/AppHost.csproj',
+                '/workspace/samples/Store/AppHost.csproj',
+            ]);
+        } finally {
+            repository.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
     test('workspace discovery with no buildable AppHosts clears stale running state', async () => {
         const workspaceFolder = {
             uri: vscode.Uri.file('/workspace'),
@@ -1023,6 +1078,9 @@ suite('AppHostDataRepository', () => {
         const appHostDiscoveryService = {
             onDidChangeCandidates: discoveryChanges.event,
             discover: async () => candidates,
+            discoverStream: async function* () {
+                yield { candidates, isComplete: true };
+            },
             dispose: () => { },
         };
         let psOptions: any;
@@ -1304,6 +1362,23 @@ suite('AppHostDataRepository', () => {
                     status: 'buildable',
                 },
             ],
+            discoverStream: async function* () {
+                yield {
+                    candidates: [
+                        {
+                            path: '/workspace/apps/Store/AppHost.csproj',
+                            language: 'csharp',
+                            status: 'buildable',
+                        },
+                        {
+                            path: '/workspace/samples/Store/AppHost.csproj',
+                            language: 'csharp',
+                            status: 'buildable',
+                        },
+                    ],
+                    isComplete: true,
+                };
+            },
         };
         getCliPathStub.rejects(new Error('CLI missing'));
         const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
@@ -1337,6 +1412,9 @@ suite('AppHostDataRepository', () => {
         const appHostDiscoveryService = {
             onDidChangeCandidates: () => ({ dispose: () => { } }),
             discover: async () => {
+                throw new Error('aspire ls failed');
+            },
+            discoverStream: async function* () {
                 throw new Error('aspire ls failed');
             },
         };
@@ -2127,6 +2205,9 @@ suite('AppHostDataRepository global polling', () => {
         }];
         const discoveryService = {
             discover: async () => candidates,
+            discoverStream: async function* () {
+                yield { candidates, isComplete: true };
+            },
             onDidChangeCandidates: discoveryChanges.event,
             dispose: () => discoveryChanges.dispose(),
         } as unknown as AppHostDiscoveryService;
@@ -2188,6 +2269,9 @@ suite('AppHostDataRepository global polling', () => {
         }];
         const discoveryService = {
             discover: async () => candidates,
+            discoverStream: async function* () {
+                yield { candidates, isComplete: true };
+            },
             onDidChangeCandidates: discoveryChanges.event,
             dispose: () => discoveryChanges.dispose(),
         } as unknown as AppHostDiscoveryService;

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -8,7 +8,9 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as cliModule from '../debugger/languages/cli';
 import { AppHostDiscoveryService, findCandidateForEditorFile, findConfiguredAppHostPaths, getDebugTargetForCandidate, selectWorkspaceAppHostPath } from '../utils/appHostDiscovery';
+import type { AppHostDiscoverySnapshot } from '../utils/appHostDiscovery';
 import type { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
+import type { ConfigInfoProvider } from '../utils/configInfoProvider';
 import { appHostDiscoveryFindFilesMaxResults } from '../utils/workspaceFileSearch';
 
 suite('AppHost discovery', () => {
@@ -542,6 +544,232 @@ suite('AppHost discovery', () => {
             }
         });
 
+        test('streams aspire ls candidates before command completion when capability is advertised', async () => {
+            stubFileSystemWatchers(sandbox);
+            const configInfoProvider = makeConfigInfoProvider(true);
+            let lineCallback: ((line: string) => void) | undefined;
+            let exitCallback: ((code: number | null) => void) | undefined;
+            const spawnStub = sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                lineCallback = options?.lineCallback;
+                exitCallback = options?.exitCallback;
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider(), configInfoProvider);
+
+            try {
+                const snapshots: AppHostDiscoverySnapshot[] = [];
+                const streamTask = collectSnapshots(service.discoverStream(makeWorkspaceFolder(buildPath('workspace'))), snapshots);
+                await waitForMicrotasks();
+
+                assert.deepStrictEqual(spawnStub.firstCall.args[2], ['ls', '--format', 'json', '--stream']);
+                assert.ok(lineCallback);
+                assert.ok(exitCallback);
+
+                lineCallback(JSON.stringify({
+                    path: buildPath('workspace', 'First', 'AppHost.csproj'),
+                    language: 'csharp',
+                    status: 'buildable',
+                }));
+                await waitForMicrotasks();
+
+                assert.strictEqual(snapshots.length, 1);
+                assert.strictEqual(snapshots[0].isComplete, false);
+                assert.deepStrictEqual(snapshots[0].candidates.map(candidate => candidate.path), [
+                    buildPath('workspace', 'First', 'AppHost.csproj'),
+                ]);
+
+                lineCallback(JSON.stringify({
+                    path: buildPath('workspace', 'Second', 'AppHost.csproj'),
+                    language: 'csharp',
+                    status: 'buildable',
+                }));
+                exitCallback(0);
+                const finalCandidates = await streamTask;
+
+                assert.deepStrictEqual(finalCandidates.map(candidate => candidate.path), [
+                    buildPath('workspace', 'First', 'AppHost.csproj'),
+                    buildPath('workspace', 'Second', 'AppHost.csproj'),
+                ]);
+                assert.strictEqual(snapshots.at(-1)?.isComplete, true);
+            }
+            finally {
+                service.dispose();
+            }
+        });
+
+        test('shares in-flight streaming discovery with promise discovery', async () => {
+            stubFileSystemWatchers(sandbox);
+            const configInfoProvider = makeConfigInfoProvider(true);
+            let lineCallback: ((line: string) => void) | undefined;
+            let exitCallback: ((code: number | null) => void) | undefined;
+            const spawnStub = sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                lineCallback = options?.lineCallback;
+                exitCallback = options?.exitCallback;
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider(), configInfoProvider);
+            const workspaceFolder = makeWorkspaceFolder(buildPath('workspace'));
+
+            try {
+                const snapshots: AppHostDiscoverySnapshot[] = [];
+                const streamTask = collectSnapshots(service.discoverStream(workspaceFolder), snapshots);
+                const discoverTask = service.discover(workspaceFolder);
+                await waitForMicrotasks();
+
+                lineCallback?.(JSON.stringify({
+                    path: buildPath('workspace', 'AppHost', 'AppHost.csproj'),
+                    language: 'csharp',
+                    status: 'buildable',
+                }));
+                exitCallback?.(0);
+
+                const [streamResult, discoverResult] = await Promise.all([streamTask, discoverTask]);
+                assert.strictEqual(spawnStub.callCount, 1);
+                assert.deepStrictEqual(streamResult, discoverResult);
+                assert.strictEqual(snapshots.length, 2);
+            }
+            finally {
+                service.dispose();
+            }
+        });
+
+        test('starts streaming discovery when stream attaches after promise-only discovery', async () => {
+            stubFileSystemWatchers(sandbox);
+            const configInfoProvider = makeConfigInfoProvider(true);
+            const spawnedDiscoveries: Array<{ args: string[]; options: any }> = [];
+            const spawnStub = sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, args = [], options) => {
+                spawnedDiscoveries.push({ args, options });
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider(), configInfoProvider);
+            const workspaceFolder = makeWorkspaceFolder(buildPath('workspace'));
+
+            try {
+                const discoverTask = service.discover(workspaceFolder);
+                await waitForMicrotasks();
+
+                const snapshots: AppHostDiscoverySnapshot[] = [];
+                const streamTask = collectSnapshots(service.discoverStream(workspaceFolder), snapshots);
+                await waitForMicrotasks();
+
+                assert.deepStrictEqual(spawnedDiscoveries.map(discovery => discovery.args), [
+                    ['ls', '--format', 'json'],
+                    ['ls', '--format', 'json', '--stream'],
+                ]);
+                assert.ok(spawnedDiscoveries[1].options.lineCallback);
+                assert.ok(spawnedDiscoveries[1].options.exitCallback);
+
+                spawnedDiscoveries[0].options.stdoutCallback(JSON.stringify([{
+                    path: buildPath('workspace', 'AppHost', 'AppHost.csproj'),
+                    language: 'csharp',
+                    status: 'buildable',
+                }]));
+                spawnedDiscoveries[0].options.exitCallback(0);
+
+                spawnedDiscoveries[1].options.lineCallback(JSON.stringify({
+                    path: buildPath('workspace', 'AppHost', 'AppHost.csproj'),
+                    language: 'csharp',
+                    status: 'buildable',
+                }));
+                await waitForMicrotasks();
+
+                assert.strictEqual(snapshots.length, 1);
+                assert.strictEqual(snapshots[0].isComplete, false);
+
+                spawnedDiscoveries[1].options.exitCallback(0);
+
+                const [discoverResult, streamResult] = await Promise.all([discoverTask, streamTask]);
+                assert.strictEqual(spawnStub.callCount, 2);
+                assert.deepStrictEqual(discoverResult, streamResult);
+                assert.strictEqual(snapshots.at(-1)?.isComplete, true);
+            }
+            finally {
+                service.dispose();
+            }
+        });
+
+        test('keeps active streaming discovery cached when replaced promise-only discovery fails', async () => {
+            stubFileSystemWatchers(sandbox);
+            const configInfoProvider = makeConfigInfoProvider(true);
+            const spawnedDiscoveries: Array<{ args: string[]; options: any }> = [];
+            const spawnStub = sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, args = [], options) => {
+                spawnedDiscoveries.push({ args, options });
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider(), configInfoProvider);
+            const workspaceFolder = makeWorkspaceFolder(buildPath('workspace'));
+
+            try {
+                const discoverTask = service.discover(workspaceFolder);
+                await waitForMicrotasks();
+
+                const firstSnapshots: AppHostDiscoverySnapshot[] = [];
+                const firstStreamTask = collectSnapshots(service.discoverStream(workspaceFolder), firstSnapshots);
+                await waitForMicrotasks();
+
+                assert.strictEqual(spawnStub.callCount, 2);
+
+                spawnedDiscoveries[0].options.stderrCallback('first discovery failed');
+                spawnedDiscoveries[0].options.exitCallback(1);
+                await waitForMicrotasks();
+                assert.deepStrictEqual(spawnedDiscoveries[2].args, ['extension', 'get-apphosts']);
+                spawnedDiscoveries[2].options.stderrCallback('legacy discovery failed');
+                spawnedDiscoveries[2].options.exitCallback(1);
+                await assert.rejects(discoverTask, /first discovery failed/);
+
+                const secondSnapshots: AppHostDiscoverySnapshot[] = [];
+                const secondStreamTask = collectSnapshots(service.discoverStream(workspaceFolder), secondSnapshots);
+                await waitForMicrotasks();
+
+                assert.strictEqual(spawnStub.callCount, 3);
+
+                spawnedDiscoveries[1].options.lineCallback(JSON.stringify({
+                    path: buildPath('workspace', 'AppHost', 'AppHost.csproj'),
+                    language: 'csharp',
+                    status: 'buildable',
+                }));
+                await waitForMicrotasks();
+                spawnedDiscoveries[1].options.exitCallback(0);
+
+                const [firstStreamResult, secondStreamResult] = await Promise.all([firstStreamTask, secondStreamTask]);
+                assert.deepStrictEqual(firstStreamResult, secondStreamResult);
+                assert.deepStrictEqual(firstSnapshots.at(-1)?.candidates, secondSnapshots.at(-1)?.candidates);
+            }
+            finally {
+                service.dispose();
+            }
+        });
+
+        test('uses buffered aspire ls when streaming capability is not advertised', async () => {
+            stubFileSystemWatchers(sandbox);
+            const configInfoProvider = makeConfigInfoProvider(false);
+            sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                options?.stdoutCallback?.(JSON.stringify([{
+                    path: buildPath('workspace', 'AppHost', 'AppHost.csproj'),
+                    language: 'csharp',
+                    status: 'buildable',
+                }]));
+                options?.exitCallback?.(0);
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider(), configInfoProvider);
+
+            try {
+                const snapshots: AppHostDiscoverySnapshot[] = [];
+                const finalCandidates = await collectSnapshots(service.discoverStream(makeWorkspaceFolder(buildPath('workspace'))), snapshots);
+
+                assert.deepStrictEqual(finalCandidates, [{
+                    path: buildPath('workspace', 'AppHost', 'AppHost.csproj'),
+                    language: 'csharp',
+                    status: 'buildable',
+                }]);
+                assert.deepStrictEqual(snapshots.map(snapshot => snapshot.isComplete), [true]);
+            }
+            finally {
+                service.dispose();
+            }
+        });
+
         test('reports both aspire ls and legacy fallback errors when discovery fails', async () => {
             stubFileSystemWatchers(sandbox);
             sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, args = [], options) => {
@@ -904,6 +1132,20 @@ function makeTerminalProvider(): AspireTerminalProvider {
         getAspireCliExecutablePath: async () => 'aspire',
         createEnvironment: () => ({}),
     } as unknown as AspireTerminalProvider;
+}
+
+function makeConfigInfoProvider(hasLsJsonStreamCapability: boolean): ConfigInfoProvider {
+    return {
+        hasCapability: async () => hasLsJsonStreamCapability,
+    } as unknown as ConfigInfoProvider;
+}
+
+async function collectSnapshots(stream: AsyncIterable<AppHostDiscoverySnapshot>, snapshots: AppHostDiscoverySnapshot[]): Promise<AppHostDiscoverySnapshot['candidates']> {
+    for await (const snapshot of stream) {
+        snapshots.push(snapshot);
+    }
+
+    return snapshots.at(-1)?.candidates ?? [];
 }
 
 function makeCancellationToken(): vscode.CancellationToken {

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -1863,6 +1863,34 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         provider.dispose();
     });
 
+    test('workspace mode keeps running AppHosts visible while streamed discovery is incomplete', () => {
+        const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
+        const repository = {
+            viewMode: 'workspace' as ViewMode,
+            appHosts: [
+                makeAppHost({ appHostPath: '/repo/apps/Store/AppHost.csproj', appHostPid: 1234 }),
+                makeAppHost({ appHostPath: '/repo/samples/Store/AppHost.csproj', appHostPid: 5678 }),
+            ],
+            workspaceResources: [],
+            workspaceAppHost: undefined,
+            workspaceAppHostPath: undefined,
+            workspaceAppHostName: undefined,
+            workspaceAppHostCandidatePaths: ['/repo/apps/Store/AppHost.csproj'],
+            workspaceAppHostDescription: undefined,
+            isWorkspaceAppHostDiscoveryComplete: false,
+            onDidChangeData,
+        } as unknown as AppHostDataRepository;
+        const provider = new AspireAppHostTreeProvider(repository, makeTerminalProvider(), makeLaunchService());
+
+        const appHostItems = provider.getChildren();
+
+        assert.deepStrictEqual(appHostItems.map(item => item.label), [
+            'apps/Store/AppHost.csproj',
+            'samples/Store/AppHost.csproj',
+        ]);
+        provider.dispose();
+    });
+
     test('workspace resource commands use the AppHost that owns the resource', () => {
         const commands: AspireSubcommand[] = [];
         const selectedHostPath = '/repo/apps/Store/AppHost.csproj';

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -1836,6 +1836,33 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         provider.dispose();
     });
 
+    test('workspace mode renders running AppHosts before workspace discovery completes', () => {
+        const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
+        const repository = {
+            viewMode: 'workspace' as ViewMode,
+            appHosts: [
+                makeAppHost({ appHostPath: '/repo/apps/Store/AppHost.csproj', appHostPid: 1234 }),
+                makeAppHost({ appHostPath: '/repo/samples/Store/AppHost.csproj', appHostPid: 5678 }),
+            ],
+            workspaceResources: [],
+            workspaceAppHost: undefined,
+            workspaceAppHostPath: undefined,
+            workspaceAppHostName: undefined,
+            workspaceAppHostCandidatePaths: [],
+            workspaceAppHostDescription: undefined,
+            onDidChangeData,
+        } as unknown as AppHostDataRepository;
+        const provider = new AspireAppHostTreeProvider(repository, makeTerminalProvider(), makeLaunchService());
+
+        const appHostItems = provider.getChildren();
+
+        assert.deepStrictEqual(appHostItems.map(item => item.label), [
+            'apps/Store/AppHost.csproj',
+            'samples/Store/AppHost.csproj',
+        ]);
+        provider.dispose();
+    });
+
     test('workspace resource commands use the AppHost that owns the resource', () => {
         const commands: AspireSubcommand[] = [];
         const selectedHostPath = '/repo/apps/Store/AppHost.csproj';

--- a/extension/src/test/configInfoProvider.test.ts
+++ b/extension/src/test/configInfoProvider.test.ts
@@ -155,4 +155,50 @@ suite('configInfoProvider tests', () => {
         assert.strictEqual(await provider.hasCapability('ls-json-stream.v1', { forceRefresh: true }), true);
         assert.strictEqual(spawnStub.callCount, 2);
     });
+
+    test('hasCapability forceRefresh bypasses in-flight config info', async () => {
+        const terminalProvider = {
+            getAspireCliExecutablePath: async () => '/usr/bin/aspire',
+            createEnvironment: () => ({}),
+        } as unknown as AspireTerminalProvider;
+        type SpawnOptions = NonNullable<Parameters<typeof cliModule.spawnCliProcess>[3]>;
+        const pendingOptions: SpawnOptions[] = [];
+        const spawnStub = sinon.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+            pendingOptions.push(options!);
+            return {} as ChildProcessWithoutNullStreams;
+        });
+        const provider = new ConfigInfoProvider(terminalProvider);
+
+        const staleCapability = provider.hasCapability('ls-json-stream.v1');
+        await Promise.resolve();
+        assert.strictEqual(spawnStub.callCount, 1);
+
+        const refreshedCapability = provider.hasCapability('ls-json-stream.v1', { forceRefresh: true });
+        await Promise.resolve();
+        assert.strictEqual(spawnStub.callCount, 2);
+
+        pendingOptions[1].stdoutCallback?.(JSON.stringify({
+            localSettingsPath: '/workspace/aspire.config.json',
+            globalSettingsPath: '/home/user/.aspire/aspire.config.json',
+            availableFeatures: [],
+            localSettingsSchema: { properties: [] },
+            globalSettingsSchema: { properties: [] },
+            capabilities: ['ls-json-stream.v1'],
+        }));
+        pendingOptions[1].exitCallback?.(0);
+        assert.strictEqual(await refreshedCapability, true);
+
+        pendingOptions[0].stdoutCallback?.(JSON.stringify({
+            localSettingsPath: '/workspace/aspire.config.json',
+            globalSettingsPath: '/home/user/.aspire/aspire.config.json',
+            availableFeatures: [],
+            localSettingsSchema: { properties: [] },
+            globalSettingsSchema: { properties: [] },
+            capabilities: [],
+        }));
+        pendingOptions[0].exitCallback?.(0);
+        assert.strictEqual(await staleCapability, false);
+        assert.strictEqual(await provider.hasCapability('ls-json-stream.v1'), true);
+        assert.strictEqual(spawnStub.callCount, 2);
+    });
 });

--- a/extension/src/test/configInfoProvider.test.ts
+++ b/extension/src/test/configInfoProvider.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import type { ChildProcessWithoutNullStreams } from 'child_process';
-import { getConfigInfo, parseConfigInfoOutput } from '../utils/configInfoProvider';
+import { ConfigInfoProvider, getConfigInfo, parseConfigInfoOutput } from '../utils/configInfoProvider';
 import type { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 import * as cliModule from '../debugger/languages/cli';
 
@@ -121,5 +121,38 @@ suite('configInfoProvider tests', () => {
         assert.ok(configInfo);
         assert.strictEqual(workingDirectory, workspaceFolder.uri.fsPath);
         assert.strictEqual(spawnStub.firstCall.args[3]?.noExtensionVariables, true);
+    });
+
+    test('hasCapability forceRefresh re-queries cached config info', async () => {
+        const terminalProvider = {
+            getAspireCliExecutablePath: async () => '/usr/bin/aspire',
+            createEnvironment: () => ({}),
+        } as unknown as AspireTerminalProvider;
+        const capabilitiesByCall = [
+            [] as string[],
+            ['ls-json-stream.v1'],
+        ];
+        let configInfoCallIndex = 0;
+        const spawnStub = sinon.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+            const capabilities = capabilitiesByCall[Math.min(configInfoCallIndex++, capabilitiesByCall.length - 1)];
+            options?.stdoutCallback?.(JSON.stringify({
+                localSettingsPath: '/workspace/aspire.config.json',
+                globalSettingsPath: '/home/user/.aspire/aspire.config.json',
+                availableFeatures: [],
+                localSettingsSchema: { properties: [] },
+                globalSettingsSchema: { properties: [] },
+                capabilities,
+            }));
+            options?.exitCallback?.(0);
+            return {} as ChildProcessWithoutNullStreams;
+        });
+        const provider = new ConfigInfoProvider(terminalProvider);
+
+        assert.strictEqual(await provider.hasCapability('ls-json-stream.v1'), false);
+        assert.strictEqual(await provider.hasCapability('ls-json-stream.v1'), false);
+        assert.strictEqual(spawnStub.callCount, 1);
+
+        assert.strictEqual(await provider.hasCapability('ls-json-stream.v1', { forceRefresh: true }), true);
+        assert.strictEqual(spawnStub.callCount, 2);
     });
 });

--- a/extension/src/types/configInfo.ts
+++ b/extension/src/types/configInfo.ts
@@ -43,3 +43,11 @@ export interface ConfigInfo {
  * `KnownCapabilities.DescribeIncludeDisabledCommands` in src/Aspire.Cli/Utils/ExtensionHelper.cs.
  */
 export const describeIncludeDisabledCommandsCapability = 'describe-include-disabled-commands.v1';
+
+/**
+ * Capability advertised by the CLI when `aspire ls --format json --stream` is available.
+ * Tooling uses this to stream AppHost discovery candidates incrementally while keeping older
+ * CLIs on the buffered `aspire ls --format json` path. Keep in sync with
+ * `KnownCapabilities.LsJsonStream` in src/Aspire.Cli/Utils/ExtensionHelper.cs.
+ */
+export const lsJsonStreamCapability = 'ls-json-stream.v1';

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -8,6 +8,8 @@ import { aspireConfigFileName, getAppHostPathFromConfig, readJsonFile } from './
 import { EnvironmentVariables } from './environment';
 import { extensionLogOutputChannel } from './logging';
 import { getAppHostDiscoveryTimeoutMs } from './settings';
+import { ConfigInfoProvider } from './configInfoProvider';
+import { lsJsonStreamCapability } from '../types/configInfo';
 import { appHostDiscoveryFindFilesMaxResults, getAppHostDiscoveryExcludeGlob, isExcludedDiscoveryUri } from './workspaceFileSearch';
 
 // Mirrors the `aspire ls --format json` candidate shape documented in
@@ -33,16 +35,27 @@ export interface AppHostProjectSearchResult {
     app_host_candidates: AppHostCandidate[];
 }
 
+export interface AppHostDiscoverySnapshot {
+    candidates: CandidateAppHostDisplayInfo[];
+    isComplete: boolean;
+}
+
 interface LegacyAppHostProjectSearchResult {
     selected_project_file: string | null;
     all_project_file_candidates: string[];
+}
+
+interface AppHostDiscoverySession {
+    final: Promise<CandidateAppHostDisplayInfo[]>;
+    stream: (cancellationToken?: vscode.CancellationToken) => AsyncIterable<AppHostDiscoverySnapshot>;
+    supportsProgress: boolean;
 }
 
 export class AppHostDiscoveryService implements vscode.Disposable {
     private static readonly _candidateChangeDebounceMs = 250;
 
     private readonly _onDidChangeCandidates = new vscode.EventEmitter<vscode.WorkspaceFolder>();
-    private readonly _cache = new Map<string, Promise<CandidateAppHostDisplayInfo[]>>();
+    private readonly _cache = new Map<string, AppHostDiscoverySession>();
     private readonly _watchers = new Map<string, vscode.Disposable[]>();
     private readonly _pendingInvalidationTimers = new Map<string, ReturnType<typeof setTimeout>>();
     private readonly _activeCliProcesses = new Set<ChildProcessWithoutNullStreams>();
@@ -50,13 +63,26 @@ export class AppHostDiscoveryService implements vscode.Disposable {
     private _disposed = false;
     readonly onDidChangeCandidates = this._onDidChangeCandidates.event;
 
-    constructor(private readonly _terminalProvider: AspireTerminalProvider) {
+    constructor(
+        private readonly _terminalProvider: AspireTerminalProvider,
+        private readonly _configInfoProvider = new ConfigInfoProvider(_terminalProvider)) {
     }
 
     async discover(workspaceFolder: vscode.WorkspaceFolder, forceRefresh = false, cancellationToken?: vscode.CancellationToken): Promise<CandidateAppHostDisplayInfo[]> {
         this._throwIfDisposed();
         throwIfCancellationRequested(cancellationToken);
 
+        return await withCancellation(this._getOrCreateDiscoverySession(workspaceFolder, forceRefresh, false).final, cancellationToken);
+    }
+
+    discoverStream(workspaceFolder: vscode.WorkspaceFolder, forceRefresh = false, cancellationToken?: vscode.CancellationToken): AsyncIterable<AppHostDiscoverySnapshot> {
+        this._throwIfDisposed();
+        throwIfCancellationRequested(cancellationToken);
+
+        return this._getOrCreateDiscoverySession(workspaceFolder, forceRefresh, true).stream(cancellationToken);
+    }
+
+    private _getOrCreateDiscoverySession(workspaceFolder: vscode.WorkspaceFolder, forceRefresh: boolean, enableProgress: boolean): AppHostDiscoverySession {
         const key = path.resolve(workspaceFolder.uri.fsPath);
         if (forceRefresh) {
             this._cache.delete(key);
@@ -64,25 +90,82 @@ export class AppHostDiscoveryService implements vscode.Disposable {
 
         this._ensureWatchers(workspaceFolder, key);
 
-        let resultPromise = this._cache.get(key);
-        if (!resultPromise) {
-            // The cached discovery promise is shared across extension features. Keep caller
-            // cancellation outside the cached operation so one cancelled refresh doesn't reject
-            // unrelated callers that are awaiting the same workspace discovery.
-            const discoveryPromise = this._discoverCore(workspaceFolder)
-                .then(candidates => this._includeConfiguredAppHostCandidate(workspaceFolder, candidates));
-            let cachedPromise: Promise<CandidateAppHostDisplayInfo[]>;
-            cachedPromise = discoveryPromise.catch(error => {
-                if (this._cache.get(key) === cachedPromise) {
-                    this._cache.delete(key);
-                }
-                throw error;
-            });
-            resultPromise = cachedPromise;
-            this._cache.set(key, resultPromise);
+        let session = this._cache.get(key);
+        if (!session || (enableProgress && !session.supportsProgress)) {
+            session = this._createDiscoverySession(workspaceFolder, key, enableProgress, forceRefresh);
+            this._cache.set(key, session);
         }
 
-        return await withCancellation(resultPromise, cancellationToken);
+        return session;
+    }
+
+    private _createDiscoverySession(workspaceFolder: vscode.WorkspaceFolder, key: string, enableProgress: boolean, forceRefresh: boolean): AppHostDiscoverySession {
+        const snapshots: AppHostDiscoverySnapshot[] = [];
+        const waiters = new Set<() => void>();
+        let completed = false;
+        let error: unknown;
+
+        const notify = () => {
+            const currentWaiters = [...waiters];
+            waiters.clear();
+            for (const waiter of currentWaiters) {
+                waiter();
+            }
+        };
+        const publish = (snapshot: AppHostDiscoverySnapshot) => {
+            snapshots.push(snapshot);
+            notify();
+        };
+        const fail = (discoveryError: unknown) => {
+            error = discoveryError;
+            completed = true;
+            notify();
+        };
+
+        const onProgress = enableProgress
+            ? (candidates: CandidateAppHostDisplayInfo[]) => publish({ candidates, isComplete: false })
+            : undefined;
+        let session: AppHostDiscoverySession | undefined;
+        const final = this._discoverCore(workspaceFolder, onProgress, enableProgress && forceRefresh)
+            .then(candidates => this._includeConfiguredAppHostCandidate(workspaceFolder, candidates))
+            .then(candidates => {
+                completed = true;
+                publish({ candidates, isComplete: true });
+                return candidates;
+            })
+            .catch(discoveryError => {
+                if (this._cache.get(key) === session) {
+                    this._cache.delete(key);
+                }
+                fail(discoveryError);
+                throw discoveryError;
+            });
+        void final.catch(() => { });
+
+        const stream = async function* (cancellationToken?: vscode.CancellationToken): AsyncIterable<AppHostDiscoverySnapshot> {
+            let index = completed && !error && snapshots.length > 0 ? snapshots.length - 1 : 0;
+            while (true) {
+                throwIfCancellationRequested(cancellationToken);
+
+                while (index < snapshots.length) {
+                    yield snapshots[index++];
+                    throwIfCancellationRequested(cancellationToken);
+                }
+
+                if (error) {
+                    throw error;
+                }
+
+                if (completed) {
+                    return;
+                }
+
+                await waitForSnapshot(waiters, cancellationToken);
+            }
+        };
+
+        session = { final, stream, supportsProgress: enableProgress };
+        return session;
     }
 
     async resolveDebugTarget(filePath: string, workspaceFolder?: vscode.WorkspaceFolder): Promise<string> {
@@ -127,9 +210,9 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         this._onDidChangeCandidates.dispose();
     }
 
-    private async _discoverCore(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
+    private async _discoverCore(workspaceFolder: vscode.WorkspaceFolder, onProgress?: (candidates: CandidateAppHostDisplayInfo[]) => void, forceCapabilityRefresh = false): Promise<CandidateAppHostDisplayInfo[]> {
         try {
-            const appHosts = await this._discoverWithLs(workspaceFolder);
+            const appHosts = await this._discoverWithLs(workspaceFolder, onProgress, forceCapabilityRefresh);
             extensionLogOutputChannel.info(`Discovered ${appHosts.length} AppHost candidate(s) via aspire ls`);
             return appHosts;
         }
@@ -163,8 +246,12 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         }
     }
 
-    private async _discoverWithLs(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
+    private async _discoverWithLs(workspaceFolder: vscode.WorkspaceFolder, onProgress?: (candidates: CandidateAppHostDisplayInfo[]) => void, forceCapabilityRefresh = false): Promise<CandidateAppHostDisplayInfo[]> {
         this._throwIfDisposed();
+
+        if (onProgress && await this._configInfoProvider.hasCapability(lsJsonStreamCapability, { suppressErrors: true, forceRefresh: forceCapabilityRefresh })) {
+            return await this._discoverWithStreamingLs(workspaceFolder, onProgress);
+        }
 
         const cliPath = await this._terminalProvider.getAspireCliExecutablePath();
         const args = ['ls', '--format', 'json'];
@@ -174,6 +261,29 @@ export class AppHostDiscoveryService implements vscode.Disposable {
 
         const output = await this._runCliForStdout(cliPath, args, workspaceFolder.uri.fsPath);
         return parseCandidateOutput(output, 'aspire ls');
+    }
+
+    private async _discoverWithStreamingLs(workspaceFolder: vscode.WorkspaceFolder, onProgress: (candidates: CandidateAppHostDisplayInfo[]) => void): Promise<CandidateAppHostDisplayInfo[]> {
+        this._throwIfDisposed();
+
+        const cliPath = await this._terminalProvider.getAspireCliExecutablePath();
+        const args = ['ls', '--format', 'json', '--stream'];
+        if (process.env[EnvironmentVariables.ASPIRE_CLI_STOP_ON_ENTRY] === 'true') {
+            args.push('--cli-wait-for-debugger');
+        }
+
+        const candidates: CandidateAppHostDisplayInfo[] = [];
+        await this._runCliForStdout(cliPath, args, workspaceFolder.uri.fsPath, {
+            lineCallback: line => {
+                const candidate = parseCandidateLine(line, 'aspire ls --format json --stream');
+                if (candidate) {
+                    candidates.push(candidate);
+                    onProgress([...candidates]);
+                }
+            },
+        });
+
+        return candidates;
     }
 
     private async _discoverWithLegacyGetAppHosts(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
@@ -277,7 +387,7 @@ export class AppHostDiscoveryService implements vscode.Disposable {
         ];
     }
 
-    private _runCliForStdout(cliPath: string, args: string[], workingDirectory: string): Promise<string> {
+    private _runCliForStdout(cliPath: string, args: string[], workingDirectory: string, options?: { lineCallback?: (line: string) => void }): Promise<string> {
         return new Promise((resolve, reject) => {
             this._throwIfDisposed();
 
@@ -325,6 +435,7 @@ export class AppHostDiscoveryService implements vscode.Disposable {
                 childProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
                     noExtensionVariables: true,
                     workingDirectory,
+                    lineCallback: options?.lineCallback,
                     stdoutCallback: data => { stdout += data; },
                     stderrCallback: data => { stderr += data; },
                     exitCallback: code => {
@@ -548,6 +659,33 @@ function parseCandidateOutput(output: string, commandName: string): CandidateApp
     throw new Error(`${commandName} returned an unexpected output shape.`);
 }
 
+// Parse NDJSON emitted by `aspire ls --format json --stream` as one complete candidate per line:
+//   {"path":"/workspace/MyApp.AppHost/MyApp.AppHost.csproj","language":"csharp","status":"buildable"}
+function parseCandidateLine(line: string, commandName: string): CandidateAppHostDisplayInfo | undefined {
+    const trimmed = line.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+
+    try {
+        const parsed = JSON.parse(trimmed);
+        if (isLsCandidate(parsed)) {
+            return {
+                path: parsed.path,
+                language: parsed.language,
+                status: parsed.status,
+            };
+        }
+
+        extensionLogOutputChannel.warn(`${commandName} returned a candidate with an unexpected shape; ignoring it.`);
+    }
+    catch (error) {
+        extensionLogOutputChannel.warn(`Failed to parse ${commandName} output line: ${formatErrorMessage(error)}`);
+    }
+
+    return undefined;
+}
+
 async function discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
     // This is the final fallback after both CLI discovery paths fail. Do not cap the
     // project scan here: VS Code returns only the first maxResults matches, which can
@@ -648,6 +786,34 @@ function withCancellation<T>(promise: Promise<T>, cancellationToken?: vscode.Can
                 disposable.dispose();
                 reject(error);
             });
+    });
+}
+
+function waitForSnapshot(waiters: Set<() => void>, cancellationToken?: vscode.CancellationToken): Promise<void> {
+    if (!cancellationToken) {
+        return new Promise<void>(resolve => waiters.add(resolve));
+    }
+
+    try {
+        throwIfCancellationRequested(cancellationToken);
+    }
+    catch (error) {
+        return Promise.reject(error);
+    }
+
+    return new Promise<void>((resolve, reject) => {
+        let disposable: vscode.Disposable;
+        const complete = () => {
+            disposable.dispose();
+            resolve();
+        };
+        disposable = cancellationToken.onCancellationRequested(() => {
+            waiters.delete(complete);
+            disposable.dispose();
+            reject(new Error('AppHost discovery was cancelled.'));
+        });
+
+        waiters.add(complete);
     });
 }
 

--- a/extension/src/utils/configInfoProvider.ts
+++ b/extension/src/utils/configInfoProvider.ts
@@ -67,21 +67,24 @@ export class ConfigInfoProvider {
     async getConfigInfo(options?: { suppressErrors?: boolean; forceRefresh?: boolean }): Promise<ConfigInfo | null> {
         if (options?.forceRefresh) {
             this._cachedConfigInfo = undefined;
+            this._inFlight = undefined;
         }
 
         if (this._cachedConfigInfo) {
             return this._cachedConfigInfo;
         }
 
-        this._inFlight ??= this._fetchConfigInfo(options?.suppressErrors ?? false);
+        const inFlight = this._inFlight ??= this._fetchConfigInfo(options?.suppressErrors ?? false);
         try {
-            const result = await this._inFlight;
-            if (result) {
+            const result = await inFlight;
+            if (result && this._inFlight === inFlight) {
                 this._cachedConfigInfo = result;
             }
             return result;
         } finally {
-            this._inFlight = undefined;
+            if (this._inFlight === inFlight) {
+                this._inFlight = undefined;
+            }
         }
     }
 

--- a/extension/src/utils/configInfoProvider.ts
+++ b/extension/src/utils/configInfoProvider.ts
@@ -89,7 +89,7 @@ export class ConfigInfoProvider {
      * Returns whether the CLI advertises the given capability token via `config info`. Capability
      * tokens are stable, locale-independent identifiers (see {@link ConfigInfo.capabilities}).
      */
-    async hasCapability(capability: string, options?: { suppressErrors?: boolean }): Promise<boolean> {
+    async hasCapability(capability: string, options?: { suppressErrors?: boolean; forceRefresh?: boolean }): Promise<boolean> {
         const configInfo = await this.getConfigInfo(options);
         return configInfo?.capabilities?.includes(capability) ?? false;
     }

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -199,10 +199,10 @@ export class AppHostDataRepository {
     private readonly _configChangeDisposable: vscode.Disposable;
     private _disposed = false;
 
-    constructor(private readonly _terminalProvider: AspireTerminalProvider, appHostDiscoveryService?: AppHostDiscoveryService) {
-        this._appHostDiscoveryService = appHostDiscoveryService ?? new AppHostDiscoveryService(_terminalProvider);
+    constructor(private readonly _terminalProvider: AspireTerminalProvider, appHostDiscoveryService?: AppHostDiscoveryService, configInfoProvider?: ConfigInfoProvider) {
+        this._configInfoProvider = configInfoProvider ?? new ConfigInfoProvider(_terminalProvider);
+        this._appHostDiscoveryService = appHostDiscoveryService ?? new AppHostDiscoveryService(_terminalProvider, this._configInfoProvider);
         this._ownsAppHostDiscoveryService = appHostDiscoveryService === undefined;
-        this._configInfoProvider = new ConfigInfoProvider(_terminalProvider);
         this._appHostDiscoveryChangeDisposable = this._appHostDiscoveryService.onDidChangeCandidates(workspaceFolder => {
             const rootFolder = vscode.workspace.workspaceFolders?.[0];
             if (rootFolder?.uri.toString() === workspaceFolder.uri.toString()) {
@@ -338,7 +338,7 @@ export class AppHostDataRepository {
             this._startDescribeWatch();
         }
         if (this._shouldPoll) {
-            this._fetchAppHosts();
+            this._startPsPolling();
         }
     }
 
@@ -370,9 +370,12 @@ export class AppHostDataRepository {
     }
 
     private get _shouldPoll(): boolean {
-        // Workspace mode still polls ps after the selected AppHost path is known so
-        // a running AppHost can be shown even when describe has no resources to emit.
-        return this._dataActive && (this._viewMode === 'global' || this._workspaceAppHostCandidatePaths.length > 0);
+        // Workspace discovery can take longer than `aspire ps`. Poll immediately so
+        // already-running AppHosts appear in the pane while idle candidates stream in.
+        return this._dataActive
+            && (this._viewMode === 'global'
+                || !this._workspaceAppHostDiscoveryComplete
+                || this._workspaceAppHostCandidatePaths.length > 0);
     }
 
     private get _shouldWatchWorkspace(): boolean {
@@ -446,15 +449,25 @@ export class AppHostDataRepository {
         this._workspaceAppHostDiscoveryInProgress = true;
         this._workspaceAppHostDiscoveryCancellationSource = cancellationSource;
 
-        this._appHostDiscoveryService.discover(rootFolder, options?.forceRefresh, cancellationSource.token).then(appHosts => {
-            if (cancellationSource.token.isCancellationRequested || !this._isCurrentWorkspaceDiscovery(discoveryVersion, rootFolder)) {
-                return;
-            }
+        void this._consumeWorkspaceAppHostDiscovery(rootFolder, discoveryVersion, options?.forceRefresh, cancellationSource);
+    }
 
-            const result = getWorkspaceAppHostProjectSearchResult(rootFolder, appHosts);
-            this._workspaceAppHostDiscoveryComplete = true;
-            this._handleWorkspaceAppHostCandidates(result.app_host_candidates, result.selected_project_file);
-        }).catch(error => {
+    private async _consumeWorkspaceAppHostDiscovery(rootFolder: vscode.WorkspaceFolder, discoveryVersion: number, forceRefresh: boolean | undefined, cancellationSource: vscode.CancellationTokenSource): Promise<void> {
+        try {
+            for await (const snapshot of this._appHostDiscoveryService.discoverStream(rootFolder, forceRefresh, cancellationSource.token)) {
+                if (cancellationSource.token.isCancellationRequested || !this._isCurrentWorkspaceDiscovery(discoveryVersion, rootFolder)) {
+                    return;
+                }
+
+                const result = getWorkspaceAppHostProjectSearchResult(rootFolder, snapshot.candidates);
+                if (snapshot.isComplete) {
+                    this._workspaceAppHostDiscoveryComplete = true;
+                    this._handleWorkspaceAppHostCandidates(result.app_host_candidates, result.selected_project_file);
+                } else {
+                    this._handleWorkspaceAppHostCandidateProgress(result.app_host_candidates);
+                }
+            }
+        } catch (error) {
             if (cancellationSource.token.isCancellationRequested || !this._isCurrentWorkspaceDiscovery(discoveryVersion, rootFolder)) {
                 return;
             }
@@ -466,7 +479,7 @@ export class AppHostDataRepository {
             this._setDescribeError(errorFetchingAppHosts(String(error)));
             this._updateWorkspaceContext({ clearLoading: true });
             this._syncPolling();
-        }).finally(() => {
+        } finally {
             cancellationSource.dispose();
             if (this._workspaceAppHostDiscoveryCancellationSource !== cancellationSource) {
                 return;
@@ -478,7 +491,24 @@ export class AppHostDataRepository {
                 this._workspaceAppHostDiscoveryRefreshQueued = false;
                 this._fetchWorkspaceAppHost({ forceRefresh: true });
             }
-        });
+        }
+    }
+
+    private _handleWorkspaceAppHostCandidateProgress(appHostCandidates: readonly AppHostCandidate[]): void {
+        const buildableAppHostCandidates = appHostCandidates.filter(isBuildableAppHostCandidate);
+        if (buildableAppHostCandidates.length === 0) {
+            return;
+        }
+
+        this._setWorkspaceAppHostCandidatePaths(buildableAppHostCandidates);
+        const selectedAppHostPath = this._workspaceAppHostPath;
+        if (selectedAppHostPath && !buildableAppHostCandidates.some(candidate => isMatchingAppHostPath(candidate.path, selectedAppHostPath))) {
+            this._clearWorkspaceAppHostSelection();
+        }
+
+        this._clearErrors();
+        this._syncPolling();
+        this._updateWorkspaceContext();
     }
 
     private _cancelWorkspaceAppHostDiscovery(): void {
@@ -1301,9 +1331,15 @@ export class AppHostDataRepository {
 
     private _handleWorkspacePsOutput(appHosts: readonly AppHostDisplayInfo[]): void {
         let workspaceAppHostPath = this._workspaceAppHostPath;
-        const workspaceAppHosts = this._workspaceAppHostCandidatePaths.length > 0
-            ? appHosts.filter(appHost => this._workspaceAppHostCandidatePaths.some(candidatePath => isMatchingAppHostPath(appHost.appHostPath, candidatePath)))
-            : [];
+        const discoveryPending = !this._workspaceAppHostDiscoveryComplete;
+        let workspaceAppHosts: AppHostDisplayInfo[];
+        if (discoveryPending) {
+            workspaceAppHosts = appHosts.filter(appHost => isPathInWorkspace(appHost.appHostPath));
+        } else if (this._workspaceAppHostCandidatePaths.length > 0) {
+            workspaceAppHosts = appHosts.filter(appHost => this._workspaceAppHostCandidatePaths.some(candidatePath => isMatchingAppHostPath(appHost.appHostPath, candidatePath)));
+        } else {
+            workspaceAppHosts = [];
+        }
         let workspaceAppHost = workspaceAppHostPath
             ? workspaceAppHosts.find(appHost => isMatchingAppHostPath(appHost.appHostPath, workspaceAppHostPath))
             : undefined;
@@ -1350,7 +1386,7 @@ export class AppHostDataRepository {
         }
 
         if (changed || this._loadingWorkspace) {
-            this._updateWorkspaceContext({ clearLoading: true });
+            this._updateWorkspaceContext({ clearLoading: !discoveryPending || workspaceAppHosts.length > 0 });
         }
     }
 
@@ -1504,7 +1540,9 @@ export class AppHostDataRepository {
                     cleanup();
                 }
             }, AppHostDataRepository._processShutdownGracePeriodMs);
-            forceKillTimer.unref();
+            if (!this._disposed) {
+                forceKillTimer.unref();
+            }
         }
     }
 }
@@ -1607,6 +1645,18 @@ function isWindowsDriveSegment(segment: string): boolean {
 
 function getComparisonKey(value: string): string {
     return process.platform === 'win32' ? value.toLowerCase() : value;
+}
+
+function isPathInWorkspace(filePath: string): boolean {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+        return false;
+    }
+
+    const relativePath = path.relative(workspaceFolder.uri.fsPath, filePath);
+    return relativePath !== ''
+        && !relativePath.startsWith('..')
+        && !path.isAbsolute(relativePath);
 }
 
 function isDescribeUnsupportedOutput(nonJsonLines: readonly string[], stderr: string): boolean {

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -934,9 +934,16 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
             const workspaceResources = [...this._repository.workspaceResources];
             const workspaceAppHost = this._repository.workspaceAppHost;
             const workspaceCandidatePaths = this._repository.workspaceAppHostCandidatePaths ?? [];
+            const runningAppHostPaths = this._repository.appHosts.map(appHost => appHost.appHostPath);
+            const discoveryPending = this._repository.isWorkspaceAppHostDiscoveryComplete === false;
             const workspaceAppHostPaths = workspaceCandidatePaths.length > 0
-                ? workspaceCandidatePaths
-                : this._repository.appHosts.map(appHost => appHost.appHostPath);
+                ? discoveryPending
+                    ? [
+                        ...workspaceCandidatePaths,
+                        ...runningAppHostPaths.filter(appHostPath => !workspaceCandidatePaths.some(candidatePath => isMatchingAppHostPath(appHostPath, candidatePath))),
+                    ]
+                    : workspaceCandidatePaths
+                : runningAppHostPaths;
 
             if (workspaceAppHostPaths.length > 1 || (workspaceResources.length === 0 && !workspaceAppHost)) {
                 const selectedAppHostPath = workspaceAppHost?.appHostPath ?? this._repository.workspaceAppHostPath;

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -934,18 +934,21 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
             const workspaceResources = [...this._repository.workspaceResources];
             const workspaceAppHost = this._repository.workspaceAppHost;
             const workspaceCandidatePaths = this._repository.workspaceAppHostCandidatePaths ?? [];
+            const workspaceAppHostPaths = workspaceCandidatePaths.length > 0
+                ? workspaceCandidatePaths
+                : this._repository.appHosts.map(appHost => appHost.appHostPath);
 
-            if (workspaceCandidatePaths.length > 1 || (workspaceResources.length === 0 && !workspaceAppHost)) {
+            if (workspaceAppHostPaths.length > 1 || (workspaceResources.length === 0 && !workspaceAppHost)) {
                 const selectedAppHostPath = workspaceAppHost?.appHostPath ?? this._repository.workspaceAppHostPath;
-                const labels = shortenPaths(workspaceCandidatePaths);
+                const labels = shortenPaths(workspaceAppHostPaths);
 
                 // When multiple workspace AppHosts are running, use global-style AppHostItem (nested view).
                 // When only one is running, use flat WorkspaceResourcesItem.
                 const runningItems: (AppHostItem | WorkspaceResourcesItem)[] = [];
                 const workspaceItems: WorkspaceAppHostItem[] = [];
 
-                for (let i = 0; i < workspaceCandidatePaths.length; i++) {
-                    const candidatePath = workspaceCandidatePaths[i];
+                for (let i = 0; i < workspaceAppHostPaths.length; i++) {
+                    const candidatePath = workspaceAppHostPaths[i];
                     // Use directory-equivalent matching (not exact path) because `aspire ls`
                     // resolves to a `.csproj` while `aspire ps` can report the AppHost source file
                     // (e.g. Program.cs) in the same directory. AppHostDataRepository uses the same

--- a/src/Aspire.Cli/Utils/ExtensionHelper.cs
+++ b/src/Aspire.Cli/Utils/ExtensionHelper.cs
@@ -43,8 +43,12 @@ internal static class KnownCapabilities
     // pass it and parse (localized) error output when an older CLI rejects it.
     public const string DescribeIncludeDisabledCommands = "describe-include-disabled-commands.v1";
 
+    // Advertised so tooling can consume `aspire ls --format json --stream` without passing
+    // the `--stream` flag to older CLIs that only support buffered JSON discovery.
+    public const string LsJsonStream = "ls-json-stream.v1";
+
     /// <summary>
     /// Gets the set of capabilities this CLI advertises to extensions.
     /// </summary>
-    public static string[] GetAdvertisedCapabilities() => [DevKit, Project, BuildDotnetUsingCli, Baseline, SecretPrompts, FilePickers, Pipelines, DescribeIncludeDisabledCommands];
+    public static string[] GetAdvertisedCapabilities() => [DevKit, Project, BuildDotnetUsingCli, Baseline, SecretPrompts, FilePickers, Pipelines, DescribeIncludeDisabledCommands, LsJsonStream];
 }

--- a/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Configuration;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -36,6 +37,14 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains("\"globalSettingsPath\"", json);
         Assert.Contains("\"availableFeatures\"", json);
         Assert.DoesNotContain("\"LocalSettingsPath\"", json);
+    }
+
+    [Fact]
+    public void KnownCapabilities_AdvertisesLsJsonStream()
+    {
+        var capabilities = KnownCapabilities.GetAdvertisedCapabilities();
+
+        Assert.Contains(KnownCapabilities.LsJsonStream, capabilities);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

The VS Code extension previously waited for buffered AppHost discovery to finish before the Aspire panel could show workspace candidates. This wires the extension to use `aspire ls --format json --stream` when the installed CLI advertises support, so buildable AppHost candidates can appear incrementally while discovery is still running.

The implementation adds a streaming discovery contract with explicit snapshots, shares in-flight discovery sessions with the existing promise-based API, and keeps backwards compatibility by falling back to buffered `aspire ls --format json`, legacy `aspire extension get-apphosts`, and workspace-file discovery for older CLIs. The CLI now advertises the `ls-json-stream.v1` capability, and the NDJSON output contract notes that tooling consumes each line as a complete candidate object.

### User-facing usage

Users do not need to configure anything. With a CLI that advertises `ls-json-stream.v1`, the extension consumes streamed discovery output:

```bash
aspire ls --format json --stream
```

Example streamed candidate line:

```json
{"path":"/path/to/MyApp.AppHost/MyApp.AppHost.csproj","language":"csharp","status":"buildable"}
```

Validation:

- `cd extension && corepack yarn run compile-tests && corepack yarn run compile-e2e`
- Targeted extension unit tests for `AppHost discovery`, `AppHostDataRepository`, and `configInfoProvider`
- `cd extension && corepack yarn run lint && corepack yarn run compile`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-method "*.KnownCapabilities_AdvertisesLsJsonStream" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No