### PR TITLE
Refactor health check to resolve URI directly from an endpoint rather…

### DIFF
--- a/src/Aspire.Hosting/ExternalServiceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ExternalServiceBuilderExtensions.cs
@@ -449,29 +449,48 @@ internal sealed class ParameterUriHealthCheck : IHealthCheck
 }
 
 /// <summary>
-/// HTTP health check that resolves its URI lazily.
+/// HTTP health check that resolves its URI from an endpoint.
 /// </summary>
-internal sealed class DeferredUriHealthCheck : IHealthCheck
+internal sealed class EndpointUriHealthCheck : IHealthCheck
 {
-    private readonly Func<Uri?> _uriFactory;
+    private readonly EndpointReference _endpoint;
+    private readonly string _path;
     private readonly int _expectedStatusCode;
     private readonly Func<HttpClient> _httpClientFactory;
 
-    public DeferredUriHealthCheck(Func<Uri?> uriFactory, int expectedStatusCode, Func<HttpClient> httpClientFactory)
+    public EndpointUriHealthCheck(EndpointReference endpoint, string path, int expectedStatusCode, Func<HttpClient> httpClientFactory)
     {
-        ArgumentNullException.ThrowIfNull(uriFactory);
+        ArgumentNullException.ThrowIfNull(endpoint);
+        ArgumentNullException.ThrowIfNull(path);
         ArgumentNullException.ThrowIfNull(httpClientFactory);
-        _uriFactory = uriFactory;
+        _endpoint = endpoint;
+        _path = path;
         _expectedStatusCode = expectedStatusCode;
         _httpClientFactory = httpClientFactory;
     }
 
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        var uri = _uriFactory();
-        if (uri is null)
+        if (!_endpoint.Exists)
         {
-            return HealthCheckResult.Unhealthy("The URI for the health check is not set. Ensure that the resource has been allocated before the health check is executed.");
+            return HealthCheckResult.Unhealthy($"The endpoint '{_endpoint.EndpointName}' does not exist on the resource.");
+        }
+
+        Uri uri;
+        try
+        {
+            var endpointValue = await _endpoint.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            if (endpointValue is null)
+            {
+                return HealthCheckResult.Unhealthy($"The endpoint '{_endpoint.EndpointName}' does not have a URL.");
+            }
+
+            var baseUri = new Uri(endpointValue, UriKind.Absolute);
+            uri = new Uri(baseUri, _path);
+        }
+        catch (Exception ex)
+        {
+            return new HealthCheckResult(context.Registration.FailureStatus, "Failed to determine the URI for the health check.", ex);
         }
 
         try

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -2823,6 +2823,17 @@ public static class ResourceBuilderExtensions
 
         var endpointName = endpoint.EndpointName;
 
+        // Validate that the endpoint exists during allocation to fail fast on misconfiguration.
+        builder.OnResourceEndpointsAllocated((_, @event, ct) =>
+        {
+            if (!endpoint.Exists)
+            {
+                throw new DistributedApplicationException($"The endpoint '{endpointName}' does not exist on the resource '{builder.Resource.Name}'.");
+            }
+
+            return Task.CompletedTask;
+        });
+
         var healthCheckKey = $"{builder.Resource.Name}_{endpointName}_{path}_{statusCode}_check";
 
         builder.ApplicationBuilder.Services.AddHttpClient();

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -2823,24 +2823,6 @@ public static class ResourceBuilderExtensions
 
         var endpointName = endpoint.EndpointName;
 
-        builder.OnResourceEndpointsAllocated((_, @event, ct) =>
-        {
-            if (!endpoint.Exists)
-            {
-                throw new DistributedApplicationException($"The endpoint '{endpointName}' does not exist on the resource '{builder.Resource.Name}'.");
-            }
-
-            return Task.CompletedTask;
-        });
-
-        Uri? uri = null;
-        builder.OnBeforeResourceStarted((_, @event, ct) =>
-        {
-            var baseUri = new Uri(endpoint.Url, UriKind.Absolute);
-            uri = new Uri(baseUri, path);
-            return Task.CompletedTask;
-        });
-
         var healthCheckKey = $"{builder.Resource.Name}_{endpointName}_{path}_{statusCode}_check";
 
         builder.ApplicationBuilder.Services.AddHttpClient();
@@ -2848,8 +2830,9 @@ public static class ResourceBuilderExtensions
 
         builder.ApplicationBuilder.Services.AddHealthChecks().Add(new HealthCheckRegistration(
             healthCheckKey,
-            serviceProvider => new DeferredUriHealthCheck(
-                () => uri,
+            serviceProvider => new EndpointUriHealthCheck(
+                endpoint,
+                path,
                 statusCode.Value,
                 () => serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient(healthCheckKey)),
             failureStatus: default,

--- a/tests/Aspire.Hosting.Tests/HealthCheckTests.cs
+++ b/tests/Aspire.Hosting.Tests/HealthCheckTests.cs
@@ -77,7 +77,7 @@ public class HealthCheckTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task WithHttpHealthCheckInitializesUriOnBeforeResourceStartedEvent()
+    public async Task WithHttpHealthCheckResolvesUriFromEndpointDuringCheck()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
 
@@ -96,13 +96,16 @@ public class HealthCheckTests(ITestOutputHelper testOutputHelper)
 
         await eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(resource.Resource, app.Services));
 
-        // The health check URI is intentionally initialized on BeforeResourceStartedEvent (not on
-        // ResourceEndpointsAllocatedEvent) so the URI reflects the final allocated endpoint. Once that
-        // event has been published the health check factory can build a valid check.
-        await eventing.PublishAsync(new BeforeResourceStartedEvent(resource.Resource, app.Services));
-
         var healthCheck = registration.Factory(app.Services);
         Assert.NotNull(healthCheck);
+
+        // The health check resolves the endpoint URI directly via GetValueAsync during CheckHealthAsync.
+        // The HTTP request will fail (nothing listening), but the error message confirms the URI was resolved.
+        var context = new HealthCheckContext { Registration = registration };
+        var result = await healthCheck.CheckHealthAsync(context);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("http://localhost:49217/", result.Description);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Refactor health check to resolve URI directly from an endpoint rather than than smuggling it via a captured variable from a lifecycle event.

At the time the health check code was written `GetValueAsync()` didn't wait for an endpoint to be allocated, so smuggling the urls through local variables was required.  But now we can simply await `endpoint.GetValueAsync()` and the task will resolve once the endpoint is avaialble.

(May conflict with merge back of #17960)

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] No
- Did you add public API?
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [X] No
