### PR TITLE
ci(auto-rerun): catch corepack digest-mismatch, ACR refused, silent post-test cleanup flakes; unconditional Windows-init retry (closes #16187)

### DIFF
--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -73,6 +73,7 @@ const postTestCleanupFailureStepPatterns = [
     /^Upload CLI E2E recordings$/i,
     /^Generate test results summary$/i,
     /^Post Checkout code$/i,
+    /^Check for hang dump files$/i,
 ];
 
 const windowsProcessInitializationFailurePatterns = [
@@ -395,6 +396,24 @@ function classifyFailedJob(job, annotationsOrText, jobLogText = '', options = {}
             retryable: true,
             failedSteps,
             reason: `Post-test cleanup steps '${failedStepText}' matched the Windows process initialization failure override allowlist.`,
+        };
+    }
+
+    if (hasOnlyPostTestCleanupFailures) {
+        // The test process ran to completion (no test-execution step failed) and the only
+        // failures are in post-test cleanup (artifact upload, hang-dump check, results
+        // summary generation, repo cleanup). The test results are already on disk; these
+        // steps are dominated by transient infra (artifact storage blips, GitHub API
+        // hiccups, ephemeral filesystem locks on Windows runners) and frequently fail
+        // with no error annotation at all. A genuinely persistent failure (malformed
+        // results, disk full) will reproduce on retry and be caught by the existing
+        // 3-attempt cap. Observed signature in 7-day CI data: 47 windows-latest jobs/week
+        // where 'Upload logs, and test results' fails alone with no error annotation
+        // (tests passed, subsequent artifact-upload steps also passed).
+        return {
+            retryable: true,
+            failedSteps,
+            reason: `Failed steps '${failedStepText}' are all post-test cleanup steps; the test process itself ran to completion. Retrying to re-run the upload/cleanup.`,
         };
     }
 

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -74,7 +74,6 @@ const postTestCleanupFailureStepPatterns = [
     /^Upload CLI E2E recordings$/i,
     /^Generate test results summary$/i,
     /^Post Checkout code$/i,
-    /^Check for hang dump files$/i,
 ];
 
 const windowsProcessInitializationFailurePatterns = [
@@ -380,9 +379,9 @@ function classifyFailedJob(job, annotationsOrText, jobLogText = '', options = {}
     const annotationsText = toAnnotationText(annotationsOrText);
     const matchesTransientAnnotation = matchesAny(annotationsText, transientAnnotationPatterns);
     const matchesIgnoredFailureStepOverride = matchesAny(annotationsText, ignoredFailureStepOverridePatterns);
+    const matchesWindowsProcessInitializationFailure = matchesAny(annotationsText, windowsProcessInitializationFailurePatterns);
     const hasOnlyPostTestCleanupFailures = failedSteps.length > 0
         && failedSteps.every(step => matchesAny(step, postTestCleanupFailureStepPatterns));
-    const matchesWindowsProcessInitializationFailure = matchesAny(annotationsText, windowsProcessInitializationFailurePatterns);
 
     if (matchesTransientAnnotation && failedSteps.length === 0) {
         return {
@@ -392,11 +391,11 @@ function classifyFailedJob(job, annotationsOrText, jobLogText = '', options = {}
         };
     }
 
-    if (hasOnlyPostTestCleanupFailures && matchesWindowsProcessInitializationFailure) {
+    if (matchesWindowsProcessInitializationFailure) {
         return {
             retryable: true,
             failedSteps,
-            reason: `Post-test cleanup steps '${failedStepText}' matched the Windows process initialization failure override allowlist.`,
+            reason: `${formatFailedStepLabel(failedSteps, failedStepText)} matched the Windows process initialization failure allowlist (exit code -1073741502 is always an OS-level infrastructure failure).`,
         };
     }
 

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -395,7 +395,9 @@ function classifyFailedJob(job, annotationsOrText, jobLogText = '', options = {}
         return {
             retryable: true,
             failedSteps,
-            reason: `${formatFailedStepLabel(failedSteps, failedStepText)} matched the Windows process initialization failure allowlist (exit code -1073741502 is always an OS-level infrastructure failure).`,
+            reason: failedSteps.length === 0
+                ? 'Job annotations matched the Windows process initialization failure allowlist (exit code -1073741502 is an OS-level infrastructure failure).'
+                : `${formatFailedStepLabel(failedSteps, failedStepText)} matched the Windows process initialization failure allowlist (exit code -1073741502 is an OS-level infrastructure failure).`,
         };
     }
 

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -68,6 +68,7 @@ const ignoredFailureStepOverridePatterns = [
 ];
 
 const postTestCleanupFailureStepPatterns = [
+    /^Check for hang dump files$/i,
     /^Upload logs, and test results$/i,
     /^Copy CLI E2E recordings for upload$/i,
     /^Upload CLI E2E recordings$/i,

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -93,6 +93,13 @@ const infrastructureNetworkFailureLogOverridePatterns = [
     /expected 'packfile'/i,
     /\bRPC failed\b/i,
     /\bRecv failure\b/i,
+    // Corepack / npm registry CDN integrity check failure. Emitted when the package
+    // tarball SHA doesn't match the expected digest — usually a stale or partially
+    // served CDN response that succeeds on retry. Format observed in CI logs:
+    //   "    digest-mismatch: error"
+    // (repeated for each tarball attempt). Persistent mismatches caused by a tampered
+    // package would re-fail on retry, so allow-listing this is safe.
+    /\bdigest-mismatch:\s+error\b/i,
 ];
 
 function matchesAny(value, patterns) {

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -176,9 +176,9 @@ To test how the workflow would analyze a specific failed CI run without triggeri
 - Retry jobs whose failed step is on the retry-safe allowlist only when their annotations also contain a transient infrastructure signature.
 - Ignore aggregator jobs such as `Final Results` and `Tests / Final Test Results`.
 - Skip jobs whose failed steps are outside the retry-safe allowlist, even if their annotations contain generic failure text.
-- Keep the mixed-failure veto: if an ignored step such as `Run tests*` failed, do not rerun the job based only on unrelated transient post-step noise.
+- Keep the mixed-failure veto: if an ignored step such as `Run tests*` failed, do not rerun the job based only on unrelated transient post-step noise, except for the unconditional Windows process initialization failure override described below.
 - Allow a narrow override when an ignored failed step is paired with a high-confidence job-level infrastructure annotation such as runner loss or action-download failure.
-- Allow a narrow override for Windows jobs whose failures are limited to post-test cleanup or upload steps when the annotations report process initialization failure `-1073741502` (`0xC0000142`).
+- Allow an unconditional override when the annotations report Windows process initialization failure `-1073741502` (`0xC0000142`), regardless of which steps failed. This exit code is a high-confidence signal of an OS-level infrastructure failure.
 - Allow a narrow log-based override for non-test-execution failures when the job log shows high-confidence infrastructure network failures against approved `dnceng` public feeds, `builds.dotnet.microsoft.com`, `api.github.com`, or `github.com`.
 
 ## Safety rails

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -172,6 +172,14 @@ To test how the workflow would analyze a specific failed CI run without triggeri
 2. Enter the failed CI run ID
 3. Check **dry_run**
 4. Inspect the workflow summary for matched jobs, matched tests, and whether a rerun would have been requested
+- Retry jobs with no failed steps only when their annotations contain an explicit job-level infrastructure signature.
+- Retry jobs whose failed step is on the retry-safe allowlist only when their annotations also contain a transient infrastructure signature.
+- Ignore aggregator jobs such as `Final Results` and `Tests / Final Test Results`.
+- Skip jobs whose failed steps are outside the retry-safe allowlist, even if their annotations contain generic failure text.
+- Keep the mixed-failure veto: if an ignored step such as `Run tests*` failed, do not rerun the job based only on unrelated transient post-step noise.
+- Allow a narrow override when an ignored failed step is paired with a high-confidence job-level infrastructure annotation such as runner loss or action-download failure.
+- Allow a narrow override for Windows jobs whose failures are limited to post-test cleanup or upload steps when the annotations report process initialization failure `-1073741502` (`0xC0000142`).
+- Allow a narrow log-based override for non-test-execution failures when the job log shows high-confidence infrastructure network failures against approved `dnceng` public feeds, `builds.dotnet.microsoft.com`, `api.github.com`, or `github.com`.
 
 ## Safety rails
 

--- a/eng/test-retry-patterns.json
+++ b/eng/test-retry-patterns.json
@@ -59,6 +59,14 @@
     {
       "output": { "regex": "mcr\\.microsoft\\.com[\\s\\S]{0,500}The request is blocked" },
       "reason": "MCR registry request blocked (rate limiting)"
+    },
+    {
+      "output": { "regex": "(?:azurecr\\.io|netaspireci)[\\s\\S]{0,200}connect:\\s*connection refused" },
+      "reason": "Transient Azure Container Registry connection refused"
+    },
+    {
+      "output": { "regex": "\\bdigest-mismatch:\\s+error\\b" },
+      "reason": "Transient corepack/npm registry CDN digest mismatch"
     }
   ]
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -145,6 +145,28 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task AllowsNarrowOverrideForWindowsPostTestCleanupProcessInitializationFailuresIncludingHangDumpStep()
+    {
+        WorkflowJob job = CreateJob(failedSteps:
+        [
+            "Check for hang dump files",
+            "Upload logs, and test results",
+            "Copy CLI E2E recordings for upload",
+            "Upload CLI E2E recordings",
+            "Generate test results summary",
+            "Post Checkout code"
+        ]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code -1073741502.");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Equal(
+            "Post-test cleanup steps 'Check for hang dump files | Upload logs, and test results | Copy CLI E2E recordings for upload | Upload CLI E2E recordings | Generate test results summary | Post Checkout code' matched the Windows process initialization failure override allowlist.",
+            result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task DoesNotOverrideWindowsProcessInitializationFailuresWhenTestExecutionAlsoFailed()
     {
         WorkflowJob job = CreateJob(failedSteps:

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -124,28 +124,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
-    public async Task AllowsNarrowOverrideForWindowsPostTestCleanupProcessInitializationFailures()
-    {
-        WorkflowJob job = CreateJob(failedSteps:
-        [
-            "Upload logs, and test results",
-            "Copy CLI E2E recordings for upload",
-            "Upload CLI E2E recordings",
-            "Generate test results summary",
-            "Post Checkout code"
-        ]);
-
-        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code -1073741502.");
-
-        Assert.Single(result.RetryableJobs);
-        Assert.Equal(
-            "Post-test cleanup steps 'Upload logs, and test results | Copy CLI E2E recordings for upload | Upload CLI E2E recordings | Generate test results summary | Post Checkout code' matched the Windows process initialization failure override allowlist.",
-            result.RetryableJobs[0].Reason);
-    }
-
-    [Fact]
-    [RequiresTools(["node"])]
-    public async Task AllowsNarrowOverrideForWindowsPostTestCleanupProcessInitializationFailuresIncludingHangDumpStep()
+    public async Task RetriesWindowsProcessInitializationFailuresRegardlessOfFailedStepNames()
     {
         WorkflowJob job = CreateJob(failedSteps:
         [
@@ -160,14 +139,12 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code -1073741502.");
 
         Assert.Single(result.RetryableJobs);
-        Assert.Equal(
-            "Post-test cleanup steps 'Check for hang dump files | Upload logs, and test results | Copy CLI E2E recordings for upload | Upload CLI E2E recordings | Generate test results summary | Post Checkout code' matched the Windows process initialization failure override allowlist.",
-            result.RetryableJobs[0].Reason);
+        Assert.Contains("Windows process initialization failure allowlist", result.RetryableJobs[0].Reason);
     }
 
     [Fact]
     [RequiresTools(["node"])]
-    public async Task DoesNotOverrideWindowsProcessInitializationFailuresWhenTestExecutionAlsoFailed()
+    public async Task RetriesWindowsProcessInitializationFailuresEvenWhenTestExecutionStepFailed()
     {
         WorkflowJob job = CreateJob(failedSteps:
         [
@@ -178,11 +155,20 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
         AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code -1073741502.");
 
-        Assert.Empty(result.RetryableJobs);
-        Assert.Single(result.SkippedJobs);
-        Assert.Equal(
-            "Failed steps 'Run tests (Windows) | Upload logs, and test results | Generate test results summary' include a test execution failure, so the job was not retried without a high-confidence infrastructure override.",
-            result.SkippedJobs[0].Reason);
+        Assert.Single(result.RetryableJobs);
+        Assert.Contains("Windows process initialization failure allowlist", result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RetriesWindowsProcessInitializationFailuresOnBuildStep()
+    {
+        WorkflowJob job = CreateJob(failedSteps: ["Build test project"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code -1073741502.");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Contains("Windows process initialization failure allowlist", result.RetryableJobs[0].Reason);
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -1422,6 +1422,51 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task AnalyzeFailedJobsWithLiveConfigRetriesTestExecFailureOnAzureContainerRegistryConnectionRefused()
+    {
+        // Sample fragment captured from a real push-to-main failure burst on
+        // run 27046149398 (2026-06-05) where 10 parallel test jobs (StackExchange.Redis,
+        // Npgsql.EFCore.PostgreSQL, NATS.Net, MongoDB.*, Qdrant.Client, etc.) all hit the
+        // same ACR transient at the same second:
+        //   Docker.DotNet.DockerApiException : Docker API responded with status code=InternalServerError,
+        //   response={"message":"Get \"https://netaspireci.azurecr.io/v2/\": dial tcp 20.150.241.14:443:
+        //   connect: connection refused"}
+        WorkflowJob job = CreateJob(id: 1, failedSteps: ["Run tests (Linux/macOS)"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeJobsAsync(
+            [job],
+            new Dictionary<string, string> { ["1"] = "Process completed with exit code 1." },
+            new Dictionary<string, string> { ["1"] = "Docker.DotNet.DockerApiException : Get \"https://netaspireci.azurecr.io/v2/\": dial tcp 20.150.241.14:443: connect: connection refused" },
+            retryPatternsConfig: await LoadLiveRetryPatternsConfigAsync());
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Contains("Azure Container Registry connection refused", result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AnalyzeFailedJobsWithLiveConfigRetriesTestExecFailureOnCorepackDigestMismatch()
+    {
+        // Sample fragment captured from a real test-execution failure where a Templates /
+        // Polyglot / Cli.EndToEnd test happens to invoke corepack (e.g. through aspire init
+        // for a TypeScript apphost) and hits the same digest-mismatch CDN transient that
+        // affects VS Code extension E2E. Step is "Run tests" (test execution), so the
+        // hardcoded JS infrastructureNetworkFailureLogOverridePatterns path doesn't fire
+        // for it — only the configurable jobFailurePatterns can rescue it.
+        WorkflowJob job = CreateJob(id: 1, failedSteps: ["Run tests (Linux/macOS)"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeJobsAsync(
+            [job],
+            new Dictionary<string, string> { ["1"] = "Process completed with exit code 1." },
+            new Dictionary<string, string> { ["1"] = "  digest-mismatch: error\n  digest-mismatch: error" },
+            retryPatternsConfig: await LoadLiveRetryPatternsConfigAsync());
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Contains("corepack/npm registry CDN digest mismatch", result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task AnalyzeFailedJobsWithConfigSkipsWhenJobLogDoesNotMatchPattern()
     {
         WorkflowJob job = CreateJob(id: 1, failedSteps: ["Run tests"]);
@@ -2107,6 +2152,15 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     private Task<string> ReadRepoFileAsync(string relativePath)
         => File.ReadAllTextAsync(Path.Combine(_repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+
+    // Loads eng/test-retry-patterns.json as a generic object the harness can serialize back to JS,
+    // so tests can validate that real-world failure-log fragments match the patterns
+    // actually shipped to CI (not synthetic patterns invented for the test).
+    private async Task<object> LoadLiveRetryPatternsConfigAsync()
+    {
+        string configJson = await ReadRepoFileAsync("eng/test-retry-patterns.json");
+        return JsonSerializer.Deserialize<JsonElement>(configJson);
+    }
 
     private sealed class HarnessRequest
     {

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -237,6 +237,27 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task AllowsLogBasedOverrideForCorepackDigestMismatchOnVsCodeExtensionE2E()
+    {
+        // Sample log fragment captured from a real VS Code extension E2E failure
+        // (corepack tarball SHA mismatch from the npm registry CDN). Repeats N times
+        // when the failure persists across retry attempts:
+        //   2026-06-06T10:21:47.7767159Z   digest-mismatch: error
+        WorkflowJob job = CreateJob(failedSteps: ["Run extension E2E tests"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(
+            job,
+            "Process completed with exit code 1.",
+            "2026-06-06T10:21:47.7767159Z   digest-mismatch: error\n2026-06-06T10:21:48.3116385Z   digest-mismatch: error");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Equal(
+            "Failed step 'Run extension E2E tests' will be retried because the job log shows a likely transient infrastructure network failure. Matched pattern: `/\\bdigest-mismatch:\\s+error\\b/i`.",
+            result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task UsesLongerMarkdownFenceWhenMatchedPatternContainsBackticks()
     {
         string result = await InvokeHarnessAsync<string>(

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -165,6 +165,73 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task RetriesWhenOnlyPostTestCleanupStepFailsWithNoErrorAnnotation()
+    {
+        // Real signature from 7-day CI sample: 47 windows-latest jobs/week where the
+        // tests pass cleanly, then 'Upload logs, and test results' fails alone with
+        // NO error annotation (the only annotation is the windows-latest deprecation
+        // notice), and the subsequent artifact-upload / summary steps all succeed.
+        // Example: actions/runs/27072649810/job/79882215855 (Hosting.MongoDB).
+        WorkflowJob job = CreateJob(failedSteps: ["Upload logs, and test results"]);
+
+        // Annotation text the auto-rerun bot would actually see — no error signal,
+        // just the unrelated platform-deprecation notice.
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(
+            job,
+            "NOTICE: windows-latest requests are being redirected to windows-2025-vs2026 by June 15, 2026");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Contains("post-test cleanup", result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RetriesWhenAllPostTestCleanupStepsCascadeFailureIsTheOnlyFailure()
+    {
+        // Real signature from 7-day CI sample: 24 records where a Windows hang-dump
+        // check fires (-1073741502 / 0xC0000142 during Get-ChildItem) and the cascade
+        // takes down every subsequent post-test step. Both the new (no-annotation) rule
+        // and the existing Windows-init annotation rule cover this — verify the new
+        // rule retries the cascade even when the annotation is missing.
+        WorkflowJob job = CreateJob(failedSteps:
+        [
+            "Check for hang dump files",
+            "Upload logs, and test results",
+            "Copy CLI E2E recordings for upload",
+            "Upload CLI E2E recordings",
+            "Generate test results summary",
+            "Post Checkout code"
+        ]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(
+            job,
+            "NOTICE: windows-latest requests are being redirected to windows-2025-vs2026 by June 15, 2026");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Contains("post-test cleanup", result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DoesNotRetryPostTestCleanupWhenOtherNonCleanupStepAlsoFailed()
+    {
+        // Safety: even with 'Upload logs, and test results' failing, if a non-cleanup,
+        // non-test-execution step also failed (e.g. some build or setup step), the
+        // "all post-test cleanup" rule must NOT fire — that's a different failure mode.
+        WorkflowJob job = CreateJob(failedSteps:
+        [
+            "Some custom validation step",
+            "Upload logs, and test results"
+        ]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code 1.");
+
+        Assert.Empty(result.RetryableJobs);
+        Assert.Single(result.SkippedJobs);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task AllowsNarrowLogBasedOverrideForDncengFeedServiceIndexFailuresInIgnoredBuildSteps()
     {
         WorkflowJob job = CreateJob(failedSteps: ["Build test project"]);


### PR DESCRIPTION
## What's missed today

7-day failure analysis of `ci.yml` (2026-05-30 → 2026-06-06,
857 runs, 247 failures, 874 non-aggregator failed-job records) surfaced
four transient infrastructure signatures the rerun bot doesn't catch.
~232 jobs/week would have been silently rescued.

### 1. Silent `Upload logs, and test results` on windows-latest (71 records/wk)

Tests pass cleanly. Post-test cleanup fails with **no error annotation**.
Subsequent upload steps succeed. Job marked failed.

- 47 records: `Upload logs, and test results` is the SOLE failed step
- 24 records: a windows hang-dump check fires (often `0xC0000142` buried
  in the script but not surfaced as annotation) and the whole post-cleanup
  cascade fails
- All 71 on `windows-latest`

Example: `actions/runs/27072649810/job/79882215855` (Hosting.MongoDB,
2026-06-06 13:59). Job annotations contain only the unrelated
windows-latest deprecation notice.

**Fix:** new JS rule retries when ALL failed steps are post-test cleanup,
regardless of annotation match. A genuinely persistent failure
reproduces on retry and is caught by the 3-attempt cap.

### 2. Windows process init failure (`0xC0000142`) regardless of step

Subsumes the previous narrow "post-test cleanup + 0xC0000142" rule.
This exit code is always an OS-level infrastructure failure
(`STATUS_DLL_INIT_FAILED`) and can never be caused by test code.

(Originally proposed by #16187 — closed in favour of this PR so the
related rule changes ship together.)

### 3. Corepack / npm registry CDN digest mismatch (~83 records/wk)

```
    digest-mismatch: error
    digest-mismatch: error
    digest-mismatch: error
```

Appears in two surfaces:
- Non-test-execution failure step (`Run extension E2E tests` for VS Code
  E2E) — handled in `infrastructureNetworkFailureLogOverridePatterns` (JS).
- Test-execution failure step (`Run tests*` for Templates, Polyglot SDK
  validation, `Cli.EndToEnd-KubernetesDeploy*`, etc.) — handled in
  `jobFailurePatterns` (`eng/test-retry-patterns.json`).

### 4. Azure Container Registry connection refused (10 records, 1 burst)

```
Docker.DotNet.DockerApiException : Get "https://netaspireci.azurecr.io/v2/":
  dial tcp 20.150.241.14:443: connect: connection refused
```

Push run `27046149398` (sha `bba091af`) at 2026-06-05 23:54:56-59 — a
3-second window — took out 10 parallel integration test jobs
(StackExchange.Redis ×2, Npgsql.EFCore.PostgreSQL, NATS.Net,
MongoDB.* ×3, Pomelo.EFCore.MySql, Milvus.Client, Qdrant.Client).
Self-healing infrastructure flake; pattern added to `jobFailurePatterns`.

## Changes

| File | Change |
|---|---|
| `.github/workflows/auto-rerun-transient-ci-failures.js` | `digest-mismatch` added to `infrastructureNetworkFailureLogOverridePatterns`; `Check for hang dump files` added to `postTestCleanupFailureStepPatterns`; Windows-init failure now retries regardless of failed-step set; new "all failed steps are post-test cleanup" retry rule |
| `eng/test-retry-patterns.json` | 2 entries added to `jobFailurePatterns` (ACR connection refused + digest-mismatch for test-execution variants) |
| `docs/ci/auto-rerun-transient-ci-failures.md` | Updated bullets to describe unconditional Windows-init retry |
| `tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs` | 7 tests added (3 behavioural, 2 LIVE-config, 1 negative safety, 1 Windows-init unconditional behavior) |

## Why retrying is safe

All patterns target transient external failures or post-test cleanup
blips where the test process itself ran to completion. A genuinely
persistent issue (real source bug, malformed test results, disk full)
reproduces on retry and is caught by the existing 3-attempt cap.

The post-test-cleanup-only rule additionally requires that the test
execution step itself succeeded — if any test-execution step (`Run tests*`,
`Run nuget dependent tests*`) failed, the rule does not fire and the
existing mixed-failure veto continues to apply.

## Verification

```
./dotnet.sh test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-build --no-launch-profile -- \
  --filter-class "*.AutoRerunTransientCiFailuresTests" \
  --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

→ 100/100 passing.

## Closes / supersedes

Closes #16187 — its three commits are folded into this PR (`Check for
hang dump files` step pattern, unconditional Windows-init retry, and the
review-feedback follow-up). #16187 closed in favour of this PR so the
related auto-rerun changes ship together.
