### PR TITLE
Add telemetry flow graph mode

### DIFF
--- a/benchmarks/Aspire.Dashboard.Benchmarks/TelemetryRepositoryBenchmarks.cs
+++ b/benchmarks/Aspire.Dashboard.Benchmarks/TelemetryRepositoryBenchmarks.cs
@@ -31,6 +31,11 @@ public class TelemetryRepositoryBenchmarks
 {
     private const int TraceCount = 250;
     private const int SpansPerTrace = 40;
+    private const int TelemetryFlowTraceCount = 100;
+    private const int TelemetryFlowResourceCount = 8;
+    private const int TelemetryFlowCallsPerTrace = 25;
+    private const int TelemetryFlowServerSpansPerCall = 2;
+    private const int EdgeKeySnapshotOperationsPerInvoke = 100_000;
 
     private readonly List<TelemetryFilter> _durationFilters =
     [
@@ -63,20 +68,26 @@ public class TelemetryRepositoryBenchmarks
     ];
 
     private RepeatedField<ResourceSpans> _resourceSpans = [];
+    private RepeatedField<ResourceSpans> _telemetryFlowResourceSpans = [];
     private TelemetryRepository _queryRepository = null!;
+    private TelemetryRepository _telemetryGraphRepository = null!;
 
     [GlobalSetup]
     public void Setup()
     {
         _resourceSpans = CreateResourceSpans(TraceCount, SpansPerTrace);
+        _telemetryFlowResourceSpans = CreateTelemetryFlowResourceSpans();
         _queryRepository = CreateRepository();
         _queryRepository.AddTraces(new AddContext(), _resourceSpans);
+        _telemetryGraphRepository = CreateRepository(TelemetryFlowTraceCount + 1);
+        _telemetryGraphRepository.AddTraces(new AddContext(), _telemetryFlowResourceSpans);
     }
 
     [GlobalCleanup]
     public void Cleanup()
     {
         _queryRepository.Dispose();
+        _telemetryGraphRepository.Dispose();
     }
 
     [Benchmark(Description = "TelemetryRepository: add 10k spans")]
@@ -89,13 +100,34 @@ public class TelemetryRepositoryBenchmarks
         return context.SuccessCount;
     }
 
+    [Benchmark(Description = "TelemetryRepository: add telemetry flow traces")]
+    public int AddTracesTelemetryFlow()
+    {
+        using var repository = CreateRepository(TelemetryFlowTraceCount + 1);
+        var context = new AddContext();
+        repository.AddTraces(context, _telemetryFlowResourceSpans);
+
+        return context.SuccessCount + repository.GetTelemetryGraphEdgeKeys().Count;
+    }
+
+    [Benchmark(Description = "TelemetryRepository: telemetry graph edge keys", OperationsPerInvoke = EdgeKeySnapshotOperationsPerInvoke)]
+    public int GetTelemetryGraphEdgeKeys()
+    {
+        var count = 0;
+        for (var i = 0; i < EdgeKeySnapshotOperationsPerInvoke; i++)
+        {
+            count += _telemetryGraphRepository.GetTelemetryGraphEdgeKeys().Count;
+        }
+
+        return count;
+    }
+
     [Benchmark(Description = "TelemetryRepository: query no filters")]
     public int GetTracesNoFilters()
     {
         var result = _queryRepository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
-            FilterText = string.Empty,
+            ResourceKeys = [],
             Filters = [],
             StartIndex = 0,
             Count = 100
@@ -109,8 +141,7 @@ public class TelemetryRepositoryBenchmarks
     {
         var result = _queryRepository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
-            FilterText = string.Empty,
+            ResourceKeys = [],
             Filters = _durationFilters,
             StartIndex = 0,
             Count = 100
@@ -124,8 +155,7 @@ public class TelemetryRepositoryBenchmarks
     {
         var result = _queryRepository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
-            FilterText = string.Empty,
+            ResourceKeys = [],
             Filters = _noMatchDurationFilters,
             StartIndex = 0,
             Count = 100
@@ -139,8 +169,7 @@ public class TelemetryRepositoryBenchmarks
     {
         var result = _queryRepository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
-            FilterText = string.Empty,
+            ResourceKeys = [],
             Filters = _noMatchAttributeFilters,
             StartIndex = 0,
             Count = 100
@@ -149,7 +178,7 @@ public class TelemetryRepositoryBenchmarks
         return result.PagedResult.Items.Count;
     }
 
-    private static TelemetryRepository CreateRepository()
+    private static TelemetryRepository CreateRepository(int maxTraceCount = TraceCount + 1)
     {
         return new TelemetryRepository(
             NullLoggerFactory.Instance,
@@ -157,7 +186,7 @@ public class TelemetryRepositoryBenchmarks
             {
                 TelemetryLimits = new TelemetryLimitOptions
                 {
-                    MaxTraceCount = TraceCount + 1
+                    MaxTraceCount = maxTraceCount
                 }
             }),
             new PauseManager(),
@@ -216,14 +245,120 @@ public class TelemetryRepositoryBenchmarks
         }
     }
 
-    private static Resource CreateResource()
+    private static RepeatedField<ResourceSpans> CreateTelemetryFlowResourceSpans()
+    {
+        var startTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var spansByResource = new List<OtlpProtoSpan>[TelemetryFlowResourceCount];
+        for (var i = 0; i < spansByResource.Length; i++)
+        {
+            spansByResource[i] = [];
+        }
+
+        for (var traceIndex = 0; traceIndex < TelemetryFlowTraceCount; traceIndex++)
+        {
+            var traceId = $"flow-trace-{traceIndex:0000}";
+            var traceStartTime = startTime.AddSeconds(traceIndex);
+            spansByResource[0].Add(CreateSpan(
+                traceId,
+                spanId: $"flow-{traceIndex:0000}-root",
+                parentSpanId: null,
+                name: "GET /checkout",
+                OtlpProtoSpan.Types.SpanKind.Server,
+                traceStartTime,
+                traceStartTime.AddMilliseconds(100)));
+
+            for (var callIndex = 0; callIndex < TelemetryFlowCallsPerTrace; callIndex++)
+            {
+                var sourceResourceIndex = callIndex % TelemetryFlowResourceCount;
+                var destinationResourceIndex = (sourceResourceIndex + 1) % TelemetryFlowResourceCount;
+                var sourceSpanId = $"flow-{traceIndex:0000}-client-{callIndex:0000}";
+                var spanStartTime = traceStartTime.AddMilliseconds(callIndex);
+
+                spansByResource[sourceResourceIndex].Add(CreateSpan(
+                    traceId,
+                    sourceSpanId,
+                    parentSpanId: sourceResourceIndex == 0 ? $"flow-{traceIndex:0000}-root" : null,
+                    name: $"HTTP service-{destinationResourceIndex}",
+                    OtlpProtoSpan.Types.SpanKind.Client,
+                    spanStartTime,
+                    spanStartTime.AddMilliseconds(10),
+                    attributes:
+                    [
+                        new KeyValue { Key = "server.address", Value = new AnyValue { StringValue = $"service-{destinationResourceIndex}" } },
+                        new KeyValue { Key = "server.port", Value = new AnyValue { StringValue = "8080" } }
+                    ]));
+
+                for (var serverSpanIndex = 0; serverSpanIndex < TelemetryFlowServerSpansPerCall; serverSpanIndex++)
+                {
+                    spansByResource[destinationResourceIndex].Add(CreateSpan(
+                        traceId,
+                        spanId: $"flow-{traceIndex:0000}-server-{callIndex:0000}-{serverSpanIndex:00}",
+                        parentSpanId: sourceSpanId,
+                        name: $"service-{destinationResourceIndex} handler",
+                        OtlpProtoSpan.Types.SpanKind.Server,
+                        spanStartTime.AddTicks(serverSpanIndex + 1),
+                        spanStartTime.AddMilliseconds(8)));
+                }
+            }
+        }
+
+        var resourceSpans = new RepeatedField<ResourceSpans>();
+        for (var i = 0; i < spansByResource.Length; i++)
+        {
+            resourceSpans.Add(new ResourceSpans
+            {
+                Resource = CreateResource($"service-{i}", $"service-{i}-instance"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = new InstrumentationScope { Name = "TelemetryFlowBenchmarkScope" },
+                        Spans = { spansByResource[i] }
+                    }
+                }
+            });
+        }
+
+        return resourceSpans;
+    }
+
+    private static OtlpProtoSpan CreateSpan(
+        string traceId,
+        string spanId,
+        string? parentSpanId,
+        string name,
+        OtlpProtoSpan.Types.SpanKind kind,
+        DateTime startTime,
+        DateTime endTime,
+        IEnumerable<KeyValue>? attributes = null)
+    {
+        var span = new OtlpProtoSpan
+        {
+            TraceId = ByteString.CopyFrom(Encoding.UTF8.GetBytes(traceId)),
+            SpanId = ByteString.CopyFrom(Encoding.UTF8.GetBytes(spanId)),
+            ParentSpanId = parentSpanId is null ? ByteString.Empty : ByteString.CopyFrom(Encoding.UTF8.GetBytes(parentSpanId)),
+            Name = name,
+            Kind = kind,
+            StartTimeUnixNano = DateTimeToUnixNanoseconds(startTime),
+            EndTimeUnixNano = DateTimeToUnixNanoseconds(endTime)
+        };
+
+        if (attributes is not null)
+        {
+            span.Attributes.Add(attributes);
+        }
+
+        return span;
+    }
+
+    private static Resource CreateResource(string name = "benchmark-app", string instanceId = "benchmark-instance")
     {
         return new Resource
         {
             Attributes =
             {
-                new KeyValue { Key = "service.name", Value = new AnyValue { StringValue = "benchmark-app" } },
-                new KeyValue { Key = "service.instance.id", Value = new AnyValue { StringValue = "benchmark-instance" } }
+                new KeyValue { Key = "service.name", Value = new AnyValue { StringValue = name } },
+                new KeyValue { Key = "service.instance.id", Value = new AnyValue { StringValue = instanceId } }
             }
         };
     }

--- a/benchmarks/Aspire.Dashboard.Benchmarks/TelemetryRepositoryBenchmarks.cs
+++ b/benchmarks/Aspire.Dashboard.Benchmarks/TelemetryRepositoryBenchmarks.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Model.ResourceGraph;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using BenchmarkDotNet.Attributes;
@@ -36,6 +37,7 @@ public class TelemetryRepositoryBenchmarks
     private const int TelemetryFlowCallsPerTrace = 25;
     private const int TelemetryFlowServerSpansPerCall = 2;
     private const int EdgeKeySnapshotOperationsPerInvoke = 100_000;
+    private const int ResourceGraphMappingOperationsPerInvoke = 10_000;
 
     private readonly List<TelemetryFilter> _durationFilters =
     [
@@ -71,6 +73,8 @@ public class TelemetryRepositoryBenchmarks
     private RepeatedField<ResourceSpans> _telemetryFlowResourceSpans = [];
     private TelemetryRepository _queryRepository = null!;
     private TelemetryRepository _telemetryGraphRepository = null!;
+    private List<ResourceViewModel> _telemetryFlowResources = [];
+    private List<TelemetryGraphEdge> _telemetryGraphEdgeKeys = [];
 
     [GlobalSetup]
     public void Setup()
@@ -81,6 +85,8 @@ public class TelemetryRepositoryBenchmarks
         _queryRepository.AddTraces(new AddContext(), _resourceSpans);
         _telemetryGraphRepository = CreateRepository(TelemetryFlowTraceCount + 1);
         _telemetryGraphRepository.AddTraces(new AddContext(), _telemetryFlowResourceSpans);
+        _telemetryFlowResources = CreateTelemetryFlowResources();
+        _telemetryGraphEdgeKeys = _telemetryGraphRepository.GetTelemetryGraphEdgeKeys();
     }
 
     [GlobalCleanup]
@@ -117,6 +123,19 @@ public class TelemetryRepositoryBenchmarks
         for (var i = 0; i < EdgeKeySnapshotOperationsPerInvoke; i++)
         {
             count += _telemetryGraphRepository.GetTelemetryGraphEdgeKeys().Count;
+        }
+
+        return count;
+    }
+
+    [Benchmark(Description = "ResourceGraph: map telemetry graph resources", OperationsPerInvoke = ResourceGraphMappingOperationsPerInvoke)]
+    public int MapTelemetryGraphResources()
+    {
+        var count = 0;
+        for (var i = 0; i < ResourceGraphMappingOperationsPerInvoke; i++)
+        {
+            var graphResources = TelemetryGraphResources.Create(_telemetryFlowResources, _telemetryGraphEdgeKeys);
+            count += graphResources.ReferencedNames.Count + graphResources.ResourceNames.Count;
         }
 
         return count;
@@ -320,6 +339,39 @@ public class TelemetryRepositoryBenchmarks
         }
 
         return resourceSpans;
+    }
+
+    private static List<ResourceViewModel> CreateTelemetryFlowResources()
+    {
+        var resources = new List<ResourceViewModel>(TelemetryFlowResourceCount);
+        for (var i = 0; i < TelemetryFlowResourceCount; i++)
+        {
+            var resourceName = $"service-{i}-instance";
+            resources.Add(new ResourceViewModel
+            {
+                Name = resourceName,
+                ResourceType = KnownResourceTypes.Project,
+                DisplayName = $"service-{i}",
+                Uid = resourceName,
+                ReplicaIndex = 0,
+                State = "Running",
+                KnownState = KnownResourceState.Running,
+                StateStyle = null,
+                CreationTimeStamp = null,
+                StartTimeStamp = null,
+                StopTimeStamp = null,
+                Environment = [],
+                Urls = [],
+                Volumes = [],
+                Relationships = [],
+                Properties = [],
+                Commands = [],
+                HealthReports = [],
+                IsHidden = false
+            });
+        }
+
+        return resources;
     }
 
     private static OtlpProtoSpan CreateSpan(

--- a/src/Aspire.Dashboard/Components/Layout/DesktopNavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/DesktopNavMenu.razor
@@ -11,19 +11,19 @@
             IconRest="ResourcesIcon()"
             IconActive="ResourcesIcon(active: true)"
             Text="@Loc[nameof(Layout.NavMenuResourcesTab)]" />
-        @if (IsResourceGraphEnabled)
-        {
-            <FluentAppBarItem
-                Href="@DashboardUrls.GraphUrl()"
-                Match="@(_isGraph ? NavLinkMatch.Prefix : NavLinkMatch.All)"
-                IconRest="GraphIcon()"
-                IconActive="GraphIcon(active: true)"
-                Text="@Loc[nameof(Layout.NavMenuGraphTab)]" />
-        }
         <FluentAppBarItem Href="@DashboardUrls.ConsoleLogsUrl()"
             IconRest="ConsoleLogsIcon()"
             IconActive="ConsoleLogsIcon(active: true)"
             Text="@Loc[nameof(Layout.NavMenuConsoleLogsTab)]" />
+    }
+    @if (IsResourceGraphEnabled)
+    {
+        <FluentAppBarItem
+            Href="@DashboardUrls.GraphUrl()"
+            Match="@(_isGraph ? NavLinkMatch.Prefix : NavLinkMatch.All)"
+            IconRest="GraphIcon()"
+            IconActive="GraphIcon(active: true)"
+            Text="@Loc[nameof(Layout.NavMenuGraphTab)]" />
     }
     <FluentAppBarItem Href="@DashboardUrls.StructuredLogsUrl()"
         IconRest="StructuredLogsIcon()"

--- a/src/Aspire.Dashboard/Components/Layout/DesktopNavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/DesktopNavMenu.razor
@@ -11,6 +11,15 @@
             IconRest="ResourcesIcon()"
             IconActive="ResourcesIcon(active: true)"
             Text="@Loc[nameof(Layout.NavMenuResourcesTab)]" />
+        @if (IsResourceGraphEnabled)
+        {
+            <FluentAppBarItem
+                Href="@DashboardUrls.GraphUrl()"
+                Match="@(_isGraph ? NavLinkMatch.Prefix : NavLinkMatch.All)"
+                IconRest="GraphIcon()"
+                IconActive="GraphIcon(active: true)"
+                Text="@Loc[nameof(Layout.NavMenuGraphTab)]" />
+        }
         <FluentAppBarItem Href="@DashboardUrls.ConsoleLogsUrl()"
             IconRest="ConsoleLogsIcon()"
             IconActive="ConsoleLogsIcon(active: true)"

--- a/src/Aspire.Dashboard/Components/Layout/DesktopNavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/DesktopNavMenu.razor.cs
@@ -67,7 +67,7 @@ public partial class DesktopNavMenu : ComponentBase, IDisposable
         if (Uri.TryCreate(location, UriKind.Absolute, out var result))
         {
             var trimmedPath = result.AbsolutePath.TrimStart('/');
-            var isResources = trimmedPath == DashboardUrls.ResourcesBasePath || trimmedPath[0] == '?';
+            var isResources = trimmedPath == DashboardUrls.ResourcesBasePath;
             var isGraph = string.Equals(trimmedPath.TrimEnd('/'), DashboardUrls.GraphBasePath, StringComparisons.UrlPath);
             if (isResources != _isResources || isGraph != _isGraph)
             {

--- a/src/Aspire.Dashboard/Components/Layout/DesktopNavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/DesktopNavMenu.razor.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
@@ -14,6 +16,10 @@ public partial class DesktopNavMenu : ComponentBase, IDisposable
     internal static Icon ResourcesIcon(bool active = false) =>
         active ? new Icons.Filled.Size24.AppFolder()
                   : new Icons.Regular.Size24.AppFolder();
+
+    internal static Icon GraphIcon(bool active = false) =>
+        active ? new Icons.Filled.Size24.ShareAndroid()
+                  : new Icons.Regular.Size24.ShareAndroid();
 
     internal static Icon ConsoleLogsIcon(bool active = false) =>
         active ? new Icons.Filled.Size24.SlideText()
@@ -34,10 +40,16 @@ public partial class DesktopNavMenu : ComponentBase, IDisposable
     [Inject]
     public required NavigationManager NavigationManager { get; init; }
 
+    [Inject]
+    public required IOptionsMonitor<DashboardOptions> DashboardOptions { get; init; }
+
+    protected bool IsResourceGraphEnabled => DashboardOptions.CurrentValue.UI.DisableResourceGraph != true;
+
     // NavLink has limited options for matching the current address when highlighting itself as active.
     // Can't use Match.All because of the query string. Can't use Match.Prefix always because it matches every page.
-    // Track whether we are on the resource page manually. If we are then change match to prefix to allow the query string.
+    // Track whether we are on the resource or graph page manually. If we are then change match to prefix to allow the query string.
     private bool _isResources;
+    private bool _isGraph;
 
     protected override void OnInitialized()
     {
@@ -56,9 +68,11 @@ public partial class DesktopNavMenu : ComponentBase, IDisposable
         {
             var trimmedPath = result.AbsolutePath.TrimStart('/');
             var isResources = trimmedPath == DashboardUrls.ResourcesBasePath || trimmedPath[0] == '?';
-            if (isResources != _isResources)
+            var isGraph = string.Equals(trimmedPath.TrimEnd('/'), DashboardUrls.GraphBasePath, StringComparisons.UrlPath);
+            if (isResources != _isResources || isGraph != _isGraph)
             {
                 _isResources = isResources;
+                _isGraph = isGraph;
                 StateHasChanged();
             }
         }

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
@@ -52,21 +52,21 @@ public partial class MobileNavMenu : ComponentBase
                 LinkMatchRegex: new Regex($"^{DashboardUrls.ResourcesUrl()}(\\?.*)?$")
             );
 
-            if (IsResourceGraphEnabled)
-            {
-                yield return new MobileNavMenuEntry(
-                    Loc[nameof(Resources.Layout.NavMenuGraphTab)],
-                    () => NavigateToAsync(DashboardUrls.GraphUrl()),
-                    DesktopNavMenu.GraphIcon(),
-                    LinkMatchRegex: GetNonIndexPageRegex(DashboardUrls.GraphUrl())
-                );
-            }
-
             yield return new MobileNavMenuEntry(
                 Loc[nameof(Resources.Layout.NavMenuConsoleLogsTab)],
                 () => NavigateToAsync(DashboardUrls.ConsoleLogsUrl()),
                 DesktopNavMenu.ConsoleLogsIcon(),
                 LinkMatchRegex: GetNonIndexPageRegex(DashboardUrls.ConsoleLogsUrl())
+            );
+        }
+
+        if (IsResourceGraphEnabled)
+        {
+            yield return new MobileNavMenuEntry(
+                Loc[nameof(Resources.Layout.NavMenuGraphTab)],
+                () => NavigateToAsync(DashboardUrls.GraphUrl()),
+                DesktopNavMenu.GraphIcon(),
+                LinkMatchRegex: GetNonIndexPageRegex(DashboardUrls.GraphUrl())
             );
         }
 

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Components.CustomIcons;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
@@ -23,10 +25,15 @@ public partial class MobileNavMenu : ComponentBase
     public required IStringLocalizer<Resources.Layout> Loc { get; init; }
 
     [Inject]
+    public required IOptionsMonitor<DashboardOptions> DashboardOptions { get; init; }
+
+    [Inject]
     public required IStringLocalizer<Resources.AIAssistant> AIAssistantLoc { get; init; }
 
     [Inject]
     public required IJSRuntime JS { get; init; }
+
+    private bool IsResourceGraphEnabled => DashboardOptions.CurrentValue.UI.DisableResourceGraph != true;
 
     private Task NavigateToAsync(string url)
     {
@@ -44,6 +51,16 @@ public partial class MobileNavMenu : ComponentBase
                 DesktopNavMenu.ResourcesIcon(),
                 LinkMatchRegex: new Regex($"^{DashboardUrls.ResourcesUrl()}(\\?.*)?$")
             );
+
+            if (IsResourceGraphEnabled)
+            {
+                yield return new MobileNavMenuEntry(
+                    Loc[nameof(Resources.Layout.NavMenuGraphTab)],
+                    () => NavigateToAsync(DashboardUrls.GraphUrl()),
+                    DesktopNavMenu.GraphIcon(),
+                    LinkMatchRegex: GetNonIndexPageRegex(DashboardUrls.GraphUrl())
+                );
+            }
 
             yield return new MobileNavMenuEntry(
                 Loc[nameof(Resources.Layout.NavMenuConsoleLogsTab)],
@@ -126,4 +143,3 @@ public partial class MobileNavMenu : ComponentBase
         return new Regex($"^({pageRelativeBasePath}|{pageRelativeBasePath}/.+)$", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
     }
 }
-

--- a/src/Aspire.Dashboard/Components/Pages/Graph.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Graph.razor
@@ -1,0 +1,32 @@
+@page "/graph"
+
+@* Keep /graph as a separate route component so Blazor doesn't reuse stale
+   Resources page state when navigating between the graph and table routes. *@
+<Resources IsGraphPageRoute="true"
+           GraphModeName="@GraphModeName"
+           ShowHiddenResources="@ShowHiddenResources"
+           HiddenTypes="@HiddenTypes"
+           HiddenStates="@HiddenStates"
+           HiddenHealthStates="@HiddenHealthStates" />
+
+@code {
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "graphMode")]
+    public string? GraphModeName { get; set; }
+
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "showHiddenResources")]
+    public bool ShowHiddenResources { get; set; }
+
+    [Parameter]
+    [SupplyParameterFromQuery]
+    public string? HiddenTypes { get; set; }
+
+    [Parameter]
+    [SupplyParameterFromQuery]
+    public string? HiddenStates { get; set; }
+
+    [Parameter]
+    [SupplyParameterFromQuery]
+    public string? HiddenHealthStates { get; set; }
+}

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -1,5 +1,4 @@
 ﻿@page "/"
-@page "/graph"
 @using Aspire.Dashboard.Components.ResourcesGridColumns
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Components.Controls.Grid

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -221,18 +221,18 @@
                                     <svg class="resource-graph @(PageViewModel.SelectedGraphMode == ResourceGraphMode.Telemetry ? "resource-graph-telemetry" : null)">
                                     </svg>
                                     <div class="resource-graph-controls">
-                                        <FluentRadioGroup TValue="ResourceGraphMode"
-                                                          Class="resource-graph-mode"
-                                                          Label="@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphModeLabel)]"
-                                                          Orientation="Orientation.Horizontal"
-                                                          @bind-Value="@PageViewModel.SelectedGraphMode"
-                                                          @bind-Value:after="OnGraphModeChangedAsync">
-                                            @if (DashboardClient.IsEnabled)
-                                            {
+                                        @if (DashboardClient.IsEnabled)
+                                        {
+                                            <FluentRadioGroup TValue="ResourceGraphMode"
+                                                              Class="resource-graph-mode"
+                                                              Label="@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphModeLabel)]"
+                                                              Orientation="Orientation.Horizontal"
+                                                              @bind-Value="@PageViewModel.SelectedGraphMode"
+                                                              @bind-Value:after="OnGraphModeChangedAsync">
                                                 <FluentRadio Value="@ResourceGraphMode.Relationships">@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphModeRelationships)]</FluentRadio>
-                                            }
-                                            <FluentRadio Value="@ResourceGraphMode.Telemetry">@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphModeTelemetry)]</FluentRadio>
-                                        </FluentRadioGroup>
+                                                <FluentRadio Value="@ResourceGraphMode.Telemetry">@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphModeTelemetry)]</FluentRadio>
+                                            </FluentRadioGroup>
+                                        }
                                         <FluentButton Appearance="Appearance.Stealth"
                                                       Class="graph-zoom-in"
                                                       Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphZoomInButton)]"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -224,9 +224,18 @@
                             @if (!_hideResourceGraph)
                             {
                                 <div class="resource-graph-container" hidden="@(PageViewModel.SelectedViewKind != ResourceViewKind.Graph)">
-                                    <svg class="resource-graph">
+                                    <svg class="resource-graph @(PageViewModel.SelectedGraphMode == ResourceGraphMode.Telemetry ? "resource-graph-telemetry" : null)">
                                     </svg>
                                     <div class="resource-graph-controls">
+                                        <FluentRadioGroup TValue="ResourceGraphMode"
+                                                          Class="resource-graph-mode"
+                                                          Label="@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphModeLabel)]"
+                                                          Orientation="Orientation.Horizontal"
+                                                          @bind-Value="@PageViewModel.SelectedGraphMode"
+                                                          @bind-Value:after="OnGraphModeChangedAsync">
+                                            <FluentRadio Value="@ResourceGraphMode.Relationships">@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphModeRelationships)]</FluentRadio>
+                                            <FluentRadio Value="@ResourceGraphMode.Telemetry">@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphModeTelemetry)]</FluentRadio>
+                                        </FluentRadioGroup>
                                         <FluentButton Appearance="Appearance.Stealth"
                                                       Class="graph-zoom-in"
                                                       Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphZoomInButton)]"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -1,4 +1,5 @@
 ﻿@page "/"
+@page "/graph"
 @using Aspire.Dashboard.Components.ResourcesGridColumns
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Components.Controls.Grid
@@ -7,7 +8,7 @@
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 @inject IStringLocalizer<Columns> ColumnsLoc
 
-<PageTitle><ApplicationName ResourceName="@nameof(Dashboard.Resources.Resources.ResourcesPageTitle)" Loc="@Loc" /></PageTitle>
+<PageTitle><ApplicationName ResourceName="@(IsGraphPage ? nameof(Dashboard.Resources.Resources.ResourcesGraphPageTitle) : nameof(Dashboard.Resources.Resources.ResourcesPageTitle))" Loc="@Loc" /></PageTitle>
 
 @{
     var showDetailsView = SelectedResource is not null;
@@ -16,7 +17,7 @@
 <div class="page-content-container">
     <AspirePageContentLayout @ref="@_contentLayout" IsSummaryDetailsViewOpen="@showDetailsView">
         <PageTitleSection>
-            <h1 class="page-header">@Loc[nameof(Dashboard.Resources.Resources.ResourcesHeader)]</h1>
+            <h1 class="page-header">@(IsGraphPage ? Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphHeader)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesHeader)])</h1>
         </PageTitleSection>
 
         <ToolbarSection>
@@ -93,12 +94,12 @@
                                 OnResize="@(r => _manager.SetWidthFraction(r.Orientation == Orientation.Horizontal ? r.Panel1Fraction : 1))">
                 <Summary>
                     <div id="resources-summary-layout-id" class="resources-summary-layout">
-                        <div class="@(!_hideResourceGraph ? "resource-tabs" : string.Empty)">
+                        <div class="resource-tabs">
                             @*
                                 Tab content isn't nested inside FluentTab elements. The tab control is just used to display the tabs.
                                 Content is located in manually created divs so they can be placed in their own CSS grid row.
                             *@
-                            @if (!_hideResourceGraph)
+                            @if (!IsGraphPage)
                             {
                                 <FluentTabs Class="resources-tab-header" ActiveTabId="@($"tab-{PageViewModel.SelectedViewKind}")" OnTabChange="@OnTabChangeAsync" Size="null">
                                     <FluentTab LabelClass="tab-label"
@@ -110,12 +111,6 @@
                                                Id="@($"tab-{ResourceViewKind.Parameters}")"
                                                Label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerParametersTab)]"
                                                Icon="@(new Icons.Regular.Size24.Key())">
-                                    </FluentTab>
-                                    <FluentTab LabelClass="tab-label"
-                                               Id="@($"tab-{ResourceViewKind.Graph}")"
-                                               aria-label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerGraphAccessibleLabel)]"
-                                               Label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerGraphTab)]"
-                                               Icon="@(new Icons.Regular.Size24.ShareAndroid())">
                                     </FluentTab>
                                 </FluentTabs>
                             }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -228,7 +228,10 @@
                                                           Orientation="Orientation.Horizontal"
                                                           @bind-Value="@PageViewModel.SelectedGraphMode"
                                                           @bind-Value:after="OnGraphModeChangedAsync">
-                                            <FluentRadio Value="@ResourceGraphMode.Relationships">@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphModeRelationships)]</FluentRadio>
+                                            @if (DashboardClient.IsEnabled)
+                                            {
+                                                <FluentRadio Value="@ResourceGraphMode.Relationships">@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphModeRelationships)]</FluentRadio>
+                                            }
                                             <FluentRadio Value="@ResourceGraphMode.Telemetry">@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphModeTelemetry)]</FluentRadio>
                                         </FluentRadioGroup>
                                         <FluentButton Appearance="Appearance.Stealth"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Text;
 using Aspire.Dashboard.Components.Layout;
 using Aspire.Dashboard.Configuration;
@@ -38,6 +39,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     private const string ActionsColumn = nameof(ActionsColumn);
 
     private Subscription? _logsSubscription;
+    private Subscription? _graphTracesSubscription;
     private IList<GridColumn>? _gridColumns;
     private EventCallback _onToggleCollapseAllCallback;
     private EventCallback _onToggleResourceTypeCallback;
@@ -87,6 +89,10 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     [Parameter]
     [SupplyParameterFromQuery(Name = "view")]
     public string? ViewKindName { get; set; }
+
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "graphMode")]
+    public string? GraphModeName { get; set; }
 
     [Parameter]
     [SupplyParameterFromQuery(Name = "showHiddenResources")]
@@ -288,6 +294,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             }
         });
 
+        UpdateGraphTracesSubscription();
+
         _loadingTcs.SetResult();
 
         async Task SubscribeResourcesAsync()
@@ -423,8 +431,71 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         }
 
         var activeResources = _resourceByName.Values.Where(Filter).OrderBy(e => e.ResourceType).ThenBy(e => e.Name).ToList();
-        var resources = activeResources.Select(r => ResourceGraphMapper.MapResource(r, _resourceByName, ColumnsLoc, _showHiddenResources, IconResolver)).ToList();
+        var telemetryReferencedNames = PageViewModel.SelectedGraphMode == ResourceGraphMode.Telemetry
+            ? GetTelemetryReferencedNames(activeResources)
+            : null;
+        if (telemetryReferencedNames is not null)
+        {
+            var telemetryResourceNames = GetTelemetryResourceNames(telemetryReferencedNames);
+            activeResources = activeResources.Where(r => telemetryResourceNames.Contains(r.Name)).ToList();
+        }
+
+        var resources = activeResources.Select(r =>
+        {
+            List<string>? referencedNames = null;
+            telemetryReferencedNames?.TryGetValue(r.Name, out referencedNames);
+            return ResourceGraphMapper.MapResource(r, _resourceByName, ColumnsLoc, _showHiddenResources, IconResolver, referencedNames);
+        }).ToList();
         await _jsModule.InvokeVoidAsync("updateResourcesGraph", resources);
+    }
+
+    private Dictionary<string, List<string>> GetTelemetryReferencedNames(List<ResourceViewModel> activeResources)
+    {
+        var activeResourceNameByResourceKey = new Dictionary<ResourceKey, string>();
+        var activeResourceNames = activeResources.Select(r => r.Name).ToHashSet(StringComparers.ResourceName);
+        foreach (var resource in activeResources)
+        {
+            activeResourceNameByResourceKey[ResourceKey.Create(resource.DisplayName, resource.Name)] = resource.Name;
+            activeResourceNameByResourceKey[new ResourceKey(resource.DisplayName, resource.Name)] = resource.Name;
+        }
+
+        var referencedNames = new Dictionary<string, List<string>>(StringComparers.ResourceName);
+        foreach (var edge in TelemetryRepository.GetTelemetryGraphEdges().Keys)
+        {
+            if (!activeResourceNameByResourceKey.TryGetValue(edge.Source, out var sourceName) ||
+                !activeResourceNameByResourceKey.TryGetValue(edge.Destination, out var destinationName) ||
+                !activeResourceNames.Contains(sourceName) ||
+                !activeResourceNames.Contains(destinationName) ||
+                string.Equals(sourceName, destinationName, StringComparisons.ResourceName))
+            {
+                continue;
+            }
+
+            ref var names = ref CollectionsMarshal.GetValueRefOrAddDefault(referencedNames, sourceName, out _);
+            names ??= [];
+            if (!names.Contains(destinationName, StringComparers.ResourceName))
+            {
+                names.Add(destinationName);
+            }
+        }
+
+        foreach (var names in referencedNames.Values)
+        {
+            names.Sort(StringComparers.ResourceName);
+        }
+
+        return referencedNames;
+    }
+
+    private static HashSet<string> GetTelemetryResourceNames(Dictionary<string, List<string>> referencedNames)
+    {
+        var resourceNames = new HashSet<string>(referencedNames.Keys, StringComparers.ResourceName);
+        foreach (var names in referencedNames.Values)
+        {
+            resourceNames.UnionWith(names);
+        }
+
+        return resourceNames;
     }
 
     private class ResourcesInterop(Resources resources)
@@ -585,6 +656,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             return;
         }
 
+        UpdateGraphTracesSubscription();
         UpdateMaxHighlightedCount();
 
         // Wait until the initial data is loaded. This is required so there isn't a race between data loading and using resources here.
@@ -894,10 +966,18 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         return OnViewChangedAsync(viewKind);
     }
 
+    private async Task OnGraphModeChangedAsync()
+    {
+        await this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: false);
+        UpdateGraphTracesSubscription();
+        await UpdateResourceGraphResourcesAsync();
+    }
+
     private async Task OnViewChangedAsync(ResourceViewKind newView)
     {
         PageViewModel.SelectedViewKind = newView;
         await this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: true);
+        UpdateGraphTracesSubscription();
 
         if (newView == ResourceViewKind.Graph)
         {
@@ -924,6 +1004,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     public sealed class ResourcesViewModel
     {
         public required ResourceViewKind SelectedViewKind { get; set; }
+        public ResourceGraphMode SelectedGraphMode { get; set; } = ResourceGraphMode.Relationships;
         public ConcurrentDictionary<string, bool> ResourceTypesToVisibility { get; } = new(StringComparers.ResourceName);
         public ConcurrentDictionary<string, bool> ResourceStatesToVisibility { get; } = new(StringComparers.ResourceState);
         public ConcurrentDictionary<string, bool> ResourceHealthStatusesToVisibility { get; } = new(StringComparer.Ordinal);
@@ -932,6 +1013,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     public class ResourcesPageState
     {
         public required string? ViewKind { get; set; }
+        public string? GraphMode { get; set; }
         public required IDictionary<string, bool> ResourceTypesToVisibility { get; set; }
         public required IDictionary<string, bool> ResourceStatesToVisibility { get; set; }
         public required IDictionary<string, bool> ResourceHealthStatusesToVisibility { get; set; }
@@ -944,12 +1026,24 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         Graph
     }
 
+    public enum ResourceGraphMode
+    {
+        Relationships,
+        Telemetry
+    }
+
     public Task UpdateViewModelFromQueryAsync(ResourcesViewModel viewModel)
     {
         // Don't allow the view to be updated from the query string if the resource graph is disabled.
         if (!_hideResourceGraph && Enum.TryParse(typeof(ResourceViewKind), ViewKindName, out var view) && view is ResourceViewKind vk)
         {
             viewModel.SelectedViewKind = vk;
+        }
+        if (viewModel.SelectedViewKind == ResourceViewKind.Graph &&
+            Enum.TryParse(typeof(ResourceGraphMode), GraphModeName, out var graphMode) &&
+            graphMode is ResourceGraphMode gm)
+        {
+            viewModel.SelectedGraphMode = gm;
         }
 
         return Task.CompletedTask;
@@ -959,6 +1053,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     {
         return DashboardUrls.ResourcesUrl(
             view: serializable.ViewKind,
+            graphMode: serializable.ViewKind == ResourceViewKind.Graph.ToString() ? serializable.GraphMode : null,
             // add resource?
             hiddenTypes: SerializeFiltersToString(serializable.ResourceTypesToVisibility),
             hiddenStates: SerializeFiltersToString(serializable.ResourceStatesToVisibility),
@@ -976,10 +1071,33 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         return new ResourcesPageState
         {
             ViewKind = PageViewModel.SelectedViewKind != ResourceViewKind.Table ? PageViewModel.SelectedViewKind.ToString() : null,
+            GraphMode = PageViewModel.SelectedViewKind == ResourceViewKind.Graph && PageViewModel.SelectedGraphMode != ResourceGraphMode.Relationships ? PageViewModel.SelectedGraphMode.ToString() : null,
             ResourceTypesToVisibility = PageViewModel.ResourceTypesToVisibility,
             ResourceStatesToVisibility = PageViewModel.ResourceStatesToVisibility,
             ResourceHealthStatusesToVisibility = PageViewModel.ResourceHealthStatusesToVisibility
         };
+    }
+
+    private void UpdateGraphTracesSubscription()
+    {
+        if (PageViewModel.SelectedViewKind == ResourceViewKind.Graph && PageViewModel.SelectedGraphMode == ResourceGraphMode.Telemetry)
+        {
+            _graphTracesSubscription ??= TelemetryRepository.OnNewTraces(null, SubscriptionType.Other, async () =>
+            {
+                await InvokeAsync(async () =>
+                {
+                    if (PageViewModel.SelectedViewKind == ResourceViewKind.Graph && PageViewModel.SelectedGraphMode == ResourceGraphMode.Telemetry)
+                    {
+                        await UpdateResourceGraphResourcesAsync();
+                    }
+                });
+            });
+        }
+        else
+        {
+            _graphTracesSubscription?.Dispose();
+            _graphTracesSubscription = null;
+        }
     }
 
     public async ValueTask DisposeAsync()
@@ -989,6 +1107,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         _resourcesInteropReference?.Dispose();
         _cts.Cancel();
         _logsSubscription?.Dispose();
+        _graphTracesSubscription?.Dispose();
         TelemetryContext.Dispose();
         await JSInteropHelpers.SafeDisposeAsync(_jsModule);
 
@@ -1014,6 +1133,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         var properties = new List<ComponentTelemetryProperty>
         {
             new(TelemetryPropertyKeys.ResourceView, new AspireTelemetryProperty(PageViewModel.SelectedViewKind.ToString(), AspireTelemetryPropertyType.UserSetting)),
+            new(TelemetryPropertyKeys.ResourceGraphMode, new AspireTelemetryProperty(PageViewModel.SelectedGraphMode.ToString(), AspireTelemetryPropertyType.UserSetting)),
             new(TelemetryPropertyKeys.ResourceTypes, new AspireTelemetryProperty(_resourceByName.Values.Select(r => TelemetryPropertyValues.GetResourceTypeTelemetryValue(r.ResourceType, r.SupportsDetailedTelemetry)).OrderBy(t => t).ToList()))
         };
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -4,7 +4,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Text;
 using Aspire.Dashboard.Components.Layout;
 using Aspire.Dashboard.Configuration;
@@ -431,60 +430,27 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         }
 
         var activeResources = _resourceByName.Values.Where(Filter).OrderBy(e => e.ResourceType).ThenBy(e => e.Name).ToList();
-        var telemetryReferencedNames = PageViewModel.SelectedGraphMode == ResourceGraphMode.Telemetry
-            ? GetTelemetryReferencedNames(activeResources)
+        var telemetryGraphResources = PageViewModel.SelectedGraphMode == ResourceGraphMode.Telemetry
+            ? TelemetryGraphResources.Create(activeResources, TelemetryRepository.GetTelemetryGraphEdgeKeys())
             : null;
-        if (telemetryReferencedNames is not null)
+        if (telemetryGraphResources is not null)
         {
-            var telemetryResourceNames = GetTelemetryResourceNames(telemetryReferencedNames);
-            activeResources = activeResources.Where(r => telemetryResourceNames.Contains(r.Name)).ToList();
+            activeResources = activeResources.Where(r => telemetryGraphResources.ResourceNames.Contains(r.Name)).ToList();
         }
 
         var resources = activeResources.Select(r =>
         {
-            HashSet<string>? referencedNames = null;
-            telemetryReferencedNames?.TryGetValue(r.Name, out referencedNames);
+            IEnumerable<string>? referencedNames = null;
+            if (telemetryGraphResources is not null)
+            {
+                referencedNames = telemetryGraphResources.ReferencedNames.TryGetValue(r.Name, out var telemetryReferencedNames)
+                    ? telemetryReferencedNames
+                    : Array.Empty<string>();
+            }
+
             return ResourceGraphMapper.MapResource(r, _resourceByName, ColumnsLoc, _showHiddenResources, IconResolver, referencedNames);
         }).ToList();
         await _jsModule.InvokeVoidAsync("updateResourcesGraph", resources);
-    }
-
-    private Dictionary<string, HashSet<string>> GetTelemetryReferencedNames(List<ResourceViewModel> activeResources)
-    {
-        var activeResourceNameByResourceKey = new Dictionary<ResourceKey, string>(activeResources.Count * 2);
-        foreach (var resource in activeResources)
-        {
-            activeResourceNameByResourceKey[ResourceKey.Create(resource.DisplayName, resource.Name)] = resource.Name;
-            activeResourceNameByResourceKey[new ResourceKey(resource.DisplayName, resource.Name)] = resource.Name;
-        }
-
-        var referencedNames = new Dictionary<string, HashSet<string>>(StringComparers.ResourceName);
-        foreach (var edge in TelemetryRepository.GetTelemetryGraphEdgeKeys())
-        {
-            if (!activeResourceNameByResourceKey.TryGetValue(edge.Source, out var sourceName) ||
-                !activeResourceNameByResourceKey.TryGetValue(edge.Destination, out var destinationName) ||
-                string.Equals(sourceName, destinationName, StringComparisons.ResourceName))
-            {
-                continue;
-            }
-
-            ref var names = ref CollectionsMarshal.GetValueRefOrAddDefault(referencedNames, sourceName, out _);
-            names ??= new HashSet<string>(StringComparers.ResourceName);
-            names.Add(destinationName);
-        }
-
-        return referencedNames;
-    }
-
-    private static HashSet<string> GetTelemetryResourceNames(Dictionary<string, HashSet<string>> referencedNames)
-    {
-        var resourceNames = new HashSet<string>(referencedNames.Keys, StringComparers.ResourceName);
-        foreach (var names in referencedNames.Values)
-        {
-            resourceNames.UnionWith(names);
-        }
-
-        return resourceNames;
     }
 
     private class ResourcesInterop(Resources resources)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -43,6 +43,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     private EventCallback _onToggleCollapseAllCallback;
     private EventCallback _onToggleResourceTypeCallback;
     private bool _hideResourceGraph;
+    private bool _disposed;
     private string _collapsedResourceNamesKey = null!;
     private Dictionary<ResourceKey, int>? _resourceUnviewedErrorCounts;
 
@@ -89,10 +90,18 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     public string SessionStorageKey => IsGraphPage ? BrowserStorageKeys.GraphPageState : BrowserStorageKeys.ResourcesPageState;
     public ResourcesViewModel PageViewModel { get; set; } = null!;
 
+    [Parameter]
+    public bool IsGraphPageRoute { get; set; }
+
     internal bool IsGraphPage
     {
         get
         {
+            if (IsGraphPageRoute)
+            {
+                return true;
+            }
+
             var relativePath = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
             var queryStart = relativePath.IndexOf('?');
             var path = queryStart >= 0 ? relativePath[..queryStart] : relativePath;
@@ -403,7 +412,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     private bool UpdateFromResource(ResourceViewModel resource, Func<string, bool> resourceTypeVisible, Func<string, bool> stateVisible, Func<string, bool> healthStatusVisible)
     {
-        // This is ok from threadsafty perspective because we are the only thread that's modifying resources.
+        // This is ok from a thread-safety perspective because we are the only thread that's modifying resources.
         bool added;
         if (_resourceByName.TryGetValue(resource.Name, out _))
         {
@@ -433,24 +442,40 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             StateHasChanged();
         }
 
-        if (PageViewModel.SelectedViewKind == ResourceViewKind.Graph && !_graphInitialized)
+        if (!_disposed && PageViewModel.SelectedViewKind == ResourceViewKind.Graph && !_graphInitialized)
         {
             // Before any awaits, set a flag to indicate the graph is initialized. This prevents the graph being initialized multiple times.
             _graphInitialized = true;
 
-            _jsModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/app-resourcegraph.js");
+            try
+            {
+                var jsModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/app-resourcegraph.js");
 
-            _resourcesInteropReference = DotNetObjectReference.Create(new ResourcesInterop(this));
+                if (_disposed)
+                {
+                    await JSInteropHelpers.SafeDisposeAsync(jsModule);
+                    return;
+                }
 
-            await _jsModule.InvokeVoidAsync("initializeResourcesGraph", _resourcesInteropReference);
-            await UpdateResourceGraphResourcesAsync();
-            await UpdateResourceGraphSelectedAsync();
+                _jsModule = jsModule;
+                _resourcesInteropReference = DotNetObjectReference.Create(new ResourcesInterop(this));
+
+                await _jsModule.InvokeVoidAsync("initializeResourcesGraph", _resourcesInteropReference);
+                await UpdateResourceGraphResourcesAsync();
+                await UpdateResourceGraphSelectedAsync();
+            }
+            catch (ObjectDisposedException) when (_disposed)
+            {
+                // Navigation can dispose the routed graph component while its first render is still
+                // importing or initializing the graph module. Ignore only that expected teardown race.
+            }
         }
     }
 
     private async Task UpdateResourceGraphResourcesAsync()
     {
-        if (PageViewModel.SelectedViewKind != ResourceViewKind.Graph || _jsModule == null)
+        var jsModule = _jsModule;
+        if (_disposed || PageViewModel.SelectedViewKind != ResourceViewKind.Graph || jsModule == null)
         {
             return;
         }
@@ -466,14 +491,27 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphTelemetryResourceType)],
                 _showHiddenResources,
                 IconResolver);
-            await _jsModule.InvokeVoidAsync("updateResourcesGraph", telemetryResources);
+            await InvokeResourceGraphModuleAsync(jsModule, "updateResourcesGraph", telemetryResources);
             return;
         }
 
         var resources = activeResources
             .Select(r => ResourceGraphMapper.MapResource(r, _resourceByName, ColumnsLoc, _showHiddenResources, IconResolver))
             .ToList();
-        await _jsModule.InvokeVoidAsync("updateResourcesGraph", resources);
+        await InvokeResourceGraphModuleAsync(jsModule, "updateResourcesGraph", resources);
+    }
+
+    private async Task InvokeResourceGraphModuleAsync(IJSObjectReference jsModule, string identifier, object? arg)
+    {
+        try
+        {
+            await jsModule.InvokeVoidAsync(identifier, arg);
+        }
+        catch (ObjectDisposedException) when (_disposed)
+        {
+            // Resource graph updates can be queued by renders or telemetry notifications just as
+            // navigation tears down the graph route. The next route/component owns any further updates.
+        }
     }
 
     private class ResourcesInterop(Resources resources)
@@ -979,9 +1017,10 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     private async Task UpdateResourceGraphSelectedAsync()
     {
-        if (_jsModule != null)
+        var jsModule = _jsModule;
+        if (!_disposed && jsModule != null)
         {
-            await _jsModule.InvokeVoidAsync("updateResourcesGraphSelected", SelectedResource?.Name);
+            await InvokeResourceGraphModuleAsync(jsModule, "updateResourcesGraphSelected", SelectedResource?.Name);
         }
     }
 
@@ -1121,6 +1160,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     public async ValueTask DisposeAsync()
     {
+        _disposed = true;
         _aiContext?.Dispose();
 
         _resourcesInteropReference?.Dispose();

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -443,6 +443,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             IEnumerable<string>? referencedNames = null;
             if (telemetryGraphResources is not null)
             {
+                // In telemetry mode, a visible resource can have only incoming calls. Pass an explicit
+                // empty reference list for those nodes so they don't fall back to model relationships.
                 referencedNames = telemetryGraphResources.ReferencedNames.TryGetValue(r.Name, out var telemetryReferencedNames)
                     ? telemetryReferencedNames
                     : Array.Empty<string>();

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -442,52 +442,41 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
         var resources = activeResources.Select(r =>
         {
-            List<string>? referencedNames = null;
+            HashSet<string>? referencedNames = null;
             telemetryReferencedNames?.TryGetValue(r.Name, out referencedNames);
             return ResourceGraphMapper.MapResource(r, _resourceByName, ColumnsLoc, _showHiddenResources, IconResolver, referencedNames);
         }).ToList();
         await _jsModule.InvokeVoidAsync("updateResourcesGraph", resources);
     }
 
-    private Dictionary<string, List<string>> GetTelemetryReferencedNames(List<ResourceViewModel> activeResources)
+    private Dictionary<string, HashSet<string>> GetTelemetryReferencedNames(List<ResourceViewModel> activeResources)
     {
-        var activeResourceNameByResourceKey = new Dictionary<ResourceKey, string>();
-        var activeResourceNames = activeResources.Select(r => r.Name).ToHashSet(StringComparers.ResourceName);
+        var activeResourceNameByResourceKey = new Dictionary<ResourceKey, string>(activeResources.Count * 2);
         foreach (var resource in activeResources)
         {
             activeResourceNameByResourceKey[ResourceKey.Create(resource.DisplayName, resource.Name)] = resource.Name;
             activeResourceNameByResourceKey[new ResourceKey(resource.DisplayName, resource.Name)] = resource.Name;
         }
 
-        var referencedNames = new Dictionary<string, List<string>>(StringComparers.ResourceName);
-        foreach (var edge in TelemetryRepository.GetTelemetryGraphEdges().Keys)
+        var referencedNames = new Dictionary<string, HashSet<string>>(StringComparers.ResourceName);
+        foreach (var edge in TelemetryRepository.GetTelemetryGraphEdgeKeys())
         {
             if (!activeResourceNameByResourceKey.TryGetValue(edge.Source, out var sourceName) ||
                 !activeResourceNameByResourceKey.TryGetValue(edge.Destination, out var destinationName) ||
-                !activeResourceNames.Contains(sourceName) ||
-                !activeResourceNames.Contains(destinationName) ||
                 string.Equals(sourceName, destinationName, StringComparisons.ResourceName))
             {
                 continue;
             }
 
             ref var names = ref CollectionsMarshal.GetValueRefOrAddDefault(referencedNames, sourceName, out _);
-            names ??= [];
-            if (!names.Contains(destinationName, StringComparers.ResourceName))
-            {
-                names.Add(destinationName);
-            }
-        }
-
-        foreach (var names in referencedNames.Values)
-        {
-            names.Sort(StringComparers.ResourceName);
+            names ??= new HashSet<string>(StringComparers.ResourceName);
+            names.Add(destinationName);
         }
 
         return referencedNames;
     }
 
-    private static HashSet<string> GetTelemetryResourceNames(Dictionary<string, List<string>> referencedNames)
+    private static HashSet<string> GetTelemetryResourceNames(Dictionary<string, HashSet<string>> referencedNames)
     {
         var resourceNames = new HashSet<string>(referencedNames.Keys, StringComparers.ResourceName);
         foreach (var names in referencedNames.Values)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -1143,7 +1143,11 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             ViewKind = IsGraphPage
                 ? ResourceViewKind.Graph.ToString()
                 : PageViewModel.SelectedViewKind != ResourceViewKind.Table ? PageViewModel.SelectedViewKind.ToString() : null,
-            GraphMode = PageViewModel.SelectedViewKind == ResourceViewKind.Graph && PageViewModel.SelectedGraphMode != ResourceGraphMode.Relationships ? PageViewModel.SelectedGraphMode.ToString() : null,
+            GraphMode = DashboardClient.IsEnabled &&
+                PageViewModel.SelectedViewKind == ResourceViewKind.Graph &&
+                PageViewModel.SelectedGraphMode != ResourceGraphMode.Relationships
+                ? PageViewModel.SelectedGraphMode.ToString()
+                : null,
             ResourceTypesToVisibility = PageViewModel.ResourceTypesToVisibility,
             ResourceStatesToVisibility = PageViewModel.ResourceStatesToVisibility,
             ResourceHealthStatusesToVisibility = PageViewModel.ResourceHealthStatusesToVisibility

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -36,6 +36,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     private const string UrlsColumn = nameof(UrlsColumn);
     private const string ValueColumn = nameof(ValueColumn);
     private const string ActionsColumn = nameof(ActionsColumn);
+    // Keep the lower-cased property name because JS reads this as `{ modeSwitch: true }`.
+    private static readonly object s_resourceGraphModeSwitchOptions = new { modeSwitch = true };
 
     private Subscription? _logsSubscription;
     private Subscription? _graphTracesSubscription;
@@ -472,7 +474,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         }
     }
 
-    private async Task UpdateResourceGraphResourcesAsync()
+    internal async Task UpdateResourceGraphResourcesAsync(bool modeSwitch = false)
     {
         var jsModule = _jsModule;
         if (_disposed || PageViewModel.SelectedViewKind != ResourceViewKind.Graph || jsModule == null)
@@ -491,21 +493,35 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphTelemetryResourceType)],
                 _showHiddenResources,
                 IconResolver);
-            await InvokeResourceGraphModuleAsync(jsModule, "updateResourcesGraph", telemetryResources);
+            if (modeSwitch)
+            {
+                await InvokeResourceGraphModuleAsync(jsModule, "updateResourcesGraph", telemetryResources, s_resourceGraphModeSwitchOptions);
+            }
+            else
+            {
+                await InvokeResourceGraphModuleAsync(jsModule, "updateResourcesGraph", telemetryResources);
+            }
             return;
         }
 
         var resources = activeResources
             .Select(r => ResourceGraphMapper.MapResource(r, _resourceByName, ColumnsLoc, _showHiddenResources, IconResolver))
             .ToList();
-        await InvokeResourceGraphModuleAsync(jsModule, "updateResourcesGraph", resources);
+        if (modeSwitch)
+        {
+            await InvokeResourceGraphModuleAsync(jsModule, "updateResourcesGraph", resources, s_resourceGraphModeSwitchOptions);
+        }
+        else
+        {
+            await InvokeResourceGraphModuleAsync(jsModule, "updateResourcesGraph", resources);
+        }
     }
 
-    private async Task InvokeResourceGraphModuleAsync(IJSObjectReference jsModule, string identifier, object? arg)
+    private async Task InvokeResourceGraphModuleAsync(IJSObjectReference jsModule, string identifier, params object?[] args)
     {
         try
         {
-            await jsModule.InvokeVoidAsync(identifier, arg);
+            await jsModule.InvokeVoidAsync(identifier, args);
         }
         catch (ObjectDisposedException) when (_disposed)
         {
@@ -992,7 +1008,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     {
         await this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: false);
         UpdateGraphTracesSubscription();
-        await UpdateResourceGraphResourcesAsync();
+        await UpdateResourceGraphResourcesAsync(modeSwitch: true);
     }
 
     private async Task OnViewChangedAsync(ResourceViewKind newView)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -81,9 +81,24 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     [Inject]
     public required ResourceMenuBuilder ResourceMenuBuilder { get; init; }
 
-    public string BasePath => DashboardUrls.ResourcesBasePath;
-    public string SessionStorageKey => BrowserStorageKeys.ResourcesPageState;
+    // Resources and Graph share this component because the graph needs the same resource
+    // subscription, filtering, details panel, and command plumbing as the table. Keep
+    // their route/session identities separate so restoring one page doesn't redirect
+    // the other to a different top-level navigation item.
+    public string BasePath => IsGraphPage ? DashboardUrls.GraphBasePath : DashboardUrls.ResourcesBasePath;
+    public string SessionStorageKey => IsGraphPage ? BrowserStorageKeys.GraphPageState : BrowserStorageKeys.ResourcesPageState;
     public ResourcesViewModel PageViewModel { get; set; } = null!;
+
+    internal bool IsGraphPage
+    {
+        get
+        {
+            var relativePath = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+            var queryStart = relativePath.IndexOf('?');
+            var path = queryStart >= 0 ? relativePath[..queryStart] : relativePath;
+            return string.Equals(path.TrimEnd('/'), DashboardUrls.GraphBasePath, StringComparisons.UrlPath);
+        }
+    }
 
     [Parameter]
     [SupplyParameterFromQuery(Name = "view")]
@@ -248,7 +263,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
         PageViewModel = new ResourcesViewModel
         {
-            SelectedViewKind = ResourceViewKind.Table
+            SelectedViewKind = IsGraphPage && !_hideResourceGraph ? ResourceViewKind.Graph : ResourceViewKind.Table
         };
 
         _resourceUnviewedErrorCounts = TelemetryRepository.GetResourceUnviewedErrorLogsCount();
@@ -608,6 +623,12 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     protected override async Task OnParametersSetAsync()
     {
+        if (IsGraphPage && _hideResourceGraph)
+        {
+            NavigationManager.NavigateTo(DashboardUrls.ResourcesUrl(), new NavigationOptions { ReplaceHistoryEntry = true });
+            return;
+        }
+
         if (await this.InitializeViewModelAsync())
         {
             return;
@@ -991,16 +1012,34 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     public Task UpdateViewModelFromQueryAsync(ResourcesViewModel viewModel)
     {
-        // Don't allow the view to be updated from the query string if the resource graph is disabled.
-        if (!_hideResourceGraph && Enum.TryParse(typeof(ResourceViewKind), ViewKindName, out var view) && view is ResourceViewKind vk)
+        if (IsGraphPage)
+        {
+            viewModel.SelectedViewKind = _hideResourceGraph ? ResourceViewKind.Table : ResourceViewKind.Graph;
+            if (viewModel.SelectedViewKind == ResourceViewKind.Graph &&
+                Enum.TryParse(typeof(ResourceGraphMode), GraphModeName, out var graphMode) &&
+                graphMode is ResourceGraphMode gm)
+            {
+                viewModel.SelectedGraphMode = gm;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        if (!_hideResourceGraph && Enum.TryParse(typeof(ResourceViewKind), ViewKindName, out var view) && view is ResourceViewKind.Graph)
+        {
+            NavigationManager.NavigateTo(DashboardUrls.GraphUrl(
+                graphMode: GraphModeName,
+                hiddenTypes: HiddenTypes,
+                hiddenStates: HiddenStates,
+                hiddenHealthStates: HiddenHealthStates), new NavigationOptions { ReplaceHistoryEntry = true });
+            return Task.CompletedTask;
+        }
+
+        if (Enum.TryParse(typeof(ResourceViewKind), ViewKindName, out view) &&
+            view is ResourceViewKind vk &&
+            vk != ResourceViewKind.Graph)
         {
             viewModel.SelectedViewKind = vk;
-        }
-        if (viewModel.SelectedViewKind == ResourceViewKind.Graph &&
-            Enum.TryParse(typeof(ResourceGraphMode), GraphModeName, out var graphMode) &&
-            graphMode is ResourceGraphMode gm)
-        {
-            viewModel.SelectedGraphMode = gm;
         }
 
         return Task.CompletedTask;
@@ -1008,9 +1047,17 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     public string GetUrlFromSerializableViewModel(ResourcesPageState serializable)
     {
+        if (IsGraphPage)
+        {
+            return DashboardUrls.GraphUrl(
+                graphMode: serializable.GraphMode,
+                hiddenTypes: SerializeFiltersToString(serializable.ResourceTypesToVisibility),
+                hiddenStates: SerializeFiltersToString(serializable.ResourceStatesToVisibility),
+                hiddenHealthStates: SerializeFiltersToString(serializable.ResourceHealthStatusesToVisibility));
+        }
+
         return DashboardUrls.ResourcesUrl(
-            view: serializable.ViewKind,
-            graphMode: serializable.ViewKind == ResourceViewKind.Graph.ToString() ? serializable.GraphMode : null,
+            view: serializable.ViewKind == ResourceViewKind.Graph.ToString() ? null : serializable.ViewKind,
             // add resource?
             hiddenTypes: SerializeFiltersToString(serializable.ResourceTypesToVisibility),
             hiddenStates: SerializeFiltersToString(serializable.ResourceStatesToVisibility),
@@ -1027,7 +1074,9 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     {
         return new ResourcesPageState
         {
-            ViewKind = PageViewModel.SelectedViewKind != ResourceViewKind.Table ? PageViewModel.SelectedViewKind.ToString() : null,
+            ViewKind = IsGraphPage
+                ? ResourceViewKind.Graph.ToString()
+                : PageViewModel.SelectedViewKind != ResourceViewKind.Table ? PageViewModel.SelectedViewKind.ToString() : null,
             GraphMode = PageViewModel.SelectedViewKind == ResourceViewKind.Graph && PageViewModel.SelectedGraphMode != ResourceGraphMode.Relationships ? PageViewModel.SelectedGraphMode.ToString() : null,
             ResourceTypesToVisibility = PageViewModel.ResourceTypesToVisibility,
             ResourceStatesToVisibility = PageViewModel.ResourceStatesToVisibility,

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -1039,6 +1039,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     {
         if (PageViewModel.SelectedViewKind == ResourceViewKind.Graph && PageViewModel.SelectedGraphMode == ResourceGraphMode.Telemetry)
         {
+            // Trace notifications can be high volume. Only subscribe while telemetry graph mode is
+            // visible so table and relationship graph views don't pay for graph remapping on every span.
             _graphTracesSubscription ??= TelemetryRepository.OnNewTraces(null, SubscriptionType.Other, async () =>
             {
                 await InvokeAsync(async () =>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -224,24 +224,27 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     protected override async Task OnInitializedAsync()
     {
-        if (!DashboardClient.IsEnabled)
+        if (!DashboardClient.IsEnabled && !IsGraphPage)
         {
             // Should never reach here.
             throw new InvalidOperationException("Unable to display the resources page because the dashboard client is not enabled.");
         }
 
         TelemetryContextProvider.Initialize(TelemetryContext);
-        _aiContext = AIContextProvider.AddNew(nameof(Resources), c =>
+        if (DashboardClient.IsEnabled)
         {
-            c.BuildIceBreakers = (builder, context) =>
+            _aiContext = AIContextProvider.AddNew(nameof(Resources), c =>
             {
-                var hasUnhealthyResources = _resourceByName.Values
-                    .Where(r => !r.IsResourceHidden(_showHiddenResources))
-                    .Any(r => r.KnownState != KnownResourceState.Running || r.HealthStatus is HealthStatus.Unhealthy or HealthStatus.Degraded);
+                c.BuildIceBreakers = (builder, context) =>
+                {
+                    var hasUnhealthyResources = _resourceByName.Values
+                        .Where(r => !r.IsResourceHidden(_showHiddenResources))
+                        .Any(r => r.KnownState != KnownResourceState.Running || r.HealthStatus is HealthStatus.Unhealthy or HealthStatus.Degraded);
 
-                builder.Resources(context, hasUnhealthyResources);
-            };
-        });
+                    builder.Resources(context, hasUnhealthyResources);
+                };
+            });
+        }
 
         (_resizeLabels, _sortLabels) = DashboardUIHelpers.CreateGridLabels(ControlsStringsLoc);
 
@@ -263,7 +266,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
         PageViewModel = new ResourcesViewModel
         {
-            SelectedViewKind = IsGraphPage && !_hideResourceGraph ? ResourceViewKind.Graph : ResourceViewKind.Table
+            SelectedViewKind = IsGraphPage && !_hideResourceGraph ? ResourceViewKind.Graph : ResourceViewKind.Table,
+            SelectedGraphMode = DashboardClient.IsEnabled ? ResourceGraphMode.Relationships : ResourceGraphMode.Telemetry
         };
 
         _resourceUnviewedErrorCounts = TelemetryRepository.GetResourceUnviewedErrorLogsCount();
@@ -281,32 +285,39 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         }
         UpdateMenuButtons();
 
-        // Must wait until after the dashboard is connected so the application name is correct.
-        await DashboardClient.WhenConnected;
-        _collapsedResourceNamesKey = BrowserStorageKeys.CollapsedResourceNamesKey(DashboardClient.ApplicationName);
-
-        var collapsedResult = await LocalStorage.GetAsync<List<string>>(_collapsedResourceNamesKey);
-        if (collapsedResult.Success)
+        if (DashboardClient.IsEnabled)
         {
-            foreach (var resourceName in collapsedResult.Value)
+            // Must wait until after the dashboard is connected so the application name is correct.
+            await DashboardClient.WhenConnected;
+            _collapsedResourceNamesKey = BrowserStorageKeys.CollapsedResourceNamesKey(DashboardClient.ApplicationName);
+
+            var collapsedResult = await LocalStorage.GetAsync<List<string>>(_collapsedResourceNamesKey);
+            if (collapsedResult.Success)
             {
-                _collapsedResourceNames.Add(resourceName);
+                foreach (var resourceName in collapsedResult.Value)
+                {
+                    _collapsedResourceNames.Add(resourceName);
+                }
             }
+
+            await SubscribeResourcesAsync();
+
+            _logsSubscription = TelemetryRepository.OnNewLogs(null, SubscriptionType.Other, async () =>
+            {
+                var newResourceUnviewedErrorCounts = TelemetryRepository.GetResourceUnviewedErrorLogsCount();
+
+                // Only update UI if the error counts have changed.
+                if (ResourceErrorCountsChanged(newResourceUnviewedErrorCounts))
+                {
+                    _resourceUnviewedErrorCounts = newResourceUnviewedErrorCounts;
+                    await InvokeAsync(_dataGrid.SafeRefreshDataAsync);
+                }
+            });
         }
-
-        await SubscribeResourcesAsync();
-
-        _logsSubscription = TelemetryRepository.OnNewLogs(null, SubscriptionType.Other, async () =>
+        else
         {
-            var newResourceUnviewedErrorCounts = TelemetryRepository.GetResourceUnviewedErrorLogsCount();
-
-            // Only update UI if the error counts have changed.
-            if (ResourceErrorCountsChanged(newResourceUnviewedErrorCounts))
-            {
-                _resourceUnviewedErrorCounts = newResourceUnviewedErrorCounts;
-                await InvokeAsync(_dataGrid.SafeRefreshDataAsync);
-            }
-        });
+            _collapsedResourceNamesKey = BrowserStorageKeys.CollapsedResourceNamesKey(nameof(Resources));
+        }
 
         UpdateGraphTracesSubscription();
 
@@ -445,28 +456,23 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         }
 
         var activeResources = _resourceByName.Values.Where(Filter).OrderBy(e => e.ResourceType).ThenBy(e => e.Name).ToList();
-        var telemetryGraphResources = PageViewModel.SelectedGraphMode == ResourceGraphMode.Telemetry
-            ? TelemetryGraphResources.Create(activeResources, TelemetryRepository.GetTelemetryGraphEdgeKeys())
-            : null;
-        if (telemetryGraphResources is not null)
+        if (PageViewModel.SelectedGraphMode == ResourceGraphMode.Telemetry)
         {
-            activeResources = activeResources.Where(r => telemetryGraphResources.ResourceNames.Contains(r.Name)).ToList();
+            var telemetryResources = TelemetryGraphResources.CreateResourceDtos(
+                activeResources,
+                TelemetryRepository.GetTelemetryGraphEdgeKeys(),
+                _resourceByName,
+                ColumnsLoc,
+                Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphTelemetryResourceType)],
+                _showHiddenResources,
+                IconResolver);
+            await _jsModule.InvokeVoidAsync("updateResourcesGraph", telemetryResources);
+            return;
         }
 
-        var resources = activeResources.Select(r =>
-        {
-            IEnumerable<string>? referencedNames = null;
-            if (telemetryGraphResources is not null)
-            {
-                // In telemetry mode, a visible resource can have only incoming calls. Pass an explicit
-                // empty reference list for those nodes so they don't fall back to model relationships.
-                referencedNames = telemetryGraphResources.ReferencedNames.TryGetValue(r.Name, out var telemetryReferencedNames)
-                    ? telemetryReferencedNames
-                    : Array.Empty<string>();
-            }
-
-            return ResourceGraphMapper.MapResource(r, _resourceByName, ColumnsLoc, _showHiddenResources, IconResolver, referencedNames);
-        }).ToList();
+        var resources = activeResources
+            .Select(r => ResourceGraphMapper.MapResource(r, _resourceByName, ColumnsLoc, _showHiddenResources, IconResolver))
+            .ToList();
         await _jsModule.InvokeVoidAsync("updateResourcesGraph", resources);
     }
 
@@ -1020,6 +1026,11 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 graphMode is ResourceGraphMode gm)
             {
                 viewModel.SelectedGraphMode = gm;
+            }
+
+            if (!DashboardClient.IsEnabled)
+            {
+                viewModel.SelectedGraphMode = ResourceGraphMode.Telemetry;
             }
 
             return Task.CompletedTask;

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -102,7 +102,14 @@
     right: 30px;
     bottom: 30px;
     display: flex;
+    align-items: center;
     column-gap: 10px;
+}
+
+::deep .resource-graph-mode {
+    background-color: var(--neutral-layer-1);
+    border-radius: 4px;
+    padding: 4px 8px;
 }
 
 ::deep .resource-graph .texts {
@@ -176,6 +183,34 @@
     stroke: var(--neutral-stroke-rest);
     stroke-width: 1;
     marker-end: url(#arrow-normal);
+}
+
+::deep .resource-graph-telemetry .resource-link {
+    stroke: var(--accent-fill-rest);
+    stroke-linecap: round;
+    stroke-opacity: 0.75;
+    stroke-width: 1.5;
+    stroke-dasharray: 8 8;
+}
+
+::deep .resource-graph-telemetry .arrow-normal {
+    fill: var(--accent-fill-rest);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    ::deep .resource-graph-telemetry .resource-link {
+        animation: telemetry-flow-link 900ms linear infinite;
+    }
+}
+
+@keyframes telemetry-flow-link {
+    from {
+        stroke-dashoffset: 0;
+    }
+
+    to {
+        stroke-dashoffset: -16;
+    }
 }
 
 ::deep .arrow-normal {

--- a/src/Aspire.Dashboard/Model/ResourceGraph/ResourceDto.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/ResourceDto.cs
@@ -12,7 +12,7 @@ public sealed class ResourceDto
     public required string DisplayName { get; init; }
     public required string Uid { get; init; }
     public required IconDto ResourceIcon { get; init; }
-    public required IconDto StateIcon { get; init; }
+    public required IconDto? StateIcon { get; init; }
     public required string? EndpointUrl { get; init; }
     public required string? EndpointText { get; init; }
     public required ImmutableArray<string> ReferencedNames { get; init; }

--- a/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
@@ -12,25 +12,9 @@ namespace Aspire.Dashboard.Model.ResourceGraph;
 
 public static class ResourceGraphMapper
 {
-    public static ResourceDto MapResource(ResourceViewModel r, IDictionary<string, ResourceViewModel> resourcesByName, IStringLocalizer<Columns> columnsLoc, bool showHiddenResources, IconResolver iconResolver)
+    public static ResourceDto MapResource(ResourceViewModel r, IDictionary<string, ResourceViewModel> resourcesByName, IStringLocalizer<Columns> columnsLoc, bool showHiddenResources, IconResolver iconResolver, IEnumerable<string>? referencedNames = null)
     {
-        var resolvedNames = new List<string>();
-
-        // Remove relationships back to the current resource. The graph doesn't display self referential relationships.
-        var filteredRelationships = r.Relationships.Where(relationship => relationship.ResourceName != r.DisplayName);
-
-        foreach (var resourceRelationships in filteredRelationships.GroupBy(r => r.ResourceName, StringComparers.ResourceName))
-        {
-            var matches = resourcesByName.Values
-                .Where(r => string.Equals(r.DisplayName, resourceRelationships.Key, StringComparisons.ResourceName))
-                .Where(r => !r.IsResourceHidden(showHiddenResources))
-                .ToList();
-
-            foreach (var match in matches)
-            {
-                resolvedNames.Add(match.Name);
-            }
-        }
+        var resolvedNames = referencedNames?.ToList() ?? ResolveRelationshipNames(r, resourcesByName, showHiddenResources);
 
         var endpoint = ResourceUrlHelpers.GetUrls(r, includeInternalUrls: false, includeNonEndpointUrls: false).FirstOrDefault()
             ?? ResourceUrlHelpers.GetUrls(r, includeInternalUrls: false, includeNonEndpointUrls: true).FirstOrDefault();
@@ -66,6 +50,29 @@ public static class ResourceGraphMapper
         };
 
         return dto;
+    }
+
+    private static List<string> ResolveRelationshipNames(ResourceViewModel r, IDictionary<string, ResourceViewModel> resourcesByName, bool showHiddenResources)
+    {
+        var resolvedNames = new List<string>();
+
+        // Remove relationships back to the current resource. The graph doesn't display self referential relationships.
+        var filteredRelationships = r.Relationships.Where(relationship => relationship.ResourceName != r.DisplayName);
+
+        foreach (var resourceRelationships in filteredRelationships.GroupBy(r => r.ResourceName, StringComparers.ResourceName))
+        {
+            var matches = resourcesByName.Values
+                .Where(r => string.Equals(r.DisplayName, resourceRelationships.Key, StringComparisons.ResourceName))
+                .Where(r => !r.IsResourceHidden(showHiddenResources))
+                .ToList();
+
+            foreach (var match in matches)
+            {
+                resolvedNames.Add(match.Name);
+            }
+        }
+
+        return resolvedNames;
     }
 
     private static string ResolvedEndpointText(DisplayedUrl? endpoint)

--- a/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
@@ -14,6 +14,9 @@ public static class ResourceGraphMapper
 {
     public static ResourceDto MapResource(ResourceViewModel r, IDictionary<string, ResourceViewModel> resourcesByName, IStringLocalizer<Columns> columnsLoc, bool showHiddenResources, IconResolver iconResolver, IEnumerable<string>? referencedNames = null)
     {
+        // Null means relationship mode should derive edges from the app model. An empty collection is
+        // meaningful in telemetry mode for resources that only have incoming calls, so keep those as
+        // explicit "no outgoing telemetry edges" instead of falling back to relationships.
         var resolvedNames = referencedNames?.ToList() ?? ResolveRelationshipNames(r, resourcesByName, showHiddenResources);
 
         var endpoint = ResourceUrlHelpers.GetUrls(r, includeInternalUrls: false, includeNonEndpointUrls: false).FirstOrDefault()

--- a/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
@@ -19,9 +19,15 @@ internal sealed class TelemetryGraphResources
 
     public static TelemetryGraphResources Create(IReadOnlyList<ResourceViewModel> activeResources, IReadOnlyList<TelemetryGraphEdge> edgeKeys)
     {
+        // Keep this projection scoped to a single graph refresh. The persistent telemetry edge index is
+        // bounded by retained traces; this avoids adding another server-side cache with a separate lifetime.
         var activeResourceNameByResourceKey = new Dictionary<ResourceKey, string>(activeResources.Count * 2);
         foreach (var resource in activeResources)
         {
+            // Telemetry edges can come from instrumented OTLP resources or from uninstrumented peer
+            // resolution. Instrumented resources usually normalize "{DisplayName}-{replica id}" via
+            // ResourceKey.Create, while peer resolution can carry the dashboard resource name as the
+            // instance id. Index both forms so telemetry flow still resolves after either path produced it.
             activeResourceNameByResourceKey[ResourceKey.Create(resource.DisplayName, resource.Name)] = resource.Name;
             activeResourceNameByResourceKey[new ResourceKey(resource.DisplayName, resource.Name)] = resource.Name;
         }

--- a/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
@@ -6,8 +6,6 @@ using System.Runtime.InteropServices;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Microsoft.Extensions.Localization;
-using Microsoft.FluentUI.AspNetCore.Components;
-using Microsoft.FluentUI.AspNetCore.Components.Extensions;
 using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Model.ResourceGraph;
@@ -144,7 +142,6 @@ internal sealed class TelemetryGraphResources
     private static ResourceDto CreateTelemetryResourceDto(string name, ResourceKey resourceKey, string telemetryResourceType, IEnumerable<string> referencedNames)
     {
         var resourceIcon = new Icons.Regular.Size24.AppGeneric();
-        var stateIcon = new Icons.Regular.Size16.CircleHint();
         return new ResourceDto
         {
             Name = name,
@@ -157,15 +154,10 @@ internal sealed class TelemetryGraphResources
                 Color = ColorGenerator.Instance.GetColorVariableByKey(name),
                 Tooltip = resourceKey.GetCompositeName()
             },
-            StateIcon = new IconDto
-            {
-                Path = ResourceGraphMapper.GetIconPathData(stateIcon),
-                Color = Color.Info.ToAttributeValue()!,
-                Tooltip = null
-            },
+            StateIcon = null,
             ReferencedNames = referencedNames.Distinct(StringComparers.ResourceName).Order(StringComparers.ResourceName).ToImmutableArray(),
             EndpointUrl = null,
-            EndpointText = ControlsStrings.ResourceGraphNoEndpoints
+            EndpointText = null
         };
     }
 }

--- a/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using Aspire.Dashboard.Otlp.Storage;
+
+namespace Aspire.Dashboard.Model.ResourceGraph;
+
+internal sealed class TelemetryGraphResources
+{
+    private TelemetryGraphResources(int resourceCapacity, int edgeCapacity)
+    {
+        ReferencedNames = new Dictionary<string, HashSet<string>>(Math.Min(resourceCapacity, edgeCapacity), StringComparers.ResourceName);
+        ResourceNames = new HashSet<string>(resourceCapacity, StringComparers.ResourceName);
+    }
+
+    public Dictionary<string, HashSet<string>> ReferencedNames { get; }
+    public HashSet<string> ResourceNames { get; }
+
+    public static TelemetryGraphResources Create(IReadOnlyList<ResourceViewModel> activeResources, IReadOnlyList<TelemetryGraphEdge> edgeKeys)
+    {
+        var activeResourceNameByResourceKey = new Dictionary<ResourceKey, string>(activeResources.Count * 2);
+        foreach (var resource in activeResources)
+        {
+            activeResourceNameByResourceKey[ResourceKey.Create(resource.DisplayName, resource.Name)] = resource.Name;
+            activeResourceNameByResourceKey[new ResourceKey(resource.DisplayName, resource.Name)] = resource.Name;
+        }
+
+        var result = new TelemetryGraphResources(activeResources.Count, edgeKeys.Count);
+        foreach (var edge in edgeKeys)
+        {
+            if (!activeResourceNameByResourceKey.TryGetValue(edge.Source, out var sourceName) ||
+                !activeResourceNameByResourceKey.TryGetValue(edge.Destination, out var destinationName) ||
+                string.Equals(sourceName, destinationName, StringComparisons.ResourceName))
+            {
+                continue;
+            }
+
+            ref var names = ref CollectionsMarshal.GetValueRefOrAddDefault(result.ReferencedNames, sourceName, out _);
+            names ??= new HashSet<string>(StringComparers.ResourceName);
+            if (names.Add(destinationName))
+            {
+                result.ResourceNames.Add(sourceName);
+                result.ResourceNames.Add(destinationName);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
@@ -1,8 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Resources;
+using Microsoft.Extensions.Localization;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Model.ResourceGraph;
 
@@ -52,5 +58,114 @@ internal sealed class TelemetryGraphResources
         }
 
         return result;
+    }
+
+    public static List<ResourceDto> CreateResourceDtos(
+        IReadOnlyList<ResourceViewModel> activeResources,
+        IReadOnlyList<TelemetryGraphEdge> edgeKeys,
+        IDictionary<string, ResourceViewModel> resourceByName,
+        IStringLocalizer<Columns> columnsLoc,
+        string telemetryResourceType,
+        bool showHiddenResources,
+        IconResolver iconResolver)
+    {
+        var activeResourcesByName = activeResources.ToDictionary(r => r.Name, StringComparers.ResourceName);
+        var resourceNameByResourceKey = new Dictionary<ResourceKey, string>(activeResources.Count * 2);
+        foreach (var resource in activeResources)
+        {
+            resourceNameByResourceKey[ResourceKey.Create(resource.DisplayName, resource.Name)] = resource.Name;
+            resourceNameByResourceKey[new ResourceKey(resource.DisplayName, resource.Name)] = resource.Name;
+        }
+
+        var referencedNames = new Dictionary<string, HashSet<string>>(StringComparers.ResourceName);
+        var telemetryResourceKeysByName = new Dictionary<string, ResourceKey>(StringComparers.ResourceName);
+        foreach (var edge in edgeKeys)
+        {
+            // Telemetry can arrive in the standalone dashboard without any AppHost resource model.
+            // In that case the raw OTLP resource key becomes the node identity. If a dashboard
+            // resource exists, use it instead so the node gets the richer icon/state/endpoint data.
+            var sourceName = ResolveResourceName(edge.Source);
+            var destinationName = ResolveResourceName(edge.Destination);
+            if (string.Equals(sourceName, destinationName, StringComparisons.ResourceName))
+            {
+                continue;
+            }
+
+            ref var names = ref CollectionsMarshal.GetValueRefOrAddDefault(referencedNames, sourceName, out _);
+            names ??= new HashSet<string>(StringComparers.ResourceName);
+            names.Add(destinationName);
+            telemetryResourceKeysByName.TryAdd(sourceName, edge.Source);
+            telemetryResourceKeysByName.TryAdd(destinationName, edge.Destination);
+        }
+
+        var dtos = new List<ResourceDto>(telemetryResourceKeysByName.Count);
+        foreach (var (resourceName, resourceKey) in telemetryResourceKeysByName.OrderBy(kvp => kvp.Key, StringComparers.ResourceName))
+        {
+            IEnumerable<string> references = referencedNames.TryGetValue(resourceName, out var telemetryReferencedNames)
+                ? telemetryReferencedNames
+                : Array.Empty<string>();
+
+            if (activeResourcesByName.TryGetValue(resourceName, out var resource))
+            {
+                dtos.Add(ResourceGraphMapper.MapResource(resource, resourceByName, columnsLoc, showHiddenResources, iconResolver, references));
+            }
+            else
+            {
+                dtos.Add(CreateTelemetryResourceDto(resourceName, resourceKey, telemetryResourceType, references));
+            }
+        }
+
+        return dtos;
+
+        string ResolveResourceName(ResourceKey resourceKey)
+        {
+            if (resourceNameByResourceKey.TryGetValue(resourceKey, out var resourceName))
+            {
+                return resourceName;
+            }
+
+            // Raw OTLP can report service.name="api" and service.instance.id="api-123".
+            // Normalize only that already-composite raw shape to the dashboard-style "api-123".
+            // Edge keys produced by ResourceKey.Create have already stripped the service-name
+            // prefix, so normalizing those again would lose the service name entirely.
+            if (resourceKey.InstanceId is { } instanceId &&
+                (string.Equals(resourceKey.Name, instanceId, StringComparisons.ResourceName) ||
+                (instanceId.Length >= resourceKey.Name.Length + 2 &&
+                instanceId.StartsWith(resourceKey.Name, StringComparisons.ResourceName) &&
+                instanceId[resourceKey.Name.Length] == '-')))
+            {
+                return ResourceKey.Create(resourceKey.Name, instanceId).GetCompositeName();
+            }
+
+            return resourceKey.GetCompositeName();
+        }
+    }
+
+    private static ResourceDto CreateTelemetryResourceDto(string name, ResourceKey resourceKey, string telemetryResourceType, IEnumerable<string> referencedNames)
+    {
+        var resourceIcon = new Icons.Regular.Size24.AppGeneric();
+        var stateIcon = new Icons.Regular.Size16.CircleHint();
+        return new ResourceDto
+        {
+            Name = name,
+            ResourceType = telemetryResourceType,
+            DisplayName = name,
+            Uid = name,
+            ResourceIcon = new IconDto
+            {
+                Path = ResourceGraphMapper.GetIconPathData(resourceIcon),
+                Color = ColorGenerator.Instance.GetColorVariableByKey(name),
+                Tooltip = resourceKey.GetCompositeName()
+            },
+            StateIcon = new IconDto
+            {
+                Path = ResourceGraphMapper.GetIconPathData(stateIcon),
+                Color = Color.Info.ToAttributeValue()!,
+                Tooltip = null
+            },
+            ReferencedNames = referencedNames.Distinct(StringComparers.ResourceName).Order(StringComparers.ResourceName).ToImmutableArray(),
+            EndpointUrl = null,
+            EndpointText = ControlsStrings.ResourceGraphNoEndpoints
+        };
     }
 }

--- a/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
@@ -12,52 +12,6 @@ namespace Aspire.Dashboard.Model.ResourceGraph;
 
 internal sealed class TelemetryGraphResources
 {
-    private TelemetryGraphResources(int resourceCapacity, int edgeCapacity)
-    {
-        ReferencedNames = new Dictionary<string, HashSet<string>>(Math.Min(resourceCapacity, edgeCapacity), StringComparers.ResourceName);
-        ResourceNames = new HashSet<string>(resourceCapacity, StringComparers.ResourceName);
-    }
-
-    public Dictionary<string, HashSet<string>> ReferencedNames { get; }
-    public HashSet<string> ResourceNames { get; }
-
-    public static TelemetryGraphResources Create(IReadOnlyList<ResourceViewModel> activeResources, IReadOnlyList<TelemetryGraphEdge> edgeKeys)
-    {
-        // Keep this projection scoped to a single graph refresh. The persistent telemetry edge index is
-        // bounded by retained traces; this avoids adding another server-side cache with a separate lifetime.
-        var activeResourceNameByResourceKey = new Dictionary<ResourceKey, string>(activeResources.Count * 2);
-        foreach (var resource in activeResources)
-        {
-            // Telemetry edges can come from instrumented OTLP resources or from uninstrumented peer
-            // resolution. Instrumented resources usually normalize "{DisplayName}-{replica id}" via
-            // ResourceKey.Create, while peer resolution can carry the dashboard resource name as the
-            // instance id. Index both forms so telemetry flow still resolves after either path produced it.
-            activeResourceNameByResourceKey[ResourceKey.Create(resource.DisplayName, resource.Name)] = resource.Name;
-            activeResourceNameByResourceKey[new ResourceKey(resource.DisplayName, resource.Name)] = resource.Name;
-        }
-
-        var result = new TelemetryGraphResources(activeResources.Count, edgeKeys.Count);
-        foreach (var edge in edgeKeys)
-        {
-            if (!activeResourceNameByResourceKey.TryGetValue(edge.Source, out var sourceName) ||
-                !activeResourceNameByResourceKey.TryGetValue(edge.Destination, out var destinationName) ||
-                string.Equals(sourceName, destinationName, StringComparisons.ResourceName))
-            {
-                continue;
-            }
-
-            ref var names = ref CollectionsMarshal.GetValueRefOrAddDefault(result.ReferencedNames, sourceName, out _);
-            names ??= new HashSet<string>(StringComparers.ResourceName);
-            if (names.Add(destinationName))
-            {
-                result.ResourceNames.Add(sourceName);
-                result.ResourceNames.Add(destinationName);
-            }
-        }
-
-        return result;
-    }
-
     public static List<ResourceDto> CreateResourceDtos(
         IReadOnlyList<ResourceViewModel> activeResources,
         IReadOnlyList<TelemetryGraphEdge> edgeKeys,

--- a/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
@@ -152,7 +152,7 @@ internal sealed class TelemetryGraphResources
             {
                 Path = ResourceGraphMapper.GetIconPathData(resourceIcon),
                 Color = ColorGenerator.Instance.GetColorVariableByKey(name),
-                Tooltip = resourceKey.GetCompositeName()
+                Tooltip = telemetryResourceType
             },
             StateIcon = null,
             ReferencedNames = referencedNames.Distinct(StringComparers.ResourceName).Order(StringComparers.ResourceName).ToImmutableArray(),

--- a/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/TelemetryGraphResources.cs
@@ -146,7 +146,7 @@ internal sealed class TelemetryGraphResources
         {
             Name = name,
             ResourceType = telemetryResourceType,
-            DisplayName = name,
+            DisplayName = resourceKey.Name,
             Uid = name,
             ResourceIcon = new IconDto
             {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryGraphEdge.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryGraphEdge.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+internal readonly record struct TelemetryGraphEdge(ResourceKey Source, ResourceKey Destination);

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -1922,11 +1922,18 @@ public sealed partial class TelemetryRepository : IDisposable
 
     private void CalculateTraceUninstrumentedPeers(OtlpTrace trace)
     {
+        HashSet<string>? spanIdsWithChildren = null;
         foreach (var span in trace.Spans)
         {
+            if (span.Kind is not (OtlpSpanKind.Client or OtlpSpanKind.Producer))
+            {
+                trace.SetSpanUninstrumentedPeer(span, null);
+                continue;
+            }
+
             // A span may indicate a call to another service but the service isn't instrumented.
             var hasPeerService = OtlpHelpers.GetPeerAddress(span.Attributes) != null;
-            var hasUninstrumentedPeer = hasPeerService && span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer && !span.GetChildSpans().Any();
+            var hasUninstrumentedPeer = hasPeerService && !(spanIdsWithChildren ??= GetSpanIdsWithChildren(trace)).Contains(span.SpanId);
             var uninstrumentedPeer = hasUninstrumentedPeer ? ResolveUninstrumentedPeerResource(span, _outgoingPeerResolvers) : null;
 
             if (uninstrumentedPeer != null)
@@ -1952,6 +1959,20 @@ public sealed partial class TelemetryRepository : IDisposable
             {
                 trace.SetSpanUninstrumentedPeer(span, null);
             }
+        }
+
+        static HashSet<string> GetSpanIdsWithChildren(OtlpTrace trace)
+        {
+            var spanIdsWithChildren = new HashSet<string>(trace.Spans.Count, StringComparers.OtlpSpanId);
+            foreach (var span in trace.Spans)
+            {
+                if (span.ParentSpanId is { Length: > 0 } parentSpanId)
+                {
+                    spanIdsWithChildren.Add(parentSpanId);
+                }
+            }
+
+            return spanIdsWithChildren;
         }
     }
 
@@ -2017,14 +2038,14 @@ public sealed partial class TelemetryRepository : IDisposable
             }
             else
             {
-                sourceSpansById ??= new Dictionary<string, OtlpSpan>(StringComparer.Ordinal);
+                sourceSpansById ??= new Dictionary<string, OtlpSpan>(trace.Spans.Count, StringComparers.OtlpSpanId);
                 sourceSpansById.Add(span.SpanId, span);
             }
         }
 
         if (sourceSpansById is not null)
         {
-            Dictionary<string, HashSet<ResourceKey>>? destinationsBySourceSpanId = null;
+            HashSet<TelemetryGraphSpanDestination>? spanDestinations = null;
             foreach (var childSpan in trace.Spans)
             {
                 if (childSpan.ParentSpanId is not { Length: > 0 } parentSpanId ||
@@ -2035,10 +2056,8 @@ public sealed partial class TelemetryRepository : IDisposable
                     continue;
                 }
 
-                destinationsBySourceSpanId ??= new Dictionary<string, HashSet<ResourceKey>>(StringComparer.Ordinal);
-                ref var destinations = ref CollectionsMarshal.GetValueRefOrAddDefault(destinationsBySourceSpanId, parentSpanId, out _);
-                destinations ??= [];
-                if (destinations.Add(childSpan.Source.ResourceKey))
+                spanDestinations ??= new HashSet<TelemetryGraphSpanDestination>(sourceSpansById.Count);
+                if (spanDestinations.Add(new TelemetryGraphSpanDestination(parentSpanId, childSpan.Source.ResourceKey)))
                 {
                     AddTelemetryGraphEdge(edges, sourceSpan.Source.ResourceKey, childSpan.Source.ResourceKey);
                 }
@@ -2057,6 +2076,8 @@ public sealed partial class TelemetryRepository : IDisposable
             CollectionsMarshal.GetValueRefOrAddDefault(edges, new TelemetryGraphEdge(source, destination), out _)++;
         }
     }
+
+    private readonly record struct TelemetryGraphSpanDestination(string SourceSpanId, ResourceKey Destination);
 
     private static ResourceViewModel? ResolveUninstrumentedPeerResource(OtlpSpan span, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
     {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -1932,6 +1932,8 @@ public sealed partial class TelemetryRepository : IDisposable
             }
 
             // A span may indicate a call to another service but the service isn't instrumented.
+            // If there is already a child server/consumer span, prefer that instrumented resource
+            // instead of also creating a synthetic peer from the client's peer attributes.
             var hasPeerService = OtlpHelpers.GetPeerAddress(span.Attributes) != null;
             var hasUninstrumentedPeer = hasPeerService && !(spanIdsWithChildren ??= GetSpanIdsWithChildren(trace)).Contains(span.SpanId);
             var uninstrumentedPeer = hasUninstrumentedPeer ? ResolveUninstrumentedPeerResource(span, _outgoingPeerResolvers) : null;
@@ -2056,6 +2058,9 @@ public sealed partial class TelemetryRepository : IDisposable
                     continue;
                 }
 
+                // A single outbound span can produce multiple server/consumer spans for the same
+                // resource. Count that as one call edge for the trace so internal handlers don't
+                // inflate the graph when they share the same parent client/producer span.
                 spanDestinations ??= new HashSet<TelemetryGraphSpanDestination>(sourceSpansById.Count);
                 if (spanDestinations.Add(new TelemetryGraphSpanDestination(parentSpanId, childSpan.Source.ResourceKey)))
                 {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -69,6 +69,8 @@ public sealed partial class TelemetryRepository : IDisposable
     // Not explicitly capped per add — bounded only by the sum of span links across in-buffer traces.
     // Cleaned up on trace eviction and clear, so growth is limited by the circular buffer capacity.
     private readonly List<OtlpSpanLink> _spanLinks = new();
+    private readonly Dictionary<TelemetryGraphEdge, int> _telemetryGraphEdges = new();
+    private readonly Dictionary<OtlpTrace, Dictionary<TelemetryGraphEdge, int>> _telemetryGraphEdgesByTrace = new();
     private readonly List<IDisposable> _peerResolverSubscriptions = new();
     internal readonly OtlpContext _otlpContext;
 
@@ -104,6 +106,8 @@ public sealed partial class TelemetryRepository : IDisposable
 
     private void TracesItemRemovedForCapacity(OtlpTrace trace)
     {
+        RemoveTraceTelemetryGraphEdges(trace);
+
         // Remove links from central collection when the span is removed.
         foreach (var span in trace.Spans)
         {
@@ -111,6 +115,20 @@ public sealed partial class TelemetryRepository : IDisposable
             {
                 _spanLinks.Remove(link);
             }
+        }
+    }
+
+    internal Dictionary<TelemetryGraphEdge, int> GetTelemetryGraphEdges()
+    {
+        _tracesLock.EnterReadLock();
+
+        try
+        {
+            return _telemetryGraphEdges.ToDictionary();
+        }
+        finally
+        {
+            _tracesLock.ExitReadLock();
         }
     }
 
@@ -1334,6 +1352,8 @@ public sealed partial class TelemetryRepository : IDisposable
                 _traceScopes.Clear();
                 _tracePropertyKeys.Clear();
                 _spanLinks.Clear();
+                _telemetryGraphEdges.Clear();
+                _telemetryGraphEdgesByTrace.Clear();
 
                 foreach (var resource in _resources.Values)
                 {
@@ -1348,6 +1368,8 @@ public sealed partial class TelemetryRepository : IDisposable
                     // Remove trace if any span matches one of the resources. This matches filter behavior.
                     if (MatchResources(trace, resources))
                     {
+                        RemoveTraceTelemetryGraphEdges(trace);
+
                         // Remove span links for the removed trace.
                         foreach (var span in trace.Spans)
                         {
@@ -1823,6 +1845,7 @@ public sealed partial class TelemetryRepository : IDisposable
                 foreach (var (_, updatedTrace) in updatedTraces)
                 {
                     CalculateTraceUninstrumentedPeers(updatedTrace);
+                    UpdateTraceTelemetryGraphEdges(updatedTrace);
                 }
             }
         }
@@ -1906,6 +1929,100 @@ public sealed partial class TelemetryRepository : IDisposable
             else
             {
                 trace.SetSpanUninstrumentedPeer(span, null);
+            }
+        }
+    }
+
+    private void UpdateTraceTelemetryGraphEdges(OtlpTrace trace)
+    {
+        RemoveTraceTelemetryGraphEdges(trace);
+
+        var edges = CalculateTraceTelemetryGraphEdges(trace);
+        if (edges.Count == 0)
+        {
+            return;
+        }
+
+        _telemetryGraphEdgesByTrace.Add(trace, edges);
+        foreach (var (edge, count) in edges)
+        {
+            CollectionsMarshal.GetValueRefOrAddDefault(_telemetryGraphEdges, edge, out _) += count;
+        }
+    }
+
+    private void RemoveTraceTelemetryGraphEdges(OtlpTrace trace)
+    {
+        if (!_telemetryGraphEdgesByTrace.Remove(trace, out var edges))
+        {
+            return;
+        }
+
+        foreach (var (edge, count) in edges)
+        {
+            if (!_telemetryGraphEdges.TryGetValue(edge, out var currentCount))
+            {
+                Debug.Fail("Expected telemetry graph edge to exist.");
+                continue;
+            }
+
+            var updatedCount = currentCount - count;
+            if (updatedCount <= 0)
+            {
+                _telemetryGraphEdges.Remove(edge);
+            }
+            else
+            {
+                _telemetryGraphEdges[edge] = updatedCount;
+            }
+        }
+    }
+
+    private static Dictionary<TelemetryGraphEdge, int> CalculateTraceTelemetryGraphEdges(OtlpTrace trace)
+    {
+        var edges = new Dictionary<TelemetryGraphEdge, int>();
+
+        foreach (var span in trace.Spans)
+        {
+            if (span.Kind is not (OtlpSpanKind.Client or OtlpSpanKind.Producer))
+            {
+                continue;
+            }
+
+            var source = span.Source.ResourceKey;
+            foreach (var destination in GetTelemetryGraphDestinations(span))
+            {
+                if (destination == source)
+                {
+                    continue;
+                }
+
+                CollectionsMarshal.GetValueRefOrAddDefault(edges, new TelemetryGraphEdge(source, destination), out _)++;
+            }
+        }
+
+        return edges;
+
+        static IEnumerable<ResourceKey> GetTelemetryGraphDestinations(OtlpSpan span)
+        {
+            if (span.UninstrumentedPeer is { } peer)
+            {
+                yield return peer.ResourceKey;
+                yield break;
+            }
+
+            HashSet<ResourceKey>? destinations = null;
+            foreach (var childSpan in span.GetChildSpans())
+            {
+                if (childSpan.Source.ResourceKey == span.Source.ResourceKey || childSpan.Kind is not (OtlpSpanKind.Server or OtlpSpanKind.Consumer))
+                {
+                    continue;
+                }
+
+                destinations ??= [];
+                if (destinations.Add(childSpan.Source.ResourceKey))
+                {
+                    yield return childSpan.Source.ResourceKey;
+                }
             }
         }
     }
@@ -2130,6 +2247,7 @@ public sealed partial class TelemetryRepository : IDisposable
                 try
                 {
                     CalculateTraceUninstrumentedPeers(trace);
+                    UpdateTraceTelemetryGraphEdges(trace);
                 }
                 catch (Exception ex)
                 {
@@ -2141,6 +2259,8 @@ public sealed partial class TelemetryRepository : IDisposable
         {
             _tracesLock.ExitWriteLock();
         }
+
+        RaiseSubscriptionChanged(_tracesSubscriptions);
 
         return Task.CompletedTask;
     }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -132,6 +132,20 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
+    internal List<TelemetryGraphEdge> GetTelemetryGraphEdgeKeys()
+    {
+        _tracesLock.EnterReadLock();
+
+        try
+        {
+            return _telemetryGraphEdges.Keys.ToList();
+        }
+        finally
+        {
+            _tracesLock.ExitReadLock();
+        }
+    }
+
     public List<OtlpResource> GetResources(bool includeUninstrumentedPeers = false)
     {
         return GetResourcesCore(includeUninstrumentedPeers, name: null);
@@ -1988,6 +2002,7 @@ public sealed partial class TelemetryRepository : IDisposable
     private static Dictionary<TelemetryGraphEdge, int> CalculateTraceTelemetryGraphEdges(OtlpTrace trace)
     {
         var edges = new Dictionary<TelemetryGraphEdge, int>();
+        Dictionary<string, OtlpSpan>? sourceSpansById = null;
 
         foreach (var span in trace.Spans)
         {
@@ -1996,42 +2011,50 @@ public sealed partial class TelemetryRepository : IDisposable
                 continue;
             }
 
-            var source = span.Source.ResourceKey;
-            foreach (var destination in GetTelemetryGraphDestinations(span))
+            if (span.UninstrumentedPeer is { } peer)
             {
-                if (destination == source)
+                AddTelemetryGraphEdge(edges, span.Source.ResourceKey, peer.ResourceKey);
+            }
+            else
+            {
+                sourceSpansById ??= new Dictionary<string, OtlpSpan>(StringComparer.Ordinal);
+                sourceSpansById.Add(span.SpanId, span);
+            }
+        }
+
+        if (sourceSpansById is not null)
+        {
+            Dictionary<string, HashSet<ResourceKey>>? destinationsBySourceSpanId = null;
+            foreach (var childSpan in trace.Spans)
+            {
+                if (childSpan.ParentSpanId is not { Length: > 0 } parentSpanId ||
+                    childSpan.Kind is not (OtlpSpanKind.Server or OtlpSpanKind.Consumer) ||
+                    !sourceSpansById.TryGetValue(parentSpanId, out var sourceSpan) ||
+                    childSpan.Source.ResourceKey == sourceSpan.Source.ResourceKey)
                 {
                     continue;
                 }
 
-                CollectionsMarshal.GetValueRefOrAddDefault(edges, new TelemetryGraphEdge(source, destination), out _)++;
+                destinationsBySourceSpanId ??= new Dictionary<string, HashSet<ResourceKey>>(StringComparer.Ordinal);
+                ref var destinations = ref CollectionsMarshal.GetValueRefOrAddDefault(destinationsBySourceSpanId, parentSpanId, out _);
+                destinations ??= [];
+                if (destinations.Add(childSpan.Source.ResourceKey))
+                {
+                    AddTelemetryGraphEdge(edges, sourceSpan.Source.ResourceKey, childSpan.Source.ResourceKey);
+                }
             }
         }
 
         return edges;
 
-        static IEnumerable<ResourceKey> GetTelemetryGraphDestinations(OtlpSpan span)
+        static void AddTelemetryGraphEdge(Dictionary<TelemetryGraphEdge, int> edges, ResourceKey source, ResourceKey destination)
         {
-            if (span.UninstrumentedPeer is { } peer)
+            if (destination == source)
             {
-                yield return peer.ResourceKey;
-                yield break;
+                return;
             }
 
-            HashSet<ResourceKey>? destinations = null;
-            foreach (var childSpan in span.GetChildSpans())
-            {
-                if (childSpan.Source.ResourceKey == span.Source.ResourceKey || childSpan.Kind is not (OtlpSpanKind.Server or OtlpSpanKind.Consumer))
-                {
-                    continue;
-                }
-
-                destinations ??= [];
-                if (destinations.Add(childSpan.Source.ResourceKey))
-                {
-                    yield return childSpan.Source.ResourceKey;
-                }
-            }
+            CollectionsMarshal.GetValueRefOrAddDefault(edges, new TelemetryGraphEdge(source, destination), out _)++;
         }
     }
 

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -69,6 +69,9 @@ public sealed partial class TelemetryRepository : IDisposable
     // Not explicitly capped per add — bounded only by the sum of span links across in-buffer traces.
     // Cleaned up on trace eviction and clear, so growth is limited by the circular buffer capacity.
     private readonly List<OtlpSpanLink> _spanLinks = new();
+    // Derived telemetry graph state is intentionally bounded by the retained trace buffer instead of
+    // a separate cache limit. The per-trace counts let trace eviction, replacement, and clear subtract
+    // exactly the edges they contributed while all mutations stay under _tracesLock.
     private readonly Dictionary<TelemetryGraphEdge, int> _telemetryGraphEdges = new();
     private readonly Dictionary<OtlpTrace, Dictionary<TelemetryGraphEdge, int>> _telemetryGraphEdgesByTrace = new();
     private readonly List<IDisposable> _peerResolverSubscriptions = new();
@@ -1838,7 +1841,9 @@ public sealed partial class TelemetryRepository : IDisposable
                             _tracePropertyKeys.Add((resourceView.Resource, kvp.Key));
                         }
 
-                        // Derived indexes should only track traces retained by the circular buffer.
+                        // CircularBuffer.Insert can reject an older incoming trace when the buffer is
+                        // full. Derived indexes must only track retained traces, otherwise a dropped
+                        // trace would leave telemetry graph edges that eviction can never subtract.
                         Debug.Assert(!traceRetained || _traces.Contains(trace), "Trace not found in traces collection.");
 
                         if (traceRetained)
@@ -1862,8 +1867,9 @@ public sealed partial class TelemetryRepository : IDisposable
                     AssertSpanLinks();
                 }
 
-                // After spans are updated, loop through traces and their spans and update uninstrumented peer values.
-                // These can change
+                // Re-evaluate peers after all spans in the batch are applied. A client/producer span can
+                // arrive before its child server/consumer span, and we only want a synthetic peer edge
+                // when the destination resource is genuinely uninstrumented.
                 foreach (var (_, updatedTrace) in updatedTraces)
                 {
                     CalculateTraceUninstrumentedPeers(updatedTrace);
@@ -2040,6 +2046,11 @@ public sealed partial class TelemetryRepository : IDisposable
             }
             else
             {
+                // OpenTelemetry uses client/producer spans for outbound work and server/consumer child
+                // spans for the receiving side:
+                // https://opentelemetry.io/docs/specs/otel/trace/api/#spankind
+                // Store outbound spans by id and resolve instrumented destinations in one child-span
+                // pass instead of scanning all children once per source span.
                 sourceSpansById ??= new Dictionary<string, OtlpSpan>(trace.Spans.Count, StringComparers.OtlpSpanId);
                 sourceSpansById.Add(span.SpanId, span);
             }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -1907,7 +1907,7 @@ public sealed partial class TelemetryRepository : IDisposable
 
     public OtlpResource? GetPeerResource(OtlpSpan span)
     {
-        var peer = ResolveUninstrumentedPeerResource(span, _outgoingPeerResolvers);
+        var peer = ResolveUninstrumentedPeerResource(span, _outgoingPeerResolvers, _logger);
         if (peer == null)
         {
             return null;
@@ -1942,7 +1942,7 @@ public sealed partial class TelemetryRepository : IDisposable
             // instead of also creating a synthetic peer from the client's peer attributes.
             var hasPeerService = OtlpHelpers.GetPeerAddress(span.Attributes) != null;
             var hasUninstrumentedPeer = hasPeerService && !(spanIdsWithChildren ??= GetSpanIdsWithChildren(trace)).Contains(span.SpanId);
-            var uninstrumentedPeer = hasUninstrumentedPeer ? ResolveUninstrumentedPeerResource(span, _outgoingPeerResolvers) : null;
+            var uninstrumentedPeer = hasUninstrumentedPeer ? ResolveUninstrumentedPeerResource(span, _outgoingPeerResolvers, _logger) : null;
 
             if (uninstrumentedPeer != null)
             {
@@ -2095,14 +2095,24 @@ public sealed partial class TelemetryRepository : IDisposable
 
     private readonly record struct TelemetryGraphSpanDestination(string SourceSpanId, ResourceKey Destination);
 
-    private static ResourceViewModel? ResolveUninstrumentedPeerResource(OtlpSpan span, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+    private static ResourceViewModel? ResolveUninstrumentedPeerResource(OtlpSpan span, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers, ILogger logger)
     {
         // Attempt to resolve uninstrumented peer to a friendly name from the span.
         foreach (var resolver in outgoingPeerResolvers)
         {
-            if (resolver.TryResolvePeer(span.Attributes, out _, out var matchedResourced))
+            try
             {
-                return matchedResourced;
+                if (resolver.TryResolvePeer(span.Attributes, out _, out var matchedResourced))
+                {
+                    return matchedResourced;
+                }
+            }
+            catch (Exception ex)
+            {
+                // Peer resolvers parse loosely structured OTLP attributes such as:
+                //   server.address: bad-peer, server.port: not-a-port
+                // Treat resolver failures as bad span data so one malformed outbound span doesn't abort ingestion.
+                logger.LogInformation(ex, "Error resolving uninstrumented peer resource.");
             }
         }
 

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -1763,6 +1763,7 @@ public sealed partial class TelemetryRepository : IDisposable
                         // We need to ensure traces are in the correct order if we're:
                         // 1. Adding a new trace.
                         // 2. The first span of the trace has changed.
+                        var traceRetained = true;
                         if (newTrace)
                         {
                             var added = false;
@@ -1778,6 +1779,10 @@ public sealed partial class TelemetryRepository : IDisposable
                             }
                             if (!added)
                             {
+                                // CircularBuffer<T>.Insert(0, item) rejects the new item when the buffer is full.
+                                // In that case the incoming trace was older than every retained trace, so don't
+                                // update derived indexes such as telemetry graph edges for a trace we didn't keep.
+                                traceRetained = !_traces.IsFull;
                                 _traces.Insert(0, trace);
                             }
                         }
@@ -1819,10 +1824,13 @@ public sealed partial class TelemetryRepository : IDisposable
                             _tracePropertyKeys.Add((resourceView.Resource, kvp.Key));
                         }
 
-                        // Newly added or updated trace should always been in the collection.
-                        Debug.Assert(_traces.Contains(trace), "Trace not found in traces collection.");
+                        // Derived indexes should only track traces retained by the circular buffer.
+                        Debug.Assert(!traceRetained || _traces.Contains(trace), "Trace not found in traces collection.");
 
-                        updatedTraces[trace.Key] = trace;
+                        if (traceRetained)
+                        {
+                            updatedTraces[trace.Key] = trace;
+                        }
 
                         // Collect span for push-based streaming (lazy init to avoid allocation when no watchers)
                         addedSpans ??= new List<OtlpSpan>();

--- a/src/Aspire.Dashboard/Resources/Layout.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Layout.Designer.cs
@@ -203,6 +203,15 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("NavMenuMetricsTab", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Graph.
+        /// </summary>
+        public static string NavMenuGraphTab {
+            get {
+                return ResourceManager.GetString("NavMenuGraphTab", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Resources.

--- a/src/Aspire.Dashboard/Resources/Layout.resx
+++ b/src/Aspire.Dashboard/Resources/Layout.resx
@@ -147,6 +147,9 @@
   <data name="NavMenuResourcesTab" xml:space="preserve">
     <value>Resources</value>
   </data>
+  <data name="NavMenuGraphTab" xml:space="preserve">
+    <value>Graph</value>
+  </data>
   <data name="NavMenuConsoleLogsTab" xml:space="preserve">
     <value>Console</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -446,6 +446,33 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesGraphResetButton", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Graph mode.
+        /// </summary>
+        public static string ResourcesGraphModeLabel {
+            get {
+                return ResourceManager.GetString("ResourcesGraphModeLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Relationships.
+        /// </summary>
+        public static string ResourcesGraphModeRelationships {
+            get {
+                return ResourceManager.GetString("ResourcesGraphModeRelationships", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Telemetry flow.
+        /// </summary>
+        public static string ResourcesGraphModeTelemetry {
+            get {
+                return ResourceManager.GetString("ResourcesGraphModeTelemetry", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Zoom in.

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -473,6 +473,24 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesGraphModeTelemetry", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Graph.
+        /// </summary>
+        public static string ResourcesGraphHeader {
+            get {
+                return ResourceManager.GetString("ResourcesGraphHeader", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} graph.
+        /// </summary>
+        public static string ResourcesGraphPageTitle {
+            get {
+                return ResourceManager.GetString("ResourcesGraphPageTitle", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Zoom in.

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -475,6 +475,15 @@ namespace Aspire.Dashboard.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Telemetry.
+        /// </summary>
+        public static string ResourcesGraphTelemetryResourceType {
+            get {
+                return ResourceManager.GetString("ResourcesGraphTelemetryResourceType", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Graph.
         /// </summary>
         public static string ResourcesGraphHeader {

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -296,6 +296,15 @@
   <data name="ResourcesGraphResetButton" xml:space="preserve">
     <value>Reset</value>
   </data>
+  <data name="ResourcesGraphModeLabel" xml:space="preserve">
+    <value>Graph mode</value>
+  </data>
+  <data name="ResourcesGraphModeRelationships" xml:space="preserve">
+    <value>Relationships</value>
+  </data>
+  <data name="ResourcesGraphModeTelemetry" xml:space="preserve">
+    <value>Telemetry flow</value>
+  </data>
   <data name="ResourcesHideTypes" xml:space="preserve">
     <value>Hide resource types</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -312,6 +312,9 @@
   <data name="ResourcesGraphModeTelemetry" xml:space="preserve">
     <value>Telemetry flow</value>
   </data>
+  <data name="ResourcesGraphTelemetryResourceType" xml:space="preserve">
+    <value>Telemetry</value>
+  </data>
   <data name="ResourcesHideTypes" xml:space="preserve">
     <value>Hide resource types</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -121,8 +121,15 @@
     <value>{0} resources</value>
     <comment>{0} is an application name</comment>
   </data>
+  <data name="ResourcesGraphPageTitle" xml:space="preserve">
+    <value>{0} graph</value>
+    <comment>{0} is an application name</comment>
+  </data>
   <data name="ResourcesHeader" xml:space="preserve">
     <value>Resources</value>
+  </data>
+  <data name="ResourcesGraphHeader" xml:space="preserve">
+    <value>Graph</value>
   </data>
   <data name="ResourcesNotFiltered" xml:space="preserve">
     <value>No filters</value>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Konzola</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">Metriky</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Konsole</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">Metriken</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Consola</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">Métricas</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Console</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">Métriques</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Console</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">Metriche</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
@@ -82,6 +82,11 @@
         <target state="translated">コンソール</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">メトリック</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
@@ -82,6 +82,11 @@
         <target state="translated">콘솔</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">메트릭</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Konsola</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">Metryki</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Console</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">Métricas</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Консоль</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">Метрики</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Konsol</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">Ölçümler</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
@@ -82,6 +82,11 @@
         <target state="translated">控制台</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">指标</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
@@ -82,6 +82,11 @@
         <target state="translated">主控台</target>
         <note />
       </trans-unit>
+      <trans-unit id="NavMenuGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuMetricsTab">
         <source>Metrics</source>
         <target state="translated">計量</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -212,6 +212,21 @@
         <target state="translated">Obsahuje filtry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">Resetovat</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Obsahuje filtry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -242,6 +242,11 @@
         <target state="translated">Resetovat</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Přiblížit</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -212,6 +212,21 @@
         <target state="translated">Hat Filter</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">Zurücksetzen</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -242,6 +242,11 @@
         <target state="translated">Zurücksetzen</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Vergrößern</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Hat Filter</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -212,6 +212,21 @@
         <target state="translated">Tiene filtros</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">Restablecer</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -242,6 +242,11 @@
         <target state="translated">Restablecer</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Acercar</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Tiene filtros</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -212,6 +212,21 @@
         <target state="translated">A des filtres</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">Réinitialiser</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -212,6 +212,11 @@
         <target state="translated">A des filtres</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -242,6 +242,11 @@
         <target state="translated">Réinitialiser</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Zoom avant</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -212,6 +212,21 @@
         <target state="translated">Con filtri</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">Reimposta</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Con filtri</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -242,6 +242,11 @@
         <target state="translated">Reimposta</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Ingrandisci</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -212,6 +212,21 @@
         <target state="translated">フィルターあり</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">リセット</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -242,6 +242,11 @@
         <target state="translated">リセット</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">拡大</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -212,6 +212,11 @@
         <target state="translated">フィルターあり</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -212,6 +212,21 @@
         <target state="translated">필터 있음</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">초기화</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -242,6 +242,11 @@
         <target state="translated">초기화</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">확대</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -212,6 +212,11 @@
         <target state="translated">필터 있음</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -212,6 +212,21 @@
         <target state="translated">Ma filtry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">Resetuj</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -242,6 +242,11 @@
         <target state="translated">Resetuj</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Powiększ</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Ma filtry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -212,6 +212,21 @@
         <target state="translated">Tem filtros</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">Redefinir</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -242,6 +242,11 @@
         <target state="translated">Redefinir</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Aumentar zoom</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Tem filtros</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -212,6 +212,21 @@
         <target state="translated">Содержит фильтры</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">Сбросить</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Содержит фильтры</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -242,6 +242,11 @@
         <target state="translated">Сбросить</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Увеличить</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -212,6 +212,21 @@
         <target state="translated">Filtreleri var</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">Sıfırla</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Filtreleri var</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -242,6 +242,11 @@
         <target state="translated">Sıfırla</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Yakınlaştır</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -212,6 +212,21 @@
         <target state="translated">具有筛选器</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">重置</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -212,6 +212,11 @@
         <target state="translated">具有筛选器</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -242,6 +242,11 @@
         <target state="translated">重置</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">放大</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -212,6 +212,21 @@
         <target state="translated">有篩選</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphModeLabel">
+        <source>Graph mode</source>
+        <target state="new">Graph mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeRelationships">
+        <source>Relationships</source>
+        <target state="new">Relationships</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphModeTelemetry">
+        <source>Telemetry flow</source>
+        <target state="new">Telemetry flow</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>
         <target state="translated">重設</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -242,6 +242,11 @@
         <target state="translated">重設</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphTelemetryResourceType">
+        <source>Telemetry</source>
+        <target state="new">Telemetry</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">放大</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -212,6 +212,11 @@
         <target state="translated">有篩選</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphHeader">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesGraphModeLabel">
         <source>Graph mode</source>
         <target state="new">Graph mode</target>
@@ -226,6 +231,11 @@
         <source>Telemetry flow</source>
         <target state="new">Telemetry flow</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphPageTitle">
+        <source>{0} graph</source>
+        <target state="new">{0} graph</target>
+        <note>{0} is an application name</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphResetButton">
         <source>Reset</source>

--- a/src/Aspire.Dashboard/Telemetry/TelemetryPropertyKeys.cs
+++ b/src/Aspire.Dashboard/Telemetry/TelemetryPropertyKeys.cs
@@ -36,6 +36,7 @@ public static class TelemetryPropertyKeys
     public const string ResourceTypes = AspireDashboardPropertyPrefix + "Resource.Types";
     public const string ResourceType = AspireDashboardPropertyPrefix + "Resource.Type";
     public const string ResourceView = AspireDashboardPropertyPrefix + "Resource.View";
+    public const string ResourceGraphMode = AspireDashboardPropertyPrefix + "Resource.GraphMode";
 
     // Error properties
     public const string ErrorRequestId = AspireDashboardPropertyPrefix + "RequestId";

--- a/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
+++ b/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
@@ -17,6 +17,7 @@ internal static class BrowserStorageKeys
     public const string MetricsPageState = "Aspire_PageState_Metrics";
     public const string ConsoleLogsPageState = "Aspire_PageState_ConsoleLogs";
     public const string ResourcesPageState = "Resources_PageState";
+    public const string GraphPageState = "Aspire_PageState_Graph";
     public const string ConsoleLogConsoleSettings = "Aspire_ConsoleLog_ConsoleSettings";
     public const string ConsoleLogFilters = "Aspire_ConsoleLog_Filters";
     public const string TextVisualizerDialogSettings = "Aspire_TextVisualizerDialog_TextVisualizerDialogSettings";

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -234,7 +234,7 @@ class ResourceGraph {
     }
 
     updateNodes(newResources) {
-        const existingNodes = this.nodes || []; // Ensure nodes is initialized
+        const existingNodesById = new Map((this.nodes || []).map(node => [node.id, node]));
         const updatedNodes = [];
 
         // calculate degree (number of connections) for each resource
@@ -252,7 +252,7 @@ class ResourceGraph {
         });
 
         newResources.forEach(resource => {
-            const existingNode = existingNodes.find(node => node.id === resource.name);
+            const existingNode = existingNodesById.get(resource.name);
             const degree = degreeMap.get(resource.name) || 1;
 
             if (existingNode) {
@@ -299,13 +299,14 @@ class ResourceGraph {
 
         this.updateNodes(newResources);
 
+        const resourceNames = new Set(newResources.map(resource => resource.name));
         this.links = [];
         for (var i = 0; i < newResources.length; i++) {
             var resource = newResources[i];
 
             var resourceLinks = resource.referencedNames
                 .filter((referencedName) => {
-                    return newResources.some(r => r.name === referencedName);
+                    return resourceNames.has(referencedName);
                 })
                 .map((referencedName, index) => {
                     return {

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -286,6 +286,9 @@ class ResourceGraph {
         this.nodes = updatedNodes;
 
         function createIcon(resourceIcon) {
+            if (!resourceIcon) {
+                return null;
+            }
             return {
                 path: resourceIcon.path,
                 color: resourceIcon.color,
@@ -416,7 +419,9 @@ class ResourceGraph {
         // Resource status
         var statusGroup = newNodesContainer
             .append("g")
-            .attr("transform", "scale(1.6) translate(14,-34)");
+            .attr("class", "resource-status")
+            .attr("transform", "scale(1.6) translate(14,-34)")
+            .style("display", n => n.stateIcon ? null : "none");
         statusGroup
             .append("circle")
             .attr("r", 8)
@@ -461,16 +466,20 @@ class ResourceGraph {
             .text(n => n.endpointText || "");
         this.nodeElementsG
             .selectAll(".resource-group")
+            .select(".resource-status")
+            .style("display", n => n.stateIcon ? null : "none");
+        this.nodeElementsG
+            .selectAll(".resource-group")
             .select(".resource-status-circle")
             .select("title")
-            .text(n => n.stateIcon.tooltip);
+            .text(n => n.stateIcon?.tooltip || "");
         this.nodeElementsG
             .selectAll(".resource-group")
             .select(".resource-status-path")
-            .attr("d", n => n.stateIcon.path)
-            .attr("fill", n => n.stateIcon.color)
+            .attr("d", n => n.stateIcon?.path || null)
+            .attr("fill", n => n.stateIcon?.color || null)
             .select("title")
-            .text(n => n.stateIcon.tooltip);
+            .text(n => n.stateIcon?.tooltip || "");
 
         // Update links
         this.linkElements = this.linkElementsG

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -15,9 +15,9 @@ export function initializeResourcesGraph(resourcesInterop) {
     }
 }
 
-export function updateResourcesGraph(resources) {
+export function updateResourcesGraph(resources, options) {
     if (resourceGraph) {
-        resourceGraph.updateResources(resources);
+        resourceGraph.updateResources(resources, options);
     }
 }
 
@@ -294,9 +294,18 @@ class ResourceGraph {
         }
     }
 
-    updateResources(newResources) {
+    updateResources(newResources, options) {
+        const modeSwitch = options?.modeSwitch === true;
+
         // Check if the overall structure of the graph has changed. i.e. nodes or links have been added or removed.
         var hasStructureChanged = this.resourcesChanged(this.resources, newResources);
+
+        if (modeSwitch) {
+            // Mode switches replace the edge semantics for the same visible graph. Stop any pending
+            // enter/exit fades so old relationship links don't briefly animate as telemetry links.
+            this.nodeElementsG.selectAll(".resource-group").interrupt();
+            this.linkElementsG.selectAll("line").interrupt();
+        }
 
         this.resources = newResources;
 
@@ -331,17 +340,21 @@ class ResourceGraph {
             .data(this.nodes, n => n.id);
 
         // Remove excess nodes:
-        this.nodeElements
-            .exit()
-            .transition()
-            .attr("opacity", 0)
-            .remove();
+        var removedNodes = this.nodeElements.exit();
+        if (modeSwitch) {
+            removedNodes.remove();
+        } else {
+            removedNodes
+                .transition()
+                .attr("opacity", 0)
+                .remove();
+        }
 
         // Resource node
         var newNodes = this.nodeElements
             .enter().append("g")
             .attr("class", "resource-group")
-            .attr("opacity", 0)
+            .attr("opacity", modeSwitch ? 1 : 0)
             .attr("resource-name", n => n.id)
             .call(this.dragDrop);
 
@@ -427,8 +440,10 @@ class ResourceGraph {
             .append("title")
             .text(n => n.label);
 
-        newNodes.transition()
-            .attr("opacity", 1);
+        if (!modeSwitch) {
+            newNodes.transition()
+                .attr("opacity", 1);
+        }
 
         this.nodeElements = newNodes.merge(this.nodeElements);
 
@@ -462,19 +477,25 @@ class ResourceGraph {
             .selectAll("line")
             .data(this.links, (d) => { return d.id; });
 
-        this.linkElements
-            .exit()
-            .transition()
-            .attr("opacity", 0)
-            .remove();
+        var removedLinks = this.linkElements.exit();
+        if (modeSwitch) {
+            removedLinks.remove();
+        } else {
+            removedLinks
+                .transition()
+                .attr("opacity", 0)
+                .remove();
+        }
 
         var newLinks = this.linkElements
             .enter().append("line")
-            .attr("opacity", 0)
+            .attr("opacity", modeSwitch ? 1 : 0)
             .attr("class", "resource-link");
 
-        newLinks.transition()
-            .attr("opacity", 1);
+        if (!modeSwitch) {
+            newLinks.transition()
+                .attr("opacity", 1);
+        }
 
         this.linkElements = newLinks.merge(this.linkElements);
 
@@ -486,11 +507,18 @@ class ResourceGraph {
         if (hasStructureChanged) {
             this.simulation.stop();
 
-            // Set alpha (give energy) and simulate the graph before rendering.
-            // This prevents the graph from jumping around when loaded or changed.
-            this.simulation.alpha(1);
-            for (let i = 0; i < 300; i++) {
-                this.simulation.tick();
+            if (modeSwitch) {
+                // Keep existing node coordinates and let the force simulation move them toward the
+                // new edge layout. Pre-ticking here makes the graph jump to the new mode in one frame.
+                this.simulation.alpha(Math.max(this.simulation.alpha(), 0.35));
+                this.onTick();
+            } else {
+                // Set alpha (give energy) and simulate the graph before rendering.
+                // This prevents the graph from jumping around when loaded or changed.
+                this.simulation.alpha(1);
+                for (let i = 0; i < 300; i++) {
+                    this.simulation.tick();
+                }
             }
         }
 

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -234,6 +234,9 @@ class ResourceGraph {
     }
 
     updateNodes(newResources) {
+        // Telemetry mode can refresh frequently while traces stream in. Preserve existing node objects
+        // for D3 simulation state, but use keyed lookup so refresh cost scales with resources instead
+        // of resources multiplied by existing nodes.
         const existingNodesById = new Map((this.nodes || []).map(node => [node.id, node]));
         const updatedNodes = [];
 
@@ -299,6 +302,8 @@ class ResourceGraph {
 
         this.updateNodes(newResources);
 
+        // Resource references are already keyed by resource name. Build a Set once so filtering links
+        // doesn't repeatedly scan the full resource list on dense telemetry graphs.
         const resourceNames = new Set(newResources.map(resource => resource.name));
         this.links = [];
         for (var i = 0; i < newResources.length; i++) {

--- a/src/Shared/DashboardUrls.cs
+++ b/src/Shared/DashboardUrls.cs
@@ -16,7 +16,7 @@ internal static class DashboardUrls
     public const string LoginBasePath = "login";
     public const string HealthBasePath = "health";
 
-    public static string ResourcesUrl(string? resource = null, string? view = null, string? hiddenTypes = null, string? hiddenStates = null, string? hiddenHealthStates = null)
+    public static string ResourcesUrl(string? resource = null, string? view = null, string? graphMode = null, string? hiddenTypes = null, string? hiddenStates = null, string? hiddenHealthStates = null)
     {
         var url = $"/{ResourcesBasePath}";
         if (resource != null)
@@ -26,6 +26,10 @@ internal static class DashboardUrls
         if (view != null)
         {
             url = AddQueryString(url, "view", view);
+        }
+        if (graphMode != null)
+        {
+            url = AddQueryString(url, "graphMode", graphMode);
         }
         if (hiddenTypes != null)
         {

--- a/src/Shared/DashboardUrls.cs
+++ b/src/Shared/DashboardUrls.cs
@@ -9,6 +9,7 @@ namespace Aspire.Dashboard.Utils;
 internal static class DashboardUrls
 {
     public const string ResourcesBasePath = "";
+    public const string GraphBasePath = "graph";
     public const string ConsoleLogBasePath = "consolelogs";
     public const string MetricsBasePath = "metrics";
     public const string StructuredLogsBasePath = "structuredlogs";
@@ -27,6 +28,29 @@ internal static class DashboardUrls
         {
             url = AddQueryString(url, "view", view);
         }
+        if (graphMode != null)
+        {
+            url = AddQueryString(url, "graphMode", graphMode);
+        }
+        if (hiddenTypes != null)
+        {
+            url = AddQueryString(url, "hiddenTypes", hiddenTypes);
+        }
+        if (hiddenStates != null)
+        {
+            url = AddQueryString(url, "hiddenStates", hiddenStates);
+        }
+        if (hiddenHealthStates != null)
+        {
+            url = AddQueryString(url, "hiddenHealthStates", hiddenHealthStates);
+        }
+
+        return url;
+    }
+
+    public static string GraphUrl(string? graphMode = null, string? hiddenTypes = null, string? hiddenStates = null, string? hiddenHealthStates = null)
+    {
+        var url = $"/{GraphBasePath}";
         if (graphMode != null)
         {
             url = AddQueryString(url, "graphMode", graphMode);

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
@@ -184,6 +184,31 @@ public partial class MainLayoutTests : DashboardTestContext
         }
     }
 
+    [Fact]
+    public void DesktopNavMenu_StandaloneDashboard_ShowsGraph()
+    {
+        SetupMainLayoutServices();
+
+        var cut = RenderComponent<DesktopNavMenu>();
+
+        Assert.Contains("Graph", cut.Markup);
+        Assert.DoesNotContain("Resources", cut.Markup);
+    }
+
+    [Fact]
+    public void DesktopNavMenu_StandaloneDashboard_GraphDisabled_HidesGraph()
+    {
+        SetupMainLayoutServices(configureOptions: o =>
+        {
+            o.UI.DisableResourceGraph = true;
+        });
+
+        var cut = RenderComponent<DesktopNavMenu>();
+
+        Assert.DoesNotContain("Graph", cut.Markup);
+        Assert.DoesNotContain("Resources", cut.Markup);
+    }
+
     private void SetupMainLayoutServices(TestLocalStorage? localStorage = null, MessageService? messageService = null, Action<DashboardOptions>? configureOptions = null)
     {
         FluentUISetupHelpers.AddCommonDashboardServices(this, localStorage: localStorage, messageService: messageService);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -7,14 +7,21 @@ using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.BrowserStorage;
+using Aspire.Dashboard.Model.ResourceGraph;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Tests.Shared;
 using Aspire.Dashboard.Utils;
+using Aspire.Tests.Shared.Telemetry;
 using Bunit;
+using Google.Protobuf.Collections;
 using ProtobufValue = Google.Protobuf.WellKnownTypes.Value;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.FluentUI.AspNetCore.Components;
+using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
 
 namespace Aspire.Dashboard.Components.Tests.Pages;
@@ -208,6 +215,140 @@ public partial class ResourcesTests : DashboardTestContext
 
         // Assert
         Assert.Single(initializeGraphInvocationHandler.Invocations);
+        Assert.DoesNotContain("resource-graph-telemetry", cut.Find("svg.resource-graph").ClassList);
+    }
+
+    [Fact]
+    public void GraphTelemetryMode_SubscribesToTraces()
+    {
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var initialResources = new List<ResourceViewModel>
+        {
+            CreateResource(
+                "Resource1",
+                "Type1",
+                "Running",
+                ImmutableArray.Create(new HealthReportViewModel("Null", null, "Description1", null))),
+        };
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: initialResources, resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>);
+        ResourceSetupHelpers.SetupResourcesPage(
+            this,
+            viewport,
+            dashboardClient);
+
+        var resourceGraphModule = JSInterop.SetupModule("/js/app-resourcegraph.js");
+        resourceGraphModule.SetupVoid("initializeResourcesGraph", _ => true);
+        resourceGraphModule.SetupVoid("updateResourcesGraph", _ => true);
+        resourceGraphModule.SetupVoid("updateResourcesGraphSelected", _ => true);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.ResourcesUrl(view: "Graph", graphMode: "Telemetry"));
+
+        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
+        var cut = RenderComponent<Components.Pages.Resources>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+
+        Assert.Equal(Components.Pages.Resources.ResourceGraphMode.Telemetry, cut.Instance.PageViewModel.SelectedGraphMode);
+        Assert.Contains("resource-graph-telemetry", cut.Find("svg.resource-graph").ClassList);
+        Assert.Collection(telemetryRepository.TracesSubscriptions, t =>
+        {
+            Assert.Equal(nameof(TelemetryRepository.OnNewTraces), t.Name);
+        });
+
+        DisposeComponents();
+
+        Assert.Empty(telemetryRepository.TracesSubscriptions);
+    }
+
+    [Fact]
+    public async Task GraphTelemetryMode_HidesResourcesWithoutTelemetryFlow()
+    {
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var initialResources = new List<ResourceViewModel>
+        {
+            CreateResource("frontend-abc", "Project", "Running", null, displayName: "frontend"),
+            CreateResource("api-def", "Project", "Running", null, displayName: "api"),
+            CreateResource("worker-ghi", "Project", "Running", null, displayName: "worker"),
+        };
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: initialResources, resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>);
+        ResourceSetupHelpers.SetupResourcesPage(
+            this,
+            viewport,
+            dashboardClient);
+
+        var resourceGraphModule = JSInterop.SetupModule("/js/app-resourcegraph.js");
+        var initializeGraphInvocationHandler = resourceGraphModule.SetupVoid("initializeResourcesGraph", _ => true);
+        initializeGraphInvocationHandler.SetVoidResult();
+        var updateGraphInvocationHandler = resourceGraphModule.SetupVoid("updateResourcesGraph", _ => true);
+        resourceGraphModule.SetupVoid("updateResourcesGraphSelected", _ => true);
+
+        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
+        var addContext = new AddContext();
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        telemetryRepository.AddTraces(addContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = TelemetryTestHelpers.CreateResource(name: "frontend", instanceId: "frontend-abc"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = TelemetryTestHelpers.CreateScope(),
+                        Spans =
+                        {
+                            TelemetryTestHelpers.CreateSpan(traceId: "1", spanId: "1-1", kind: Span.Types.SpanKind.Client, startTime: testTime.AddMinutes(1), endTime: testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = TelemetryTestHelpers.CreateResource(name: "api", instanceId: "api-def"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = TelemetryTestHelpers.CreateScope(),
+                        Spans =
+                        {
+                            TelemetryTestHelpers.CreateSpan(traceId: "1", spanId: "1-2", parentSpanId: "1-1", kind: Span.Types.SpanKind.Server, startTime: testTime.AddMinutes(1), endTime: testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.ResourcesUrl(view: "Graph", graphMode: "Telemetry"));
+
+        var cut = RenderComponent<Components.Pages.Resources>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+        Assert.Equal(Components.Pages.Resources.ResourceViewKind.Graph, cut.Instance.PageViewModel.SelectedViewKind);
+        Assert.Equal(Components.Pages.Resources.ResourceGraphMode.Telemetry, cut.Instance.PageViewModel.SelectedGraphMode);
+        cut.Render();
+
+        Assert.NotEmpty(initializeGraphInvocationHandler.Invocations);
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(() => updateGraphInvocationHandler.Invocations.Count > 0, "Resource graph updated");
+
+        var graphResources = Assert.IsAssignableFrom<IEnumerable<ResourceDto>>(updateGraphInvocationHandler.Invocations.Last().Arguments[0]).OrderBy(r => r.Name).ToList();
+        Assert.Collection(graphResources,
+            r =>
+            {
+                Assert.Equal("api-def", r.Name);
+                Assert.Empty(r.ReferencedNames);
+            },
+            r =>
+            {
+                Assert.Equal("frontend-abc", r.Name);
+                var referencedName = Assert.Single(r.ReferencedNames);
+                Assert.Equal("api-def", referencedName);
+            });
     }
 
     [Fact]
@@ -362,7 +503,8 @@ public partial class ResourcesTests : DashboardTestContext
         bool isHidden = false,
         string? stateStyle = null,
         ImmutableDictionary<string, ResourcePropertyViewModel>? properties = null,
-        int? replicaIndex = null)
+        int? replicaIndex = null,
+        string? displayName = null)
     {
         return new ResourceViewModel
         {
@@ -370,7 +512,7 @@ public partial class ResourcesTests : DashboardTestContext
             ResourceType = type,
             State = state,
             KnownState = state is not null && Enum.TryParse<KnownResourceState>(state, out var knownState) ? knownState : null,
-            DisplayName = name,
+            DisplayName = displayName ?? name,
             Uid = name,
             ReplicaIndex = replicaIndex ?? 0,
             HealthReports = healthReports ?? [],

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -557,12 +557,18 @@ public partial class ResourcesTests : DashboardTestContext
             {
                 Assert.Equal("api-def", r.Name);
                 Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Null(r.StateIcon);
+                Assert.Null(r.EndpointUrl);
+                Assert.Null(r.EndpointText);
                 Assert.Empty(r.ReferencedNames);
             },
             r =>
             {
                 Assert.Equal("frontend-abc", r.Name);
                 Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Null(r.StateIcon);
+                Assert.Null(r.EndpointUrl);
+                Assert.Null(r.EndpointText);
                 var referencedName = Assert.Single(r.ReferencedNames);
                 Assert.Equal("api-def", referencedName);
             });

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -256,6 +256,9 @@ public partial class ResourcesTests : DashboardTestContext
         Assert.Equal(Components.Pages.Resources.ResourceGraphMode.Telemetry, cut.Instance.PageViewModel.SelectedGraphMode);
         Assert.Equal("Graph", cut.Find("h1").TextContent);
         Assert.DoesNotContain("tab-Graph", cut.Markup);
+        Assert.Contains("Graph mode", cut.Markup);
+        Assert.Contains("Relationships", cut.Markup);
+        Assert.Contains("Telemetry flow", cut.Markup);
     }
 
     [Fact]
@@ -540,6 +543,10 @@ public partial class ResourcesTests : DashboardTestContext
         Assert.Equal(Components.Pages.Resources.ResourceViewKind.Graph, cut.Instance.PageViewModel.SelectedViewKind);
         Assert.Equal(Components.Pages.Resources.ResourceGraphMode.Telemetry, cut.Instance.PageViewModel.SelectedGraphMode);
         cut.Render();
+        Assert.DoesNotContain("Graph mode", cut.Markup);
+        Assert.DoesNotContain("Relationships", cut.Markup);
+        Assert.DoesNotContain("Telemetry flow", cut.Markup);
+        Assert.Null(cut.Instance.ConvertViewModelToSerializable().GraphMode);
 
         Assert.NotEmpty(initializeGraphInvocationHandler.Invocations);
         await AsyncTestHelpers.AssertIsTrueRetryAsync(() => updateGraphInvocationHandler.Invocations.Count > 0, "Resource graph updated");

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -259,6 +259,47 @@ public partial class ResourcesTests : DashboardTestContext
     }
 
     [Fact]
+    public void GraphRouteWrapper_SelectsGraphView()
+    {
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var initialResources = new List<ResourceViewModel>
+        {
+            CreateResource(
+                "Resource1",
+                "Type1",
+                "Running",
+                ImmutableArray.Create(new HealthReportViewModel("Null", null, "Description1", null))),
+        };
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: initialResources, resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>);
+        ResourceSetupHelpers.SetupResourcesPage(
+            this,
+            viewport,
+            dashboardClient);
+
+        var resourceGraphModule = JSInterop.SetupModule("/js/app-resourcegraph.js");
+        resourceGraphModule.SetupVoid("initializeResourcesGraph", _ => true);
+        resourceGraphModule.SetupVoid("updateResourcesGraph", _ => true);
+        resourceGraphModule.SetupVoid("updateResourcesGraphSelected", _ => true);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.GraphUrl(graphMode: "Telemetry"));
+
+        var cut = RenderComponent<Components.Pages.Graph>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+
+        var resources = cut.FindComponent<Components.Pages.Resources>();
+        Assert.True(resources.Instance.IsGraphPage);
+        Assert.Equal(DashboardUrls.GraphBasePath, resources.Instance.BasePath);
+        Assert.Equal(BrowserStorageKeys.GraphPageState, resources.Instance.SessionStorageKey);
+        Assert.Equal(Components.Pages.Resources.ResourceViewKind.Graph, resources.Instance.PageViewModel.SelectedViewKind);
+        Assert.Equal(Components.Pages.Resources.ResourceGraphMode.Telemetry, resources.Instance.PageViewModel.SelectedGraphMode);
+        Assert.Equal("Graph", cut.Find("h1").TextContent);
+        Assert.DoesNotContain("tab-Graph", cut.Markup);
+    }
+
+    [Fact]
     public void GraphTelemetryMode_SubscribesToTraces()
     {
         var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -344,6 +344,50 @@ public partial class ResourcesTests : DashboardTestContext
     }
 
     [Fact]
+    public async Task GraphModeChange_UpdatesGraphAsModeSwitch()
+    {
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var initialResources = new List<ResourceViewModel>
+        {
+            CreateResource(
+                "Resource1",
+                "Type1",
+                "Running",
+                ImmutableArray.Create(new HealthReportViewModel("Null", null, "Description1", null))),
+        };
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: initialResources, resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>);
+        ResourceSetupHelpers.SetupResourcesPage(
+            this,
+            viewport,
+            dashboardClient);
+
+        var resourceGraphModule = JSInterop.SetupModule("/js/app-resourcegraph.js");
+        resourceGraphModule.SetupVoid("initializeResourcesGraph", _ => true);
+        var updateGraphInvocationHandler = resourceGraphModule.SetupVoid("updateResourcesGraph", _ => true);
+        updateGraphInvocationHandler.SetVoidResult();
+        resourceGraphModule.SetupVoid("updateResourcesGraphSelected", _ => true);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.GraphUrl());
+
+        var cut = RenderComponent<Components.Pages.Resources>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+
+        cut.Instance.PageViewModel.SelectedGraphMode = Components.Pages.Resources.ResourceGraphMode.Telemetry;
+        await cut.Instance.UpdateResourceGraphResourcesAsync(modeSwitch: true);
+
+        var arguments = updateGraphInvocationHandler.Invocations.Last().Arguments;
+        Assert.Equal(2, arguments.Count);
+        var options = arguments[1];
+        Assert.NotNull(options);
+        var modeSwitchProperty = options!.GetType().GetProperty("modeSwitch");
+        Assert.NotNull(modeSwitchProperty);
+        Assert.True((bool)modeSwitchProperty.GetValue(options)!);
+    }
+
+    [Fact]
     public async Task GraphTelemetryMode_HidesResourcesWithoutTelemetryFlow()
     {
         var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -269,7 +269,7 @@ public partial class ResourcesTests : DashboardTestContext
         var initialResources = new List<ResourceViewModel>
         {
             CreateResource("frontend-abc", "Project", "Running", null, displayName: "frontend"),
-            CreateResource("api-def", "Project", "Running", null, displayName: "api"),
+            CreateResource("api-def", "Project", "Running", null, displayName: "api", relationships: [new RelationshipViewModel("worker", "Reference")]),
             CreateResource("worker-ghi", "Project", "Running", null, displayName: "worker"),
         };
         var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: initialResources, resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>);
@@ -504,7 +504,8 @@ public partial class ResourcesTests : DashboardTestContext
         string? stateStyle = null,
         ImmutableDictionary<string, ResourcePropertyViewModel>? properties = null,
         int? replicaIndex = null,
-        string? displayName = null)
+        string? displayName = null,
+        ImmutableArray<RelationshipViewModel>? relationships = null)
     {
         return new ResourceViewModel
         {
@@ -524,7 +525,7 @@ public partial class ResourcesTests : DashboardTestContext
             Environment = [],
             Urls = [],
             Volumes = [],
-            Relationships = [],
+            Relationships = relationships ?? [],
             Properties = properties ?? ImmutableDictionary<string, ResourcePropertyViewModel>.Empty,
             Commands = [],
             IsHidden = isHidden,

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -203,7 +203,7 @@ public partial class ResourcesTests : DashboardTestContext
         var initializeGraphInvocationHandler = resourceGraphModule.SetupVoid("initializeResourcesGraph", _ => true);
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
-        navigationManager.NavigateTo(DashboardUrls.ResourcesUrl(view: "Graph"));
+        navigationManager.NavigateTo(DashboardUrls.GraphUrl());
 
         // Act
         var cut = RenderComponent<Components.Pages.Resources>(builder =>
@@ -216,6 +216,46 @@ public partial class ResourcesTests : DashboardTestContext
         // Assert
         Assert.Single(initializeGraphInvocationHandler.Invocations);
         Assert.DoesNotContain("resource-graph-telemetry", cut.Find("svg.resource-graph").ClassList);
+    }
+
+    [Fact]
+    public void GraphRoute_SelectsGraphView()
+    {
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var initialResources = new List<ResourceViewModel>
+        {
+            CreateResource(
+                "Resource1",
+                "Type1",
+                "Running",
+                ImmutableArray.Create(new HealthReportViewModel("Null", null, "Description1", null))),
+        };
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: initialResources, resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>);
+        ResourceSetupHelpers.SetupResourcesPage(
+            this,
+            viewport,
+            dashboardClient);
+
+        var resourceGraphModule = JSInterop.SetupModule("/js/app-resourcegraph.js");
+        resourceGraphModule.SetupVoid("initializeResourcesGraph", _ => true);
+        resourceGraphModule.SetupVoid("updateResourcesGraph", _ => true);
+        resourceGraphModule.SetupVoid("updateResourcesGraphSelected", _ => true);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.GraphUrl(graphMode: "Telemetry"));
+
+        var cut = RenderComponent<Components.Pages.Resources>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+
+        Assert.True(cut.Instance.IsGraphPage);
+        Assert.Equal(DashboardUrls.GraphBasePath, cut.Instance.BasePath);
+        Assert.Equal(BrowserStorageKeys.GraphPageState, cut.Instance.SessionStorageKey);
+        Assert.Equal(Components.Pages.Resources.ResourceViewKind.Graph, cut.Instance.PageViewModel.SelectedViewKind);
+        Assert.Equal(Components.Pages.Resources.ResourceGraphMode.Telemetry, cut.Instance.PageViewModel.SelectedGraphMode);
+        Assert.Equal("Graph", cut.Find("h1").TextContent);
+        Assert.DoesNotContain("tab-Graph", cut.Markup);
     }
 
     [Fact]
@@ -242,7 +282,7 @@ public partial class ResourcesTests : DashboardTestContext
         resourceGraphModule.SetupVoid("updateResourcesGraphSelected", _ => true);
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
-        navigationManager.NavigateTo(DashboardUrls.ResourcesUrl(view: "Graph", graphMode: "Telemetry"));
+        navigationManager.NavigateTo(DashboardUrls.GraphUrl(graphMode: "Telemetry"));
 
         var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
         var cut = RenderComponent<Components.Pages.Resources>(builder =>
@@ -323,7 +363,7 @@ public partial class ResourcesTests : DashboardTestContext
         Assert.Equal(0, addContext.FailureCount);
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
-        navigationManager.NavigateTo(DashboardUrls.ResourcesUrl(view: "Graph", graphMode: "Telemetry"));
+        navigationManager.NavigateTo(DashboardUrls.GraphUrl(graphMode: "Telemetry"));
 
         var cut = RenderComponent<Components.Pages.Resources>(builder =>
         {
@@ -426,6 +466,47 @@ public partial class ResourcesTests : DashboardTestContext
                 Assert.Equal("Healthy", kvp.Key);
                 Assert.True(kvp.Value);
             });
+    }
+
+    [Fact]
+    public void ResourcesRoute_StaleGraphSessionState_DoesNotRedirectToGraph()
+    {
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var initialResources = new List<ResourceViewModel>
+        {
+            CreateResource("Resource1", "Type1", "Running", null),
+        };
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: initialResources,
+            resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>);
+        ResourceSetupHelpers.SetupResourcesPage(this, viewport, dashboardClient);
+
+        var sessionStorage = (TestSessionStorage)Services.GetRequiredService<ISessionStorage>();
+        sessionStorage.OnGetAsync = key =>
+        {
+            if (key is BrowserStorageKeys.ResourcesPageState)
+            {
+                return (true,
+                    new Components.Pages.Resources.ResourcesPageState
+                    {
+                        ResourceTypesToVisibility = new Dictionary<string, bool> { { "Type1", true } },
+                        ResourceStatesToVisibility = new Dictionary<string, bool> { { "Running", true } },
+                        ResourceHealthStatusesToVisibility = new Dictionary<string, bool>(),
+                        ViewKind = Components.Pages.Resources.ResourceViewKind.Graph.ToString(),
+                        GraphMode = Components.Pages.Resources.ResourceGraphMode.Telemetry.ToString(),
+                    });
+            }
+
+            return (false, null);
+        };
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.ResourcesUrl());
+
+        var cut = RenderComponent<Components.Pages.Resources>(builder => { builder.AddCascadingValue(viewport); });
+
+        Assert.False(cut.Instance.IsGraphPage);
+        Assert.Equal(Components.Pages.Resources.ResourceViewKind.Table, cut.Instance.PageViewModel.SelectedViewKind);
+        Assert.Equal("/", new Uri(navigationManager.Uri).PathAndQuery);
     }
 
     private static void AssertResourceFilterListEquals(IRenderedComponent<Components.Pages.Resources> cut, IEnumerable<KeyValuePair<string, bool>> types, IEnumerable<KeyValuePair<string, bool>> states, IEnumerable<KeyValuePair<string, bool>> healthStates)

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -392,6 +392,91 @@ public partial class ResourcesTests : DashboardTestContext
     }
 
     [Fact]
+    public async Task GraphRoute_StandaloneDashboard_UsesTelemetryResources()
+    {
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var dashboardClient = new TestDashboardClient(isEnabled: false);
+        ResourceSetupHelpers.SetupResourcesPage(
+            this,
+            viewport,
+            dashboardClient);
+
+        var resourceGraphModule = JSInterop.SetupModule("/js/app-resourcegraph.js");
+        var initializeGraphInvocationHandler = resourceGraphModule.SetupVoid("initializeResourcesGraph", _ => true);
+        initializeGraphInvocationHandler.SetVoidResult();
+        var updateGraphInvocationHandler = resourceGraphModule.SetupVoid("updateResourcesGraph", _ => true);
+        resourceGraphModule.SetupVoid("updateResourcesGraphSelected", _ => true);
+
+        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
+        var addContext = new AddContext();
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        telemetryRepository.AddTraces(addContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = TelemetryTestHelpers.CreateResource(name: "frontend", instanceId: "frontend-abc"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = TelemetryTestHelpers.CreateScope(),
+                        Spans =
+                        {
+                            TelemetryTestHelpers.CreateSpan(traceId: "1", spanId: "1-1", kind: Span.Types.SpanKind.Client, startTime: testTime.AddMinutes(1), endTime: testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = TelemetryTestHelpers.CreateResource(name: "api", instanceId: "api-def"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = TelemetryTestHelpers.CreateScope(),
+                        Spans =
+                        {
+                            TelemetryTestHelpers.CreateSpan(traceId: "1", spanId: "1-2", parentSpanId: "1-1", kind: Span.Types.SpanKind.Server, startTime: testTime.AddMinutes(1), endTime: testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.GraphUrl(graphMode: "Relationships"));
+
+        var cut = RenderComponent<Components.Pages.Resources>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+        Assert.Equal(Components.Pages.Resources.ResourceViewKind.Graph, cut.Instance.PageViewModel.SelectedViewKind);
+        Assert.Equal(Components.Pages.Resources.ResourceGraphMode.Telemetry, cut.Instance.PageViewModel.SelectedGraphMode);
+        cut.Render();
+
+        Assert.NotEmpty(initializeGraphInvocationHandler.Invocations);
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(() => updateGraphInvocationHandler.Invocations.Count > 0, "Resource graph updated");
+
+        var graphResources = Assert.IsAssignableFrom<IEnumerable<ResourceDto>>(updateGraphInvocationHandler.Invocations.Last().Arguments[0]).OrderBy(r => r.Name).ToList();
+        Assert.Collection(graphResources,
+            r =>
+            {
+                Assert.Equal("api-def", r.Name);
+                Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Empty(r.ReferencedNames);
+            },
+            r =>
+            {
+                Assert.Equal("frontend-abc", r.Name);
+                Assert.Equal("Telemetry", r.ResourceType);
+                var referencedName = Assert.Single(r.ReferencedNames);
+                Assert.Equal("api-def", referencedName);
+            });
+    }
+
+    [Fact]
     public void ResourceFilters_ApplyExistingFiltersOnInitialRender()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -557,6 +557,7 @@ public partial class ResourcesTests : DashboardTestContext
             {
                 Assert.Equal("api-def", r.Name);
                 Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Equal("api", r.DisplayName);
                 Assert.Null(r.StateIcon);
                 Assert.Null(r.EndpointUrl);
                 Assert.Null(r.EndpointText);
@@ -566,6 +567,7 @@ public partial class ResourcesTests : DashboardTestContext
             {
                 Assert.Equal("frontend-abc", r.Name);
                 Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Equal("frontend", r.DisplayName);
                 Assert.Null(r.StateIcon);
                 Assert.Null(r.EndpointUrl);
                 Assert.Null(r.EndpointText);

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
@@ -57,6 +57,7 @@ internal static class FluentUISetupHelpers
         var module = context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/AnchoredRegion/FluentAnchoredRegion.razor.js"));
         module.SetupVoid("goToNextFocusableElement", _ => true);
         module.SetupVoid("initializeKeyboardNavigation", _ => true);
+        module.SetupVoid("disposeKeyboardNavigation", _ => true);
         module.SetupVoid("removeKeyboardNavigation", _ => true);
     }
 

--- a/tests/Aspire.Dashboard.Tests/DashboardUrlsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardUrlsTests.cs
@@ -78,6 +78,12 @@ public class DashboardUrlsTests
     }
 
     [Fact]
+    public void ResourcesUrl_WithGraphMode_AppendsQueryParameter()
+    {
+        Assert.Equal("/?view=Graph&graphMode=Telemetry", DashboardUrls.ResourcesUrl(view: "Graph", graphMode: "Telemetry"));
+    }
+
+    [Fact]
     public void SetLanguagesUrl_HtmlValues_CorrectlyEscaped()
     {
         Assert.Equal("/api/set-language?language=fr-FR&redirectUrl=%2Fhi", DashboardUrls.SetLanguageUrl("fr-FR", "/hi"));

--- a/tests/Aspire.Dashboard.Tests/DashboardUrlsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardUrlsTests.cs
@@ -84,6 +84,12 @@ public class DashboardUrlsTests
     }
 
     [Fact]
+    public void GraphUrl_WithGraphMode_AppendsQueryParameter()
+    {
+        Assert.Equal("/graph?graphMode=Telemetry", DashboardUrls.GraphUrl(graphMode: "Telemetry"));
+    }
+
+    [Fact]
     public void SetLanguagesUrl_HtmlValues_CorrectlyEscaped()
     {
         Assert.Equal("/api/set-language?language=fr-FR&redirectUrl=%2Fhi", DashboardUrls.SetLanguageUrl("fr-FR", "/hi"));

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
@@ -189,12 +189,18 @@ public class ResourceGraphMapperTests
             {
                 Assert.Equal("api-def456", r.Name);
                 Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Null(r.StateIcon);
+                Assert.Null(r.EndpointUrl);
+                Assert.Null(r.EndpointText);
                 Assert.Empty(r.ReferencedNames);
             },
             r =>
             {
                 Assert.Equal("frontend-abc123", r.Name);
                 Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Null(r.StateIcon);
+                Assert.Null(r.EndpointUrl);
+                Assert.Null(r.EndpointText);
                 var referencedName = Assert.Single(r.ReferencedNames);
                 Assert.Equal("api-def456", referencedName);
             });
@@ -227,12 +233,57 @@ public class ResourceGraphMapperTests
             {
                 Assert.Equal("api-def456", r.Name);
                 Assert.Equal("Container", r.ResourceType);
+                Assert.NotNull(r.StateIcon);
+                Assert.NotNull(r.EndpointText);
                 Assert.Empty(r.ReferencedNames);
             },
             r =>
             {
                 Assert.Equal("frontend-abc123", r.Name);
                 Assert.Equal("Project", r.ResourceType);
+                Assert.NotNull(r.StateIcon);
+                Assert.NotNull(r.EndpointText);
+                var referencedName = Assert.Single(r.ReferencedNames);
+                Assert.Equal("api-def456", referencedName);
+            });
+    }
+
+    [Fact]
+    public void TelemetryGraphResources_CreateResourceDtos_KeepsUnmatchedTelemetryPeersMetadataFree()
+    {
+        var frontend = ModelTestHelpers.CreateResource("frontend-abc123", displayName: "frontend", resourceType: "Project", relationships: ImmutableArray<RelationshipViewModel>.Empty);
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            [frontend.Name] = frontend,
+        };
+
+        var graphResources = TelemetryGraphResources.CreateResourceDtos(
+            [frontend],
+            [
+                new TelemetryGraphEdge(ResourceKey.Create("frontend", "frontend-abc123"), ResourceKey.Create("api", "api-def456"))
+            ],
+            resources,
+            new TestStringLocalizer<Columns>(),
+            "Telemetry",
+            showHiddenResources: false,
+            _iconResolver);
+
+        Assert.Collection(graphResources.OrderBy(r => r.Name, StringComparers.ResourceName),
+            r =>
+            {
+                Assert.Equal("api-def456", r.Name);
+                Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Null(r.StateIcon);
+                Assert.Null(r.EndpointUrl);
+                Assert.Null(r.EndpointText);
+                Assert.Empty(r.ReferencedNames);
+            },
+            r =>
+            {
+                Assert.Equal("frontend-abc123", r.Name);
+                Assert.Equal("Project", r.ResourceType);
+                Assert.NotNull(r.StateIcon);
+                Assert.NotNull(r.EndpointText);
                 var referencedName = Assert.Single(r.ReferencedNames);
                 Assert.Equal("api-def456", referencedName);
             });

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.ResourceGraph;
+using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Aspire.Tests.Shared.DashboardModel;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -135,5 +136,37 @@ public class ResourceGraphMapperTests
 
         // Assert - non-parameter resources should always have endpoint text (even if "No endpoints")
         Assert.NotNull(dto.EndpointText);
+    }
+
+    [Fact]
+    public void TelemetryGraphResources_Create_MapsActiveTelemetryEdges()
+    {
+        var frontend = ModelTestHelpers.CreateResource("frontend-abc123", displayName: "frontend", relationships: ImmutableArray<RelationshipViewModel>.Empty);
+        var api = ModelTestHelpers.CreateResource("api-def456", displayName: "api", relationships: ImmutableArray<RelationshipViewModel>.Empty);
+        var database = ModelTestHelpers.CreateResource("database-ghi789", displayName: "database", relationships: ImmutableArray<RelationshipViewModel>.Empty);
+
+        var graphResources = TelemetryGraphResources.Create(
+            [frontend, api, database],
+            [
+                new TelemetryGraphEdge(ResourceKey.Create("frontend", "frontend-abc123"), ResourceKey.Create("api", "api-def456")),
+                new TelemetryGraphEdge(new ResourceKey("api", "api-def456"), ResourceKey.Create("database", "database-ghi789")),
+                new TelemetryGraphEdge(ResourceKey.Create("frontend", "frontend-abc123"), ResourceKey.Create("api", "api-def456")),
+                new TelemetryGraphEdge(ResourceKey.Create("api", "api-def456"), ResourceKey.Create("api", "api-def456")),
+                new TelemetryGraphEdge(ResourceKey.Create("frontend", "frontend-abc123"), new ResourceKey("missing", null))
+            ]);
+
+        Assert.Collection(graphResources.ReferencedNames.OrderBy(kvp => kvp.Key, StringComparers.ResourceName),
+            kvp =>
+            {
+                Assert.Equal("api-def456", kvp.Key);
+                Assert.Equal(["database-ghi789"], kvp.Value.Order(StringComparers.ResourceName));
+            },
+            kvp =>
+            {
+                Assert.Equal("frontend-abc123", kvp.Key);
+                Assert.Equal(["api-def456"], kvp.Value.Order(StringComparers.ResourceName));
+            });
+
+        Assert.Equal(["api-def456", "database-ghi789", "frontend-abc123"], graphResources.ResourceNames.Order(StringComparers.ResourceName));
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
@@ -139,13 +139,19 @@ public class ResourceGraphMapperTests
     }
 
     [Fact]
-    public void TelemetryGraphResources_Create_MapsActiveTelemetryEdges()
+    public void TelemetryGraphResources_CreateResourceDtos_MapsActiveTelemetryEdges()
     {
         var frontend = ModelTestHelpers.CreateResource("frontend-abc123", displayName: "frontend", relationships: ImmutableArray<RelationshipViewModel>.Empty);
         var api = ModelTestHelpers.CreateResource("api-def456", displayName: "api", relationships: ImmutableArray<RelationshipViewModel>.Empty);
         var database = ModelTestHelpers.CreateResource("database-ghi789", displayName: "database", relationships: ImmutableArray<RelationshipViewModel>.Empty);
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            [frontend.Name] = frontend,
+            [api.Name] = api,
+            [database.Name] = database,
+        };
 
-        var graphResources = TelemetryGraphResources.Create(
+        var graphResources = TelemetryGraphResources.CreateResourceDtos(
             [frontend, api, database],
             [
                 new TelemetryGraphEdge(ResourceKey.Create("frontend", "frontend-abc123"), ResourceKey.Create("api", "api-def456")),
@@ -153,21 +159,36 @@ public class ResourceGraphMapperTests
                 new TelemetryGraphEdge(ResourceKey.Create("frontend", "frontend-abc123"), ResourceKey.Create("api", "api-def456")),
                 new TelemetryGraphEdge(ResourceKey.Create("api", "api-def456"), ResourceKey.Create("api", "api-def456")),
                 new TelemetryGraphEdge(ResourceKey.Create("frontend", "frontend-abc123"), new ResourceKey("missing", null))
-            ]);
+            ],
+            resources,
+            new TestStringLocalizer<Columns>(),
+            "Telemetry",
+            showHiddenResources: false,
+            _iconResolver);
 
-        Assert.Collection(graphResources.ReferencedNames.OrderBy(kvp => kvp.Key, StringComparers.ResourceName),
-            kvp =>
+        Assert.Collection(graphResources.OrderBy(r => r.Name, StringComparers.ResourceName),
+            r =>
             {
-                Assert.Equal("api-def456", kvp.Key);
-                Assert.Equal(["database-ghi789"], kvp.Value.Order(StringComparers.ResourceName));
+                Assert.Equal("api-def456", r.Name);
+                Assert.Equal(["database-ghi789"], r.ReferencedNames);
             },
-            kvp =>
+            r =>
             {
-                Assert.Equal("frontend-abc123", kvp.Key);
-                Assert.Equal(["api-def456"], kvp.Value.Order(StringComparers.ResourceName));
+                Assert.Equal("database-ghi789", r.Name);
+                Assert.Empty(r.ReferencedNames);
+            },
+            r =>
+            {
+                Assert.Equal("frontend-abc123", r.Name);
+                Assert.Equal(["api-def456", "missing"], r.ReferencedNames);
+            },
+            r =>
+            {
+                Assert.Equal("missing", r.Name);
+                Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Equal("missing", r.DisplayName);
+                Assert.Null(r.StateIcon);
             });
-
-        Assert.Equal(["api-def456", "database-ghi789", "frontend-abc123"], graphResources.ResourceNames.Order(StringComparers.ResourceName));
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
@@ -190,6 +190,7 @@ public class ResourceGraphMapperTests
                 Assert.Equal("api-def456", r.Name);
                 Assert.Equal("Telemetry", r.ResourceType);
                 Assert.Equal("api", r.DisplayName);
+                Assert.Equal("Telemetry", r.ResourceIcon.Tooltip);
                 Assert.Null(r.StateIcon);
                 Assert.Null(r.EndpointUrl);
                 Assert.Null(r.EndpointText);
@@ -200,6 +201,7 @@ public class ResourceGraphMapperTests
                 Assert.Equal("frontend-abc123", r.Name);
                 Assert.Equal("Telemetry", r.ResourceType);
                 Assert.Equal("frontend", r.DisplayName);
+                Assert.Equal("Telemetry", r.ResourceIcon.Tooltip);
                 Assert.Null(r.StateIcon);
                 Assert.Null(r.EndpointUrl);
                 Assert.Null(r.EndpointText);

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
@@ -169,4 +169,72 @@ public class ResourceGraphMapperTests
 
         Assert.Equal(["api-def456", "database-ghi789", "frontend-abc123"], graphResources.ResourceNames.Order(StringComparers.ResourceName));
     }
+
+    [Fact]
+    public void TelemetryGraphResources_CreateResourceDtos_MapsTelemetryOnlyEdges()
+    {
+        var graphResources = TelemetryGraphResources.CreateResourceDtos(
+            [],
+            [
+                new TelemetryGraphEdge(ResourceKey.Create("frontend", "frontend-abc123"), ResourceKey.Create("api", "api-def456"))
+            ],
+            new Dictionary<string, ResourceViewModel>(),
+            new TestStringLocalizer<Columns>(),
+            "Telemetry",
+            showHiddenResources: false,
+            _iconResolver);
+
+        Assert.Collection(graphResources.OrderBy(r => r.Name, StringComparers.ResourceName),
+            r =>
+            {
+                Assert.Equal("api-def456", r.Name);
+                Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Empty(r.ReferencedNames);
+            },
+            r =>
+            {
+                Assert.Equal("frontend-abc123", r.Name);
+                Assert.Equal("Telemetry", r.ResourceType);
+                var referencedName = Assert.Single(r.ReferencedNames);
+                Assert.Equal("api-def456", referencedName);
+            });
+    }
+
+    [Fact]
+    public void TelemetryGraphResources_CreateResourceDtos_EnhancesMatchingResources()
+    {
+        var frontend = ModelTestHelpers.CreateResource("frontend-abc123", displayName: "frontend", resourceType: "Project", relationships: ImmutableArray<RelationshipViewModel>.Empty);
+        var api = ModelTestHelpers.CreateResource("api-def456", displayName: "api", resourceType: "Container", relationships: ImmutableArray<RelationshipViewModel>.Empty);
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            [frontend.Name] = frontend,
+            [api.Name] = api,
+        };
+
+        var graphResources = TelemetryGraphResources.CreateResourceDtos(
+            [frontend, api],
+            [
+                new TelemetryGraphEdge(ResourceKey.Create("frontend", "frontend-abc123"), ResourceKey.Create("api", "api-def456"))
+            ],
+            resources,
+            new TestStringLocalizer<Columns>(),
+            "Telemetry",
+            showHiddenResources: false,
+            _iconResolver);
+
+        Assert.Collection(graphResources.OrderBy(r => r.Name, StringComparers.ResourceName),
+            r =>
+            {
+                Assert.Equal("api-def456", r.Name);
+                Assert.Equal("Container", r.ResourceType);
+                Assert.Empty(r.ReferencedNames);
+            },
+            r =>
+            {
+                Assert.Equal("frontend-abc123", r.Name);
+                Assert.Equal("Project", r.ResourceType);
+                var referencedName = Assert.Single(r.ReferencedNames);
+                Assert.Equal("api-def456", referencedName);
+            });
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
@@ -189,6 +189,7 @@ public class ResourceGraphMapperTests
             {
                 Assert.Equal("api-def456", r.Name);
                 Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Equal("api", r.DisplayName);
                 Assert.Null(r.StateIcon);
                 Assert.Null(r.EndpointUrl);
                 Assert.Null(r.EndpointText);
@@ -198,6 +199,7 @@ public class ResourceGraphMapperTests
             {
                 Assert.Equal("frontend-abc123", r.Name);
                 Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Equal("frontend", r.DisplayName);
                 Assert.Null(r.StateIcon);
                 Assert.Null(r.EndpointUrl);
                 Assert.Null(r.EndpointText);
@@ -273,6 +275,7 @@ public class ResourceGraphMapperTests
             {
                 Assert.Equal("api-def456", r.Name);
                 Assert.Equal("Telemetry", r.ResourceType);
+                Assert.Equal("api", r.DisplayName);
                 Assert.Null(r.StateIcon);
                 Assert.Null(r.EndpointUrl);
                 Assert.Null(r.EndpointText);

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -107,6 +107,19 @@ public class TraceTests
     }
 
     [Fact]
+    public void GetTelemetryGraphEdges_InstrumentedChildServerSpanWithPeerAttributes_AddsInstrumentedEdge()
+    {
+        var repository = CreateRepository(outgoingPeerResolvers: [new TestOutgoingPeerResolver()]);
+
+        AddInstrumentedCallTrace(repository, clientAttributes: [new KeyValuePair<string, string>("server.address", "localhost")]);
+
+        var edge = Assert.Single(repository.GetTelemetryGraphEdges());
+        Assert.Equal(new ResourceKey("frontend", "frontend-abc"), edge.Key.Source);
+        Assert.Equal(new ResourceKey("api", "api-def"), edge.Key.Destination);
+        Assert.Equal(1, edge.Value);
+    }
+
+    [Fact]
     public void GetTelemetryGraphEdges_MultipleChildServerSpansForSameResource_AddsSingleEdge()
     {
         var repository = CreateRepository();
@@ -1146,7 +1159,7 @@ public class TraceTests
         Assert.Equal(0, addContext.FailureCount);
     }
 
-    private static void AddInstrumentedCallTrace(TelemetryRepository repository)
+    private static void AddInstrumentedCallTrace(TelemetryRepository repository, IEnumerable<KeyValuePair<string, string>>? clientAttributes = null)
     {
         var addContext = new AddContext();
         repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
@@ -1161,7 +1174,7 @@ public class TraceTests
                         Scope = CreateScope(),
                         Spans =
                         {
-                            CreateSpan(traceId: "1", spanId: "1-1", kind: Span.Types.SpanKind.Client, startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(2))
+                            CreateSpan(traceId: "1", spanId: "1-1", kind: Span.Types.SpanKind.Client, startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(2), attributes: clientAttributes)
                         }
                     }
                 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -94,6 +94,120 @@ public class TraceTests
     }
 
     [Fact]
+    public void GetTelemetryGraphEdges_InstrumentedChildServerSpan_AddsEdge()
+    {
+        var repository = CreateRepository();
+
+        AddInstrumentedCallTrace(repository);
+
+        var edge = Assert.Single(repository.GetTelemetryGraphEdges());
+        Assert.Equal(new ResourceKey("frontend", "frontend-abc"), edge.Key.Source);
+        Assert.Equal(new ResourceKey("api", "api-def"), edge.Key.Destination);
+        Assert.Equal(1, edge.Value);
+    }
+
+    [Fact]
+    public void GetTelemetryGraphEdges_MultipleChildServerSpansForSameResource_AddsSingleEdge()
+    {
+        var repository = CreateRepository();
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "frontend", instanceId: "frontend-abc"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", kind: Span.Types.SpanKind.Client, startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "api", instanceId: "api-def"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-2", parentSpanId: "1-1", kind: Span.Types.SpanKind.Server, startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(2)),
+                            CreateSpan(traceId: "1", spanId: "1-3", parentSpanId: "1-1", kind: Span.Types.SpanKind.Server, startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+        var edge = Assert.Single(repository.GetTelemetryGraphEdges());
+        Assert.Equal(new ResourceKey("frontend", "frontend-abc"), edge.Key.Source);
+        Assert.Equal(new ResourceKey("api", "api-def"), edge.Key.Destination);
+        Assert.Equal(1, edge.Value);
+    }
+
+    [Fact]
+    public void GetTelemetryGraphEdges_UninstrumentedPeer_AddsEdge()
+    {
+        var peerResource = ModelTestHelpers.CreateResource("postgres", displayName: "postgres");
+        var peerResolver = new TestOutgoingPeerResolver(_ => ("postgres", peerResource));
+        var repository = CreateRepository(outgoingPeerResolvers: [peerResolver]);
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "api", instanceId: "api-def"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                kind: Span.Types.SpanKind.Client,
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(2),
+                                attributes: [new KeyValuePair<string, string>("server.address", "localhost")])
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+        var edge = Assert.Single(repository.GetTelemetryGraphEdges());
+        Assert.Equal(new ResourceKey("api", "api-def"), edge.Key.Source);
+        Assert.Equal(new ResourceKey("postgres", null), edge.Key.Destination);
+        Assert.Equal(1, edge.Value);
+    }
+
+    [Fact]
+    public void GetTelemetryGraphEdges_ClearTraces_RemovesEdges()
+    {
+        var repository = CreateRepository();
+        AddInstrumentedCallTrace(repository);
+
+        Assert.NotEmpty(repository.GetTelemetryGraphEdges());
+
+        repository.ClearTraces();
+
+        Assert.Empty(repository.GetTelemetryGraphEdges());
+    }
+
+    [Fact]
     public void AddTraces_SelfParent_Reject()
     {
         // Arrange
@@ -985,6 +1099,46 @@ public class TraceTests
                             {
                                 link1
                             })
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+    }
+
+    private static void AddInstrumentedCallTrace(TelemetryRepository repository)
+    {
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "frontend", instanceId: "frontend-abc"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", kind: Span.Types.SpanKind.Client, startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "api", instanceId: "api-def"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-2", parentSpanId: "1-1", kind: Span.Types.SpanKind.Server, startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(2))
                         }
                     }
                 }
@@ -2209,6 +2363,7 @@ public class TraceTests
                 AssertId("1-2", s.SpanId);
                 Assert.Null(s.UninstrumentedPeer);
             });
+        Assert.Empty(repository.GetTelemetryGraphEdges());
 
         matchPeer = true;
         await outgoingPeerResolver.InvokePeerChanges();
@@ -2251,6 +2406,11 @@ public class TraceTests
                 Assert.NotNull(s.UninstrumentedPeer);
                 Assert.Equal("TestPeer", s.UninstrumentedPeer.ResourceName);
             });
+
+        var edge = Assert.Single(repository.GetTelemetryGraphEdges());
+        Assert.Equal(new ResourceKey("TestService", "TestId"), edge.Key.Source);
+        Assert.Equal(new ResourceKey("TestPeer", null), edge.Key.Destination);
+        Assert.Equal(1, edge.Value);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -208,6 +208,44 @@ public class TraceTests
     }
 
     [Fact]
+    public void GetTelemetryGraphEdges_RejectedTraceFromFullBuffer_DoesNotAddEdge()
+    {
+        var peerResource = ModelTestHelpers.CreateResource("postgres", displayName: "postgres");
+        var peerResolver = new TestOutgoingPeerResolver(_ => ("postgres", peerResource));
+        var repository = CreateRepository(maxTraceCount: 1, outgoingPeerResolvers: [peerResolver]);
+        AddTrace(repository, traceId: "2", startTime: s_testTime.AddMinutes(2));
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "api", instanceId: "api-def"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                kind: Span.Types.SpanKind.Client,
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(2),
+                                attributes: [new KeyValuePair<string, string>("server.address", "localhost")])
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+        Assert.Empty(repository.GetTelemetryGraphEdges());
+    }
+
+    [Fact]
     public void AddTraces_SelfParent_Reject()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -208,6 +208,165 @@ public class TraceTests
     }
 
     [Fact]
+    public void GetTelemetryGraphEdges_MalformedOtelTrace_DoesNotCrash()
+    {
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = new OpenTelemetry.Proto.Resource.V1.Resource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "bad-trace",
+                                spanId: string.Empty,
+                                kind: Span.Types.SpanKind.Client,
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(2),
+                                attributes:
+                                [
+                                    new KeyValuePair<string, string>("server.address", string.Empty),
+                                    new KeyValuePair<string, string>("server.port", "not-a-port")
+                                ]),
+                            CreateSpan(
+                                traceId: "bad-trace",
+                                spanId: "orphan-server",
+                                parentSpanId: "missing-parent",
+                                kind: Span.Types.SpanKind.Server,
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(2)),
+                            CreateSpan(
+                                traceId: "bad-trace",
+                                spanId: "negative-duration",
+                                parentSpanId: "another-missing-parent",
+                                kind: Span.Types.SpanKind.Unspecified,
+                                startTime: s_testTime.AddMinutes(3),
+                                endTime: s_testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+        Assert.Empty(repository.GetTelemetryGraphEdges());
+
+        var trace = Assert.Single(repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }).PagedResult.Items);
+        Assert.Equal(3, trace.Spans.Count);
+        Assert.Equal(new ResourceKey("unknown_service", null), trace.FirstSpan.Source.ResourceKey);
+    }
+
+    [Fact]
+    public void GetTelemetryGraphEdges_MissingResourceServiceName_UsesFallbackResourceKey()
+    {
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = new OpenTelemetry.Proto.Resource.V1.Resource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                kind: Span.Types.SpanKind.Client,
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "api", instanceId: "api-def"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-2",
+                                parentSpanId: "1-1",
+                                kind: Span.Types.SpanKind.Server,
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+        var edge = Assert.Single(repository.GetTelemetryGraphEdges());
+        Assert.Equal(new ResourceKey("unknown_service", null), edge.Key.Source);
+        Assert.Equal(new ResourceKey("api", "api-def"), edge.Key.Destination);
+        Assert.Equal(1, edge.Value);
+    }
+
+    [Fact]
+    public void GetTelemetryGraphEdges_PeerResolverThrows_DoesNotCrash()
+    {
+        var testSink = new TestSink();
+        var factory = LoggerFactory.Create(b => b.AddProvider(new TestLoggerProvider(testSink)));
+        var peerResolver = new TestOutgoingPeerResolver(_ => throw new FormatException("Bad peer address."));
+        var repository = CreateRepository(loggerFactory: factory, outgoingPeerResolvers: [peerResolver]);
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "api", instanceId: "api-def"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                kind: Span.Types.SpanKind.Client,
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(2),
+                                attributes: [new KeyValuePair<string, string>("server.address", "bad-peer")])
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+        Assert.Empty(repository.GetTelemetryGraphEdges());
+        var write = Assert.Single(testSink.Writes, w => w.Message == "Error resolving uninstrumented peer resource.");
+        Assert.IsType<FormatException>(write.Exception);
+    }
+
+    [Fact]
     public void GetTelemetryGraphEdges_ClearTraces_RemovesEdges()
     {
         var repository = CreateRepository();


### PR DESCRIPTION
## Description

The resource graph currently shows explicit AppHost relationships, but users also need to understand how resources communicate at runtime. This adds a telemetry flow mode to the dashboard resources graph so edges can be inferred from observed trace spans instead of relationship metadata.

In graph view, users can switch between Relationships and Telemetry flow. Telemetry flow hides resources with no observed incoming or outgoing calls, animates call-flow edges with a reduced-motion-safe CSS animation, and keeps the mode in URL/session state (`?view=Graph&graphMode=Telemetry`). The telemetry repository tracks graph edges incrementally as traces are added, updated, evicted, cleared, or resolved through uninstrumented peers.

### User-facing usage

Open Resources -> Graph and choose Telemetry flow to visualize observed runtime calls between resources.

![Telemetry flow graph](https://github.com/user-attachments/assets/9dcc17eb-340e-489d-945f-873566599234)



![Telemetry flow graph animation](https://github.com/user-attachments/assets/fc608b10-1839-4b5c-b3e8-d591fa93d893)

Telemetry-only graph with no AppHost resources:

![Telemetry-only graph animation](https://github.com/user-attachments/assets/0a4bbf89-decc-4e85-b81e-8bf4957602ed)


Validation:
- `dotnet test --project tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj --no-launch-profile -- --filter-class "*.ResourcesTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- TestShop E2E: catalog load, add to cart, checkout, order processing, and dashboard telemetry graph rendering.
- Stress playground: trace-heavy routes rendered telemetry graph without browser errors.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No






