### PR TITLE
Collect AI agent skill-usage telemetry (CLI command + agent init hooks)

### DIFF
--- a/.github/workflows/verify-aspire-skills-bundle.yml
+++ b/.github/workflows/verify-aspire-skills-bundle.yml
@@ -5,7 +5,10 @@ on:
   pull_request:
     paths:
       - 'src/Aspire.Cli/Agents/AspireSkills/Embedded/**'
+      - 'src/Aspire.Cli/Agents/Hooks/track-telemetry.sh'
+      - 'src/Aspire.Cli/Agents/Hooks/track-telemetry.ps1'
       - 'eng/scripts/verify-aspire-skills-bundle.ps1'
+      - 'eng/scripts/aspire-skills-bundle.common.ps1'
       - '.github/workflows/verify-aspire-skills-bundle.yml'
 
 permissions:

--- a/eng/scripts/aspire-skills-bundle.common.ps1
+++ b/eng/scripts/aspire-skills-bundle.common.ps1
@@ -1,0 +1,113 @@
+#!/usr/bin/env pwsh
+
+# Shared helpers for syncing and verifying the embedded Aspire telemetry hook scripts
+# (track-telemetry.sh / track-telemetry.ps1).
+#
+# The hook scripts live canonically in microsoft/aspire-skills under hooks/scripts/. They are SOURCE
+# files (not build outputs), so they are pinned to the immutable commit that an aspire-skills release
+# tag points at and fetched through the GitHub contents API. Hashing is always done over
+# LF-normalized UTF-8 (no BOM) content so the recorded hash is stable regardless of the checkout's
+# line-ending policy: .sh is `eol=lf` while .ps1 is `text=auto` (checked out CRLF on Windows).
+
+Set-StrictMode -Version Latest
+
+$script:AspireSkillsHookFileNames = @('track-telemetry.sh', 'track-telemetry.ps1')
+$script:AspireSkillsHookRepoDirectory = 'hooks/scripts'
+
+function Get-AspireSkillsHookFileNames {
+    return $script:AspireSkillsHookFileNames
+}
+
+function Invoke-AspireSkillsGitHubApi {
+    param([Parameter(Mandatory = $true)][string]$Endpoint)
+
+    # Suppress the native-command auto-throw locally so the explicit exit-code check below runs and
+    # gh's own diagnostics (for example "gh: Not Found (HTTP 404)") are preserved in the thrown
+    # message. Callers use that text to tell an absent path (an expected 404) from a real failure.
+    $PSNativeCommandUseErrorActionPreference = $false
+
+    $stderr = ''
+    $stdout = & gh api $Endpoint 2>&1 | ForEach-Object {
+        if ($_ -is [System.Management.Automation.ErrorRecord]) {
+            $stderr += "$($_.ToString())`n"
+        }
+        else {
+            $_
+        }
+    }
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh api $Endpoint failed with exit code $LASTEXITCODE. $($stderr.Trim())"
+    }
+
+    return $stdout
+}
+
+function ConvertTo-LfUtf8Bytes {
+    param([Parameter(Mandatory = $true)][AllowEmptyCollection()][byte[]]$Bytes)
+
+    # Strip a UTF-8 BOM if present, then normalize CRLF/CR to LF. A BOM or CRLF in track-telemetry.sh
+    # would break the shebang/shell on POSIX hosts, and normalizing makes the recorded hash independent
+    # of how git checked the file out.
+    $text = [System.Text.UTF8Encoding]::new($false).GetString($Bytes)
+    if ($text.Length -gt 0 -and $text[0] -eq [char]0xFEFF) {
+        $text = $text.Substring(1)
+    }
+
+    $text = $text -replace "`r`n", "`n" -replace "`r", "`n"
+    return [System.Text.UTF8Encoding]::new($false).GetBytes($text)
+}
+
+function Get-AspireSkillsSha256Hex {
+    param([Parameter(Mandatory = $true)][AllowEmptyCollection()][byte[]]$Bytes)
+
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        return [System.BitConverter]::ToString($sha.ComputeHash($Bytes)).Replace('-', '').ToLowerInvariant()
+    }
+    finally {
+        $sha.Dispose()
+    }
+}
+
+function Get-AspireSkillsReleaseCommitSha {
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$Tag
+    )
+
+    # Resolve the tag to the commit it points at (dereferences annotated tags). Pinning to the commit
+    # rather than the tag means a force-moved tag cannot silently change what gets synced or verified.
+    $sha = (Invoke-AspireSkillsGitHubApi "repos/$Repository/commits/$Tag" | ConvertFrom-Json).sha
+    if ([string]::IsNullOrWhiteSpace($sha)) {
+        throw "Could not resolve a commit SHA for tag '$Tag' in '$Repository'."
+    }
+
+    return $sha
+}
+
+function Get-AspireSkillsHookContent {
+    # Fetch a single hook script from aspire-skills at an immutable commit and return its
+    # LF-normalized UTF-8 bytes.
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$CommitSha,
+        [Parameter(Mandatory = $true)][string]$FileName
+    )
+
+    $path = "$script:AspireSkillsHookRepoDirectory/$FileName"
+    $endpoint = "repos/$Repository/contents/$path" + "?ref=$CommitSha"
+    $response = Invoke-AspireSkillsGitHubApi $endpoint | ConvertFrom-Json
+
+    if ($response.type -ne 'file') {
+        throw "Aspire skills hook '$path' at commit '$CommitSha' is not a file (type '$($response.type)')."
+    }
+
+    if ($response.name -ne $FileName) {
+        throw "Aspire skills hook response name '$($response.name)' did not match expected '$FileName'."
+    }
+
+    # The contents API returns base64 with embedded newlines; strip all whitespace before decoding.
+    $rawBytes = [System.Convert]::FromBase64String(($response.content -replace '\s', ''))
+    return ConvertTo-LfUtf8Bytes -Bytes $rawBytes
+}

--- a/eng/scripts/update-aspire-skills-bundle.ps1
+++ b/eng/scripts/update-aspire-skills-bundle.ps1
@@ -16,6 +16,9 @@ $embeddedDir = Join-Path $repoRoot 'src\Aspire.Cli\Agents\AspireSkills\Embedded'
 $metadataPath = Join-Path $embeddedDir 'aspire-skills.metadata.json'
 $installerPath = Join-Path $repoRoot 'src\Aspire.Cli\Agents\AspireSkills\AspireSkillsInstaller.cs'
 $cliProjectPath = Join-Path $repoRoot 'src\Aspire.Cli\Aspire.Cli.csproj'
+$hooksDir = Join-Path $repoRoot 'src\Aspire.Cli\Agents\Hooks'
+
+. (Join-Path $scriptDir 'aspire-skills-bundle.common.ps1')
 
 function Invoke-GitHubCli {
     param(
@@ -132,6 +135,51 @@ try {
 
     Copy-Item -Path $archivePath -Destination $targetArchivePath -Force
 
+    # Sync the telemetry hook scripts from the same release. Hooks are SOURCE files in aspire-skills
+    # (hooks/scripts/track-telemetry.{sh,ps1}), so they are pinned to the immutable commit the release
+    # tag points at and fetched via the contents API (see aspire-skills-bundle.common.ps1). Releases
+    # that predate the telemetry hooks feature do not contain hooks/scripts/*, so a missing hook is a
+    # warning + skip during the transition rather than a hard failure of the whole bundle update;
+    # verification only enforces hooks once they are recorded in metadata.
+    New-Item -ItemType Directory -Force -Path $hooksDir | Out-Null
+    $hookMetadata = $null
+    try {
+        $hookCommitSha = Get-AspireSkillsReleaseCommitSha -Repository $Repository -Tag $release.tagName
+
+        # Fetch every hook first and only write to disk + record metadata once all fetches succeed.
+        # Writing inside the fetch loop could leave one fresh + one stale file (and no hooks metadata)
+        # if a later fetch failed, after which verify-aspire-skills-bundle.ps1 would silently skip hook
+        # verification. Collecting first makes the on-disk update atomic.
+        $hookContents = [ordered]@{}
+        $hookHashes = [ordered]@{}
+        foreach ($hookFileName in Get-AspireSkillsHookFileNames) {
+            Write-Host "Syncing hook script '$hookFileName' from '$Repository' at commit '$hookCommitSha'..."
+            $hookBytes = Get-AspireSkillsHookContent -Repository $Repository -CommitSha $hookCommitSha -FileName $hookFileName
+            $hookContents[$hookFileName] = $hookBytes
+            $hookHashes[$hookFileName] = Get-AspireSkillsSha256Hex -Bytes $hookBytes
+        }
+
+        foreach ($hookFileName in $hookContents.Keys) {
+            [System.IO.File]::WriteAllBytes((Join-Path $hooksDir $hookFileName), $hookContents[$hookFileName])
+        }
+
+        $hookMetadata = [ordered]@{
+            commitSha = $hookCommitSha
+            files = $hookHashes
+        }
+    }
+    catch {
+        # A release that predates the telemetry hooks feature has no hooks/scripts/* (HTTP 404); that
+        # is the only expected soft-skip during the transition. Any other failure (transient network,
+        # auth, rate limit) stays fatal so a real error can never silently ship a hook-less bundle.
+        if ($_.Exception.Message -match 'HTTP 404|Not Found') {
+            Write-Warning "Skipping telemetry hook sync for release '$($release.tagName)': hooks not present in this release."
+        }
+        else {
+            throw
+        }
+    }
+
     $metadata = [ordered]@{
         version = $normalizedVersion
         repository = $Repository
@@ -139,7 +187,10 @@ try {
         assetName = $asset.name
         sha256 = $hash
     }
-    Set-TextFile -Path $metadataPath -Content ($metadata | ConvertTo-Json)
+    if ($null -ne $hookMetadata) {
+        $metadata['hooks'] = $hookMetadata
+    }
+    Set-TextFile -Path $metadataPath -Content ($metadata | ConvertTo-Json -Depth 10)
 
     $installerContent = Get-Content -Raw -Path $installerPath
     $installerContent = [regex]::Replace(

--- a/eng/scripts/verify-aspire-skills-bundle.ps1
+++ b/eng/scripts/verify-aspire-skills-bundle.ps1
@@ -13,6 +13,9 @@ $scriptDir = $PSScriptRoot
 $repoRoot = (Resolve-Path (Join-Path $scriptDir '..\..')).Path
 $embeddedDir = Join-Path $repoRoot 'src\Aspire.Cli\Agents\AspireSkills\Embedded'
 $metadataPath = Join-Path $embeddedDir 'aspire-skills.metadata.json'
+$hooksDir = Join-Path $repoRoot 'src\Aspire.Cli\Agents\Hooks'
+
+. (Join-Path $scriptDir 'aspire-skills-bundle.common.ps1')
 
 if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
     throw "The GitHub CLI ('gh') is required to verify the embedded Aspire skills bundle."
@@ -59,5 +62,54 @@ gh attestation verify $archivePath `
     --repo $metadata.repository `
     --cert-identity $certIdentity `
     --cert-oidc-issuer 'https://token.actions.githubusercontent.com'
+# Explicitly fail on a non-zero exit. This is the security-critical gate, and the native
+# command error-action auto-throw is not honored on older hosts (Windows PowerShell 5.1), where
+# a failed or abstained attestation would otherwise fall through and be reported as verified.
+if ($LASTEXITCODE -ne 0) {
+    throw "GitHub artifact attestation verification failed for '$archivePath' (exit code $LASTEXITCODE)."
+}
 
 Write-Host "Embedded Aspire skills bundle '$($metadata.assetName)' verified against GitHub artifact attestation."
+
+# Verify the embedded telemetry hook scripts when the bundle records them. The hooks block is only
+# present once update-aspire-skills-bundle.ps1 has synced hooks from a release that contains them, so
+# older bundles (which predate the feature) skip this check. When present, cross-check both that the
+# embedded file matches the recorded hash AND that the recorded hash matches the canonical source at
+# the pinned aspire-skills commit, so a hand-edit that also updates the metadata hash cannot pass.
+if ($metadata.PSObject.Properties.Name -contains 'hooks') {
+    $hooks = $metadata.hooks
+
+    if ([string]::IsNullOrWhiteSpace($hooks.commitSha)) {
+        throw "Embedded Aspire skills metadata 'hooks' block must specify the aspire-skills commit SHA the hooks were pinned to."
+    }
+
+    if (-not ($hooks.PSObject.Properties.Name -contains 'files')) {
+        throw "Embedded Aspire skills metadata 'hooks' block must record a 'files' map of hook hashes."
+    }
+
+    foreach ($hookFileName in Get-AspireSkillsHookFileNames) {
+        if (-not ($hooks.files.PSObject.Properties.Name -contains $hookFileName)) {
+            throw "Embedded Aspire skills metadata 'hooks' block is missing a recorded hash for '$hookFileName'."
+        }
+
+        $recordedHash = $hooks.files.$hookFileName
+
+        $embeddedHookPath = Join-Path $hooksDir $hookFileName
+        if (-not (Test-Path $embeddedHookPath)) {
+            throw "Embedded telemetry hook script was not found at '$embeddedHookPath'."
+        }
+
+        # Hash over LF-normalized bytes so .ps1 (text=auto) checked out with CRLF on Windows matches.
+        $embeddedHash = Get-AspireSkillsSha256Hex -Bytes (ConvertTo-LfUtf8Bytes -Bytes ([System.IO.File]::ReadAllBytes($embeddedHookPath)))
+        if ($embeddedHash -ne $recordedHash) {
+            throw "Embedded telemetry hook '$hookFileName' SHA-256 mismatch. Expected '$recordedHash', got '$embeddedHash'. Re-run update-aspire-skills-bundle.ps1."
+        }
+
+        $sourceHash = Get-AspireSkillsSha256Hex -Bytes (Get-AspireSkillsHookContent -Repository $metadata.repository -CommitSha $hooks.commitSha -FileName $hookFileName)
+        if ($sourceHash -ne $recordedHash) {
+            throw "Telemetry hook '$hookFileName' does not match '$($metadata.repository)' at commit '$($hooks.commitSha)'. Expected '$recordedHash', got '$sourceHash'."
+        }
+    }
+
+    Write-Host "Embedded telemetry hook scripts verified against '$($metadata.repository)' at commit '$($hooks.commitSha)'."
+}

--- a/src/Aspire.Cli/Agents/AgentClientKind.cs
+++ b/src/Aspire.Cli/Agents/AgentClientKind.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Agents;
+
+/// <summary>
+/// Identifies an agent client (CLI/editor) that Aspire can configure during <c>aspire agent init</c>.
+/// </summary>
+internal enum AgentClientKind
+{
+    /// <summary>GitHub Copilot CLI.</summary>
+    CopilotCli,
+
+    /// <summary>Anthropic Claude Code.</summary>
+    ClaudeCode,
+
+    /// <summary>Visual Studio Code.</summary>
+    VsCode,
+
+    /// <summary>OpenCode.</summary>
+    OpenCode,
+}

--- a/src/Aspire.Cli/Agents/AgentEnvironmentScanContext.cs
+++ b/src/Aspire.Cli/Agents/AgentEnvironmentScanContext.cs
@@ -10,6 +10,7 @@ internal sealed class AgentEnvironmentScanContext
 {
     private readonly List<AgentEnvironmentApplicator> _applicators = [];
     private readonly HashSet<string> _skillBaseDirectories = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<AgentClientKind> _detectedClients = [];
 
     /// <summary>
     /// Gets the working directory being scanned.
@@ -58,4 +59,20 @@ internal sealed class AgentEnvironmentScanContext
     /// Gets the registered skill base directories for all detected agent environments.
     /// </summary>
     public IReadOnlyCollection<string> SkillBaseDirectories => _skillBaseDirectories;
+
+    /// <summary>
+    /// Records that an agent client was detected as present in the environment. Used to scope
+    /// telemetry hook registration to the clients the user actually has, independent of whether the
+    /// Aspire MCP server still needs configuring.
+    /// </summary>
+    /// <param name="client">The detected agent client.</param>
+    public void AddDetectedClient(AgentClientKind client)
+    {
+        _detectedClients.Add(client);
+    }
+
+    /// <summary>
+    /// Gets the set of agent clients detected as present in the environment.
+    /// </summary>
+    public IReadOnlyCollection<AgentClientKind> DetectedClients => _detectedClients;
 }

--- a/src/Aspire.Cli/Agents/ClaudeCode/ClaudeCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/ClaudeCode/ClaudeCodeAgentEnvironmentScanner.cs
@@ -55,6 +55,8 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
 
         if (claudeCodeFolder is not null)
         {
+            context.AddDetectedClient(AgentClientKind.ClaudeCode);
+
             // If .claude folder is found, override the workspace root with its parent directory
             var workspaceRoot = claudeCodeFolder.Parent ?? context.RepositoryRoot;
             _logger.LogDebug("Inferred workspace root from .claude folder parent: {WorkspaceRoot}", workspaceRoot.FullName);
@@ -84,6 +86,8 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
             if (claudeCodeVersion is not null)
             {
                 _logger.LogDebug("Found Claude Code CLI version: {Version}", claudeCodeVersion);
+
+                context.AddDetectedClient(AgentClientKind.ClaudeCode);
 
                 // Claude Code is installed - offer to create config at workspace root
                 if (!HasAspireServerConfigured(context.RepositoryRoot))

--- a/src/Aspire.Cli/Agents/CopilotCli/CopilotCliAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/CopilotCli/CopilotCliAgentEnvironmentScanner.cs
@@ -61,6 +61,8 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
         {
             _logger.LogDebug("Detected VSCode terminal environment. Assuming GitHub Copilot CLI is available to avoid potential hangs from interactive installation prompts.");
 
+            context.AddDetectedClient(AgentClientKind.CopilotCli);
+
             // Check if the aspire server is already configured in the global config
             _logger.LogDebug("Checking if Aspire MCP server is already configured in Copilot CLI global config...");
             if (!HasAspireServerConfigured(homeDirectory))
@@ -92,6 +94,8 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
         }
 
         _logger.LogDebug("Found GitHub Copilot CLI version: {Version}", copilotVersion);
+
+        context.AddDetectedClient(AgentClientKind.CopilotCli);
 
         // Check if the aspire server is already configured in the global config
         _logger.LogDebug("Checking if Aspire MCP server is already configured in Copilot CLI global config...");

--- a/src/Aspire.Cli/Agents/Hooks/HookCommandFormatter.cs
+++ b/src/Aspire.Cli/Agents/Hooks/HookCommandFormatter.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Agents.Hooks;
+
+/// <summary>
+/// Builds the shell command strings used in agent hook configuration entries, with correct quoting
+/// for paths that may contain spaces or apostrophes.
+/// </summary>
+internal static class HookCommandFormatter
+{
+    /// <summary>
+    /// Quotes a path as a single bash argument. Bash single quotes are literal, so an embedded
+    /// apostrophe is closed, escaped, and reopened: <c>'</c> becomes <c>'\''</c>.
+    /// Example: <c>/home/o'brien/x.sh</c> → <c>'/home/o'\''brien/x.sh'</c>.
+    /// </summary>
+    public static string QuoteForBash(string path)
+        => "'" + path.Replace("'", "'\\''") + "'";
+
+    /// <summary>
+    /// Quotes a path as a single PowerShell literal string. PowerShell single quotes are literal and
+    /// an embedded apostrophe is doubled: <c>'</c> becomes <c>''</c>.
+    /// Example: <c>C:\Users\o'brien\x.ps1</c> → <c>'C:\Users\o''brien\x.ps1'</c>.
+    /// </summary>
+    public static string QuoteForPowerShell(string path)
+        => "'" + path.Replace("'", "''") + "'";
+
+    /// <summary>
+    /// Builds the Unix command that runs the shell hook script via bash. Running through <c>bash</c>
+    /// (rather than executing the path directly) avoids depending on the executable bit surviving.
+    /// </summary>
+    public static string BuildBashCommand(string shellScriptPath)
+        => "bash " + QuoteForBash(shellScriptPath);
+
+    /// <summary>
+    /// Builds the Windows command that runs the PowerShell hook script. A child <c>powershell</c> is
+    /// spawned with an explicit bypass policy so the script runs regardless of the ambient execution
+    /// policy, and <c>-NoProfile</c> avoids profile side effects and startup cost.
+    /// </summary>
+    public static string BuildPowerShellCommand(string powerShellScriptPath)
+        => "powershell -NoProfile -ExecutionPolicy Bypass -File " + QuoteForPowerShell(powerShellScriptPath);
+}

--- a/src/Aspire.Cli/Agents/Hooks/HookCommandFormatter.cs
+++ b/src/Aspire.Cli/Agents/Hooks/HookCommandFormatter.cs
@@ -4,8 +4,9 @@
 namespace Aspire.Cli.Agents.Hooks;
 
 /// <summary>
-/// Builds the shell command strings used in agent hook configuration entries, with correct quoting
-/// for paths that may contain spaces or apostrophes.
+/// Builds the shell-form command strings used in the GitHub Copilot CLI hook configuration, with correct
+/// quoting for paths that may contain spaces or apostrophes. Claude Code hooks instead use exec form
+/// (<c>command</c> + <c>args</c>), which passes the script path as a discrete argument and needs no quoting.
 /// </summary>
 internal static class HookCommandFormatter
 {
@@ -15,7 +16,7 @@ internal static class HookCommandFormatter
     /// Example: <c>/home/o'brien/x.sh</c> → <c>'/home/o'\''brien/x.sh'</c>.
     /// </summary>
     public static string QuoteForBash(string path)
-        => "'" + path.Replace("'", "'\\''") + "'";
+        => $"'{path.Replace("'", "'\\''")}'";
 
     /// <summary>
     /// Quotes a path as a single PowerShell literal string. PowerShell single quotes are literal and
@@ -23,20 +24,23 @@ internal static class HookCommandFormatter
     /// Example: <c>C:\Users\o'brien\x.ps1</c> → <c>'C:\Users\o''brien\x.ps1'</c>.
     /// </summary>
     public static string QuoteForPowerShell(string path)
-        => "'" + path.Replace("'", "''") + "'";
+        => $"'{path.Replace("'", "''")}'";
 
     /// <summary>
     /// Builds the Unix command that runs the shell hook script via bash. Running through <c>bash</c>
     /// (rather than executing the path directly) avoids depending on the executable bit surviving.
     /// </summary>
     public static string BuildBashCommand(string shellScriptPath)
-        => "bash " + QuoteForBash(shellScriptPath);
+        => $"bash {QuoteForBash(shellScriptPath)}";
 
     /// <summary>
-    /// Builds the Windows command that runs the PowerShell hook script. A child <c>powershell</c> is
-    /// spawned with an explicit bypass policy so the script runs regardless of the ambient execution
-    /// policy, and <c>-NoProfile</c> avoids profile side effects and startup cost.
+    /// Builds the Windows command that runs the PowerShell hook script with PowerShell 7+ (<c>pwsh</c>).
+    /// The GitHub Copilot CLI hooks reference makes <c>pwsh</c> a hard Windows prerequisite, so the Copilot
+    /// hook must invoke it rather than Windows PowerShell; see
+    /// https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks. It is spawned
+    /// with an explicit bypass policy so the script runs regardless of the ambient execution policy, and
+    /// <c>-NoProfile</c> avoids profile side effects and startup cost.
     /// </summary>
-    public static string BuildPowerShellCommand(string powerShellScriptPath)
-        => "powershell -NoProfile -ExecutionPolicy Bypass -File " + QuoteForPowerShell(powerShellScriptPath);
+    public static string BuildPwshCommand(string powerShellScriptPath)
+        => $"pwsh -NoProfile -ExecutionPolicy Bypass -File {QuoteForPowerShell(powerShellScriptPath)}";
 }

--- a/src/Aspire.Cli/Agents/Hooks/ITelemetryHookConfigurator.cs
+++ b/src/Aspire.Cli/Agents/Hooks/ITelemetryHookConfigurator.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Agents.Hooks;
+
+/// <summary>
+/// Registers the Aspire agent telemetry <c>PostToolUse</c> hooks into the user-level configuration of
+/// each detected agent client, mirroring the behavior of the azure-skills plugin hooks. Whether
+/// telemetry is actually transmitted remains gated by the telemetry opt-out environment variables;
+/// this only wires the hooks up.
+/// </summary>
+internal interface ITelemetryHookConfigurator
+{
+    /// <summary>
+    /// Materializes the hook scripts and registers them for each supported, detected agent client.
+    /// </summary>
+    /// <param name="detectedClients">The agent clients detected during the environment scan.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A summary of which clients were configured and which were skipped (and why).</returns>
+    Task<TelemetryHookConfigurationResult> ConfigureAsync(
+        IReadOnlyCollection<AgentClientKind> detectedClients,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// The reason a telemetry hook could not be registered for a client.
+/// </summary>
+internal enum TelemetryHookSkipReason
+{
+    /// <summary>The client's existing configuration file contained malformed JSON.</summary>
+    MalformedConfig,
+
+    /// <summary>The client's existing configuration had a hooks shape Aspire does not recognize.</summary>
+    UnexpectedConfigShape,
+
+    /// <summary>Writing the client's configuration failed.</summary>
+    WriteFailed,
+}
+
+/// <summary>
+/// Describes a client whose telemetry hook registration was skipped.
+/// </summary>
+/// <param name="Client">The client that was skipped.</param>
+/// <param name="Reason">Why registration was skipped.</param>
+internal sealed record TelemetryHookSkip(AgentClientKind Client, TelemetryHookSkipReason Reason);
+
+/// <summary>
+/// The outcome of <see cref="ITelemetryHookConfigurator.ConfigureAsync"/>.
+/// </summary>
+/// <param name="ConfiguredClients">Clients whose telemetry hook was registered or refreshed.</param>
+/// <param name="Skipped">Clients whose registration was skipped, with the reason.</param>
+internal sealed record TelemetryHookConfigurationResult(
+    IReadOnlyList<AgentClientKind> ConfiguredClients,
+    IReadOnlyList<TelemetryHookSkip> Skipped);

--- a/src/Aspire.Cli/Agents/Hooks/ITelemetryHookInstaller.cs
+++ b/src/Aspire.Cli/Agents/Hooks/ITelemetryHookInstaller.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Agents.Hooks;
+
+/// <summary>
+/// Materializes the embedded agent telemetry hook scripts to a stable location on disk so that
+/// per-client hook configuration written by <c>aspire agent init</c> can reference them by an
+/// absolute path.
+/// </summary>
+internal interface ITelemetryHookInstaller
+{
+    /// <summary>
+    /// Ensures the <c>track-telemetry.sh</c> and <c>track-telemetry.ps1</c> scripts exist under the
+    /// stable hooks directory (<c>~/.aspire/hooks</c>) with up-to-date content, and returns their
+    /// absolute paths. The shell script is written with LF line endings and the executable bit set
+    /// on non-Windows platforms. Re-running refreshes the content so an upgraded CLI updates the
+    /// scripts in place.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The resolved absolute paths to the materialized scripts.</returns>
+    Task<TelemetryHookScripts> EnsureInstalledAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// The absolute paths to the materialized agent telemetry hook scripts.
+/// </summary>
+/// <param name="ShellScriptPath">Absolute path to the materialized <c>track-telemetry.sh</c>.</param>
+/// <param name="PowerShellScriptPath">Absolute path to the materialized <c>track-telemetry.ps1</c>.</param>
+internal sealed record TelemetryHookScripts(string ShellScriptPath, string PowerShellScriptPath);

--- a/src/Aspire.Cli/Agents/Hooks/TelemetryHookConfigurator.cs
+++ b/src/Aspire.Cli/Agents/Hooks/TelemetryHookConfigurator.cs
@@ -120,8 +120,10 @@ internal sealed class TelemetryHookConfigurator : ITelemetryHookConfigurator
             var filePath = Path.Combine(hooksDirectory, CopilotHookFileName);
 
             // Owned file: a full overwrite is trivially idempotent. The Copilot CLI hooks reference
-            // (https://docs.github.com/en/copilot/reference/hooks-reference) defines `bash`/`powershell`
-            // as shell command strings, so we pass `bash '<sh>'` / `powershell ... -File '<ps1>'`.
+            // (https://docs.github.com/en/copilot/reference/hooks-reference) defines `bash` and
+            // `powershell` as keys whose values are shell command strings. The `powershell` value
+            // invokes `pwsh` (PowerShell 7+) because that is the documented Windows prerequisite for
+            // Copilot CLI hooks.
             var config = new JsonObject
             {
                 ["version"] = 1,
@@ -132,7 +134,7 @@ internal sealed class TelemetryHookConfigurator : ITelemetryHookConfigurator
                         {
                             ["type"] = "command",
                             ["bash"] = HookCommandFormatter.BuildBashCommand(scripts.ShellScriptPath),
-                            ["powershell"] = HookCommandFormatter.BuildPowerShellCommand(scripts.PowerShellScriptPath),
+                            ["powershell"] = HookCommandFormatter.BuildPwshCommand(scripts.PowerShellScriptPath),
                             ["timeoutSec"] = HookTimeoutSeconds,
                         }),
                 },
@@ -188,10 +190,9 @@ internal sealed class TelemetryHookConfigurator : ITelemetryHookConfigurator
                 case JsonObject existing:
                     settings = existing;
                     break;
-                // Valid JSON whose root isn't an object (array/string/number/bool) means another tool
-                // owns this file in a shape we don't recognize. Calling JsonNode.AsObject() here would
-                // throw InvalidOperationException (not JsonException), which would escape both this
-                // method and the best-effort callers and crash `agent init`; skip instead of clobbering.
+                // Root is valid JSON but not an object (array/string/number/bool): another tool owns this
+                // file in a shape we don't recognize. AsObject() would throw InvalidOperationException (not
+                // JsonException), escape the best-effort callers, and crash `agent init`. Skip instead.
                 default:
                     return TelemetryHookSkipReason.UnexpectedConfigShape;
             }
@@ -201,9 +202,8 @@ internal sealed class TelemetryHookConfigurator : ITelemetryHookConfigurator
             settings = new JsonObject();
         }
 
-        // The `hooks` value and its `PostToolUse` child must have the documented shapes. An unexpected
-        // shape means another tool owns this file in a way we don't recognize, so we skip rather than risk
-        // corrupting it.
+        // `hooks` and its `PostToolUse` child must have the documented shapes; an unexpected shape means
+        // another tool owns the file, so skip rather than risk corrupting it.
         JsonObject hooks;
         if (settings.TryGetPropertyValue("hooks", out var hooksNode))
         {
@@ -240,12 +240,30 @@ internal sealed class TelemetryHookConfigurator : ITelemetryHookConfigurator
         // refreshes the command if the script path changed across CLI upgrades.
         RemoveExistingAspireEntries(postToolUse);
 
-        // On Windows run the .ps1, otherwise run the .sh under bash. The path is single-quoted, which
-        // preserves spaces in both bash and PowerShell. A literal apostrophe in the home path is the one
-        // case the two shells quote differently; that is rare enough on Windows to accept.
-        var command = OperatingSystem.IsWindows()
-            ? HookCommandFormatter.BuildPowerShellCommand(scripts.PowerShellScriptPath)
-            : HookCommandFormatter.BuildBashCommand(scripts.ShellScriptPath);
+        // Claude Code runs a path-referencing hook best in exec form (`command` + `args`): the executable
+        // is spawned directly with no shell, so the script path passes through verbatim with no quoting.
+        // Shell form is avoided because on Windows Claude runs the command line through Git Bash (or
+        // PowerShell only when Git Bash is absent), which would mismatch PowerShell-style path quoting. The
+        // Claude hooks reference recommends exec form for any hook that references a script path; see the
+        // "Exec form and shell form" / "Reference scripts by path" sections in
+        // https://docs.claude.com/en/docs/claude-code/hooks.
+        string command;
+        JsonArray commandArgs;
+        if (OperatingSystem.IsWindows())
+        {
+            // Use modern PowerShell 7+ (pwsh), consistent with the Copilot hook. pwsh is the documented
+            // Windows prerequisite for agent hooks; if it is absent the hook simply does not run, the same
+            // as Copilot. `-ExecutionPolicy Bypass` is passed straight to the process (exec form has no
+            // shell) so the local script runs regardless of the machine policy; `-NoProfile` avoids profile
+            // side effects and startup cost.
+            command = "pwsh";
+            commandArgs = new JsonArray("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scripts.PowerShellScriptPath);
+        }
+        else
+        {
+            command = "bash";
+            commandArgs = new JsonArray(scripts.ShellScriptPath);
+        }
 
         postToolUse.Add((JsonNode?)new JsonObject
         {
@@ -255,6 +273,7 @@ internal sealed class TelemetryHookConfigurator : ITelemetryHookConfigurator
                 {
                     ["type"] = "command",
                     ["command"] = command,
+                    ["args"] = commandArgs,
                     // Bound the hook so a stuck telemetry call can never stall a Claude session. The shell
                     // scripts also self-limit, but Claude's own timeout is the reliable backstop.
                     ["timeout"] = HookTimeoutSeconds,
@@ -318,22 +337,44 @@ internal sealed class TelemetryHookConfigurator : ITelemetryHookConfigurator
 
     private static bool IsAspireHook(JsonNode? node)
     {
-        // Our command embeds the materialized script path, which always ends in the distinctive
-        // file names track-telemetry.sh / track-telemetry.ps1. Matching on those file names (rather
-        // than just "aspire") avoids removing an unrelated user hook, while still catching a stale
-        // entry that points at a previous script location after the home directory moved.
-        if (node is not JsonObject hook
-            || !hook.TryGetPropertyValue("command", out var commandNode)
-            || commandNode is not JsonValue commandValue
-            || !commandValue.TryGetValue<string>(out var command)
-            || command is null)
+        // Match the distinctive script file name (track-telemetry.sh/.ps1) wherever a hook entry can
+        // carry the path: an `args` element in exec form (the form we write), or embedded in the
+        // `command` shell string in shell form. Both forms are valid in the hook schema, so checking
+        // each keeps re-init idempotent regardless of which one an existing entry uses. Matching the
+        // file name rather than just "aspire" avoids removing an unrelated user hook.
+        if (node is not JsonObject hook)
         {
             return false;
         }
 
-        return command.Contains("track-telemetry.sh", StringComparison.OrdinalIgnoreCase)
-            || command.Contains("track-telemetry.ps1", StringComparison.OrdinalIgnoreCase);
+        if (hook.TryGetPropertyValue("command", out var commandNode)
+            && commandNode is JsonValue commandValue
+            && commandValue.TryGetValue<string>(out var command)
+            && ReferencesTelemetryScript(command))
+        {
+            return true;
+        }
+
+        if (hook.TryGetPropertyValue("args", out var argsNode) && argsNode is JsonArray args)
+        {
+            foreach (var arg in args)
+            {
+                if (arg is JsonValue argValue
+                    && argValue.TryGetValue<string>(out var argString)
+                    && ReferencesTelemetryScript(argString))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
+
+    private static bool ReferencesTelemetryScript(string? value)
+        => value is not null
+            && (value.Contains("track-telemetry.sh", StringComparison.OrdinalIgnoreCase)
+                || value.Contains("track-telemetry.ps1", StringComparison.OrdinalIgnoreCase));
 
     private static async Task WriteJsonAtomicAsync(string path, JsonObject config, CancellationToken cancellationToken)
     {

--- a/src/Aspire.Cli/Agents/Hooks/TelemetryHookConfigurator.cs
+++ b/src/Aspire.Cli/Agents/Hooks/TelemetryHookConfigurator.cs
@@ -1,0 +1,330 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Agents.Hooks;
+
+/// <summary>
+/// Default <see cref="ITelemetryHookConfigurator"/>. Materializes the hook scripts once and writes the
+/// <c>PostToolUse</c> hook into each supported client's <b>user-level</b> configuration.
+/// </summary>
+/// <remarks>
+/// Only user-level configuration is ever written. The GitHub Copilot CLI hooks reference confirms that
+/// Copilot reads cross-tool <c>.claude/settings.json</c> only at the repository level (never <c>~/.claude</c>),
+/// so the Copilot user hook (<c>~/.copilot/hooks/aspire-telemetry.json</c>) and the Claude user hook
+/// (<c>~/.claude/settings.json</c>) cannot both fire for the same event — the hook is registered exactly
+/// once per client by construction.
+/// See https://docs.github.com/en/copilot/reference/hooks-reference.
+/// </remarks>
+internal sealed class TelemetryHookConfigurator : ITelemetryHookConfigurator
+{
+    private const string CopilotFolderName = ".copilot";
+    private const string CopilotHooksDirectoryName = "hooks";
+    private const string CopilotHookFileName = "aspire-telemetry.json";
+    private const string CopilotHomeEnvironmentVariable = "COPILOT_HOME";
+
+    private const string ClaudeFolderName = ".claude";
+    private const string ClaudeSettingsFileName = "settings.json";
+    private const string ClaudePostToolUseKey = "PostToolUse";
+
+    private const int HookTimeoutSeconds = 30;
+
+    private readonly ITelemetryHookInstaller _installer;
+    private readonly CliExecutionContext _executionContext;
+    private readonly IEnvironment _environment;
+    private readonly ILogger<TelemetryHookConfigurator> _logger;
+
+    public TelemetryHookConfigurator(
+        ITelemetryHookInstaller installer,
+        CliExecutionContext executionContext,
+        IEnvironment environment,
+        ILogger<TelemetryHookConfigurator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(installer);
+        ArgumentNullException.ThrowIfNull(executionContext);
+        ArgumentNullException.ThrowIfNull(environment);
+        ArgumentNullException.ThrowIfNull(logger);
+        _installer = installer;
+        _executionContext = executionContext;
+        _environment = environment;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<TelemetryHookConfigurationResult> ConfigureAsync(
+        IReadOnlyCollection<AgentClientKind> detectedClients,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(detectedClients);
+
+        var configured = new List<AgentClientKind>();
+        var skipped = new List<TelemetryHookSkip>();
+
+        // VS Code and OpenCode hook schemas are not yet verified, so they are intentionally not
+        // configured here even though they are detected/marked. Only configure once per client kind.
+        var supported = detectedClients
+            .Where(static c => c is AgentClientKind.CopilotCli or AgentClientKind.ClaudeCode)
+            .Distinct()
+            .ToList();
+
+        if (supported.Count == 0)
+        {
+            return new TelemetryHookConfigurationResult(configured, skipped);
+        }
+
+        // Materialize the scripts once; every supported client references the same absolute paths.
+        var scripts = await _installer.EnsureInstalledAsync(cancellationToken);
+
+        foreach (var client in supported)
+        {
+            switch (client)
+            {
+                case AgentClientKind.CopilotCli:
+                    if (await TryConfigureCopilotAsync(scripts, cancellationToken))
+                    {
+                        configured.Add(client);
+                    }
+                    else
+                    {
+                        skipped.Add(new TelemetryHookSkip(client, TelemetryHookSkipReason.WriteFailed));
+                    }
+                    break;
+
+                case AgentClientKind.ClaudeCode:
+                    var claudeSkipReason = await ConfigureClaudeAsync(scripts, cancellationToken);
+                    if (claudeSkipReason is { } reason)
+                    {
+                        skipped.Add(new TelemetryHookSkip(client, reason));
+                    }
+                    else
+                    {
+                        configured.Add(client);
+                    }
+                    break;
+            }
+        }
+
+        return new TelemetryHookConfigurationResult(configured, skipped);
+    }
+
+    private async Task<bool> TryConfigureCopilotAsync(TelemetryHookScripts scripts, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var hooksDirectory = ResolveCopilotHooksDirectory();
+            Directory.CreateDirectory(hooksDirectory);
+
+            var filePath = Path.Combine(hooksDirectory, CopilotHookFileName);
+
+            // Owned file: a full overwrite is trivially idempotent. The Copilot CLI hooks reference
+            // (https://docs.github.com/en/copilot/reference/hooks-reference) defines `bash`/`powershell`
+            // as shell command strings, so we pass `bash '<sh>'` / `powershell ... -File '<ps1>'`.
+            var config = new JsonObject
+            {
+                ["version"] = 1,
+                ["hooks"] = new JsonObject
+                {
+                    ["postToolUse"] = new JsonArray(
+                        new JsonObject
+                        {
+                            ["type"] = "command",
+                            ["bash"] = HookCommandFormatter.BuildBashCommand(scripts.ShellScriptPath),
+                            ["powershell"] = HookCommandFormatter.BuildPowerShellCommand(scripts.PowerShellScriptPath),
+                            ["timeoutSec"] = HookTimeoutSeconds,
+                        }),
+                },
+            };
+
+            await WriteJsonAtomicAsync(filePath, config, cancellationToken);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogDebug(ex, "Failed to write Copilot CLI telemetry hook configuration.");
+            return false;
+        }
+    }
+
+    private async Task<TelemetryHookSkipReason?> ConfigureClaudeAsync(TelemetryHookScripts scripts, CancellationToken cancellationToken)
+    {
+        var claudeDirectory = Path.Combine(_executionContext.HomeDirectory.FullName, ClaudeFolderName);
+        var settingsPath = Path.Combine(claudeDirectory, ClaudeSettingsFileName);
+
+        JsonObject settings;
+        if (File.Exists(settingsPath))
+        {
+            string content;
+            try
+            {
+                content = await File.ReadAllTextAsync(settingsPath, cancellationToken);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                _logger.LogDebug(ex, "Failed to read Claude settings at {Path}.", settingsPath);
+                return TelemetryHookSkipReason.WriteFailed;
+            }
+
+            try
+            {
+                settings = JsonNode.Parse(content)?.AsObject() ?? new JsonObject();
+            }
+            catch (JsonException ex)
+            {
+                // Never clobber a file we can't understand; leave it untouched and report the skip.
+                _logger.LogDebug(ex, "Claude settings at {Path} contained malformed JSON; skipping hook registration.", settingsPath);
+                return TelemetryHookSkipReason.MalformedConfig;
+            }
+        }
+        else
+        {
+            settings = new JsonObject();
+        }
+
+        // The `hooks` value and its `PostToolUse` child must have the documented shapes. An unexpected
+        // shape means another tool owns this file in a way we don't recognize, so we skip rather than risk
+        // corrupting it.
+        JsonObject hooks;
+        if (settings.TryGetPropertyValue("hooks", out var hooksNode))
+        {
+            if (hooksNode is not JsonObject hooksObject)
+            {
+                return TelemetryHookSkipReason.UnexpectedConfigShape;
+            }
+
+            hooks = hooksObject;
+        }
+        else
+        {
+            hooks = new JsonObject();
+            settings["hooks"] = hooks;
+        }
+
+        JsonArray postToolUse;
+        if (hooks.TryGetPropertyValue(ClaudePostToolUseKey, out var postToolUseNode))
+        {
+            if (postToolUseNode is not JsonArray postToolUseArray)
+            {
+                return TelemetryHookSkipReason.UnexpectedConfigShape;
+            }
+
+            postToolUse = postToolUseArray;
+        }
+        else
+        {
+            postToolUse = new JsonArray();
+            hooks[ClaudePostToolUseKey] = postToolUse;
+        }
+
+        // Idempotent: drop any previously written Aspire entry before adding exactly one. This also
+        // refreshes the command if the script path changed across CLI upgrades.
+        RemoveExistingAspireEntries(postToolUse);
+
+        // On Windows run the .ps1, otherwise run the .sh under bash. The path is single-quoted, which
+        // preserves spaces in both bash and PowerShell. A literal apostrophe in the home path is the one
+        // case the two shells quote differently; that is rare enough on Windows to accept.
+        var command = OperatingSystem.IsWindows()
+            ? HookCommandFormatter.BuildPowerShellCommand(scripts.PowerShellScriptPath)
+            : HookCommandFormatter.BuildBashCommand(scripts.ShellScriptPath);
+
+        postToolUse.Add((JsonNode?)new JsonObject
+        {
+            ["matcher"] = "*",
+            ["hooks"] = new JsonArray(
+                new JsonObject
+                {
+                    ["type"] = "command",
+                    ["command"] = command,
+                    // Bound the hook so a stuck telemetry call can never stall a Claude session. The shell
+                    // scripts also self-limit, but Claude's own timeout is the reliable backstop.
+                    ["timeout"] = HookTimeoutSeconds,
+                }),
+        });
+
+        try
+        {
+            Directory.CreateDirectory(claudeDirectory);
+            await WriteJsonAtomicAsync(settingsPath, settings, cancellationToken);
+            return null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogDebug(ex, "Failed to write Claude settings at {Path}.", settingsPath);
+            return TelemetryHookSkipReason.WriteFailed;
+        }
+    }
+
+    private string ResolveCopilotHooksDirectory()
+    {
+        // The Copilot CLI hooks reference resolves the user-level hooks directory from COPILOT_HOME when
+        // set, otherwise ~/.copilot/hooks. Mirror that so the hook lands where Copilot actually reads it.
+        var copilotHome = _environment.GetEnvironmentVariable(CopilotHomeEnvironmentVariable);
+        if (!string.IsNullOrEmpty(copilotHome))
+        {
+            return Path.Combine(copilotHome, CopilotHooksDirectoryName);
+        }
+
+        return Path.Combine(_executionContext.HomeDirectory.FullName, CopilotFolderName, CopilotHooksDirectoryName);
+    }
+
+    private static void RemoveExistingAspireEntries(JsonArray postToolUse)
+    {
+        // Iterate in reverse so removals don't shift indices we still need to visit. Remove individual
+        // Aspire hook entries (not whole groups) so a user-authored hook sharing a matcher group survives,
+        // then drop any group left empty by that removal.
+        for (var groupIndex = postToolUse.Count - 1; groupIndex >= 0; groupIndex--)
+        {
+            if (postToolUse[groupIndex] is not JsonObject group
+                || !group.TryGetPropertyValue("hooks", out var innerNode)
+                || innerNode is not JsonArray innerHooks)
+            {
+                continue;
+            }
+
+            for (var hookIndex = innerHooks.Count - 1; hookIndex >= 0; hookIndex--)
+            {
+                if (IsAspireHook(innerHooks[hookIndex]))
+                {
+                    innerHooks.RemoveAt(hookIndex);
+                }
+            }
+
+            if (innerHooks.Count == 0)
+            {
+                postToolUse.RemoveAt(groupIndex);
+            }
+        }
+    }
+
+    private static bool IsAspireHook(JsonNode? node)
+    {
+        // Our command embeds the materialized script path, which always ends in the distinctive
+        // file names track-telemetry.sh / track-telemetry.ps1. Matching on those file names (rather
+        // than just "aspire") avoids removing an unrelated user hook, while still catching a stale
+        // entry that points at a previous script location after the home directory moved.
+        if (node is not JsonObject hook
+            || !hook.TryGetPropertyValue("command", out var commandNode)
+            || commandNode is not JsonValue commandValue
+            || !commandValue.TryGetValue<string>(out var command)
+            || command is null)
+        {
+            return false;
+        }
+
+        return command.Contains("track-telemetry.sh", StringComparison.OrdinalIgnoreCase)
+            || command.Contains("track-telemetry.ps1", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task WriteJsonAtomicAsync(string path, JsonObject config, CancellationToken cancellationToken)
+    {
+        var json = JsonSerializer.Serialize(config, JsonSourceGenerationContext.Default.JsonObject);
+
+        // Write to a sibling temp file then move into place so a concurrently firing hook never reads a
+        // half-written config.
+        var tempPath = path + ".tmp-" + Guid.NewGuid().ToString("N");
+        await File.WriteAllTextAsync(tempPath, json, cancellationToken);
+        File.Move(tempPath, path, overwrite: true);
+    }
+}

--- a/src/Aspire.Cli/Agents/Hooks/TelemetryHookConfigurator.cs
+++ b/src/Aspire.Cli/Agents/Hooks/TelemetryHookConfigurator.cs
@@ -167,15 +167,33 @@ internal sealed class TelemetryHookConfigurator : ITelemetryHookConfigurator
                 return TelemetryHookSkipReason.WriteFailed;
             }
 
+            JsonNode? parsed;
             try
             {
-                settings = JsonNode.Parse(content)?.AsObject() ?? new JsonObject();
+                parsed = JsonNode.Parse(content);
             }
             catch (JsonException ex)
             {
                 // Never clobber a file we can't understand; leave it untouched and report the skip.
                 _logger.LogDebug(ex, "Claude settings at {Path} contained malformed JSON; skipping hook registration.", settingsPath);
                 return TelemetryHookSkipReason.MalformedConfig;
+            }
+
+            switch (parsed)
+            {
+                // An empty file or a literal `null` document: start from a fresh object.
+                case null:
+                    settings = new JsonObject();
+                    break;
+                case JsonObject existing:
+                    settings = existing;
+                    break;
+                // Valid JSON whose root isn't an object (array/string/number/bool) means another tool
+                // owns this file in a shape we don't recognize. Calling JsonNode.AsObject() here would
+                // throw InvalidOperationException (not JsonException), which would escape both this
+                // method and the best-effort callers and crash `agent init`; skip instead of clobbering.
+                default:
+                    return TelemetryHookSkipReason.UnexpectedConfigShape;
             }
         }
         else

--- a/src/Aspire.Cli/Agents/Hooks/TelemetryHookInstaller.cs
+++ b/src/Aspire.Cli/Agents/Hooks/TelemetryHookInstaller.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Agents.Hooks;
+
+/// <summary>
+/// Default <see cref="ITelemetryHookInstaller"/> that materializes the hook scripts embedded in the
+/// CLI assembly to <c>~/.aspire/hooks</c>.
+/// </summary>
+internal sealed class TelemetryHookInstaller : ITelemetryHookInstaller
+{
+    // LogicalNames declared in Aspire.Cli.csproj.
+    private const string ShellResourceName = "track-telemetry.sh";
+    private const string PowerShellResourceName = "track-telemetry.ps1";
+
+    private const string HooksDirectoryName = "hooks";
+
+    // UTF-8 without a BOM: the shell script must not begin with a BOM or the shebang is ignored,
+    // and the PowerShell script is ASCII so a BOM is unnecessary.
+    private static readonly UTF8Encoding s_utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+
+    private readonly CliExecutionContext _executionContext;
+    private readonly ILogger<TelemetryHookInstaller> _logger;
+
+    public TelemetryHookInstaller(CliExecutionContext executionContext, ILogger<TelemetryHookInstaller> logger)
+    {
+        ArgumentNullException.ThrowIfNull(executionContext);
+        ArgumentNullException.ThrowIfNull(logger);
+        _executionContext = executionContext;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<TelemetryHookScripts> EnsureInstalledAsync(CancellationToken cancellationToken)
+    {
+        var hooksDirectory = Path.Combine(_executionContext.AspireHomeDirectory.FullName, HooksDirectoryName);
+        Directory.CreateDirectory(hooksDirectory);
+
+        var shellPath = Path.Combine(hooksDirectory, ShellResourceName);
+        var powerShellPath = Path.Combine(hooksDirectory, PowerShellResourceName);
+
+        // The shell script must use LF endings even on Windows because the agent may run it under a
+        // POSIX shell (WSL/Git bash); CRLF would surface as `$'\r': command not found` errors.
+        var shellContent = NormalizeToLf(ReadEmbeddedText(ShellResourceName));
+        var powerShellContent = ReadEmbeddedText(PowerShellResourceName);
+
+        await WriteFileIfChangedAsync(shellPath, shellContent, cancellationToken);
+        await WriteFileIfChangedAsync(powerShellPath, powerShellContent, cancellationToken);
+
+        // Ensure the shell script is executable so a `bash <path>` (or direct exec) hook entry works.
+        // Spawning `chmod` would add PATH/shell failure modes, so use the platform API directly.
+        TrySetExecutable(shellPath);
+
+        return new TelemetryHookScripts(shellPath, powerShellPath);
+    }
+
+    private static string NormalizeToLf(string content)
+        => content.Replace("\r\n", "\n").Replace("\r", "\n");
+
+    private static string ReadEmbeddedText(string resourceName)
+    {
+        using var stream = typeof(TelemetryHookInstaller).Assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded telemetry hook script '{resourceName}' was not found in the CLI assembly.");
+        using var reader = new StreamReader(stream, s_utf8NoBom);
+        return reader.ReadToEnd();
+    }
+
+    private async Task WriteFileIfChangedAsync(string path, string content, CancellationToken cancellationToken)
+    {
+        // Skip the write when the content already matches so a running hook isn't disturbed and the
+        // file mtime stays stable across repeated `agent init` runs.
+        if (File.Exists(path))
+        {
+            try
+            {
+                var existing = await File.ReadAllTextAsync(path, s_utf8NoBom, cancellationToken);
+                if (string.Equals(existing, content, StringComparison.Ordinal))
+                {
+                    return;
+                }
+            }
+            catch (IOException ex)
+            {
+                _logger.LogDebug(ex, "Could not read existing telemetry hook script at {Path}; it will be rewritten.", path);
+            }
+        }
+
+        // Write to a sibling temp file then atomically move into place so a concurrently executing
+        // hook never observes a partially written script.
+        var tempPath = path + ".tmp-" + Guid.NewGuid().ToString("N");
+        await File.WriteAllTextAsync(tempPath, content, s_utf8NoBom, cancellationToken);
+        File.Move(tempPath, path, overwrite: true);
+    }
+
+    private void TrySetExecutable(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
+        {
+            var mode = File.GetUnixFileMode(path);
+            File.SetUnixFileMode(path, mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            // Non-fatal: a `bash <path>` hook entry still runs the script without the executable bit.
+            _logger.LogDebug(ex, "Could not set executable bit on telemetry hook script at {Path}.", path);
+        }
+    }
+}

--- a/src/Aspire.Cli/Agents/Hooks/track-telemetry.ps1
+++ b/src/Aspire.Cli/Agents/Hooks/track-telemetry.ps1
@@ -1,0 +1,182 @@
+# Telemetry tracking hook for Aspire Skills.
+#
+# Runs on every agent PostToolUse event. Reads the hook JSON from stdin, detects when an
+# Aspire skill, Aspire MCP tool, or Aspire skill reference file was used, and forwards a
+# low-cardinality usage event to `aspire agent telemetry`. The Aspire CLI command owns the
+# actual opt-out + publishing logic; this script only classifies the event and shells out.
+#
+# Hook contract: a PostToolUse hook MUST always print a single JSON object to stdout and exit
+# 0, otherwise it can break the agent session. Every code path here ends in Write-Success.
+#
+# Compatible with Windows PowerShell 5.1 and PowerShell 7+. See track-telemetry.sh for the
+# full client-format / event-type / privacy notes (the logic here mirrors that script).
+
+$ErrorActionPreference = "SilentlyContinue"
+
+# Allowlist of Aspire-owned skill names (keep in sync with github.com/microsoft/aspire-skills).
+# A shared .agents/skills directory can also contain third-party skills, so a path/name is only
+# treated as Aspire when its skill segment is one of these.
+$AspireSkills = @('aspire', 'aspire-init', 'aspireify', 'aspire-orchestration', 'aspire-deployment', 'aspire-monitoring')
+
+function Write-Success {
+    Write-Output '{"continue":true}'
+    exit 0
+}
+
+function Test-OptOut([string] $value) {
+    return $value -eq '1' -or $value -ieq 'true'
+}
+
+# Opt out when either the global Aspire CLI telemetry switch or the AI-specific switch is set.
+if ((Test-OptOut $env:ASPIRE_CLI_TELEMETRY_OPTOUT) -or (Test-OptOut $env:ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT)) {
+    Write-Success
+}
+
+# Read the entire payload from stdin (one complete JSON object per hook invocation).
+try {
+    $rawInput = [Console]::In.ReadToEnd()
+} catch {
+    Write-Success
+}
+
+if ([string]::IsNullOrWhiteSpace($rawInput)) {
+    Write-Success
+}
+
+# Parse-fail -> skip telemetry, never guess.
+try {
+    $data = $rawInput | ConvertFrom-Json -ErrorAction Stop
+} catch {
+    Write-Success
+}
+
+# Copilot CLI camelCase vs Claude/VS Code snake_case.
+$toolName = $data.toolName
+if (-not $toolName) { $toolName = $data.tool_name }
+
+$sessionId = $data.sessionId
+if (-not $sessionId) { $sessionId = $data.session_id }
+
+$toolInput = $data.toolArgs
+if (-not $toolInput) { $toolInput = $data.tool_input }
+
+$timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+# Detect the client (used only for a low-cardinality client-name tag).
+$propertyNames = @()
+if ($data.PSObject -and $data.PSObject.Properties) { $propertyNames = $data.PSObject.Properties.Name }
+$hasHookEventName = $propertyNames -contains 'hook_event_name'
+$hasToolArgs = $propertyNames -contains 'toolArgs'
+
+if ($env:COPILOT_CLI -eq '1') {
+    $clientName = 'copilot-cli'
+} elseif ($hasHookEventName) {
+    $toolUseId = [string]$data.tool_use_id
+    $transcriptPath = ([string]$data.transcript_path) -replace '\\', '/'
+    if ($toolUseId -match '__vscode' -or $transcriptPath -match '/Code( - Insiders)?/') {
+        $clientName = 'vscode'
+    } else {
+        $clientName = 'claude-code'
+    }
+} elseif ($hasToolArgs) {
+    $clientName = 'copilot-cli'
+} else {
+    $clientName = 'unknown'
+}
+
+if (-not $toolName) {
+    Write-Success
+}
+
+function Get-ToolInputPath($inputObject) {
+    if (-not $inputObject) { return $null }
+    if ($inputObject.path) { return [string]$inputObject.path }
+    if ($inputObject.filePath) { return [string]$inputObject.filePath }
+    if ($inputObject.file_path) { return [string]$inputObject.file_path }
+    return $null
+}
+
+function Test-AspireSkill([string] $candidate) {
+    return $AspireSkills -contains $candidate
+}
+
+$shouldTrack = $false
+$eventType = $null
+$skillName = $null
+$mcpToolName = $null
+$fileReference = $null
+
+# --- skill_invocation via the skill/Skill tool ---
+if ($toolName -eq 'skill' -or $toolName -eq 'Skill') {
+    $candidate = [string]$toolInput.skill
+    # Claude prefixes plugin skill names, e.g. "aspire:aspire-deployment".
+    if ($candidate.StartsWith('aspire:')) { $candidate = $candidate.Substring(7) }
+    if (Test-AspireSkill $candidate) {
+        $skillName = $candidate
+        $eventType = 'skill_invocation'
+        $shouldTrack = $true
+    }
+}
+
+# --- skill_invocation / reference_file_read via a file read tool ---
+if ($toolName -eq 'view' -or $toolName -eq 'Read' -or $toolName -eq 'read_file') {
+    $pathToCheck = Get-ToolInputPath $toolInput
+    if ($pathToCheck) {
+        # Normalize separators and collapse duplicate slashes.
+        $normalized = ($pathToCheck -replace '\\', '/') -replace '/+', '/'
+        # Capture the skill segment after skills/ and the remainder.
+        $skillSegment = $null
+        $remainder = $null
+        if ($normalized -match '(?:^|/)skills/([^/]+)/(.+)$') {
+            $skillSegment = $Matches[1]
+            $remainder = $Matches[2]
+        }
+        if ($skillSegment -and (Test-AspireSkill $skillSegment)) {
+            if ($remainder -imatch '(^|/)skill\.md$') {
+                # A SKILL.md read is a skill invocation, not a reference-file read.
+                if (-not $shouldTrack) {
+                    $skillName = $skillSegment
+                    $eventType = 'skill_invocation'
+                    $shouldTrack = $true
+                }
+            } elseif (-not $shouldTrack -and $remainder) {
+                # Forward only the relative path after skills/ (e.g. aspire/references/deploy.md).
+                $fileReference = "$skillSegment/$remainder"
+                $eventType = 'reference_file_read'
+                $shouldTrack = $true
+            }
+        }
+    }
+}
+
+# --- tool_invocation via an Aspire MCP tool prefix ---
+# Conservative exact prefixes:
+#   Copilot: aspire-<tool>   Claude: mcp__aspire__<tool>   VS Code: mcp_aspire_<tool>
+if ($toolName.StartsWith('aspire-') -or $toolName.StartsWith('mcp__aspire__') -or $toolName.StartsWith('mcp_aspire_')) {
+    $mcpToolName = $toolName
+    $eventType = 'tool_invocation'
+    $shouldTrack = $true
+}
+
+if (-not $shouldTrack) {
+    Write-Success
+}
+
+# Resolve the Aspire CLI. ASPIRE_CLI_COMMAND lets tests substitute a recording stub.
+$aspireCmd = $env:ASPIRE_CLI_COMMAND
+if (-not $aspireCmd) { $aspireCmd = 'aspire' }
+
+# Build the argument vector explicitly so untrusted hook values are passed as discrete args.
+$cmdArgs = @('agent', 'telemetry', '--event-type', $eventType, '--client-name', $clientName, '--timestamp', $timestamp)
+if ($sessionId) { $cmdArgs += @('--session-id', [string]$sessionId) }
+if ($skillName) { $cmdArgs += @('--skill-name', $skillName) }
+if ($mcpToolName) { $cmdArgs += @('--tool-name', $mcpToolName) }
+if ($fileReference) { $cmdArgs += @('--file-reference', $fileReference) }
+
+# Redirect all child output to null so a banner/log line can never contaminate hook stdout;
+# swallow every failure so the hook still returns success.
+try {
+    & $aspireCmd @cmdArgs *> $null
+} catch { }
+
+Write-Success

--- a/src/Aspire.Cli/Agents/Hooks/track-telemetry.ps1
+++ b/src/Aspire.Cli/Agents/Hooks/track-telemetry.ps1
@@ -27,8 +27,10 @@ function Test-OptOut([string] $value) {
     return $value -eq '1' -or $value -ieq 'true'
 }
 
-# Opt out when either the global Aspire CLI telemetry switch or the AI-specific switch is set.
-if ((Test-OptOut $env:ASPIRE_CLI_TELEMETRY_OPTOUT) -or (Test-OptOut $env:ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT)) {
+# Opt out when the Aspire CLI telemetry switch is set. This is the single opt-out that also
+# gates the `aspire agent telemetry` command path, so honoring it here avoids spawning the CLI
+# at all for opted-out users.
+if (Test-OptOut $env:ASPIRE_CLI_TELEMETRY_OPTOUT) {
     Write-Success
 }
 

--- a/src/Aspire.Cli/Agents/Hooks/track-telemetry.ps1
+++ b/src/Aspire.Cli/Agents/Hooks/track-telemetry.ps1
@@ -6,12 +6,22 @@
 # actual opt-out + publishing logic; this script only classifies the event and shells out.
 #
 # Hook contract: a PostToolUse hook MUST always print a single JSON object to stdout and exit
-# 0, otherwise it can break the agent session. Every code path here ends in Write-Success.
+# 0, otherwise it can break the agent session. Intentional exits call Write-Success; a top-level
+# trap is the last-resort net that satisfies the contract on any unhandled terminating error.
 #
-# Compatible with Windows PowerShell 5.1 and PowerShell 7+. See track-telemetry.sh for the
-# full client-format / event-type / privacy notes (the logic here mirrors that script).
+# Runs with PowerShell 7+ (pwsh): the hook installer always registers it as `pwsh -File ...`, which
+# the GitHub Copilot CLI hooks reference also makes a hard Windows prerequisite. See
+# track-telemetry.sh for the full client-format / event-type / privacy notes (the logic here mirrors
+# that script).
 
 $ErrorActionPreference = "SilentlyContinue"
+
+# Last-resort net for the hook contract: any unhandled terminating error still prints exactly one
+# {"continue":true} and exits 0 instead of breaking the agent's tool loop.
+trap {
+    Write-Output '{"continue":true}'
+    exit 0
+}
 
 # Allowlist of Aspire-owned skill names (keep in sync with github.com/microsoft/aspire-skills).
 # A shared .agents/skills directory can also contain third-party skills, so a path/name is only
@@ -24,6 +34,8 @@ function Write-Success {
 }
 
 function Test-OptOut([string] $value) {
+    # PowerShell -eq / -ieq are case-insensitive, so this accepts 1 and any-case true,
+    # matching the lower-cased check in track-telemetry.sh.
     return $value -eq '1' -or $value -ieq 'true'
 }
 
@@ -34,21 +46,24 @@ if (Test-OptOut $env:ASPIRE_CLI_TELEMETRY_OPTOUT) {
     Write-Success
 }
 
-# Read the entire payload from stdin (one complete JSON object per hook invocation).
-try {
-    $rawInput = [Console]::In.ReadToEnd()
-} catch {
-    Write-Success
-}
+# Read the entire payload from stdin (one complete JSON object per hook invocation). A read
+# failure is exotic and falls through to the top-level trap, which still returns success.
+$rawInput = [Console]::In.ReadToEnd()
 
 if ([string]::IsNullOrWhiteSpace($rawInput)) {
     Write-Success
 }
 
-# Parse-fail -> skip telemetry, never guess.
-try {
-    $data = $rawInput | ConvertFrom-Json -ErrorAction Stop
-} catch {
+# Fast path: most PostToolUse events are not Aspire-related. Everything we track carries
+# "skill"/"aspire" in the payload (the skill tool name, an aspire-/mcp__aspire__ tool name, or a
+# .../skills/<aspire-skill>/ path), so skip JSON parsing entirely when neither appears.
+if ($rawInput -notmatch 'skill|aspire') {
+    Write-Success
+}
+
+# A malformed payload yields $null here (or throws into the trap); either way we never guess.
+$data = $rawInput | ConvertFrom-Json
+if (-not $data) {
     Write-Success
 }
 
@@ -59,8 +74,11 @@ if (-not $toolName) { $toolName = $data.tool_name }
 $sessionId = $data.sessionId
 if (-not $sessionId) { $sessionId = $data.session_id }
 
-$toolInput = $data.toolArgs
-if (-not $toolInput) { $toolInput = $data.tool_input }
+# Copilot encodes toolArgs as a JSON string with escaped quotes (\"field\":\"value\"); unescaping
+# them turns it — and the nested-object form Claude/VS Code send (tool_input:{...}) — into the same
+# flat "field":"value" pairs. The classification below reads nested fields straight out of this text
+# by name, best-effort, rather than assuming the payload's shape or which client produced it.
+$normalizedInput = $rawInput -replace '\\"', '"'
 
 $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 
@@ -90,11 +108,11 @@ if (-not $toolName) {
     Write-Success
 }
 
-function Get-ToolInputPath($inputObject) {
-    if (-not $inputObject) { return $null }
-    if ($inputObject.path) { return [string]$inputObject.path }
-    if ($inputObject.filePath) { return [string]$inputObject.filePath }
-    if ($inputObject.file_path) { return [string]$inputObject.file_path }
+# Read a string field's value from anywhere in the normalized payload by name (first match wins).
+# Used for the nested tool-input values whose container shape differs across clients.
+function Get-PayloadField([string] $name) {
+    $match = [regex]::Match($normalizedInput, '"' + [regex]::Escape($name) + '"\s*:\s*"([^"]*)"')
+    if ($match.Success) { return $match.Groups[1].Value }
     return $null
 }
 
@@ -110,7 +128,7 @@ $fileReference = $null
 
 # --- skill_invocation via the skill/Skill tool ---
 if ($toolName -eq 'skill' -or $toolName -eq 'Skill') {
-    $candidate = [string]$toolInput.skill
+    $candidate = [string](Get-PayloadField 'skill')
     # Claude prefixes plugin skill names, e.g. "aspire:aspire-deployment".
     if ($candidate.StartsWith('aspire:')) { $candidate = $candidate.Substring(7) }
     if (Test-AspireSkill $candidate) {
@@ -122,7 +140,9 @@ if ($toolName -eq 'skill' -or $toolName -eq 'Skill') {
 
 # --- skill_invocation / reference_file_read via a file read tool ---
 if ($toolName -eq 'view' -or $toolName -eq 'Read' -or $toolName -eq 'read_file') {
-    $pathToCheck = Get-ToolInputPath $toolInput
+    $pathToCheck = Get-PayloadField 'path'
+    if (-not $pathToCheck) { $pathToCheck = Get-PayloadField 'filePath' }
+    if (-not $pathToCheck) { $pathToCheck = Get-PayloadField 'file_path' }
     if ($pathToCheck) {
         # Normalize separators and collapse duplicate slashes.
         $normalized = ($pathToCheck -replace '\\', '/') -replace '/+', '/'
@@ -175,10 +195,30 @@ if ($skillName) { $cmdArgs += @('--skill-name', $skillName) }
 if ($mcpToolName) { $cmdArgs += @('--tool-name', $mcpToolName) }
 if ($fileReference) { $cmdArgs += @('--file-reference', $fileReference) }
 
-# Redirect all child output to null so a banner/log line can never contaminate hook stdout;
-# swallow every failure so the hook still returns success.
-try {
-    & $aspireCmd @cmdArgs *> $null
-} catch { }
+# Bound the call so a hung or slow CLI can't stall the agent's tool loop (mirrors the bash
+# `timeout 10`). Run the CLI as a child process we can wait on and kill: an executable on PATH
+# (the production `aspire`) is launched directly, while a .ps1 — used by the hook's tests via
+# ASPIRE_CLI_COMMAND — is launched through pwsh. stdout/stderr are redirected and drained so a
+# banner/log line can neither contaminate the hook's stdout nor deadlock on a full pipe buffer.
+# Any failure here is swallowed by the top-level trap.
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+if ($aspireCmd -like '*.ps1') {
+    $psi.FileName = 'pwsh'
+    foreach ($a in (@('-NoProfile', '-File', $aspireCmd) + $cmdArgs)) { $psi.ArgumentList.Add([string]$a) }
+}
+else {
+    $psi.FileName = $aspireCmd
+    foreach ($a in $cmdArgs) { $psi.ArgumentList.Add([string]$a) }
+}
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow = $true
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$proc = [System.Diagnostics.Process]::Start($psi)
+$null = $proc.StandardOutput.ReadToEndAsync()
+$null = $proc.StandardError.ReadToEndAsync()
+if (-not $proc.WaitForExit(10000)) {
+    try { $proc.Kill() } catch { }
+}
 
 Write-Success

--- a/src/Aspire.Cli/Agents/Hooks/track-telemetry.sh
+++ b/src/Aspire.Cli/Agents/Hooks/track-telemetry.sh
@@ -60,11 +60,10 @@ return_success() {
     exit 0
 }
 
-# Opt out when either the global Aspire CLI telemetry switch or the AI-specific switch is set.
+# Opt out when the Aspire CLI telemetry switch is set. This is the single opt-out that also
+# gates the `aspire agent telemetry` command path, so honoring it here avoids spawning the CLI
+# at all for opted-out users.
 case "${ASPIRE_CLI_TELEMETRY_OPTOUT}" in
-    1|true|TRUE|True) return_success ;;
-esac
-case "${ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT}" in
     1|true|TRUE|True) return_success ;;
 esac
 

--- a/src/Aspire.Cli/Agents/Hooks/track-telemetry.sh
+++ b/src/Aspire.Cli/Agents/Hooks/track-telemetry.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+# Telemetry tracking hook for Aspire Skills.
+#
+# Runs on every agent PostToolUse event. Reads the hook JSON from stdin, detects when an
+# Aspire skill, Aspire MCP tool, or Aspire skill reference file was used, and forwards a
+# low-cardinality usage event to `aspire agent telemetry`. The Aspire CLI command owns the
+# actual opt-out + publishing logic; this script only classifies the event and shells out.
+#
+# Hook contract: a PostToolUse hook MUST always print a single JSON object to stdout and exit
+# 0, otherwise it can break the agent session. Every code path here ends in return_success.
+#
+# === Client format reference ===
+#
+# Copilot CLI:
+#   - Field names: camelCase (toolName, sessionId, toolArgs) when the hook event is configured
+#     in camelCase (postToolUse); snake_case (tool_name, ...) when configured in PascalCase
+#     (PostToolUse, "VS Code compatible" payload). We handle both.
+#   - Tool names: lowercase (skill, view)
+#   - Aspire MCP prefix: aspire-<tool>            (e.g. aspire-list_resources)
+#   - Detection: COPILOT_CLI=1, or a "toolArgs" field present
+#
+# Claude Code:
+#   - Field names: snake_case (tool_name, session_id, tool_input, hook_event_name)
+#   - Tool names: PascalCase (Skill, Read, Edit)
+#   - Aspire MCP prefix: mcp__aspire__<tool>      (server named "aspire" in .mcp.json)
+#   - Skill prefix: aspire:<skill-name> (plugin install) — stripped before allowlist match
+#   - Detection: has "hook_event_name", tool_use_id does NOT contain "__vscode"
+#
+# VS Code:
+#   - Field names: snake_case (tool_name, session_id, tool_input, hook_event_name)
+#   - Tool names: snake_case (read_file)
+#   - Aspire MCP prefix: mcp_aspire_<tool>
+#   - Detection: has "hook_event_name", tool_use_id contains "__vscode" or transcript_path has /Code/
+#
+# === Event types emitted ===
+#
+# 1. skill_invocation     - the skill/Skill tool ran with an Aspire skill name, OR a SKILL.md
+#                           under .../skills/<aspire-skill>/SKILL.md was read.   (--skill-name)
+# 2. tool_invocation      - a tool matching an Aspire MCP prefix ran.            (--tool-name)
+# 3. reference_file_read  - a non-SKILL.md file under .../skills/<aspire-skill>/ was read.
+#                                                                                (--file-reference)
+#
+# Privacy: only Aspire-owned identifiers are forwarded. Skill/tool names are matched against an
+# allowlist of the skills shipped by github.com/microsoft/aspire-skills, and reference files are
+# only forwarded as the repo-relative path *after* skills/<skill>/ — never absolute paths, repo
+# names, or user names. The Aspire CLI command independently re-validates and drops anything else.
+
+# Never abort the agent: failures must be silent and we must still emit {"continue":true}.
+set +e
+
+# Allowlist of Aspire-owned skill names (must stay in sync with the skills shipped by
+# github.com/microsoft/aspire-skills). A shared .agents/skills directory can also contain
+# third-party skills (dotnet-inspect, playwright, ...), so a path/name is only treated as
+# Aspire when its skill segment is one of these.
+ASPIRE_SKILLS="aspire aspire-init aspireify aspire-orchestration aspire-deployment aspire-monitoring"
+
+return_success() {
+    echo '{"continue":true}'
+    exit 0
+}
+
+# Opt out when either the global Aspire CLI telemetry switch or the AI-specific switch is set.
+case "${ASPIRE_CLI_TELEMETRY_OPTOUT}" in
+    1|true|TRUE|True) return_success ;;
+esac
+case "${ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT}" in
+    1|true|TRUE|True) return_success ;;
+esac
+
+# Extract a top-level string field, e.g. "toolName": "view"  ->  view
+# Uses sed (portable; no jq/grep -P dependency).
+extract_json_field() {
+    printf '%s' "$1" | sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n 1
+}
+
+# Extract a nested string field from toolArgs (Copilot) or tool_input (Claude/VS Code).
+extract_nested_field() {
+    local json="$1" field="$2" value=""
+    value=$(printf '%s' "$json" | sed -n "s/.*\"toolArgs\"[[:space:]]*:[[:space:]]*{[^}]*\"$field\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n 1)
+    if [ -z "$value" ]; then
+        value=$(printf '%s' "$json" | sed -n "s/.*\"tool_input\"[[:space:]]*:[[:space:]]*{[^}]*\"$field\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n 1)
+    fi
+    printf '%s' "$value"
+}
+
+# Extract a file path from tool input, trying the documented field names in order.
+extract_nested_path() {
+    local json="$1" value=""
+    for field in path filePath file_path; do
+        value=$(extract_nested_field "$json" "$field")
+        if [ -n "$value" ]; then
+            break
+        fi
+    done
+    printf '%s' "$value"
+}
+
+# Return 0 when $1 is an allowlisted Aspire skill name.
+is_aspire_skill() {
+    local candidate="$1" name
+    for name in $ASPIRE_SKILLS; do
+        if [ "$candidate" = "$name" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# No stdin (interactive) means nothing to track.
+if [ -t 0 ]; then
+    return_success
+fi
+
+rawInput=$(cat)
+if [ -z "$rawInput" ]; then
+    return_success
+fi
+
+toolName=$(extract_json_field "$rawInput" "toolName")
+[ -z "$toolName" ] && toolName=$(extract_json_field "$rawInput" "tool_name")
+
+sessionId=$(extract_json_field "$rawInput" "sessionId")
+[ -z "$sessionId" ] && sessionId=$(extract_json_field "$rawInput" "session_id")
+
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Detect the client (used only for a low-cardinality client-name tag).
+if [ "$COPILOT_CLI" = "1" ]; then
+    clientName="copilot-cli"
+elif printf '%s' "$rawInput" | grep -q '"hook_event_name"'; then
+    toolUseId=$(extract_json_field "$rawInput" "tool_use_id")
+    transcriptPath=$(extract_json_field "$rawInput" "transcript_path")
+    transcriptPathNorm=$(printf '%s' "$transcriptPath" | tr '\\' '/')
+    case "$toolUseId$transcriptPathNorm" in
+        *__vscode*|*/Code/*|*/Code\ -\ Insiders/*) clientName="vscode" ;;
+        *) clientName="claude-code" ;;
+    esac
+elif printf '%s' "$rawInput" | grep -q '"toolArgs"'; then
+    clientName="copilot-cli"
+else
+    clientName="unknown"
+fi
+
+# Nothing to classify without a tool name.
+if [ -z "$toolName" ]; then
+    return_success
+fi
+
+shouldTrack=false
+eventType=""
+skillName=""
+mcpToolName=""
+fileReference=""
+
+# --- skill_invocation via the skill/Skill tool ---
+if [ "$toolName" = "skill" ] || [ "$toolName" = "Skill" ]; then
+    candidate=$(extract_nested_field "$rawInput" "skill")
+    # Claude prefixes plugin skill names, e.g. "aspire:aspire-deployment".
+    candidate="${candidate#aspire:}"
+    if is_aspire_skill "$candidate"; then
+        skillName="$candidate"
+        eventType="skill_invocation"
+        shouldTrack=true
+    fi
+fi
+
+# --- skill_invocation / reference_file_read via a file read tool ---
+# Copilot CLI: view, Claude Code: Read, VS Code: read_file.
+if [ "$toolName" = "view" ] || [ "$toolName" = "Read" ] || [ "$toolName" = "read_file" ]; then
+    pathToCheck=$(extract_nested_path "$rawInput")
+    if [ -n "$pathToCheck" ]; then
+        # Normalize separators and collapse duplicate slashes. Example inputs:
+        #   .agents/skills/aspire/SKILL.md
+        #   /home/me/proj/.github/skills/aspire-deployment/references/deploy.md
+        #   C:\src\.claude\skills\aspireify\SKILL.md
+        normalized=$(printf '%s' "$pathToCheck" | tr '\\' '/' | sed 's|//*|/|g')
+        # Capture the skill segment after skills/. We only honor allowlisted Aspire skills.
+        skillSegment=$(printf '%s' "$normalized" | sed -n 's|.*/skills/\([^/]*\)/.*|\1|p')
+        if [ -z "$skillSegment" ]; then
+            # Handles a leading "skills/<skill>/..." with no parent directory.
+            skillSegment=$(printf '%s' "$normalized" | sed -n 's|^skills/\([^/]*\)/.*|\1|p')
+        fi
+        if [ -n "$skillSegment" ] && is_aspire_skill "$skillSegment"; then
+            remainder=$(printf '%s' "$normalized" | sed -n 's|.*/skills/||p')
+            [ -z "$remainder" ] && remainder=$(printf '%s' "$normalized" | sed -n 's|^skills/||p')
+            case "$remainder" in
+                */SKILL.md|SKILL.md|*/skill.md|skill.md)
+                    # A SKILL.md read is a skill invocation, not a reference-file read.
+                    if [ "$shouldTrack" = false ]; then
+                        skillName="$skillSegment"
+                        eventType="skill_invocation"
+                        shouldTrack=true
+                    fi
+                    ;;
+                *)
+                    if [ "$shouldTrack" = false ] && [ -n "$remainder" ]; then
+                        # Forward only the relative path after skills/ (e.g. aspire/references/deploy.md).
+                        fileReference="$remainder"
+                        eventType="reference_file_read"
+                        shouldTrack=true
+                    fi
+                    ;;
+            esac
+        fi
+    fi
+fi
+
+# --- tool_invocation via an Aspire MCP tool prefix ---
+# Conservative exact prefixes (avoid matching arbitrary "*aspire*" tools):
+#   Copilot: aspire-<tool>   Claude: mcp__aspire__<tool>   VS Code: mcp_aspire_<tool>
+case "$toolName" in
+    aspire-*|mcp__aspire__*|mcp_aspire_*)
+        mcpToolName="$toolName"
+        eventType="tool_invocation"
+        shouldTrack=true
+        ;;
+esac
+
+if [ "$shouldTrack" != true ]; then
+    return_success
+fi
+
+# Resolve the Aspire CLI. ASPIRE_CLI_COMMAND lets tests substitute a recording stub.
+aspireCmd="${ASPIRE_CLI_COMMAND:-aspire}"
+
+# Build the argument vector explicitly so untrusted hook values are passed as discrete args
+# (never concatenated into a shell string).
+args=(agent telemetry --event-type "$eventType" --client-name "$clientName" --timestamp "$timestamp")
+[ -n "$sessionId" ] && args+=(--session-id "$sessionId")
+[ -n "$skillName" ] && args+=(--skill-name "$skillName")
+[ -n "$mcpToolName" ] && args+=(--tool-name "$mcpToolName")
+[ -n "$fileReference" ] && args+=(--file-reference "$fileReference")
+
+# Redirect all child output to null so a banner/log line can never contaminate hook stdout.
+# Bound the call so a hung CLI can't stall the agent; swallow every failure.
+if command -v timeout >/dev/null 2>&1; then
+    timeout 10 "$aspireCmd" "${args[@]}" >/dev/null 2>&1
+else
+    "$aspireCmd" "${args[@]}" >/dev/null 2>&1
+fi
+
+return_success

--- a/src/Aspire.Cli/Agents/Hooks/track-telemetry.sh
+++ b/src/Aspire.Cli/Agents/Hooks/track-telemetry.sh
@@ -8,7 +8,8 @@
 # actual opt-out + publishing logic; this script only classifies the event and shells out.
 #
 # Hook contract: a PostToolUse hook MUST always print a single JSON object to stdout and exit
-# 0, otherwise it can break the agent session. Every code path here ends in return_success.
+# 0, otherwise it can break the agent session. A single EXIT trap guarantees that response is
+# emitted exactly once, however the script leaves.
 #
 # === Client format reference ===
 #
@@ -49,22 +50,30 @@
 # Never abort the agent: failures must be silent and we must still emit {"continue":true}.
 set +e
 
+# Hook contract enforcement: always print exactly one {"continue":true} and exit 0, however the
+# script leaves — normal completion, an early `exit 0`, or an unexpected failure under `set +e`.
+# A single EXIT trap is the one guaranteed emit point, so every other path just calls `exit 0`
+# and never prints the response itself.
+_emitted=0
+emit_continue() {
+    [ "$_emitted" -eq 0 ] || return 0
+    _emitted=1
+    printf '%s\n' '{"continue":true}'
+}
+trap emit_continue EXIT
+
 # Allowlist of Aspire-owned skill names (must stay in sync with the skills shipped by
 # github.com/microsoft/aspire-skills). A shared .agents/skills directory can also contain
 # third-party skills (dotnet-inspect, playwright, ...), so a path/name is only treated as
 # Aspire when its skill segment is one of these.
 ASPIRE_SKILLS="aspire aspire-init aspireify aspire-orchestration aspire-deployment aspire-monitoring"
 
-return_success() {
-    echo '{"continue":true}'
-    exit 0
-}
-
 # Opt out when the Aspire CLI telemetry switch is set. This is the single opt-out that also
 # gates the `aspire agent telemetry` command path, so honoring it here avoids spawning the CLI
-# at all for opted-out users.
-case "${ASPIRE_CLI_TELEMETRY_OPTOUT}" in
-    1|true|TRUE|True) return_success ;;
+# at all for opted-out users. Lower-case first so the accepted set (1 / any-case true) matches
+# the PowerShell hook's case-insensitive check exactly.
+case "$(printf '%s' "${ASPIRE_CLI_TELEMETRY_OPTOUT}" | tr '[:upper:]' '[:lower:]')" in
+    1|true) exit 0 ;;
 esac
 
 # Extract a top-level string field, e.g. "toolName": "view"  ->  view
@@ -73,14 +82,18 @@ extract_json_field() {
     printf '%s' "$1" | sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n 1
 }
 
-# Extract a nested string field from toolArgs (Copilot) or tool_input (Claude/VS Code).
+# Read a string field's value from anywhere in the payload, best-effort, without assuming the
+# payload's shape or which client produced it. The nested tool input arrives in two shapes:
+#   - Claude/VS Code send a real nested object:   "tool_input":{"file_path":"..."}
+#   - Copilot sends toolArgs as a JSON-encoded STRING whose quotes are escaped:
+#       "toolArgs":"{\"path\":\"C:\\Users\\me\\skills\\aspire\\SKILL.md\"}"
+# Unescaping \" -> " turns the string form into the same flat "field":"value" pairs as the object
+# form, so a single extractor reads both. The value's own backslashes (doubled Windows path
+# separators) are left intact; the caller's path normalization (tr '\\' '/') collapses them.
 extract_nested_field() {
-    local json="$1" field="$2" value=""
-    value=$(printf '%s' "$json" | sed -n "s/.*\"toolArgs\"[[:space:]]*:[[:space:]]*{[^}]*\"$field\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n 1)
-    if [ -z "$value" ]; then
-        value=$(printf '%s' "$json" | sed -n "s/.*\"tool_input\"[[:space:]]*:[[:space:]]*{[^}]*\"$field\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n 1)
-    fi
-    printf '%s' "$value"
+    local unescaped
+    unescaped=$(printf '%s' "$1" | sed 's/\\"/"/g')
+    extract_json_field "$unescaped" "$2"
 }
 
 # Extract a file path from tool input, trying the documented field names in order.
@@ -108,13 +121,22 @@ is_aspire_skill() {
 
 # No stdin (interactive) means nothing to track.
 if [ -t 0 ]; then
-    return_success
+    exit 0
 fi
 
 rawInput=$(cat)
 if [ -z "$rawInput" ]; then
-    return_success
+    exit 0
 fi
+
+# Fast path: the vast majority of PostToolUse events are not Aspire-related. Everything we track
+# carries "skill"/"Skill" or "aspire" somewhere in the payload (the skill tool name, an aspire-/
+# mcp__aspire__ tool name, or a .../skills/<aspire-skill>/ path), so when none of those appear we
+# return immediately and skip all of the sed/grep extraction below.
+case "$rawInput" in
+    *skill*|*Skill*|*aspire*|*Aspire*) ;;
+    *) exit 0 ;;
+esac
 
 toolName=$(extract_json_field "$rawInput" "toolName")
 [ -z "$toolName" ] && toolName=$(extract_json_field "$rawInput" "tool_name")
@@ -143,7 +165,7 @@ fi
 
 # Nothing to classify without a tool name.
 if [ -z "$toolName" ]; then
-    return_success
+    exit 0
 fi
 
 shouldTrack=false
@@ -217,7 +239,7 @@ case "$toolName" in
 esac
 
 if [ "$shouldTrack" != true ]; then
-    return_success
+    exit 0
 fi
 
 # Resolve the Aspire CLI. ASPIRE_CLI_COMMAND lets tests substitute a recording stub.
@@ -239,4 +261,6 @@ else
     "$aspireCmd" "${args[@]}" >/dev/null 2>&1
 fi
 
-return_success
+# Explicit exit 0: the EXIT trap prints the response, but we must not let the CLI's exit code
+# (e.g. timeout's 124) leak through as the hook's exit code.
+exit 0

--- a/src/Aspire.Cli/Agents/OpenCode/OpenCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/OpenCode/OpenCodeAgentEnvironmentScanner.cs
@@ -53,6 +53,8 @@ internal sealed class OpenCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
         {
             _logger.LogDebug("Found existing opencode.jsonc at: {ConfigFilePath}", configFilePath);
 
+            context.AddDetectedClient(AgentClientKind.OpenCode);
+
             // Check if aspire is already configured
             _logger.LogDebug("Checking if Aspire MCP server is already configured in opencode.jsonc...");
             if (!HasAspireServerConfigured(configFilePath))
@@ -78,6 +80,9 @@ internal sealed class OpenCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
             if (openCodeVersion is not null)
             {
                 _logger.LogDebug("Found OpenCode CLI version: {Version}", openCodeVersion);
+
+                context.AddDetectedClient(AgentClientKind.OpenCode);
+
                 // OpenCode is installed - offer to create config
                 _logger.LogDebug("Adding OpenCode applicator to create new opencode.jsonc at: {ConfigDirectory}", configDirectory.FullName);
                 context.AddApplicator(CreateApplicator(configDirectory));

--- a/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
@@ -60,6 +60,8 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
         {
             _logger.LogDebug("Found .vscode folder at: {VsCodeFolder}", vsCodeFolder.FullName);
 
+            context.AddDetectedClient(AgentClientKind.VsCode);
+
             // Check if the aspire server is already configured
             if (!HasAspireServerConfigured(vsCodeFolder))
             {
@@ -78,6 +80,9 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
         else if (await IsVsCodeAvailableAsync(cancellationToken).ConfigureAwait(false))
         {
             _logger.LogDebug("No .vscode folder found, but VS Code is available on the system");
+
+            context.AddDetectedClient(AgentClientKind.VsCode);
+
             // No .vscode folder found, but VS Code is available
             // Use workspace root for new .vscode folder
             var targetVsCodeFolder = new DirectoryInfo(Path.Combine(context.RepositoryRoot.FullName, VsCodeFolderName));

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -313,6 +313,15 @@
     <EmbeddedResource Include="Agents\AspireSkills\Embedded\aspire-skills.metadata.json" LogicalName="aspire-skills.metadata.json">
       <WithCulture>false</WithCulture>
     </EmbeddedResource>
+    <!-- Agent PostToolUse telemetry hook scripts. Materialized to ~/.aspire/hooks/ by
+         TelemetryHookInstaller and registered into each detected agent client's user-level
+         config during `aspire agent init`. -->
+    <EmbeddedResource Include="Agents\Hooks\track-telemetry.sh" LogicalName="track-telemetry.sh">
+      <WithCulture>false</WithCulture>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Agents\Hooks\track-telemetry.ps1" LogicalName="track-telemetry.ps1">
+      <WithCulture>false</WithCulture>
+    </EmbeddedResource>
   </ItemGroup>
 
 

--- a/src/Aspire.Cli/Commands/AgentCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentCommand.cs
@@ -15,10 +15,12 @@ internal sealed class AgentCommand : ParentCommand
     public AgentCommand(
         AgentMcpCommand mcpCommand,
         AgentInitCommand initCommand,
+        AgentTelemetryCommand telemetryCommand,
         CommonCommandServices services)
         : base("agent", AgentCommandStrings.Description, services)
     {
         Subcommands.Add(mcpCommand);
         Subcommands.Add(initCommand);
+        Subcommands.Add(telemetryCommand);
     }
 }

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -61,7 +61,6 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         Options.Add(s_workspaceRootOption);
         Options.Add(s_skillLocationsOption);
         Options.Add(s_skillsOption);
-        Options.Add(s_noTelemetryHooksOption);
     }
 
     private static readonly Option<string?> s_workspaceRootOption = new("--workspace-root")
@@ -85,11 +84,6 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             ConsoleInteractionService.AllChoice,
             ConsoleInteractionService.NoneChoice),
         Recursive = true
-    };
-
-    private static readonly Option<bool> s_noTelemetryHooksOption = new("--no-telemetry-hooks")
-    {
-        Description = AgentCommandStrings.InitCommand_NoTelemetryHooksOptionDescription
     };
 
     /// <summary>
@@ -476,14 +470,10 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         }
 
         // --- Phase 6: Install agent telemetry hooks (default-on, parity with azure-skills) ---
-        // Hooks are installed for every detected, supported client unless the user opted out with
-        // --no-telemetry-hooks. Whether telemetry is actually transmitted stays gated by the opt-out
-        // environment variables that the hook scripts and the `agent telemetry` command both re-check.
-        var telemetryHooksDisabled = parseResult?.GetValue(s_noTelemetryHooksOption) ?? false;
-        if (!telemetryHooksDisabled)
-        {
-            hasErrors |= await ConfigureTelemetryHooksAsync(context, cancellationToken);
-        }
+        // Hooks are installed for every detected, supported client. Whether telemetry is actually
+        // transmitted stays gated by the single ASPIRE_CLI_TELEMETRY_OPTOUT opt-out, which both the
+        // hook scripts and the `aspire agent telemetry` command path re-check at runtime.
+        await ConfigureTelemetryHooksAsync(context, cancellationToken);
 
         if (hasErrors)
         {
@@ -500,18 +490,21 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             selectedSkills);
     }
 
-    private async Task<bool> ConfigureTelemetryHooksAsync(AgentEnvironmentScanContext context, CancellationToken cancellationToken)
+    private async Task ConfigureTelemetryHooksAsync(AgentEnvironmentScanContext context, CancellationToken cancellationToken)
     {
         TelemetryHookConfigurationResult result;
         try
         {
             result = await _telemetryHookConfigurator.ConfigureAsync(context.DetectedClients, cancellationToken);
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // Hook installation is best-effort transparency tooling; never fail `agent init` over it.
+            // This deliberately catches everything except cancellation: besides file IO failures, a
+            // corrupted CLI build could surface a missing embedded hook script as an
+            // InvalidOperationException, and that must not abort the whole command either.
             InteractionService.DisplaySubtleMessage(ex.Message);
-            return false;
+            return;
         }
 
         if (result.ConfiguredClients.Count > 0)
@@ -529,16 +522,13 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             {
                 TelemetryHookSkipReason.MalformedConfig => string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_TelemetryHookSkippedMalformedConfig, clientName),
                 TelemetryHookSkipReason.UnexpectedConfigShape => string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_TelemetryHookSkippedUnexpectedShape, clientName),
-                TelemetryHookSkipReason.WriteFailed => string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_TelemetryHookWriteFailed, clientName),
                 _ => string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_TelemetryHookWriteFailed, clientName),
             };
 
+            // Skips are surfaced to the user but never treated as command failures: a user-owned
+            // config we can't safely modify must not break `agent init`.
             InteractionService.DisplaySubtleMessage(message);
         }
-
-        // Skips are surfaced to the user but are not treated as command failures: a user-owned config we
-        // can't safely modify must not break `agent init`.
-        return false;
     }
 
     private static string GetClientDisplayName(AgentClientKind client)

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Text.Json;
 using Aspire.Cli.Agents;
 using Aspire.Cli.Agents.AspireSkills;
+using Aspire.Cli.Agents.Hooks;
 using Aspire.Cli.Agents.Playwright;
 using Aspire.Cli.Git;
 using Aspire.Cli.Interaction;
@@ -28,6 +29,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
     private readonly PlaywrightCliInstaller _playwrightCliInstaller;
     private readonly IGitRepository _gitRepository;
     private readonly ILanguageDiscovery _languageDiscovery;
+    private readonly ITelemetryHookConfigurator _telemetryHookConfigurator;
 
     /// <summary>
     /// AgentInitCommand does not need template package metadata prefetching.
@@ -45,6 +47,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         PlaywrightCliInstaller playwrightCliInstaller,
         IGitRepository gitRepository,
         ILanguageDiscovery languageDiscovery,
+        ITelemetryHookConfigurator telemetryHookConfigurator,
         CommonCommandServices services)
         : base("init", AgentCommandStrings.InitCommand_Description, services)
     {
@@ -53,10 +56,12 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         _playwrightCliInstaller = playwrightCliInstaller;
         _gitRepository = gitRepository;
         _languageDiscovery = languageDiscovery;
+        _telemetryHookConfigurator = telemetryHookConfigurator;
 
         Options.Add(s_workspaceRootOption);
         Options.Add(s_skillLocationsOption);
         Options.Add(s_skillsOption);
+        Options.Add(s_noTelemetryHooksOption);
     }
 
     private static readonly Option<string?> s_workspaceRootOption = new("--workspace-root")
@@ -80,6 +85,11 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             ConsoleInteractionService.AllChoice,
             ConsoleInteractionService.NoneChoice),
         Recursive = true
+    };
+
+    private static readonly Option<bool> s_noTelemetryHooksOption = new("--no-telemetry-hooks")
+    {
+        Description = AgentCommandStrings.InitCommand_NoTelemetryHooksOptionDescription
     };
 
     /// <summary>
@@ -465,6 +475,16 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             }
         }
 
+        // --- Phase 6: Install agent telemetry hooks (default-on, parity with azure-skills) ---
+        // Hooks are installed for every detected, supported client unless the user opted out with
+        // --no-telemetry-hooks. Whether telemetry is actually transmitted stays gated by the opt-out
+        // environment variables that the hook scripts and the `agent telemetry` command both re-check.
+        var telemetryHooksDisabled = parseResult?.GetValue(s_noTelemetryHooksOption) ?? false;
+        if (!telemetryHooksDisabled)
+        {
+            hasErrors |= await ConfigureTelemetryHooksAsync(context, cancellationToken);
+        }
+
         if (hasErrors)
         {
             InteractionService.DisplayMessage(KnownEmojis.Warning, AgentCommandStrings.ConfigurationCompletedWithErrors);
@@ -479,6 +499,57 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             selectedLocations,
             selectedSkills);
     }
+
+    private async Task<bool> ConfigureTelemetryHooksAsync(AgentEnvironmentScanContext context, CancellationToken cancellationToken)
+    {
+        TelemetryHookConfigurationResult result;
+        try
+        {
+            result = await _telemetryHookConfigurator.ConfigureAsync(context.DetectedClients, cancellationToken);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Hook installation is best-effort transparency tooling; never fail `agent init` over it.
+            InteractionService.DisplaySubtleMessage(ex.Message);
+            return false;
+        }
+
+        if (result.ConfiguredClients.Count > 0)
+        {
+            var clientNames = string.Join(", ", result.ConfiguredClients.Select(GetClientDisplayName));
+            InteractionService.DisplayMessage(
+                KnownEmojis.BarChart,
+                string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_TelemetryHooksInstalled, clientNames));
+        }
+
+        foreach (var skip in result.Skipped)
+        {
+            var clientName = GetClientDisplayName(skip.Client);
+            var message = skip.Reason switch
+            {
+                TelemetryHookSkipReason.MalformedConfig => string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_TelemetryHookSkippedMalformedConfig, clientName),
+                TelemetryHookSkipReason.UnexpectedConfigShape => string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_TelemetryHookSkippedUnexpectedShape, clientName),
+                TelemetryHookSkipReason.WriteFailed => string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_TelemetryHookWriteFailed, clientName),
+                _ => string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_TelemetryHookWriteFailed, clientName),
+            };
+
+            InteractionService.DisplaySubtleMessage(message);
+        }
+
+        // Skips are surfaced to the user but are not treated as command failures: a user-owned config we
+        // can't safely modify must not break `agent init`.
+        return false;
+    }
+
+    private static string GetClientDisplayName(AgentClientKind client)
+        => client switch
+        {
+            AgentClientKind.CopilotCli => "GitHub Copilot CLI",
+            AgentClientKind.ClaudeCode => "Claude Code",
+            AgentClientKind.VsCode => "VS Code",
+            AgentClientKind.OpenCode => "OpenCode",
+            _ => client.ToString(),
+        };
 
     private async Task<(IReadOnlyList<SkillDefinition> Skills, AspireSkillsBundle? Bundle, string? FailureMessage)> ResolveAvailableSkillsAsync(LanguageId? detectedLanguage, CancellationToken cancellationToken)
     {

--- a/src/Aspire.Cli/Commands/AgentTelemetryCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentTelemetryCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Diagnostics;
 using System.Globalization;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
@@ -22,8 +21,8 @@ namespace Aspire.Cli.Commands;
 /// and unmatched tokens are ignored, so option binding can never fail before the handler runs and a
 /// newer hook script passing an unknown flag cannot break an older CLI.
 ///
-/// The opt-out (<c>ASPIRE_CLI_TELEMETRY_OPTOUT</c> / <c>ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT</c>) and
-/// the suppression of the generic <c>aspire/cli/main</c> span for this command path are handled in
+/// The opt-out (<c>ASPIRE_CLI_TELEMETRY_OPTOUT</c>) and the suppression of the generic
+/// <c>aspire/cli/main</c> span for this command path are handled in
 /// <see cref="TelemetryManager"/> and <c>Program</c> before the host is built. When telemetry is
 /// opted out no reported provider is created, so <see cref="AspireCliTelemetry.StartReportedActivity(string, System.Diagnostics.ActivityKind)"/>
 /// returns <see langword="null"/> here and the command is a no-op.
@@ -97,22 +96,27 @@ internal sealed class AgentTelemetryCommand : BaseCommand
     {
         try
         {
+            // Validate every value up front. Invalid or oversized values are dropped (never recorded),
+            // so a parser bug in a hook script cannot leak an absolute path, user name, or other
+            // sensitive/high-cardinality data into telemetry.
+            var tags = CollectValidTags(parseResult);
+
+            // Nothing valid survived validation (for example a newer hook script paired with an older
+            // CLI dropped every field): emit no span rather than a tagless one.
+            if (tags.Count is 0)
+            {
+                return Task.FromResult(CommandResult.Success());
+            }
+
             // Activity is null when telemetry is opted out (no reported provider) or no listener is
             // attached; in that case this is a no-op, which is the desired behavior.
             using var activity = Telemetry.StartReportedActivity(TelemetryConstants.Activities.AgentTelemetry);
             if (activity is not null)
             {
-                // Defense-in-depth: even though the hook scripts only pass Aspire-owned identifiers,
-                // each value is validated here so a parser bug in a script cannot leak an absolute
-                // path, user name, or other sensitive/high-cardinality data into telemetry. Invalid
-                // values are dropped (the tag is simply not set), never recorded.
-                SetIfValid(activity, TelemetryConstants.Tags.AgentEventType, parseResult.GetValue(_eventTypeOption), static v => s_knownEventTypes.Contains(v, StringComparer.Ordinal));
-                SetIfValid(activity, TelemetryConstants.Tags.AgentClientName, parseResult.GetValue(_clientNameOption), static v => IsSafeIdentifier(v, maxLength: 64));
-                SetIfValid(activity, TelemetryConstants.Tags.AgentSessionId, parseResult.GetValue(_sessionIdOption), static v => IsSafeIdentifier(v, maxLength: 128));
-                SetIfValid(activity, TelemetryConstants.Tags.AgentSkillName, parseResult.GetValue(_skillNameOption), static v => IsSafeIdentifier(v, maxLength: 128));
-                SetIfValid(activity, TelemetryConstants.Tags.AgentToolName, parseResult.GetValue(_toolNameOption), static v => IsSafeIdentifier(v, maxLength: 128));
-                SetIfValid(activity, TelemetryConstants.Tags.AgentFileReference, parseResult.GetValue(_fileReferenceOption), IsSafeReference);
-                SetIfValid(activity, TelemetryConstants.Tags.AgentEventTimestamp, parseResult.GetValue(_timestampOption), IsValidTimestamp);
+                foreach (var (name, value) in tags)
+                {
+                    activity.SetTag(name, value);
+                }
             }
         }
         catch
@@ -123,14 +127,27 @@ internal sealed class AgentTelemetryCommand : BaseCommand
         return Task.FromResult(CommandResult.Success());
     }
 
-    private static void SetIfValid(Activity activity, string name, string? value, Func<string, bool> isValid)
+    private List<(string Name, string Value)> CollectValidTags(ParseResult parseResult)
     {
-        if (string.IsNullOrWhiteSpace(value) || !isValid(value))
-        {
-            return;
-        }
+        var tags = new List<(string Name, string Value)>();
 
-        activity.SetTag(name, value);
+        AddIfValid(tags, TelemetryConstants.Tags.AgentEventType, parseResult.GetValue(_eventTypeOption), static v => s_knownEventTypes.Contains(v, StringComparer.Ordinal));
+        AddIfValid(tags, TelemetryConstants.Tags.AgentClientName, parseResult.GetValue(_clientNameOption), static v => IsSafeIdentifier(v, maxLength: 64));
+        AddIfValid(tags, TelemetryConstants.Tags.AgentSessionId, parseResult.GetValue(_sessionIdOption), static v => IsSafeIdentifier(v, maxLength: 128));
+        AddIfValid(tags, TelemetryConstants.Tags.AgentSkillName, parseResult.GetValue(_skillNameOption), static v => IsSafeIdentifier(v, maxLength: 128));
+        AddIfValid(tags, TelemetryConstants.Tags.AgentToolName, parseResult.GetValue(_toolNameOption), static v => IsSafeIdentifier(v, maxLength: 128));
+        AddIfValid(tags, TelemetryConstants.Tags.AgentFileReference, parseResult.GetValue(_fileReferenceOption), IsSafeReference);
+        AddIfValid(tags, TelemetryConstants.Tags.AgentEventTimestamp, parseResult.GetValue(_timestampOption), IsValidTimestamp);
+
+        return tags;
+    }
+
+    private static void AddIfValid(List<(string Name, string Value)> tags, string name, string? value, Func<string, bool> isValid)
+    {
+        if (!string.IsNullOrWhiteSpace(value) && isValid(value))
+        {
+            tags.Add((name, value));
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/AgentTelemetryCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentTelemetryCommand.cs
@@ -1,0 +1,195 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Diagnostics;
+using System.Globalization;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Hidden, machine-facing command invoked by the agent telemetry hook scripts
+/// (<c>track-telemetry.sh</c> / <c>track-telemetry.ps1</c>) on each agent <c>PostToolUse</c>
+/// event. It records a single reported activity describing the Aspire skill, MCP tool, or
+/// reference-file usage that the hook detected.
+/// </summary>
+/// <remarks>
+/// Hook-safety contract: this command must never throw and must always exit 0. A hook that fails
+/// or writes unexpected output can break the host agent's tool loop, so every operation is wrapped
+/// so that any failure degrades to a successful no-op. All options are optional and unvalidated,
+/// and unmatched tokens are ignored, so option binding can never fail before the handler runs and a
+/// newer hook script passing an unknown flag cannot break an older CLI.
+///
+/// The opt-out (<c>ASPIRE_CLI_TELEMETRY_OPTOUT</c> / <c>ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT</c>) and
+/// the suppression of the generic <c>aspire/cli/main</c> span for this command path are handled in
+/// <see cref="TelemetryManager"/> and <c>Program</c> before the host is built. When telemetry is
+/// opted out no reported provider is created, so <see cref="AspireCliTelemetry.StartReportedActivity(string, System.Diagnostics.ActivityKind)"/>
+/// returns <see langword="null"/> here and the command is a no-op.
+/// </remarks>
+internal sealed class AgentTelemetryCommand : BaseCommand
+{
+    // Defensive cap so a malformed or hostile hook payload cannot push oversized or
+    // high-cardinality values into the telemetry backend. Real values (skill names, tool names,
+    // skills-relative reference paths) are well under this length.
+    private const int MaxTagValueLength = 256;
+
+    // The only event types the hook scripts emit. Anything else is dropped so a script bug or a
+    // crafted argument cannot introduce arbitrary, high-cardinality event categories.
+    private static readonly string[] s_knownEventTypes = ["skill_invocation", "tool_invocation", "reference_file_read"];
+
+    private readonly Option<string?> _eventTypeOption = new("--event-type")
+    {
+        Description = AgentCommandStrings.AgentTelemetryCommand_EventTypeDescription
+    };
+
+    private readonly Option<string?> _clientNameOption = new("--client-name")
+    {
+        Description = AgentCommandStrings.AgentTelemetryCommand_ClientNameDescription
+    };
+
+    private readonly Option<string?> _sessionIdOption = new("--session-id")
+    {
+        Description = AgentCommandStrings.AgentTelemetryCommand_SessionIdDescription
+    };
+
+    private readonly Option<string?> _skillNameOption = new("--skill-name")
+    {
+        Description = AgentCommandStrings.AgentTelemetryCommand_SkillNameDescription
+    };
+
+    private readonly Option<string?> _toolNameOption = new("--tool-name")
+    {
+        Description = AgentCommandStrings.AgentTelemetryCommand_ToolNameDescription
+    };
+
+    private readonly Option<string?> _fileReferenceOption = new("--file-reference")
+    {
+        Description = AgentCommandStrings.AgentTelemetryCommand_FileReferenceDescription
+    };
+
+    private readonly Option<string?> _timestampOption = new("--timestamp")
+    {
+        Description = AgentCommandStrings.AgentTelemetryCommand_TimestampDescription
+    };
+
+    public AgentTelemetryCommand(CommonCommandServices services)
+        : base("telemetry", AgentCommandStrings.AgentTelemetryCommand_Description, services)
+    {
+        // This command is an implementation detail of the agent hook scripts, not a user-facing
+        // command, so keep it out of help output.
+        Hidden = true;
+
+        // Never fail the hook because a newer script passes a flag this CLI version does not know.
+        TreatUnmatchedTokensAsErrors = false;
+
+        Options.Add(_eventTypeOption);
+        Options.Add(_clientNameOption);
+        Options.Add(_sessionIdOption);
+        Options.Add(_skillNameOption);
+        Options.Add(_toolNameOption);
+        Options.Add(_fileReferenceOption);
+        Options.Add(_timestampOption);
+    }
+
+    protected override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Activity is null when telemetry is opted out (no reported provider) or no listener is
+            // attached; in that case this is a no-op, which is the desired behavior.
+            using var activity = Telemetry.StartReportedActivity(TelemetryConstants.Activities.AgentTelemetry);
+            if (activity is not null)
+            {
+                // Defense-in-depth: even though the hook scripts only pass Aspire-owned identifiers,
+                // each value is validated here so a parser bug in a script cannot leak an absolute
+                // path, user name, or other sensitive/high-cardinality data into telemetry. Invalid
+                // values are dropped (the tag is simply not set), never recorded.
+                SetIfValid(activity, TelemetryConstants.Tags.AgentEventType, parseResult.GetValue(_eventTypeOption), static v => s_knownEventTypes.Contains(v, StringComparer.Ordinal));
+                SetIfValid(activity, TelemetryConstants.Tags.AgentClientName, parseResult.GetValue(_clientNameOption), static v => IsSafeIdentifier(v, maxLength: 64));
+                SetIfValid(activity, TelemetryConstants.Tags.AgentSessionId, parseResult.GetValue(_sessionIdOption), static v => IsSafeIdentifier(v, maxLength: 128));
+                SetIfValid(activity, TelemetryConstants.Tags.AgentSkillName, parseResult.GetValue(_skillNameOption), static v => IsSafeIdentifier(v, maxLength: 128));
+                SetIfValid(activity, TelemetryConstants.Tags.AgentToolName, parseResult.GetValue(_toolNameOption), static v => IsSafeIdentifier(v, maxLength: 128));
+                SetIfValid(activity, TelemetryConstants.Tags.AgentFileReference, parseResult.GetValue(_fileReferenceOption), IsSafeReference);
+                SetIfValid(activity, TelemetryConstants.Tags.AgentEventTimestamp, parseResult.GetValue(_timestampOption), IsValidTimestamp);
+            }
+        }
+        catch
+        {
+            // Telemetry must never break the calling agent's hook. Swallow everything and exit 0.
+        }
+
+        return Task.FromResult(CommandResult.Success());
+    }
+
+    private static void SetIfValid(Activity activity, string name, string? value, Func<string, bool> isValid)
+    {
+        if (string.IsNullOrWhiteSpace(value) || !isValid(value))
+        {
+            return;
+        }
+
+        activity.SetTag(name, value);
+    }
+
+    /// <summary>
+    /// Validates an opaque identifier/name value: a bounded length and a conservative ASCII charset
+    /// (letters, digits, '-', '_', '.'). This rejects whitespace, path separators, and other
+    /// characters that would indicate the value is not an Aspire-owned identifier.
+    /// </summary>
+    private static bool IsSafeIdentifier(string value, int maxLength)
+    {
+        if (value.Length > maxLength)
+        {
+            return false;
+        }
+
+        foreach (var c in value)
+        {
+            if (!char.IsAsciiLetterOrDigit(c) && c is not ('-' or '_' or '.'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Validates a skills-relative reference path. Only forward-slash relative paths within the
+    /// Aspire skills tree are recorded; absolute paths, drive letters, UNC paths, parent traversal,
+    /// home (<c>~</c>) references, and backslashes are rejected so no machine-specific or
+    /// user-identifying path can be captured.
+    /// </summary>
+    private static bool IsSafeReference(string value)
+    {
+        if (value.Length > MaxTagValueLength ||
+            value.StartsWith('/') ||
+            value.StartsWith('~') ||
+            value.Contains('\\') ||
+            value.Contains("..", StringComparison.Ordinal) ||
+            Path.IsPathRooted(value))
+        {
+            return false;
+        }
+
+        foreach (var c in value)
+        {
+            if (!char.IsAsciiLetterOrDigit(c) && c is not ('-' or '_' or '.' or '/'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Validates that the timestamp value parses as a round-trippable date/time so a free-form string
+    /// cannot be recorded under the timestamp tag.
+    /// </summary>
+    private static bool IsValidTimestamp(string value)
+        => value.Length <= MaxTagValueLength &&
+           DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out _);
+}

--- a/src/Aspire.Cli/Commands/McpInitCommand.cs
+++ b/src/Aspire.Cli/Commands/McpInitCommand.cs
@@ -36,6 +36,7 @@ internal sealed class McpInitCommand : BaseCommand, IPackageMetaPrefetchingComma
         PlaywrightCliInstaller playwrightCliInstaller,
         IGitRepository gitRepository,
         ILanguageDiscovery languageDiscovery,
+        Aspire.Cli.Agents.Hooks.ITelemetryHookConfigurator telemetryHookConfigurator,
         CommonCommandServices services)
         : base("init", McpCommandStrings.InitCommand_Description, services)
     {
@@ -46,6 +47,7 @@ internal sealed class McpInitCommand : BaseCommand, IPackageMetaPrefetchingComma
             playwrightCliInstaller,
             gitRepository,
             languageDiscovery,
+            telemetryHookConfigurator,
             services);
     }
 

--- a/src/Aspire.Cli/Interaction/KnownEmojis.cs
+++ b/src/Aspire.Cli/Interaction/KnownEmojis.cs
@@ -30,6 +30,7 @@ internal readonly struct KnownEmoji(string name, string? textColor = null)
 internal static class KnownEmojis
 {
     public static readonly KnownEmoji Bug = new("bug", "red");
+    public static readonly KnownEmoji BarChart = new("bar_chart", "blue");
     public static readonly KnownEmoji CheckMarkButton = new("check_mark_button", "green");
     public static readonly KnownEmoji CrossMark = new("cross_mark", "red");
     public static readonly KnownEmoji FileFolder = new("file_folder", "yellow");

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -633,6 +633,7 @@ public class Program
         builder.Services.AddTransient<AgentCommand>();
         builder.Services.AddTransient<AgentMcpCommand>();
         builder.Services.AddTransient<AgentInitCommand>();
+        builder.Services.AddTransient<AgentTelemetryCommand>();
         builder.Services.AddTransient<TelemetryCommand>();
         builder.Services.AddTransient<TelemetryLogsCommand>();
         builder.Services.AddTransient<TelemetrySpansCommand>();
@@ -1008,8 +1009,18 @@ public class Program
         // Log feature state at startup for diagnostics
         app.Services.GetRequiredService<IFeatures>().LogFeatureState();
 
+        // The agent telemetry command is invoked fire-and-forget by the agent telemetry hook
+        // scripts on every PostToolUse event. It emits its own dedicated reported span, so the
+        // generic aspire/cli/main span is suppressed below to avoid double-counting CLI usage, and
+        // the first-run telemetry notice is skipped so a background hook cannot silently consume the
+        // notice the user is meant to see on their first interactive command.
+        var isAgentTelemetryInvocation = AgentTelemetryInvocation.Matches(args);
+
         // Display first run experience if this is the first time the CLI is run on this machine
-        await DisplayFirstTimeUseNoticeIfNeededAsync(app.Services, args, cancellationManager.Token);
+        if (!isAgentTelemetryInvocation)
+        {
+            await DisplayFirstTimeUseNoticeIfNeededAsync(app.Services, args, cancellationManager.Token);
+        }
 
         var rootCommand = app.Services.GetRequiredService<RootCommand>();
         var invokeConfig = new InvocationConfiguration()
@@ -1021,7 +1032,13 @@ public class Program
         };
 
         app.Services.GetRequiredService<CliExecutionContext>();
-        using var mainActivity = telemetry.StartReportedActivity(TelemetryConstants.Activities.Main, ActivityKind.Internal);
+
+        // Suppress the generic main span for the agent telemetry command path: that command emits
+        // its own aspire/cli/agent_telemetry span, and creating the main span too would record a
+        // second span (inflating ordinary CLI-usage metrics) for every hook event.
+        using var mainActivity = isAgentTelemetryInvocation
+            ? null
+            : telemetry.StartReportedActivity(TelemetryConstants.Activities.Main, ActivityKind.Internal);
         ProfileCaptureService.ProfileCaptureSession? profileCaptureSession = null;
 
         if (mainActivity != null)
@@ -1105,6 +1122,22 @@ public class Program
             {
                 mainActivity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, exitCode);
                 mainActivity?.Stop();
+            }
+
+            // The agent telemetry command runs fire-and-forget from an agent hook and the process
+            // exits immediately after. The short Release shutdown flush window is not enough to
+            // reliably export the single just-created span, so force a bounded reported-provider
+            // flush here before returning. This is a no-op when telemetry is opted out (no provider).
+            if (isAgentTelemetryInvocation)
+            {
+                try
+                {
+                    await telemetryManager.ForceFlushReportedAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    // A telemetry flush failure must never change the hook's exit code.
+                }
             }
 
             if (profileCaptureSession is not null)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -553,6 +553,10 @@ public class Program
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentEnvironmentScanner, ClaudeCodeAgentEnvironmentScanner>());
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentEnvironmentScanner, DeprecatedMcpCommandScanner>());
 
+        // Agent telemetry hook installation/configuration.
+        builder.Services.AddSingleton<Aspire.Cli.Agents.Hooks.ITelemetryHookInstaller, Aspire.Cli.Agents.Hooks.TelemetryHookInstaller>();
+        builder.Services.AddSingleton<Aspire.Cli.Agents.Hooks.ITelemetryHookConfigurator, Aspire.Cli.Agents.Hooks.TelemetryHookConfigurator>();
+
         // Template factories.
         builder.Services.AddSingleton<TemplateNuGetConfigService>();
         builder.Services.AddSingleton<ITemplateProvider, TemplateProvider>();

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
@@ -250,6 +250,51 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Skip installing the agent telemetry hooks that record Aspire skill and tool usage..
+        /// </summary>
+        internal static string InitCommand_NoTelemetryHooksOptionDescription {
+            get {
+                return ResourceManager.GetString("InitCommand_NoTelemetryHooksOptionDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Installed Aspire agent telemetry hooks for: {0}. ....
+        /// </summary>
+        internal static string InitCommand_TelemetryHooksInstalled {
+            get {
+                return ResourceManager.GetString("InitCommand_TelemetryHooksInstalled", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Skipped the telemetry hook for {0} because its configuration file contains malformed JSON..
+        /// </summary>
+        internal static string InitCommand_TelemetryHookSkippedMalformedConfig {
+            get {
+                return ResourceManager.GetString("InitCommand_TelemetryHookSkippedMalformedConfig", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Skipped the telemetry hook for {0} because its configuration has an unexpected shape..
+        /// </summary>
+        internal static string InitCommand_TelemetryHookSkippedUnexpectedShape {
+            get {
+                return ResourceManager.GetString("InitCommand_TelemetryHookSkippedUnexpectedShape", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Skipped the telemetry hook for {0} because its configuration could not be written..
+        /// </summary>
+        internal static string InitCommand_TelemetryHookWriteFailed {
+            get {
+                return ResourceManager.GetString("InitCommand_TelemetryHookWriteFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Aspire CLI commands and workflows for distributed apps.
         /// </summary>
         internal static string SkillDescription_Aspire {

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
@@ -250,16 +250,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Skip installing the agent telemetry hooks that record Aspire skill and tool usage..
-        /// </summary>
-        internal static string InitCommand_NoTelemetryHooksOptionDescription {
-            get {
-                return ResourceManager.GetString("InitCommand_NoTelemetryHooksOptionDescription", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Installed Aspire agent telemetry hooks for: {0}. ....
+        ///   Looks up a localized string similar to Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true..
         /// </summary>
         internal static string InitCommand_TelemetryHooksInstalled {
             get {

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
@@ -563,5 +563,77 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("InitCommand_SkillsOptionDescription", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly..
+        /// </summary>
+        internal static string AgentTelemetryCommand_Description {
+            get {
+                return ResourceManager.GetString("AgentTelemetryCommand_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The telemetry event type (skill_invocation, tool_invocation, or reference_file_read).
+        /// </summary>
+        internal static string AgentTelemetryCommand_EventTypeDescription {
+            get {
+                return ResourceManager.GetString("AgentTelemetryCommand_EventTypeDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode).
+        /// </summary>
+        internal static string AgentTelemetryCommand_ClientNameDescription {
+            get {
+                return ResourceManager.GetString("AgentTelemetryCommand_ClientNameDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The opaque AI agent session identifier.
+        /// </summary>
+        internal static string AgentTelemetryCommand_SessionIdDescription {
+            get {
+                return ResourceManager.GetString("AgentTelemetryCommand_SessionIdDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The Aspire skill name for a skill_invocation event.
+        /// </summary>
+        internal static string AgentTelemetryCommand_SkillNameDescription {
+            get {
+                return ResourceManager.GetString("AgentTelemetryCommand_SkillNameDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The Aspire MCP tool name for a tool_invocation event.
+        /// </summary>
+        internal static string AgentTelemetryCommand_ToolNameDescription {
+            get {
+                return ResourceManager.GetString("AgentTelemetryCommand_ToolNameDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The Aspire skills-relative reference file path for a reference_file_read event.
+        /// </summary>
+        internal static string AgentTelemetryCommand_FileReferenceDescription {
+            get {
+                return ResourceManager.GetString("AgentTelemetryCommand_FileReferenceDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The timestamp recorded for the event.
+        /// </summary>
+        internal static string AgentTelemetryCommand_TimestampDescription {
+            get {
+                return ResourceManager.GetString("AgentTelemetryCommand_TimestampDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.resx
@@ -123,11 +123,8 @@
   <data name="InitCommand_ConfiguresDetectedAgentEnvironments" xml:space="preserve">
     <value>(configures detected agent environments)</value>
   </data>
-  <data name="InitCommand_NoTelemetryHooksOptionDescription" xml:space="preserve">
-    <value>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</value>
-  </data>
   <data name="InitCommand_TelemetryHooksInstalled" xml:space="preserve">
-    <value>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</value>
+    <value>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</value>
   </data>
   <data name="InitCommand_TelemetryHookSkippedMalformedConfig" xml:space="preserve">
     <value>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</value>

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.resx
@@ -123,6 +123,21 @@
   <data name="InitCommand_ConfiguresDetectedAgentEnvironments" xml:space="preserve">
     <value>(configures detected agent environments)</value>
   </data>
+  <data name="InitCommand_NoTelemetryHooksOptionDescription" xml:space="preserve">
+    <value>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</value>
+  </data>
+  <data name="InitCommand_TelemetryHooksInstalled" xml:space="preserve">
+    <value>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</value>
+  </data>
+  <data name="InitCommand_TelemetryHookSkippedMalformedConfig" xml:space="preserve">
+    <value>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</value>
+  </data>
+  <data name="InitCommand_TelemetryHookSkippedUnexpectedShape" xml:space="preserve">
+    <value>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</value>
+  </data>
+  <data name="InitCommand_TelemetryHookWriteFailed" xml:space="preserve">
+    <value>Skipped the telemetry hook for {0} because its configuration could not be written.</value>
+  </data>
   <data name="SkillDescription_Aspire" xml:space="preserve">
     <value>Aspire CLI commands and workflows for distributed apps</value>
   </data>

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.resx
@@ -228,4 +228,28 @@
   <data name="InitCommand_SkillsOptionDescription" xml:space="preserve">
     <value>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</value>
   </data>
+  <data name="AgentTelemetryCommand_Description" xml:space="preserve">
+    <value>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</value>
+  </data>
+  <data name="AgentTelemetryCommand_EventTypeDescription" xml:space="preserve">
+    <value>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</value>
+  </data>
+  <data name="AgentTelemetryCommand_ClientNameDescription" xml:space="preserve">
+    <value>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</value>
+  </data>
+  <data name="AgentTelemetryCommand_SessionIdDescription" xml:space="preserve">
+    <value>The opaque AI agent session identifier</value>
+  </data>
+  <data name="AgentTelemetryCommand_SkillNameDescription" xml:space="preserve">
+    <value>The Aspire skill name for a skill_invocation event</value>
+  </data>
+  <data name="AgentTelemetryCommand_ToolNameDescription" xml:space="preserve">
+    <value>The Aspire MCP tool name for a tool_invocation event</value>
+  </data>
+  <data name="AgentTelemetryCommand_FileReferenceDescription" xml:space="preserve">
+    <value>The Aspire skills-relative reference file path for a reference_file_read event</value>
+  </data>
+  <data name="AgentTelemetryCommand_TimestampDescription" xml:space="preserve">
+    <value>The timestamp recorded for the event</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
@@ -2,6 +2,46 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AgentTelemetryCommand_ClientNameDescription">
+        <source>The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</source>
+        <target state="new">The AI agent client that produced the event (for example copilot-cli, claude-code, or vscode)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_Description">
+        <source>Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</source>
+        <target state="new">Record AI agent skill and tool usage telemetry. Invoked by the Aspire agent telemetry hook scripts; not intended to be run directly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_EventTypeDescription">
+        <source>The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</source>
+        <target state="new">The telemetry event type (skill_invocation, tool_invocation, or reference_file_read)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_FileReferenceDescription">
+        <source>The Aspire skills-relative reference file path for a reference_file_read event</source>
+        <target state="new">The Aspire skills-relative reference file path for a reference_file_read event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SessionIdDescription">
+        <source>The opaque AI agent session identifier</source>
+        <target state="new">The opaque AI agent session identifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_SkillNameDescription">
+        <source>The Aspire skill name for a skill_invocation event</source>
+        <target state="new">The Aspire skill name for a skill_invocation event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_TimestampDescription">
+        <source>The timestamp recorded for the event</source>
+        <target state="new">The timestamp recorded for the event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AgentTelemetryCommand_ToolNameDescription">
+        <source>The Aspire MCP tool name for a tool_invocation event</source>
+        <target state="new">The Aspire MCP tool name for a tool_invocation event</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
         <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
         <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
@@ -147,6 +147,11 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
+        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
+        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -160,6 +165,26 @@
       <trans-unit id="InitCommand_SkillsOptionDescription">
         <source>Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</source>
         <target state="new">Comma-separated list of skills to install. Bundle skills are loaded dynamically; CLI-provided skills include {0}. Use '{1}' or '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedMalformedConfig">
+        <source>Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration file contains malformed JSON.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookSkippedUnexpectedShape">
+        <source>Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration has an unexpected shape.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHookWriteFailed">
+        <source>Skipped the telemetry hook for {0} because its configuration could not be written.</source>
+        <target state="new">Skipped the telemetry hook for {0} because its configuration could not be written.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_TelemetryHooksInstalled">
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
@@ -147,11 +147,6 @@
         <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_NoTelemetryHooksOptionDescription">
-        <source>Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</source>
-        <target state="new">Skip installing the agent telemetry hooks that record Aspire skill and tool usage.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">
         <source>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</source>
         <target state="new">Playwright CLI requires npm, which was not found on PATH. Skipping installation.</target>
@@ -183,8 +178,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_TelemetryHooksInstalled">
-        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</source>
-        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT=true, or re-run with --no-telemetry-hooks to remove the install step.</target>
+        <source>Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</source>
+        <target state="new">Installed Aspire agent telemetry hooks for: {0}. Only Aspire skill, MCP tool, and reference-file usage is recorded. Opt out anytime by setting ASPIRE_CLI_TELEMETRY_OPTOUT=true.</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_WorkspaceRootOptionDescription">

--- a/src/Aspire.Cli/Telemetry/AgentTelemetryInvocation.cs
+++ b/src/Aspire.Cli/Telemetry/AgentTelemetryInvocation.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Telemetry;
+
+/// <summary>
+/// Detects whether the current CLI invocation targets the hidden <c>aspire agent telemetry</c>
+/// command used by the agent telemetry hook scripts.
+/// </summary>
+/// <remarks>
+/// This check runs against the raw command-line arguments before the host and telemetry
+/// pipeline are built, which lets the CLI:
+/// <list type="bullet">
+///   <item>apply the agent-specific opt-out (<c>ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT</c>) before
+///   any reported telemetry provider is created; and</item>
+///   <item>suppress the generic <c>aspire/cli/main</c> reported span so a hook event emits only
+///   the single dedicated <c>aspire/cli/agent_telemetry</c> span rather than two spans.</item>
+/// </list>
+/// The hook scripts always invoke the command as <c>aspire agent telemetry ...</c> with no global
+/// options preceding the command path, so the detector requires <c>agent</c> and <c>telemetry</c>
+/// to be the first two arguments. Matching only the leading tokens (rather than anywhere in the
+/// argument list) avoids false positives where <c>agent</c>/<c>telemetry</c> appear as option or
+/// positional values of an unrelated command (for example <c>aspire config set agent telemetry</c>).
+/// A manual invocation that places a global option before the command path is intentionally not
+/// matched; the only consequence is that the generic main span is not suppressed for that rare case.
+/// </remarks>
+internal static class AgentTelemetryInvocation
+{
+    private const string AgentCommandName = "agent";
+    private const string TelemetryCommandName = "telemetry";
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="args"/> represents an
+    /// <c>aspire agent telemetry</c> invocation.
+    /// </summary>
+    /// <param name="args">The raw command-line arguments passed to the CLI.</param>
+    public static bool Matches(string[]? args)
+    {
+        return args is { Length: >= 2 } &&
+            string.Equals(args[0], AgentCommandName, StringComparison.Ordinal) &&
+            string.Equals(args[1], TelemetryCommandName, StringComparison.Ordinal);
+    }
+}

--- a/src/Aspire.Cli/Telemetry/AgentTelemetryInvocation.cs
+++ b/src/Aspire.Cli/Telemetry/AgentTelemetryInvocation.cs
@@ -9,13 +9,9 @@ namespace Aspire.Cli.Telemetry;
 /// </summary>
 /// <remarks>
 /// This check runs against the raw command-line arguments before the host and telemetry
-/// pipeline are built, which lets the CLI:
-/// <list type="bullet">
-///   <item>apply the agent-specific opt-out (<c>ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT</c>) before
-///   any reported telemetry provider is created; and</item>
-///   <item>suppress the generic <c>aspire/cli/main</c> reported span so a hook event emits only
-///   the single dedicated <c>aspire/cli/agent_telemetry</c> span rather than two spans.</item>
-/// </list>
+/// pipeline are built, which lets the CLI suppress the generic <c>aspire/cli/main</c> reported
+/// span so a hook event emits only the single dedicated <c>aspire/cli/agent_telemetry</c> span
+/// rather than two spans.
 /// The hook scripts always invoke the command as <c>aspire agent telemetry ...</c> with no global
 /// options preceding the command path, so the detector requires <c>agent</c> and <c>telemetry</c>
 /// to be the first two arguments. Matching only the leading tokens (rather than anywhere in the

--- a/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
@@ -32,13 +32,6 @@ internal sealed class AspireCliTelemetry : IHostedService
     internal const string TelemetryOptOutConfigKey = "ASPIRE_CLI_TELEMETRY_OPTOUT";
 
     /// <summary>
-    /// Environment variable to opt out of AI agent telemetry only. Set to "1" or "true" to
-    /// disable telemetry produced by the agent telemetry hook scripts (the
-    /// <c>aspire agent telemetry</c> command path) while leaving general CLI telemetry enabled.
-    /// </summary>
-    internal const string AgentTelemetryOptOutConfigKey = "ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT";
-
-    /// <summary>
     /// Environment variable for OpenTelemetry Protocol exporter endpoint.
     /// </summary>
     internal const string OtlpExporterEndpointConfigKey = KnownOtelConfigNames.ExporterOtlpEndpoint;

--- a/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
@@ -32,6 +32,13 @@ internal sealed class AspireCliTelemetry : IHostedService
     internal const string TelemetryOptOutConfigKey = "ASPIRE_CLI_TELEMETRY_OPTOUT";
 
     /// <summary>
+    /// Environment variable to opt out of AI agent telemetry only. Set to "1" or "true" to
+    /// disable telemetry produced by the agent telemetry hook scripts (the
+    /// <c>aspire agent telemetry</c> command path) while leaving general CLI telemetry enabled.
+    /// </summary>
+    internal const string AgentTelemetryOptOutConfigKey = "ASPIRE_CLI_AGENT_TELEMETRY_OPTOUT";
+
+    /// <summary>
     /// Environment variable for OpenTelemetry Protocol exporter endpoint.
     /// </summary>
     internal const string OtlpExporterEndpointConfigKey = KnownOtelConfigNames.ExporterOtlpEndpoint;

--- a/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
@@ -175,6 +175,46 @@ internal static class TelemetryConstants
         /// Absence of this tag indicates success.
         /// </summary>
         public const string ErrorType = "error.type";
+
+        /// <summary>
+        /// Tag for the AI agent telemetry event type forwarded by the hook scripts.
+        /// One of <c>skill_invocation</c>, <c>tool_invocation</c>, or <c>reference_file_read</c>.
+        /// </summary>
+        public const string AgentEventType = "aspire.cli.agent.event_type";
+
+        /// <summary>
+        /// Tag for the AI agent client that produced the event (for example <c>copilot-cli</c>,
+        /// <c>claude-code</c>, or <c>vscode</c>).
+        /// </summary>
+        public const string AgentClientName = "aspire.cli.agent.client_name";
+
+        /// <summary>
+        /// Tag for the AI agent session identifier. This is an opaque per-session GUID and does
+        /// not identify a user or machine.
+        /// </summary>
+        public const string AgentSessionId = "aspire.cli.agent.session_id";
+
+        /// <summary>
+        /// Tag for the Aspire skill name associated with a <c>skill_invocation</c> event.
+        /// </summary>
+        public const string AgentSkillName = "aspire.cli.agent.skill_name";
+
+        /// <summary>
+        /// Tag for the Aspire MCP tool name associated with a <c>tool_invocation</c> event.
+        /// </summary>
+        public const string AgentToolName = "aspire.cli.agent.tool_name";
+
+        /// <summary>
+        /// Tag for the Aspire skills-relative reference file path associated with a
+        /// <c>reference_file_read</c> event. Only the path after the <c>skills/</c> segment is
+        /// recorded so that no absolute path, repository name, or user name is captured.
+        /// </summary>
+        public const string AgentFileReference = "aspire.cli.agent.file_reference";
+
+        /// <summary>
+        /// Tag for the timestamp the hook recorded for the AI agent event.
+        /// </summary>
+        public const string AgentEventTimestamp = "aspire.cli.agent.event_timestamp";
     }
 
     /// <summary>
@@ -196,6 +236,12 @@ internal static class TelemetryConstants
         /// Activity name for running an app host.
         /// </summary>
         public const string RunAppHost = "aspire/cli/run_apphost";
+
+        /// <summary>
+        /// Activity name for an AI agent skill/tool/reference telemetry event forwarded by the
+        /// agent telemetry hook scripts.
+        /// </summary>
+        public const string AgentTelemetry = "aspire/cli/agent_telemetry";
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Telemetry/TelemetryManager.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryManager.cs
@@ -45,6 +45,12 @@ internal sealed class TelemetryManager : IDisposable
 #endif
     private const int ProfilingForceFlushTimeoutMilliseconds = 5000;
 
+    // The agent telemetry command runs fire-and-forget from an agent hook and exits immediately,
+    // so the short Release shutdown flush (200ms) is not enough to reliably export the single
+    // just-created span. The command path force-flushes the reported provider with this larger
+    // bound before exit so the event is not silently dropped.
+    private const int ReportedForceFlushTimeoutMilliseconds = 3000;
+
     private readonly TracerProvider? _azureMonitorProvider;
     private readonly TracerProvider? _profilingProvider;
     private readonly TracerProvider? _debugDiagnosticProvider;
@@ -92,6 +98,18 @@ internal sealed class TelemetryManager : IDisposable
                     o.ConnectionString = ApplicationInsightsConnectionString;
                     o.EnableLiveMetrics = false;
                     o.StorageDirectory = GetTelemetryStoragePath();
+
+                    // Capture 100% of reported telemetry. The exporter defaults to a RateLimitedSampler
+                    // (TracesPerSecond = 5), which keeps a span with probability
+                    // min(elapsed_since_provider_built * tracesPerSecond, 1). That model assumes a
+                    // long-lived, high-volume process; the CLI is the opposite (fire-and-forget, often a
+                    // single span per process), so every span is judged at cold-start probability and
+                    // ~half are silently dropped as a startup-timing artifact rather than a deliberate
+                    // policy. Reported volume is a handful of spans per run, so full capture is cheap and
+                    // is what adoption analytics needs. TracesPerSecond takes precedence over SamplingRatio
+                    // in the exporter, so it must be nulled for the 100% ratio to take effect.
+                    o.TracesPerSecond = null;
+                    o.SamplingRatio = 1.0f;
                 });
 
 #if DEBUG
@@ -178,6 +196,24 @@ internal sealed class TelemetryManager : IDisposable
         return Task.Run(() =>
         {
             _profilingProvider?.ForceFlush(ProfilingForceFlushTimeoutMilliseconds);
+        });
+    }
+
+    /// <summary>
+    /// Flushes reported telemetry without shutting down other telemetry providers.
+    /// </summary>
+    /// <remarks>
+    /// Used by the <c>aspire agent telemetry</c> command, which is invoked fire-and-forget from an
+    /// agent hook and exits immediately. The normal shutdown flush window is too short to reliably
+    /// drain a single just-created span, so this bounded flush ensures the event leaves the process.
+    /// </remarks>
+    public Task ForceFlushReportedAsync()
+    {
+        // See ForceFlushProfilingAsync for why this runs the synchronous, bounded
+        // ForceFlush(int) on the thread pool rather than taking a CancellationToken.
+        return Task.Run(() =>
+        {
+            _azureMonitorProvider?.ForceFlush(ReportedForceFlushTimeoutMilliseconds);
         });
     }
 

--- a/tests/Aspire.Cli.Tests/Agents/HookCommandFormatterTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/HookCommandFormatterTests.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Agents.Hooks;
+
+namespace Aspire.Cli.Tests.Agents;
+
+public class HookCommandFormatterTests
+{
+    [Theory]
+    [InlineData("/home/user/.aspire/hooks/track-telemetry.sh", "'/home/user/.aspire/hooks/track-telemetry.sh'")]
+    [InlineData("/home/space dir/x.sh", "'/home/space dir/x.sh'")]
+    // bash single quotes are literal, so an apostrophe closes, escapes, and reopens: ' -> '\''
+    [InlineData("/home/o'brien/x.sh", "'/home/o'\\''brien/x.sh'")]
+    public void QuoteForBash_QuotesAndEscapesApostrophes(string input, string expected)
+    {
+        Assert.Equal(expected, HookCommandFormatter.QuoteForBash(input));
+    }
+
+    [Theory]
+    [InlineData(@"C:\Users\user\.aspire\hooks\track-telemetry.ps1", @"'C:\Users\user\.aspire\hooks\track-telemetry.ps1'")]
+    [InlineData(@"C:\Users\space dir\x.ps1", @"'C:\Users\space dir\x.ps1'")]
+    // PowerShell single quotes are literal, so an apostrophe is doubled: ' -> ''
+    [InlineData(@"C:\Users\o'brien\x.ps1", @"'C:\Users\o''brien\x.ps1'")]
+    public void QuoteForPowerShell_QuotesAndDoublesApostrophes(string input, string expected)
+    {
+        Assert.Equal(expected, HookCommandFormatter.QuoteForPowerShell(input));
+    }
+
+    [Fact]
+    public void BuildBashCommand_PrefixesBash()
+    {
+        Assert.Equal("bash '/x/y.sh'", HookCommandFormatter.BuildBashCommand("/x/y.sh"));
+    }
+
+    [Fact]
+    public void BuildPowerShellCommand_UsesNoProfileBypassFile()
+    {
+        Assert.Equal(
+            @"powershell -NoProfile -ExecutionPolicy Bypass -File 'C:\x\y.ps1'",
+            HookCommandFormatter.BuildPowerShellCommand(@"C:\x\y.ps1"));
+    }
+}

--- a/tests/Aspire.Cli.Tests/Agents/HookCommandFormatterTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/HookCommandFormatterTests.cs
@@ -34,10 +34,10 @@ public class HookCommandFormatterTests
     }
 
     [Fact]
-    public void BuildPowerShellCommand_UsesNoProfileBypassFile()
+    public void BuildPwshCommand_UsesPwshWithNoProfileBypassFile()
     {
         Assert.Equal(
-            @"powershell -NoProfile -ExecutionPolicy Bypass -File 'C:\x\y.ps1'",
-            HookCommandFormatter.BuildPowerShellCommand(@"C:\x\y.ps1"));
+            @"pwsh -NoProfile -ExecutionPolicy Bypass -File 'C:\x\y.ps1'",
+            HookCommandFormatter.BuildPwshCommand(@"C:\x\y.ps1"));
     }
 }

--- a/tests/Aspire.Cli.Tests/Agents/TelemetryHookConfiguratorTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/TelemetryHookConfiguratorTests.cs
@@ -167,6 +167,26 @@ public class TelemetryHookConfiguratorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ConfigureAsync_SkipsClaude_WhenSettingsRootIsNotAnObject()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var claudeDirectory = Directory.CreateDirectory(Path.Combine(home.FullName, ".claude"));
+        var settingsPath = Path.Combine(claudeDirectory.FullName, "settings.json");
+        // Valid JSON, but the root is an array rather than an object. JsonNode.AsObject() throws
+        // InvalidOperationException on this input, so the configurator must skip it like any other
+        // unrecognized shape instead of letting that exception crash `agent init`.
+        const string nonObjectRoot = "[1, 2, 3]";
+        await File.WriteAllTextAsync(settingsPath, nonObjectRoot).DefaultTimeout();
+
+        var configurator = CreateConfigurator(workspace, home);
+        var result = await configurator.ConfigureAsync([AgentClientKind.ClaudeCode], CancellationToken.None).DefaultTimeout();
+
+        Assert.Contains(result.Skipped, s => s.Client == AgentClientKind.ClaudeCode && s.Reason == TelemetryHookSkipReason.UnexpectedConfigShape);
+        Assert.Equal(nonObjectRoot, await File.ReadAllTextAsync(settingsPath).DefaultTimeout());
+    }
+
+    [Fact]
     public async Task ConfigureAsync_IsNoOp_ForUnsupportedClients()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Agents/TelemetryHookConfiguratorTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/TelemetryHookConfiguratorTests.cs
@@ -1,0 +1,244 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+using Aspire.Cli.Agents;
+using Aspire.Cli.Agents.Hooks;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Agents;
+
+public class TelemetryHookConfiguratorTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task ConfigureAsync_WritesCopilotUserHook_WithExpectedShape()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var configurator = CreateConfigurator(workspace, home);
+
+        var result = await configurator.ConfigureAsync([AgentClientKind.CopilotCli], CancellationToken.None).DefaultTimeout();
+
+        Assert.Contains(AgentClientKind.CopilotCli, result.ConfiguredClients);
+        Assert.Empty(result.Skipped);
+
+        var hookFile = Path.Combine(home.FullName, ".copilot", "hooks", "aspire-telemetry.json");
+        Assert.True(File.Exists(hookFile));
+
+        var root = JsonNode.Parse(await File.ReadAllTextAsync(hookFile).DefaultTimeout())!.AsObject();
+        Assert.Equal(1, (int)root["version"]!);
+
+        var entry = root["hooks"]!["postToolUse"]!.AsArray()[0]!.AsObject();
+        Assert.Equal("command", (string)entry["type"]!);
+        Assert.Equal(30, (int)entry["timeoutSec"]!);
+        Assert.Contains("track-telemetry.sh", (string)entry["bash"]!);
+        Assert.StartsWith("bash ", (string)entry["bash"]!);
+        Assert.Contains("track-telemetry.ps1", (string)entry["powershell"]!);
+        Assert.Contains("-File ", (string)entry["powershell"]!);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_HonorsCopilotHomeEnvironmentVariable()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var copilotHome = workspace.CreateDirectory("custom-copilot");
+        var configurator = CreateConfigurator(workspace, home, new Dictionary<string, string?>
+        {
+            ["COPILOT_HOME"] = copilotHome.FullName,
+        });
+
+        await configurator.ConfigureAsync([AgentClientKind.CopilotCli], CancellationToken.None).DefaultTimeout();
+
+        Assert.True(File.Exists(Path.Combine(copilotHome.FullName, "hooks", "aspire-telemetry.json")));
+        Assert.False(Directory.Exists(Path.Combine(home.FullName, ".copilot")));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_WritesClaudeUserHook_WithTimeout()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var configurator = CreateConfigurator(workspace, home);
+
+        var result = await configurator.ConfigureAsync([AgentClientKind.ClaudeCode], CancellationToken.None).DefaultTimeout();
+
+        Assert.Contains(AgentClientKind.ClaudeCode, result.ConfiguredClients);
+        Assert.Empty(result.Skipped);
+
+        var postToolUse = await ReadClaudePostToolUseAsync(home).DefaultTimeout();
+        var ourGroups = CountAspireGroups(postToolUse);
+        Assert.Equal(1, ourGroups);
+
+        var entry = FindAspireHook(postToolUse);
+        Assert.Equal("command", (string)entry["type"]!);
+        Assert.Equal(30, (int)entry["timeout"]!);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_IsIdempotent_ForClaude()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var configurator = CreateConfigurator(workspace, home);
+
+        await configurator.ConfigureAsync([AgentClientKind.ClaudeCode], CancellationToken.None).DefaultTimeout();
+        await configurator.ConfigureAsync([AgentClientKind.ClaudeCode], CancellationToken.None).DefaultTimeout();
+
+        var postToolUse = await ReadClaudePostToolUseAsync(home).DefaultTimeout();
+        Assert.Equal(1, CountAspireGroups(postToolUse));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_PreservesExistingClaudeConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var claudeDirectory = Directory.CreateDirectory(Path.Combine(home.FullName, ".claude"));
+        var settingsPath = Path.Combine(claudeDirectory.FullName, "settings.json");
+
+        var existing = new JsonObject
+        {
+            ["model"] = "claude-opus",
+            ["hooks"] = new JsonObject
+            {
+                ["PostToolUse"] = new JsonArray(
+                    new JsonObject
+                    {
+                        ["matcher"] = "Write",
+                        ["hooks"] = new JsonArray(
+                            new JsonObject
+                            {
+                                ["type"] = "command",
+                                ["command"] = "echo existing",
+                            }),
+                    }),
+            },
+        };
+        await File.WriteAllTextAsync(settingsPath, existing.ToJsonString()).DefaultTimeout();
+
+        var configurator = CreateConfigurator(workspace, home);
+        await configurator.ConfigureAsync([AgentClientKind.ClaudeCode], CancellationToken.None).DefaultTimeout();
+
+        var root = JsonNode.Parse(await File.ReadAllTextAsync(settingsPath).DefaultTimeout())!.AsObject();
+        Assert.Equal("claude-opus", (string)root["model"]!);
+
+        var postToolUse = root["hooks"]!["PostToolUse"]!.AsArray();
+        Assert.Contains(postToolUse, group => GroupContainsCommand(group, "echo existing"));
+        Assert.Equal(1, CountAspireGroups(postToolUse));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_SkipsClaude_WhenSettingsAreMalformed()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var claudeDirectory = Directory.CreateDirectory(Path.Combine(home.FullName, ".claude"));
+        var settingsPath = Path.Combine(claudeDirectory.FullName, "settings.json");
+        const string malformed = "{ this is not valid json";
+        await File.WriteAllTextAsync(settingsPath, malformed).DefaultTimeout();
+
+        var configurator = CreateConfigurator(workspace, home);
+        var result = await configurator.ConfigureAsync([AgentClientKind.ClaudeCode], CancellationToken.None).DefaultTimeout();
+
+        Assert.DoesNotContain(AgentClientKind.ClaudeCode, result.ConfiguredClients);
+        Assert.Contains(result.Skipped, s => s.Client == AgentClientKind.ClaudeCode && s.Reason == TelemetryHookSkipReason.MalformedConfig);
+        // The malformed file must be left untouched, never clobbered.
+        Assert.Equal(malformed, await File.ReadAllTextAsync(settingsPath).DefaultTimeout());
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_SkipsClaude_WhenHooksShapeIsUnexpected()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var claudeDirectory = Directory.CreateDirectory(Path.Combine(home.FullName, ".claude"));
+        var settingsPath = Path.Combine(claudeDirectory.FullName, "settings.json");
+        const string unexpected = "{\"hooks\":\"not-an-object\"}";
+        await File.WriteAllTextAsync(settingsPath, unexpected).DefaultTimeout();
+
+        var configurator = CreateConfigurator(workspace, home);
+        var result = await configurator.ConfigureAsync([AgentClientKind.ClaudeCode], CancellationToken.None).DefaultTimeout();
+
+        Assert.Contains(result.Skipped, s => s.Client == AgentClientKind.ClaudeCode && s.Reason == TelemetryHookSkipReason.UnexpectedConfigShape);
+        Assert.Equal(unexpected, await File.ReadAllTextAsync(settingsPath).DefaultTimeout());
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_IsNoOp_ForUnsupportedClients()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var configurator = CreateConfigurator(workspace, home);
+
+        var result = await configurator.ConfigureAsync(
+            [AgentClientKind.VsCode, AgentClientKind.OpenCode],
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Empty(result.ConfiguredClients);
+        Assert.Empty(result.Skipped);
+        // Nothing is materialized when no supported client is present.
+        Assert.False(Directory.Exists(Path.Combine(home.FullName, ".aspire", "hooks")));
+        Assert.False(Directory.Exists(Path.Combine(home.FullName, ".copilot")));
+        Assert.False(Directory.Exists(Path.Combine(home.FullName, ".claude")));
+    }
+
+    private static async Task<JsonArray> ReadClaudePostToolUseAsync(DirectoryInfo home)
+    {
+        var settingsPath = Path.Combine(home.FullName, ".claude", "settings.json");
+        var root = JsonNode.Parse(await File.ReadAllTextAsync(settingsPath))!.AsObject();
+        return root["hooks"]!["PostToolUse"]!.AsArray();
+    }
+
+    private static int CountAspireGroups(JsonArray postToolUse)
+        => postToolUse.Count(GroupContainsAspireHook);
+
+    private static bool GroupContainsAspireHook(JsonNode? group)
+        => group is JsonObject obj
+            && obj["hooks"] is JsonArray hooks
+            && hooks.Any(h => h is JsonObject ho
+                && ho["command"] is JsonValue v
+                && v.ToString().Contains("track-telemetry", StringComparison.OrdinalIgnoreCase));
+
+    private static bool GroupContainsCommand(JsonNode? group, string command)
+        => group is JsonObject obj
+            && obj["hooks"] is JsonArray hooks
+            && hooks.Any(h => h is JsonObject ho
+                && ho["command"] is JsonValue v
+                && v.ToString() == command);
+
+    private static JsonObject FindAspireHook(JsonArray postToolUse)
+    {
+        foreach (var group in postToolUse)
+        {
+            if (group is JsonObject obj && obj["hooks"] is JsonArray hooks)
+            {
+                foreach (var hook in hooks)
+                {
+                    if (hook is JsonObject ho && ho["command"] is JsonValue v
+                        && v.ToString().Contains("track-telemetry", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ho;
+                    }
+                }
+            }
+        }
+
+        throw new InvalidOperationException("No Aspire hook entry was found.");
+    }
+
+    private static TelemetryHookConfigurator CreateConfigurator(
+        TemporaryWorkspace workspace,
+        DirectoryInfo home,
+        IReadOnlyDictionary<string, string?>? environmentVariables = null)
+    {
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(
+            workspace.WorkspaceRoot,
+            homeDirectory: home);
+        var environment = new TestEnvironment(environmentVariables);
+        var installer = new TelemetryHookInstaller(executionContext, NullLogger<TelemetryHookInstaller>.Instance);
+        return new TelemetryHookConfigurator(installer, executionContext, environment, NullLogger<TelemetryHookConfigurator>.Instance);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Agents/TelemetryHookConfiguratorTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/TelemetryHookConfiguratorTests.cs
@@ -37,6 +37,8 @@ public class TelemetryHookConfiguratorTests(ITestOutputHelper outputHelper)
         Assert.StartsWith("bash ", (string)entry["bash"]!);
         Assert.Contains("track-telemetry.ps1", (string)entry["powershell"]!);
         Assert.Contains("-File ", (string)entry["powershell"]!);
+        // Copilot CLI requires PowerShell 7+ on Windows, so the hook must invoke pwsh, not Windows PowerShell.
+        Assert.StartsWith("pwsh ", (string)entry["powershell"]!);
     }
 
     [Fact]
@@ -75,6 +77,22 @@ public class TelemetryHookConfiguratorTests(ITestOutputHelper outputHelper)
         var entry = FindAspireHook(postToolUse);
         Assert.Equal("command", (string)entry["type"]!);
         Assert.Equal(30, (int)entry["timeout"]!);
+
+        // Claude uses exec form (command + args): the executable is spawned directly and the script path is
+        // a discrete argument, not part of a shell command string.
+        var execCommand = (string)entry["command"]!;
+        var args = entry["args"]!.AsArray().Select(a => (string)a!).ToArray();
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal("pwsh", execCommand);
+            Assert.Contains("-File", args);
+            Assert.Contains(args, a => a.EndsWith("track-telemetry.ps1", StringComparison.OrdinalIgnoreCase));
+        }
+        else
+        {
+            Assert.Equal("bash", execCommand);
+            Assert.Contains(args, a => a.EndsWith("track-telemetry.sh", StringComparison.OrdinalIgnoreCase));
+        }
     }
 
     [Fact]
@@ -218,9 +236,17 @@ public class TelemetryHookConfiguratorTests(ITestOutputHelper outputHelper)
     private static bool GroupContainsAspireHook(JsonNode? group)
         => group is JsonObject obj
             && obj["hooks"] is JsonArray hooks
-            && hooks.Any(h => h is JsonObject ho
-                && ho["command"] is JsonValue v
-                && v.ToString().Contains("track-telemetry", StringComparison.OrdinalIgnoreCase));
+            && hooks.Any(HookReferencesTelemetryScript);
+
+    // The Aspire hook can carry the script path in the shell-form `command` string or, for Claude's exec
+    // form, in an `args` element. Check both so helpers locate the entry regardless of format.
+    private static bool HookReferencesTelemetryScript(JsonNode? hook)
+        => hook is JsonObject ho
+            && (JsonValueHasTelemetryScript(ho["command"])
+                || (ho["args"] is JsonArray args && args.Any(JsonValueHasTelemetryScript)));
+
+    private static bool JsonValueHasTelemetryScript(JsonNode? node)
+        => node is JsonValue v && v.ToString().Contains("track-telemetry", StringComparison.OrdinalIgnoreCase);
 
     private static bool GroupContainsCommand(JsonNode? group, string command)
         => group is JsonObject obj
@@ -237,8 +263,7 @@ public class TelemetryHookConfiguratorTests(ITestOutputHelper outputHelper)
             {
                 foreach (var hook in hooks)
                 {
-                    if (hook is JsonObject ho && ho["command"] is JsonValue v
-                        && v.ToString().Contains("track-telemetry", StringComparison.OrdinalIgnoreCase))
+                    if (hook is JsonObject ho && HookReferencesTelemetryScript(ho))
                     {
                         return ho;
                     }

--- a/tests/Aspire.Cli.Tests/Agents/TelemetryHookInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/TelemetryHookInstallerTests.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Agents.Hooks;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Agents;
+
+public class TelemetryHookInstallerTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task EnsureInstalledAsync_MaterializesBothScriptsUnderAspireHooksDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var installer = CreateInstaller(workspace, home);
+
+        var scripts = await installer.EnsureInstalledAsync(CancellationToken.None).DefaultTimeout();
+
+        var expectedDirectory = Path.Combine(home.FullName, ".aspire", "hooks");
+        Assert.Equal(Path.Combine(expectedDirectory, "track-telemetry.sh"), scripts.ShellScriptPath);
+        Assert.Equal(Path.Combine(expectedDirectory, "track-telemetry.ps1"), scripts.PowerShellScriptPath);
+        Assert.True(File.Exists(scripts.ShellScriptPath));
+        Assert.True(File.Exists(scripts.PowerShellScriptPath));
+    }
+
+    [Fact]
+    public async Task EnsureInstalledAsync_ShellScriptUsesLfEndingsAndNoBom()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var installer = CreateInstaller(workspace, home);
+
+        var scripts = await installer.EnsureInstalledAsync(CancellationToken.None).DefaultTimeout();
+
+        var bytes = await File.ReadAllBytesAsync(scripts.ShellScriptPath).DefaultTimeout();
+        // A UTF-8 BOM (EF BB BF) before the shebang stops the kernel from honoring `#!`.
+        Assert.False(bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF);
+        Assert.DoesNotContain((byte)'\r', bytes);
+
+        var content = await File.ReadAllTextAsync(scripts.ShellScriptPath).DefaultTimeout();
+        Assert.StartsWith("#!", content);
+    }
+
+    [Fact]
+    public async Task EnsureInstalledAsync_IsIdempotent_WhenContentUnchanged()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var installer = CreateInstaller(workspace, home);
+
+        var first = await installer.EnsureInstalledAsync(CancellationToken.None).DefaultTimeout();
+        var firstShellContent = await File.ReadAllTextAsync(first.ShellScriptPath).DefaultTimeout();
+
+        var second = await installer.EnsureInstalledAsync(CancellationToken.None).DefaultTimeout();
+        var secondShellContent = await File.ReadAllTextAsync(second.ShellScriptPath).DefaultTimeout();
+
+        Assert.Equal(first.ShellScriptPath, second.ShellScriptPath);
+        Assert.Equal(firstShellContent, secondShellContent);
+    }
+
+    [Fact]
+    public async Task EnsureInstalledAsync_RewritesScript_WhenExistingContentDiffers()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var installer = CreateInstaller(workspace, home);
+
+        var hooksDirectory = Path.Combine(home.FullName, ".aspire", "hooks");
+        Directory.CreateDirectory(hooksDirectory);
+        var shellPath = Path.Combine(hooksDirectory, "track-telemetry.sh");
+        await File.WriteAllTextAsync(shellPath, "stale-content").DefaultTimeout();
+
+        var scripts = await installer.EnsureInstalledAsync(CancellationToken.None).DefaultTimeout();
+
+        var content = await File.ReadAllTextAsync(scripts.ShellScriptPath).DefaultTimeout();
+        Assert.NotEqual("stale-content", content);
+        Assert.StartsWith("#!", content);
+    }
+
+    [Fact]
+    public async Task EnsureInstalledAsync_SetsExecutableBit_OnNonWindows()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var installer = CreateInstaller(workspace, home);
+
+        var scripts = await installer.EnsureInstalledAsync(CancellationToken.None).DefaultTimeout();
+
+        var mode = File.GetUnixFileMode(scripts.ShellScriptPath);
+        Assert.True(mode.HasFlag(UnixFileMode.UserExecute));
+    }
+
+    private static TelemetryHookInstaller CreateInstaller(TemporaryWorkspace workspace, DirectoryInfo home)
+    {
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(workspace.WorkspaceRoot, homeDirectory: home);
+        return new TelemetryHookInstaller(executionContext, NullLogger<TelemetryHookInstaller>.Instance);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Agents/TelemetryHookScriptTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/TelemetryHookScriptTests.cs
@@ -1,0 +1,347 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Cli.Agents.Hooks;
+using Aspire.Cli.Tests.Utils;
+using Aspire.TestUtilities;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Agents;
+
+/// <summary>
+/// Behavior tests for the embedded telemetry hook scripts (<c>track-telemetry.sh</c> /
+/// <c>track-telemetry.ps1</c>). The scripts are materialized through the real
+/// <see cref="TelemetryHookInstaller"/> so the shipped resources are exercised, and a recording stub
+/// substituted via the <c>ASPIRE_CLI_COMMAND</c> override captures the argument vector the script
+/// would pass to <c>aspire agent telemetry</c> — or records nothing when the script classifies the
+/// event as non-Aspire, opted out, or unparseable. Every case also asserts the hook prints exactly
+/// <c>{"continue":true}</c>, the contract a PostToolUse hook must honor.
+/// </summary>
+public class TelemetryHookScriptTests(ITestOutputHelper outputHelper)
+{
+    private const string CaptureFileEnvName = "ASPIRE_HOOK_TEST_CAPTURE_FILE";
+    private const string ContinueResponse = """{"continue":true}""";
+
+    [Fact]
+    [RequiresTools(["bash"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "The shell hook targets POSIX shells; the PowerShell hook covers Windows.")]
+    public async Task Bash_SkillInvocation_Copilot_ForwardsSkillName()
+    {
+        var run = await RunBashHookAsync(
+            """{"toolName":"skill","sessionId":"session-1","toolArgs":{"skill":"aspire"}}""",
+            new() { ["COPILOT_CLI"] = "1" });
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "skill_invocation");
+        AssertArg(args, "--client-name", "copilot-cli");
+        AssertArg(args, "--skill-name", "aspire");
+        AssertArg(args, "--session-id", "session-1");
+    }
+
+    [Fact]
+    [RequiresTools(["bash"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "The shell hook targets POSIX shells; the PowerShell hook covers Windows.")]
+    public async Task Bash_McpTool_Claude_ForwardsToolName()
+    {
+        var run = await RunBashHookAsync(
+            """{"hook_event_name":"PostToolUse","tool_name":"mcp__aspire__list_resources"}""");
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "tool_invocation");
+        AssertArg(args, "--client-name", "claude-code");
+        AssertArg(args, "--tool-name", "mcp__aspire__list_resources");
+    }
+
+    [Fact]
+    [RequiresTools(["bash"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "The shell hook targets POSIX shells; the PowerShell hook covers Windows.")]
+    public async Task Bash_ReferenceFileRead_ForwardsRelativePath()
+    {
+        var run = await RunBashHookAsync(
+            """{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":".agents/skills/aspire/references/deploy.md"}}""");
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "reference_file_read");
+        // Only the repo-relative path after skills/<skill>/ is forwarded — never the absolute path.
+        AssertArg(args, "--file-reference", "aspire/references/deploy.md");
+    }
+
+    [Fact]
+    [RequiresTools(["bash"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "The shell hook targets POSIX shells; the PowerShell hook covers Windows.")]
+    public async Task Bash_NonAspireToolOrFile_DoesNotInvokeCli()
+    {
+        var run = await RunBashHookAsync(
+            """{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":"/home/user/notes.txt"}}""");
+
+        AssertContinue(run);
+        AssertNotInvoked(run);
+    }
+
+    [Fact]
+    [RequiresTools(["bash"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "The shell hook targets POSIX shells; the PowerShell hook covers Windows.")]
+    public async Task Bash_OptedOut_DoesNotInvokeCli()
+    {
+        var run = await RunBashHookAsync(
+            """{"toolName":"skill","toolArgs":{"skill":"aspire"}}""",
+            new() { ["COPILOT_CLI"] = "1", ["ASPIRE_CLI_TELEMETRY_OPTOUT"] = "1" });
+
+        AssertContinue(run);
+        AssertNotInvoked(run);
+    }
+
+    [Fact]
+    [RequiresTools(["bash"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "The shell hook targets POSIX shells; the PowerShell hook covers Windows.")]
+    public async Task Bash_UnrecognizedPayload_DoesNotInvokeCli()
+    {
+        // No tool fields the sed extraction can recognize -> nothing to classify, hook stays silent.
+        var run = await RunBashHookAsync("not-json-at-all");
+
+        AssertContinue(run);
+        AssertNotInvoked(run);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Pwsh_SkillInvocation_Copilot_ForwardsSkillName()
+    {
+        var run = await RunPwshHookAsync(
+            """{"toolName":"skill","sessionId":"session-1","toolArgs":{"skill":"aspire"}}""",
+            new() { ["COPILOT_CLI"] = "1" });
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "skill_invocation");
+        AssertArg(args, "--client-name", "copilot-cli");
+        AssertArg(args, "--skill-name", "aspire");
+        AssertArg(args, "--session-id", "session-1");
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Pwsh_McpTool_Claude_ForwardsToolName()
+    {
+        var run = await RunPwshHookAsync(
+            """{"hook_event_name":"PostToolUse","tool_name":"mcp__aspire__list_resources"}""");
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "tool_invocation");
+        AssertArg(args, "--client-name", "claude-code");
+        AssertArg(args, "--tool-name", "mcp__aspire__list_resources");
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Pwsh_NonAspireTool_DoesNotInvokeCli()
+    {
+        var run = await RunPwshHookAsync(
+            """{"hook_event_name":"PostToolUse","tool_name":"read_file","tool_input":{"path":"/tmp/notes.txt"}}""");
+
+        AssertContinue(run);
+        AssertNotInvoked(run);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Pwsh_OptedOut_DoesNotInvokeCli()
+    {
+        var run = await RunPwshHookAsync(
+            """{"toolName":"skill","toolArgs":{"skill":"aspire"}}""",
+            new() { ["COPILOT_CLI"] = "1", ["ASPIRE_CLI_TELEMETRY_OPTOUT"] = "true" });
+
+        AssertContinue(run);
+        AssertNotInvoked(run);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Pwsh_MalformedJson_DoesNotInvokeCli()
+    {
+        var run = await RunPwshHookAsync("{ this is not valid json");
+
+        AssertContinue(run);
+        AssertNotInvoked(run);
+    }
+
+    private async Task<HookRun> RunBashHookAsync(string payload, Dictionary<string, string?>? extraEnv = null)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var scripts = await MaterializeScriptsAsync(workspace).DefaultTimeout();
+        var capturePath = Path.Combine(workspace.WorkspaceRoot.FullName, "capture.txt");
+        var recorderPath = CreateBashRecorder(workspace.WorkspaceRoot.FullName);
+
+        var result = RunProcess("bash", [scripts.ShellScriptPath], payload, BuildEnvironment(recorderPath, capturePath, extraEnv));
+
+        return new HookRun(result, ReadCapturedArgs(capturePath));
+    }
+
+    private async Task<HookRun> RunPwshHookAsync(string payload, Dictionary<string, string?>? extraEnv = null)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var scripts = await MaterializeScriptsAsync(workspace).DefaultTimeout();
+        var capturePath = Path.Combine(workspace.WorkspaceRoot.FullName, "capture.txt");
+        var recorderPath = CreatePwshRecorder(workspace.WorkspaceRoot.FullName);
+
+        // -ExecutionPolicy Bypass so the locally created hook and recorder run on Windows agents.
+        var result = RunProcess("pwsh", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scripts.PowerShellScriptPath], payload, BuildEnvironment(recorderPath, capturePath, extraEnv));
+
+        return new HookRun(result, ReadCapturedArgs(capturePath));
+    }
+
+    private static async Task<TelemetryHookScripts> MaterializeScriptsAsync(TemporaryWorkspace workspace)
+    {
+        var home = workspace.CreateDirectory("home");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(workspace.WorkspaceRoot, homeDirectory: home);
+        var installer = new TelemetryHookInstaller(executionContext, NullLogger<TelemetryHookInstaller>.Instance);
+        return await installer.EnsureInstalledAsync(CancellationToken.None);
+    }
+
+    private static string CreateBashRecorder(string directory)
+    {
+        var path = Path.Combine(directory, "recorder.sh");
+        // Writes each received argument on its own line so assertions can match discrete tokens.
+        File.WriteAllText(path, "#!/bin/bash\nprintf '%s\\n' \"$@\" > \"$ASPIRE_HOOK_TEST_CAPTURE_FILE\"\n");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        }
+
+        return path;
+    }
+
+    private static string CreatePwshRecorder(string directory)
+    {
+        var path = Path.Combine(directory, "recorder.ps1");
+        // A simple (non-advanced) script collects every argument, including --flag tokens, into $args.
+        File.WriteAllText(path, "$args | Set-Content -LiteralPath $env:ASPIRE_HOOK_TEST_CAPTURE_FILE\n");
+        return path;
+    }
+
+    private static Dictionary<string, string?> BuildEnvironment(string recorderPath, string capturePath, Dictionary<string, string?>? extraEnv)
+    {
+        var environment = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["ASPIRE_CLI_COMMAND"] = recorderPath,
+            [CaptureFileEnvName] = capturePath
+        };
+
+        if (extraEnv is not null)
+        {
+            foreach (var pair in extraEnv)
+            {
+                environment[pair.Key] = pair.Value;
+            }
+        }
+
+        return environment;
+    }
+
+    private static string[]? ReadCapturedArgs(string capturePath)
+        => File.Exists(capturePath)
+            ? File.ReadAllLines(capturePath).Where(line => line.Length > 0).ToArray()
+            : null;
+
+    private static void AssertContinue(HookRun run)
+        => Assert.Equal(ContinueResponse, run.Result.StdOut.Trim());
+
+    private static string[] AssertInvoked(HookRun run)
+    {
+        Assert.NotNull(run.CapturedArgs);
+        Assert.Equal("agent", run.CapturedArgs![0]);
+        Assert.Equal("telemetry", run.CapturedArgs[1]);
+        return run.CapturedArgs;
+    }
+
+    private static void AssertNotInvoked(HookRun run)
+        => Assert.Null(run.CapturedArgs);
+
+    private static void AssertArg(string[] args, string name, string value)
+    {
+        var index = Array.IndexOf(args, name);
+        Assert.True(index >= 0 && index + 1 < args.Length, $"Expected '{name} {value}' in [{string.Join(' ', args)}]");
+        Assert.Equal(value, args[index + 1]);
+    }
+
+    private static ProcessResult RunProcess(string fileName, IReadOnlyList<string> arguments, string stdinPayload, Dictionary<string, string?> environment)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        foreach (var argument in arguments)
+        {
+            psi.ArgumentList.Add(argument);
+        }
+
+        // Clear ambient values so the host environment can't change client detection or opt-out.
+        psi.Environment.Remove("COPILOT_CLI");
+        psi.Environment.Remove("ASPIRE_CLI_TELEMETRY_OPTOUT");
+        foreach (var pair in environment)
+        {
+            if (pair.Value is null)
+            {
+                psi.Environment.Remove(pair.Key);
+            }
+            else
+            {
+                psi.Environment[pair.Key] = pair.Value;
+            }
+        }
+
+        using var process = Process.Start(psi)!;
+
+        try
+        {
+            process.StandardInput.Write(stdinPayload);
+            process.StandardInput.Close();
+        }
+        catch (IOException)
+        {
+            // The hook may exit before reading stdin (for example on the opt-out path), which closes
+            // the pipe early. That is expected; the captured output below is what matters.
+        }
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        try
+        {
+            process.WaitForExitAsync(timeout.Token).GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException)
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            throw new TimeoutException($"Hook process '{fileName}' did not exit within 30 seconds.");
+        }
+
+        var stdout = stdoutTask.GetAwaiter().GetResult();
+        var stderr = stderrTask.GetAwaiter().GetResult();
+        return new ProcessResult(process.ExitCode, stdout, stderr);
+    }
+
+    private sealed record HookRun(ProcessResult Result, string[]? CapturedArgs);
+
+    private sealed record ProcessResult(int ExitCode, string StdOut, string StdErr);
+}

--- a/tests/Aspire.Cli.Tests/Agents/TelemetryHookScriptTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/TelemetryHookScriptTests.cs
@@ -109,6 +109,53 @@ public class TelemetryHookScriptTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    [RequiresTools(["bash"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "The shell hook targets POSIX shells; the PowerShell hook covers Windows.")]
+    public async Task Bash_SkillMdRead_ForwardsSkillName()
+    {
+        var run = await RunBashHookAsync(
+            """{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":".agents/skills/aspire/SKILL.md"}}""");
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        // Reading a skill's SKILL.md counts as using the skill, not a reference-file read.
+        AssertArg(args, "--event-type", "skill_invocation");
+        AssertArg(args, "--skill-name", "aspire");
+    }
+
+    [Fact]
+    [RequiresTools(["bash"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "The shell hook targets POSIX shells; the PowerShell hook covers Windows.")]
+    public async Task Bash_SkillTool_Claude_StripsAspirePrefix()
+    {
+        var run = await RunBashHookAsync(
+            """{"hook_event_name":"PostToolUse","tool_name":"Skill","tool_input":{"skill":"aspire:aspire-deployment"}}""");
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "skill_invocation");
+        AssertArg(args, "--client-name", "claude-code");
+        // Claude prefixes plugin skill names with "aspire:"; the hook strips it before the allowlist match.
+        AssertArg(args, "--skill-name", "aspire-deployment");
+    }
+
+    [Fact]
+    [RequiresTools(["bash"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "The shell hook targets POSIX shells; the PowerShell hook covers Windows.")]
+    public async Task Bash_McpTool_VsCode_DetectsClient()
+    {
+        var run = await RunBashHookAsync(
+            """{"hook_event_name":"PostToolUse","tool_name":"mcp_aspire_list_resources","tool_use_id":"toolu_01__vscode"}""");
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "tool_invocation");
+        // A __vscode marker in tool_use_id distinguishes the VS Code client from Claude Code.
+        AssertArg(args, "--client-name", "vscode");
+        AssertArg(args, "--tool-name", "mcp_aspire_list_resources");
+    }
+
+    [Fact]
     [RequiresTools(["pwsh"])]
     public async Task Pwsh_SkillInvocation_Copilot_ForwardsSkillName()
     {
@@ -169,6 +216,63 @@ public class TelemetryHookScriptTests(ITestOutputHelper outputHelper)
 
         AssertContinue(run);
         AssertNotInvoked(run);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Pwsh_ReferenceFileRead_ForwardsRelativePath()
+    {
+        var run = await RunPwshHookAsync(
+            """{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":".agents/skills/aspire/references/deploy.md"}}""");
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "reference_file_read");
+        // Only the repo-relative path after skills/<skill>/ is forwarded — never the absolute path.
+        AssertArg(args, "--file-reference", "aspire/references/deploy.md");
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Pwsh_SkillMdRead_ForwardsSkillName()
+    {
+        var run = await RunPwshHookAsync(
+            """{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":".agents/skills/aspire/SKILL.md"}}""");
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "skill_invocation");
+        AssertArg(args, "--skill-name", "aspire");
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Pwsh_SkillTool_Claude_StripsAspirePrefix()
+    {
+        var run = await RunPwshHookAsync(
+            """{"hook_event_name":"PostToolUse","tool_name":"Skill","tool_input":{"skill":"aspire:aspire-deployment"}}""");
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "skill_invocation");
+        AssertArg(args, "--client-name", "claude-code");
+        // Claude prefixes plugin skill names with "aspire:"; the hook strips it before the allowlist match.
+        AssertArg(args, "--skill-name", "aspire-deployment");
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Pwsh_McpTool_VsCode_DetectsClient()
+    {
+        var run = await RunPwshHookAsync(
+            """{"hook_event_name":"PostToolUse","tool_name":"mcp_aspire_list_resources","tool_use_id":"toolu_01__vscode"}""");
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "tool_invocation");
+        // A __vscode marker in tool_use_id distinguishes the VS Code client from Claude Code.
+        AssertArg(args, "--client-name", "vscode");
+        AssertArg(args, "--tool-name", "mcp_aspire_list_resources");
     }
 
     private async Task<HookRun> RunBashHookAsync(string payload, Dictionary<string, string?>? extraEnv = null)

--- a/tests/Aspire.Cli.Tests/Agents/TelemetryHookScriptTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/TelemetryHookScriptTests.cs
@@ -155,6 +155,58 @@ public class TelemetryHookScriptTests(ITestOutputHelper outputHelper)
         AssertArg(args, "--tool-name", "mcp_aspire_list_resources");
     }
 
+    // Copilot CLI delivers toolArgs as a JSON-encoded STRING (e.g. "toolArgs":"{\"skill\":\"aspire\"}"),
+    // not a nested object, so its skill/view events look different on the wire than every other client.
+    // These fixtures capture that real shape to lock in the shape-agnostic extraction.
+
+    [Fact]
+    [RequiresTools(["bash"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "The shell hook targets POSIX shells; the PowerShell hook covers Windows.")]
+    public async Task Bash_SkillInvocation_CopilotStringArgs_ForwardsSkillName()
+    {
+        var run = await RunBashHookAsync(
+            """{"toolName":"skill","sessionId":"session-1","toolArgs":"{\"skill\":\"aspire\"}"}""",
+            new() { ["COPILOT_CLI"] = "1" });
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "skill_invocation");
+        AssertArg(args, "--client-name", "copilot-cli");
+        AssertArg(args, "--skill-name", "aspire");
+    }
+
+    [Fact]
+    [RequiresTools(["bash"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "The shell hook targets POSIX shells; the PowerShell hook covers Windows.")]
+    public async Task Bash_SkillMdRead_CopilotStringArgs_ForwardsSkillName()
+    {
+        // The exact real Copilot shape: a view tool whose toolArgs is a JSON string with a
+        // Windows path whose separators arrive as doubled backslashes ("C:\\proj\\skills\\...").
+        var run = await RunBashHookAsync(
+            """{"toolName":"view","sessionId":"session-1","toolArgs":"{\"path\":\"C:\\\\proj\\\\skills\\\\aspire\\\\SKILL.md\"}"}""",
+            new() { ["COPILOT_CLI"] = "1" });
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "skill_invocation");
+        AssertArg(args, "--skill-name", "aspire");
+    }
+
+    [Fact]
+    [RequiresTools(["bash"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "The shell hook targets POSIX shells; the PowerShell hook covers Windows.")]
+    public async Task Bash_ReferenceFileRead_CopilotStringArgs_ForwardsRelativePath()
+    {
+        var run = await RunBashHookAsync(
+            """{"toolName":"view","sessionId":"session-1","toolArgs":"{\"path\":\"workspace/.agents/skills/aspire/references/deploy.md\"}"}""",
+            new() { ["COPILOT_CLI"] = "1" });
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "reference_file_read");
+        AssertArg(args, "--file-reference", "aspire/references/deploy.md");
+    }
+
     [Fact]
     [RequiresTools(["pwsh"])]
     public async Task Pwsh_SkillInvocation_Copilot_ForwardsSkillName()
@@ -273,6 +325,54 @@ public class TelemetryHookScriptTests(ITestOutputHelper outputHelper)
         // A __vscode marker in tool_use_id distinguishes the VS Code client from Claude Code.
         AssertArg(args, "--client-name", "vscode");
         AssertArg(args, "--tool-name", "mcp_aspire_list_resources");
+    }
+
+    // Copilot CLI delivers toolArgs as a JSON-encoded STRING (e.g. "toolArgs":"{\"skill\":\"aspire\"}"),
+    // not a nested object. These fixtures capture that real shape to lock in the shape-agnostic extraction.
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Pwsh_SkillInvocation_CopilotStringArgs_ForwardsSkillName()
+    {
+        var run = await RunPwshHookAsync(
+            """{"toolName":"skill","sessionId":"session-1","toolArgs":"{\"skill\":\"aspire\"}"}""",
+            new() { ["COPILOT_CLI"] = "1" });
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "skill_invocation");
+        AssertArg(args, "--client-name", "copilot-cli");
+        AssertArg(args, "--skill-name", "aspire");
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Pwsh_SkillMdRead_CopilotStringArgs_ForwardsSkillName()
+    {
+        // The exact real Copilot shape: a view tool whose toolArgs is a JSON string with a
+        // Windows path whose separators arrive as doubled backslashes ("C:\\proj\\skills\\...").
+        var run = await RunPwshHookAsync(
+            """{"toolName":"view","sessionId":"session-1","toolArgs":"{\"path\":\"C:\\\\proj\\\\skills\\\\aspire\\\\SKILL.md\"}"}""",
+            new() { ["COPILOT_CLI"] = "1" });
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "skill_invocation");
+        AssertArg(args, "--skill-name", "aspire");
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Pwsh_ReferenceFileRead_CopilotStringArgs_ForwardsRelativePath()
+    {
+        var run = await RunPwshHookAsync(
+            """{"toolName":"view","sessionId":"session-1","toolArgs":"{\"path\":\"workspace/.agents/skills/aspire/references/deploy.md\"}"}""",
+            new() { ["COPILOT_CLI"] = "1" });
+
+        AssertContinue(run);
+        var args = AssertInvoked(run);
+        AssertArg(args, "--event-type", "reference_file_read");
+        AssertArg(args, "--file-reference", "aspire/references/deploy.md");
     }
 
     private async Task<HookRun> RunBashHookAsync(string payload, Dictionary<string, string?>? extraEnv = null)

--- a/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
@@ -891,10 +891,67 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
         return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
     }
 
+    [Fact]
+    public async Task AgentInitCommand_DefaultOn_InstallsTelemetryHook_ForDetectedClient()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var homeDirectory = workspace.CreateDirectory("fake-home");
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContext(workspace.WorkspaceRoot, homeDirectory);
+            options.AgentEnvironmentDetectorFactory = _ => new FakeDetectingDetector(AgentClientKind.CopilotCli);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"agent init --workspace-root {workspace.WorkspaceRoot.FullName} --skill-locations none --skills none");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var hookFile = Path.Combine(homeDirectory.FullName, ".copilot", "hooks", "aspire-telemetry.json");
+        Assert.True(File.Exists(hookFile), $"Expected telemetry hook at {hookFile}");
+    }
+
+    [Fact]
+    public async Task AgentInitCommand_NoTelemetryHooks_SkipsInstall()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var homeDirectory = workspace.CreateDirectory("fake-home");
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContext(workspace.WorkspaceRoot, homeDirectory);
+            options.AgentEnvironmentDetectorFactory = _ => new FakeDetectingDetector(AgentClientKind.CopilotCli);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"agent init --workspace-root {workspace.WorkspaceRoot.FullName} --skill-locations none --skills none --no-telemetry-hooks");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var copilotDirectory = Path.Combine(homeDirectory.FullName, ".copilot");
+        Assert.False(Directory.Exists(copilotDirectory), $"Expected no Copilot hook directory but found {copilotDirectory}");
+    }
+
     private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo homeDirectory)
     {
         return TestExecutionContextHelper.CreateExecutionContext(
             workingDirectory,
             homeDirectory: homeDirectory);
+    }
+
+    /// <summary>
+    /// A detector that marks a single client as detected without contributing applicators, so the
+    /// telemetry hook wiring in <c>agent init</c> can be exercised without real client installations.
+    /// </summary>
+    private sealed class FakeDetectingDetector(AgentClientKind client) : IAgentEnvironmentDetector
+    {
+        public Task<AgentEnvironmentApplicator[]> DetectAsync(AgentEnvironmentScanContext context, CancellationToken cancellationToken)
+        {
+            context.AddDetectedClient(client);
+            return Task.FromResult(Array.Empty<AgentEnvironmentApplicator>());
+        }
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using Aspire.Cli.Agents;
 using Aspire.Cli.Agents.AspireSkills;
+using Aspire.Cli.Agents.Hooks;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
@@ -914,25 +915,33 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task AgentInitCommand_NoTelemetryHooks_SkipsInstall()
+    public async Task AgentInitCommand_DoesNotFail_WhenTelemetryHookConfigurationThrows()
     {
+        // Hook installation is best-effort transparency tooling. A non-IO failure such as a missing
+        // embedded hook script (InvalidOperationException from the installer) must not abort `agent init`.
+        const string failureMessage = "simulated hook configuration failure";
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var homeDirectory = workspace.CreateDirectory("fake-home");
+        var interactionService = new TestInteractionService();
+        var subtleMessages = new List<string>();
+        interactionService.DisplaySubtleMessageCallback = subtleMessages.Add;
+
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.CliExecutionContextFactory = _ => CreateExecutionContext(workspace.WorkspaceRoot, homeDirectory);
             options.AgentEnvironmentDetectorFactory = _ => new FakeDetectingDetector(AgentClientKind.CopilotCli);
+            options.InteractionServiceFactory = _ => interactionService;
+            options.TelemetryHookConfiguratorFactory = _ => new ThrowingTelemetryHookConfigurator(failureMessage);
         });
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse($"agent init --workspace-root {workspace.WorkspaceRoot.FullName} --skill-locations none --skills none --no-telemetry-hooks");
+        var result = command.Parse($"agent init --workspace-root {workspace.WorkspaceRoot.FullName} --skill-locations none --skills none");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(CliExitCodes.Success, exitCode);
-        var copilotDirectory = Path.Combine(homeDirectory.FullName, ".copilot");
-        Assert.False(Directory.Exists(copilotDirectory), $"Expected no Copilot hook directory but found {copilotDirectory}");
+        Assert.Contains(failureMessage, subtleMessages);
     }
 
     private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo homeDirectory)
@@ -953,5 +962,18 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
             context.AddDetectedClient(client);
             return Task.FromResult(Array.Empty<AgentEnvironmentApplicator>());
         }
+    }
+
+    /// <summary>
+    /// A configurator that always throws, simulating a non-IO failure (e.g. a missing embedded hook
+    /// script surfacing as <see cref="InvalidOperationException"/>) so the best-effort catch in
+    /// <c>agent init</c> can be verified to never abort the command.
+    /// </summary>
+    private sealed class ThrowingTelemetryHookConfigurator(string message) : ITelemetryHookConfigurator
+    {
+        public Task<TelemetryHookConfigurationResult> ConfigureAsync(
+            IReadOnlyCollection<AgentClientKind> detectedClients,
+            CancellationToken cancellationToken)
+            => throw new InvalidOperationException(message);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/AgentTelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentTelemetryCommandTests.cs
@@ -1,0 +1,248 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Tests.Telemetry;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class AgentTelemetryCommandTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task AgentTelemetry_EmitsReportedActivityWithProvidedTags()
+    {
+        var (capturedActivities, listener) = CreateCapturingListener(out var reportedSourceName);
+        using (listener)
+        {
+            using var workspace = TemporaryWorkspace.Create(outputHelper);
+            var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+            {
+                options.TelemetryFactory = _ => TestTelemetryHelper.CreateInitializedTelemetry(reportedSourceName, $"Diag.{Path.GetRandomFileName()}");
+            });
+            using var provider = services.BuildServiceProvider();
+
+            var command = provider.GetRequiredService<RootCommand>();
+            var result = command.Parse("agent telemetry --event-type skill_invocation --client-name copilot-cli --session-id 11111111-1111-1111-1111-111111111111 --skill-name aspire --timestamp 2026-01-01T00:00:00Z");
+
+            var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+            Assert.Equal(CliExitCodes.Success, exitCode);
+
+            var activity = Assert.Single(capturedActivities);
+            Assert.Equal(TelemetryConstants.Activities.AgentTelemetry, activity.OperationName);
+
+            var tags = activity.Tags.ToDictionary(t => t.Key, t => t.Value);
+            Assert.Equal("skill_invocation", tags[TelemetryConstants.Tags.AgentEventType]);
+            Assert.Equal("copilot-cli", tags[TelemetryConstants.Tags.AgentClientName]);
+            Assert.Equal("11111111-1111-1111-1111-111111111111", tags[TelemetryConstants.Tags.AgentSessionId]);
+            Assert.Equal("aspire", tags[TelemetryConstants.Tags.AgentSkillName]);
+            Assert.Equal("2026-01-01T00:00:00Z", tags[TelemetryConstants.Tags.AgentEventTimestamp]);
+        }
+    }
+
+    [Fact]
+    public async Task AgentTelemetry_DoesNotEmitTagsForMissingOptions()
+    {
+        var (capturedActivities, listener) = CreateCapturingListener(out var reportedSourceName);
+        using (listener)
+        {
+            using var workspace = TemporaryWorkspace.Create(outputHelper);
+            var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+            {
+                options.TelemetryFactory = _ => TestTelemetryHelper.CreateInitializedTelemetry(reportedSourceName, $"Diag.{Path.GetRandomFileName()}");
+            });
+            using var provider = services.BuildServiceProvider();
+
+            var command = provider.GetRequiredService<RootCommand>();
+            var result = command.Parse("agent telemetry --event-type tool_invocation --tool-name aspire-list_resources");
+
+            var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+            Assert.Equal(CliExitCodes.Success, exitCode);
+
+            var activity = Assert.Single(capturedActivities);
+            var tags = activity.Tags.ToDictionary(t => t.Key, t => t.Value);
+            Assert.Equal("tool_invocation", tags[TelemetryConstants.Tags.AgentEventType]);
+            Assert.Equal("aspire-list_resources", tags[TelemetryConstants.Tags.AgentToolName]);
+            Assert.False(tags.ContainsKey(TelemetryConstants.Tags.AgentSkillName));
+            Assert.False(tags.ContainsKey(TelemetryConstants.Tags.AgentFileReference));
+            Assert.False(tags.ContainsKey(TelemetryConstants.Tags.AgentClientName));
+        }
+    }
+
+    [Fact]
+    public async Task AgentTelemetry_DropsOverlongAndUnsafeValues()
+    {
+        var (capturedActivities, listener) = CreateCapturingListener(out var reportedSourceName);
+        using (listener)
+        {
+            using var workspace = TemporaryWorkspace.Create(outputHelper);
+            var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+            {
+                options.TelemetryFactory = _ => TestTelemetryHelper.CreateInitializedTelemetry(reportedSourceName, $"Diag.{Path.GetRandomFileName()}");
+            });
+            using var provider = services.BuildServiceProvider();
+
+            var longValue = new string('a', 1000);
+            var command = provider.GetRequiredService<RootCommand>();
+            var result = command.Parse($"agent telemetry --event-type reference_file_read --file-reference {longValue}");
+
+            var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+            Assert.Equal(CliExitCodes.Success, exitCode);
+
+            var activity = Assert.Single(capturedActivities);
+            var tags = activity.Tags.ToDictionary(t => t.Key, t => t.Value);
+            // An overlong file reference is dropped (not truncated) so oversized values never reach the backend.
+            Assert.False(tags.ContainsKey(TelemetryConstants.Tags.AgentFileReference));
+            Assert.Equal("reference_file_read", tags[TelemetryConstants.Tags.AgentEventType]);
+        }
+    }
+
+    [Theory]
+    [InlineData("/etc/passwd")]
+    [InlineData("C:\\Users\\someone\\secret.txt")]
+    [InlineData("../../etc/passwd")]
+    [InlineData("~/secret")]
+    public async Task AgentTelemetry_DropsUnsafeFileReferences(string fileReference)
+    {
+        var (capturedActivities, listener) = CreateCapturingListener(out var reportedSourceName);
+        using (listener)
+        {
+            using var workspace = TemporaryWorkspace.Create(outputHelper);
+            var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+            {
+                options.TelemetryFactory = _ => TestTelemetryHelper.CreateInitializedTelemetry(reportedSourceName, $"Diag.{Path.GetRandomFileName()}");
+            });
+            using var provider = services.BuildServiceProvider();
+
+            var command = provider.GetRequiredService<RootCommand>();
+            var result = command.Parse(["agent", "telemetry", "--event-type", "reference_file_read", "--file-reference", fileReference]);
+
+            var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+            Assert.Equal(CliExitCodes.Success, exitCode);
+
+            var activity = Assert.Single(capturedActivities);
+            var tags = activity.Tags.ToDictionary(t => t.Key, t => t.Value);
+            Assert.False(tags.ContainsKey(TelemetryConstants.Tags.AgentFileReference));
+        }
+    }
+
+    [Fact]
+    public async Task AgentTelemetry_DropsUnknownEventType()
+    {
+        var (capturedActivities, listener) = CreateCapturingListener(out var reportedSourceName);
+        using (listener)
+        {
+            using var workspace = TemporaryWorkspace.Create(outputHelper);
+            var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+            {
+                options.TelemetryFactory = _ => TestTelemetryHelper.CreateInitializedTelemetry(reportedSourceName, $"Diag.{Path.GetRandomFileName()}");
+            });
+            using var provider = services.BuildServiceProvider();
+
+            var command = provider.GetRequiredService<RootCommand>();
+            var result = command.Parse("agent telemetry --event-type not_a_real_event --skill-name aspire");
+
+            var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+            Assert.Equal(CliExitCodes.Success, exitCode);
+
+            var activity = Assert.Single(capturedActivities);
+            var tags = activity.Tags.ToDictionary(t => t.Key, t => t.Value);
+            Assert.False(tags.ContainsKey(TelemetryConstants.Tags.AgentEventType));
+            Assert.Equal("aspire", tags[TelemetryConstants.Tags.AgentSkillName]);
+        }
+    }
+
+    [Fact]
+    public async Task AgentTelemetry_ExitsZero_WithUnknownToken()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        // A newer hook script may pass a flag this CLI version does not understand; it must not fail.
+        var result = command.Parse("agent telemetry --event-type skill_invocation --some-future-flag value");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task AgentTelemetry_ExitsZero_WithNoOptions()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("agent telemetry");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+    }
+
+    [Fact]
+    public void AgentTelemetry_IsHidden()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AgentTelemetryCommand>();
+        Assert.True(command.Hidden);
+    }
+
+    [Fact]
+    public async Task AgentTelemetry_RecordsValidRelativeFileReference()
+    {
+        var (capturedActivities, listener) = CreateCapturingListener(out var reportedSourceName);
+        using (listener)
+        {
+            using var workspace = TemporaryWorkspace.Create(outputHelper);
+            var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+            {
+                options.TelemetryFactory = _ => TestTelemetryHelper.CreateInitializedTelemetry(reportedSourceName, $"Diag.{Path.GetRandomFileName()}");
+            });
+            using var provider = services.BuildServiceProvider();
+
+            var command = provider.GetRequiredService<RootCommand>();
+            var result = command.Parse("agent telemetry --event-type reference_file_read --file-reference aspire/references/deploy.md");
+
+            var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+            Assert.Equal(CliExitCodes.Success, exitCode);
+
+            var activity = Assert.Single(capturedActivities);
+            var tags = activity.Tags.ToDictionary(t => t.Key, t => t.Value);
+            Assert.Equal("aspire/references/deploy.md", tags[TelemetryConstants.Tags.AgentFileReference]);
+        }
+    }
+
+    private static (List<Activity> Activities, ActivityListener Listener) CreateCapturingListener(out string reportedSourceName)
+    {
+        reportedSourceName = $"Test.{Path.GetRandomFileName()}";
+        var captured = new List<Activity>();
+        var sourceName = reportedSourceName;
+
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == sourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity => captured.Add(activity)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        return (captured, listener);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/AgentTelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentTelemetryCommandTests.cs
@@ -162,6 +162,31 @@ public class AgentTelemetryCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task AgentTelemetry_EmitsNoActivity_WhenAllValuesInvalid()
+    {
+        var (capturedActivities, listener) = CreateCapturingListener(out var reportedSourceName);
+        using (listener)
+        {
+            using var workspace = TemporaryWorkspace.Create(outputHelper);
+            var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+            {
+                options.TelemetryFactory = _ => TestTelemetryHelper.CreateInitializedTelemetry(reportedSourceName, $"Diag.{Path.GetRandomFileName()}");
+            });
+            using var provider = services.BuildServiceProvider();
+
+            var command = provider.GetRequiredService<RootCommand>();
+            // Every value fails validation (unknown event type, identifier with a space, absolute path).
+            // When nothing survives, the command must emit no span at all rather than a tagless one.
+            var result = command.Parse(["agent", "telemetry", "--event-type", "not_a_real_event", "--skill-name", "bad name", "--file-reference", "/etc/passwd"]);
+
+            var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+            Assert.Equal(CliExitCodes.Success, exitCode);
+            Assert.Empty(capturedActivities);
+        }
+    }
+
+    [Fact]
     public async Task AgentTelemetry_ExitsZero_WithUnknownToken()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Telemetry/AgentTelemetryInvocationTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/AgentTelemetryInvocationTests.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Telemetry;
+
+namespace Aspire.Cli.Tests.Telemetry;
+
+public class AgentTelemetryInvocationTests
+{
+    [Theory]
+    [InlineData("agent telemetry")]
+    [InlineData("agent telemetry --event-type skill_invocation")]
+    [InlineData("agent telemetry --skill-name aspire --timestamp 2026-01-01T00:00:00Z")]
+    public void Matches_ReturnsTrue_ForAgentTelemetryInvocation(string commandLine)
+    {
+        Assert.True(AgentTelemetryInvocation.Matches(commandLine.Split(' ')));
+    }
+
+    [Theory]
+    [InlineData("agent")]
+    [InlineData("agent mcp")]
+    [InlineData("agent init")]
+    [InlineData("telemetry")]
+    [InlineData("run")]
+    [InlineData("--debug agent telemetry")]
+    [InlineData("config set agent telemetry")]
+    public void Matches_ReturnsFalse_ForOtherInvocations(string commandLine)
+    {
+        Assert.False(AgentTelemetryInvocation.Matches(commandLine.Split(' ')));
+    }
+
+    [Fact]
+    public void Matches_ReturnsFalse_ForEmptyArgs()
+    {
+        Assert.False(AgentTelemetryInvocation.Matches([]));
+    }
+
+    [Fact]
+    public void Matches_ReturnsFalse_ForNullArgs()
+    {
+        Assert.False(AgentTelemetryInvocation.Matches(null));
+    }
+}

--- a/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -280,60 +280,30 @@ public class TelemetryConfigurationTests
     [Theory]
     [InlineData("1")]
     [InlineData("true")]
-    public void AzureMonitor_Disabled_ForAgentTelemetry_WhenAgentTelemetryOptOutSet(string optOutValue)
+    public void AzureMonitor_Disabled_ForAgentTelemetry_WhenGlobalOptOutSet(string optOutValue)
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                [AspireCliTelemetry.AgentTelemetryOptOutConfigKey] = optOutValue
+                [AspireCliTelemetry.TelemetryOptOutConfigKey] = optOutValue
             })
             .Build();
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
 
-        using var manager = new TelemetryManager(configuration, ["agent", "telemetry", "--event-type", "skill_invocation"]);
+        using var manager = new TelemetryManager(configuration, tagsSource, ["agent", "telemetry", "--event-type", "skill_invocation"]);
 
         Assert.False(manager.HasAzureMonitor);
-    }
-
-    [Fact]
-    public void AzureMonitor_Enabled_ForNonAgentCommand_WhenOnlyAgentTelemetryOptOutSet()
-    {
-        // The dedicated AI opt-out must not disable general CLI telemetry; it only suppresses
-        // the agent telemetry command path.
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [AspireCliTelemetry.AgentTelemetryOptOutConfigKey] = "true"
-            })
-            .Build();
-
-        using var manager = new TelemetryManager(configuration, ["run"]);
-
-        Assert.True(manager.HasAzureMonitor);
     }
 
     [Fact]
     public void AzureMonitor_Enabled_ForAgentTelemetry_WhenNoOptOutSet()
     {
         var configuration = new ConfigurationBuilder().Build();
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
 
-        using var manager = new TelemetryManager(configuration, ["agent", "telemetry", "--event-type", "skill_invocation"]);
+        using var manager = new TelemetryManager(configuration, tagsSource, ["agent", "telemetry", "--event-type", "skill_invocation"]);
 
         Assert.True(manager.HasAzureMonitor);
-    }
-
-    [Fact]
-    public void AzureMonitor_Disabled_ForAgentTelemetry_WhenGlobalOptOutSet()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [AspireCliTelemetry.TelemetryOptOutConfigKey] = "true"
-            })
-            .Build();
-
-        using var manager = new TelemetryManager(configuration, ["agent", "telemetry", "--event-type", "skill_invocation"]);
-
-        Assert.False(manager.HasAzureMonitor);
     }
 
     private static ActivityListener CreateActivityListener(string sourceName)

--- a/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -277,6 +277,65 @@ public class TelemetryConfigurationTests
         Assert.False(manager.HasAzureMonitor);
     }
 
+    [Theory]
+    [InlineData("1")]
+    [InlineData("true")]
+    public void AzureMonitor_Disabled_ForAgentTelemetry_WhenAgentTelemetryOptOutSet(string optOutValue)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [AspireCliTelemetry.AgentTelemetryOptOutConfigKey] = optOutValue
+            })
+            .Build();
+
+        using var manager = new TelemetryManager(configuration, ["agent", "telemetry", "--event-type", "skill_invocation"]);
+
+        Assert.False(manager.HasAzureMonitor);
+    }
+
+    [Fact]
+    public void AzureMonitor_Enabled_ForNonAgentCommand_WhenOnlyAgentTelemetryOptOutSet()
+    {
+        // The dedicated AI opt-out must not disable general CLI telemetry; it only suppresses
+        // the agent telemetry command path.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [AspireCliTelemetry.AgentTelemetryOptOutConfigKey] = "true"
+            })
+            .Build();
+
+        using var manager = new TelemetryManager(configuration, ["run"]);
+
+        Assert.True(manager.HasAzureMonitor);
+    }
+
+    [Fact]
+    public void AzureMonitor_Enabled_ForAgentTelemetry_WhenNoOptOutSet()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        using var manager = new TelemetryManager(configuration, ["agent", "telemetry", "--event-type", "skill_invocation"]);
+
+        Assert.True(manager.HasAzureMonitor);
+    }
+
+    [Fact]
+    public void AzureMonitor_Disabled_ForAgentTelemetry_WhenGlobalOptOutSet()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [AspireCliTelemetry.TelemetryOptOutConfigKey] = "true"
+            })
+            .Build();
+
+        using var manager = new TelemetryManager(configuration, ["agent", "telemetry", "--event-type", "skill_invocation"]);
+
+        Assert.False(manager.HasAzureMonitor);
+    }
+
     private static ActivityListener CreateActivityListener(string sourceName)
     {
         var listener = new ActivityListener

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -278,6 +278,7 @@ internal static class CliTestHelper
         services.AddTransient<AgentCommand>();
         services.AddTransient<AgentMcpCommand>();
         services.AddTransient<AgentInitCommand>();
+        services.AddTransient<AgentTelemetryCommand>();
         services.AddSingleton<ResourceColorMap>();
         services.AddTransient<TelemetryCommand>();
         services.AddTransient<TelemetryLogsCommand>();

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using Aspire.Cli.Acquisition;
 using Aspire.Cli.Agents;
+using Aspire.Cli.Agents.Hooks;
 using Aspire.Cli.Agents.AspireSkills;
 using Aspire.Cli.Agents.Playwright;
 using Aspire.Cli.Backchannel;
@@ -158,8 +159,8 @@ internal static class CliTestHelper
         services.AddSingleton(options.AspireSkillsInstallerFactory);
         services.AddSingleton(options.PlaywrightCliRunnerFactory);
         services.AddSingleton<PlaywrightCliInstaller>();
-        services.AddSingleton<Aspire.Cli.Agents.Hooks.ITelemetryHookInstaller, Aspire.Cli.Agents.Hooks.TelemetryHookInstaller>();
-        services.AddSingleton<Aspire.Cli.Agents.Hooks.ITelemetryHookConfigurator, Aspire.Cli.Agents.Hooks.TelemetryHookConfigurator>();
+        services.AddSingleton<ITelemetryHookInstaller, TelemetryHookInstaller>();
+        services.AddSingleton(options.TelemetryHookConfiguratorFactory);
         services.AddSingleton(options.ScaffoldingServiceFactory);
         services.AddSingleton<IAppHostServerProjectFactory, AppHostServerProjectFactory>();
         services.AddSingleton<IAppHostServerSessionFactory, AppHostServerSessionFactory>();
@@ -660,6 +661,12 @@ internal sealed class CliServiceCollectionTestOptions
     public Func<IServiceProvider, IAspireSkillsInstaller> AspireSkillsInstallerFactory { get; set; } = serviceProvider => new FakeAspireSkillsInstaller(serviceProvider.GetRequiredService<CliExecutionContext>());
 
     public Func<IServiceProvider, IPlaywrightCliRunner> PlaywrightCliRunnerFactory { get; set; } = _ => new FakePlaywrightCliRunner();
+
+    // Defaults to the real configurator (resolving ITelemetryHookInstaller/CliExecutionContext/IEnvironment
+    // from DI) so agent-init tests exercise the shipped behavior; a test can override it to simulate a
+    // failure and assert hook installation never aborts `agent init`.
+    public Func<IServiceProvider, ITelemetryHookConfigurator> TelemetryHookConfiguratorFactory { get; set; }
+        = serviceProvider => ActivatorUtilities.CreateInstance<TelemetryHookConfigurator>(serviceProvider);
 
     public Func<IServiceProvider, ILanguageService> LanguageServiceFactory { get; set; } = (IServiceProvider serviceProvider) =>
     {

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -158,6 +158,8 @@ internal static class CliTestHelper
         services.AddSingleton(options.AspireSkillsInstallerFactory);
         services.AddSingleton(options.PlaywrightCliRunnerFactory);
         services.AddSingleton<PlaywrightCliInstaller>();
+        services.AddSingleton<Aspire.Cli.Agents.Hooks.ITelemetryHookInstaller, Aspire.Cli.Agents.Hooks.TelemetryHookInstaller>();
+        services.AddSingleton<Aspire.Cli.Agents.Hooks.ITelemetryHookConfigurator, Aspire.Cli.Agents.Hooks.TelemetryHookConfigurator>();
         services.AddSingleton(options.ScaffoldingServiceFactory);
         services.AddSingleton<IAppHostServerProjectFactory, AppHostServerProjectFactory>();
         services.AddSingleton<IAppHostServerSessionFactory, AppHostServerSessionFactory>();

--- a/tests/Infrastructure.Tests/PowerShellScripts/AspireSkillsBundleHashTests.cs
+++ b/tests/Infrastructure.Tests/PowerShellScripts/AspireSkillsBundleHashTests.cs
@@ -1,0 +1,190 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Offline guards for the hashing helpers in <c>eng/scripts/aspire-skills-bundle.common.ps1</c> that
+/// the embedded-bundle verification (<c>verify-aspire-skills-bundle.ps1</c>) relies on. Those helpers
+/// hash the telemetry hook scripts over LF-normalized UTF-8 (no BOM) so the recorded hash is stable no
+/// matter how git checked the file out — <c>track-telemetry.ps1</c> is <c>text=auto</c> and lands with
+/// CRLF on Windows, while <c>track-telemetry.sh</c> is <c>eol=lf</c>.
+/// </summary>
+/// <remarks>
+/// The hook-hash branch of the verify script only runs once a companion aspire-skills release records a
+/// <c>hooks</c> metadata block, so CI does not exercise it on this repo today. That makes a normalization
+/// regression invisible until the bundle update lands — an awkward place to discover it. These tests pin
+/// the contract now, exercising only the offline helpers (no GitHub contents API fetch).
+/// </remarks>
+public sealed class AspireSkillsBundleHashTests : IDisposable
+{
+    // SHA-256 of the LF, UTF-8 (no BOM) bytes of CanonicalText, computed independently of the script
+    // under test (so this is a real oracle, not a tautology). Every line-ending variant of the same
+    // logical content must normalize to this one hash.
+    private const string ExpectedSha256 = "83fd2d53ae2f0c5f2326321934026cf6f0c3397f17aa1ba0887178155c220931";
+
+    // Canonical hook-like content using LF placeholders; each test rewrites the newlines per style.
+    private const string CanonicalText = "#!/usr/bin/env bash\necho 'aspire'\n";
+
+    private readonly TestTempDirectory _tempDir = new();
+    private readonly string _commonScriptPath;
+    private readonly ITestOutputHelper _output;
+
+    public AspireSkillsBundleHashTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _commonScriptPath = Path.Combine(RepoRoot.Path, "eng", "scripts", "aspire-skills-bundle.common.ps1");
+    }
+
+    public void Dispose() => _tempDir.Dispose();
+
+    [Theory]
+    [RequiresTools(["pwsh"])]
+    [InlineData(LineEndings.Lf)]
+    [InlineData(LineEndings.Crlf)]
+    [InlineData(LineEndings.Cr)]
+    [InlineData(LineEndings.BomCrlf)]
+    public async Task NormalizesEveryLineEndingVariantToTheSameHash(LineEndings lineEndings)
+    {
+        var inputPath = Path.Combine(_tempDir.Path, $"input-{lineEndings}.bin");
+        File.WriteAllBytes(inputPath, BuildInput(lineEndings));
+
+        var hash = await RunHashDriverAsync(inputPath);
+
+        Assert.Equal(ExpectedSha256, hash);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task HookFileNamesMatchTheEmbeddedHookScripts()
+    {
+        var names = await RunHookNamesDriverAsync();
+
+        // The verify loop iterates Get-AspireSkillsHookFileNames and requires a recorded hash for each,
+        // so the list must stay in lockstep with the hook scripts actually shipped. A rename on disk that
+        // is not mirrored in the array would leave the renamed script unverified with no failure signal.
+        var hooksDir = Path.Combine(RepoRoot.Path, "src", "Aspire.Cli", "Agents", "Hooks");
+        var onDisk = Directory.EnumerateFiles(hooksDir, "track-telemetry.*")
+            .Select(Path.GetFileName)
+            .OrderBy(static n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(onDisk, names.OrderBy(static n => n, StringComparer.Ordinal).ToArray());
+    }
+
+    private async Task<string> RunHashDriverAsync(string inputPath)
+    {
+        // Dot-source the library and run only its offline helpers; the C# side owns the exact input bytes
+        // (including CRLF/CR/BOM) so the script under test is what decides the resulting hash.
+        var driverPath = WriteDriver(
+            "hash-driver.ps1",
+            """
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $true)][string]$CommonScript,
+                [Parameter(Mandatory = $true)][string]$InputFile
+            )
+
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+
+            . $CommonScript
+
+            $bytes = [System.IO.File]::ReadAllBytes($InputFile)
+            $normalized = ConvertTo-LfUtf8Bytes -Bytes $bytes
+            Write-Output (Get-AspireSkillsSha256Hex -Bytes $normalized)
+            """);
+
+        var result = await RunDriverAsync(
+            driverPath,
+            "-CommonScript", $"\"{_commonScriptPath}\"",
+            "-InputFile", $"\"{inputPath}\"");
+
+        var hash = ReadLines(result.Output)
+            .FirstOrDefault(static l => l.Length == 64 && l.All(static c => char.IsAsciiHexDigitLower(c)));
+
+        Assert.True(hash is not null, $"Expected a SHA-256 line in driver output:{Environment.NewLine}{result.Output}");
+        return hash!;
+    }
+
+    private async Task<string[]> RunHookNamesDriverAsync()
+    {
+        var driverPath = WriteDriver(
+            "names-driver.ps1",
+            """
+            [CmdletBinding()]
+            param([Parameter(Mandatory = $true)][string]$CommonScript)
+
+            Set-StrictMode -Version Latest
+            $ErrorActionPreference = 'Stop'
+
+            . $CommonScript
+
+            Write-Output ("NAMES=" + ((Get-AspireSkillsHookFileNames) -join ';'))
+            """);
+
+        var result = await RunDriverAsync(driverPath, "-CommonScript", $"\"{_commonScriptPath}\"");
+
+        var line = ReadLines(result.Output)
+            .FirstOrDefault(static l => l.StartsWith("NAMES=", StringComparison.Ordinal));
+
+        Assert.NotNull(line);
+        return line!["NAMES=".Length..].Split(';', StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private async Task<CommandResult> RunDriverAsync(string driverPath, params string[] args)
+    {
+        using var cmd = new PowerShellCommand(driverPath, _output).WithTimeout(TimeSpan.FromMinutes(1));
+        var result = await cmd.ExecuteAsync(args);
+        result.EnsureSuccessful();
+        return result;
+    }
+
+    private string WriteDriver(string fileName, string content)
+    {
+        var path = Path.Combine(_tempDir.Path, fileName);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static IEnumerable<string> ReadLines(string output)
+        => output.Split('\n').Select(static l => l.Trim('\r', ' '));
+
+    private static byte[] BuildInput(LineEndings lineEndings)
+    {
+        var newline = lineEndings switch
+        {
+            LineEndings.Lf => "\n",
+            LineEndings.Crlf or LineEndings.BomCrlf => "\r\n",
+            LineEndings.Cr => "\r",
+            _ => throw new ArgumentOutOfRangeException(nameof(lineEndings))
+        };
+
+        var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        var body = utf8.GetBytes(CanonicalText.Replace("\n", newline));
+
+        if (lineEndings != LineEndings.BomCrlf)
+        {
+            return body;
+        }
+
+        // Prepend a UTF-8 BOM (EF BB BF) so the helper's BOM-stripping path is exercised too.
+        ReadOnlySpan<byte> bom = [0xEF, 0xBB, 0xBF];
+        var withBom = new byte[bom.Length + body.Length];
+        bom.CopyTo(withBom);
+        body.CopyTo(withBom.AsSpan(bom.Length));
+        return withBom;
+    }
+
+    public enum LineEndings
+    {
+        Lf,
+        Crlf,
+        Cr,
+        BomCrlf
+    }
+}


### PR DESCRIPTION
## Description

Adds opt-out, low-cardinality usage telemetry for Aspire's own AI skills and MCP tools, mirroring the approach used by `microsoft/azure-skills`.

Two parts:

1. **Hidden `aspire agent telemetry` command** — receives the parsed hook values and records a single `aspire/cli/agent_telemetry` reported activity through the existing CLI telemetry pipeline. It honors opt-out before creating any provider, suppresses the automatic `aspire/cli/main` span (so each hook event is one event, not an inflated command span), force-flushes the reported provider for reliable one-shot export, validates/normalizes every value (emitting **no** span when nothing valid survives), and always exits 0 so a hook can never break the agent.
2. **Auto-registration during `aspire agent init`** — materializes the `track-telemetry.{sh,ps1}` scripts to `~/.aspire/hooks` and writes a `PostToolUse` hook into each detected supported client's **user-level** config (GitHub Copilot CLI `~/.copilot/hooks/aspire-telemetry.json` and Claude Code `~/.claude/settings.json`). Hooks are always installed, for parity with azure-skills. Conservative JSON merge (never clobbers malformed/unexpected configs), idempotent, AOT-safe.

Privacy: only Aspire-owned identifiers are recorded (allowlisted skill/tool names, the skill-relative reference path, a session GUID) — never absolute paths, repo/user names, file contents, or tool arguments.

Opt-out: a **single** switch, `ASPIRE_CLI_TELEMETRY_OPTOUT`, disables all CLI telemetry including AI agent skill usage. It's checked by the hook scripts (a fast short-circuit) and honored by the command before anything is sent.

Tests include `TelemetryHookScriptTests`, which run the real embedded `track-telemetry.{sh,ps1}` scripts end-to-end and assert the resulting `agent telemetry` invocation.

Draft pending coordinated review with the companion PRs (hook scripts in microsoft/aspire-skills#30, docs in microsoft/aspire.dev#1229). Clients shipped now: Copilot CLI + Claude Code; VS Code / OpenCode hook schemas are deferred. See the tracking issue for known edge cases.

Part of #18008

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No