### PR TITLE
Honor --no-build for TypeScript AppHosts

### DIFF
--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -602,7 +602,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 // appHostSystemCts is linked to cancellationToken) tears down the guest process. The
                 // launcher will kill the guest's process tree when this token cancels.
                 (guestExitCode, guestOutput) = await ExecuteGuestAppHostAsync(
-                    appHostFile, directory, environmentVariables, enableHotReload, rpcClient, launcher, StartBackchannelConnectionAfterGuestAppHostLaunchesAsync, appHostSystemToken);
+                    appHostFile, directory, environmentVariables, enableHotReload, context.NoBuild, rpcClient, launcher, StartBackchannelConnectionAfterGuestAppHostLaunchesAsync, appHostSystemToken);
             }
 
             // If the user cancelled (Ctrl+C), surface that as cancellation instead of a "guest failed"
@@ -1111,7 +1111,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 // Step 6: Execute the guest apphost for publishing
                 // Pass the publish arguments (e.g., --operation publish --step deploy)
                 (guestExitCode, guestOutput) = await ExecuteGuestAppHostForPublishAsync(
-                    appHostFile, directory, environmentVariables, context.Arguments, rpcClient, cancellationToken);
+                    appHostFile, directory, environmentVariables, context.Arguments, context.NoBuild, rpcClient, cancellationToken);
             }
 
             if (guestExitCode != 0)
@@ -1875,6 +1875,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         DirectoryInfo directory,
         IDictionary<string, string> environmentVariables,
         bool watchMode,
+        bool noBuild,
         IAppHostRpcClient rpcClient,
         IGuestProcessLauncher launcher,
         Func<Task>? afterAppHostLaunchedAsync,
@@ -1888,7 +1889,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             return (CliExitCodes.FailedToDotnetRunAppHost, new OutputCollector());
         }
 
-        return await _guestRuntime.RunAsync(appHostFile, directory, environmentVariables, watchMode, launcher, cancellationToken, afterAppHostLaunchedAsync: afterAppHostLaunchedAsync);
+        return await _guestRuntime.RunAsync(appHostFile, directory, environmentVariables, watchMode, launcher, cancellationToken, noBuild: noBuild, afterAppHostLaunchedAsync: afterAppHostLaunchedAsync);
     }
 
     /// <summary>
@@ -1899,6 +1900,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         DirectoryInfo directory,
         IDictionary<string, string> environmentVariables,
         string[]? publishArgs,
+        bool noBuild,
         IAppHostRpcClient rpcClient,
         CancellationToken cancellationToken)
     {
@@ -1910,7 +1912,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             return (CliExitCodes.FailedToDotnetRunAppHost, new OutputCollector());
         }
 
-        return await _guestRuntime.PublishAsync(appHostFile, directory, environmentVariables, publishArgs, _guestRuntime.CreateDefaultLauncher(), cancellationToken);
+        return await _guestRuntime.PublishAsync(appHostFile, directory, environmentVariables, publishArgs, _guestRuntime.CreateDefaultLauncher(), cancellationToken, noBuild: noBuild);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -144,6 +144,7 @@ internal sealed class GuestRuntime
     /// <param name="watchMode">Whether to run in watch mode for hot reload.</param>
     /// <param name="launcher">Strategy for launching the process.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="noBuild">Whether to skip pre-execution build/check commands.</param>
     /// <param name="afterAppHostLaunchedAsync">Callback invoked after the AppHost execute command has launched.</param>
     /// <returns>A tuple of the exit code and captured output (null when launched via extension).</returns>
     public async Task<(int ExitCode, OutputCollector? Output)> RunAsync(
@@ -153,6 +154,7 @@ internal sealed class GuestRuntime
         bool watchMode,
         IGuestProcessLauncher launcher,
         CancellationToken cancellationToken,
+        bool noBuild = false,
         Func<Task>? afterAppHostLaunchedAsync = null)
     {
         var useWatchCommand = watchMode && _spec.WatchExecute is not null;
@@ -161,7 +163,7 @@ internal sealed class GuestRuntime
             : _spec.Execute;
 
         await EnsureMigrationFilesExistAsync(directory, cancellationToken);
-        if (!useWatchCommand)
+        if (!useWatchCommand && !noBuild)
         {
             var preExecuteResult = await RunPreExecuteCommandsAsync(appHostFile, directory, environmentVariables, launcher, cancellationToken);
             if (preExecuteResult.ExitCode != 0)
@@ -185,6 +187,7 @@ internal sealed class GuestRuntime
     /// <param name="publishArgs">Additional arguments for publishing.</param>
     /// <param name="launcher">Strategy for launching the process.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="noBuild">Whether to skip pre-execution build/check commands.</param>
     /// <returns>A tuple of the exit code and captured output.</returns>
     public async Task<(int ExitCode, OutputCollector? Output)> PublishAsync(
         FileInfo appHostFile,
@@ -192,15 +195,19 @@ internal sealed class GuestRuntime
         IDictionary<string, string> environmentVariables,
         string[]? publishArgs,
         IGuestProcessLauncher launcher,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool noBuild = false)
     {
         var commandSpec = _spec.PublishExecute ?? _spec.Execute;
 
         await EnsureMigrationFilesExistAsync(directory, cancellationToken);
-        var preExecuteResult = await RunPreExecuteCommandsAsync(appHostFile, directory, environmentVariables, launcher, cancellationToken);
-        if (preExecuteResult.ExitCode != 0)
+        if (!noBuild)
         {
-            return preExecuteResult;
+            var preExecuteResult = await RunPreExecuteCommandsAsync(appHostFile, directory, environmentVariables, launcher, cancellationToken);
+            if (preExecuteResult.ExitCode != 0)
+            {
+                return preExecuteResult;
+            }
         }
 
         var phase = _spec.PublishExecute is not null

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -55,6 +55,24 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         };
     }
 
+    private static RuntimeSpec CreateTypeScriptRuntimeSpec()
+    {
+        return CreateTestSpec(
+            execute: new CommandSpec
+            {
+                Command = "npx",
+                Args = ["--no-install", "tsx", "--tsconfig", "tsconfig.apphost.json", "{appHostFile}"]
+            },
+            preExecute:
+            [
+                new CommandSpec
+                {
+                    Command = "npx",
+                    Args = ["--no-install", "tsc", "--noEmit", "-p", "tsconfig.apphost.json"]
+                }
+            ]);
+    }
+
     [Fact]
     public void Language_ReturnsSpecLanguage()
     {
@@ -161,6 +179,31 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         Assert.Equal("typecheck-cmd", launcher.Calls[0].Command);
         Assert.Equal(["--project", directory.FullName], launcher.Calls[0].Args);
         Assert.Equal("run-cmd", launcher.Calls[1].Command);
+    }
+
+    [Fact]
+    public async Task RunAsync_NoBuildSkipsTypeScriptTscAndRunsAppHost()
+    {
+        var spec = CreateTypeScriptRuntimeSpec();
+        var runtime = CreateRuntime(spec);
+        var launcher = new RecordingLauncher();
+        var appHostFile = new FileInfo("/tmp/apphost.ts");
+        var directory = new DirectoryInfo("/tmp");
+
+        var (exitCode, _) = await runtime.RunAsync(
+            appHostFile,
+            directory,
+            new Dictionary<string, string>(),
+            watchMode: false,
+            launcher,
+            CancellationToken.None,
+            noBuild: true);
+
+        Assert.Equal(0, exitCode);
+        var call = Assert.Single(launcher.Calls);
+        Assert.Equal("npx", call.Command);
+        Assert.Equal(["--no-install", "tsx", "--tsconfig", "tsconfig.apphost.json", appHostFile.FullName], call.Args);
+        Assert.DoesNotContain(launcher.Calls, recordedCall => recordedCall.Args.Contains("tsc"));
     }
 
     [Fact]
@@ -372,6 +415,31 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         Assert.Equal(2, launcher.Calls.Count);
         Assert.Equal("typecheck-cmd", launcher.Calls[0].Command);
         Assert.Equal("publish-cmd", launcher.Calls[1].Command);
+    }
+
+    [Fact]
+    public async Task PublishAsync_NoBuildSkipsTypeScriptTscAndRunsAppHost()
+    {
+        var spec = CreateTypeScriptRuntimeSpec();
+        var runtime = CreateRuntime(spec);
+        var launcher = new RecordingLauncher();
+        var appHostFile = new FileInfo("/tmp/apphost.ts");
+        var directory = new DirectoryInfo("/tmp");
+
+        var (exitCode, _) = await runtime.PublishAsync(
+            appHostFile,
+            directory,
+            new Dictionary<string, string>(),
+            ["--operation", "publish"],
+            launcher,
+            CancellationToken.None,
+            noBuild: true);
+
+        Assert.Equal(0, exitCode);
+        var call = Assert.Single(launcher.Calls);
+        Assert.Equal("npx", call.Command);
+        Assert.Equal(["--no-install", "tsx", "--tsconfig", "tsconfig.apphost.json", appHostFile.FullName, "--operation", "publish"], call.Args);
+        Assert.DoesNotContain(launcher.Calls, recordedCall => recordedCall.Args.Contains("tsc"));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -203,7 +203,6 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         var call = Assert.Single(launcher.Calls);
         Assert.Equal("npx", call.Command);
         Assert.Equal(["--no-install", "tsx", "--tsconfig", "tsconfig.apphost.json", appHostFile.FullName], call.Args);
-        Assert.DoesNotContain(launcher.Calls, recordedCall => recordedCall.Args.Contains("tsc"));
     }
 
     [Fact]
@@ -439,7 +438,6 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         var call = Assert.Single(launcher.Calls);
         Assert.Equal("npx", call.Command);
         Assert.Equal(["--no-install", "tsx", "--tsconfig", "tsconfig.apphost.json", appHostFile.FullName, "--operation", "publish"], call.Args);
-        Assert.DoesNotContain(launcher.Calls, recordedCall => recordedCall.Args.Contains("tsc"));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

`--no-build` should let users skip build and typecheck work before launching an AppHost. TypeScript AppHosts still ran the guest pre-execute command (`npx --no-install tsc --noEmit`) during run and publish, so `--no-build` did not fully honor that contract for TypeScript.

This threads `NoBuild` through the guest AppHost run and publish paths and skips runtime pre-execute build/check commands when it is set. The AppHost execution command still runs, so TypeScript AppHosts continue to launch through `tsx` with the normal run or publish arguments.

### User-facing usage

```bash
aspire run --apphost apphost.mts --no-build
aspire publish --apphost apphost.mts --no-build --output-path ./publish
```

### Validation

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-method "*.GuestRuntimeTests.RunAsync_NoBuildSkipsTypeScriptTscAndRunsAppHost" --filter-method "*.GuestRuntimeTests.PublishAsync_NoBuildSkipsTypeScriptTscAndRunsAppHost" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-build --no-launch-profile -- --filter-class "*.GuestRuntimeTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Manual TypeScript AppHost smoke with a deliberate `TS2322`: normal `run`/`publish` fail in `tsc`, while `run --no-build` reaches AppHost execution and `publish --no-build` succeeds without `TS2322`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No