### PR TITLE
Fix stealth button background in dashboard dialogs

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.css
@@ -14,6 +14,10 @@
     display: inline-flex;
 }
 
+::deep .column-header {
+    align-content: center;
+}
+
 .button-container {
     display: grid;
     grid-template-columns: 1fr auto;

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -363,13 +363,15 @@ fluent-dialog fluent-toolbar {
     background-color: var(--dialog-background-color);
 }
 
-/* Changing the dialog's fill color means stealth buttons on the dialog have the wrong background,
-   so change it to match */
+/*
+    Changing the dialog's fill color means stealth buttons on the dialog have the wrong background, so change it to match
+    Set to transparent instead of dialog background color so it looks good when inside a dialog's table header row (Manage Data).
+*/
 fluent-dialog fluent-button[appearance=stealth]:not(:hover)::part(control),
 fluent-dialog fluent-button[appearance=lightweight]:not(:hover)::part(control),
 fluent-dialog fluent-anchor[appearance=stealth]:not(:hover)::part(control),
 fluent-dialog fluent-anchor[appearance=lightweight]:not(:hover)::part(control) {
-    background: var(--dialog-background-color);
+    background: transparent;
 }
 
 /* But changing the stealth button's background in dialogs means the stealth buttons used as headers for grid cells


### PR DESCRIPTION
## Description

Fix stealth/lightweight button backgrounds in dashboard dialogs to use `transparent` instead of `var(--dialog-background-color)`. This ensures buttons look correct when rendered inside a table header row (e.g., the Manage Data dialog).

Also adds `align-content: center` to ManageDataDialog column headers for proper vertical alignment.

After:
<img width="1238" height="954" alt="image" src="https://github.com/user-attachments/assets/a4b25dc9-e044-41d8-a532-b338402bc21b" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
