### PR TITLE
Support process command arguments and TypeScript callbacks

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
@@ -126,6 +126,11 @@ internal sealed class ProcessCommandExportOptions
     public bool? KillEntireProcessTree { get; set; }
 
     /// <summary>
+    /// A callback that creates the local process specification when the command is invoked.
+    /// </summary>
+    public Func<ExecuteCommandContext, Task<ProcessCommandSpecExportData>>? CreateProcessSpec { get; set; }
+
+    /// <summary>
     /// Optional command configuration.
     /// </summary>
     public CommandOptions? CommandOptions { get; set; }

--- a/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
@@ -128,7 +128,7 @@ internal sealed class ProcessCommandExportOptions
     /// <summary>
     /// A callback that creates the local process specification when the command is invoked.
     /// </summary>
-    public Func<ExecuteCommandContext, Task<ProcessCommandSpecExportData>>? CreateProcessSpec { get; set; }
+    public Func<ExecuteCommandContext, Task<ProcessCommandSpecExportData>>? CreateProcessSpec { get; init; }
 
     /// <summary>
     /// Optional command configuration.

--- a/src/Aspire.Hosting/ApplicationModel/ProcessCommandResultContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProcessCommandResultContext.cs
@@ -46,6 +46,13 @@ public sealed class ProcessCommandResultContext
     /// named-payload clients are mapped by <see cref="InteractionInput.Name"/>.
     /// </para>
     /// </remarks>
+    /// <example>
+    /// Read a declared command argument when producing a custom result:
+    /// <code>
+    /// GetCommandResult = context =>
+    ///     Task.FromResult(CommandResults.Success("received", context.Arguments.GetString("message")!));
+    /// </code>
+    /// </example>
     public InteractionInputCollection Arguments { get; init; } = new([]);
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ProcessCommandResultContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProcessCommandResultContext.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.ApplicationModel;
 
+#pragma warning disable ASPIREINTERACTION001 // Process command arguments intentionally reuse the experimental interaction input model.
+
 /// <summary>
 /// Context passed to callback to configure <see cref="ExecuteCommandResult"/> when using
 /// <see cref="ResourceBuilderExtensions.WithProcessCommand{TResource}(IResourceBuilder{TResource}, string, string, Func{ExecuteCommandContext, ValueTask{ProcessCommandSpec}}, ProcessCommandOptions?)"/>.
@@ -33,6 +35,18 @@ public sealed class ProcessCommandResultContext
     /// Gets the cancellation token.
     /// </summary>
     public required CancellationToken CancellationToken { get; init; }
+
+    /// <summary>
+    /// Gets the invocation arguments supplied by the client when the command is executed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The collection contains the arguments described by the command's <see cref="CommandOptions.Arguments"/> with their
+    /// submitted values populated. CLI positional arguments are mapped by declaration order. Dashboard, MCP, and other
+    /// named-payload clients are mapped by <see cref="InteractionInput.Name"/>.
+    /// </para>
+    /// </remarks>
+    public InteractionInputCollection Arguments { get; init; } = new([]);
 
     /// <summary>
     /// Gets the process command specification used for the command invocation.
@@ -65,3 +79,5 @@ public sealed class ProcessCommandResultContext
         return ProcessOutputCapture.FormatOutput(Output, TotalOutputLineCount, maxLines, outputDescription);
     }
 }
+
+#pragma warning restore ASPIREINTERACTION001

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -3463,6 +3463,7 @@ public static class ResourceBuilderExtensions
                 ResourceName = context.ResourceName,
                 Logger = context.Logger,
                 CancellationToken = context.CancellationToken,
+                Arguments = context.Arguments,
                 ProcessCommandSpec = processCommandSpec,
                 ExitCode = processResult.ExitCode,
                 Output = processResult.ProcessOutput,

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -3266,6 +3266,7 @@ public static class ResourceBuilderExtensions
     /// Adds a command to the resource that starts a local process created by a callback when invoked.
     /// </summary>
     [Experimental("ASPIREPROCESSCOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [Obsolete("Use withProcessCommand with createProcessSpec in the options object instead.")]
     [AspireExport("withProcessCommandFactory")]
     internal static IResourceBuilder<TResource> WithProcessCommandFactoryExport<TResource>(
         this IResourceBuilder<TResource> builder,

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -3240,6 +3240,21 @@ public static class ResourceBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(options);
 
+        if (options.CreateProcessSpec is { } createProcessSpec)
+        {
+            return builder.WithProcessCommand(
+                commandName,
+                displayName,
+                async context =>
+                {
+                    var processCommandSpec = await createProcessSpec(context).ConfigureAwait(false)
+                        ?? throw new InvalidOperationException("The process command specification factory returned null.");
+
+                    return CreateProcessCommandSpec(processCommandSpec);
+                },
+                CreateProcessCommandOptions(options));
+        }
+
         return builder.WithProcessCommand(
             commandName,
             displayName,

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
@@ -252,6 +252,88 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
+    public async Task ProcessCommandCallbackReceivesCliArguments()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        if (strategy.Mode == CliInstallMode.InstallScript && strategy.Quality is null && strategy.Version is null)
+        {
+            Assert.Skip("This test exercises unreleased TypeScript AppHost SDK surface. Build a local Aspire CLI bundle or run in CI so the test uses current PR bits instead of the GA CLI.");
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(
+            repoRoot,
+            strategy,
+            output,
+            variant: CliE2ETestHelpers.DockerfileVariant.DotNet,
+            mountDockerSocket: false,
+            workspace: workspace);
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        await auto.TypeAsync("aspire init --language typescript --non-interactive");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Created apphost.mts", timeout: TimeSpan.FromMinutes(2));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire restore");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("SDK code restored successfully", timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.mts");
+        var newContent = """
+            import { createBuilder, InputType } from './.aspire/modules/aspire.mjs';
+
+            const builder = await createBuilder();
+
+            const target = await builder.addParameter("target");
+            await target.withProcessCommand("node-message", "Node message", {
+                createProcessSpec: async (context) => {
+                    const args = await context.arguments();
+                    const message = await args.requiredValue("message");
+                    return {
+                        executablePath: "node",
+                        arguments: ["-e", "console.log(process.argv[1])", message],
+                    };
+                },
+                commandOptions: {
+                    arguments: [{
+                        name: "message",
+                        inputType: InputType.Text,
+                        required: true,
+                    }],
+                },
+            });
+
+            await builder.build().run();
+            """;
+
+        File.WriteAllText(appHostPath, newContent);
+
+        await auto.TypeAsync("npx tsc --noEmit --project tsconfig.apphost.json");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        await auto.AspireStartAsync(counter);
+        await auto.AssertResourcesExistAsync(counter, "target");
+
+        await auto.TypeAsync("aspire resource target node-message --message hello-from-typescript-e2e");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("hello-from-typescript-e2e", timeout: TimeSpan.FromSeconds(30));
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+        await auto.AspireStopAsync(counter);
+    }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
     public async Task UnAwaitedChainsCompileWithAutoResolvePromises()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -619,6 +619,7 @@ type ProcessCommandExportOptions struct {
 	InheritEnvironmentVariables *bool `json:"InheritEnvironmentVariables,omitempty"`
 	StandardInputContent string `json:"StandardInputContent,omitempty"`
 	KillEntireProcessTree *bool `json:"KillEntireProcessTree,omitempty"`
+	CreateProcessSpec func(...any) any `json:"CreateProcessSpec,omitempty"`
 	CommandOptions *CommandOptions `json:"CommandOptions,omitempty"`
 	MaxOutputLineCount *float64 `json:"MaxOutputLineCount,omitempty"`
 	DisplayImmediately *bool `json:"DisplayImmediately,omitempty"`
@@ -635,6 +636,7 @@ func (d *ProcessCommandExportOptions) ToMap() map[string]any {
 	if d.InheritEnvironmentVariables != nil { m["InheritEnvironmentVariables"] = serializeValue(d.InheritEnvironmentVariables) }
 	m["StandardInputContent"] = serializeValue(d.StandardInputContent)
 	if d.KillEntireProcessTree != nil { m["KillEntireProcessTree"] = serializeValue(d.KillEntireProcessTree) }
+	if d.CreateProcessSpec != nil { m["CreateProcessSpec"] = serializeValue(d.CreateProcessSpec) }
 	if d.CommandOptions != nil { m["CommandOptions"] = serializeValue(d.CommandOptions) }
 	if d.MaxOutputLineCount != nil { m["MaxOutputLineCount"] = serializeValue(d.MaxOutputLineCount) }
 	if d.DisplayImmediately != nil { m["DisplayImmediately"] = serializeValue(d.DisplayImmediately) }

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -16114,6 +16114,7 @@ public class ProcessCommandExportOptions implements JsonSerializable {
     private Boolean inheritEnvironmentVariables;
     private String standardInputContent;
     private Boolean killEntireProcessTree;
+    private Object createProcessSpec;
     private CommandOptions commandOptions;
     private Double maxOutputLineCount;
     private Boolean displayImmediately;
@@ -16133,6 +16134,8 @@ public class ProcessCommandExportOptions implements JsonSerializable {
     public void setStandardInputContent(String value) { this.standardInputContent = value; }
     public Boolean getKillEntireProcessTree() { return killEntireProcessTree; }
     public void setKillEntireProcessTree(Boolean value) { this.killEntireProcessTree = value; }
+    public Object getCreateProcessSpec() { return createProcessSpec; }
+    public void setCreateProcessSpec(Object value) { this.createProcessSpec = value; }
     public CommandOptions getCommandOptions() { return commandOptions; }
     public void setCommandOptions(CommandOptions value) { this.commandOptions = value; }
     public Double getMaxOutputLineCount() { return maxOutputLineCount; }
@@ -16159,6 +16162,8 @@ public class ProcessCommandExportOptions implements JsonSerializable {
         value.setStandardInputContent(standardInputContentValue == null ? null : (String) standardInputContentValue);
         var killEntireProcessTreeValue = map.get("KillEntireProcessTree");
         value.setKillEntireProcessTree(killEntireProcessTreeValue == null ? null : (Boolean) killEntireProcessTreeValue);
+        var createProcessSpecValue = map.get("CreateProcessSpec");
+        value.setCreateProcessSpec(createProcessSpecValue);
         var commandOptionsValue = map.get("CommandOptions");
         value.setCommandOptions(commandOptionsValue == null ? null : CommandOptions.fromMap((Map<String, Object>) commandOptionsValue));
         var maxOutputLineCountValue = map.get("MaxOutputLineCount");
@@ -16179,6 +16184,7 @@ public class ProcessCommandExportOptions implements JsonSerializable {
         map.put("InheritEnvironmentVariables", AspireClient.serializeValue(inheritEnvironmentVariables));
         map.put("StandardInputContent", AspireClient.serializeValue(standardInputContent));
         map.put("KillEntireProcessTree", AspireClient.serializeValue(killEntireProcessTree));
+        map.put("CreateProcessSpec", AspireClient.serializeValue(createProcessSpec));
         map.put("CommandOptions", AspireClient.serializeValue(commandOptions));
         map.put("MaxOutputLineCount", AspireClient.serializeValue(maxOutputLineCount));
         map.put("DisplayImmediately", AspireClient.serializeValue(displayImmediately));

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1882,6 +1882,7 @@ class ProcessCommandExportOptions(typing.TypedDict, total=False):
     InheritEnvironmentVariables: bool | None
     StandardInputContent: str | None
     KillEntireProcessTree: bool | None
+    CreateProcessSpec: typing.Callable
     CommandOptions: CommandOptions
     MaxOutputLineCount: int | None
     DisplayImmediately: bool | None

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -1137,6 +1137,8 @@ pub struct ProcessCommandExportOptions {
     pub standard_input_content: String,
     #[serde(rename = "KillEntireProcessTree", skip_serializing_if = "Option::is_none")]
     pub kill_entire_process_tree: Option<bool>,
+    #[serde(rename = "CreateProcessSpec", skip_serializing_if = "Option::is_none")]
+    pub create_process_spec: Option<Value>,
     #[serde(rename = "CommandOptions")]
     pub command_options: CommandOptions,
     #[serde(rename = "MaxOutputLineCount", skip_serializing_if = "Option::is_none")]
@@ -1160,6 +1162,9 @@ impl ProcessCommandExportOptions {
         map.insert("StandardInputContent".to_string(), serde_json::to_value(&self.standard_input_content).unwrap_or(Value::Null));
         if let Some(ref v) = self.kill_entire_process_tree {
             map.insert("KillEntireProcessTree".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.create_process_spec {
+            map.insert("CreateProcessSpec".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         map.insert("CommandOptions".to_string(), serde_json::to_value(&self.command_options).unwrap_or(Value::Null));
         if let Some(ref v) = self.max_output_line_count {

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -1040,7 +1040,10 @@ public class AtsTypeScriptCodeGeneratorTests
 
         var files = _generator.GenerateDistributedApplication(atsContext);
         var aspireTs = files["aspire.mts"];
+        var processCommandExportOptions = Assert.Single(atsContext.DtoTypes, dto => dto.Name == "ProcessCommandExportOptions");
+        var createProcessSpec = Assert.Single(processCommandExportOptions.Properties, property => property.Name == "CreateProcessSpec");
 
+        Assert.True(createProcessSpec.IsOptional);
         Assert.Contains("const ____optionsForRpcPrepareRequestId = ____optionsForRpcPrepareRequest ? registerCallback", aspireTs);
         Assert.Contains("createProcessSpec?: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>;", aspireTs);
         Assert.Contains("const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback", aspireTs);

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -1045,6 +1045,7 @@ public class AtsTypeScriptCodeGeneratorTests
         Assert.Contains("createProcessSpec?: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>;", aspireTs);
         Assert.Contains("const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback", aspireTs);
         Assert.Contains("__optionsForRpcData[\"createProcessSpec\"] = ____optionsForRpcCreateProcessSpecId;", aspireTs);
+        Assert.Contains("@deprecated Use withProcessCommand with createProcessSpec in the options object instead.", aspireTs);
         Assert.Contains("const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;", aspireTs);
         Assert.Contains("const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };", aspireTs);
         Assert.Contains("const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback", aspireTs);

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -1042,6 +1042,9 @@ public class AtsTypeScriptCodeGeneratorTests
         var aspireTs = files["aspire.mts"];
 
         Assert.Contains("const ____optionsForRpcPrepareRequestId = ____optionsForRpcPrepareRequest ? registerCallback", aspireTs);
+        Assert.Contains("createProcessSpec?: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>;", aspireTs);
+        Assert.Contains("const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback", aspireTs);
+        Assert.Contains("__optionsForRpcData[\"createProcessSpec\"] = ____optionsForRpcCreateProcessSpecId;", aspireTs);
         Assert.Contains("const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;", aspireTs);
         Assert.Contains("const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };", aspireTs);
         Assert.Contains("const ______optionsForRpcCommandOptionsForRpcValidateArgumentsId = ______optionsForRpcCommandOptionsForRpcValidateArguments ? registerCallback", aspireTs);

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -11994,6 +11994,7 @@ export interface ContainerRegistryResource {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ContainerRegistryResourcePromise;
     /**
@@ -12272,6 +12273,7 @@ export interface ContainerRegistryResourcePromise extends PromiseLike<ContainerR
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ContainerRegistryResourcePromise;
     /**
@@ -12882,6 +12884,7 @@ class ContainerRegistryResourceImpl extends ResourceBuilderBase<ContainerRegistr
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ContainerRegistryResourcePromise {
         return new ContainerRegistryResourcePromiseImpl(this._withProcessCommandFactoryInternal(commandName, displayName, createProcessSpec, options), this._client);
@@ -14276,6 +14279,7 @@ export interface ContainerResource {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ContainerResourcePromise;
     /**
@@ -15016,6 +15020,7 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ContainerResourcePromise;
     /**
@@ -16764,6 +16769,7 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._withProcessCommandFactoryInternal(commandName, displayName, createProcessSpec, options), this._client);
@@ -18611,6 +18617,7 @@ export interface CSharpAppResource {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): CSharpAppResourcePromise;
     /**
@@ -19179,6 +19186,7 @@ export interface CSharpAppResourcePromise extends PromiseLike<CSharpAppResource>
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): CSharpAppResourcePromise;
     /**
@@ -20523,6 +20531,7 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._withProcessCommandFactoryInternal(commandName, displayName, createProcessSpec, options), this._client);
@@ -22322,6 +22331,7 @@ export interface DotnetToolResource {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): DotnetToolResourcePromise;
     /**
@@ -22912,6 +22922,7 @@ export interface DotnetToolResourcePromise extends PromiseLike<DotnetToolResourc
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): DotnetToolResourcePromise;
     /**
@@ -24340,6 +24351,7 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._withProcessCommandFactoryInternal(commandName, displayName, createProcessSpec, options), this._client);
@@ -26110,6 +26122,7 @@ export interface ExecutableResource {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ExecutableResourcePromise;
     /**
@@ -26667,6 +26680,7 @@ export interface ExecutableResourcePromise extends PromiseLike<ExecutableResourc
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ExecutableResourcePromise;
     /**
@@ -27991,6 +28005,7 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._withProcessCommandFactoryInternal(commandName, displayName, createProcessSpec, options), this._client);
@@ -29579,6 +29594,7 @@ export interface ExternalServiceResource {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ExternalServiceResourcePromise;
     /**
@@ -29862,6 +29878,7 @@ export interface ExternalServiceResourcePromise extends PromiseLike<ExternalServ
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ExternalServiceResourcePromise;
     /**
@@ -30496,6 +30513,7 @@ class ExternalServiceResourceImpl extends ResourceBuilderBase<ExternalServiceRes
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ExternalServiceResourcePromise {
         return new ExternalServiceResourcePromiseImpl(this._withProcessCommandFactoryInternal(commandName, displayName, createProcessSpec, options), this._client);
@@ -31582,6 +31600,7 @@ export interface ParameterResource {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ParameterResourcePromise;
     /**
@@ -31873,6 +31892,7 @@ export interface ParameterResourcePromise extends PromiseLike<ParameterResource>
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ParameterResourcePromise;
     /**
@@ -32525,6 +32545,7 @@ class ParameterResourceImpl extends ResourceBuilderBase<ParameterResourceHandle>
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ParameterResourcePromise {
         return new ParameterResourcePromiseImpl(this._withProcessCommandFactoryInternal(commandName, displayName, createProcessSpec, options), this._client);
@@ -33763,6 +33784,7 @@ export interface ProjectResource {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ProjectResourcePromise;
     /**
@@ -34331,6 +34353,7 @@ export interface ProjectResourcePromise extends PromiseLike<ProjectResource> {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ProjectResourcePromise;
     /**
@@ -35676,6 +35699,7 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._withProcessCommandFactoryInternal(commandName, displayName, createProcessSpec, options), this._client);
@@ -37611,6 +37635,7 @@ export interface TestDatabaseResource {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): TestDatabaseResourcePromise;
     /**
@@ -38351,6 +38376,7 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): TestDatabaseResourcePromise;
     /**
@@ -40098,6 +40124,7 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._withProcessCommandFactoryInternal(commandName, displayName, createProcessSpec, options), this._client);
@@ -42125,6 +42152,7 @@ export interface TestRedisResource {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): TestRedisResourcePromise;
     /**
@@ -42929,6 +42957,7 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): TestRedisResourcePromise;
     /**
@@ -44760,6 +44789,7 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._withProcessCommandFactoryInternal(commandName, displayName, createProcessSpec, options), this._client);
@@ -47042,6 +47072,7 @@ export interface TestVaultResource {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): TestVaultResourcePromise;
     /**
@@ -47784,6 +47815,7 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): TestVaultResourcePromise;
     /**
@@ -49533,6 +49565,7 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._withProcessCommandFactoryInternal(commandName, displayName, createProcessSpec, options), this._client);
@@ -51558,6 +51591,7 @@ export interface Resource {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ResourcePromise;
     /**
@@ -51836,6 +51870,7 @@ export interface ResourcePromise extends PromiseLike<Resource> {
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ResourcePromise;
     /**
@@ -52447,6 +52482,7 @@ class ResourceImpl extends ResourceBuilderBase<IResourceHandle> implements Resou
     /**
      * Adds a command to the resource that starts a local process created by a callback when invoked.
      * @param options Additional options.
+     * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ResourcePromise {
         return new ResourcePromiseImpl(this._withProcessCommandFactoryInternal(commandName, displayName, createProcessSpec, options), this._client);

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -944,6 +944,8 @@ export interface ProcessCommandExportOptions {
     standardInputContent?: string | null;
     /** A value indicating whether the entire process tree should be killed when the process is disposed. */
     killEntireProcessTree?: boolean | null;
+    /** A callback that creates the local process specification when the command is invoked. */
+    createProcessSpec?: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>;
     /** Optional command configuration. */
     commandOptions?: CommandOptions;
     /** The maximum number of stdout and stderr output lines returned as command result data. */
@@ -12786,6 +12788,15 @@ class ContainerRegistryResourceImpl extends ResourceBuilderBase<ContainerRegistr
         const __optionsForRpc = options === null ? options : { ...options };
         if (__optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCreateProcessSpec = __optionsForRpc.createProcessSpec;
+            if (____optionsForRpcCreateProcessSpec !== undefined) {
+                const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as ExecuteCommandContextHandle;
+                    const arg = new ExecuteCommandContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcCreateProcessSpec(arg);
+                }) : undefined;
+                __optionsForRpcData["createProcessSpec"] = ____optionsForRpcCreateProcessSpecId;
+            }
             const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
             if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
                 const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
@@ -16659,6 +16670,15 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
         const __optionsForRpc = options === null ? options : { ...options };
         if (__optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCreateProcessSpec = __optionsForRpc.createProcessSpec;
+            if (____optionsForRpcCreateProcessSpec !== undefined) {
+                const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as ExecuteCommandContextHandle;
+                    const arg = new ExecuteCommandContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcCreateProcessSpec(arg);
+                }) : undefined;
+                __optionsForRpcData["createProcessSpec"] = ____optionsForRpcCreateProcessSpecId;
+            }
             const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
             if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
                 const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
@@ -20409,6 +20429,15 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
         const __optionsForRpc = options === null ? options : { ...options };
         if (__optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCreateProcessSpec = __optionsForRpc.createProcessSpec;
+            if (____optionsForRpcCreateProcessSpec !== undefined) {
+                const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as ExecuteCommandContextHandle;
+                    const arg = new ExecuteCommandContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcCreateProcessSpec(arg);
+                }) : undefined;
+                __optionsForRpcData["createProcessSpec"] = ____optionsForRpcCreateProcessSpecId;
+            }
             const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
             if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
                 const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
@@ -24217,6 +24246,15 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
         const __optionsForRpc = options === null ? options : { ...options };
         if (__optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCreateProcessSpec = __optionsForRpc.createProcessSpec;
+            if (____optionsForRpcCreateProcessSpec !== undefined) {
+                const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as ExecuteCommandContextHandle;
+                    const arg = new ExecuteCommandContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcCreateProcessSpec(arg);
+                }) : undefined;
+                __optionsForRpcData["createProcessSpec"] = ____optionsForRpcCreateProcessSpecId;
+            }
             const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
             if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
                 const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
@@ -27859,6 +27897,15 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
         const __optionsForRpc = options === null ? options : { ...options };
         if (__optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCreateProcessSpec = __optionsForRpc.createProcessSpec;
+            if (____optionsForRpcCreateProcessSpec !== undefined) {
+                const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as ExecuteCommandContextHandle;
+                    const arg = new ExecuteCommandContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcCreateProcessSpec(arg);
+                }) : undefined;
+                __optionsForRpcData["createProcessSpec"] = ____optionsForRpcCreateProcessSpecId;
+            }
             const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
             if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
                 const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
@@ -30355,6 +30402,15 @@ class ExternalServiceResourceImpl extends ResourceBuilderBase<ExternalServiceRes
         const __optionsForRpc = options === null ? options : { ...options };
         if (__optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCreateProcessSpec = __optionsForRpc.createProcessSpec;
+            if (____optionsForRpcCreateProcessSpec !== undefined) {
+                const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as ExecuteCommandContextHandle;
+                    const arg = new ExecuteCommandContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcCreateProcessSpec(arg);
+                }) : undefined;
+                __optionsForRpcData["createProcessSpec"] = ____optionsForRpcCreateProcessSpecId;
+            }
             const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
             if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
                 const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
@@ -32375,6 +32431,15 @@ class ParameterResourceImpl extends ResourceBuilderBase<ParameterResourceHandle>
         const __optionsForRpc = options === null ? options : { ...options };
         if (__optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCreateProcessSpec = __optionsForRpc.createProcessSpec;
+            if (____optionsForRpcCreateProcessSpec !== undefined) {
+                const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as ExecuteCommandContextHandle;
+                    const arg = new ExecuteCommandContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcCreateProcessSpec(arg);
+                }) : undefined;
+                __optionsForRpcData["createProcessSpec"] = ____optionsForRpcCreateProcessSpecId;
+            }
             const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
             if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
                 const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
@@ -35517,6 +35582,15 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
         const __optionsForRpc = options === null ? options : { ...options };
         if (__optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCreateProcessSpec = __optionsForRpc.createProcessSpec;
+            if (____optionsForRpcCreateProcessSpec !== undefined) {
+                const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as ExecuteCommandContextHandle;
+                    const arg = new ExecuteCommandContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcCreateProcessSpec(arg);
+                }) : undefined;
+                __optionsForRpcData["createProcessSpec"] = ____optionsForRpcCreateProcessSpecId;
+            }
             const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
             if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
                 const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
@@ -39930,6 +40004,15 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
         const __optionsForRpc = options === null ? options : { ...options };
         if (__optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCreateProcessSpec = __optionsForRpc.createProcessSpec;
+            if (____optionsForRpcCreateProcessSpec !== undefined) {
+                const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as ExecuteCommandContextHandle;
+                    const arg = new ExecuteCommandContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcCreateProcessSpec(arg);
+                }) : undefined;
+                __optionsForRpcData["createProcessSpec"] = ____optionsForRpcCreateProcessSpecId;
+            }
             const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
             if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
                 const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
@@ -44583,6 +44666,15 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
         const __optionsForRpc = options === null ? options : { ...options };
         if (__optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCreateProcessSpec = __optionsForRpc.createProcessSpec;
+            if (____optionsForRpcCreateProcessSpec !== undefined) {
+                const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as ExecuteCommandContextHandle;
+                    const arg = new ExecuteCommandContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcCreateProcessSpec(arg);
+                }) : undefined;
+                __optionsForRpcData["createProcessSpec"] = ____optionsForRpcCreateProcessSpecId;
+            }
             const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
             if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
                 const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
@@ -49347,6 +49439,15 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
         const __optionsForRpc = options === null ? options : { ...options };
         if (__optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCreateProcessSpec = __optionsForRpc.createProcessSpec;
+            if (____optionsForRpcCreateProcessSpec !== undefined) {
+                const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as ExecuteCommandContextHandle;
+                    const arg = new ExecuteCommandContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcCreateProcessSpec(arg);
+                }) : undefined;
+                __optionsForRpcData["createProcessSpec"] = ____optionsForRpcCreateProcessSpecId;
+            }
             const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
             if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
                 const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };
@@ -52252,6 +52353,15 @@ class ResourceImpl extends ResourceBuilderBase<IResourceHandle> implements Resou
         const __optionsForRpc = options === null ? options : { ...options };
         if (__optionsForRpc !== null) {
             const __optionsForRpcData = __optionsForRpc as Record<string, unknown>;
+            const ____optionsForRpcCreateProcessSpec = __optionsForRpc.createProcessSpec;
+            if (____optionsForRpcCreateProcessSpec !== undefined) {
+                const ____optionsForRpcCreateProcessSpecId = ____optionsForRpcCreateProcessSpec ? registerCallback(async (argData: unknown) => {
+                    const argHandle = wrapIfHandle(argData) as ExecuteCommandContextHandle;
+                    const arg = new ExecuteCommandContextImpl(argHandle, this._client);
+                    return await ____optionsForRpcCreateProcessSpec(arg);
+                }) : undefined;
+                __optionsForRpcData["createProcessSpec"] = ____optionsForRpcCreateProcessSpecId;
+            }
             const ____optionsForRpcCommandOptions = __optionsForRpc.commandOptions;
             if (____optionsForRpcCommandOptions !== undefined && ____optionsForRpcCommandOptions !== null) {
                 const ____optionsForRpcCommandOptionsForRpc = { ...____optionsForRpcCommandOptions };

--- a/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
@@ -137,6 +137,69 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task WithProcessCommandExport_CreateProcessSpecReceivesExecutionContextAndArguments()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(output: ["options-callback-line"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        ExecuteCommandContext? capturedContext = null;
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommandExport(
+                "options-callback-command",
+                "Run options callback command",
+                new ProcessCommandExportOptions
+                {
+                    CreateProcessSpec = context =>
+                    {
+                        capturedContext = context;
+                        var message = context.Arguments.GetString("message") ?? string.Empty;
+
+                        return Task.FromResult(new ProcessCommandSpecExportData
+                        {
+                            ExecutablePath = "options-callback-executable",
+                            Arguments = ["--message", message]
+                        });
+                    },
+                    CommandOptions = new CommandOptions
+                    {
+                        Arguments =
+                        [
+                            new InteractionInput
+                            {
+                                Name = "message",
+                                InputType = InputType.Text
+                            }
+                        ]
+                    }
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var arguments = new InteractionInputCollection(
+        [
+            new InteractionInput
+            {
+                Name = "message",
+                InputType = InputType.Text,
+                Value = "hello-from-options-callback"
+            }
+        ]);
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "options-callback-command", arguments).DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Contains("options-callback-line", result.Data?.Value);
+        Assert.NotNull(capturedContext);
+        Assert.Equal("hello-from-options-callback", capturedContext.Arguments.GetString("message"));
+
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.Equal("options-callback-executable", processSpec.ExecutablePath);
+        Assert.Equal(["--message", "hello-from-options-callback"], processSpec.ArgumentList);
+    }
+
+    [Fact]
     public async Task WithProcessCommandFactoryExport_ProcessFactoryReceivesExecutionContextAndArguments()
     {
         var processRunner = new TestProcessRunner();

--- a/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
@@ -18,6 +18,7 @@ namespace Aspire.Hosting.Tests;
 
 #pragma warning disable ASPIREINTERACTION001 // InteractionInput is used to describe resource command arguments.
 #pragma warning disable ASPIREPROCESSCOMMAND001 // Process command APIs are experimental.
+#pragma warning disable CS0618 // Tests intentionally cover the deprecated TypeScript withProcessCommandFactory export.
 
 [Trait("Partition", "6")]
 public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)

--- a/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
@@ -1,12 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Aspire.Hosting.Dcp.Process;
+using Aspire.Hosting.Diagnostics;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Testing;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using AuxiliaryBackchannelRpcTarget = Aspire.Hosting.Backchannel.AuxiliaryBackchannelRpcTarget;
+using ExecuteResourceCommandRequest = Aspire.Hosting.Backchannel.ExecuteResourceCommandRequest;
 
 namespace Aspire.Hosting.Tests;
 
@@ -325,6 +331,70 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
 
         var processSpec = Assert.Single(processRunner.ProcessSpecs);
         Assert.Equal(["hello-from-argument"], processSpec.ArgumentList);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_BackchannelNamedArgumentsFlowToProcessFactoryAndResultContext()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(output: ["hello-from-backchannel"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        ProcessCommandResultContext? capturedResultContext = null;
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "echo-argument",
+                "Echo argument",
+                context =>
+                {
+                    var message = context.Arguments.GetString("message");
+                    return CreateProcessCommandSpec(arguments: ["--message", message ?? string.Empty]);
+                },
+                new ProcessCommandOptions
+                {
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "message",
+                            InputType = InputType.Text
+                        }
+                    ],
+                    GetCommandResult = resultContext =>
+                    {
+                        capturedResultContext = resultContext;
+                        return Task.FromResult(CommandResults.Success("received argument", resultContext.Arguments.GetString("message")!));
+                    }
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            app.Services.GetRequiredService<IConfiguration>(),
+            app.Services.GetRequiredService<ProfilingTelemetry>(),
+            app.Services);
+
+        var response = await target.ExecuteResourceCommandAsync(new ExecuteResourceCommandRequest
+        {
+            ResourceName = resource.Resource.Name,
+            CommandName = "echo-argument",
+            Arguments = JsonSerializer.SerializeToNode(new
+            {
+                message = "hello-from-backchannel"
+            })
+        }).DefaultTimeout();
+
+        Assert.True(response.Success, response.Message);
+        Assert.Equal("received argument", response.Message);
+        Assert.Equal("hello-from-backchannel", response.Value?.Value);
+
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.Equal(["--message", "hello-from-backchannel"], processSpec.ArgumentList);
+
+        Assert.NotNull(capturedResultContext);
+        Assert.Equal("hello-from-backchannel", capturedResultContext.Arguments.GetString("message"));
     }
 
     [Fact]

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
@@ -781,6 +781,30 @@ await container.withProcessCommand("node-stdin", "Node stdin", {
     },
     maxOutputLineCount: 10,
 });
+await container.withProcessCommand("node-message", "Node message", {
+    createProcessSpec: async (context) => {
+        const args = await context.arguments();
+        const message = await args.requiredValue("message");
+
+        return {
+            executablePath: "node",
+            arguments: ["-e", "console.log(process.argv[1])", message],
+        };
+    },
+    commandOptions: {
+        description: "Runs node with an argument supplied when the process command is invoked.",
+        iconName: "WindowConsole",
+        arguments: [
+            {
+                name: "message",
+                inputType: InputType.Text,
+                required: true,
+            },
+        ],
+    },
+    maxOutputLineCount: 10,
+    displayImmediately: false,
+});
 
 // withHttpCommand
 await container.withHttpCommand("/health", "Health Check");


### PR DESCRIPTION
## Description

`WithProcessCommand` command arguments now work end-to-end for process spec callbacks, result callbacks, CLI/backchannel invocation, and TypeScript/polyglot AppHosts.

References https://github.com/microsoft/aspire/issues/17648.

The TypeScript `withProcessCommand` options object now accepts `createProcessSpec`, so TypeScript AppHosts can declare command arguments and read the values from the execution context without a generator special-case or a separate overload shape. The existing DTO callback marshalling handles the callback property alongside nested `commandOptions`.

The legacy TypeScript `withProcessCommandFactory(...)` surface remains callable for compatibility, but is now emitted with `@deprecated` guidance to use `withProcessCommand(..., { createProcessSpec, commandOptions })` instead.

### User-facing usage

C# AppHost:

```csharp
builder.AddResource(new MyResource("worker"))
    .WithProcessCommand(
        "say",
        "Say",
        context => new ProcessCommandSpec("echo")
        {
            Arguments = [context.Arguments.GetString("message") ?? ""]
        },
        new ProcessCommandOptions
        {
            Arguments =
            [
                new InteractionInput
                {
                    Name = "message",
                    InputType = InputType.Text,
                    Required = true
                }
            ],
            GetCommandResult = context =>
                Task.FromResult(CommandResults.Success("received", context.Arguments.GetString("message")!))
        });
```

TypeScript AppHost:

```typescript
await container.withProcessCommand("node-message", "Node message", {
  createProcessSpec: async (context) => {
    const args = await context.arguments();
    const message = await args.requiredValue("message");

    return {
      executablePath: "node",
      arguments: ["-e", "console.log(process.argv[1])", message]
    };
  },
  commandOptions: {
    arguments: [
      { name: "message", inputType: InputType.Text, required: true }
    ]
  }
});
```

CLI invocation:

```bash
aspire resource worker say --message "hello"
```

Validation:

- `./restore.sh`
- `dotnet test --project tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.WithProcessCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.ResourceCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `cd tests/PolyglotAppHosts/Aspire.Hosting/TypeScript && npm ci --ignore-scripts --no-audit --no-fund && dotnet run --no-build --project ../../../../src/Aspire.Cli/Aspire.Cli.csproj -- restore && npm run build`
- `ASPIRE_E2E_ARCHIVE=/tmp/aspire-e2e.tar.gz dotnet test --project tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj --no-launch-profile -- --filter-method "*.ProcessCommandCallbackReceivesCliArguments" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`