### PR TITLE
Fix stale AppHost backchannel sockets blocking CLI commands

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -135,9 +135,15 @@ internal sealed class AppHostConnectionResolver(
             }
 
             var targetPath = projectFile.FullName;
-            var matchingSockets = AppHostHelper.FindMatchingSockets(
+            var matchingSockets = AppHostHelper.FindMatchingNonOrphanedSockets(
                 targetPath,
-                executionContext.HomeDirectory.FullName);
+                executionContext.HomeDirectory.FullName,
+                Environment.ProcessId,
+                out var orphanedSocketsDeleted);
+            if (orphanedSocketsDeleted > 0)
+            {
+                logger.LogDebug("Cleaned up {Count} orphaned socket(s) while resolving AppHost connection.", orphanedSocketsDeleted);
+            }
 
             // Try each matching socket until we get a connection
             foreach (var socketPath in matchingSockets)

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -139,11 +139,7 @@ internal sealed class AppHostConnectionResolver(
                 targetPath,
                 executionContext.HomeDirectory.FullName,
                 Environment.ProcessId,
-                out var orphanedSocketsDeleted);
-            if (orphanedSocketsDeleted > 0)
-            {
-                logger.LogDebug("Cleaned up {Count} orphaned socket(s) while resolving AppHost connection.", orphanedSocketsDeleted);
-            }
+                logger);
 
             // Try each matching socket until we get a connection
             foreach (var socketPath in matchingSockets)

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -233,11 +233,7 @@ internal sealed class AppHostLauncher(
             effectiveAppHostFile.FullName,
             executionContext.HomeDirectory.FullName,
             Environment.ProcessId,
-            out var orphanedSocketsDeleted);
-        if (orphanedSocketsDeleted > 0)
-        {
-            logger.LogDebug("Cleaned up {Count} orphaned socket(s) before stopping running AppHost instances.", orphanedSocketsDeleted);
-        }
+            logger);
 
         if (existingSockets.Length > 0)
         {

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -229,9 +229,15 @@ internal sealed class AppHostLauncher(
 
     private async Task StopExistingInstancesAsync(FileInfo effectiveAppHostFile, CancellationToken cancellationToken)
     {
-        var existingSockets = AppHostHelper.FindMatchingSockets(
+        var existingSockets = AppHostHelper.FindMatchingNonOrphanedSockets(
             effectiveAppHostFile.FullName,
-            executionContext.HomeDirectory.FullName);
+            executionContext.HomeDirectory.FullName,
+            Environment.ProcessId,
+            out var orphanedSocketsDeleted);
+        if (orphanedSocketsDeleted > 0)
+        {
+            logger.LogDebug("Cleaned up {Count} orphaned socket(s) before stopping running AppHost instances.", orphanedSocketsDeleted);
+        }
 
         if (existingSockets.Length > 0)
         {

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -1168,7 +1168,15 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     /// <inheritdoc />
     public async Task<RunningInstanceResult> FindAndStopRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken)
     {
-        var matchingSockets = AppHostHelper.FindMatchingSockets(appHostFile.FullName, homeDirectory.FullName);
+        var matchingSockets = AppHostHelper.FindMatchingNonOrphanedSockets(
+            appHostFile.FullName,
+            homeDirectory.FullName,
+            Environment.ProcessId,
+            out var orphanedSocketsDeleted);
+        if (orphanedSocketsDeleted > 0)
+        {
+            _logger.LogDebug("Cleaned up {Count} orphaned socket(s) before stopping running AppHost instances.", orphanedSocketsDeleted);
+        }
 
         // Check if any socket files exist
         if (matchingSockets.Length == 0)

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -1172,11 +1172,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             appHostFile.FullName,
             homeDirectory.FullName,
             Environment.ProcessId,
-            out var orphanedSocketsDeleted);
-        if (orphanedSocketsDeleted > 0)
-        {
-            _logger.LogDebug("Cleaned up {Count} orphaned socket(s) before stopping running AppHost instances.", orphanedSocketsDeleted);
-        }
+            _logger);
 
         // Check if any socket files exist
         if (matchingSockets.Length == 0)

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1489,11 +1489,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             genericAppHostPath,
             homeDirectory.FullName,
             Environment.ProcessId,
-            out var orphanedSocketsDeleted);
-        if (orphanedSocketsDeleted > 0)
-        {
-            _logger.LogDebug("Cleaned up {Count} orphaned socket(s) before stopping running AppHost instances.", orphanedSocketsDeleted);
-        }
+            _logger);
 
         // Check if any socket files exist
         if (matchingSockets.Length == 0)

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1485,7 +1485,15 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         var genericAppHostPath = appHostServerProject.GetInstanceIdentifier();
 
         // Find matching sockets for this AppHost
-        var matchingSockets = AppHostHelper.FindMatchingSockets(genericAppHostPath, homeDirectory.FullName);
+        var matchingSockets = AppHostHelper.FindMatchingNonOrphanedSockets(
+            genericAppHostPath,
+            homeDirectory.FullName,
+            Environment.ProcessId,
+            out var orphanedSocketsDeleted);
+        if (orphanedSocketsDeleted > 0)
+        {
+            _logger.LogDebug("Cleaned up {Count} orphaned socket(s) before stopping running AppHost instances.", orphanedSocketsDeleted);
+        }
 
         // Check if any socket files exist
         if (matchingSockets.Length == 0)

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Hosting.Backchannel;
+using Microsoft.Extensions.Logging;
 using Semver;
 
 namespace Aspire.Cli.Utils;
@@ -132,10 +133,20 @@ internal static class AppHostHelper
     /// <summary>
     /// Finds matching socket files and deletes PID-qualified sockets whose owning process has exited.
     /// </summary>
-    internal static string[] FindMatchingNonOrphanedSockets(string appHostPath, string homeDirectory, int currentPid, out int deletedCount)
+    internal static string[] FindMatchingNonOrphanedSockets(
+        string appHostPath,
+        string homeDirectory,
+        int currentPid,
+        ILogger logger)
     {
         var matchingSockets = BackchannelConstants.FindMatchingSockets(appHostPath, homeDirectory);
-        return PruneOrphanedSockets(matchingSockets, currentPid, out deletedCount);
+        var remainingSockets = PruneOrphanedSockets(matchingSockets, currentPid, out var deletedCount);
+        if (deletedCount > 0)
+        {
+            logger.LogDebug("Cleaned up {Count} orphaned AppHost socket(s).", deletedCount);
+        }
+
+        return remainingSockets;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -151,22 +151,23 @@ internal static class AppHostHelper
             var pid = BackchannelConstants.ExtractPid(socketPath);
             if (pid is { } pidValue && pidValue != currentPid && !BackchannelConstants.ProcessExists(pidValue))
             {
-                try
+                if (!BackchannelConstants.ProcessExists(pidValue))
                 {
                     // Socket names include the owning PID in the compact/current legacy formats:
                     //   {appHostId}{instanceId}.{pid}
                     //   auxi.sock.{hash}.{instanceHash}.{pid}
                     // After a crash or reboot these files can remain, and connecting to them
                     // reports "connection refused" even though there is no AppHost to stop.
-                    if (!BackchannelConstants.ProcessExists(pidValue))
+                    try
                     {
                         File.Delete(socketPath);
                         deletedCount++;
-                        continue;
                     }
-                }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-                {
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                    {
+                    }
+
+                    continue;
                 }
             }
 

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -105,7 +105,7 @@ internal static class AppHostHelper
     /// Since socket names now include a randomized instance ID and the AppHost's PID
     /// (e.g., <c>{appHostId}{instanceId}.{pid}</c>),
     /// the CLI cannot compute the exact socket path. Use this prefix with a glob pattern
-    /// to find matching sockets, or use <see cref="FindMatchingSockets"/> instead.
+    /// to find matching sockets, or use <see cref="FindMatchingNonOrphanedSockets"/> instead.
     /// </remarks>
     /// <param name="appHostPath">The full path to the AppHost project file or assembly.</param>
     /// <param name="homeDirectory">The user's home directory.</param>
@@ -130,13 +130,51 @@ internal static class AppHostHelper
         => BackchannelConstants.ComputeLegacyHashes(appHostPath);
 
     /// <summary>
-    /// Finds all socket files matching the given AppHost path.
+    /// Finds matching socket files and deletes PID-qualified sockets whose owning process has exited.
     /// </summary>
-    /// <param name="appHostPath">The full path to the AppHost project file or assembly.</param>
-    /// <param name="homeDirectory">The user's home directory.</param>
-    /// <returns>An array of socket file paths, or empty if none found.</returns>
-    internal static string[] FindMatchingSockets(string appHostPath, string homeDirectory)
-        => BackchannelConstants.FindMatchingSockets(appHostPath, homeDirectory);
+    internal static string[] FindMatchingNonOrphanedSockets(string appHostPath, string homeDirectory, int currentPid, out int deletedCount)
+    {
+        var matchingSockets = BackchannelConstants.FindMatchingSockets(appHostPath, homeDirectory);
+        return PruneOrphanedSockets(matchingSockets, currentPid, out deletedCount);
+    }
+
+    /// <summary>
+    /// Deletes PID-qualified socket files whose owning process has exited and returns sockets that should still be probed.
+    /// </summary>
+    private static string[] PruneOrphanedSockets(string[] socketPaths, int currentPid, out int deletedCount)
+    {
+        deletedCount = 0;
+        var remainingSockets = new List<string>(socketPaths.Length);
+
+        foreach (var socketPath in socketPaths)
+        {
+            var pid = BackchannelConstants.ExtractPid(socketPath);
+            if (pid is { } pidValue && pidValue != currentPid && !BackchannelConstants.ProcessExists(pidValue))
+            {
+                try
+                {
+                    // Socket names include the owning PID in the compact/current legacy formats:
+                    //   {appHostId}{instanceId}.{pid}
+                    //   auxi.sock.{hash}.{instanceHash}.{pid}
+                    // After a crash or reboot these files can remain, and connecting to them
+                    // reports "connection refused" even though there is no AppHost to stop.
+                    if (!BackchannelConstants.ProcessExists(pidValue))
+                    {
+                        File.Delete(socketPath);
+                        deletedCount++;
+                        continue;
+                    }
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                }
+            }
+
+            remainingSockets.Add(socketPath);
+        }
+
+        return [.. remainingSockets];
+    }
 
     /// <summary>
     /// Extracts the hash portion from an auxiliary socket path.

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Backchannel;
@@ -49,6 +50,34 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
         Assert.Equal(
             string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.AppHostNotRunningAtPath, Path.Combine("TestAppHost", "TestAppHost.csproj")),
             result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ResolveConnectionAsync_WithExplicitProjectFile_DeletesDeadPidSocketAndReturnsNotRunning()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectFile = CreateProjectFile(workspace.WorkspaceRoot, "TestAppHost", "TestAppHost.csproj");
+        var socketPath = CreateMatchingSocketFile(projectFile.FullName, workspace.WorkspaceRoot, int.MaxValue - 1);
+        var resolver = new AppHostConnectionResolver(
+            new TestAuxiliaryBackchannelMonitor(),
+            new TestInteractionService(),
+            new TestProjectLocator(),
+            executionContext,
+            NullLogger.Instance);
+
+        var result = await resolver.ResolveConnectionAsync(
+            projectFile,
+            "Scanning",
+            "Select",
+            SharedCommandStrings.AppHostNotRunning,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(
+            string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.AppHostNotRunningAtPath, Path.Combine("TestAppHost", "TestAppHost.csproj")),
+            result.ErrorMessage);
+        Assert.False(File.Exists(socketPath));
     }
 
     [Fact]
@@ -140,5 +169,19 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
         var projectFile = new FileInfo(Path.Combine(directory.FullName, fileName));
         File.WriteAllText(projectFile.FullName, "<Project />");
         return projectFile;
+    }
+
+    private static string CreateMatchingSocketFile(string appHostPath, DirectoryInfo homeDirectory, int pid)
+    {
+        var backchannelsDir = Path.Combine(homeDirectory.FullName, ".aspire", "cli", "bch");
+        Directory.CreateDirectory(backchannelsDir);
+
+        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, homeDirectory.FullName);
+        var appHostId = Path.GetFileName(prefix);
+        var socketPath = Path.Combine(
+            backchannelsDir,
+            $"{appHostId}a1b2C3d4.{pid.ToString(CultureInfo.InvariantCulture)}");
+        File.WriteAllText(socketPath, "");
+        return socketPath;
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Diagnostics;
@@ -149,6 +150,35 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
         Assert.Equal(CliExitCodes.Success, result.ExitCode);
         Assert.Contains(RunCommandStrings.StartingAppHostInBackground, harness.InteractionService.DynamicStatusTexts);
         Assert.Empty(harness.InteractionService.DisplayedErrors);
+    }
+
+    [Fact]
+    public async Task LaunchDetachedAsync_DeletesDeadPidSocketBeforeStartingChildProcess()
+    {
+        using var harness = AppHostLauncherHarness.Create(outputHelper);
+        var socketPath = harness.CreateMatchingSocketFile(int.MaxValue - 1);
+        harness.AddConnection(new TestAppHostAuxiliaryBackchannel
+        {
+            SupportsV3 = true,
+            DashboardUrlsState = new DashboardUrlsState { BaseUrlWithLoginToken = "https://localhost:18888/login?t=test" },
+            WaitForAppHostReadyHandler = _ => Task.FromResult<WaitForAppHostReadyResponse?>(new WaitForAppHostReadyResponse { IsReady = true })
+        });
+        harness.ProcessLauncher.Mode = TestDetachedProcessLauncher.ChildProcessMode.StayAlive;
+
+        var result = await harness.Launcher.LaunchDetachedAsync(
+            harness.AppHostFile,
+            format: null,
+            isolated: false,
+            isExtensionHost: false,
+            waitForDebugger: false,
+            timeoutSeconds: 120,
+            globalArgs: [],
+            additionalArgs: [],
+            stopAfterLaunchDelay: null,
+            CancellationToken.None);
+
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        Assert.False(File.Exists(socketPath));
     }
 
     [Fact]
@@ -742,6 +772,20 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
             };
 
             Monitor.AddConnection(hash, $"{socketPrefix}.sock", connection);
+        }
+
+        public string CreateMatchingSocketFile(int pid)
+        {
+            var backchannelsDir = Path.Combine(_homeDirectory.FullName, ".aspire", "cli", "bch");
+            Directory.CreateDirectory(backchannelsDir);
+
+            var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(AppHostFile.FullName, _homeDirectory.FullName);
+            var appHostId = Path.GetFileName(prefix);
+            var socketPath = Path.Combine(
+                backchannelsDir,
+                $"{appHostId}a1b2C3d4.{pid.ToString(CultureInfo.InvariantCulture)}");
+            File.WriteAllText(socketPath, "");
+            return socketPath;
         }
 
         public void Dispose()

--- a/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
@@ -195,6 +195,40 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
     }
 
     [Fact]
+    public async Task FindAndStopRunningInstanceAsync_CleansUpDeadPidSocketAndReturnsNoRunningInstance()
+    {
+        var appHostFile = CreateSingleFileAppHost();
+        var runner = new TestDotNetCliRunner();
+        var project = CreateDotNetAppHostProject(runner);
+        var socketPath = CreateMatchingSocketFile(appHostFile.FullName, int.MaxValue - 1);
+
+        var result = await project.FindAndStopRunningInstanceAsync(
+            appHostFile,
+            _workspace.WorkspaceRoot,
+            CancellationToken.None);
+
+        Assert.Equal(RunningInstanceResult.NoRunningInstance, result);
+        Assert.False(File.Exists(socketPath));
+    }
+
+    [Fact]
+    public async Task FindAndStopRunningInstanceAsync_KeepsLivePidSocketAndReportsStopFailureWhenConnectionFails()
+    {
+        var appHostFile = CreateSingleFileAppHost();
+        var runner = new TestDotNetCliRunner();
+        var project = CreateDotNetAppHostProject(runner);
+        var socketPath = CreateMatchingSocketFile(appHostFile.FullName, Environment.ProcessId);
+
+        var result = await project.FindAndStopRunningInstanceAsync(
+            appHostFile,
+            _workspace.WorkspaceRoot,
+            CancellationToken.None);
+
+        Assert.Equal(RunningInstanceResult.StopFailed, result);
+        Assert.True(File.Exists(socketPath));
+    }
+
+    [Fact]
     public async Task RunAsync_ProjectAppHostUsingCliBundlePassesBundleEnvironmentToRunner()
     {
         var appHostFile = CreateProjectAppHost();
@@ -1402,6 +1436,20 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             """.Replace("{0}", useCliBundleProperty, StringComparison.Ordinal));
 
         return new FileInfo(appHostPath);
+    }
+
+    private string CreateMatchingSocketFile(string appHostPath, int pid)
+    {
+        var backchannelsDir = Path.Combine(_workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch");
+        Directory.CreateDirectory(backchannelsDir);
+
+        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, _workspace.WorkspaceRoot.FullName);
+        var appHostId = Path.GetFileName(prefix);
+        var socketPath = Path.Combine(
+            backchannelsDir,
+            $"{appHostId}a1b2C3d4.{pid.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+        File.WriteAllText(socketPath, "");
+        return socketPath;
     }
 
     private FileInfo CreateBuiltAppHostAssembly(string fileName)

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -9,6 +9,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -667,6 +668,30 @@ public class GuestAppHostProjectTests : IDisposable
     }
 
     [Fact]
+    public async Task FindAndStopRunningInstanceAsync_CleansUpDeadPidSocketAndReturnsNoRunningInstance()
+    {
+        var appHostPath = Path.Combine(_workspace.WorkspaceRoot.FullName, "apphost.ts");
+        await File.WriteAllTextAsync(appHostPath, "// test apphost");
+
+        var factory = new TestAppHostServerProjectFactory
+        {
+            CreateAsyncCallback = (appPath, _) =>
+                Task.FromResult<IAppHostServerProject>(new FakeFailingAppHostServerProject(appPath))
+        };
+
+        var project = CreateGuestAppHostProject(appHostServerProjectFactory: factory);
+        var socketPath = CreateMatchingSocketFile(_workspace.WorkspaceRoot.FullName, int.MaxValue - 1);
+
+        var result = await project.FindAndStopRunningInstanceAsync(
+            new FileInfo(appHostPath),
+            _workspace.WorkspaceRoot,
+            CancellationToken.None);
+
+        Assert.Equal(RunningInstanceResult.NoRunningInstance, result);
+        Assert.False(File.Exists(socketPath));
+    }
+
+    [Fact]
     public async Task UpdatePackagesAsync_ExplicitStableChannel_WhenRegenerationFails_DoesNotMutateConfig()
     {
         var configPath = Path.Combine(_workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
@@ -901,6 +926,20 @@ public class GuestAppHostProjectTests : IDisposable
 
     private GuestAppHostProject CreateGuestAppHostProject()
         => CreateGuestAppHostProject(interactionService: null, identityChannel: "local");
+
+    private string CreateMatchingSocketFile(string appHostPath, int pid)
+    {
+        var backchannelsDir = Path.Combine(_workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch");
+        Directory.CreateDirectory(backchannelsDir);
+
+        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, _workspace.WorkspaceRoot.FullName);
+        var appHostId = Path.GetFileName(prefix);
+        var socketPath = Path.Combine(
+            backchannelsDir,
+            $"{appHostId}a1b2C3d4.{pid.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+        File.WriteAllText(socketPath, "");
+        return socketPath;
+    }
 
     private GuestAppHostProject CreateGuestAppHostProject(
         TestInteractionService? interactionService = null,

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -233,7 +233,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
         var homeDirectory = "/nonexistent/home/directory";
 
-        var sockets = AppHostHelper.FindMatchingSockets(appHostPath, homeDirectory);
+        var sockets = BackchannelConstants.FindMatchingSockets(appHostPath, homeDirectory);
 
         Assert.Empty(sockets);
     }
@@ -258,7 +258,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var otherSocket = Path.Combine(backchannelsDir, "differentId1a1b2C3d4.99999");
         File.WriteAllText(otherSocket, "");
 
-        var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
+        var sockets = BackchannelConstants.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
 
         Assert.Equal(2, sockets.Length);
         Assert.Contains(socket1, sockets);
@@ -283,7 +283,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var legacyPidSocket = Path.Combine(legacyBackchannelsDir, $"auxi.sock.{hash}.12345");
         File.WriteAllText(legacyPidSocket, "");
 
-        var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
+        var sockets = BackchannelConstants.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
 
         // Should find both old and new format
         Assert.Equal(2, sockets.Length);
@@ -311,7 +311,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var badPid = Path.Combine(backchannelsDir, $"{appHostId}AbCdEfGh.notapid");
         File.WriteAllText(badPid, "");
 
-        var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
+        var sockets = BackchannelConstants.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
 
         // Should NOT match the similar hash
         Assert.Empty(sockets);
@@ -330,7 +330,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var otherSocket = Path.Combine(backchannelsDir, "differentId1a1b2C3d4.99999");
         File.WriteAllText(otherSocket, "");
 
-        var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
+        var sockets = BackchannelConstants.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
 
         Assert.Empty(sockets);
     }
@@ -366,6 +366,43 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Assert.False(File.Exists(orphanedSocket), "Orphaned socket should be deleted");
         Assert.True(File.Exists(liveSocket), "Live socket should still exist");
     }
+
+    [Fact]
+    public void FindMatchingNonOrphanedSockets_RemovesDeadPidSocketsAndKeepsLiveAndPidlessSockets()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch");
+        Directory.CreateDirectory(backchannelsDir);
+
+        var appHostPath = "/path/to/MyApp.AppHost.csproj";
+        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
+        var appHostId = Path.GetFileName(prefix);
+        var deadPid = int.MaxValue - 1;
+        var currentPid = Environment.ProcessId;
+
+        var orphanedSocket = Path.Combine(backchannelsDir, $"{appHostId}a1b2C3d4.{deadPid}");
+        var liveSocket = Path.Combine(backchannelsDir, $"{appHostId}Z9y8X7w6.{currentPid}");
+        var pidlessSocket = Path.Combine(backchannelsDir, appHostId);
+        File.WriteAllText(orphanedSocket, "");
+        File.WriteAllText(liveSocket, "");
+        File.WriteAllText(pidlessSocket, "");
+
+        var remainingSockets = AppHostHelper.FindMatchingNonOrphanedSockets(
+            appHostPath,
+            workspace.WorkspaceRoot.FullName,
+            currentPid,
+            out var deletedCount);
+
+        Assert.Equal(1, deletedCount);
+        Assert.Equal(2, remainingSockets.Length);
+        Assert.Contains(liveSocket, remainingSockets);
+        Assert.Contains(pidlessSocket, remainingSockets);
+        Assert.DoesNotContain(orphanedSocket, remainingSockets);
+        Assert.False(File.Exists(orphanedSocket));
+        Assert.True(File.Exists(liveSocket));
+        Assert.True(File.Exists(pidlessSocket));
+    }
+
     [Theory]
     [InlineData("10.0.0", true)]
     [InlineData("9.2.0", true)]
@@ -458,7 +495,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var socket = Path.Combine(backchannelsDir, $"{appHostId}a1b2C3d4.12345");
         File.WriteAllText(socket, "");
 
-        var found = AppHostHelper.FindMatchingSockets(mixedPath, workspace.WorkspaceRoot.FullName);
+        var found = BackchannelConstants.FindMatchingSockets(mixedPath, workspace.WorkspaceRoot.FullName);
         Assert.Single(found);
         Assert.Contains(socket, found);
     }
@@ -490,8 +527,8 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         File.WriteAllText(socket, "");
 
         // Both path variants should find the socket
-        var fromUpper = AppHostHelper.FindMatchingSockets(upperDrivePath, workspace.WorkspaceRoot.FullName);
-        var fromLower = AppHostHelper.FindMatchingSockets(lowerDrivePath, workspace.WorkspaceRoot.FullName);
+        var fromUpper = BackchannelConstants.FindMatchingSockets(upperDrivePath, workspace.WorkspaceRoot.FullName);
+        var fromLower = BackchannelConstants.FindMatchingSockets(lowerDrivePath, workspace.WorkspaceRoot.FullName);
 
         Assert.Single(fromUpper);
         Assert.Single(fromLower);
@@ -523,7 +560,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Assert.NotEqual(currentHash, legacyHash);
 
         // FindMatchingSockets should still find the legacy socket via fallback
-        var found = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
+        var found = BackchannelConstants.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
         Assert.Single(found);
         Assert.Contains(legacySocket, found);
     }

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -5,6 +5,7 @@ using Aspire.Cli.Tests.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Utils;
 using Aspire.Hosting.Backchannel;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Utils;
 
@@ -391,13 +392,12 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
             appHostPath,
             workspace.WorkspaceRoot.FullName,
             currentPid,
-            out var deletedCount);
+            NullLogger.Instance);
 
-        Assert.Equal(1, deletedCount);
-        Assert.Equal(2, remainingSockets.Length);
-        Assert.Contains(liveSocket, remainingSockets);
-        Assert.Contains(pidlessSocket, remainingSockets);
-        Assert.DoesNotContain(orphanedSocket, remainingSockets);
+        Assert.Collection(
+            remainingSockets.Order(StringComparer.Ordinal),
+            socket => Assert.Equal(pidlessSocket, socket),
+            socket => Assert.Equal(liveSocket, socket));
         Assert.False(File.Exists(orphanedSocket));
         Assert.True(File.Exists(liveSocket));
         Assert.True(File.Exists(pidlessSocket));


### PR DESCRIPTION
## Description

Fixes #17441

`aspire add` and related CLI paths can discover stale AppHost backchannel socket files from a process that has already exited. Previously, the CLI attempted to connect to those sockets, hit `Connection refused`, and reported that it could not stop a running AppHost even when no AppHost was running.

This change prunes PID-qualified orphaned AppHost backchannel sockets before stop/connect paths probe them. The cleanup only deletes matching sockets when the socket filename includes a PID and that PID is no longer running, with a second process-existence check immediately before deletion. Live PID sockets and PID-less legacy sockets are preserved.

The .NET/file AppHost, guest AppHost, explicit `--apphost` connection resolver, and detached AppHost launcher paths now use the pruning helper before probing sockets.

### User-facing usage

Users can retry the same command; stale PID-qualified sockets are cleaned up automatically:

```bash
aspire add redis --apphost apphost.cs --non-interactive
```

Manual verification:

- Created a real stale AF_UNIX backchannel socket under an isolated `HOME` that matched a file-based AppHost and a dead PID.
- Installed Aspire `13.5.0-preview.1.26307.4` failed with `Connection refused` and `Unable to stop one or more running Aspire AppHost instances`.
- Repo-local Aspire `13.5.0-dev` logged `Cleaned up 1 orphaned socket(s)`, deleted the stale socket, and successfully added `Aspire.Hosting.Redis`.

Validation:

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-method "*.ResolveConnectionAsync_WithExplicitProjectFile_DeletesDeadPidSocketAndReturnsNotRunning" --filter-method "*.LaunchDetachedAsync_DeletesDeadPidSocketBeforeStartingChildProcess" --filter-method "*.FindAndStopRunningInstanceAsync_CleansUpDeadPidSocketAndReturnsNoRunningInstance" --filter-method "*.FindMatchingNonOrphanedSockets_RemovesDeadPidSocketsAndKeepsLiveAndPidlessSockets" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-build --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
