### PR TITLE
Add C++ Aspire hosting integration

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -51,6 +51,7 @@
     <Project Path="src/Aspire.Hosting.Integration.Analyzers/Aspire.Hosting.Integration.Analyzers.csproj" />
     <Project Path="src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj" />
     <Project Path="src/Aspire.Hosting.Browsers/Aspire.Hosting.Browsers.csproj" />
+    <Project Path="src/Aspire.Hosting.Cpp/Aspire.Hosting.Cpp.csproj" />
     <Project Path="src/Aspire.Hosting.DevTunnels/Aspire.Hosting.DevTunnels.csproj" />
     <Project Path="src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj" />
     <Project Path="src/Aspire.Hosting.EntityFrameworkCore/Aspire.Hosting.EntityFrameworkCore.csproj" />
@@ -503,6 +504,7 @@
     <Project Path="tests/Aspire.Hosting.Azure.Kubernetes.Tests/Aspire.Hosting.Azure.Kubernetes.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.Browsers.Tests/Aspire.Hosting.Browsers.Tests.csproj" />
+    <Project Path="tests/Aspire.Hosting.Cpp.Tests/Aspire.Hosting.Cpp.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.Containers.Tests/Aspire.Hosting.Containers.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.DevTunnels.Tests/Aspire.Hosting.DevTunnels.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.DotnetTool.Tests/Aspire.Hosting.DotnetTool.Tests.csproj" />

--- a/playground/CppHello/CppHello.AppHost/CppHello.AppHost.csproj
+++ b/playground/CppHello/CppHello.AppHost/CppHello.AppHost.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Cpp" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Docker" />
   </ItemGroup>
 
 </Project>
-

--- a/playground/CppHello/CppHello.AppHost/CppHello.AppHost.csproj
+++ b/playground/CppHello/CppHello.AppHost/CppHello.AppHost.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>3fb85454-5af1-4da2-b645-87ebee3d2c49</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Cpp" />
+  </ItemGroup>
+
+</Project>
+

--- a/playground/CppHello/CppHello.AppHost/Program.cs
+++ b/playground/CppHello/CppHello.AppHost/Program.cs
@@ -4,6 +4,7 @@ builder.AddDockerComposeEnvironment("docker-compose");
 
 builder.AddCMakeApp("cpp-api", "../cpp-api", targetName: "cpp-api")
        .WithVcpkg()
+       .WithCMakeInstall()
        .WithHttpEndpoint(env: "PORT")
        .WithExternalHttpEndpoints();
 

--- a/playground/CppHello/CppHello.AppHost/Program.cs
+++ b/playground/CppHello/CppHello.AppHost/Program.cs
@@ -1,15 +1,9 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-var vcpkgRoot = Environment.GetEnvironmentVariable("VCPKG_ROOT")
-    ?? throw new InvalidOperationException("Set VCPKG_ROOT to the root of your vcpkg installation before running this playground.");
+builder.AddDockerComposeEnvironment("docker-compose");
 
 builder.AddCMakeApp("cpp-api", "../cpp-api", targetName: "cpp-api")
-       .WithRequiredBuildTool("vcpkg", "https://vcpkg.io/")
-       .WithRequiredBuildTool("ninja", "https://ninja-build.org/")
-       .WithConfigureArgs(
-          "-G",
-          "Ninja",
-          $"-DCMAKE_TOOLCHAIN_FILE={Path.Combine(vcpkgRoot, "scripts", "buildsystems", "vcpkg.cmake")}")
+       .WithVcpkg()
        .WithHttpEndpoint(env: "PORT")
        .WithExternalHttpEndpoints();
 

--- a/playground/CppHello/CppHello.AppHost/Program.cs
+++ b/playground/CppHello/CppHello.AppHost/Program.cs
@@ -1,0 +1,16 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+var vcpkgRoot = Environment.GetEnvironmentVariable("VCPKG_ROOT")
+    ?? throw new InvalidOperationException("Set VCPKG_ROOT to the root of your vcpkg installation before running this playground.");
+
+builder.AddCMakeApp("cpp-api", "../cpp-api", targetName: "cpp-api")
+       .WithRequiredBuildTool("vcpkg", "https://vcpkg.io/")
+       .WithRequiredBuildTool("ninja", "https://ninja-build.org/")
+       .WithConfigureArgs(
+          "-G",
+          "Ninja",
+          $"-DCMAKE_TOOLCHAIN_FILE={Path.Combine(vcpkgRoot, "scripts", "buildsystems", "vcpkg.cmake")}")
+       .WithHttpEndpoint(env: "PORT")
+       .WithExternalHttpEndpoints();
+
+builder.Build().Run();

--- a/playground/CppHello/README.md
+++ b/playground/CppHello/README.md
@@ -1,6 +1,7 @@
 # C++ hello Aspire playground
 
 This playground demonstrates hosting a C++ HTTP API built with CMake and vcpkg from an Aspire AppHost.
+The AppHost uses `WithCMakeInstall()`, so deployment copies the CMake install prefix rather than only the built executable.
 
 ## Prerequisites
 
@@ -23,4 +24,4 @@ The C++ API reads the `PORT` environment variable provided by Aspire and exposes
 aspire deploy --apphost CppHello.AppHost/CppHello.AppHost.csproj
 ```
 
-The generated Dockerfile bootstraps vcpkg in the build container, so Docker Compose deployment does not require `VCPKG_ROOT` on the deployment host.
+The generated Dockerfile bootstraps vcpkg in the build container and runs `cmake --install`, so Docker Compose deployment does not require `VCPKG_ROOT` on the deployment host.

--- a/playground/CppHello/README.md
+++ b/playground/CppHello/README.md
@@ -5,7 +5,6 @@ This playground demonstrates hosting a C++ HTTP API built with CMake and vcpkg f
 ## Prerequisites
 
 - CMake
-- Ninja
 - A C++ compiler toolchain
 - vcpkg with `VCPKG_ROOT` set to the root of the vcpkg installation
 
@@ -17,3 +16,11 @@ aspire wait cpp-api --apphost CppHello.AppHost/CppHello.AppHost.csproj
 ```
 
 The C++ API reads the `PORT` environment variable provided by Aspire and exposes `/` and `/health`.
+
+## Deploy to Docker Compose
+
+```bash
+aspire deploy --apphost CppHello.AppHost/CppHello.AppHost.csproj
+```
+
+The generated Dockerfile bootstraps vcpkg in the build container, so Docker Compose deployment does not require `VCPKG_ROOT` on the deployment host.

--- a/playground/CppHello/README.md
+++ b/playground/CppHello/README.md
@@ -1,0 +1,19 @@
+# C++ hello Aspire playground
+
+This playground demonstrates hosting a C++ HTTP API built with CMake and vcpkg from an Aspire AppHost.
+
+## Prerequisites
+
+- CMake
+- Ninja
+- A C++ compiler toolchain
+- vcpkg with `VCPKG_ROOT` set to the root of the vcpkg installation
+
+## Run
+
+```bash
+aspire start --apphost CppHello.AppHost/CppHello.AppHost.csproj
+aspire wait cpp-api --apphost CppHello.AppHost/CppHello.AppHost.csproj
+```
+
+The C++ API reads the `PORT` environment variable provided by Aspire and exposes `/` and `/health`.

--- a/playground/CppHello/cpp-api/CMakeLists.txt
+++ b/playground/CppHello/cpp-api/CMakeLists.txt
@@ -9,3 +9,4 @@ add_executable(cpp-api main.cpp)
 target_compile_features(cpp-api PRIVATE cxx_std_20)
 target_link_libraries(cpp-api PRIVATE httplib::httplib)
 
+install(TARGETS cpp-api RUNTIME DESTINATION bin)

--- a/playground/CppHello/cpp-api/CMakeLists.txt
+++ b/playground/CppHello/cpp-api/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(cpp_api LANGUAGES CXX)
+
+find_package(httplib CONFIG REQUIRED)
+
+add_executable(cpp-api main.cpp)
+
+target_compile_features(cpp-api PRIVATE cxx_std_20)
+target_link_libraries(cpp-api PRIVATE httplib::httplib)
+

--- a/playground/CppHello/cpp-api/main.cpp
+++ b/playground/CppHello/cpp-api/main.cpp
@@ -1,0 +1,26 @@
+#include <cstdlib>
+#include <iostream>
+
+#include <httplib.h>
+
+int main()
+{
+    const char* portValue = std::getenv("PORT");
+    int port = portValue != nullptr ? std::atoi(portValue) : 8080;
+
+    httplib::Server server;
+
+    server.Get("/", [](const httplib::Request&, httplib::Response& response)
+    {
+        response.set_content("Hello from C++ on Aspire!\n", "text/plain");
+    });
+
+    server.Get("/health", [](const httplib::Request&, httplib::Response& response)
+    {
+        response.set_content("Healthy\n", "text/plain");
+    });
+
+    std::cout << "C++ API listening on port " << port << std::endl;
+    server.listen("0.0.0.0", port);
+}
+

--- a/playground/CppHello/cpp-api/vcpkg.json
+++ b/playground/CppHello/cpp-api/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": [
+    {
+      "name": "cpp-httplib",
+      "default-features": false
+    }
+  ]
+}

--- a/src/Aspire.Hosting.Cpp/Aspire.Hosting.Cpp.csproj
+++ b/src/Aspire.Hosting.Cpp/Aspire.Hosting.Cpp.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <PackageTags>aspire integration hosting c++ cpp cmake native framework runtime</PackageTags>
+    <Description>C++ CMake application support for Aspire.</Description>
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Cpp.Tests" />
+  </ItemGroup>
+
+</Project>
+

--- a/src/Aspire.Hosting.Cpp/CMakeAnnotations.cs
+++ b/src/Aspire.Hosting.Cpp/CMakeAnnotations.cs
@@ -25,6 +25,11 @@ internal sealed class CMakeBuildTypeAnnotation(string buildType) : IResourceAnno
     public string BuildType { get; } = buildType;
 }
 
+internal sealed class CMakeVcpkgAnnotation(string? root) : IResourceAnnotation
+{
+    public string? Root { get; } = root;
+}
+
 internal sealed class CMakeConfigureResourceAnnotation(IResourceBuilder<ExecutableResource> resourceBuilder) : IResourceAnnotation
 {
     public IResourceBuilder<ExecutableResource> ResourceBuilder { get; } = resourceBuilder;

--- a/src/Aspire.Hosting.Cpp/CMakeAnnotations.cs
+++ b/src/Aspire.Hosting.Cpp/CMakeAnnotations.cs
@@ -30,12 +30,22 @@ internal sealed class CMakeVcpkgAnnotation(string? root) : IResourceAnnotation
     public string? Root { get; } = root;
 }
 
+internal sealed class CMakeInstallAnnotation(string? executableRelativePath) : IResourceAnnotation
+{
+    public string? ExecutableRelativePath { get; } = executableRelativePath;
+}
+
 internal sealed class CMakeConfigureResourceAnnotation(IResourceBuilder<ExecutableResource> resourceBuilder) : IResourceAnnotation
 {
     public IResourceBuilder<ExecutableResource> ResourceBuilder { get; } = resourceBuilder;
 }
 
 internal sealed class CMakeBuildResourceAnnotation(IResourceBuilder<ExecutableResource> resourceBuilder) : IResourceAnnotation
+{
+    public IResourceBuilder<ExecutableResource> ResourceBuilder { get; } = resourceBuilder;
+}
+
+internal sealed class CMakeInstallResourceAnnotation(IResourceBuilder<ExecutableResource> resourceBuilder) : IResourceAnnotation
 {
     public IResourceBuilder<ExecutableResource> ResourceBuilder { get; } = resourceBuilder;
 }

--- a/src/Aspire.Hosting.Cpp/CMakeAnnotations.cs
+++ b/src/Aspire.Hosting.Cpp/CMakeAnnotations.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Cpp;
+
+internal sealed class CMakeAppArgsAnnotation(object[] args) : IResourceAnnotation
+{
+    public object[] Args { get; } = args;
+}
+
+internal sealed class CMakeConfigureArgsAnnotation(string[] args) : IResourceAnnotation
+{
+    public string[] Args { get; } = args;
+}
+
+internal sealed class CMakeBuildArgsAnnotation(string[] args) : IResourceAnnotation
+{
+    public string[] Args { get; } = args;
+}
+
+internal sealed class CMakeBuildTypeAnnotation(string buildType) : IResourceAnnotation
+{
+    public string BuildType { get; } = buildType;
+}
+
+internal sealed class CMakeConfigureResourceAnnotation(IResourceBuilder<ExecutableResource> resourceBuilder) : IResourceAnnotation
+{
+    public IResourceBuilder<ExecutableResource> ResourceBuilder { get; } = resourceBuilder;
+}
+
+internal sealed class CMakeBuildResourceAnnotation(IResourceBuilder<ExecutableResource> resourceBuilder) : IResourceAnnotation
+{
+    public IResourceBuilder<ExecutableResource> ResourceBuilder { get; } = resourceBuilder;
+}

--- a/src/Aspire.Hosting.Cpp/CMakeAppResource.cs
+++ b/src/Aspire.Hosting.Cpp/CMakeAppResource.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Cpp;
+
+/// <summary>
+/// Represents a C++ application built by CMake in the distributed application model.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This resource allows C++ applications that use CMake to run as part of a distributed application.
+/// The resource configures the CMake build directory, executes the selected CMake target, and can
+/// expose endpoints for service discovery like other Aspire resources.
+/// </para>
+/// <para>
+/// Aspire injects OpenTelemetry environment variables for this resource when configured by
+/// <c>AddCMakeApp</c>, but the C++ application must use an OpenTelemetry-capable library or SDK
+/// to emit telemetry.
+/// </para>
+/// </remarks>
+/// <example>
+/// Add a C++ HTTP API built with CMake:
+/// <code lang="csharp">
+/// var builder = DistributedApplication.CreateBuilder(args);
+///
+/// builder.AddCMakeApp("api", "../cpp-api", targetName: "api")
+///        .WithHttpEndpoint(env: "PORT");
+///
+/// builder.Build().Run();
+/// </code>
+/// </example>
+public class CMakeAppResource : ExecutableResource, IResourceWithServiceDiscovery, IContainerFilesDestinationResource
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CMakeAppResource"/> class.
+    /// </summary>
+    /// <param name="name">The name of the resource in the distributed application model.</param>
+    /// <param name="sourceDirectory">The directory containing the CMake project.</param>
+    /// <param name="buildDirectory">The directory used for CMake configure and build output.</param>
+    /// <param name="targetName">The CMake target to build before running the application.</param>
+    /// <param name="executablePath">The path to the executable produced by the CMake target.</param>
+    /// <param name="runtimeOutputDirectory">The directory passed to CMake for executable target output.</param>
+    public CMakeAppResource(
+        string name,
+        string sourceDirectory,
+        string buildDirectory,
+        string targetName,
+        string executablePath,
+        string runtimeOutputDirectory)
+        : base(name, executablePath, sourceDirectory)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sourceDirectory);
+        ArgumentException.ThrowIfNullOrEmpty(buildDirectory);
+        ArgumentException.ThrowIfNullOrEmpty(targetName);
+        ArgumentException.ThrowIfNullOrEmpty(runtimeOutputDirectory);
+
+        SourceDirectory = sourceDirectory;
+        BuildDirectory = buildDirectory;
+        TargetName = targetName;
+        RuntimeOutputDirectory = runtimeOutputDirectory;
+    }
+
+    /// <summary>
+    /// Gets the directory containing the CMake project.
+    /// </summary>
+    public string SourceDirectory { get; }
+
+    /// <summary>
+    /// Gets the directory used for CMake configure and build output.
+    /// </summary>
+    public string BuildDirectory { get; }
+
+    /// <summary>
+    /// Gets the CMake target to build before running the application.
+    /// </summary>
+    public string TargetName { get; }
+
+    /// <summary>
+    /// Gets the directory passed to CMake for executable target output.
+    /// </summary>
+    public string RuntimeOutputDirectory { get; }
+}
+

--- a/src/Aspire.Hosting.Cpp/CMakeAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Cpp/CMakeAppResourceBuilderExtensions.cs
@@ -25,9 +25,13 @@ public static class CMakeAppResourceBuilderExtensions
     private const string DefaultPublishBuildType = "Release";
     private const string DefaultCMakeHelpLink = "https://cmake.org/download/";
     private const string DefaultVcpkgHelpLink = "https://vcpkg.io/";
+    private const string DefaultInstallDirectoryName = "aspire-install";
     private const string DefaultBuildImage = "debian:bookworm";
     private const string DefaultRuntimeImage = "debian:bookworm-slim";
     private const string VcpkgCommand = "vcpkg";
+    private const string DockerBuildDirectory = "/src/.aspire/cmake/docker-build";
+    private const string DockerRuntimeOutputDirectory = "/src/.aspire/cmake/docker-bin";
+    private const string DockerInstallDirectory = "/src/.aspire/cmake/docker-install";
     private const string DockerVcpkgRoot = "/opt/vcpkg";
     private const string DockerVcpkgToolchainFile = "/opt/vcpkg/scripts/buildsystems/vcpkg.cmake";
 
@@ -142,6 +146,7 @@ public static class CMakeAppResourceBuilderExtensions
                     var publishBuildType = GetBuildType(resource, DefaultPublishBuildType);
                     var targetName = resource.TargetName;
                     var executableName = GetDockerExecutableFileName(targetName);
+                    resource.TryGetLastAnnotation<CMakeInstallAnnotation>(out var installAnnotation);
                     var usesVcpkg = resource.TryGetLastAnnotation<CMakeVcpkgAnnotation>(out _);
                     var buildPackages = usesVcpkg
                         ? "build-essential cmake ninja-build ca-certificates git curl zip unzip tar pkg-config"
@@ -163,22 +168,38 @@ public static class CMakeAppResourceBuilderExtensions
                         .Copy(".", ".")
                         .RunWithMounts(
                             BuildDockerConfigureCommand(resource, publishBuildType),
-                            "type=cache,target=/src/.aspire/cmake/docker-build")
+                            $"type=cache,target={DockerBuildDirectory}")
                         .RunWithMounts(
                             BuildDockerBuildCommand(resource, publishBuildType),
-                            "type=cache,target=/src/.aspire/cmake/docker-build");
+                            $"type=cache,target={DockerBuildDirectory}");
+
+                    if (installAnnotation is not null)
+                    {
+                        buildStage.RunWithMounts(
+                            BuildDockerInstallCommand(publishBuildType),
+                            $"type=cache,target={DockerBuildDirectory}");
+                    }
 
                     context.Builder.AddContainerFilesStages(context.Resource, logger);
 
-                    context.Builder
+                    var runtimeStage = context.Builder
                         .From(runtimeImage)
                         .Run("apt-get update && apt-get install -y --no-install-recommends ca-certificates libstdc++6 && rm -rf /var/lib/apt/lists/*")
                         .Run("groupadd --system --gid 999 app && useradd --system --gid 999 --uid 999 --no-create-home app")
                         .WorkDir("/app")
-                        .AddContainerFiles(context.Resource, "/app", logger)
-                        .CopyFrom(buildStage.StageName!, $"/src/.aspire/cmake/docker-bin/{executableName}", $"/app/{executableName}")
-                        .User("app")
-                        .Entrypoint([$"/app/{executableName}"]);
+                        .AddContainerFiles(context.Resource, "/app", logger);
+
+                    if (installAnnotation is not null)
+                    {
+                        var executableRelativePath = GetDockerInstallExecutableRelativePath(resource, installAnnotation.ExecutableRelativePath);
+                        runtimeStage.CopyFrom(buildStage.StageName!, $"{DockerInstallDirectory}/", "/app/");
+                        runtimeStage.User("app").Entrypoint([$"/app/{executableRelativePath}"]);
+                    }
+                    else
+                    {
+                        runtimeStage.CopyFrom(buildStage.StageName!, $"{DockerRuntimeOutputDirectory}/{executableName}", $"/app/{executableName}");
+                        runtimeStage.User("app").Entrypoint([$"/app/{executableName}"]);
+                    }
                 });
             });
 
@@ -329,6 +350,56 @@ public static class CMakeAppResourceBuilderExtensions
     }
 
     /// <summary>
+    /// Configures the CMake application to run from the output of <c>cmake --install</c>.
+    /// </summary>
+    /// <typeparam name="T">The type of the CMake application resource.</typeparam>
+    /// <param name="builder">The resource builder for the CMake application.</param>
+    /// <param name="executableRelativePath">
+    /// The executable path relative to the CMake install prefix. When <see langword="null"/>, defaults to
+    /// <c>bin/&lt;targetName&gt;</c>.
+    /// </param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// <para>
+    /// Use this method when the CMake project has <c>install()</c> rules that define the runtime closure.
+    /// Local run mode adds a hidden <c>cmake --install</c> resource after the build resource. Generated
+    /// Dockerfiles install into an intermediate prefix and copy the full installed tree into the runtime image.
+    /// </para>
+    /// <para>
+    /// If the installed executable is not under <c>bin/&lt;targetName&gt;</c>, pass the relative path to
+    /// <paramref name="executableRelativePath"/>. Use this parameter instead of <see cref="WithExecutablePath{T}"/>
+    /// when install mode is enabled.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// Run and publish a CMake application from its install output:
+    /// <code lang="csharp">
+    /// builder.AddCMakeApp("api", "../cpp-api", targetName: "api")
+    ///        .WithCMakeInstall()
+    ///        .WithHttpEndpoint(env: "PORT");
+    /// </code>
+    /// </example>
+    [AspireExport]
+    public static IResourceBuilder<T> WithCMakeInstall<T>(this IResourceBuilder<T> builder, string? executableRelativePath = null)
+        where T : CMakeAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ValidateExecutableRelativePath(executableRelativePath);
+
+        builder.WithAnnotation(new CMakeInstallAnnotation(executableRelativePath), ResourceAnnotationMutationBehavior.Replace);
+        builder.WithCommand(GetLocalInstallExecutablePath(builder.Resource, executableRelativePath));
+
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode &&
+            !builder.Resource.TryGetLastAnnotation<CMakeInstallResourceAnnotation>(out _))
+        {
+            AddCMakeInstallResource(builder);
+        }
+
+        return builder;
+    }
+
+    /// <summary>
     /// Configures the path to the executable produced by the CMake target.
     /// </summary>
     /// <typeparam name="T">The type of the CMake application resource.</typeparam>
@@ -342,6 +413,11 @@ public static class CMakeAppResourceBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(executablePath);
+
+        if (builder.Resource.TryGetLastAnnotation<CMakeInstallAnnotation>(out _))
+        {
+            throw new InvalidOperationException("WithExecutablePath cannot be used after WithCMakeInstall. Pass the installed executable path to WithCMakeInstall instead.");
+        }
 
         executablePath = Path.GetFullPath(executablePath, builder.ApplicationBuilder.AppHostDirectory);
         return builder.WithCommand(executablePath);
@@ -416,6 +492,29 @@ public static class CMakeAppResourceBuilderExtensions
             .WaitForCompletion(build);
     }
 
+    private static void AddCMakeInstallResource(IResourceBuilder<CMakeAppResource> builder)
+    {
+        var resource = builder.Resource;
+
+        if (!resource.TryGetLastAnnotation<CMakeBuildResourceAnnotation>(out var buildAnnotation))
+        {
+            throw new InvalidOperationException("CMake install resources can only be added in run mode after the CMake build resource has been created.");
+        }
+
+        var installResource = new ExecutableResource($"{resource.Name}-cmake-install", CMakeCommand, resource.SourceDirectory);
+
+        var install = builder.ApplicationBuilder
+            .AddResource(installResource)
+            .WithArgs(ctx => AddInstallArgs(resource, ctx.Args))
+            .WithRequiredCommand(CMakeCommand, DefaultCMakeHelpLink)
+            .ExcludeFromManifest()
+            .WaitForCompletion(buildAnnotation.ResourceBuilder);
+
+        builder
+            .WithAnnotation(new CMakeInstallResourceAnnotation(install))
+            .WaitForCompletion(install);
+    }
+
     private static void AddConfigureArgs(CMakeAppResource resource, IList<object> args)
     {
         var buildType = GetBuildType(resource, DefaultRunBuildType);
@@ -467,6 +566,16 @@ public static class CMakeAppResourceBuilderExtensions
         }
     }
 
+    private static void AddInstallArgs(CMakeAppResource resource, IList<object> args)
+    {
+        args.Add("--install");
+        args.Add(resource.BuildDirectory);
+        args.Add("--config");
+        args.Add(GetBuildType(resource, DefaultRunBuildType));
+        args.Add("--prefix");
+        args.Add(GetInstallDirectory(resource));
+    }
+
     private static void AddRange(IList<object> args, IEnumerable<object> values)
     {
         foreach (var value in values)
@@ -506,21 +615,19 @@ public static class CMakeAppResourceBuilderExtensions
 
     private static string BuildDockerConfigureCommand(CMakeAppResource resource, string buildType)
     {
-        var runtimeOutputDirectory = "/src/.aspire/cmake/docker-bin";
-
         var args = new List<string>
         {
             "cmake",
             "-S", ".",
-            "-B", "/src/.aspire/cmake/docker-build",
+            "-B", DockerBuildDirectory,
             "-G", "Ninja",
             $"-DCMAKE_BUILD_TYPE={ShellQuote(buildType)}",
-            $"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY={runtimeOutputDirectory}"
+            $"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY={DockerRuntimeOutputDirectory}"
         };
 
         foreach (var configurationName in GetCommonConfigurationNames(buildType))
         {
-            args.Add($"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{configurationName.ToUpperInvariant()}={runtimeOutputDirectory}");
+            args.Add($"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{configurationName.ToUpperInvariant()}={DockerRuntimeOutputDirectory}");
         }
 
         var usesVcpkg = resource.TryGetLastAnnotation<CMakeVcpkgAnnotation>(out _);
@@ -551,7 +658,7 @@ public static class CMakeAppResourceBuilderExtensions
         {
             "cmake",
             "--build",
-            "/src/.aspire/cmake/docker-build",
+            DockerBuildDirectory,
             "--config",
             ShellQuote(buildType),
             "--target",
@@ -569,8 +676,63 @@ public static class CMakeAppResourceBuilderExtensions
         return string.Join(" ", args);
     }
 
+    private static string BuildDockerInstallCommand(string buildType)
+    {
+        var args = new List<string>
+        {
+            "cmake",
+            "--install",
+            DockerBuildDirectory,
+            "--config",
+            ShellQuote(buildType),
+            "--prefix",
+            DockerInstallDirectory
+        };
+
+        return string.Join(" ", args);
+    }
+
     private static string GetVcpkgToolchainFile(string vcpkgRoot) =>
         Path.Combine(vcpkgRoot, "scripts", "buildsystems", "vcpkg.cmake");
+
+    private static string GetInstallDirectory(CMakeAppResource resource) =>
+        Path.Combine(resource.BuildDirectory, DefaultInstallDirectoryName);
+
+    private static string GetLocalInstallExecutablePath(CMakeAppResource resource, string? executableRelativePath)
+    {
+        var relativePath = executableRelativePath ?? Path.Combine("bin", GetExecutableFileName(resource.TargetName));
+        relativePath = NormalizeLocalRelativePath(relativePath);
+
+        return Path.Combine(GetInstallDirectory(resource), relativePath);
+    }
+
+    private static string GetDockerInstallExecutableRelativePath(CMakeAppResource resource, string? executableRelativePath) =>
+        NormalizeDockerRelativePath(executableRelativePath ?? $"bin/{GetDockerExecutableFileName(resource.TargetName)}");
+
+    private static string NormalizeLocalRelativePath(string path) =>
+        path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+
+    private static string NormalizeDockerRelativePath(string path) =>
+        path.Replace('\\', '/');
+
+    private static void ValidateExecutableRelativePath(string? executableRelativePath)
+    {
+        if (executableRelativePath is null)
+        {
+            return;
+        }
+
+        ArgumentException.ThrowIfNullOrEmpty(executableRelativePath);
+
+        if (Path.IsPathRooted(executableRelativePath) ||
+            executableRelativePath.StartsWith('/') ||
+            executableRelativePath.StartsWith('\\') ||
+            executableRelativePath.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries).Contains("..", StringComparer.Ordinal) ||
+            (executableRelativePath.Length >= 2 && char.IsAsciiLetter(executableRelativePath[0]) && executableRelativePath[1] == ':'))
+        {
+            throw new ArgumentException("The executable path must be relative to the CMake install prefix.", nameof(executableRelativePath));
+        }
+    }
 
     private static bool IsVcpkgToolchainFileArg(string arg)
     {

--- a/src/Aspire.Hosting.Cpp/CMakeAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Cpp/CMakeAppResourceBuilderExtensions.cs
@@ -24,8 +24,12 @@ public static class CMakeAppResourceBuilderExtensions
     private const string DefaultRunBuildType = "Debug";
     private const string DefaultPublishBuildType = "Release";
     private const string DefaultCMakeHelpLink = "https://cmake.org/download/";
+    private const string DefaultVcpkgHelpLink = "https://vcpkg.io/";
     private const string DefaultBuildImage = "debian:bookworm";
     private const string DefaultRuntimeImage = "debian:bookworm-slim";
+    private const string VcpkgCommand = "vcpkg";
+    private const string DockerVcpkgRoot = "/opt/vcpkg";
+    private const string DockerVcpkgToolchainFile = "/opt/vcpkg/scripts/buildsystems/vcpkg.cmake";
 
     /// <summary>
     /// Adds a C++ application built with CMake to the application model.
@@ -138,11 +142,24 @@ public static class CMakeAppResourceBuilderExtensions
                     var publishBuildType = GetBuildType(resource, DefaultPublishBuildType);
                     var targetName = resource.TargetName;
                     var executableName = GetDockerExecutableFileName(targetName);
+                    var usesVcpkg = resource.TryGetLastAnnotation<CMakeVcpkgAnnotation>(out _);
+                    var buildPackages = usesVcpkg
+                        ? "build-essential cmake ninja-build ca-certificates git curl zip unzip tar pkg-config"
+                        : "build-essential cmake ninja-build ca-certificates";
 
                     var buildStage = context.Builder
                         .From(buildImage, "build")
                         .WorkDir("/src")
-                        .Run("apt-get update && apt-get install -y --no-install-recommends build-essential cmake ninja-build ca-certificates && rm -rf /var/lib/apt/lists/*")
+                        .Run($"apt-get update && apt-get install -y --no-install-recommends {buildPackages} && rm -rf /var/lib/apt/lists/*");
+
+                    if (usesVcpkg)
+                    {
+                        buildStage
+                            .Run($"git clone --depth=1 https://github.com/microsoft/vcpkg {DockerVcpkgRoot} && {DockerVcpkgRoot}/bootstrap-vcpkg.sh -disableMetrics")
+                            .Env("VCPKG_ROOT", DockerVcpkgRoot);
+                    }
+
+                    buildStage
                         .Copy(".", ".")
                         .RunWithMounts(
                             BuildDockerConfigureCommand(resource, publishBuildType),
@@ -263,6 +280,55 @@ public static class CMakeAppResourceBuilderExtensions
     }
 
     /// <summary>
+    /// Configures the CMake application to use vcpkg for dependency resolution.
+    /// </summary>
+    /// <typeparam name="T">The type of the CMake application resource.</typeparam>
+    /// <param name="builder">The resource builder for the CMake application.</param>
+    /// <param name="vcpkgRoot">
+    /// The path to the local vcpkg root. When <see langword="null"/> in run mode, the <c>VCPKG_ROOT</c>
+    /// environment variable is used.
+    /// </param>
+    /// <param name="helpLink">An optional URL shown to users when the local vcpkg command is missing.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// <para>
+    /// In run mode, this method adds the local vcpkg CMake toolchain file to the configure command and
+    /// declares the <c>vcpkg</c> command as a required build tool. In publish mode, generated Dockerfiles
+    /// bootstrap vcpkg inside the build image and use the container-local toolchain path.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// Use vcpkg manifest mode for a CMake application:
+    /// <code lang="csharp">
+    /// builder.AddCMakeApp("api", "../cpp-api", targetName: "api")
+    ///        .WithVcpkg()
+    ///        .WithHttpEndpoint(env: "PORT");
+    /// </code>
+    /// </example>
+    [AspireExport]
+    public static IResourceBuilder<T> WithVcpkg<T>(this IResourceBuilder<T> builder, string? vcpkgRoot = null, string? helpLink = DefaultVcpkgHelpLink)
+        where T : CMakeAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (vcpkgRoot is not null)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(vcpkgRoot);
+        }
+
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        {
+            vcpkgRoot ??= Environment.GetEnvironmentVariable("VCPKG_ROOT")
+                ?? throw new InvalidOperationException("Set VCPKG_ROOT to the root of your vcpkg installation, or pass the vcpkg root path to WithVcpkg.");
+
+            builder.WithRequiredBuildTool(VcpkgCommand, helpLink);
+        }
+
+        return builder.WithAnnotation(new CMakeVcpkgAnnotation(vcpkgRoot), ResourceAnnotationMutationBehavior.Replace);
+    }
+
+    /// <summary>
     /// Configures the path to the executable produced by the CMake target.
     /// </summary>
     /// <typeparam name="T">The type of the CMake application resource.</typeparam>
@@ -366,9 +432,23 @@ public static class CMakeAppResourceBuilderExtensions
             args.Add($"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{configurationName.ToUpperInvariant()}={resource.RuntimeOutputDirectory}");
         }
 
+        var usesVcpkg = resource.TryGetLastAnnotation<CMakeVcpkgAnnotation>(out var vcpkgAnnotation);
+        if (vcpkgAnnotation?.Root is not null)
+        {
+            args.Add($"-DCMAKE_TOOLCHAIN_FILE={GetVcpkgToolchainFile(vcpkgAnnotation.Root)}");
+        }
+
         if (resource.TryGetLastAnnotation<CMakeConfigureArgsAnnotation>(out var configureArgsAnnotation))
         {
-            AddRange(args, configureArgsAnnotation.Args);
+            foreach (var arg in configureArgsAnnotation.Args)
+            {
+                if (usesVcpkg && IsVcpkgToolchainFileArg(arg))
+                {
+                    continue;
+                }
+
+                args.Add(arg);
+            }
         }
     }
 
@@ -443,10 +523,21 @@ public static class CMakeAppResourceBuilderExtensions
             args.Add($"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{configurationName.ToUpperInvariant()}={runtimeOutputDirectory}");
         }
 
+        var usesVcpkg = resource.TryGetLastAnnotation<CMakeVcpkgAnnotation>(out _);
+        if (usesVcpkg)
+        {
+            args.Add($"-DCMAKE_TOOLCHAIN_FILE={DockerVcpkgToolchainFile}");
+        }
+
         if (resource.TryGetLastAnnotation<CMakeConfigureArgsAnnotation>(out var configureArgsAnnotation))
         {
             foreach (var arg in configureArgsAnnotation.Args)
             {
+                if (usesVcpkg && IsVcpkgToolchainFileArg(arg))
+                {
+                    continue;
+                }
+
                 args.Add(ShellQuote(arg));
             }
         }
@@ -476,6 +567,22 @@ public static class CMakeAppResourceBuilderExtensions
         }
 
         return string.Join(" ", args);
+    }
+
+    private static string GetVcpkgToolchainFile(string vcpkgRoot) =>
+        Path.Combine(vcpkgRoot, "scripts", "buildsystems", "vcpkg.cmake");
+
+    private static bool IsVcpkgToolchainFileArg(string arg)
+    {
+        const string toolchainPrefix = "-DCMAKE_TOOLCHAIN_FILE=";
+
+        if (!arg.StartsWith(toolchainPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var toolchainPath = arg[toolchainPrefix.Length..].Replace('\\', '/');
+        return toolchainPath.EndsWith("/scripts/buildsystems/vcpkg.cmake", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Cpp/CMakeAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Cpp/CMakeAppResourceBuilderExtensions.cs
@@ -1,0 +1,487 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIRECOMMAND001
+#pragma warning disable ASPIREDOCKERFILEBUILDER001
+#pragma warning disable ASPIREEXTENSION001
+#pragma warning disable ASPIREPIPELINES001
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.ApplicationModel.Docker;
+using Aspire.Hosting.Cpp;
+using Aspire.Hosting.Pipelines;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides extension methods for adding C++ CMake applications to an <see cref="IDistributedApplicationBuilder"/>.
+/// </summary>
+public static class CMakeAppResourceBuilderExtensions
+{
+    private const string CMakeCommand = "cmake";
+    private const string DefaultRunBuildType = "Debug";
+    private const string DefaultPublishBuildType = "Release";
+    private const string DefaultCMakeHelpLink = "https://cmake.org/download/";
+    private const string DefaultBuildImage = "debian:bookworm";
+    private const string DefaultRuntimeImage = "debian:bookworm-slim";
+
+    /// <summary>
+    /// Adds a C++ application built with CMake to the application model.
+    /// </summary>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/> to add the resource to.</param>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="sourceDirectory">The path to the directory containing the CMake project.</param>
+    /// <param name="targetName">The CMake target to build before running the application.</param>
+    /// <param name="buildDirectory">
+    /// The CMake build directory. When <see langword="null"/>, defaults to
+    /// <c>&lt;sourceDirectory&gt;/.aspire/cmake/&lt;name&gt;/build</c>.
+    /// </param>
+    /// <param name="executablePath">
+    /// The path to the executable produced by <paramref name="targetName"/>. When <see langword="null"/>,
+    /// the executable is expected under Aspire's managed runtime output directory.
+    /// </param>
+    /// <param name="buildType">
+    /// The CMake build configuration. When <see langword="null"/>, defaults to <c>Debug</c> for local run
+    /// and <c>Release</c> for generated Dockerfiles.
+    /// </param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// <para>
+    /// The local development workflow creates two setup resources that run before the application:
+    /// <c>cmake -S ... -B ...</c> and <c>cmake --build ... --target ...</c>. The application resource
+    /// waits for the build resource to complete successfully before launching the executable.
+    /// </para>
+    /// <para>
+    /// The generated CMake configure command sets <c>CMAKE_RUNTIME_OUTPUT_DIRECTORY</c> and the common
+    /// per-configuration output directory variables so single-config and multi-config generators write
+    /// executables to a deterministic location. Projects with custom output names or directories can use
+    /// <see cref="WithExecutablePath{T}"/> and <see cref="WithConfigureArgs{T}"/> to override the default.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// Add a C++ HTTP API that reads its port from the <c>PORT</c> environment variable:
+    /// <code lang="csharp">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// builder.AddCMakeApp("api", "../cpp-api", targetName: "api")
+    ///        .WithHttpEndpoint(env: "PORT")
+    ///        .WithExternalHttpEndpoints();
+    ///
+    /// builder.Build().Run();
+    /// </code>
+    /// </example>
+    [AspireExport]
+    public static IResourceBuilder<CMakeAppResource> AddCMakeApp(
+        this IDistributedApplicationBuilder builder,
+        [ResourceName] string name,
+        string sourceDirectory,
+        string targetName,
+        string? buildDirectory = null,
+        string? executablePath = null,
+        string? buildType = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(sourceDirectory);
+        ArgumentException.ThrowIfNullOrEmpty(targetName);
+
+        if (buildType is not null)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(buildType);
+        }
+
+        sourceDirectory = Path.GetFullPath(sourceDirectory, builder.AppHostDirectory);
+        buildDirectory = buildDirectory is null
+            ? Path.Combine(sourceDirectory, ".aspire", "cmake", name, "build")
+            : Path.GetFullPath(buildDirectory, builder.AppHostDirectory);
+
+        var runtimeOutputDirectory = Path.Combine(buildDirectory, "aspire-bin");
+        executablePath = executablePath is null
+            ? Path.Combine(runtimeOutputDirectory, GetExecutableFileName(targetName))
+            : Path.GetFullPath(executablePath, builder.AppHostDirectory);
+
+        var resource = new CMakeAppResource(
+            name,
+            sourceDirectory,
+            buildDirectory,
+            targetName,
+            executablePath,
+            runtimeOutputDirectory);
+
+        var resourceBuilder = builder.AddResource(resource)
+            .WithArgs(ctx =>
+            {
+                if (ctx.Resource.TryGetLastAnnotation<CMakeAppArgsAnnotation>(out var argsAnnotation))
+                {
+                    AddRange(ctx.Args, argsAnnotation.Args);
+                }
+            })
+            .WithRequiredCommand(CMakeCommand, DefaultCMakeHelpLink)
+            .WithOtlpExporter()
+            .PublishAsDockerFile(containerBuilder =>
+            {
+                if (File.Exists(Path.Combine(sourceDirectory, "Dockerfile")))
+                {
+                    return;
+                }
+
+                containerBuilder.WithDockerfileBuilder(sourceDirectory, context =>
+                {
+                    var logger = context.Services.GetService<ILogger<CMakeAppResource>>();
+                    context.Resource.TryGetLastAnnotation<DockerfileBaseImageAnnotation>(out var baseImageAnnotation);
+
+                    var buildImage = baseImageAnnotation?.BuildImage ?? DefaultBuildImage;
+                    var runtimeImage = baseImageAnnotation?.RuntimeImage ?? DefaultRuntimeImage;
+                    var publishBuildType = GetBuildType(resource, DefaultPublishBuildType);
+                    var targetName = resource.TargetName;
+                    var executableName = GetDockerExecutableFileName(targetName);
+
+                    var buildStage = context.Builder
+                        .From(buildImage, "build")
+                        .WorkDir("/src")
+                        .Run("apt-get update && apt-get install -y --no-install-recommends build-essential cmake ninja-build ca-certificates && rm -rf /var/lib/apt/lists/*")
+                        .Copy(".", ".")
+                        .RunWithMounts(
+                            BuildDockerConfigureCommand(resource, publishBuildType),
+                            "type=cache,target=/src/.aspire/cmake/docker-build")
+                        .RunWithMounts(
+                            BuildDockerBuildCommand(resource, publishBuildType),
+                            "type=cache,target=/src/.aspire/cmake/docker-build");
+
+                    context.Builder.AddContainerFilesStages(context.Resource, logger);
+
+                    context.Builder
+                        .From(runtimeImage)
+                        .Run("apt-get update && apt-get install -y --no-install-recommends ca-certificates libstdc++6 && rm -rf /var/lib/apt/lists/*")
+                        .Run("groupadd --system --gid 999 app && useradd --system --gid 999 --uid 999 --no-create-home app")
+                        .WorkDir("/app")
+                        .AddContainerFiles(context.Resource, "/app", logger)
+                        .CopyFrom(buildStage.StageName!, $"/src/.aspire/cmake/docker-bin/{executableName}", $"/app/{executableName}")
+                        .User("app")
+                        .Entrypoint([$"/app/{executableName}"]);
+                });
+            });
+
+        if (buildType is not null)
+        {
+            resourceBuilder.WithBuildType(buildType);
+        }
+
+        if (builder.ExecutionContext.IsRunMode)
+        {
+            AddCMakeSetupResources(resourceBuilder);
+        }
+
+        resourceBuilder.WithPipelineConfiguration(context =>
+        {
+            if (resourceBuilder.Resource.TryGetAnnotationsOfType<ContainerFilesDestinationAnnotation>(out var containerFilesAnnotations))
+            {
+                var buildSteps = context.GetSteps(resourceBuilder.Resource, WellKnownPipelineTags.BuildCompute);
+                foreach (var containerFile in containerFilesAnnotations)
+                {
+                    buildSteps.DependsOn(context.GetSteps(containerFile.Source, WellKnownPipelineTags.BuildCompute));
+                }
+            }
+        });
+
+        return resourceBuilder;
+    }
+
+    /// <summary>
+    /// Passes extra arguments to the C++ application at runtime.
+    /// </summary>
+    /// <typeparam name="T">The type of the CMake application resource.</typeparam>
+    /// <param name="builder">The resource builder for the CMake application.</param>
+    /// <param name="args">The arguments to pass to the application executable.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExport]
+    public static IResourceBuilder<T> WithAppArgs<T>(this IResourceBuilder<T> builder, params object[] args)
+        where T : CMakeAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(args);
+
+        return builder.WithAnnotation(new CMakeAppArgsAnnotation(args), ResourceAnnotationMutationBehavior.Replace);
+    }
+
+    /// <summary>
+    /// Adds extra arguments to the generated <c>cmake -S ... -B ...</c> configure command.
+    /// </summary>
+    /// <typeparam name="T">The type of the CMake application resource.</typeparam>
+    /// <param name="builder">The resource builder for the CMake application.</param>
+    /// <param name="args">The arguments to append to the CMake configure command.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExport]
+    public static IResourceBuilder<T> WithConfigureArgs<T>(this IResourceBuilder<T> builder, params string[] args)
+        where T : CMakeAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(args);
+
+        return builder.WithAnnotation(new CMakeConfigureArgsAnnotation(args), ResourceAnnotationMutationBehavior.Replace);
+    }
+
+    /// <summary>
+    /// Adds extra arguments to the generated <c>cmake --build</c> command.
+    /// </summary>
+    /// <typeparam name="T">The type of the CMake application resource.</typeparam>
+    /// <param name="builder">The resource builder for the CMake application.</param>
+    /// <param name="args">The arguments to append to the CMake build command.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExport]
+    public static IResourceBuilder<T> WithBuildArgs<T>(this IResourceBuilder<T> builder, params string[] args)
+        where T : CMakeAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(args);
+
+        return builder.WithAnnotation(new CMakeBuildArgsAnnotation(args), ResourceAnnotationMutationBehavior.Replace);
+    }
+
+    /// <summary>
+    /// Configures the CMake build type used by the local build and generated Dockerfile.
+    /// </summary>
+    /// <typeparam name="T">The type of the CMake application resource.</typeparam>
+    /// <param name="builder">The resource builder for the CMake application.</param>
+    /// <param name="buildType">The CMake build type, such as <c>Debug</c> or <c>Release</c>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExport]
+    public static IResourceBuilder<T> WithBuildType<T>(this IResourceBuilder<T> builder, string buildType)
+        where T : CMakeAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(buildType);
+
+        return builder.WithAnnotation(new CMakeBuildTypeAnnotation(buildType), ResourceAnnotationMutationBehavior.Replace);
+    }
+
+    /// <summary>
+    /// Configures the path to the executable produced by the CMake target.
+    /// </summary>
+    /// <typeparam name="T">The type of the CMake application resource.</typeparam>
+    /// <param name="builder">The resource builder for the CMake application.</param>
+    /// <param name="executablePath">The path to the executable to run. Relative paths are resolved from the AppHost directory.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExport]
+    public static IResourceBuilder<T> WithExecutablePath<T>(this IResourceBuilder<T> builder, string executablePath)
+        where T : CMakeAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(executablePath);
+
+        executablePath = Path.GetFullPath(executablePath, builder.ApplicationBuilder.AppHostDirectory);
+        return builder.WithCommand(executablePath);
+    }
+
+    /// <summary>
+    /// Declares that the CMake application requires an additional build tool to be available on the local machine PATH.
+    /// </summary>
+    /// <typeparam name="T">The type of the CMake application resource.</typeparam>
+    /// <param name="builder">The resource builder for the CMake application.</param>
+    /// <param name="command">The command that should be available on the local machine PATH.</param>
+    /// <param name="helpLink">An optional URL shown to users when the command is missing.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExport]
+    public static IResourceBuilder<T> WithRequiredBuildTool<T>(this IResourceBuilder<T> builder, string command, string? helpLink = null)
+        where T : CMakeAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(command);
+
+        return builder.WithRequiredCommand(command, helpLink);
+    }
+
+    /// <summary>
+    /// Declares that the CMake application requires additional build tools to be available on the local machine PATH.
+    /// </summary>
+    /// <typeparam name="T">The type of the CMake application resource.</typeparam>
+    /// <param name="builder">The resource builder for the CMake application.</param>
+    /// <param name="tools">The build tools that should be available on the local machine PATH.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExportIgnore(Reason = "Uses CMakeBuildTool, which is not ATS-compatible. Polyglot app hosts can call withRequiredBuildTool repeatedly.")]
+    public static IResourceBuilder<T> WithRequiredBuildTools<T>(this IResourceBuilder<T> builder, params CMakeBuildTool[] tools)
+        where T : CMakeAppResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(tools);
+
+        foreach (var tool in tools)
+        {
+            ArgumentNullException.ThrowIfNull(tool);
+            builder.WithRequiredBuildTool(tool.Command, tool.HelpLink);
+        }
+
+        return builder;
+    }
+
+    private static void AddCMakeSetupResources(IResourceBuilder<CMakeAppResource> builder)
+    {
+        var resource = builder.Resource;
+        var configureResource = new ExecutableResource($"{resource.Name}-cmake-configure", CMakeCommand, resource.SourceDirectory);
+
+        var configure = builder.ApplicationBuilder
+            .AddResource(configureResource)
+            .WithArgs(ctx => AddConfigureArgs(resource, ctx.Args))
+            .WithRequiredCommand(CMakeCommand, DefaultCMakeHelpLink)
+            .ExcludeFromManifest();
+
+        var buildResource = new ExecutableResource($"{resource.Name}-cmake-build", CMakeCommand, resource.SourceDirectory);
+
+        var build = builder.ApplicationBuilder
+            .AddResource(buildResource)
+            .WithArgs(ctx => AddBuildArgs(resource, ctx.Args))
+            .WithRequiredCommand(CMakeCommand, DefaultCMakeHelpLink)
+            .ExcludeFromManifest()
+            .WaitForCompletion(configure);
+
+        builder
+            .WithAnnotation(new CMakeConfigureResourceAnnotation(configure))
+            .WithAnnotation(new CMakeBuildResourceAnnotation(build))
+            .WaitForCompletion(build);
+    }
+
+    private static void AddConfigureArgs(CMakeAppResource resource, IList<object> args)
+    {
+        var buildType = GetBuildType(resource, DefaultRunBuildType);
+
+        args.Add("-S");
+        args.Add(resource.SourceDirectory);
+        args.Add("-B");
+        args.Add(resource.BuildDirectory);
+        args.Add($"-DCMAKE_BUILD_TYPE={buildType}");
+        args.Add($"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY={resource.RuntimeOutputDirectory}");
+
+        foreach (var configurationName in GetCommonConfigurationNames(buildType))
+        {
+            args.Add($"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{configurationName.ToUpperInvariant()}={resource.RuntimeOutputDirectory}");
+        }
+
+        if (resource.TryGetLastAnnotation<CMakeConfigureArgsAnnotation>(out var configureArgsAnnotation))
+        {
+            AddRange(args, configureArgsAnnotation.Args);
+        }
+    }
+
+    private static void AddBuildArgs(CMakeAppResource resource, IList<object> args)
+    {
+        args.Add("--build");
+        args.Add(resource.BuildDirectory);
+        args.Add("--config");
+        args.Add(GetBuildType(resource, DefaultRunBuildType));
+        args.Add("--target");
+        args.Add(resource.TargetName);
+
+        if (resource.TryGetLastAnnotation<CMakeBuildArgsAnnotation>(out var buildArgsAnnotation))
+        {
+            AddRange(args, buildArgsAnnotation.Args);
+        }
+    }
+
+    private static void AddRange(IList<object> args, IEnumerable<object> values)
+    {
+        foreach (var value in values)
+        {
+            args.Add(value);
+        }
+    }
+
+    private static string GetBuildType(IResource resource, string defaultBuildType) =>
+        resource.TryGetLastAnnotation<CMakeBuildTypeAnnotation>(out var buildTypeAnnotation)
+            ? buildTypeAnnotation.BuildType
+            : defaultBuildType;
+
+    private static IEnumerable<string> GetCommonConfigurationNames(string buildType)
+    {
+        var names = new[] { buildType, "Debug", "Release", "RelWithDebInfo", "MinSizeRel" };
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var name in names)
+        {
+            if (seen.Add(name))
+            {
+                yield return name;
+            }
+        }
+    }
+
+    private static string GetExecutableFileName(string targetName) =>
+        OperatingSystem.IsWindows() && !targetName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+            ? $"{targetName}.exe"
+            : targetName;
+
+    private static string GetDockerExecutableFileName(string targetName) =>
+        targetName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+            ? targetName[..^4]
+            : targetName;
+
+    private static string BuildDockerConfigureCommand(CMakeAppResource resource, string buildType)
+    {
+        var runtimeOutputDirectory = "/src/.aspire/cmake/docker-bin";
+
+        var args = new List<string>
+        {
+            "cmake",
+            "-S", ".",
+            "-B", "/src/.aspire/cmake/docker-build",
+            "-G", "Ninja",
+            $"-DCMAKE_BUILD_TYPE={ShellQuote(buildType)}",
+            $"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY={runtimeOutputDirectory}"
+        };
+
+        foreach (var configurationName in GetCommonConfigurationNames(buildType))
+        {
+            args.Add($"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{configurationName.ToUpperInvariant()}={runtimeOutputDirectory}");
+        }
+
+        if (resource.TryGetLastAnnotation<CMakeConfigureArgsAnnotation>(out var configureArgsAnnotation))
+        {
+            foreach (var arg in configureArgsAnnotation.Args)
+            {
+                args.Add(ShellQuote(arg));
+            }
+        }
+
+        return string.Join(" ", args);
+    }
+
+    private static string BuildDockerBuildCommand(CMakeAppResource resource, string buildType)
+    {
+        var args = new List<string>
+        {
+            "cmake",
+            "--build",
+            "/src/.aspire/cmake/docker-build",
+            "--config",
+            ShellQuote(buildType),
+            "--target",
+            ShellQuote(resource.TargetName)
+        };
+
+        if (resource.TryGetLastAnnotation<CMakeBuildArgsAnnotation>(out var buildArgsAnnotation))
+        {
+            foreach (var arg in buildArgsAnnotation.Args)
+            {
+                args.Add(ShellQuote(arg));
+            }
+        }
+
+        return string.Join(" ", args);
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="value"/> in POSIX single quotes for Dockerfile shell-form commands.
+    /// Embedded single quotes are escaped with the standard POSIX <c>'\''</c> sequence.
+    /// </summary>
+    private static string ShellQuote(string value) =>
+        $"'{value.Replace("'", "'\\''", StringComparison.Ordinal)}'";
+}

--- a/src/Aspire.Hosting.Cpp/CMakeBuildTool.cs
+++ b/src/Aspire.Hosting.Cpp/CMakeBuildTool.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Cpp;
+
+/// <summary>
+/// Describes a command-line tool required to configure, build, or package a C++ application.
+/// </summary>
+/// <param name="Command">The command that should be available on the local machine PATH.</param>
+/// <param name="HelpLink">An optional URL shown to users when the command is missing.</param>
+public sealed record CMakeBuildTool(string Command, string? HelpLink = null);
+

--- a/src/Aspire.Hosting.Cpp/README.md
+++ b/src/Aspire.Hosting.Cpp/README.md
@@ -25,6 +25,7 @@ Then, in the AppHost, add a C++ CMake application resource with either C# or Typ
 ```csharp
 var api = builder.AddCMakeApp("api", "../cpp-api", targetName: "api")
                  .WithVcpkg()
+                 .WithCMakeInstall()
                  .WithHttpEndpoint(env: "PORT")
                  .WithExternalHttpEndpoints();
 ```
@@ -34,6 +35,7 @@ var api = builder.AddCMakeApp("api", "../cpp-api", targetName: "api")
 ```typescript
 const api = await builder.addCMakeApp("api", "../cpp-api", "api")
     .withVcpkg()
+    .withCMakeInstall()
     .withHttpEndpoint({ env: "PORT" })
     .withExternalHttpEndpoints();
 ```
@@ -41,6 +43,8 @@ const api = await builder.addCMakeApp("api", "../cpp-api", "api")
 `AddCMakeApp` runs `cmake -S ... -B ...` and `cmake --build ... --target ...` before launching the built executable. Pass application arguments with `WithAppArgs`, CMake configure arguments with `WithConfigureArgs`, and CMake build arguments with `WithBuildArgs`.
 
 `WithVcpkg` uses the local `VCPKG_ROOT` value in run mode and bootstraps vcpkg in generated Dockerfiles for deployment.
+
+`WithCMakeInstall` runs `cmake --install` after building and launches the executable from the install prefix. Use it when the CMake project has `install()` rules that define the files to include in the runtime container image.
 
 ## Additional documentation
 

--- a/src/Aspire.Hosting.Cpp/README.md
+++ b/src/Aspire.Hosting.Cpp/README.md
@@ -6,7 +6,7 @@ Use this integration to model, configure, and orchestrate a C++ CMake applicatio
 
 ### Prerequisites
 
-CMake must be available on the PATH of the machine running the AppHost. The CMake project also needs a working C++ toolchain such as MSVC Build Tools, GCC, or Clang. Declare additional tools such as Ninja, vcpkg, or Conan with `WithRequiredBuildTool`.
+CMake must be available on the PATH of the machine running the AppHost. The CMake project also needs a working C++ toolchain such as MSVC Build Tools, GCC, or Clang. Declare additional tools such as Ninja or Conan with `WithRequiredBuildTool`. Use `WithVcpkg` for vcpkg manifest-mode projects.
 
 ### Add the integration
 
@@ -24,7 +24,7 @@ Then, in the AppHost, add a C++ CMake application resource with either C# or Typ
 
 ```csharp
 var api = builder.AddCMakeApp("api", "../cpp-api", targetName: "api")
-                 .WithRequiredBuildTool("ninja", "https://ninja-build.org/")
+                 .WithVcpkg()
                  .WithHttpEndpoint(env: "PORT")
                  .WithExternalHttpEndpoints();
 ```
@@ -33,12 +33,14 @@ var api = builder.AddCMakeApp("api", "../cpp-api", targetName: "api")
 
 ```typescript
 const api = await builder.addCMakeApp("api", "../cpp-api", "api")
-    .withRequiredBuildTool("ninja", "https://ninja-build.org/")
+    .withVcpkg()
     .withHttpEndpoint({ env: "PORT" })
     .withExternalHttpEndpoints();
 ```
 
 `AddCMakeApp` runs `cmake -S ... -B ...` and `cmake --build ... --target ...` before launching the built executable. Pass application arguments with `WithAppArgs`, CMake configure arguments with `WithConfigureArgs`, and CMake build arguments with `WithBuildArgs`.
+
+`WithVcpkg` uses the local `VCPKG_ROOT` value in run mode and bootstraps vcpkg in generated Dockerfiles for deployment.
 
 ## Additional documentation
 
@@ -49,4 +51,3 @@ https://learn.microsoft.com/vcpkg/
 ## Feedback & contributing
 
 https://github.com/microsoft/aspire
-

--- a/src/Aspire.Hosting.Cpp/README.md
+++ b/src/Aspire.Hosting.Cpp/README.md
@@ -1,0 +1,52 @@
+# C++ hosting integration
+
+Use this integration to model, configure, and orchestrate a C++ CMake application in an Aspire solution.
+
+## Getting started
+
+### Prerequisites
+
+CMake must be available on the PATH of the machine running the AppHost. The CMake project also needs a working C++ toolchain such as MSVC Build Tools, GCC, or Clang. Declare additional tools such as Ninja, vcpkg, or Conan with `WithRequiredBuildTool`.
+
+### Add the integration
+
+From your AppHost directory, add the `Aspire.Hosting.Cpp` integration with the Aspire CLI:
+
+```bash
+aspire add Aspire.Hosting.Cpp
+```
+
+## Usage example
+
+Then, in the AppHost, add a C++ CMake application resource with either C# or TypeScript:
+
+**C#**
+
+```csharp
+var api = builder.AddCMakeApp("api", "../cpp-api", targetName: "api")
+                 .WithRequiredBuildTool("ninja", "https://ninja-build.org/")
+                 .WithHttpEndpoint(env: "PORT")
+                 .WithExternalHttpEndpoints();
+```
+
+**TypeScript**
+
+```typescript
+const api = await builder.addCMakeApp("api", "../cpp-api", "api")
+    .withRequiredBuildTool("ninja", "https://ninja-build.org/")
+    .withHttpEndpoint({ env: "PORT" })
+    .withExternalHttpEndpoints();
+```
+
+`AddCMakeApp` runs `cmake -S ... -B ...` and `cmake --build ... --target ...` before launching the built executable. Pass application arguments with `WithAppArgs`, CMake configure arguments with `WithConfigureArgs`, and CMake build arguments with `WithBuildArgs`.
+
+## Additional documentation
+
+https://aspire.dev/integrations/gallery/
+https://cmake.org/documentation/
+https://learn.microsoft.com/vcpkg/
+
+## Feedback & contributing
+
+https://github.com/microsoft/aspire
+

--- a/tests/Aspire.Hosting.Cpp.Tests/AddCMakeAppTests.cs
+++ b/tests/Aspire.Hosting.Cpp.Tests/AddCMakeAppTests.cs
@@ -122,6 +122,50 @@ public class AddCMakeAppTests
     }
 
     [Fact]
+    public async Task InstallResourceInstallsAfterBuildAndAppWaitsForInstall()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithBuildType("RelWithDebInfo")
+            .WithCMakeInstall();
+
+        var buildBuilder = GetBuildBuilder(app.Resource);
+        var installBuilder = GetInstallBuilder(app.Resource);
+        var installDirectory = Path.Combine(app.Resource.BuildDirectory, "aspire-install");
+        var args = await ArgumentEvaluator.GetArgumentListAsync(installBuilder.Resource);
+
+        Assert.Same(installBuilder.Resource, builder.Resources.First(r => r.Name == "api-cmake-install"));
+        Assert.Equal(["--install", app.Resource.BuildDirectory, "--config", "RelWithDebInfo", "--prefix", installDirectory], args);
+        Assert.Contains(installBuilder.Resource.Annotations.OfType<WaitAnnotation>(), a => a.Resource == buildBuilder.Resource && a.WaitType == WaitType.WaitForCompletion);
+        Assert.Contains(app.Resource.Annotations.OfType<WaitAnnotation>(), a => a.Resource == installBuilder.Resource && a.WaitType == WaitType.WaitForCompletion);
+        Assert.EndsWith(Path.Combine(".aspire", "cmake", "api", "build", "aspire-install", "bin", GetExecutableFileName("api")), app.Resource.Command);
+    }
+
+    [Fact]
+    public void WithCMakeInstallCreatesSingleInstallResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithCMakeInstall("bin/api")
+            .WithCMakeInstall("sbin/api");
+
+        Assert.Equal(1, builder.Resources.Count(r => r.Name == "api-cmake-install"));
+        Assert.EndsWith(Path.Combine("aspire-install", "sbin", "api"), app.Resource.Command);
+    }
+
+    [Fact]
+    public void WithCMakeInstallDoesNotCreateInstallResourceInPublishMode()
+    {
+        using var outputDir = new TestTempDirectory();
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputDir.Path, step: "publish-manifest");
+
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithCMakeInstall();
+
+        Assert.False(app.Resource.TryGetLastAnnotation<CMakeInstallResourceAnnotation>(out _));
+    }
+
+    [Fact]
     public void AddCMakeAppCreatesConfigureAndBuildSiblingsInRunMode()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
@@ -219,6 +263,33 @@ public class AddCMakeAppTests
     }
 
     [Fact]
+    public async Task VerifyPublish_GeneratesInstallDockerfile()
+    {
+        using var sourceDir = new TestTempDirectory();
+        using var outputDir = new TestTempDirectory();
+
+        File.WriteAllText(Path.Combine(sourceDir.Path, "CMakeLists.txt"), """
+            cmake_minimum_required(VERSION 3.20)
+            project(api LANGUAGES CXX)
+            add_executable(api main.cpp)
+            install(TARGETS api RUNTIME DESTINATION bin)
+            install(FILES config.json DESTINATION etc/api)
+            """);
+        File.WriteAllText(Path.Combine(sourceDir.Path, "main.cpp"), "int main() { return 0; }");
+        File.WriteAllText(Path.Combine(sourceDir.Path, "config.json"), "{}");
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputDir.Path, step: "publish-manifest");
+        builder.AddCMakeApp("api", sourceDir.Path, "api")
+            .WithCMakeInstall();
+
+        builder.Build().Run();
+
+        var content = await File.ReadAllTextAsync(Path.Combine(outputDir.Path, "api.Dockerfile"));
+
+        await Verify(content);
+    }
+
+    [Fact]
     public async Task VerifyPublish_GeneratesVcpkgDockerfile()
     {
         using var sourceDir = new TestTempDirectory();
@@ -247,6 +318,44 @@ public class AddCMakeAppTests
         builder.AddCMakeApp("api", sourceDir.Path, "api")
             .WithVcpkg()
             .WithConfigureArgs(@"-DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake");
+
+        builder.Build().Run();
+
+        var content = await File.ReadAllTextAsync(Path.Combine(outputDir.Path, "api.Dockerfile"));
+
+        await Verify(content);
+    }
+
+    [Fact]
+    public async Task VerifyPublish_GeneratesVcpkgInstallDockerfile()
+    {
+        using var sourceDir = new TestTempDirectory();
+        using var outputDir = new TestTempDirectory();
+
+        File.WriteAllText(Path.Combine(sourceDir.Path, "CMakeLists.txt"), """
+            cmake_minimum_required(VERSION 3.20)
+            project(api LANGUAGES CXX)
+            find_package(httplib CONFIG REQUIRED)
+            add_executable(api main.cpp)
+            target_link_libraries(api PRIVATE httplib::httplib)
+            install(TARGETS api RUNTIME DESTINATION bin)
+            """);
+        File.WriteAllText(Path.Combine(sourceDir.Path, "main.cpp"), "int main() { return 0; }");
+        File.WriteAllText(Path.Combine(sourceDir.Path, "vcpkg.json"), """
+            {
+              "dependencies": [
+                {
+                  "name": "cpp-httplib",
+                  "default-features": false
+                }
+              ]
+            }
+            """);
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputDir.Path, step: "publish-manifest");
+        builder.AddCMakeApp("api", sourceDir.Path, "api")
+            .WithVcpkg()
+            .WithCMakeInstall();
 
         builder.Build().Run();
 
@@ -290,4 +399,13 @@ public class AddCMakeAppTests
         Assert.True(resource.TryGetLastAnnotation<CMakeBuildResourceAnnotation>(out var annotation));
         return annotation.ResourceBuilder;
     }
+
+    private static IResourceBuilder<ExecutableResource> GetInstallBuilder(CMakeAppResource resource)
+    {
+        Assert.True(resource.TryGetLastAnnotation<CMakeInstallResourceAnnotation>(out var annotation));
+        return annotation.ResourceBuilder;
+    }
+
+    private static string GetExecutableFileName(string targetName) =>
+        OperatingSystem.IsWindows() ? $"{targetName}.exe" : targetName;
 }

--- a/tests/Aspire.Hosting.Cpp.Tests/AddCMakeAppTests.cs
+++ b/tests/Aspire.Hosting.Cpp.Tests/AddCMakeAppTests.cs
@@ -21,28 +21,18 @@ public class AddCMakeAppTests
             .WithHttpEndpoint(port: 8080, env: "PORT");
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
-        var command = app.Resource.Command.Replace('\\', '/');
 
-        var expected = $$"""
-            {
-              "type": "executable.v0",
-              "workingDirectory": ".",
-              "command": "{{command}}",
-              "env": {
-                "PORT": "{api.bindings.http.targetPort}"
-              },
-              "bindings": {
-                "http": {
-                  "scheme": "http",
-                  "protocol": "tcp",
-                  "transport": "http",
-                  "port": 8080,
-                  "targetPort": 8000
-                }
-              }
-            }
-            """;
-        Assert.Equal(expected, manifest.ToString().Replace('\\', '/'));
+        Assert.Equal("executable.v0", manifest["type"]!.GetValue<string>());
+        Assert.Equal(".", manifest["workingDirectory"]!.GetValue<string>());
+        Assert.Equal(app.Resource.Command, manifest["command"]!.GetValue<string>());
+        Assert.Equal("{api.bindings.http.targetPort}", manifest["env"]!["PORT"]!.GetValue<string>());
+
+        var httpBinding = manifest["bindings"]!["http"]!;
+        Assert.Equal("http", httpBinding["scheme"]!.GetValue<string>());
+        Assert.Equal("tcp", httpBinding["protocol"]!.GetValue<string>());
+        Assert.Equal("http", httpBinding["transport"]!.GetValue<string>());
+        Assert.Equal(8080, httpBinding["port"]!.GetValue<int>());
+        Assert.Equal(8000, httpBinding["targetPort"]!.GetValue<int>());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Cpp.Tests/AddCMakeAppTests.cs
+++ b/tests/Aspire.Hosting.Cpp.Tests/AddCMakeAppTests.cs
@@ -80,6 +80,22 @@ public class AddCMakeAppTests
     }
 
     [Fact]
+    public async Task ConfigureResourceUsesVcpkgToolchainInRunMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var vcpkgRoot = Path.Combine(builder.AppHostDirectory, "vcpkg");
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithVcpkg(vcpkgRoot)
+            .WithConfigureArgs($"-DCMAKE_TOOLCHAIN_FILE={Path.Combine(vcpkgRoot, "scripts", "buildsystems", "vcpkg.cmake")}");
+
+        var configureBuilder = GetConfigureBuilder(app.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(configureBuilder.Resource);
+
+        Assert.Single(args, arg => arg is string value && value.StartsWith("-DCMAKE_TOOLCHAIN_FILE=", StringComparison.Ordinal));
+        Assert.Contains($"-DCMAKE_TOOLCHAIN_FILE={Path.Combine(vcpkgRoot, "scripts", "buildsystems", "vcpkg.cmake")}", args);
+    }
+
+    [Fact]
     public async Task BuildResourceBuildsSelectedTarget()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -194,6 +210,43 @@ public class AddCMakeAppTests
         builder.AddCMakeApp("api", sourceDir.Path, "api")
             .WithConfigureArgs("-DENABLE_HTTP=ON", "-DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake")
             .WithBuildArgs("--parallel", "4");
+
+        builder.Build().Run();
+
+        var content = await File.ReadAllTextAsync(Path.Combine(outputDir.Path, "api.Dockerfile"));
+
+        await Verify(content);
+    }
+
+    [Fact]
+    public async Task VerifyPublish_GeneratesVcpkgDockerfile()
+    {
+        using var sourceDir = new TestTempDirectory();
+        using var outputDir = new TestTempDirectory();
+
+        File.WriteAllText(Path.Combine(sourceDir.Path, "CMakeLists.txt"), """
+            cmake_minimum_required(VERSION 3.20)
+            project(api LANGUAGES CXX)
+            find_package(httplib CONFIG REQUIRED)
+            add_executable(api main.cpp)
+            target_link_libraries(api PRIVATE httplib::httplib)
+            """);
+        File.WriteAllText(Path.Combine(sourceDir.Path, "main.cpp"), "int main() { return 0; }");
+        File.WriteAllText(Path.Combine(sourceDir.Path, "vcpkg.json"), """
+            {
+              "dependencies": [
+                {
+                  "name": "cpp-httplib",
+                  "default-features": false
+                }
+              ]
+            }
+            """);
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputDir.Path, step: "publish-manifest");
+        builder.AddCMakeApp("api", sourceDir.Path, "api")
+            .WithVcpkg()
+            .WithConfigureArgs(@"-DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake");
 
         builder.Build().Run();
 

--- a/tests/Aspire.Hosting.Cpp.Tests/AddCMakeAppTests.cs
+++ b/tests/Aspire.Hosting.Cpp.Tests/AddCMakeAppTests.cs
@@ -1,0 +1,240 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIRECOMMAND001
+#pragma warning disable ASPIREDOCKERFILEBUILDER001
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Cpp.Tests;
+
+public class AddCMakeAppTests
+{
+    [Fact]
+    public async Task VerifyManifest_CMakeApp()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var app = builder.AddCMakeApp("api", AppContext.BaseDirectory, "api")
+            .WithHttpEndpoint(port: 8080, env: "PORT");
+
+        var manifest = await ManifestUtils.GetManifest(app.Resource);
+        var command = app.Resource.Command.Replace('\\', '/');
+
+        var expected = $$"""
+            {
+              "type": "executable.v0",
+              "workingDirectory": ".",
+              "command": "{{command}}",
+              "env": {
+                "PORT": "{api.bindings.http.targetPort}"
+              },
+              "bindings": {
+                "http": {
+                  "scheme": "http",
+                  "protocol": "tcp",
+                  "transport": "http",
+                  "port": 8080,
+                  "targetPort": 8000
+                }
+              }
+            }
+            """;
+        Assert.Equal(expected, manifest.ToString().Replace('\\', '/'));
+    }
+
+    [Fact]
+    public async Task ConfigureResourceUsesManagedOutputDirectories()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api");
+
+        var configureBuilder = GetConfigureBuilder(app.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(configureBuilder.Resource);
+
+        Assert.Contains("-S", args);
+        Assert.Contains(builder.AppHostDirectory, args);
+        Assert.Contains("-B", args);
+        Assert.Contains(app.Resource.BuildDirectory, args);
+        Assert.Contains("-DCMAKE_BUILD_TYPE=Debug", args);
+        Assert.Contains($"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY={app.Resource.RuntimeOutputDirectory}", args);
+        Assert.Contains($"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG={app.Resource.RuntimeOutputDirectory}", args);
+        Assert.Contains($"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE={app.Resource.RuntimeOutputDirectory}", args);
+    }
+
+    [Fact]
+    public async Task ConfigureResourceAppendsConfigureArgs()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithConfigureArgs("-G", "Ninja", "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake");
+
+        var configureBuilder = GetConfigureBuilder(app.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(configureBuilder.Resource);
+
+        Assert.Equal("-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake", args[^1]);
+        Assert.Contains("-G", args);
+        Assert.Contains("Ninja", args);
+    }
+
+    [Fact]
+    public async Task BuildResourceBuildsSelectedTarget()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api");
+
+        var buildBuilder = GetBuildBuilder(app.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(buildBuilder.Resource);
+
+        Assert.Equal(["--build", app.Resource.BuildDirectory, "--config", "Debug", "--target", "api"], args);
+    }
+
+    [Fact]
+    public async Task BuildResourceUsesBuildTypeAndBuildArgs()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithBuildType("RelWithDebInfo")
+            .WithBuildArgs("--parallel", "4");
+
+        var buildBuilder = GetBuildBuilder(app.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(buildBuilder.Resource);
+
+        Assert.Equal(["--build", app.Resource.BuildDirectory, "--config", "RelWithDebInfo", "--target", "api", "--parallel", "4"], args);
+    }
+
+    [Fact]
+    public void AddCMakeAppCreatesConfigureAndBuildSiblingsInRunMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api");
+
+        var configure = GetConfigureBuilder(app.Resource);
+        var build = GetBuildBuilder(app.Resource);
+
+        Assert.Same(configure.Resource, builder.Resources.First(r => r.Name == "api-cmake-configure"));
+        Assert.Same(build.Resource, builder.Resources.First(r => r.Name == "api-cmake-build"));
+        Assert.Contains(build.Resource.Annotations.OfType<WaitAnnotation>(), a => a.Resource == configure.Resource && a.WaitType == WaitType.WaitForCompletion);
+        Assert.Contains(app.Resource.Annotations.OfType<WaitAnnotation>(), a => a.Resource == build.Resource && a.WaitType == WaitType.WaitForCompletion);
+    }
+
+    [Fact]
+    public void AddCMakeAppDoesNotCreateConfigureAndBuildSiblingsInPublishMode()
+    {
+        using var outputDir = new TestTempDirectory();
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputDir.Path, step: "publish-manifest");
+
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api");
+
+        Assert.False(app.Resource.TryGetLastAnnotation<CMakeConfigureResourceAnnotation>(out _));
+        Assert.False(app.Resource.TryGetLastAnnotation<CMakeBuildResourceAnnotation>(out _));
+    }
+
+    [Fact]
+    public async Task VerifyPublish_GeneratesDockerfile()
+    {
+        using var sourceDir = new TestTempDirectory();
+        using var outputDir = new TestTempDirectory();
+
+        File.WriteAllText(Path.Combine(sourceDir.Path, "CMakeLists.txt"), """
+            cmake_minimum_required(VERSION 3.20)
+            project(api LANGUAGES CXX)
+            add_executable(api main.cpp)
+            """);
+        File.WriteAllText(Path.Combine(sourceDir.Path, "main.cpp"), "int main() { return 0; }");
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputDir.Path, step: "publish-manifest");
+        builder.AddCMakeApp("api", sourceDir.Path, "api");
+
+        builder.Build().Run();
+
+        var content = await File.ReadAllTextAsync(Path.Combine(outputDir.Path, "api.Dockerfile"));
+
+        await Verify(content);
+    }
+
+    [Fact]
+    public async Task VerifyPublish_RespectsDockerfileBaseImageAnnotation()
+    {
+        using var sourceDir = new TestTempDirectory();
+        using var outputDir = new TestTempDirectory();
+
+        File.WriteAllText(Path.Combine(sourceDir.Path, "CMakeLists.txt"), """
+            cmake_minimum_required(VERSION 3.20)
+            project(api LANGUAGES CXX)
+            add_executable(api main.cpp)
+            """);
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputDir.Path, step: "publish-manifest");
+        builder.AddCMakeApp("api", sourceDir.Path, "api")
+            .WithDockerfileBaseImage(buildImage: "ubuntu:24.04", runtimeImage: "ubuntu:24.04");
+
+        builder.Build().Run();
+
+        var content = await File.ReadAllTextAsync(Path.Combine(outputDir.Path, "api.Dockerfile"));
+
+        await Verify(content);
+    }
+
+    [Fact]
+    public async Task VerifyPublish_PropagatesConfigureAndBuildArgsToDockerfile()
+    {
+        using var sourceDir = new TestTempDirectory();
+        using var outputDir = new TestTempDirectory();
+
+        File.WriteAllText(Path.Combine(sourceDir.Path, "CMakeLists.txt"), """
+            cmake_minimum_required(VERSION 3.20)
+            project(api LANGUAGES CXX)
+            add_executable(api main.cpp)
+            """);
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputDir.Path, step: "publish-manifest");
+        builder.AddCMakeApp("api", sourceDir.Path, "api")
+            .WithConfigureArgs("-DENABLE_HTTP=ON", "-DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake")
+            .WithBuildArgs("--parallel", "4");
+
+        builder.Build().Run();
+
+        var content = await File.ReadAllTextAsync(Path.Combine(outputDir.Path, "api.Dockerfile"));
+
+        await Verify(content);
+    }
+
+    [Fact]
+    public void VerifyPublish_SkipsDockerfileGeneration_WhenDockerfileExists()
+    {
+        using var sourceDir = new TestTempDirectory();
+        using var outputDir = new TestTempDirectory();
+
+        File.WriteAllText(Path.Combine(sourceDir.Path, "Dockerfile"), "FROM scratch");
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputDir.Path, step: "publish-manifest");
+        var app = builder.AddCMakeApp("api", sourceDir.Path, "api");
+
+        Assert.False(app.Resource.TryGetLastAnnotation<DockerfileBuilderCallbackAnnotation>(out _));
+    }
+
+    [Fact]
+    public void CMakeAppResource_ImplementsIContainerFilesDestinationResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+        var app = builder.AddCMakeApp("api", AppContext.BaseDirectory, "api");
+
+        Assert.IsType<CMakeAppResource>(app.Resource, exactMatch: false);
+        Assert.True(app.Resource is IContainerFilesDestinationResource);
+    }
+
+    private static IResourceBuilder<ExecutableResource> GetConfigureBuilder(CMakeAppResource resource)
+    {
+        Assert.True(resource.TryGetLastAnnotation<CMakeConfigureResourceAnnotation>(out var annotation));
+        return annotation.ResourceBuilder;
+    }
+
+    private static IResourceBuilder<ExecutableResource> GetBuildBuilder(CMakeAppResource resource)
+    {
+        Assert.True(resource.TryGetLastAnnotation<CMakeBuildResourceAnnotation>(out var annotation));
+        return annotation.ResourceBuilder;
+    }
+}

--- a/tests/Aspire.Hosting.Cpp.Tests/Aspire.Hosting.Cpp.Tests.csproj
+++ b/tests/Aspire.Hosting.Cpp.Tests/Aspire.Hosting.Cpp.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aspire.Hosting.AppHost\Aspire.Hosting.AppHost.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Cpp\Aspire.Hosting.Cpp.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Verify.XunitV3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(TestsSharedDir)\TestModuleInitializer.cs" />
+  </ItemGroup>
+
+</Project>
+

--- a/tests/Aspire.Hosting.Cpp.Tests/CMakeAppPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Cpp.Tests/CMakeAppPublicApiTests.cs
@@ -227,6 +227,57 @@ public class CMakeAppPublicApiTests
         Assert.True(app.Resource.TryGetLastAnnotation<CMakeVcpkgAnnotation>(out _));
     }
 
+    [Fact]
+    public void WithCMakeInstallShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<CMakeAppResource> builder = null!;
+
+        var action = () => builder.WithCMakeInstall();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("/bin/api")]
+    [InlineData("../api")]
+    [InlineData("bin/../api")]
+    [InlineData(@"C:\api\bin\api.exe")]
+    public void WithCMakeInstallShouldThrowWhenExecutableRelativePathIsInvalid(string executableRelativePath)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var action = () => builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithCMakeInstall(executableRelativePath);
+
+        var exception = Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(executableRelativePath), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithCMakeInstallUpdatesExecutablePath()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithCMakeInstall("sbin/api");
+
+        Assert.EndsWith(Path.Combine(".aspire", "cmake", "api", "build", "aspire-install", "sbin", "api"), app.Resource.Command);
+    }
+
+    [Fact]
+    public void WithExecutablePathShouldThrowAfterWithCMakeInstall()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithCMakeInstall();
+        var action = () => app.WithExecutablePath("/bin/api");
+
+        Assert.Throws<InvalidOperationException>(action);
+    }
+
     private static string GetExecutableFileName(string targetName) =>
         OperatingSystem.IsWindows() ? $"{targetName}.exe" : targetName;
 }

--- a/tests/Aspire.Hosting.Cpp.Tests/CMakeAppPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Cpp.Tests/CMakeAppPublicApiTests.cs
@@ -174,6 +174,59 @@ public class CMakeAppPublicApiTests
         Assert.Contains(annotations, a => a.Command == "vcpkg");
     }
 
+    [Fact]
+    public void WithVcpkgShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<CMakeAppResource> builder = null!;
+
+        var action = () => builder.WithVcpkg("/vcpkg");
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithVcpkgShouldThrowWhenRootIsEmpty()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var vcpkgRoot = string.Empty;
+
+        var action = () => builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithVcpkg(vcpkgRoot);
+
+        var exception = Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(vcpkgRoot), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task WithVcpkgAddsRequiredCommandAndConfigureArgs()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var vcpkgRoot = Path.Combine(builder.AppHostDirectory, "vcpkg");
+
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithVcpkg(vcpkgRoot);
+
+        Assert.True(app.Resource.TryGetAnnotationsOfType<RequiredCommandAnnotation>(out var annotations));
+        Assert.Contains(annotations, a => a.Command == "vcpkg" && a.HelpLink == "https://vcpkg.io/");
+
+        var configure = app.Resource.Annotations.OfType<CMakeConfigureResourceAnnotation>().Single().ResourceBuilder.Resource;
+        var args = await ArgumentEvaluator.GetArgumentListAsync(configure);
+        Assert.Contains($"-DCMAKE_TOOLCHAIN_FILE={Path.Combine(vcpkgRoot, "scripts", "buildsystems", "vcpkg.cmake")}", args);
+    }
+
+    [Fact]
+    public void WithVcpkgDoesNotRequireLocalRootInPublishMode()
+    {
+        using var outputDir = new TestTempDirectory();
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, outputDir.Path, step: "publish-manifest");
+
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithVcpkg();
+
+        Assert.True(app.Resource.TryGetLastAnnotation<CMakeVcpkgAnnotation>(out _));
+    }
+
     private static string GetExecutableFileName(string targetName) =>
         OperatingSystem.IsWindows() ? $"{targetName}.exe" : targetName;
 }

--- a/tests/Aspire.Hosting.Cpp.Tests/CMakeAppPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Cpp.Tests/CMakeAppPublicApiTests.cs
@@ -1,0 +1,179 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIRECOMMAND001
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Cpp.Tests;
+
+public class CMakeAppPublicApiTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CtorCMakeAppResourceShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => new CMakeAppResource(name, "/src/cpp-api", "/src/cpp-api/build", "api", "/src/cpp-api/build/api", "/src/cpp-api/build/bin");
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CtorCMakeAppResourceShouldThrowWhenTargetNameIsNullOrEmpty(bool isNull)
+    {
+        var targetName = isNull ? null! : string.Empty;
+
+        var action = () => new CMakeAppResource("api", "/src/cpp-api", "/src/cpp-api/build", targetName, "/src/cpp-api/build/api", "/src/cpp-api/build/bin");
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(targetName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddCMakeAppShouldThrowWhenBuilderIsNull()
+    {
+        IDistributedApplicationBuilder builder = null!;
+
+        var action = () => builder.AddCMakeApp("api", "/src/cpp-api", "api");
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddCMakeAppShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddCMakeApp(name, "/src/cpp-api", "api");
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddCMakeAppShouldThrowWhenSourceDirectoryIsNullOrEmpty(bool isNull)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var sourceDirectory = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddCMakeApp("api", sourceDirectory, "api");
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(sourceDirectory), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddCMakeAppShouldThrowWhenTargetNameIsNullOrEmpty(bool isNull)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var targetName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddCMakeApp("api", "/src/cpp-api", targetName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(targetName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddCMakeAppCreatesExecutableResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api");
+
+        Assert.EndsWith(Path.Combine(".aspire", "cmake", "api", "build", "aspire-bin", GetExecutableFileName("api")), app.Resource.Command);
+        Assert.Equal(builder.AppHostDirectory, app.Resource.SourceDirectory);
+        Assert.Equal("api", app.Resource.TargetName);
+    }
+
+    [Fact]
+    public async Task AddCMakeAppDefaultApplicationArgsAreEmpty()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api");
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
+
+        Assert.Empty(args);
+    }
+
+    [Fact]
+    public void WithAppArgsShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<CMakeAppResource> builder = null!;
+
+        var action = () => builder.WithAppArgs("--config", "dev.json");
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task WithAppArgsPassesArgumentsToApplication()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithAppArgs("--config", "dev.json");
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
+
+        Assert.Equal(["--config", "dev.json"], args);
+    }
+
+    [Fact]
+    public void WithRequiredBuildToolAddsRequiredCommandAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithRequiredBuildTool("ninja", "https://ninja-build.org/");
+
+        Assert.True(app.Resource.TryGetAnnotationsOfType<RequiredCommandAnnotation>(out var annotations));
+        Assert.Contains(annotations, a => a.Command == "cmake");
+        Assert.Contains(annotations, a => a.Command == "ninja" && a.HelpLink == "https://ninja-build.org/");
+    }
+
+    [Fact]
+    public void WithRequiredBuildToolsAddsAllRequiredCommandAnnotations()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var app = builder.AddCMakeApp("api", builder.AppHostDirectory, "api")
+            .WithRequiredBuildTools(
+                new CMakeBuildTool("ninja", "https://ninja-build.org/"),
+                new CMakeBuildTool("vcpkg", "https://vcpkg.io/"));
+
+        Assert.True(app.Resource.TryGetAnnotationsOfType<RequiredCommandAnnotation>(out var annotations));
+        Assert.Contains(annotations, a => a.Command == "ninja");
+        Assert.Contains(annotations, a => a.Command == "vcpkg");
+    }
+
+    private static string GetExecutableFileName(string targetName) =>
+        OperatingSystem.IsWindows() ? $"{targetName}.exe" : targetName;
+}

--- a/tests/Aspire.Hosting.Cpp.Tests/Snapshots/AddCMakeAppTests.VerifyPublish_GeneratesDockerfile.verified.txt
+++ b/tests/Aspire.Hosting.Cpp.Tests/Snapshots/AddCMakeAppTests.VerifyPublish_GeneratesDockerfile.verified.txt
@@ -1,0 +1,17 @@
+FROM debian:bookworm AS build
+WORKDIR /src
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential cmake ninja-build ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY . .
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake -S . -B /src/.aspire/cmake/docker-build -G Ninja -DCMAKE_BUILD_TYPE='Release' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL=/src/.aspire/cmake/docker-bin
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake --build /src/.aspire/cmake/docker-build --config 'Release' --target 'api'
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libstdc++6 && rm -rf /var/lib/apt/lists/*
+RUN groupadd --system --gid 999 app && useradd --system --gid 999 --uid 999 --no-create-home app
+WORKDIR /app
+COPY --from=build /src/.aspire/cmake/docker-bin/api /app/api
+USER app
+ENTRYPOINT ["/app/api"]
+

--- a/tests/Aspire.Hosting.Cpp.Tests/Snapshots/AddCMakeAppTests.VerifyPublish_GeneratesInstallDockerfile.verified.txt
+++ b/tests/Aspire.Hosting.Cpp.Tests/Snapshots/AddCMakeAppTests.VerifyPublish_GeneratesInstallDockerfile.verified.txt
@@ -1,0 +1,18 @@
+﻿FROM debian:bookworm AS build
+WORKDIR /src
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential cmake ninja-build ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY . .
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake -S . -B /src/.aspire/cmake/docker-build -G Ninja -DCMAKE_BUILD_TYPE='Release' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL=/src/.aspire/cmake/docker-bin
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake --build /src/.aspire/cmake/docker-build --config 'Release' --target 'api'
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake --install /src/.aspire/cmake/docker-build --config 'Release' --prefix /src/.aspire/cmake/docker-install
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libstdc++6 && rm -rf /var/lib/apt/lists/*
+RUN groupadd --system --gid 999 app && useradd --system --gid 999 --uid 999 --no-create-home app
+WORKDIR /app
+COPY --from=build /src/.aspire/cmake/docker-install/ /app/
+USER app
+ENTRYPOINT ["/app/bin/api"]

--- a/tests/Aspire.Hosting.Cpp.Tests/Snapshots/AddCMakeAppTests.VerifyPublish_GeneratesVcpkgDockerfile.verified.txt
+++ b/tests/Aspire.Hosting.Cpp.Tests/Snapshots/AddCMakeAppTests.VerifyPublish_GeneratesVcpkgDockerfile.verified.txt
@@ -1,0 +1,18 @@
+﻿FROM debian:bookworm AS build
+WORKDIR /src
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential cmake ninja-build ca-certificates git curl zip unzip tar pkg-config && rm -rf /var/lib/apt/lists/*
+RUN git clone --depth=1 https://github.com/microsoft/vcpkg /opt/vcpkg && /opt/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+ENV VCPKG_ROOT=/opt/vcpkg
+COPY . .
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake -S . -B /src/.aspire/cmake/docker-build -G Ninja -DCMAKE_BUILD_TYPE='Release' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL=/src/.aspire/cmake/docker-bin -DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake --build /src/.aspire/cmake/docker-build --config 'Release' --target 'api'
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libstdc++6 && rm -rf /var/lib/apt/lists/*
+RUN groupadd --system --gid 999 app && useradd --system --gid 999 --uid 999 --no-create-home app
+WORKDIR /app
+COPY --from=build /src/.aspire/cmake/docker-bin/api /app/api
+USER app
+ENTRYPOINT ["/app/api"]

--- a/tests/Aspire.Hosting.Cpp.Tests/Snapshots/AddCMakeAppTests.VerifyPublish_GeneratesVcpkgInstallDockerfile.verified.txt
+++ b/tests/Aspire.Hosting.Cpp.Tests/Snapshots/AddCMakeAppTests.VerifyPublish_GeneratesVcpkgInstallDockerfile.verified.txt
@@ -1,0 +1,20 @@
+﻿FROM debian:bookworm AS build
+WORKDIR /src
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential cmake ninja-build ca-certificates git curl zip unzip tar pkg-config && rm -rf /var/lib/apt/lists/*
+RUN git clone --depth=1 https://github.com/microsoft/vcpkg /opt/vcpkg && /opt/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+ENV VCPKG_ROOT=/opt/vcpkg
+COPY . .
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake -S . -B /src/.aspire/cmake/docker-build -G Ninja -DCMAKE_BUILD_TYPE='Release' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL=/src/.aspire/cmake/docker-bin -DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake --build /src/.aspire/cmake/docker-build --config 'Release' --target 'api'
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake --install /src/.aspire/cmake/docker-build --config 'Release' --prefix /src/.aspire/cmake/docker-install
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libstdc++6 && rm -rf /var/lib/apt/lists/*
+RUN groupadd --system --gid 999 app && useradd --system --gid 999 --uid 999 --no-create-home app
+WORKDIR /app
+COPY --from=build /src/.aspire/cmake/docker-install/ /app/
+USER app
+ENTRYPOINT ["/app/bin/api"]

--- a/tests/Aspire.Hosting.Cpp.Tests/Snapshots/AddCMakeAppTests.VerifyPublish_PropagatesConfigureAndBuildArgsToDockerfile.verified.txt
+++ b/tests/Aspire.Hosting.Cpp.Tests/Snapshots/AddCMakeAppTests.VerifyPublish_PropagatesConfigureAndBuildArgsToDockerfile.verified.txt
@@ -1,0 +1,17 @@
+FROM debian:bookworm AS build
+WORKDIR /src
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential cmake ninja-build ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY . .
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake -S . -B /src/.aspire/cmake/docker-build -G Ninja -DCMAKE_BUILD_TYPE='Release' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL=/src/.aspire/cmake/docker-bin '-DENABLE_HTTP=ON' '-DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake'
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake --build /src/.aspire/cmake/docker-build --config 'Release' --target 'api' '--parallel' '4'
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libstdc++6 && rm -rf /var/lib/apt/lists/*
+RUN groupadd --system --gid 999 app && useradd --system --gid 999 --uid 999 --no-create-home app
+WORKDIR /app
+COPY --from=build /src/.aspire/cmake/docker-bin/api /app/api
+USER app
+ENTRYPOINT ["/app/api"]
+

--- a/tests/Aspire.Hosting.Cpp.Tests/Snapshots/AddCMakeAppTests.VerifyPublish_RespectsDockerfileBaseImageAnnotation.verified.txt
+++ b/tests/Aspire.Hosting.Cpp.Tests/Snapshots/AddCMakeAppTests.VerifyPublish_RespectsDockerfileBaseImageAnnotation.verified.txt
@@ -1,0 +1,17 @@
+FROM ubuntu:24.04 AS build
+WORKDIR /src
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential cmake ninja-build ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY . .
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake -S . -B /src/.aspire/cmake/docker-build -G Ninja -DCMAKE_BUILD_TYPE='Release' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO=/src/.aspire/cmake/docker-bin -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL=/src/.aspire/cmake/docker-bin
+RUN --mount=type=cache,target=/src/.aspire/cmake/docker-build \
+    cmake --build /src/.aspire/cmake/docker-build --config 'Release' --target 'api'
+
+FROM ubuntu:24.04
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libstdc++6 && rm -rf /var/lib/apt/lists/*
+RUN groupadd --system --gid 999 app && useradd --system --gid 999 --uid 999 --no-create-home app
+WORKDIR /app
+COPY --from=build /src/.aspire/cmake/docker-bin/api /app/api
+USER app
+ENTRYPOINT ["/app/api"]
+


### PR DESCRIPTION
## Description

Adds a first-party CMake-based C++ hosting integration so Aspire apps can model native C++ services directly instead of hand-wiring raw executable resources. The integration configures and builds the CMake target before launch, validates required local build tools, and generates container publish artifacts for projects that do not provide their own Dockerfile.

The sample demonstrates a `cpp-httplib` HTTP API built with CMake and vcpkg, including Docker Compose deployment through `Aspire.Hosting.Docker`. `WithVcpkg()` keeps local run mode simple by using `VCPKG_ROOT`, while generated Dockerfiles bootstrap vcpkg inside the build container and use a container-local toolchain path so host vcpkg paths do not leak into deployment artifacts.

This also adds `WithCMakeInstall()`, which uses `cmake --install` as the runtime boundary. Local run mode adds a hidden install resource after the build resource and launches the installed executable. Dockerfile publish installs into an intermediate prefix, copies the full installed tree into `/app`, and uses the installed executable as the entrypoint.

### User-facing usage

C# AppHost:

```csharp
var api = builder.AddCMakeApp("api", "../cpp-api", targetName: "api")
                 .WithVcpkg()
                 .WithCMakeInstall()
                 .WithHttpEndpoint(env: "PORT")
                 .WithExternalHttpEndpoints();
```

TypeScript AppHost:

```typescript
const api = await builder.addCMakeApp("api", "../cpp-api", "api")
    .withVcpkg()
    .withCMakeInstall()
    .withHttpEndpoint({ env: "PORT" })
    .withExternalHttpEndpoints();
```

### Implementation notes

- Adds `Aspire.Hosting.Cpp` with `AddCMakeApp`, configure/build/app argument helpers, executable path override, build type configuration, required build tool helpers, `WithVcpkg()`, and `WithCMakeInstall()`.
- Creates hidden configure/build executable resources for local run, with the app waiting for `cmake --build` to complete successfully before launching.
- `WithCMakeInstall()` creates a hidden install executable resource, waits for it before launching the app, and expects the installed executable under `bin/<targetName>` by default.
- Uses a deterministic `.aspire/cmake/<resource>/build/aspire-bin` runtime output directory for build output, and `.aspire/cmake/<resource>/build/aspire-install` for local install output.
- Generates a default multi-stage Dockerfile for publish unless the C++ project already has a Dockerfile.
- Adds Docker Compose deployment to the playground AppHost and verifies the published Dockerfile uses `/opt/vcpkg` and `/src/.aspire/cmake/docker-install` rather than host-local paths.

### Security considerations

This change adds APIs that run local build tools declared by the AppHost author and generates Dockerfile commands from AppHost-provided CMake configure/build arguments. The implementation treats these as developer-authored inputs, not untrusted remote data, and quotes generated Dockerfile command arguments before emitting shell script lines. `WithCMakeInstall()` rejects absolute and parent-traversal executable paths so the configured entrypoint remains relative to the CMake install prefix. Formal security review has not been completed.

Fixes # (issue): N/A

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No

Validation:

- `dotnet build playground/CppHello/CppHello.AppHost/CppHello.AppHost.csproj --no-restore`
- `dotnet test --project tests/Aspire.Hosting.Cpp.Tests/Aspire.Hosting.Cpp.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `aspire publish --apphost playground/CppHello/CppHello.AppHost/CppHello.AppHost.csproj --list-steps --non-interactive`
- `aspire publish --apphost playground/CppHello/CppHello.AppHost/CppHello.AppHost.csproj --non-interactive`
- `aspire deploy --apphost playground/CppHello/CppHello.AppHost/CppHello.AppHost.csproj --non-interactive`
- Deployed `cpp-api` verified with `curl` for `/` returning `Hello from C++ on Aspire!` and `/health` returning `Healthy`
- `aspire destroy --apphost playground/CppHello/CppHello.AppHost/CppHello.AppHost.csproj --yes --non-interactive`
- Local install-mode run revalidated with `aspire start --isolated --non-interactive`, `aspire wait cpp-api`, `aspire describe` showing the installed executable path, and `curl` for `/` and `/health`