### PR TITLE
Update specs/appmodel.md with AfterEndpointsAllocatedEvent deprecation

### DIFF
--- a/docs/specs/appmodel.md
+++ b/docs/specs/appmodel.md
@@ -685,7 +685,9 @@ Use the `IsAllocated` property on an `EndpointReference` to check if an endpoint
 
 Endpoint resolution happens during the startup sequence of the DistributedApplication. To safely access endpoint values (e.g., Url, Host, Port), you must wait until endpoints are allocated.
 
-Aspire provides eventing APIs, such as `AfterEndpointsAllocatedEvent`, to access endpoints after allocation. These APIs ensure code executes only when endpoints are ready. 
+Aspire provides eventing APIs, such as `ResourceEndpointsAllocatedEvent`, to access endpoints after allocation for a specific resource. These APIs ensure code executes only when endpoints are ready.
+
+> **Note:** The older application-level `AfterEndpointsAllocatedEvent` is **deprecated** and will be removed in a future version. Prefer the resource-specific `ResourceEndpointsAllocatedEvent` (to react when a particular resource's endpoints are allocated) or `BeforeResourceStartedEvent` (for last-chance setup just before a resource starts) depending on your needs.
 
 #### Example: Checking Allocation and Using Eventing
 
@@ -711,8 +713,8 @@ catch (Exception ex)
     Console.WriteLine($"Error accessing Url: {ex.Message}");
 }
 
-// Subscribe to AfterEndpointsAllocatedEvent for resolved properties
-builder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>(
+// Subscribe to ResourceEndpointsAllocatedEvent for the specific resource
+builder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>(redis.Resource,
     (@event, cancellationToken) =>
     {
         Console.WriteLine($"Endpoint allocated: {endpoint.IsAllocated}");


### PR DESCRIPTION
## Description

`AfterEndpointsAllocatedEvent` is deprecated but the appmodel.md spec file was not yet updated.