### PR TITLE
Support pnpm patched dependencies

### DIFF
--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting;
@@ -1888,21 +1889,28 @@ public static class JavaScriptHostingExtensions
             packageFilesSourcePattern += " pnpm-workspace.yaml";
         }
 
-        resource
-            .WithAnnotation(new JavaScriptPackageManagerAnnotation("pnpm", runScriptCommand: "run", cacheMount: "/pnpm/store")
+        var pmAnnotation = new JavaScriptPackageManagerAnnotation("pnpm", runScriptCommand: "run", cacheMount: "/pnpm/store")
+        {
+            PackageFilesPatterns = { new CopyFilePattern(packageFilesSourcePattern, "./") },
+            // pnpm does not strip the -- separator and passes it to the script, causing Vite to ignore subsequent arguments.
+            CommandSeparator = null,
+            // pnpm is not included in the Node.js Docker image by default, so we need to enable it via corepack
+            InitializeDockerBuildStage = stage => stage.Run("corepack enable pnpm"),
+            InitializeDockerRuntimeStage = stage =>
             {
-                PackageFilesPatterns = [new CopyFilePattern(packageFilesSourcePattern, "./"), .. (hasPnpmWorkspace ? GetPnpmPatchedDependenciesFilePatterns(pnpmWorkspacePath) : [])],
-                // pnpm does not strip the -- separator and passes it to the script, causing Vite to ignore subsequent arguments.
-                CommandSeparator = null,
-                // pnpm is not included in the Node.js Docker image by default, so we need to enable it via corepack
-                InitializeDockerBuildStage = stage => stage.Run("corepack enable pnpm"),
-                InitializeDockerRuntimeStage = stage =>
-                {
-                    // Corepack's shim is not enough by itself: without invoking pnpm during the image build,
-                    // the first container start can try to download pnpm before running the app.
-                    stage.Run("corepack enable pnpm && pnpm --version");
-                },
-            })
+                // Corepack's shim is not enough by itself: without invoking pnpm during the image build,
+                // the first container start can try to download pnpm before running the app.
+                stage.Run("corepack enable pnpm && pnpm --version");
+            },
+        };
+
+        if (hasPnpmWorkspace)
+        {
+            pmAnnotation.PackageFilesPatterns.AddRange(GetPnpmPatchedDependenciesFilePatterns(pnpmWorkspacePath));
+        }
+
+        resource
+            .WithAnnotation(pmAnnotation)
             .WithAnnotation(new JavaScriptInstallCommandAnnotation(["install", .. installArgs])
             {
                 ProductionInstallArgs = "--prod"
@@ -2436,9 +2444,18 @@ public static class JavaScriptHostingExtensions
     /// <returns>An enumerable of <see cref="CopyFilePattern"/> representing the patched dependencies.</returns>
     private static IEnumerable<CopyFilePattern> GetPnpmPatchedDependenciesFilePatterns(string pnpmWorkspacePath)
     {
-        using var reader = new StreamReader(pnpmWorkspacePath);
-        var pnpmWorkspaceYaml = new Deserializer().Deserialize(reader);
-        var copyPatterns = new Dictionary<string, string>(); // key: distination path, value: patch file path
+        object? pnpmWorkspaceYaml = null;
+        var copyPatterns = new Dictionary<string, List<string>>(); // key: destination path, value: patch files path
+
+        try
+        {
+            using var reader = new StreamReader(pnpmWorkspacePath);
+            pnpmWorkspaceYaml = new Deserializer().Deserialize(reader);
+        }
+        catch (Exception ex) when (ex is IOException or YamlException)
+        {
+            // logger.LogWarning(ex, "Failed to parse pnpm workspace file");
+        }
 
         if (pnpmWorkspaceYaml is Dictionary<object, object> yamlDict &&
             yamlDict.TryGetValue("patchedDependencies", out var patchedDependenciesObj) &&
@@ -2452,18 +2469,18 @@ public static class JavaScriptHostingExtensions
                     var dirIdx = sourcePath.LastIndexOf('/');
                     var destDir = dirIdx >= 0 ? sourcePath[..dirIdx] : ".";
 
-                    if (copyPatterns.ContainsKey(destDir))
+                    if (copyPatterns.TryGetValue(destDir, out var files))
                     {
-                        copyPatterns[destDir] += $" {sourcePath}";
+                        files.Add(sourcePath);
                     }
                     else
                     {
-                        copyPatterns[destDir] = sourcePath;
+                        copyPatterns[destDir] = [sourcePath];
                     }
                 }
             }
         }
 
-        return copyPatterns.Select(kvp => new CopyFilePattern(kvp.Value, kvp.Key));
+        return copyPatterns.Select(kvp => new CopyFilePattern(string.Join(' ', kvp.Value), kvp.Key));
     }
 }

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting;
 
@@ -1871,7 +1872,8 @@ public static class JavaScriptHostingExtensions
 
         var workingDirectory = resource.Resource.WorkingDirectory;
         var hasPnpmLock = File.Exists(Path.Combine(workingDirectory, "pnpm-lock.yaml"));
-        var hasPnpmWorkspace = File.Exists(Path.Combine(workingDirectory, "pnpm-workspace.yaml"));
+        var pnpmWorkspacePath = Path.Combine(workingDirectory, "pnpm-workspace.yaml");
+        var hasPnpmWorkspace = File.Exists(pnpmWorkspacePath);
 
         installArgs ??= GetDefaultPnpmInstallArgs(resource, hasPnpmLock);
 
@@ -1889,7 +1891,7 @@ public static class JavaScriptHostingExtensions
         resource
             .WithAnnotation(new JavaScriptPackageManagerAnnotation("pnpm", runScriptCommand: "run", cacheMount: "/pnpm/store")
             {
-                PackageFilesPatterns = { new CopyFilePattern(packageFilesSourcePattern, "./") },
+                PackageFilesPatterns = [new CopyFilePattern(packageFilesSourcePattern, "./"), .. (hasPnpmWorkspace ? GetPnpmPatchedDependenciesFilePatterns(pnpmWorkspacePath) : [])],
                 // pnpm does not strip the -- separator and passes it to the script, causing Vite to ignore subsequent arguments.
                 CommandSeparator = null,
                 // pnpm is not included in the Node.js Docker image by default, so we need to enable it via corepack
@@ -2425,5 +2427,43 @@ public static class JavaScriptHostingExtensions
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Parses the pnpm-workspace.yaml file to extract patched dependencies and constructs copy patterns for them.
+    /// </summary>
+    /// <param name="pnpmWorkspacePath">The path to the pnpm-workspace.yaml file.</param>
+    /// <returns>An enumerable of <see cref="CopyFilePattern"/> representing the patched dependencies.</returns>
+    private static IEnumerable<CopyFilePattern> GetPnpmPatchedDependenciesFilePatterns(string pnpmWorkspacePath)
+    {
+        using var reader = new StreamReader(pnpmWorkspacePath);
+        var pnpmWorkspaceYaml = new Deserializer().Deserialize(reader);
+        var copyPatterns = new Dictionary<string, string>(); // key: distination path, value: patch file path
+
+        if (pnpmWorkspaceYaml is Dictionary<object, object> yamlDict &&
+            yamlDict.TryGetValue("patchedDependencies", out var patchedDependenciesObj) &&
+            patchedDependenciesObj is Dictionary<object, object> patchedDependencies)
+        {
+            foreach (var (_, pdPath) in patchedDependencies)
+            {
+                var sourcePath = pdPath as string;
+                if (!string.IsNullOrEmpty(sourcePath))
+                {
+                    var dirIdx = sourcePath.LastIndexOf('/');
+                    var destDir = dirIdx >= 0 ? sourcePath[..dirIdx] : ".";
+
+                    if (copyPatterns.ContainsKey(destDir))
+                    {
+                        copyPatterns[destDir] += $" {sourcePath}";
+                    }
+                    else
+                    {
+                        copyPatterns[destDir] = sourcePath;
+                    }
+                }
+            }
+        }
+
+        return copyPatterns.Select(kvp => new CopyFilePattern(kvp.Value, kvp.Key));
     }
 }

--- a/src/Aspire.Hosting.JavaScript/JavaScriptPackageManagerAnnotation.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptPackageManagerAnnotation.cs
@@ -39,7 +39,7 @@ public sealed class JavaScriptPackageManagerAnnotation(string executableName, st
     /// <summary>
     /// Gets the file patterns for package dependency files.
     /// </summary>
-    public List<CopyFilePattern> PackageFilesPatterns { get; } = [];
+    public List<CopyFilePattern> PackageFilesPatterns { get; init; } = [];
 
     /// <summary>
     /// Gets or sets a callback to initialize the Docker build stage before installing packages.

--- a/src/Aspire.Hosting.JavaScript/JavaScriptPackageManagerAnnotation.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptPackageManagerAnnotation.cs
@@ -39,7 +39,7 @@ public sealed class JavaScriptPackageManagerAnnotation(string executableName, st
     /// <summary>
     /// Gets the file patterns for package dependency files.
     /// </summary>
-    public List<CopyFilePattern> PackageFilesPatterns { get; init; } = [];
+    public List<CopyFilePattern> PackageFilesPatterns { get; } = [];
 
     /// <summary>
     /// Gets or sets a callback to initialize the Docker build stage before installing packages.


### PR DESCRIPTION
## Description

When using pnpm with patched dependencies (via [pnpm patch](https://pnpm.io/cli/patch)), the patch files need to be copied into Docker containers during the build process.


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
