### PR TITLE
Isolate testing builder user secrets

### DIFF
--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -18,6 +18,7 @@ using Aspire.Hosting.Utils;
 using Aspire.Shared;
 using Aspire.Shared.UserSecrets;
 using Microsoft.Extensions.Logging;
+using Semver;
 
 namespace Aspire.Cli.Projects;
 
@@ -263,23 +264,6 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
         var env = new Dictionary<string, string>(context.EnvironmentVariables);
 
-        // Handle isolated mode - randomize ports and isolate user secrets
-        string? isolatedUserSecretsId = null;
-        if (context.Isolated)
-        {
-            using var isolatedModeActivity = _profilingTelemetry.StartAppHostConfigureIsolatedMode();
-            try
-            {
-                isolatedUserSecretsId = await ConfigureIsolatedModeAsync(effectiveAppHostFile, env, cancellationToken);
-                _logger.LogInformation("Aspire run isolated. Isolated UserSecretsId: {IsolatedUserSecretsId}", isolatedUserSecretsId);
-            }
-            catch (Exception ex)
-            {
-                isolatedModeActivity.SetError(ex.Message);
-                throw;
-            }
-        }
-
         // Enable debug logging in the app host so that debug-level output is
         // captured in the CLI log file for diagnostics. Defaults to Debug but
         // can be overridden via --log-level.
@@ -306,6 +290,8 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         {
             return exitCode;
         }
+
+        using var legacyIsolatedUserSecretsLease = await ConfigureIsolatedModeIfNeededAsync(context, effectiveAppHostFile, isSingleFileAppHost, env, cancellationToken);
 
         // Two separate bundle interactions:
         //  - injectDcpAndDashboard: only true when the AppHost opted into AspireUseCliBundle.
@@ -352,52 +338,41 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             : null;
 
         // Start the apphost - the runner will signal the backchannel when ready
-        try
+        // The AppHost may already have been built above, but watch mode intentionally still
+        // runs with builds enabled. Passing --no-build through to dotnet watch breaks hot reload
+        // because watch owns the incremental build loop and its environment setup.
+        //
+        // This means watch mode can do a second no-op build after the CLI pre-build succeeds.
+        // That tradeoff is intentional: the pre-build makes initial compiler errors terminate
+        // aspire run instead of leaving dotnet watch idle waiting for edits before a backchannel
+        // ever becomes available.
+        //
+        // noRestore is only relevant when noBuild is false because --no-build implies --no-restore.
+        var noBuild = !watch || context.NoBuild;
+        using var runDotnetActivity = _profilingTelemetry.StartAppHostRunDotnetLifetime(watch, noBuild, context.NoRestore);
+        if (directRun is not null)
         {
-            // The AppHost may already have been built above, but watch mode intentionally still
-            // runs with builds enabled. Passing --no-build through to dotnet watch breaks hot reload
-            // because watch owns the incremental build loop and its environment setup.
-            //
-            // This means watch mode can do a second no-op build after the CLI pre-build succeeds.
-            // That tradeoff is intentional: the pre-build makes initial compiler errors terminate
-            // aspire run instead of leaving dotnet watch idle waiting for edits before a backchannel
-            // ever becomes available.
-            //
-            // noRestore is only relevant when noBuild is false because --no-build implies --no-restore.
-            var noBuild = !watch || context.NoBuild;
-            using var runDotnetActivity = _profilingTelemetry.StartAppHostRunDotnetLifetime(watch, noBuild, context.NoRestore);
-            if (directRun is not null)
-            {
-                return await _runner.RunAppHostCommandAsync(
-                    effectiveAppHostFile,
-                    directRun.Command,
-                    directRun.WorkingDirectory,
-                    directRun.Arguments,
-                    directRun.Environment,
-                    backchannelCompletionSource,
-                    runOptions,
-                    cancellationToken);
-            }
-
-            return await _runner.RunAsync(
+            return await _runner.RunAppHostCommandAsync(
                 effectiveAppHostFile,
-                watch,
-                noBuild,
-                context.NoRestore,
-                context.UnmatchedTokens,
-                env,
+                directRun.Command,
+                directRun.WorkingDirectory,
+                directRun.Arguments,
+                directRun.Environment,
                 backchannelCompletionSource,
                 runOptions,
                 cancellationToken);
         }
-        finally
-        {
-            // Clean up isolated user secrets when the run completes
-            if (!string.IsNullOrEmpty(isolatedUserSecretsId))
-            {
-                IsolatedUserSecretsHelper.CleanupIsolatedUserSecrets(isolatedUserSecretsId);
-            }
-        }
+
+        return await _runner.RunAsync(
+            effectiveAppHostFile,
+            watch,
+            noBuild,
+            context.NoRestore,
+            context.UnmatchedTokens,
+            env,
+            backchannelCompletionSource,
+            runOptions,
+            cancellationToken);
     }
 
     private async Task EnsureDevCertificatesTrustedAsync(AppHostProjectContext context, Dictionary<string, string> env, CancellationToken cancellationToken)
@@ -1245,9 +1220,9 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     {
         try
         {
-            // Read UserSecretsId from the shared AppHost build info cache so isolated mode
-            // does not pay for a second `dotnet msbuild -getProperty` invocation when the
-            // run path already fetched the AppHost metadata for validation/compat.
+            // Read UserSecretsId from the shared AppHost build info cache so callers do not pay
+            // for another `dotnet msbuild -getProperty` invocation when the run path already
+            // fetched the AppHost metadata for validation/compat.
             var info = await _appHostInfoResolver.GetAppHostInfoAsync(projectFile, cancellationToken);
             return info.UserSecretsId;
         }
@@ -1344,11 +1319,6 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     /// an Aspire repo checkout (typically <c>dotnet run --project src/Aspire.Cli</c>).
     /// Returns <c>null</c> in release builds and when no repo-local build exists.
     /// </summary>
-    /// <summary>
-    /// Resolves the repo-local <c>aspire-managed</c> binary when the CLI is running from
-    /// an Aspire repo checkout (typically <c>dotnet run --project src/Aspire.Cli</c>).
-    /// Returns <c>null</c> in release builds and when no repo-local build exists.
-    /// </summary>
     private static string? TryGetRepoLocalManagedPath()
     {
         if (RepoLocalManagedPathProviderOverride is { } overrideProvider)
@@ -1363,33 +1333,85 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     /// <summary>
     /// Configures isolated mode by enabling port randomization and isolating user secrets.
     /// </summary>
+    /// <param name="context">The AppHost run context.</param>
     /// <param name="appHostFile">The app host project file.</param>
+    /// <param name="isSingleFileAppHost">Whether the AppHost is file-based.</param>
     /// <param name="env">The environment variables dictionary to modify.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The isolated user secrets ID if created, or null if no isolation was needed.</returns>
+    /// <returns>A cleanup lease when the CLI used the legacy user-secrets isolation path; otherwise <see langword="null"/>.</returns>
+    private async Task<IDisposable?> ConfigureIsolatedModeIfNeededAsync(
+        AppHostProjectContext context,
+        FileInfo appHostFile,
+        bool isSingleFileAppHost,
+        Dictionary<string, string> env,
+        CancellationToken cancellationToken)
+    {
+        if (!context.Isolated)
+        {
+            return null;
+        }
+
+        using var isolatedModeActivity = _profilingTelemetry.StartAppHostConfigureIsolatedMode();
+        try
+        {
+            var isolatedUserSecretsId = await ConfigureIsolatedModeAsync(appHostFile, isSingleFileAppHost, env, cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation("Aspire run isolated.");
+
+            return string.IsNullOrEmpty(isolatedUserSecretsId)
+                ? null
+                : new LegacyIsolatedUserSecretsLease(isolatedUserSecretsId);
+        }
+        catch (Exception ex)
+        {
+            isolatedModeActivity.SetError(ex.Message);
+            context.BuildCompletionSource?.TrySetResult(false);
+            throw;
+        }
+    }
+
     private async Task<string?> ConfigureIsolatedModeAsync(
         FileInfo appHostFile,
+        bool isSingleFileAppHost,
         Dictionary<string, string> env,
         CancellationToken cancellationToken)
     {
         // Enable port randomization for isolated mode
         env["DcpPublisher__RandomizePorts"] = "true";
 
-        // Get the UserSecretsId from the project and create isolated copy
-        var userSecretsId = await QueryUserSecretsIdAsync(appHostFile, cancellationToken);
-        if (!string.IsNullOrEmpty(userSecretsId))
+        if (isSingleFileAppHost || await AppHostSupportsNativeUserSecretsIsolationAsync(appHostFile, cancellationToken).ConfigureAwait(false))
         {
-            _interactionService.DisplayMessage(KnownEmojis.Key, RunCommandStrings.CopyingUserSecrets);
-            var isolatedUserSecretsId = IsolatedUserSecretsHelper.CreateIsolatedUserSecrets(userSecretsId);
-            if (!string.IsNullOrEmpty(isolatedUserSecretsId))
-            {
-                // Override the user secrets ID for this run
-                env["DOTNET_USER_SECRETS_ID"] = isolatedUserSecretsId;
-                return isolatedUserSecretsId;
-            }
+            env[KnownConfigNames.IsolateUserSecrets] = "true";
+            return null;
         }
 
-        return null;
+        var userSecretsId = await QueryUserSecretsIdAsync(appHostFile, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(userSecretsId))
+        {
+            return null;
+        }
+
+        _interactionService.DisplayMessage(KnownEmojis.Key, RunCommandStrings.CopyingUserSecrets);
+        var isolatedUserSecretsId = IsolatedUserSecretsHelper.CreateIsolatedUserSecrets(userSecretsId);
+        if (!string.IsNullOrEmpty(isolatedUserSecretsId))
+        {
+            // Older AppHosts do not understand ASPIRE_ISOLATE_USER_SECRETS, so the CLI preserves
+            // the original --isolated behavior by overriding the user-secrets ID for that run.
+            env["DOTNET_USER_SECRETS_ID"] = isolatedUserSecretsId;
+        }
+
+        return isolatedUserSecretsId;
+    }
+
+    private async Task<bool> AppHostSupportsNativeUserSecretsIsolationAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+    {
+        var info = await _appHostInfoResolver.GetAppHostInfoAsync(appHostFile, cancellationToken).ConfigureAwait(false);
+        if (!SemVersion.TryParse(info.AspireHostingVersion, SemVersionStyles.Any, out var appHostVersion) ||
+            !SemVersion.TryParse(VersionHelper.GetDefaultSdkVersion(), SemVersionStyles.Any, out var currentVersion))
+        {
+            return true;
+        }
+
+        return SemVersion.ComparePrecedence(appHostVersion, currentVersion) >= 0;
     }
 
     private sealed record DirectAppHostRunSpec(
@@ -1397,4 +1419,12 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         DirectoryInfo WorkingDirectory,
         string[] Arguments,
         Dictionary<string, string> Environment);
+
+    private sealed class LegacyIsolatedUserSecretsLease(string isolatedUserSecretsId) : IDisposable
+    {
+        public void Dispose()
+        {
+            IsolatedUserSecretsHelper.CleanupIsolatedUserSecrets(isolatedUserSecretsId);
+        }
+    }
 }

--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -317,8 +317,23 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
             }
         }
 
+        // Preserve the explicit ASPIRE_USER_SECRETS_ID contract: callers that provide a
+        // store are asking the AppHost to persist state there across runs. Otherwise,
+        // isolate the AppHost assembly's default user-secrets store so testing builders
+        // don't mutate developer secrets or race each other when generating parameters.
+        if (!HasConfiguredValue(KnownConfigNames.AspireUserSecretsId) &&
+            !HasConfiguredValue(KnownConfigNames.IsolateUserSecrets))
+        {
+            additionalConfig[KnownConfigNames.IsolateUserSecrets] = "true";
+        }
+
         hostBuilderOptions.Configuration ??= new();
         hostBuilderOptions.Configuration.AddInMemoryCollection(additionalConfig);
+
+        bool HasConfiguredValue(string key) =>
+            existingConfig[key] is not null ||
+            additionalConfig.ContainsKey(key) ||
+            Environment.GetEnvironmentVariable(key) is not null;
 
         void SetDefault(string key, string? value)
         {
@@ -582,7 +597,11 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
             _disposing = true;
             if (innerHost is IAsyncDisposable asyncDisposable)
             {
-                await asyncDisposable.DisposeAsync().AsTask().WaitAsync(appFactory._disposingCts.Token).ConfigureAwait(false);
+                // The factory disposal token is canceled before the app is disposed. Using it here
+                // cancels host disposal before DI can dispose singleton services registered by the AppHost.
+                // The outer DistributedApplicationFactory.DisposeAsync path already bounds app disposal
+                // with the configured shutdown timeout.
+                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
             }
             else
             {

--- a/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
@@ -112,7 +112,15 @@ public static class DistributedApplicationTestingBuilder
         ArgumentNullException.ThrowIfNull(configureBuilder, nameof(configureBuilder));
 
         var factory = new SuspendingDistributedApplicationFactory(entryPoint, args, configureBuilder);
-        return await factory.CreateBuilderAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await factory.CreateBuilderAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            await factory.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
     }
 
     /// <summary>
@@ -228,6 +236,8 @@ public static class DistributedApplicationTestingBuilder
 
         private sealed class Builder(SuspendingDistributedApplicationFactory factory, DistributedApplicationBuilder innerBuilder) : IDistributedApplicationTestingBuilder
         {
+            private DistributedApplication? _app;
+
             public ConfigurationManager Configuration => innerBuilder.Configuration;
 
             public string AppHostDirectory => innerBuilder.AppHostDirectory;
@@ -255,19 +265,61 @@ public static class DistributedApplicationTestingBuilder
             public async Task<DistributedApplication> BuildAsync(CancellationToken cancellationToken)
             {
                 var innerApp = await factory.BuildAsync(cancellationToken).ConfigureAwait(false);
-                return new DelegatedDistributedApplication(new DelegatedHost(factory, innerApp));
+                return _app = new DelegatedDistributedApplication(new DelegatedHost(factory, innerApp));
             }
 
             public IResourceBuilder<T> CreateResourceBuilder<T>(T resource) where T : IResource => innerBuilder.CreateResourceBuilder(resource);
 
             public void Dispose()
             {
-                factory.Dispose();
+                if (_app is null)
+                {
+                    try
+                    {
+                        Build();
+                    }
+                    catch
+                    {
+                        // Suppress.
+                    }
+                }
+
+                if (_app is { } app)
+                {
+                    app.Dispose();
+                }
+                else
+                {
+                    factory.Dispose();
+                }
             }
 
             public async ValueTask DisposeAsync()
             {
-                await factory.DisposeAsync().ConfigureAwait(false);
+                if (_app is null)
+                {
+                    try
+                    {
+                        await BuildAsync(CancellationToken.None).ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // Suppress.
+                    }
+                }
+
+                if (_app is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                }
+                else if (_app is { } app)
+                {
+                    app.Dispose();
+                }
+                else
+                {
+                    await factory.DisposeAsync().ConfigureAwait(false);
+                }
             }
         }
 
@@ -321,19 +373,23 @@ public static class DistributedApplicationTestingBuilder
         }
     }
 
-    private sealed class TestingBuilder(
-        string[] args,
-        Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder,
-        Assembly? appHostAssembly = null)
-        : IDistributedApplicationTestingBuilder
+    private sealed class TestingBuilder : IDistributedApplicationTestingBuilder
     {
-        private readonly DistributedApplicationBuilder _innerBuilder = CreateInnerBuilder(args, configureBuilder, appHostAssembly);
+        private readonly DistributedApplicationBuilder _innerBuilder;
         private DistributedApplication? _app;
+
+        public TestingBuilder(
+            string[] args,
+            Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder,
+            Assembly? appHostAssembly = null)
+        {
+            _innerBuilder = CreateInnerBuilder(args, configureBuilder, appHostAssembly);
+        }
 
         private static DistributedApplicationBuilder CreateInnerBuilder(
             string[] args,
             Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder,
-            Assembly? appHostAssembly = null)
+            Assembly? appHostAssembly)
         {
             var builder = TestingBuilderFactory.CreateBuilder(args, onConstructing: (applicationOptions, hostBuilderOptions) =>
             {

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -57,6 +57,7 @@
     <Compile Include="$(SharedDir)BackchannelConstants.cs" Link="Backchannel\BackchannelConstants.cs" />
     <Compile Include="$(SharedDir)TerminalHost\*.cs" Link="Backchannel\TerminalHost\%(Filename)%(Extension)" />
     <Compile Include="$(SharedDir)UserSecrets\UserSecretsPathHelper.cs" Link="UserSecrets\UserSecretsPathHelper.cs" />
+    <Compile Include="$(SharedDir)UserSecrets\IsolatedUserSecretsHelper.cs" Link="UserSecrets\IsolatedUserSecretsHelper.cs" />
     <Compile Include="$(SharedDir)X509Certificate2Extensions.cs" Link="Utils\X509Certificate2Extensions.cs" />
     <Compile Include="$(SharedDir)PasswordGenerator.cs" Link="Utils\PasswordGenerator.cs" />
     <Compile Include="$(SharedDir)ProcessSignaler.cs" Link="Utils\ProcessSignaler.cs" />

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -30,11 +30,13 @@ using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Pipelines.Internal;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.UserSecrets;
+using Aspire.Hosting.VersionChecking;
 using Aspire.Shared;
 using Aspire.Shared.UserSecrets;
-using Microsoft.Extensions.Configuration.UserSecrets;
-using Aspire.Hosting.VersionChecking;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.CommandLine;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+using Microsoft.Extensions.Configuration.UserSecrets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -202,8 +204,22 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder = new HostApplicationBuilder(innerBuilderOptions);
 
         var configuredUserSecretsId = _innerBuilder.Configuration[KnownConfigNames.AspireUserSecretsId];
+        var assemblyUserSecretsId = AppHostAssembly?.GetCustomAttribute<UserSecretsIdAttribute>()?.UserSecretsId;
         var userSecretsId = ResolveUserSecretsId(AppHostAssembly, _innerBuilder.Configuration);
-        AddConfiguredUserSecrets(_innerBuilder.Configuration, AppHostAssembly, configuredUserSecretsId, _innerBuilder.Environment.IsDevelopment());
+        var isolateUserSecrets = _innerBuilder.Configuration.GetValue(KnownConfigNames.IsolateUserSecrets, false);
+        var isolatedUserSecretsSourceIndex = -1;
+        if (isolateUserSecrets)
+        {
+            isolatedUserSecretsSourceIndex = RemoveUserSecretsSource(_innerBuilder.Configuration, assemblyUserSecretsId);
+            if (isolatedUserSecretsSourceIndex < 0)
+            {
+                isolatedUserSecretsSourceIndex = FindUserSecretsSourceInsertionIndex(_innerBuilder.Configuration);
+            }
+        }
+        else
+        {
+            AddConfiguredUserSecrets(_innerBuilder.Configuration, AppHostAssembly, configuredUserSecretsId, _innerBuilder.Environment.IsDevelopment());
+        }
 
         _innerBuilder.Services.AddSingleton(TimeProvider.System);
 
@@ -340,15 +356,28 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             return _directoryService;
         });
 
-        // Create and register the user secrets manager (uses the userSecretsId resolved at top of constructor)
+        // Create and register the user secrets manager. Isolated mode redirects generated parameter
+        // writes to a per-run user-secrets ID so parallel AppHost instances don't share state.
         var userSecretsFactory = new UserSecretsManagerFactory(_directoryService);
 
-        _userSecretsManager = !string.IsNullOrEmpty(userSecretsId)
-            ? userSecretsFactory.GetOrCreateFromId(userSecretsId)
-            : NoopUserSecretsManager.Instance;
+        if (isolateUserSecrets && !string.IsNullOrEmpty(userSecretsId))
+        {
+            _userSecretsManager = userSecretsFactory.CreateIsolatedFromId(userSecretsId);
 
-        // Always register IUserSecretsManager so dependencies can resolve
-        _innerBuilder.Services.AddSingleton(_userSecretsManager);
+            if (_innerBuilder.Environment.IsDevelopment())
+            {
+                AddJsonFileAt(_innerBuilder.Configuration, _userSecretsManager.FilePath, isolatedUserSecretsSourceIndex);
+            }
+        }
+        else
+        {
+            _userSecretsManager = !string.IsNullOrEmpty(userSecretsId)
+                ? userSecretsFactory.GetOrCreateFromId(userSecretsId)
+                : NoopUserSecretsManager.Instance;
+        }
+
+        // Always register IUserSecretsManager so dependencies can resolve.
+        _innerBuilder.Services.AddSingleton<IUserSecretsManager>(_ => _userSecretsManager);
 
         _innerBuilder.Services.AddSingleton(sp => new DistributedApplicationModel(Resources));
         _innerBuilder.Services.AddSingleton<PipelineExecutor>();
@@ -791,31 +820,52 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
     /// <inheritdoc />
     public DistributedApplication Build()
     {
-        ProfilingTelemetry.RecordAppHostStartupEvent(ProfilingTelemetry.Events.AppHostBuildStarted, _innerBuilder.Configuration);
-        LogAppBuilding(this);
+        DistributedApplication? application = null;
 
-        // ResourceCollection enforces unique names on Add/Insert/Set, but IResourceCollection
-        // could have a different implementation that doesn't. Validate as a safety net.
-        foreach (var duplicateResourceName in Resources.GroupBy(r => r.Name, StringComparers.ResourceName)
-            .Where(g => g.Count() > 1)
-            .Select(g => g.Key))
+        try
         {
-            throw new DistributedApplicationException($"Multiple resources with the name '{duplicateResourceName}'. Resource names are case-insensitive.");
-        }
+            ProfilingTelemetry.RecordAppHostStartupEvent(ProfilingTelemetry.Events.AppHostBuildStarted, _innerBuilder.Configuration);
+            LogAppBuilding(this);
 
-        // Validate resource names. Resources added directly to the collection bypass AddResource validation.
-        foreach (var resource in Resources)
+            // ResourceCollection enforces unique names on Add/Insert/Set, but IResourceCollection
+            // could have a different implementation that doesn't. Validate as a safety net.
+            foreach (var duplicateResourceName in Resources.GroupBy(r => r.Name, StringComparers.ResourceName)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key))
+            {
+                throw new DistributedApplicationException($"Multiple resources with the name '{duplicateResourceName}'. Resource names are case-insensitive.");
+            }
+
+            // Validate resource names. Resources added directly to the collection bypass AddResource validation.
+            foreach (var resource in Resources)
+            {
+                ValidateResourceName(resource);
+            }
+
+            application = new DistributedApplication(_innerBuilder.Build());
+
+            _executionContextOptions.Services = application.Services.GetRequiredService<IServiceProvider>();
+            // UserSecretsManager can own isolated stores allocated while configuring the builder. Resolve it
+            // after the host is built so DI tracks and disposes those stores with the host.
+            application.Services.GetRequiredService<IUserSecretsManager>();
+
+            LogAppBuilt(application);
+            ProfilingTelemetry.RecordAppHostStartupEvent(ProfilingTelemetry.Events.AppHostBuildCompleted, _innerBuilder.Configuration);
+            return application;
+        }
+        catch
         {
-            ValidateResourceName(resource);
+            if (application is not null)
+            {
+                application.Dispose();
+            }
+            else if (_userSecretsManager is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+
+            throw;
         }
-
-        var application = new DistributedApplication(_innerBuilder.Build());
-
-        _executionContextOptions.Services = application.Services.GetRequiredService<IServiceProvider>();
-
-        LogAppBuilt(application);
-        ProfilingTelemetry.RecordAppHostStartupEvent(ProfilingTelemetry.Events.AppHostBuildCompleted, _innerBuilder.Configuration);
-        return application;
     }
 
     /// <inheritdoc />
@@ -865,16 +915,17 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         }
     }
 
-    internal static void RemoveUserSecretsSource(IConfigurationManager configuration, string? userSecretsId)
+    internal static int RemoveUserSecretsSource(IConfigurationManager configuration, string? userSecretsId)
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
         if (string.IsNullOrWhiteSpace(userSecretsId))
         {
-            return;
+            return -1;
         }
 
         var userSecretsFilePath = Path.GetFullPath(UserSecretsPathHelper.GetSecretsPathFromSecretsId(userSecretsId));
+        var removedSourceIndex = -1;
 
         for (var i = configuration.Sources.Count - 1; i >= 0; i--)
         {
@@ -893,8 +944,39 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             if (filePath is not null && PathsEqual(filePath, userSecretsFilePath))
             {
                 configuration.Sources.RemoveAt(i);
+                removedSourceIndex = i;
             }
         }
+
+        return removedSourceIndex;
+    }
+
+    private static void AddJsonFileAt(IConfigurationManager configuration, string filePath, int sourceIndex)
+    {
+        var sourceCount = configuration.Sources.Count;
+        configuration.AddJsonFile(filePath, optional: true, reloadOnChange: false);
+
+        if (sourceIndex < 0 || sourceIndex >= sourceCount)
+        {
+            return;
+        }
+
+        var source = configuration.Sources[configuration.Sources.Count - 1];
+        configuration.Sources.RemoveAt(configuration.Sources.Count - 1);
+        configuration.Sources.Insert(sourceIndex, source);
+    }
+
+    private static int FindUserSecretsSourceInsertionIndex(IConfigurationManager configuration)
+    {
+        for (var i = 0; i < configuration.Sources.Count; i++)
+        {
+            if (configuration.Sources[i] is EnvironmentVariablesConfigurationSource { Prefix: null or "" } or CommandLineConfigurationSource)
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     private static void ValidateResourceName(IResource resource)

--- a/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
+++ b/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
@@ -55,6 +55,23 @@ internal sealed class UserSecretsManagerFactory
     }
 
     /// <summary>
+    /// Creates a user secrets manager backed by an isolated user secrets ID.
+    /// </summary>
+    public IUserSecretsManager CreateIsolatedFromId(string userSecretsId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userSecretsId);
+
+        var isolatedUserSecretsId = IsolatedUserSecretsHelper.CreateIsolatedUserSecrets(userSecretsId);
+        if (isolatedUserSecretsId is null)
+        {
+            return NoopUserSecretsManager.Instance;
+        }
+
+        var filePath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(isolatedUserSecretsId);
+        return new UserSecretsManager(filePath, _fileSystemService, isolatedUserSecretsId);
+    }
+
+    /// <summary>
     /// Gets or creates a user secrets manager for the specified user secrets ID.
     /// </summary>
     public IUserSecretsManager GetOrCreateFromId(string? userSecretsId)
@@ -77,17 +94,20 @@ internal sealed class UserSecretsManagerFactory
         return GetOrCreateFromId(userSecretsId);
     }
 
-    private sealed class UserSecretsManager : IUserSecretsManager
+    private sealed class UserSecretsManager : IUserSecretsManager, IDisposable, IAsyncDisposable
     {
         private static readonly JsonSerializerOptions s_jsonSerializerOptions = new() { WriteIndented = true };
 
         private readonly SemaphoreSlim _semaphore = new(1, 1);
         private readonly IFileSystemService _fileSystemService;
+        private readonly string? _isolatedUserSecretsId;
+        private bool _disposed;
 
-        public UserSecretsManager(string filePath, IFileSystemService fileSystemService)
+        public UserSecretsManager(string filePath, IFileSystemService fileSystemService, string? isolatedUserSecretsId = null)
         {
             FilePath = filePath;
             _fileSystemService = fileSystemService;
+            _isolatedUserSecretsId = isolatedUserSecretsId;
         }
 
         public bool IsAvailable => true;
@@ -174,6 +194,24 @@ internal sealed class UserSecretsManagerFactory
             {
                 _semaphore.Release();
             }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _semaphore.Dispose();
+            IsolatedUserSecretsHelper.CleanupIsolatedUserSecrets(_isolatedUserSecretsId);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return ValueTask.CompletedTask;
         }
 
         private void SetSecretCore(string name, string value)

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -44,6 +44,7 @@ internal static class KnownConfigNames
     public const string AppHostLogLevel = "ASPIRE_APPHOST_LOGLEVEL";
     public const string AspireLogLevel = "ASPIRE_LOGLEVEL";
     public const string TestingDisableHttpClient = "ASPIRE_TESTING_DISABLE_HTTP_CLIENT";
+    public const string IsolateUserSecrets = "ASPIRE_ISOLATE_USER_SECRETS";
     public const string InteractivityEnabled = "ASPIRE_INTERACTIVITY_ENABLED";
     public const string EnableContainerTunnel = "ASPIRE_ENABLE_CONTAINER_TUNNEL";
     public const string AspireUserSecretsId = "ASPIRE_USER_SECRETS_ID";

--- a/src/Shared/UserSecrets/IsolatedUserSecretsHelper.cs
+++ b/src/Shared/UserSecrets/IsolatedUserSecretsHelper.cs
@@ -9,10 +9,10 @@ namespace Aspire.Shared.UserSecrets;
 internal static class IsolatedUserSecretsHelper
 {
     /// <summary>
-    /// Creates an isolated copy of user secrets with a new random ID.
+    /// Creates an isolated user secrets ID with a copy of the existing secrets when present.
     /// </summary>
     /// <param name="originalUserSecretsId">The original user secrets ID from the project.</param>
-    /// <returns>The new isolated user secrets ID, or null if no secrets exist to copy.</returns>
+    /// <returns>The new isolated user secrets ID, or null when no original user secrets ID was specified.</returns>
     public static string? CreateIsolatedUserSecrets(string? originalUserSecretsId)
     {
         if (string.IsNullOrWhiteSpace(originalUserSecretsId))
@@ -22,25 +22,19 @@ internal static class IsolatedUserSecretsHelper
 
         var originalSecretsPath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(originalUserSecretsId);
 
-        // If the original secrets file doesn't exist, there's nothing to copy
-        if (!File.Exists(originalSecretsPath))
-        {
-            return null;
-        }
-
-        // Generate a new random user secrets ID
         var isolatedUserSecretsId = Guid.NewGuid().ToString();
         var isolatedSecretsPath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(isolatedUserSecretsId);
 
-        // Ensure the directory exists
         var isolatedSecretsDir = Path.GetDirectoryName(isolatedSecretsPath);
         if (!string.IsNullOrEmpty(isolatedSecretsDir) && !Directory.Exists(isolatedSecretsDir))
         {
             Directory.CreateDirectory(isolatedSecretsDir);
         }
 
-        // Copy the secrets file
-        File.Copy(originalSecretsPath, isolatedSecretsPath, overwrite: true);
+        if (File.Exists(originalSecretsPath))
+        {
+            File.Copy(originalSecretsPath, isolatedSecretsPath, overwrite: true);
+        }
 
         return isolatedUserSecretsId;
     }

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -2702,14 +2702,91 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task RunCommand_WithIsolatedOption_SetsRandomizePortsAndIsolatesUserSecrets()
+    public async Task RunCommand_WithIsolatedOption_SetsRandomizePortsAndRequestsUserSecretsIsolation()
     {
         var tcs = new TaskCompletionSource<Dictionary<string, string>>(TaskCreationOptions.RunContinuationsAsynchronously);
         var originalUserSecretsId = Guid.NewGuid().ToString();
 
-        // Set up user secrets file to simulate existing secrets
+        var backchannelFactory = (IServiceProvider sp) =>
+        {
+            var backchannel = new TestAppHostBackchannel();
+            backchannel.GetAppHostLogEntriesAsyncCallback = ReturnLogEntriesUntilCancelledAsync;
+            return backchannel;
+        };
+
+        var runnerFactory = (IServiceProvider sp) =>
+        {
+            var runner = new TestDotNetCliRunner();
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
+            runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
+
+            // After issue #17197 the AppHost MSBuild inspection is fetched once and cached,
+            // so the IsAspireHost shape and UserSecretsId both come back in the same response.
+            runner.GetProjectItemsAndPropertiesAsyncCallback = (projectFile, items, properties, options, ct) =>
+            {
+                var json = $$$"""
+                    {
+                      "Properties": {
+                        "IsAspireHost": "true",
+                        "AspireHostingSDKVersion": "{{{VersionHelper.GetDefaultTemplateVersion()}}}",
+                        "UserSecretsId": "{{{originalUserSecretsId}}}"
+                      },
+                      "Items": {}
+                    }
+                    """;
+                return (0, JsonDocument.Parse(json));
+            };
+
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
+            {
+                tcs.SetResult(env?.ToDictionary() ?? []);
+
+                var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
+                backchannelCompletionSource!.SetResult(backchannel);
+                return 0;
+            };
+
+            return runner;
+        };
+
+        var projectLocatorFactory = (IServiceProvider sp) => new TestProjectLocator();
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = projectLocatorFactory;
+            options.AppHostBackchannelFactory = backchannelFactory;
+            options.DotNetCliRunnerFactory = runnerFactory;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run --isolated");
+
+        using var cts = new CancellationTokenSource();
+        var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
+
+        var capturedEnv = await tcs.Task.DefaultTimeout();
+        cts.Cancel();
+
+        var exitCode = await pendingRun.DefaultTimeout();
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        Assert.True(capturedEnv.ContainsKey("DcpPublisher__RandomizePorts"), "DcpPublisher__RandomizePorts should be set in isolated mode");
+        Assert.Equal("true", capturedEnv["DcpPublisher__RandomizePorts"]);
+        Assert.True(capturedEnv.ContainsKey(KnownConfigNames.IsolateUserSecrets), $"{KnownConfigNames.IsolateUserSecrets} should be set in isolated mode");
+        Assert.Equal("true", capturedEnv[KnownConfigNames.IsolateUserSecrets]);
+        Assert.False(capturedEnv.ContainsKey("DOTNET_USER_SECRETS_ID"), "The AppHost owns user-secrets isolation.");
+    }
+
+    [Fact]
+    public async Task RunCommand_WithIsolatedOption_UsesLegacyUserSecretsIsolationForOldAppHost()
+    {
+        var tcs = new TaskCompletionSource<Dictionary<string, string>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var originalUserSecretsId = Guid.NewGuid().ToString();
         var originalSecretsPath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(originalUserSecretsId);
         var originalSecretsDir = Path.GetDirectoryName(originalSecretsPath)!;
+        string? isolatedSecretsPath = null;
         Directory.CreateDirectory(originalSecretsDir);
         File.WriteAllText(originalSecretsPath, """{"TestSecret": "TestValue"}""");
 
@@ -2726,17 +2803,15 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             {
                 var runner = new TestDotNetCliRunner();
                 runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
-                runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
+                runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, "13.4.0");
 
-                // After issue #17197 the AppHost MSBuild inspection is fetched once and cached,
-                // so the IsAspireHost shape and UserSecretsId both come back in the same response.
                 runner.GetProjectItemsAndPropertiesAsyncCallback = (projectFile, items, properties, options, ct) =>
                 {
                     var json = $$$"""
                         {
                           "Properties": {
                             "IsAspireHost": "true",
-                            "AspireHostingSDKVersion": "{{{VersionHelper.GetDefaultTemplateVersion()}}}",
+                            "AspireHostingSDKVersion": "13.4.0",
                             "UserSecretsId": "{{{originalUserSecretsId}}}"
                           },
                           "Items": {}
@@ -2747,11 +2822,19 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
                 runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
                 {
-                    // Capture environment variables
                     tcs.SetResult(env?.ToDictionary() ?? []);
 
                     var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
                     backchannelCompletionSource!.SetResult(backchannel);
+
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                    }
+
                     return 0;
                 };
 
@@ -2775,34 +2858,40 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             using var cts = new CancellationTokenSource();
             var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
 
-            // Give the command time to start and set up
             var capturedEnv = await tcs.Task.DefaultTimeout();
+            Assert.True(capturedEnv.ContainsKey("DcpPublisher__RandomizePorts"), "DcpPublisher__RandomizePorts should be set in isolated mode");
+            Assert.Equal("true", capturedEnv["DcpPublisher__RandomizePorts"]);
+            Assert.False(capturedEnv.ContainsKey(KnownConfigNames.IsolateUserSecrets), "Old AppHosts do not understand the native isolation flag.");
+            Assert.True(capturedEnv.TryGetValue("DOTNET_USER_SECRETS_ID", out var isolatedUserSecretsId), "Old AppHosts need the CLI to override DOTNET_USER_SECRETS_ID.");
+            Assert.NotEqual(originalUserSecretsId, isolatedUserSecretsId);
 
-            // Simulate CTRL-C
+            isolatedSecretsPath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(isolatedUserSecretsId);
+            Assert.True(File.Exists(isolatedSecretsPath));
+            Assert.Contains("TestSecret", File.ReadAllText(isolatedSecretsPath));
+
             cts.Cancel();
 
             var exitCode = await pendingRun.DefaultTimeout();
             Assert.Equal(CliExitCodes.Success, exitCode);
-
-            // Verify DcpPublisher__RandomizePorts is set to true for isolated mode
-            Assert.True(capturedEnv.ContainsKey("DcpPublisher__RandomizePorts"), "DcpPublisher__RandomizePorts should be set in isolated mode");
-            Assert.Equal("true", capturedEnv["DcpPublisher__RandomizePorts"]);
-
-            // Verify DOTNET_USER_SECRETS_ID is set to a different value (isolated secrets)
-            Assert.True(capturedEnv.ContainsKey("DOTNET_USER_SECRETS_ID"), "DOTNET_USER_SECRETS_ID should be set in isolated mode with user secrets");
-            Assert.NotEqual(originalUserSecretsId, capturedEnv["DOTNET_USER_SECRETS_ID"]);
-
-            // Verify the isolated secrets ID is a valid GUID
-            Assert.True(Guid.TryParse(capturedEnv["DOTNET_USER_SECRETS_ID"], out _), "Isolated user secrets ID should be a valid GUID");
         }
         finally
         {
-            // Clean up the original secrets file we created
-            if (File.Exists(originalSecretsPath))
+            if (!string.IsNullOrEmpty(isolatedSecretsPath))
             {
-                File.Delete(originalSecretsPath);
+                var isolatedSecretsDir = Path.GetDirectoryName(isolatedSecretsPath)!;
+                if (File.Exists(isolatedSecretsPath))
+                {
+                    File.Delete(isolatedSecretsPath);
+                }
+
+                if (Directory.Exists(isolatedSecretsDir) && Directory.GetFiles(isolatedSecretsDir).Length == 0)
+                {
+                    Directory.Delete(isolatedSecretsDir);
+                }
             }
-            if (Directory.Exists(originalSecretsDir) && !Directory.EnumerateFileSystemEntries(originalSecretsDir).Any())
+
+            File.Delete(originalSecretsPath);
+            if (Directory.Exists(originalSecretsDir) && Directory.GetFiles(originalSecretsDir).Length == 0)
             {
                 Directory.Delete(originalSecretsDir);
             }

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Tests;
 using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.UserSecrets;
 using Aspire.Hosting.Utils;
 using Aspire.TestProject;
 using Aspire.TestUtilities;
@@ -17,12 +18,16 @@ using Xunit;
 
 #pragma warning disable ASPIRECERTIFICATES001
 #pragma warning disable ASPIRECONTAINERSHELLEXECUTION001
+#pragma warning disable ASPIREFILESYSTEM001
+#pragma warning disable ASPIREUSERSECRETS001
 
 namespace Aspire.Hosting.Testing.Tests;
 
 public class TestingBuilderTests(ITestOutputHelper output)
 {
     private static readonly TimeSpan s_appAliveCheckTimeout = TimeSpan.FromMinutes(1);
+    private const string AspireUserSecretsIdConfigKey = "ASPIRE_USER_SECRETS_ID";
+    private const string IsolateUserSecretsConfigKey = "ASPIRE_ISOLATE_USER_SECRETS";
 
     [Fact]
     [ActiveIssue("https://github.com/dotnet/dnceng/issues/6232", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnAzdoBuildMachine))]
@@ -126,6 +131,295 @@ public class TestingBuilderTests(ITestOutputHelper output)
     {
         var builder = await DistributedApplicationTestingBuilder.CreateAsync<Projects.TestingAppHost1_AppHost>();
         Assert.Equal(Environments.Development, builder.Environment.EnvironmentName);
+    }
+
+    [Fact]
+    public async Task CreateAsyncUsesCopiedIsolatedUserSecretsStore()
+    {
+        var sourceUserSecretsId = Guid.NewGuid().ToString();
+        var sourceManager = CreateUserSecretsManager(sourceUserSecretsId);
+        var probeKey = $"IsolationProbe:{Guid.NewGuid():N}";
+        var probeValue = Guid.NewGuid().ToString("N");
+        Assert.True(sourceManager.TrySetSecret(probeKey, probeValue));
+
+        string? isolatedUserSecretsFilePath = null;
+        try
+        {
+            await using var builder = await DistributedApplicationTestingBuilder.CreateAsync(
+                typeof(Projects.TestingAppHost1_AppHost),
+                [$"{AspireUserSecretsIdConfigKey}={sourceUserSecretsId}", $"{IsolateUserSecretsConfigKey}=true"],
+                (_, _) => { });
+
+            isolatedUserSecretsFilePath = builder.UserSecretsManager.FilePath;
+
+            Assert.Equal(sourceUserSecretsId, builder.Configuration[AspireUserSecretsIdConfigKey]);
+            Assert.NotEqual(sourceManager.FilePath, isolatedUserSecretsFilePath);
+            Assert.Equal("secrets.json", Path.GetFileName(isolatedUserSecretsFilePath));
+            Assert.True(Directory.Exists(Path.GetDirectoryName(isolatedUserSecretsFilePath)));
+            Assert.Equal(probeValue, builder.Configuration[probeKey]);
+            Assert.True(builder.UserSecretsManager.TrySetSecret("IsolationProbe", "isolated"));
+            Assert.True(File.Exists(isolatedUserSecretsFilePath));
+        }
+        finally
+        {
+            DeleteUserSecretsFile(sourceManager.FilePath);
+        }
+
+        Assert.False(File.Exists(isolatedUserSecretsFilePath));
+    }
+
+    [Fact]
+    public void CreateUsesCopiedIsolatedUserSecretsStore()
+    {
+        var sourceUserSecretsId = Guid.NewGuid().ToString();
+        var sourceManager = CreateUserSecretsManager(sourceUserSecretsId);
+        var probeKey = $"IsolationProbe:{Guid.NewGuid():N}";
+        var probeValue = Guid.NewGuid().ToString("N");
+        Assert.True(sourceManager.TrySetSecret(probeKey, probeValue));
+
+        string? isolatedUserSecretsFilePath = null;
+        try
+        {
+            using var builder = DistributedApplicationTestingBuilder.Create(
+                [$"{AspireUserSecretsIdConfigKey}={sourceUserSecretsId}", $"{IsolateUserSecretsConfigKey}=true"],
+                (_, _) => { },
+                typeof(Projects.TestingAppHost1_AppHost).Assembly);
+
+            isolatedUserSecretsFilePath = builder.UserSecretsManager.FilePath;
+
+            Assert.Equal(sourceUserSecretsId, builder.Configuration[AspireUserSecretsIdConfigKey]);
+            Assert.NotEqual(sourceManager.FilePath, isolatedUserSecretsFilePath);
+            Assert.Equal("secrets.json", Path.GetFileName(isolatedUserSecretsFilePath));
+            Assert.True(Directory.Exists(Path.GetDirectoryName(isolatedUserSecretsFilePath)));
+            Assert.Equal(probeValue, builder.Configuration[probeKey]);
+            Assert.True(builder.UserSecretsManager.TrySetSecret("IsolationProbe", "isolated"));
+            Assert.True(File.Exists(isolatedUserSecretsFilePath));
+        }
+        finally
+        {
+            DeleteUserSecretsFile(sourceManager.FilePath);
+        }
+
+        Assert.False(File.Exists(isolatedUserSecretsFilePath));
+    }
+
+    [Fact]
+    public void ConfigureBuilderDefaultsToIsolatedUserSecretsWhenUserSecretsIdIsImplicit()
+    {
+        var applicationOptions = new DistributedApplicationOptions();
+        var hostBuilderOptions = new HostApplicationBuilderSettings();
+
+        DistributedApplicationFactory.ConfigureBuilder(
+            [],
+            applicationOptions,
+            hostBuilderOptions,
+            typeof(Projects.TestingAppHost1_AppHost).Assembly,
+            (_, _) => { });
+
+        var configuration = new ConfigurationManager();
+        configuration.AddCommandLine(applicationOptions.Args ?? []);
+        configuration.AddConfiguration(hostBuilderOptions.Configuration!);
+
+        Assert.Equal("true", configuration[IsolateUserSecretsConfigKey]);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CreatePreservesExplicitUserSecretsStoreByDefault(bool directArgs)
+    {
+        var sourceUserSecretsId = Guid.NewGuid().ToString();
+        var sourceManager = CreateUserSecretsManager(sourceUserSecretsId);
+        DeleteUserSecretsFile(sourceManager.FilePath);
+        string[] args = directArgs ? [$"{AspireUserSecretsIdConfigKey}={sourceUserSecretsId}"] : [];
+        Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder = directArgs
+            ? (_, _) => { }
+            : (_, settings) =>
+            {
+                settings.Configuration ??= new();
+                settings.Configuration.AddInMemoryCollection(
+                    new Dictionary<string, string?>
+                    {
+                        [AspireUserSecretsIdConfigKey] = sourceUserSecretsId
+                    });
+            };
+
+        try
+        {
+            using var builder = DistributedApplicationTestingBuilder.Create(
+                args,
+                configureBuilder,
+                typeof(Projects.TestingAppHost1_AppHost).Assembly);
+
+            Assert.Equal(sourceUserSecretsId, builder.Configuration[AspireUserSecretsIdConfigKey]);
+            Assert.Equal(sourceManager.FilePath, builder.UserSecretsManager.FilePath);
+            Assert.True(builder.UserSecretsManager.TrySetSecret("ExplicitStoreProbe", "persisted"));
+            Assert.Equal("persisted", GetUserSecrets(sourceManager.FilePath)["ExplicitStoreProbe"]);
+        }
+        finally
+        {
+            DeleteUserSecretsFile(sourceManager.FilePath);
+        }
+    }
+
+    [Fact]
+    public async Task CreateAsyncCommandLineConfigurationOverridesCopiedIsolatedUserSecretsStore()
+    {
+        var sourceUserSecretsId = Guid.NewGuid().ToString();
+        var sourceManager = CreateUserSecretsManager(sourceUserSecretsId);
+        var probeKey = $"IsolationProbe{Guid.NewGuid():N}";
+        Assert.True(sourceManager.TrySetSecret(probeKey, "secret"));
+
+        string? isolatedUserSecretsFilePath = null;
+        try
+        {
+            await using var builder = await DistributedApplicationTestingBuilder.CreateAsync(
+                typeof(Projects.TestingAppHost1_AppHost),
+                [$"{AspireUserSecretsIdConfigKey}={sourceUserSecretsId}", $"{IsolateUserSecretsConfigKey}=true", $"{probeKey}=command-line"],
+                (_, _) => { });
+
+            isolatedUserSecretsFilePath = builder.UserSecretsManager.FilePath;
+
+            Assert.Equal("command-line", builder.Configuration[probeKey]);
+        }
+        finally
+        {
+            DeleteUserSecretsFile(sourceManager.FilePath);
+        }
+
+        Assert.False(File.Exists(isolatedUserSecretsFilePath));
+    }
+
+    [Fact]
+    public void CreateUsesUniqueIsolatedUserSecretsStoresWhenConfiguredStoreDoesNotExist()
+    {
+        var sourceUserSecretsId = Guid.NewGuid().ToString();
+        var sourceManager = CreateUserSecretsManager(sourceUserSecretsId);
+        DeleteUserSecretsFile(sourceManager.FilePath);
+
+        string? firstIsolatedUserSecretsFilePath = null;
+        string? secondIsolatedUserSecretsFilePath = null;
+
+        try
+        {
+            using var firstBuilder = DistributedApplicationTestingBuilder.Create(
+                [$"{AspireUserSecretsIdConfigKey}={sourceUserSecretsId}", $"{IsolateUserSecretsConfigKey}=true"],
+                (_, _) => { },
+                typeof(Projects.TestingAppHost1_AppHost).Assembly);
+            using var secondBuilder = DistributedApplicationTestingBuilder.Create(
+                [$"{AspireUserSecretsIdConfigKey}={sourceUserSecretsId}", $"{IsolateUserSecretsConfigKey}=true"],
+                (_, _) => { },
+                typeof(Projects.TestingAppHost1_AppHost).Assembly);
+
+            firstIsolatedUserSecretsFilePath = firstBuilder.UserSecretsManager.FilePath;
+            secondIsolatedUserSecretsFilePath = secondBuilder.UserSecretsManager.FilePath;
+
+            Assert.Equal(sourceUserSecretsId, firstBuilder.Configuration[AspireUserSecretsIdConfigKey]);
+            Assert.Equal(sourceUserSecretsId, secondBuilder.Configuration[AspireUserSecretsIdConfigKey]);
+            Assert.NotEqual(sourceManager.FilePath, firstIsolatedUserSecretsFilePath);
+            Assert.NotEqual(sourceManager.FilePath, secondIsolatedUserSecretsFilePath);
+            Assert.NotEqual(firstIsolatedUserSecretsFilePath, secondIsolatedUserSecretsFilePath);
+            Assert.True(Directory.Exists(Path.GetDirectoryName(firstIsolatedUserSecretsFilePath)));
+            Assert.True(Directory.Exists(Path.GetDirectoryName(secondIsolatedUserSecretsFilePath)));
+
+            Assert.True(firstBuilder.UserSecretsManager.TrySetSecret("IsolationProbe", "first"));
+            Assert.True(secondBuilder.UserSecretsManager.TrySetSecret("IsolationProbe", "second"));
+            Assert.False(File.Exists(sourceManager.FilePath));
+            Assert.True(File.Exists(firstIsolatedUserSecretsFilePath));
+            Assert.True(File.Exists(secondIsolatedUserSecretsFilePath));
+        }
+        finally
+        {
+            DeleteUserSecretsFile(sourceManager.FilePath);
+        }
+
+        Assert.False(File.Exists(firstIsolatedUserSecretsFilePath));
+        Assert.False(File.Exists(secondIsolatedUserSecretsFilePath));
+    }
+
+    [Fact]
+    public void CreateDisposesIsolatedUserSecretsStoreWhenBuildFailsBeforeHostIsBuilt()
+    {
+        var sourceUserSecretsId = Guid.NewGuid().ToString();
+        var sourceManager = CreateUserSecretsManager(sourceUserSecretsId);
+        DeleteUserSecretsFile(sourceManager.FilePath);
+
+        string? isolatedUserSecretsFilePath = null;
+
+        try
+        {
+            using var builder = DistributedApplicationTestingBuilder.Create(
+                [$"{AspireUserSecretsIdConfigKey}={sourceUserSecretsId}", $"{IsolateUserSecretsConfigKey}=true"],
+                (_, _) => { },
+                typeof(Projects.TestingAppHost1_AppHost).Assembly);
+
+            var longName = new string('a', 65);
+
+            isolatedUserSecretsFilePath = builder.UserSecretsManager.FilePath;
+            Assert.True(Directory.Exists(Path.GetDirectoryName(isolatedUserSecretsFilePath)));
+            builder.Resources.Add(new ContainerResource(longName));
+
+            var ex = Assert.Throws<ArgumentException>(builder.Build);
+            Assert.Equal($"Resource name '{longName}' is invalid. Name must be between 1 and 64 characters long. (Parameter 'name')", ex.Message);
+        }
+        finally
+        {
+            DeleteUserSecretsFile(sourceManager.FilePath);
+        }
+
+        Assert.False(Directory.Exists(Path.GetDirectoryName(isolatedUserSecretsFilePath)));
+    }
+
+    [Fact]
+    public async Task ConcurrentTestingBuildersPersistGeneratedParametersToIsolatedStores()
+    {
+        var sourceUserSecretsId = Guid.NewGuid().ToString();
+        var sourceManager = CreateUserSecretsManager(sourceUserSecretsId);
+        DeleteUserSecretsFile(sourceManager.FilePath);
+
+        var appHostAssembly = typeof(Projects.TestingAppHost1_AppHost).Assembly;
+        var results = await Task.WhenAll(
+            Enumerable.Range(0, 2).Select(_ => Task.Run(CreatePersistedParameter)));
+
+        Assert.NotEqual(results[0].IsolatedUserSecretsFilePath, results[1].IsolatedUserSecretsFilePath);
+        Assert.False(File.Exists(sourceManager.FilePath));
+
+        foreach (var result in results)
+        {
+            Assert.Equal(result.GeneratedValue, result.PersistedValue);
+            Assert.False(File.Exists(result.IsolatedUserSecretsFilePath));
+        }
+
+        PersistedParameterResult CreatePersistedParameter()
+        {
+            string? isolatedUserSecretsFilePath = null;
+            string? generatedValue = null;
+            string? persistedValue = null;
+
+            using (var builder = DistributedApplicationTestingBuilder.Create(
+                [$"{AspireUserSecretsIdConfigKey}={sourceUserSecretsId}", $"{IsolateUserSecretsConfigKey}=true"],
+                (_, _) => { },
+                appHostAssembly))
+            {
+                isolatedUserSecretsFilePath = builder.UserSecretsManager.FilePath;
+                Assert.Equal(sourceUserSecretsId, builder.Configuration[AspireUserSecretsIdConfigKey]);
+                Assert.NotEqual(sourceManager.FilePath, isolatedUserSecretsFilePath);
+
+                var parameter = builder.AddParameter(
+                    "concurrent-password",
+                    new GenerateParameterDefault(),
+                    secret: true,
+                    persist: true).Resource;
+
+                generatedValue = parameter.GetValueAsync(CancellationToken.None).AsTask().GetAwaiter().GetResult();
+                persistedValue = GetUserSecrets(isolatedUserSecretsFilePath)["Parameters:concurrent-password"];
+            }
+
+            return new PersistedParameterResult(
+                isolatedUserSecretsFilePath!,
+                generatedValue!,
+                persistedValue!);
+        }
     }
 
     [Theory]
@@ -638,6 +932,56 @@ public class TestingBuilderTests(ITestOutputHelper output)
         var ex = await Assert.ThrowsAsync<ArgumentException>(() => app.StartAsync());
         Assert.Equal("ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL must contain a local loopback address.", ex.Message);
     }
+
+    private static IUserSecretsManager CreateUserSecretsManager(string userSecretsId)
+    {
+        var factory = new UserSecretsManagerFactory(
+            new FileSystemService(
+                new ConfigurationBuilder().Build()));
+        return factory.GetOrCreateFromId(userSecretsId);
+    }
+
+    private static void DeleteUserSecretsFile(string? userSecretsFilePath)
+    {
+        if (string.IsNullOrWhiteSpace(userSecretsFilePath))
+        {
+            return;
+        }
+
+        if (File.Exists(userSecretsFilePath))
+        {
+            File.Delete(userSecretsFilePath);
+        }
+
+        var directory = Path.GetDirectoryName(userSecretsFilePath);
+        if (!string.IsNullOrEmpty(directory) &&
+            Directory.Exists(directory) &&
+            !Directory.EnumerateFileSystemEntries(directory).Any())
+        {
+            Directory.Delete(directory);
+        }
+    }
+
+    private static Dictionary<string, string?> GetUserSecrets(string userSecretsFilePath)
+    {
+        if (!File.Exists(userSecretsFilePath))
+        {
+            return [];
+        }
+
+        var config = new ConfigurationBuilder()
+            .AddJsonFile(userSecretsFilePath, optional: true)
+            .Build();
+
+        return config.AsEnumerable()
+            .Where(kvp => kvp.Value is not null)
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+    }
+
+    private sealed record PersistedParameterResult(
+        string IsolatedUserSecretsFilePath,
+        string GeneratedValue,
+        string PersistedValue);
 
     private sealed record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
     {

--- a/tests/Aspire.Hosting.Tests/IsolatedUserSecretsHelperTests.cs
+++ b/tests/Aspire.Hosting.Tests/IsolatedUserSecretsHelperTests.cs
@@ -3,15 +3,15 @@
 
 using Aspire.Shared.UserSecrets;
 
-namespace Aspire.Cli.Tests.Utils;
+namespace Aspire.Hosting.Tests;
 
+[Trait("Partition", "2")]
 public class IsolatedUserSecretsHelperTests : IDisposable
 {
     private readonly List<string> _createdSecretIds = [];
 
     public void Dispose()
     {
-        // Clean up any secrets created during tests
         foreach (var secretId in _createdSecretIds)
         {
             IsolatedUserSecretsHelper.CleanupIsolatedUserSecrets(secretId);
@@ -43,19 +43,23 @@ public class IsolatedUserSecretsHelperTests : IDisposable
     }
 
     [Fact]
-    public void CreateIsolatedUserSecrets_WithNonExistentSecrets_ReturnsNull()
+    public void CreateIsolatedUserSecrets_WithNonExistentSecrets_CreatesIsolatedIdWithoutCopy()
     {
         var nonExistentId = Guid.NewGuid().ToString();
 
         var result = IsolatedUserSecretsHelper.CreateIsolatedUserSecrets(nonExistentId);
 
-        Assert.Null(result);
+        Assert.NotNull(result);
+        Assert.NotEqual(nonExistentId, result);
+        _createdSecretIds.Add(result);
+
+        var isolatedPath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(result);
+        Assert.False(File.Exists(isolatedPath));
     }
 
     [Fact]
     public void CreateIsolatedUserSecrets_WithExistingSecrets_CreatesIsolatedCopy()
     {
-        // Arrange - create a source secrets file
         var sourceId = Guid.NewGuid().ToString();
         var sourcePath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(sourceId);
         var sourceDir = Path.GetDirectoryName(sourcePath)!;
@@ -63,10 +67,8 @@ public class IsolatedUserSecretsHelperTests : IDisposable
         File.WriteAllText(sourcePath, """{"TestKey": "TestValue"}""");
         _createdSecretIds.Add(sourceId);
 
-        // Act
         var isolatedId = IsolatedUserSecretsHelper.CreateIsolatedUserSecrets(sourceId);
 
-        // Assert
         Assert.NotNull(isolatedId);
         Assert.NotEqual(sourceId, isolatedId);
         _createdSecretIds.Add(isolatedId);
@@ -108,23 +110,18 @@ public class IsolatedUserSecretsHelperTests : IDisposable
     [Fact]
     public void CleanupIsolatedUserSecrets_WithExistingSecrets_DeletesSecretsFileAndDirectory()
     {
-        // Arrange - create a secrets file
         var secretId = Guid.NewGuid().ToString();
         var secretsPath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(secretId);
         var secretsDir = Path.GetDirectoryName(secretsPath)!;
         Directory.CreateDirectory(secretsDir);
         File.WriteAllText(secretsPath, """{"TestKey": "TestValue"}""");
 
-        // Verify file exists before cleanup
         Assert.True(File.Exists(secretsPath));
         Assert.True(Directory.Exists(secretsDir));
 
-        // Act
         IsolatedUserSecretsHelper.CleanupIsolatedUserSecrets(secretId);
 
-        // Assert
         Assert.False(File.Exists(secretsPath));
         Assert.False(Directory.Exists(secretsDir));
     }
-
 }


### PR DESCRIPTION
## Description

Fixes #13720
Replaces #13774

`DistributedApplicationTestingBuilder` instances can run in parallel for the same AppHost. Before this change, persisted generated parameters wrote into the AppHost's normal user-secrets store, so concurrent test builders could overwrite each other's generated values and mutate machine-local secrets.

This change unifies isolation with an AppHost-owned path. Current CLI/AppHost pairs use `ASPIRE_ISOLATE_USER_SECRETS=true`; Hosting responds by creating a per-run user-secrets ID, copying existing secrets when present, removing the ambient AppHost user-secrets configuration source, reading from the isolated store in Development, and using that same store as the `IUserSecretsManager` write target. `DistributedApplicationTestingBuilder` sets the same isolation flag by default, so testing and CLI behavior share the same implementation.

For compatibility, a new CLI running an older AppHost falls back to the previous CLI-managed behavior: it copies the AppHost user-secrets store, sets `DOTNET_USER_SECRETS_ID` for that run, and cleans up the copied store when the run ends. That preserves `--isolated` for old AppHosts that do not understand `ASPIRE_ISOLATE_USER_SECRETS`.

The default user-secrets manager owns cleanup for isolated stores through DI disposal. The build failure path also disposes the manager directly if the host fails before DI takes ownership, so isolated stores are cleaned up even when `Build()` throws before the host is built.

Validation:

```bash
dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-method "*.RunCommand_WithIsolatedOption_SetsRandomizePortsAndRequestsUserSecretsIsolation" --filter-method "*.RunCommand_WithIsolatedOption_UsesLegacyUserSecretsIsolationForOldAppHost" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"

dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.IsolatedUserSecretsHelperTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"

dotnet test --project tests/Aspire.Hosting.Testing.Tests/Aspire.Hosting.Testing.Tests.csproj --no-launch-profile -- --filter-method "*.ConcurrentTestingBuildersPersistGeneratedParametersToIsolatedStores" --filter-method "*.CreateAsyncUsesCopiedIsolatedUserSecretsStore" --filter-method "*.CreateUsesCopiedIsolatedUserSecretsStore" --filter-method "*.CreateUsesUniqueIsolatedUserSecretsStoresWhenConfiguredStoreDoesNotExist" --filter-method "*.CreateDisposesIsolatedUserSecretsStoreWhenBuildFailsBeforeHostIsBuilt" --filter-method "*.EnvironmentDefaultsToDevelopment" --filter-method "*.CanSetEnvironment" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"

git --no-pager diff --check
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No