### PR TITLE
Obsolete ServiceProvider property, add Services property on context types

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppEnvironmentContext.cs
@@ -19,7 +19,7 @@ internal sealed class ContainerAppEnvironmentContext(
 
     public AzureContainerAppEnvironmentResource Environment => environment;
 
-    public IServiceProvider ServiceProvider => serviceProvider;
+    public IServiceProvider Services => serviceProvider;
 
     private readonly Dictionary<IResource, BaseContainerAppContext> _containerApps = new(new ResourceNameComparer());
     private readonly List<(string ResourceName, string[] EndpointNames)> _upgradedEndpoints = [];

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentContext.cs
@@ -19,7 +19,7 @@ internal sealed class AzureAppServiceEnvironmentContext(
 
     public AzureAppServiceEnvironmentResource Environment => environment;
 
-    public IServiceProvider ServiceProvider => serviceProvider;
+    public IServiceProvider Services => serviceProvider;
 
     private readonly Dictionary<IResource, AzureAppServiceWebsiteContext> _appServices = new(new ResourceNameComparer());
     private readonly List<(string ResourceName, string[] EndpointNames)> _upgradedEndpoints = [];

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -394,7 +394,7 @@ public static class AzureKustoBuilderExtensions
             {
                 // If the launcher fails (which may mean we're in a remote session or can't detect a browser),
                 // show a notification with a clickable link to the Kusto Web Explorer
-                var interactionService = context.ServiceProvider.GetRequiredService<IInteractionService>();
+                var interactionService = context.Services.GetRequiredService<IInteractionService>();
                 if (interactionService.IsAvailable)
                 {
                     _ = await interactionService.PromptMessageBoxAsync(

--- a/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
@@ -619,7 +619,7 @@ public static class BlazorGatewayExtensions
         DistributedApplicationModel? model;
         try
         {
-            model = context.ExecutionContext.ServiceProvider.GetService<DistributedApplicationModel>();
+            model = context.ExecutionContext.Services.GetService<DistributedApplicationModel>();
         }
         catch (InvalidOperationException)
         {

--- a/src/Aspire.Hosting.Browsers/BrowserLogsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Browsers/BrowserLogsBuilderExtensions.cs
@@ -156,11 +156,11 @@ public static class BrowserLogsBuilderExtensions
                 {
                     try
                     {
-                        var configuration = context.ServiceProvider.GetRequiredService<IConfiguration>();
-                        var configurationStore = context.ServiceProvider.GetRequiredService<BrowserLogsConfigurationStore>();
+                        var configuration = context.Services.GetRequiredService<IConfiguration>();
+                        var configurationStore = context.Services.GetRequiredService<BrowserLogsConfigurationStore>();
                         var currentConfiguration = browserLogsResource.ResolveCurrentConfiguration(configuration, configurationStore);
                         var url = ResolveBrowserUrl(parentResource);
-                        var sessionManager = context.ServiceProvider.GetRequiredService<IBrowserLogsSessionManager>();
+                        var sessionManager = context.Services.GetRequiredService<IBrowserLogsSessionManager>();
                         await sessionManager.StartSessionAsync(browserLogsResource, currentConfiguration, context.ResourceName, url, context.CancellationToken).ConfigureAwait(false);
                         return CommandResults.Success();
                     }
@@ -183,7 +183,7 @@ public static class BrowserLogsBuilderExtensions
                             return ResourceCommandState.Disabled;
                         }
 
-                        var resourceNotifications = context.ServiceProvider.GetRequiredService<ResourceNotificationService>();
+                        var resourceNotifications = context.Services.GetRequiredService<ResourceNotificationService>();
                         if (resourceNotifications.TryGetCurrentState(parentResource.Name, out var resourceEvent))
                         {
                             var parentState = resourceEvent.Snapshot.State?.Text;
@@ -203,7 +203,7 @@ public static class BrowserLogsBuilderExtensions
                 {
                     try
                     {
-                        var configurationManager = context.ServiceProvider.GetRequiredService<BrowserLogsConfigurationManager>();
+                        var configurationManager = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();
                         return await configurationManager.ConfigureAsync(browserLogsResource, context.Arguments, context.CancellationToken).ConfigureAwait(false);
                     }
                     catch (Exception ex)
@@ -224,7 +224,7 @@ public static class BrowserLogsBuilderExtensions
                     },
                     UpdateState = context =>
                     {
-                        var interactionService = context.ServiceProvider.GetRequiredService<IInteractionService>();
+                        var interactionService = context.Services.GetRequiredService<IInteractionService>();
                         return interactionService.IsAvailable
                             ? ResourceCommandState.Enabled
                             : ResourceCommandState.Disabled;
@@ -237,7 +237,7 @@ public static class BrowserLogsBuilderExtensions
                 {
                     try
                     {
-                        var sessionManager = context.ServiceProvider.GetRequiredService<IBrowserLogsSessionManager>();
+                        var sessionManager = context.Services.GetRequiredService<IBrowserLogsSessionManager>();
                         var result = await sessionManager.CaptureScreenshotAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
                         var resultJson = JsonSerializer.Serialize(
                             new BrowserLogsScreenshotCommandResult(

--- a/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
@@ -88,7 +88,7 @@ internal sealed class DockerComposePublishingContext(
                 {
                     var dockerfileContext = new DockerfileFactoryContext
                     {
-                        Services = executionContext.ServiceProvider,
+                        Services = executionContext.Services,
                         Resource = serviceResource.TargetResource,
                         CancellationToken = cancellationToken
                     };
@@ -111,7 +111,7 @@ internal sealed class DockerComposePublishingContext(
                 {
                     foreach (var a in fsAnnotations)
                     {
-                        var files = await a.Callback(new() { Model = serviceResource.TargetResource, ServiceProvider = executionContext.ServiceProvider }, CancellationToken.None).ConfigureAwait(false);
+                        var files = await a.Callback(new() { Model = serviceResource.TargetResource, Services = executionContext.Services }, CancellationToken.None).ConfigureAwait(false);
                         foreach (var file in files)
                         {
                             HandleComposeFileConfig(composeFile, composeService, file, a.DefaultOwner, a.DefaultGroup, a.Umask ?? DefaultUmask, a.DestinationPath);

--- a/src/Aspire.Hosting.EntityFrameworkCore/EFResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.EntityFrameworkCore/EFResourceBuilderExtensions.cs
@@ -408,7 +408,7 @@ public static class EFResourceBuilderExtensions
 
     private static async Task<ExecuteCommandResult> StartEfToolResourceAsync(ExecuteCommandContext context, DotnetToolResource toolResource)
     {
-        var notificationService = context.ServiceProvider.GetRequiredService<ResourceNotificationService>();
+        var notificationService = context.Services.GetRequiredService<ResourceNotificationService>();
         var resourceStarted = false;
         Process? process = null;
 
@@ -424,7 +424,7 @@ public static class EFResourceBuilderExtensions
                 };
             }
 
-            var executionContext = context.ServiceProvider.GetService<DistributedApplicationExecutionContext>()
+            var executionContext = context.Services.GetService<DistributedApplicationExecutionContext>()
                 ?? new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
 
             var executionConfiguration = await ExecutionConfigurationBuilder.Create(toolResource)
@@ -515,7 +515,7 @@ public static class EFResourceBuilderExtensions
                 State = KnownResourceStates.Running
             }).ConfigureAwait(false);
 
-            var resourceLoggerService = context.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+            var resourceLoggerService = context.Services.GetRequiredService<ResourceLoggerService>();
             var resourceLogger = resourceLoggerService.GetLogger(toolResource);
 
             var stderrBuilder = new StringBuilder();
@@ -796,9 +796,9 @@ public static class EFResourceBuilderExtensions
         bool waitForDependencies,
         Func<EFCoreOperationExecutor, ILogger, IInteractionService?, Task<ExecuteCommandResult>> executeOperation)
     {
-        var resourceLoggerService = context.ServiceProvider.GetRequiredService<ResourceLoggerService>();
-        var resourceNotificationService = context.ServiceProvider.GetRequiredService<ResourceNotificationService>();
-        var interactionService = context.ServiceProvider.GetService<IInteractionService>();
+        var resourceLoggerService = context.Services.GetRequiredService<ResourceLoggerService>();
+        var resourceNotificationService = context.Services.GetRequiredService<ResourceNotificationService>();
+        var interactionService = context.Services.GetService<IInteractionService>();
         var logger = resourceLoggerService.GetLogger(migrationResource);
 
         if (migrationResource.IsExecutingCommand)
@@ -826,7 +826,7 @@ public static class EFResourceBuilderExtensions
                 migrationResource.DbContextTypeName,
                 logger,
                 context.CancellationToken,
-                context.ServiceProvider,
+                context.Services,
                 migrationResource.ToolResource);
 
             var result = await executeOperation(executor, logger, interactionService).ConfigureAwait(false);

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -1475,7 +1475,7 @@ public static class JavaScriptHostingExtensions
                     }
                     catch (Exception ex)
                     {
-                        var resourceLoggerService = ctx.ExecutionContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+                        var resourceLoggerService = ctx.ExecutionContext.Services.GetRequiredService<ResourceLoggerService>();
                         var resourceLogger = resourceLoggerService.GetLogger(resource);
 
                         resourceLogger.LogWarning(ex, "Failed to generate Aspire Vite HTTPS config wrapper for resource '{ResourceName}'. Falling back to existing Vite config without Aspire modifications. Automatic HTTPS configuration won't be available", resource.Name);

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
@@ -86,7 +86,7 @@ internal sealed class KubernetesPublishingContext(
                 {
                     var dockerfileContext = new DockerfileFactoryContext
                     {
-                        Services = executionContext.ServiceProvider,
+                        Services = executionContext.Services,
                         Resource = serviceResource.TargetResource,
                         CancellationToken = cancellationToken
                     };

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -217,7 +217,7 @@ public static class PostgresBuilderExtensions
                 destinationPath: "/pgadmin4",
                 callback: async (context, cancellationToken) =>
                 {
-                    var appModel = context.ServiceProvider.GetRequiredService<DistributedApplicationModel>();
+                    var appModel = context.Services.GetRequiredService<DistributedApplicationModel>();
                     var postgresInstances = builder.ApplicationBuilder.Resources.OfType<PostgresServerResource>();
 
                     return [
@@ -333,7 +333,7 @@ public static class PostgresBuilderExtensions
                 destinationPath: "/",
                 callback: async (context, ct) =>
                 {
-                    var appModel = context.ServiceProvider.GetRequiredService<DistributedApplicationModel>();
+                    var appModel = context.Services.GetRequiredService<DistributedApplicationModel>();
                     var postgresInstances = builder.ApplicationBuilder.Resources.OfType<PostgresDatabaseResource>();
 
                     // Add the bookmarks to the pgweb container
@@ -421,7 +421,7 @@ public static class PostgresBuilderExtensions
         // When running in the context of Codespaces we need to set some additional environment
         // variables so that PGAdmin will trust the forwarded headers that Codespaces port
         // forwarding will send.
-        var config = context.ExecutionContext.ServiceProvider.GetRequiredService<IConfiguration>();
+        var config = context.ExecutionContext.Services.GetRequiredService<IConfiguration>();
         if (context.ExecutionContext.IsRunMode && config.GetValue<bool>("CODESPACES", false))
         {
             context.EnvironmentVariables["PGADMIN_CONFIG_PROXY_X_HOST_COUNT"] = "1";

--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -406,7 +406,7 @@ public static class PythonAppResourceBuilderExtensions
             {
                 if (ctx.Scope == CertificateTrustScope.Append)
                 {
-                    var resourceLogger = ctx.ExecutionContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+                    var resourceLogger = ctx.ExecutionContext.Services.GetRequiredService<ResourceLoggerService>();
                     var logger = resourceLogger.GetLogger(ctx.Resource);
                     logger.LogInformation("Certificate trust scope is set to 'Append', but Python resources do not support appending to the default certificate authorities; only OTLP certificate trust will be applied.");
                 }

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -167,7 +167,7 @@ public static class RedisBuilderExtensions
 
                 if (ctx.Password is not null)
                 {
-                    var resourceLogger = ctx.ExecutionContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+                    var resourceLogger = ctx.ExecutionContext.Services.GetRequiredService<ResourceLoggerService>();
                     var logger = resourceLogger.GetLogger(redis);
                     logger.LogError($"Cannot configure an encrypted certificate for redis resource '{redis.Name}'");
                 }
@@ -365,7 +365,7 @@ public static class RedisBuilderExtensions
 
                     if (ctx.Password != null)
                     {
-                        var resourceLogger = ctx.ExecutionContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+                        var resourceLogger = ctx.ExecutionContext.Services.GetRequiredService<ResourceLoggerService>();
                         var logger = resourceLogger.GetLogger(resource);
                         logger.LogError($"Cannot configure an encrypted certificate for redis insight resource '{resource.Name}'");
                     }

--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -78,7 +78,7 @@ public static class YarpResourceExtensions
         {
             yarpBuilder.WithEnvironment(ctx =>
             {
-                var developerCertificateService = ctx.ExecutionContext.ServiceProvider.GetRequiredService<IDeveloperCertificateService>();
+                var developerCertificateService = ctx.ExecutionContext.Services.GetRequiredService<IDeveloperCertificateService>();
                 if (!developerCertificateService.SupportsContainerTrust)
                 {
                     // On systems without the ASP.NET DevCert updates introduced in .NET 10, YARP will not trust the cert used

--- a/src/Aspire.Hosting/ApplicationModel/AfterEndpointsAllocatedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AfterEndpointsAllocatedEvent.cs
@@ -20,7 +20,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <code lang="C#">
 /// var builder = DistributedApplication.CreateBuilder(args);
 /// builder.Eventing.Subscribe&lt;AfterEndpointsAllocatedEvent&gt;(async (@event, cancellationToken) =&gt; {
-///   var appModel = @event.ServiceProvider.GetRequiredService&lt;DistributedApplicationModel&gt;();
+///   var appModel = @event.Services.GetRequiredService&lt;DistributedApplicationModel&gt;();
 ///   // Update configuration of resource based on final endpoint configuration
 /// });
 /// </code>

--- a/src/Aspire.Hosting/ApplicationModel/AfterResourcesCreatedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AfterResourcesCreatedEvent.cs
@@ -21,7 +21,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <code lang="C#">
 /// var builder = DistributedApplication.CreateBuilder(args);
 /// builder.Eventing.Subscribe&lt;AfterResourcesCreatedEvent&gt;(async (@event, cancellationToken) =&gt; {
-///   var appModel = @event.ServiceProvider.GetRequiredService&lt;DistributedApplicationModel&gt;();
+///   var appModel = @event.Services.GetRequiredService&lt;DistributedApplicationModel&gt;();
 ///   // Run post startup logic.
 /// });
 /// </code>

--- a/src/Aspire.Hosting/ApplicationModel/BeforeStartEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/BeforeStartEvent.cs
@@ -21,7 +21,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <code lang="C#">
 /// var builder = DistributedApplication.CreateBuilder(args);
 /// builder.Eventing.Subscribe&lt;BeforeStartEvent&gt;(async (@event, cancellationToken) =&gt; {
-///   var appModel = @event.ServiceProvider.GetRequiredService&lt;DistributedApplicationModel&gt;();
+///   var appModel = @event.Services.GetRequiredService&lt;DistributedApplicationModel&gt;();
 ///   // Mutate the distributed application model.
 /// });
 /// </code>

--- a/src/Aspire.Hosting/ApplicationModel/CertificateTrustExecutionConfigurationGatherer.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CertificateTrustExecutionConfigurationGatherer.cs
@@ -31,7 +31,7 @@ internal class CertificateTrustExecutionConfigurationGatherer : IExecutionConfig
     public async ValueTask GatherAsync(IExecutionConfigurationGathererContext context, IResource resource, ILogger resourceLogger, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var developerCertificateService = executionContext.ServiceProvider.GetRequiredService<IDeveloperCertificateService>();
+        var developerCertificateService = executionContext.Services.GetRequiredService<IDeveloperCertificateService>();
         var trustDevCert = developerCertificateService.TrustCertificate;
 
         // Add additional certificate trust configuration metadata

--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -25,7 +25,7 @@ internal static class CommandsConfigurationExtensions
             displayName: CommandStrings.StartName,
             executeCommand: async context =>
             {
-                var orchestrator = context.ServiceProvider.GetRequiredService<ApplicationOrchestrator>();
+                var orchestrator = context.Services.GetRequiredService<ApplicationOrchestrator>();
 
                 await orchestrator.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
                 return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStarted, resource.GetResolvedDisplayResourceName(context.ResourceName)) };
@@ -58,7 +58,7 @@ internal static class CommandsConfigurationExtensions
             displayName: CommandStrings.StopName,
             executeCommand: async context =>
             {
-                var orchestrator = context.ServiceProvider.GetRequiredService<ApplicationOrchestrator>();
+                var orchestrator = context.Services.GetRequiredService<ApplicationOrchestrator>();
 
                 await orchestrator.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
                 return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStopped, resource.GetResolvedDisplayResourceName(context.ResourceName)) };
@@ -97,7 +97,7 @@ internal static class CommandsConfigurationExtensions
             displayName: CommandStrings.RestartName,
             executeCommand: async context =>
             {
-                var orchestrator = context.ServiceProvider.GetRequiredService<ApplicationOrchestrator>();
+                var orchestrator = context.Services.GetRequiredService<ApplicationOrchestrator>();
 
                 await orchestrator.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
                 await orchestrator.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
@@ -193,10 +193,10 @@ internal static class CommandsConfigurationExtensions
 
     private static async Task<ExecuteCommandResult> ExecuteRebuildAsync(ExecuteCommandContext context, ProjectResource projectResource)
     {
-        var orchestrator = context.ServiceProvider.GetRequiredService<ApplicationOrchestrator>();
-        var resourceNotificationService = context.ServiceProvider.GetRequiredService<ResourceNotificationService>();
-        var loggerService = context.ServiceProvider.GetRequiredService<ResourceLoggerService>();
-        var model = context.ServiceProvider.GetRequiredService<DistributedApplicationModel>();
+        var orchestrator = context.Services.GetRequiredService<ApplicationOrchestrator>();
+        var resourceNotificationService = context.Services.GetRequiredService<ResourceNotificationService>();
+        var loggerService = context.Services.GetRequiredService<ResourceLoggerService>();
+        var model = context.Services.GetRequiredService<DistributedApplicationModel>();
 
         var rebuilderResource = model.Resources.OfType<ProjectRebuilderResource>().FirstOrDefault(r => r.Parent == projectResource);
         if (rebuilderResource is null)

--- a/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
@@ -271,7 +271,17 @@ public sealed class ContainerFileSystemCallbackContext
     /// <summary>
     /// A <see cref="IServiceProvider"/> that can be used to resolve services in the callback.
     /// </summary>
-    public required IServiceProvider ServiceProvider { get; init; }
+    [Obsolete("Use Services instead.")]
+    public IServiceProvider ServiceProvider
+    {
+        get => Services;
+        init => Services = value;
+    }
+
+    /// <summary>
+    /// A <see cref="IServiceProvider"/> that can be used to resolve services in the callback.
+    /// </summary>
+    public required IServiceProvider Services { get; init; }
 
     /// <summary>
     /// The app model resource the callback is associated with.

--- a/src/Aspire.Hosting/ApplicationModel/ContainerImageReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerImageReference.cs
@@ -45,7 +45,7 @@ public class ContainerImageReference : IManifestExpressionProvider, IValueWithRe
     async ValueTask<string?> IValueProvider.GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken)
     {
         // Check if this resource is configured to save as an archive instead of pushing to a registry
-        if (context.ExecutionContext?.ServiceProvider is { } serviceProvider)
+        if (context.ExecutionContext?.Services is { } serviceProvider)
         {
             var logger = Resource.GetLogger(serviceProvider);
             var buildOptionsContext = await Resource.ProcessContainerBuildOptionsCallbackAsync(

--- a/src/Aspire.Hosting/ApplicationModel/ExecutionConfigurationBuilder.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutionConfigurationBuilder.cs
@@ -92,7 +92,7 @@ public sealed class ExecutionConfigurationBuilder : IExecutionConfigurationBuild
     /// <inheritdoc />
     public async Task<IExecutionConfigurationResult> BuildAsync(DistributedApplicationExecutionContext executionContext, ILogger? resourceLogger = null, CancellationToken cancellationToken = default)
     {
-        resourceLogger ??= _resource.GetLogger(executionContext.ServiceProvider);
+        resourceLogger ??= _resource.GetLogger(executionContext.Services);
 
         var context = new ExecutionConfigurationGathererContext();
 

--- a/src/Aspire.Hosting/ApplicationModel/HostUrl.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HostUrl.cs
@@ -48,13 +48,13 @@ public record HostUrl(string Url) : IExpressionValue, IValueProvider, IManifestE
                     // We're given a URL from the point of view of the host, so need to figure how to modify the URL to be correct from the point of view of the container.
                     // This could simply be replacing the hostname, but if the container tunnel is running, we may need to translate the port as well.
                     // Without doing this, we wouldn't be able to resolve the OTEL address correctly from a container as it currently depends on HostUrl rather than the dashboard endpoints.
-                    var options = context.ExecutionContext.ServiceProvider.GetRequiredService<IOptions<DcpOptions>>();
+                    var options = context.ExecutionContext.Services.GetRequiredService<IOptions<DcpOptions>>();
 
-                    var infoService = context.ExecutionContext.ServiceProvider.GetRequiredService<IDcpDependencyCheckService>();
+                    var infoService = context.ExecutionContext.Services.GetRequiredService<IDcpDependencyCheckService>();
                     var dcpInfo = await infoService.GetDcpInfoAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
                     var containerHostName = dcpInfo?.Containers?.ContainerHostName ?? KnownHostNames.DockerDesktopHostBridge;
-                    var model = context.ExecutionContext.ServiceProvider.GetService<DistributedApplicationModel>();
+                    var model = context.ExecutionContext.Services.GetService<DistributedApplicationModel>();
                     EndpointReference? targetEndpoint = null;
 
                     if (options.Value.EnableAspireContainerTunnel && model is { })
@@ -107,9 +107,9 @@ public record HostUrl(string Url) : IExpressionValue, IValueProvider, IManifestE
             var replacementHost = KnownHostNames.DockerDesktopHostBridge;
             if (context.ExecutionContext?.IsRunMode == true)
             {
-                var options = context.ExecutionContext.ServiceProvider.GetRequiredService<IOptions<DcpOptions>>();
+                var options = context.ExecutionContext.Services.GetRequiredService<IOptions<DcpOptions>>();
 
-                var infoService = context.ExecutionContext.ServiceProvider.GetRequiredService<IDcpDependencyCheckService>();
+                var infoService = context.ExecutionContext.Services.GetRequiredService<IDcpDependencyCheckService>();
                 var dcpInfo = await infoService.GetDcpInfoAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 replacementHost = options.Value.EnableAspireContainerTunnel ? KnownHostNames.DefaultContainerTunnelHostName : dcpInfo?.Containers?.ContainerHostName ?? KnownHostNames.DockerDesktopHostBridge;

--- a/src/Aspire.Hosting/ApplicationModel/HttpCommandContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HttpCommandContext.cs
@@ -15,7 +15,17 @@ public sealed class HttpCommandRequestContext
     /// <summary>
     /// The service provider.
     /// </summary>
-    public required IServiceProvider ServiceProvider { get; init; }
+    [Obsolete("Use Services instead.")]
+    public IServiceProvider ServiceProvider
+    {
+        get => Services;
+        init => Services = value;
+    }
+
+    /// <summary>
+    /// The service provider.
+    /// </summary>
+    public required IServiceProvider Services { get; init; }
 
     /// <summary>
     /// The name of the resource the command was configured on.
@@ -92,7 +102,17 @@ public sealed class HttpCommandResultContext
     /// <summary>
     /// The service provider.
     /// </summary>
-    public required IServiceProvider ServiceProvider { get; init; }
+    [Obsolete("Use Services instead.")]
+    public IServiceProvider ServiceProvider
+    {
+        get => Services;
+        init => Services = value;
+    }
+
+    /// <summary>
+    /// The service provider.
+    /// </summary>
+    public required IServiceProvider Services { get; init; }
 
     /// <summary>
     /// The name of the resource the command was configured on.

--- a/src/Aspire.Hosting/ApplicationModel/HttpsCertificateExecutionConfigurationGatherer.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HttpsCertificateExecutionConfigurationGatherer.cs
@@ -38,7 +38,7 @@ internal class HttpsCertificateExecutionConfigurationGatherer : IExecutionConfig
         X509Certificate2? certificate = effectiveAnnotation.Certificate;
         if (certificate is null)
         {
-            var developerCertificateService = executionContext.ServiceProvider.GetRequiredService<IDeveloperCertificateService>();
+            var developerCertificateService = executionContext.Services.GetRequiredService<IDeveloperCertificateService>();
             if (effectiveAnnotation.UseDeveloperCertificate.GetValueOrDefault(developerCertificateService.UseForHttps))
             {
                 certificate = developerCertificateService.Certificates.FirstOrDefault();

--- a/src/Aspire.Hosting/ApplicationModel/ProcessCommandResultContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProcessCommandResultContext.cs
@@ -19,7 +19,17 @@ public sealed class ProcessCommandResultContext
     /// <summary>
     /// Gets the service provider.
     /// </summary>
-    public required IServiceProvider ServiceProvider { get; init; }
+    [Obsolete("Use Services instead.")]
+    public IServiceProvider ServiceProvider
+    {
+        get => Services;
+        init => Services = value;
+    }
+
+    /// <summary>
+    /// Gets the service provider.
+    /// </summary>
+    public required IServiceProvider Services { get; init; }
 
     /// <summary>
     /// Gets the name of the resource the command was configured on.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -374,8 +374,19 @@ public sealed class UpdateCommandStateContext
     /// <summary>
     /// The service provider.
     /// </summary>
+    [Obsolete("Use Services instead.")]
     [AspireExportIgnore(Reason = "IServiceProvider is not usable from polyglot command state callbacks.")]
-    public required IServiceProvider ServiceProvider { get; init; }
+    public IServiceProvider ServiceProvider
+    {
+        get => Services;
+        init => Services = value;
+    }
+
+    /// <summary>
+    /// The service provider.
+    /// </summary>
+    [AspireExportIgnore(Reason = "IServiceProvider is not usable from polyglot command state callbacks.")]
+    public required IServiceProvider Services { get; init; }
 }
 
 /// <summary>
@@ -432,8 +443,19 @@ public sealed class ExecuteCommandContext
     /// <summary>
     /// The service provider.
     /// </summary>
+    [Obsolete("Use Services instead.")]
     [AspireExportIgnore(Reason = "IServiceProvider is not usable from polyglot command callbacks.")]
-    public required IServiceProvider ServiceProvider { get; init; }
+    public IServiceProvider ServiceProvider
+    {
+        get => Services;
+        init => Services = value;
+    }
+
+    /// <summary>
+    /// The service provider.
+    /// </summary>
+    [AspireExportIgnore(Reason = "IServiceProvider is not usable from polyglot command callbacks.")]
+    public required IServiceProvider Services { get; init; }
 
     /// <summary>
     /// The resource name.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -365,7 +365,7 @@ public class ResourceCommandService
                 var context = new ExecuteCommandContext
                 {
                     ResourceName = resourceId,
-                    ServiceProvider = _serviceProvider,
+                    Services = _serviceProvider,
                     CancellationToken = cancellationToken,
                     Logger = logger,
                     Arguments = arguments

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1730,7 +1730,7 @@ public static class ResourceExtensions
         DistributedApplicationModel? model;
         try
         {
-            model = executionContext.ServiceProvider.GetService<DistributedApplicationModel>();
+            model = executionContext.Services.GetService<DistributedApplicationModel>();
         }
         catch (InvalidOperationException)
         {

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -1066,7 +1066,7 @@ public class ResourceNotificationService : IDisposable
             else
             {
                 // Command already exists in snapshot. Update its state based on annotation callback.
-                var newState = annotation.UpdateState(new UpdateCommandStateContext { ResourceSnapshot = previousState, ServiceProvider = _serviceProvider });
+                var newState = annotation.UpdateState(new UpdateCommandStateContext { ResourceSnapshot = previousState, Services = _serviceProvider });
 
                 if (existingCommand.State != newState)
                 {
@@ -1109,7 +1109,7 @@ public class ResourceNotificationService : IDisposable
 
         static ResourceCommandSnapshot CreateCommandFromAnnotation(ResourceCommandAnnotation annotation, CustomResourceSnapshot previousState, IServiceProvider serviceProvider)
         {
-            var state = annotation.UpdateState(new UpdateCommandStateContext { ResourceSnapshot = previousState, ServiceProvider = serviceProvider });
+            var state = annotation.UpdateState(new UpdateCommandStateContext { ResourceSnapshot = previousState, Services = serviceProvider });
 
 #pragma warning disable CS0618 // Parameter is obsolete but still flowed for compatibility.
 #pragma warning disable ASPIREINTERACTION001 // Command arguments intentionally reuse the experimental interaction input model.

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -1430,7 +1430,7 @@ public static class ContainerResourceBuilderExtensions
     /// builder.AddContainer("mycontainer", "myimage")
     ///     .WithContainerFiles("/", (context, cancellationToken) =>
     ///     {
-    ///         var appModel = context.ServiceProvider.GetRequiredService&lt;DistributedApplicationModel&gt;();
+    ///         var appModel = context.Services.GetRequiredService&lt;DistributedApplicationModel&gt;();
     ///         var postgresInstances = appModel.Resources.OfType&lt;PostgresDatabaseResource&gt;();
     ///
     ///         return [

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -425,7 +425,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
         {
             // If the dashboard has an HTTPS endpoint and we haven't already applied an HTTPS certificate configuration (no HttpsCertificateConfigurationCallbackAnnotation),
             // apply a default configuration with a valid trusted dev cert instance.
-            var developerCertificateService = executionContext.ServiceProvider.GetRequiredService<IDeveloperCertificateService>();
+            var developerCertificateService = executionContext.Services.GetRequiredService<IDeveloperCertificateService>();
             var trustDeveloperCertificate = developerCertificateService.TrustCertificate;
             if (dashboardResource.TryGetLastAnnotation<CertificateAuthorityCollectionAnnotation>(out var certificateAuthorityAnnotation))
             {
@@ -611,7 +611,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
             // If allowed origins are not configured then calculate allowed origins from endpoints.
             if (string.IsNullOrEmpty(allowedOrigins))
             {
-                var model = context.ExecutionContext.ServiceProvider.GetRequiredService<DistributedApplicationModel>();
+                var model = context.ExecutionContext.Services.GetRequiredService<DistributedApplicationModel>();
                 allowedOrigins = GetAllowedOriginsFromResourceEndpoints(model);
             }
 

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -840,7 +840,7 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
                     new()
                     {
                         Model = context.Resource,
-                        ServiceProvider = _executionContext.ServiceProvider,
+                        Services = _executionContext.Services,
                         HttpsCertificateContext = context.HttpsCertificateContext,
                     },
                     cancellationToken).ConfigureAwait(false);
@@ -894,7 +894,7 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
     {
         if (modelContainerResource.Annotations.OfType<DockerfileBuildAnnotation>().SingleOrDefault() is { } dockerfileBuildAnnotation)
         {
-            await DockerfileHelper.ExecuteDockerfileFactoryAsync(dockerfileBuildAnnotation, modelContainerResource, executionContext.ServiceProvider, cancellationToken).ConfigureAwait(false);
+            await DockerfileHelper.ExecuteDockerfileFactoryAsync(dockerfileBuildAnnotation, modelContainerResource, executionContext.Services, cancellationToken).ConfigureAwait(false);
 
             var dcpBuildArgs = new List<EnvVar>();
 
@@ -944,7 +944,7 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
 
 #pragma warning disable ASPIREPIPELINES003 // ContainerBuildOptions APIs are experimental.
             var buildOptionsContext = await modelContainerResource.ProcessContainerBuildOptionsCallbackAsync(
-                executionContext.ServiceProvider,
+                executionContext.Services,
                 logger,
                 executionContext,
                 cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1246,7 +1246,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             }
         }
 
-        var ev = new ResourceEndpointsAllocatedEvent(resource, _executionContext.ServiceProvider);
+        var ev = new ResourceEndpointsAllocatedEvent(resource, _executionContext.Services);
         await _distributedApplicationEventing.PublishAsync(ev, EventDispatchBehavior.BlockingSequential, ct).ConfigureAwait(false);
         return true;
     }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -802,7 +802,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         var application = new DistributedApplication(_innerBuilder.Build());
 
-        _executionContextOptions.ServiceProvider = application.Services.GetRequiredService<IServiceProvider>();
+        _executionContextOptions.Services = application.Services.GetRequiredService<IServiceProvider>();
 
         LogAppBuilt(application);
         ProfilingTelemetry.RecordAppHostStartupEvent(ProfilingTelemetry.Events.AppHostBuildCompleted, _innerBuilder.Configuration);

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
@@ -59,7 +59,14 @@ public class DistributedApplicationExecutionContext
     /// The <see cref="IServiceProvider"/> for the AppHost.
     /// </summary>
     /// <exception cref="InvalidOperationException" accessor="get">Thrown when the <see cref="IServiceProvider"/> is not available.</exception>
-    public IServiceProvider ServiceProvider
+    [Obsolete("Use Services instead.")]
+    public IServiceProvider ServiceProvider => Services;
+
+    /// <summary>
+    /// The <see cref="IServiceProvider"/> for the AppHost.
+    /// </summary>
+    /// <exception cref="InvalidOperationException" accessor="get">Thrown when the <see cref="IServiceProvider"/> is not available.</exception>
+    public IServiceProvider Services
     {
         get
         {
@@ -68,7 +75,7 @@ public class DistributedApplicationExecutionContext
                 throw new InvalidOperationException("IServiceProvider is not available because execution context was not constructed with DistributedApplicationExecutionContextOptions.");
             }
 
-            if (options.ServiceProvider is not { } serviceProvider)
+            if (options.Services is not { } serviceProvider)
             {
                 throw new InvalidOperationException("IServiceProvider is not available because the container has not yet been built.");
             }

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContextOptions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContextOptions.cs
@@ -33,7 +33,17 @@ public class DistributedApplicationExecutionContextOptions
     /// <summary>
     /// The <see cref="IServiceProvider"/> for the AppHost.
     /// </summary>
-    public IServiceProvider? ServiceProvider { get; set; }
+    [Obsolete("Use Services instead.")]
+    public IServiceProvider? ServiceProvider
+    {
+        get => Services;
+        set => Services = value;
+    }
+
+    /// <summary>
+    /// The <see cref="IServiceProvider"/> for the AppHost.
+    /// </summary>
+    public IServiceProvider? Services { get; set; }
 
     /// <summary>
     /// The operation currently being performed by the AppHost.

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -106,7 +106,7 @@ internal record QueueLoadOptions(
     CancellationToken CancellationToken,
     InteractionInput Input,
     InteractionInputCollection AllInputs,
-    IServiceProvider ServiceProvider);
+    IServiceProvider Services);
 
 internal sealed class InputLoadingState(InputLoadOptions options)
 {
@@ -173,7 +173,7 @@ internal sealed class InputLoadingState(InputLoadOptions options)
                 {
                     AllInputs = options.AllInputs,
                     Input = options.Input,
-                    Services = options.ServiceProvider,
+                    Services = options.Services,
                     CancellationToken = currentToken
                 }).ConfigureAwait(false);
                 lock (_lock)

--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -194,7 +194,7 @@ public static class OtlpConfigurationExtensions
         DistributedApplicationModel? model;
         try
         {
-            model = context.ExecutionContext.ServiceProvider.GetService<DistributedApplicationModel>();
+            model = context.ExecutionContext.Services.GetService<DistributedApplicationModel>();
         }
         catch (InvalidOperationException)
         {

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -493,7 +493,7 @@ public static class ProjectResourceBuilderExtensions
             if (ctx.Scope != CertificateTrustScope.None && OperatingSystem.IsWindows())
             {
                 // Log if the user attempts to enable certificate trust customization on Windows for .NET projects.
-                var resourceLogger = ctx.ExecutionContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+                var resourceLogger = ctx.ExecutionContext.Services.GetRequiredService<ResourceLoggerService>();
                 var logger = resourceLogger.GetLogger(builder.Resource);
                 logger.LogWarning("Certificate trust scope is set to '{Scope}', but the feature is not supported for .NET projects on Windows. No certificate trust customization will be applied. Set the certificate trust scope to 'None' to disable this warning.", Enum.GetName(ctx.Scope));
                 return Task.CompletedTask;

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -378,7 +378,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 var resourceDockerfilePath = Path.Combine(manifestDirectory, $"{container.Name}.Dockerfile");
                 var dockerfileContext = new DockerfileFactoryContext
                 {
-                    Services = ExecutionContext.ServiceProvider,
+                    Services = ExecutionContext.Services,
                     Resource = container,
                     CancellationToken = CancellationToken
                 };

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -3296,7 +3296,7 @@ public static class ResourceBuilderExtensions
     internal static async Task<ExecuteCommandResult> ExecuteProcessCommandAsync(ExecuteCommandContext context, ProcessCommandSpec processCommandSpec, ProcessCommandOptions commandOptions)
     {
         var processSpec = CreateProcessSpec(context, processCommandSpec, commandOptions);
-        var processRunner = context.ServiceProvider.GetRequiredService<IProcessRunner>();
+        var processRunner = context.Services.GetRequiredService<IProcessRunner>();
         var (pendingProcessResult, processDisposable) = processRunner.Run(processSpec);
 
         await using (processDisposable.ConfigureAwait(false))
@@ -3477,7 +3477,7 @@ public static class ResourceBuilderExtensions
         {
             var resultContext = new ProcessCommandResultContext
             {
-                ServiceProvider = context.ServiceProvider,
+                Services = context.Services,
                 ResourceName = context.ResourceName,
                 Logger = context.Logger,
                 CancellationToken = context.CancellationToken,
@@ -3724,13 +3724,13 @@ public static class ResourceBuilderExtensions
                     return new ExecuteCommandResult { Success = false, Message = "Endpoints are not yet allocated." };
                 }
                 var uri = new UriBuilder(endpoint.Url) { Path = path }.Uri;
-                var httpClient = context.ServiceProvider.GetRequiredService<IHttpClientFactory>().CreateClient(commandOptions.HttpClientName ?? Options.DefaultName);
+                var httpClient = context.Services.GetRequiredService<IHttpClientFactory>().CreateClient(commandOptions.HttpClientName ?? Options.DefaultName);
                 var request = new HttpRequestMessage(commandOptions.Method, uri);
                 if (commandOptions.PrepareRequest is not null)
                 {
                     var requestContext = new HttpCommandRequestContext
                     {
-                        ServiceProvider = context.ServiceProvider,
+                        Services = context.Services,
                         ResourceName = context.ResourceName,
                         Endpoint = endpoint,
                         CancellationToken = context.CancellationToken,
@@ -3748,7 +3748,7 @@ public static class ResourceBuilderExtensions
                     {
                         var resultContext = new HttpCommandResultContext
                         {
-                            ServiceProvider = context.ServiceProvider,
+                            Services = context.Services,
                             ResourceName = context.ResourceName,
                             Endpoint = endpoint,
                             CancellationToken = context.CancellationToken,

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
@@ -352,7 +352,7 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         var configAnnotation = eventHubsEmulatorResource.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
 
         Assert.Equal("/Eventhubs_Emulator/ConfigFiles", configAnnotation.DestinationPath);
-        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = eventHubsEmulatorResource, ServiceProvider = app.Services }, CancellationToken.None);
+        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = eventHubsEmulatorResource, Services = app.Services }, CancellationToken.None);
         var configFile = Assert.IsType<ContainerFile>(Assert.Single(configFiles));
         Assert.Equal("Config.json", configFile.Name);
 
@@ -413,7 +413,7 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         var configAnnotation = eventHubsEmulatorResource.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
 
         Assert.Equal("/Eventhubs_Emulator/ConfigFiles", configAnnotation.DestinationPath);
-        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = eventHubsEmulatorResource, ServiceProvider = app.Services }, CancellationToken.None);
+        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = eventHubsEmulatorResource, Services = app.Services }, CancellationToken.None);
         var configFile = Assert.IsType<ContainerFile>(Assert.Single(configFiles));
         Assert.Equal("Config.json", configFile.Name);
 
@@ -487,7 +487,7 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         var configAnnotation = eventHubsEmulatorResource.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
 
         Assert.Equal("/Eventhubs_Emulator/ConfigFiles", configAnnotation.DestinationPath);
-        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = eventHubsEmulatorResource, ServiceProvider = app.Services }, CancellationToken.None);
+        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = eventHubsEmulatorResource, Services = app.Services }, CancellationToken.None);
         var configFile = Assert.IsType<ContainerFile>(Assert.Single(configFiles));
         Assert.Equal("Config.json", configFile.Name);
         Assert.Equal(configJsonPath, configFile.SourcePath);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -369,7 +369,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var configAnnotation = serviceBusEmulatorResource.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
 
         Assert.Equal("/ServiceBus_Emulator/ConfigFiles", configAnnotation.DestinationPath);
-        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = serviceBusEmulatorResource, ServiceProvider = app.Services }, CancellationToken.None);
+        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = serviceBusEmulatorResource, Services = app.Services }, CancellationToken.None);
         var configFile = Assert.IsType<ContainerFile>(Assert.Single(configFiles));
         Assert.Equal("Config.json", configFile.Name);
 
@@ -468,7 +468,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var configAnnotation = serviceBusEmulatorResource.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
 
         Assert.Equal("/ServiceBus_Emulator/ConfigFiles", configAnnotation.DestinationPath);
-        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = serviceBusEmulatorResource, ServiceProvider = app.Services }, CancellationToken.None);
+        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = serviceBusEmulatorResource, Services = app.Services }, CancellationToken.None);
         var configFile = Assert.IsType<ContainerFile>(Assert.Single(configFiles));
         Assert.Equal("Config.json", configFile.Name);
 
@@ -524,7 +524,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var configAnnotation = serviceBusEmulatorResource.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
 
         Assert.Equal("/ServiceBus_Emulator/ConfigFiles", configAnnotation.DestinationPath);
-        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = serviceBusEmulatorResource, ServiceProvider = app.Services }, CancellationToken.None);
+        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = serviceBusEmulatorResource, Services = app.Services }, CancellationToken.None);
         var configFile = Assert.IsType<ContainerFile>(Assert.Single(configFiles));
         Assert.Equal("Config.json", configFile.Name);
 
@@ -583,7 +583,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var configAnnotation = serviceBusEmulatorResource.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
 
         Assert.Equal("/ServiceBus_Emulator/ConfigFiles", configAnnotation.DestinationPath);
-        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = serviceBusEmulatorResource, ServiceProvider = app.Services }, CancellationToken.None);
+        var configFiles = await configAnnotation.Callback(new ContainerFileSystemCallbackContext { Model = serviceBusEmulatorResource, Services = app.Services }, CancellationToken.None);
         var configFile = Assert.IsType<ContainerFile>(Assert.Single(configFiles));
         Assert.Equal("Config.json", configFile.Name);
 

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -9273,6 +9273,7 @@ type DistributedApplicationExecutionContext interface {
 	Operation() (DistributedApplicationOperation, error)
 	PublisherName() (string, error)
 	ServiceProvider() ServiceProvider
+	Services() ServiceProvider
 	SetPublisherName(value string) DistributedApplicationExecutionContext
 	Err() error
 }
@@ -9361,6 +9362,25 @@ func (s *distributedApplicationExecutionContext) ServiceProvider() ServiceProvid
 	href, ok := result.(handleReference)
 	if !ok {
 		err := fmt.Errorf("aspire: Aspire.Hosting/DistributedApplicationExecutionContext.serviceProvider returned unexpected type %T", result)
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// Services the `IServiceProvider` for the AppHost.
+func (s *distributedApplicationExecutionContext) Services() ServiceProvider {
+	if s.err != nil { return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/DistributedApplicationExecutionContext.services", reqArgs)
+	if err != nil {
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting/DistributedApplicationExecutionContext.services returned unexpected type %T", result)
 		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
 	}
 	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -6899,6 +6899,14 @@ public class DistributedApplicationExecutionContext extends HandleWrapperBase {
         return (IServiceProvider) result;
     }
 
+    /** The `IServiceProvider` for the AppHost. */
+    public IServiceProvider services() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting/DistributedApplicationExecutionContext.services", reqArgs);
+        return (IServiceProvider) result;
+    }
+
     /** Returns true if the current operation is publishing. */
     public boolean isPublishMode() {
         Map<String, Object> reqArgs = new HashMap<>();

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -3854,6 +3854,15 @@ class DistributedApplicationExecutionContext:
         return typing.cast(AbstractServiceProvider, result)
 
     @_cached_property
+    def services(self) -> AbstractServiceProvider:
+        """The `IServiceProvider` for the AppHost."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/DistributedApplicationExecutionContext.services',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractServiceProvider, result)
+
+    @_cached_property
     def is_publish_mode(self) -> bool:
         """Returns true if the current operation is publishing."""
         result = self._client.invoke_capability(

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -5485,6 +5485,15 @@ impl DistributedApplicationExecutionContext {
         Ok(IServiceProvider::new(handle, self.client.clone()))
     }
 
+    /// The `IServiceProvider` for the AppHost.
+    pub fn services(&self) -> Result<IServiceProvider, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/DistributedApplicationExecutionContext.services", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IServiceProvider::new(handle, self.client.clone()))
+    }
+
     /// Returns true if the current operation is publishing.
     pub fn is_publish_mode(&self) -> Result<bool, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -2842,6 +2842,8 @@ export interface DistributedApplicationExecutionContext {
     operation(): Promise<DistributedApplicationOperation>;
     /** The `IServiceProvider` for the AppHost. */
     serviceProvider(): ServiceProviderPromise;
+    /** The `IServiceProvider` for the AppHost. */
+    services(): ServiceProviderPromise;
     /** Returns true if the current operation is publishing. */
     isPublishMode(): Promise<boolean>;
     /** Returns true if the current operation is running. */
@@ -2853,6 +2855,8 @@ export interface DistributedApplicationExecutionContextPromise extends PromiseLi
     operation(): Promise<DistributedApplicationOperation>;
     /** The `IServiceProvider` for the AppHost. */
     serviceProvider(): ServiceProviderPromise;
+    /** The `IServiceProvider` for the AppHost. */
+    services(): ServiceProviderPromise;
     /** Returns true if the current operation is publishing. */
     isPublishMode(): Promise<boolean>;
     /** Returns true if the current operation is running. */
@@ -2903,6 +2907,17 @@ class DistributedApplicationExecutionContextImpl implements DistributedApplicati
         return new ServiceProviderPromiseImpl(promise, this._client, false);
     }
 
+    services(): ServiceProviderPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IServiceProviderHandle>(
+                'Aspire.Hosting/DistributedApplicationExecutionContext.services',
+                { context: this._handle }
+            );
+            return new ServiceProviderImpl(handle, this._client);
+        })();
+        return new ServiceProviderPromiseImpl(promise, this._client, false);
+    }
+
     async isPublishMode(): Promise<boolean> {
         return await this._client.invokeCapability<boolean>(
             'Aspire.Hosting/DistributedApplicationExecutionContext.isPublishMode',
@@ -2940,6 +2955,10 @@ class DistributedApplicationExecutionContextPromiseImpl implements DistributedAp
 
     serviceProvider(): ServiceProviderPromise {
         return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.serviceProvider()), this._client, false);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
     }
 
     isPublishMode(): Promise<boolean> {

--- a/tests/Aspire.Hosting.EntityFrameworkCore.Tests/EFMigrationCommandsTests.cs
+++ b/tests/Aspire.Hosting.EntityFrameworkCore.Tests/EFMigrationCommandsTests.cs
@@ -209,7 +209,7 @@ public class EFMigrationCommandsTests
             var state = command.UpdateState(new UpdateCommandStateContext
             {
                 ResourceSnapshot = snapshot,
-                ServiceProvider = builder.Services.BuildServiceProvider()
+                Services = builder.Services.BuildServiceProvider()
             });
             Assert.Equal(ResourceCommandState.Enabled, state);
         }
@@ -239,7 +239,7 @@ public class EFMigrationCommandsTests
             var state = command.UpdateState(new UpdateCommandStateContext
             {
                 ResourceSnapshot = snapshot,
-                ServiceProvider = builder.Services.BuildServiceProvider()
+                Services = builder.Services.BuildServiceProvider()
             });
             Assert.Equal(ResourceCommandState.Disabled, state);
         }
@@ -270,7 +270,7 @@ public class EFMigrationCommandsTests
             var state = command.UpdateState(new UpdateCommandStateContext
             {
                 ResourceSnapshot = snapshot,
-                ServiceProvider = builder.Services.BuildServiceProvider()
+                Services = builder.Services.BuildServiceProvider()
             });
             Assert.Equal(ResourceCommandState.Disabled, state);
         }
@@ -290,7 +290,7 @@ public class EFMigrationCommandsTests
             var state = command.UpdateState(new UpdateCommandStateContext
             {
                 ResourceSnapshot = snapshot,
-                ServiceProvider = builder.Services.BuildServiceProvider()
+                Services = builder.Services.BuildServiceProvider()
             });
             Assert.Equal(ResourceCommandState.Enabled, state);
         }

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakPublicApiTests.cs
@@ -162,7 +162,7 @@ public class KeycloakPublicApiTests
 
         var containerAnnotation = keycloak.Resource.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
 
-        var entries = await containerAnnotation.Callback(new() { Model = keycloakResource, ServiceProvider = app.Services }, CancellationToken.None);
+        var entries = await containerAnnotation.Callback(new() { Model = keycloakResource, Services = app.Services }, CancellationToken.None);
 
         Assert.Equal("/opt/keycloak/data/import", containerAnnotation.DestinationPath);
     }
@@ -187,7 +187,7 @@ public class KeycloakPublicApiTests
 
         var containerAnnotation = keycloak.Resource.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
 
-        var entries = await containerAnnotation.Callback(new() { Model = keycloakResource, ServiceProvider = app.Services }, CancellationToken.None);
+        var entries = await containerAnnotation.Callback(new() { Model = keycloakResource, Services = app.Services }, CancellationToken.None);
 
         Assert.Equal("/opt/keycloak/data/import", containerAnnotation.DestinationPath);
         var realmFile = Assert.IsType<ContainerFile>(Assert.Single(entries));

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -499,7 +499,7 @@ public class AddPostgresTests
         Assert.Null(createServers.DefaultOwner);
         Assert.Null(createServers.DefaultGroup);
 
-        var entries = await createServers.Callback(new() { Model = pgadmin, ServiceProvider = app.Services }, CancellationToken.None);
+        var entries = await createServers.Callback(new() { Model = pgadmin, Services = app.Services }, CancellationToken.None);
 
         var serversFile = Assert.IsType<ContainerFile>(entries.First());
         Assert.NotNull(serversFile.Contents);
@@ -563,7 +563,7 @@ public class AddPostgresTests
         Assert.Null(createBookmarks.DefaultOwner);
         Assert.Null(createBookmarks.DefaultGroup);
 
-        var entries = await createBookmarks.Callback(new() { Model = pgweb, ServiceProvider = app.Services }, CancellationToken.None);
+        var entries = await createBookmarks.Callback(new() { Model = pgweb, Services = app.Services }, CancellationToken.None);
 
         var pgWebDirectory = Assert.IsType<ContainerDirectory>(entries.First());
         Assert.Equal(".pgweb", pgWebDirectory.Name);

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
@@ -150,7 +150,7 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
 
         var context = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)
         {
-            ServiceProvider = new TestServiceProvider().AddService(model)
+            Services = new TestServiceProvider().AddService(model)
         });
         var dashboardEnvironment = await ExecutionConfigurationBuilder.Create(dashboardResource)
             .WithEnvironmentVariablesConfig()
@@ -194,7 +194,7 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
 
         var context = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)
         {
-            ServiceProvider = new TestServiceProvider().AddService(model)
+            Services = new TestServiceProvider().AddService(model)
         });
         // Act
         await hook.ConfigureEnvironmentVariables(new EnvironmentCallbackContext(context, environmentVariables: envVars, resource: dashboardResource));
@@ -664,7 +664,7 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
             .AddService<IDeveloperCertificateService>(new TestDeveloperCertificateService([], supportsContainerTrust: true, trustCertificate: true, tlsTerminate: true));
         var executionContext = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)
         {
-            ServiceProvider = executionContextServiceProvider
+            Services = executionContextServiceProvider
         });
 
         return new DashboardEventHandlers(

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -4842,7 +4842,7 @@ public class DcpExecutorTests
         var nameGenerator = new DcpNameGenerator(configuration, Options.Create(dcpOptions));
         var executionContext = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)
             {
-                ServiceProvider = new TestServiceProvider(configuration)
+                Services = new TestServiceProvider(configuration)
                     .AddService<IDeveloperCertificateService>(developerCertificateService)
                     .AddService(distributedAppModel)
                     .AddService(Options.Create(dcpOptions))

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -526,7 +526,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         resourceLoggerService ??= new ResourceLoggerService();
 
         var executionContext = new DistributedApplicationExecutionContext(
-            new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { ServiceProvider = serviceProvider });
+            new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { Services = serviceProvider });
 
         return new ApplicationOrchestrator(
             distributedAppModel,

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -788,7 +788,7 @@ public class ParameterProcessorTests
                {
                    // This should not throw InvalidOperationException
                    // when using the proper execution context constructor
-                   var sp = context.ExecutionContext.ServiceProvider;
+                   var sp = context.ExecutionContext.Services;
                    serviceProviderAccessed = sp is not null;
                    context.EnvironmentVariables["TEST_ENV"] = param;
                });
@@ -1292,7 +1292,7 @@ public class ParameterProcessorTests
         var executionContext = new DistributedApplicationExecutionContext(
             new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Publish, "manifest")
             {
-                ServiceProvider = serviceProvider
+                Services = serviceProvider
             });
 
         var parameterProcessor = CreateParameterProcessor(executionContext: executionContext);

--- a/tests/Aspire.Hosting.Tests/ResourceCommandAnnotationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandAnnotationTests.cs
@@ -64,7 +64,7 @@ public class ResourceCommandAnnotationTests
                 ResourceType = "test",
                 State = resourceState
             },
-            ServiceProvider = new ServiceCollection().BuildServiceProvider()
+            Services = new ServiceCollection().BuildServiceProvider()
         });
 
         // Assert
@@ -144,7 +144,7 @@ public class ResourceCommandAnnotationTests
                 ResourceType = "test",
                 State = resourceState
             },
-            ServiceProvider = new ServiceCollection().BuildServiceProvider()
+            Services = new ServiceCollection().BuildServiceProvider()
         });
 
         Assert.Equal(commandState, state);

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -1336,7 +1336,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
                 displayName: "My command",
                 executeCommand: e =>
                 {
-                    var interactionService = e.ServiceProvider.GetRequiredService<IInteractionService>();
+                    var interactionService = e.Services.GetRequiredService<IInteractionService>();
                     isAvailableDuringExecution = interactionService.IsAvailable;
                     return Task.FromResult(CommandResults.Success());
                 });
@@ -1366,7 +1366,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
                 displayName: "My command",
                 executeCommand: e =>
                 {
-                    var interactionService = e.ServiceProvider.GetRequiredService<IInteractionService>();
+                    var interactionService = e.Services.GetRequiredService<IInteractionService>();
                     isAvailableDuringExecution = interactionService.IsAvailable;
                     return Task.FromResult(CommandResults.Success());
                 });

--- a/tests/Aspire.Hosting.Tests/ResourceDependencyTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceDependencyTests.cs
@@ -89,7 +89,7 @@ public class ResourceDependencyTests
         var executionContext = new DistributedApplicationExecutionContext(
             new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)
             {
-                ServiceProvider = serviceProvider
+                Services = serviceProvider
             });
 
         var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);

--- a/tests/Aspire.Hosting.Tests/Utils/ArgumentEvaluator.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/ArgumentEvaluator.cs
@@ -13,7 +13,7 @@ public sealed class ArgumentEvaluator
         var executionContext = new DistributedApplicationExecutionContext(
             new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)
             {
-                ServiceProvider = serviceProvider,
+                Services = serviceProvider,
             });
 
         var executionConfiguration = await ExecutionConfigurationBuilder.Create(resource)

--- a/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
@@ -15,7 +15,7 @@ public static class EnvironmentVariableEvaluator
     {
         var executionContext = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(applicationOperation)
         {
-            ServiceProvider = serviceProvider
+            Services = serviceProvider
         });
 
         var executionConfiguration = await ExecutionConfigurationBuilder.Create(resource)

--- a/tests/Aspire.Hosting.Tests/Utils/ManifestUtils.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/ManifestUtils.cs
@@ -28,7 +28,7 @@ public sealed class ManifestUtils
         var options = new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Publish);
         var executionContext = new DistributedApplicationExecutionContext(options);
         serviceCollection.AddSingleton(executionContext);
-        options.ServiceProvider = serviceCollection.BuildServiceProvider();
+        options.Services = serviceCollection.BuildServiceProvider();
         
         writer.WriteStartObject();
         var context = new ManifestPublishingContext(executionContext, Path.Combine(manifestDirectory, "manifest.json"), writer);
@@ -50,7 +50,7 @@ public sealed class ManifestUtils
         var writer = new Utf8JsonWriter(ms, new() { Indented = true });
         var options = new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Publish)
         {
-            ServiceProvider = new ServiceCollection().BuildServiceProvider()
+            Services = new ServiceCollection().BuildServiceProvider()
         };
         var executionContext = new DistributedApplicationExecutionContext(options);
         var context = new ManifestPublishingContext(executionContext, Path.Combine(manifestDirectory, "manifest.json"), writer);
@@ -69,7 +69,7 @@ public sealed class ManifestUtils
         var writer = new Utf8JsonWriter(ms);
         var options = new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Publish)
         {
-            ServiceProvider = new ServiceCollection().BuildServiceProvider()
+            Services = new ServiceCollection().BuildServiceProvider()
         };
         var executionContext = new DistributedApplicationExecutionContext(options);
         var context = new ManifestPublishingContext(executionContext, Path.Combine(Environment.CurrentDirectory, "manifest.json"), writer);

--- a/tests/Aspire.Hosting.Tests/WithCertificateAuthorityCollection.cs
+++ b/tests/Aspire.Hosting.Tests/WithCertificateAuthorityCollection.cs
@@ -21,7 +21,7 @@ public class WithCertificateAuthorityCollectionTests
                                {
                                    Assert.NotNull(context.Resource);
 
-                                   var sp = context.ExecutionContext.ServiceProvider;
+                                   var sp = context.ExecutionContext.Services;
                                    context.EnvironmentVariables["SP_AVAILABLE"] = sp is not null ? "true" : "false";
                                })
                                .WithCertificateAuthorityCollection(bundle1)

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -21,7 +21,7 @@ public class WithEnvironmentTests
                                {
                                    Assert.NotNull(context.Resource);
 
-                                   var sp = context.ExecutionContext.ServiceProvider;
+                                   var sp = context.ExecutionContext.Services;
                                    context.EnvironmentVariables["SP_AVAILABLE"] = sp is not null ? "true" : "false";
                                });
 

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -583,7 +583,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
                 PrepareRequest = requestContext =>
                 {
                     Assert.NotNull(requestContext);
-                    Assert.NotNull(requestContext.ServiceProvider);
+                    Assert.NotNull(requestContext.Services);
                     Assert.Equal(service.Resource.Name, requestContext.ResourceName);
                     Assert.NotNull(requestContext.Endpoint);
                     Assert.NotNull(requestContext.HttpClient);
@@ -627,7 +627,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
                 GetCommandResult = resultContext =>
                 {
                     Assert.NotNull(resultContext);
-                    Assert.NotNull(resultContext.ServiceProvider);
+                    Assert.NotNull(resultContext.Services);
                     Assert.Equal(service.Resource.Name, resultContext.ResourceName);
                     Assert.NotNull(resultContext.Endpoint);
                     Assert.NotNull(resultContext.HttpClient);

--- a/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
@@ -389,7 +389,7 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
         Assert.Contains("hello-from-argument", result.Data?.Value);
         Assert.NotNull(capturedContext);
         Assert.Equal(resource.Resource.Name, capturedContext.ResourceName);
-        Assert.NotNull(capturedContext.ServiceProvider);
+        Assert.NotNull(capturedContext.Services);
         Assert.Equal("hello-from-argument", capturedContext.Arguments.GetString("message"));
         Assert.NotNull(capturedContext.Logger);
 
@@ -799,7 +799,7 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
         Assert.NotNull(capturedContext);
         Assert.Equal(42, capturedContext.ExitCode);
         Assert.Equal(resource.Resource.Name, capturedContext.ResourceName);
-        Assert.NotNull(capturedContext.ServiceProvider);
+        Assert.NotNull(capturedContext.Services);
         Assert.NotNull(capturedContext.Logger);
         Assert.Equal(["custom-argument"], capturedContext.ProcessCommandSpec.Arguments);
         Assert.Equal(["{\"status\":\"custom\"}", "diagnostic-line"], capturedContext.Output);

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -114,7 +114,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
             {
                 try
                 {
-                    tcs.TrySetResult(c.ExecutionContext.ServiceProvider);
+                    tcs.TrySetResult(c.ExecutionContext.Services);
                 }
                 catch (InvalidOperationException ex)
                 {


### PR DESCRIPTION
## Description

Renames the `ServiceProvider` property to `Services` on all hosting context types for consistency with existing patterns (e.g., `BeforeStartEvent.Services`, `DistributedApplication.Services`).

The `ServiceProvider` property is marked `[Obsolete("Use Services instead.")]` on all public context types to preserve backward compatibility. A new `Services` property is added as the preferred replacement. Internal types are renamed directly without the obsolete shim.

### Affected types

- `UpdateCommandStateContext`
- `ExecuteCommandContext`
- `ContainerFileSystemCallbackContext`
- `HttpCommandRequestContext`
- `HttpCommandResultContext`
- `ProcessCommandResultContext`
- `DistributedApplicationExecutionContext`
- `DistributedApplicationExecutionContextOptions`
- `ContainerAppEnvironmentContext` (internal, renamed directly)
- `AzureAppServiceEnvironmentContext` (internal, renamed directly)

### User-facing usage

Consumers should migrate from:
```csharp
executeCommand: async context =>
{
    var orchestrator = context.ServiceProvider.GetRequiredService<ApplicationOrchestrator>();
}
```

To:
```csharp
executeCommand: async context =>
{
    var orchestrator = context.Services.GetRequiredService<ApplicationOrchestrator>();
}
```

### Breaking changes

This obsoletes the `ServiceProvider` property on several public context types. Existing code continues to compile with an obsolete warning. No source break occurs unless `TreatWarningsAsErrors` is enabled for the obsolete diagnostic.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
