### PR TITLE
Allow either required npm publish owner

### DIFF
--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -820,8 +820,8 @@ extends:
                       [System.Collections.Generic.HashSet[string]] $actualAliases,
                       [System.Collections.Generic.HashSet[string]] $requiredAliases,
                       [string] $parameterName) {
-                      $matches = @($requiredAliases | Where-Object { $actualAliases.Contains($_) })
-                      if ($matches.Count -eq 0) {
+                      $matchingAliases = @($requiredAliases | Where-Object { $actualAliases.Contains($_) })
+                      if ($matchingAliases.Count -eq 0) {
                         $requiredAliasList = ($requiredAliases | Sort-Object) -join ', '
                         Write-Error "$parameterName must include at least one required ESRP owner alias: $requiredAliasList."
                         exit 1

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -816,6 +816,18 @@ extends:
                       }
                     }
 
+                    function Assert-ContainsAnyRequiredNpmAlias(
+                      [System.Collections.Generic.HashSet[string]] $actualAliases,
+                      [System.Collections.Generic.HashSet[string]] $requiredAliases,
+                      [string] $parameterName) {
+                      $matches = @($requiredAliases | Where-Object { $actualAliases.Contains($_) })
+                      if ($matches.Count -eq 0) {
+                        $requiredAliasList = ($requiredAliases | Sort-Object) -join ', '
+                        Write-Error "$parameterName must include at least one required ESRP owner alias: $requiredAliasList."
+                        exit 1
+                      }
+                    }
+
                     $owners = "${{ parameters.NpmPublishOwners }}"
                     $approvers = "${{ parameters.NpmPublishApprovers }}"
                     $requiredNpmOwnersValue = "$(NPM_PUBLISH_REQUIRED_OWNERS)"
@@ -846,7 +858,7 @@ extends:
                       exit 1
                     }
 
-                    Assert-ContainsRequiredNpmAliases $normalizedOwners $requiredNpmOwners 'NpmPublishOwners'
+                    Assert-ContainsAnyRequiredNpmAlias $normalizedOwners $requiredNpmOwners 'NpmPublishOwners'
                     Assert-ContainsRequiredNpmAliases $normalizedApprovers $requiredNpmApprovers 'NpmPublishApprovers'
 
                     $overlappingAliases = @($normalizedOwners | Where-Object { $normalizedApprovers.Contains($_) })

--- a/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
@@ -117,6 +117,16 @@ public sealed class ReleasePublishNugetPipelineTests
     }
 
     [Fact]
+    public async Task NpmEsrpOwnersRequireAnyConfiguredOwnerAlias()
+    {
+        var pipeline = await ReadRepoFileAsync("eng/pipelines/release-publish-nuget.yml");
+
+        Assert.Contains("Assert-ContainsAnyRequiredNpmAlias $normalizedOwners $requiredNpmOwners 'NpmPublishOwners'", pipeline);
+        Assert.DoesNotContain("Assert-ContainsRequiredNpmAliases $normalizedOwners $requiredNpmOwners 'NpmPublishOwners'", pipeline);
+        Assert.Contains("Assert-ContainsRequiredNpmAliases $normalizedApprovers $requiredNpmApprovers 'NpmPublishApprovers'", pipeline);
+    }
+
+    [Fact]
     public async Task ValidatesPublishedNpmPackageFromRegistryAfterPublish()
     {
         var pipeline = await ReadRepoFileAsync("eng/pipelines/release-publish-nuget.yml");


### PR DESCRIPTION
## Summary
- allow npm ESRP owner validation to accept either configured required owner instead of requiring both
- keep approver validation requiring all configured approvers
- add a pipeline regression test for the owner/approver split

## Testing
- `dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
