### PR TITLE
Revert stress apphost changes from #17825 and #17112

### DIFF
--- a/playground/Stress/Stress.AppHost/AppHost.cs
+++ b/playground/Stress/Stress.AppHost/AppHost.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 #pragma warning disable ASPIREDOTNETTOOL
-#pragma warning disable ASPIREPERSISTENCE001 // Resource lifetime APIs are experimental.
 
 var builder = DistributedApplication.CreateBuilder(args);
 builder.Services.AddHttpClient();
@@ -100,9 +99,6 @@ builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard
 builder.AddExecutable("executableWithSingleArg", "dotnet", Environment.CurrentDirectory, "--version");
 builder.AddExecutable("executableWithSingleEscapedArg", "dotnet", Environment.CurrentDirectory, "one two");
 builder.AddExecutable("executableWithMultipleArgs", "dotnet", Environment.CurrentDirectory, "--version", "one two");
-var stressEmptyProjectPath = new Projects.Stress_Empty().ProjectPath;
-builder.AddExecutable("persistentExecutable", "dotnet", Environment.CurrentDirectory, "run", "--project", stressEmptyProjectPath, "--no-build")
-    .WithPersistentLifetime();
 
 IResourceBuilder<IResource>? previousResourceBuilder = null;
 

--- a/playground/Stress/Stress.AppHost/AppHost.cs
+++ b/playground/Stress/Stress.AppHost/AppHost.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 #pragma warning disable ASPIREDOTNETTOOL
-#pragma warning disable ASPIREINTERACTION001
 #pragma warning disable ASPIREPERSISTENCE001 // Resource lifetime APIs are experimental.
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -19,10 +18,6 @@ builder.Services.AddHealthChecks().AddAsyncCheck("health-test", async (ct) =>
 var manualArgSource = builder.AddExecutable("manual-arg-source", "dotnet", Environment.CurrentDirectory)
     .WithHttpEndpoint(targetPort: 8088);
 var manualArgEndpoint = manualArgSource.GetEndpoint("http");
-var stressEmptyProjectPath = new Projects.Stress_Empty().ProjectPath;
-const string interactionContainerImage = "alpine";
-const string interactionContainerEntrypoint = "/bin/sh";
-string[] interactionContainerArgs = ["-c", "while true; do sleep 3600; done"];
 
 manualArgSource.WithArgs("--dashboard-port")
     .WithArgs(c => c.Args.Add(manualArgEndpoint.Property(EndpointProperty.Port)));
@@ -40,45 +35,6 @@ builder.AddDotnetTool("manual-dotnet-tool-args", "dotnet-dump")
     .WithArgs("--version", "--dashboard-port")
     .WithArgs(c => c.Args.Add(manualArgEndpoint.Property(EndpointProperty.Port)))
     .WithExplicitStart();
-
-builder.AddExecutable("manual-environment-interaction", "dotnet", Environment.CurrentDirectory, "run", "--project", stressEmptyProjectPath, "--no-build")
-    .WithExplicitStart()
-    .WithEnvironment(context => PromptForEnvironmentValueAsync(
-        context,
-        "MANUAL_ENVIRONMENT_INTERACTION_VALUE",
-        "Explicit start executable environment callback",
-        "This prompt should only appear after manually starting the session-scoped executable."));
-
-builder.AddExecutable("persistent-environment-interaction", "dotnet", Environment.CurrentDirectory, "run", "--project", stressEmptyProjectPath, "--no-build")
-    .WithPersistentLifetime()
-    .WithExplicitStart()
-    .WithEnvironment(context => PromptForEnvironmentValueAsync(
-        context,
-        "PERSISTENT_EXECUTABLE_ENVIRONMENT_INTERACTION_VALUE",
-        "Persistent executable environment callback",
-        "This prompt appears during startup because persistent executable resources are registered with DCP immediately."));
-
-builder.AddContainer("manual-container-environment-interaction", interactionContainerImage)
-    .WithEntrypoint(interactionContainerEntrypoint)
-    .WithArgs(interactionContainerArgs)
-    .WithExplicitStart()
-    .WithEnvironment(context => PromptForEnvironmentValueAsync(
-        context,
-        "MANUAL_CONTAINER_ENVIRONMENT_INTERACTION_VALUE",
-        "Explicit start container environment callback",
-        "This prompt should only appear after manually starting the session-scoped container."));
-
-builder.AddContainer("persistent-container-environment-interaction", interactionContainerImage)
-    .WithContainerName("stress-persistent-container-environment-interaction")
-    .WithEntrypoint(interactionContainerEntrypoint)
-    .WithArgs(interactionContainerArgs)
-    .WithPersistentLifetime()
-    .WithExplicitStart()
-    .WithEnvironment(context => PromptForEnvironmentValueAsync(
-        context,
-        "PERSISTENT_CONTAINER_ENVIRONMENT_INTERACTION_VALUE",
-        "Persistent container environment callback",
-        "This prompt appears during startup because persistent container resources are registered with DCP immediately."));
 
 for (var i = 0; i < 2; i++)
 {
@@ -144,6 +100,7 @@ builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard
 builder.AddExecutable("executableWithSingleArg", "dotnet", Environment.CurrentDirectory, "--version");
 builder.AddExecutable("executableWithSingleEscapedArg", "dotnet", Environment.CurrentDirectory, "one two");
 builder.AddExecutable("executableWithMultipleArgs", "dotnet", Environment.CurrentDirectory, "--version", "one two");
+var stressEmptyProjectPath = new Projects.Stress_Empty().ProjectPath;
 builder.AddExecutable("persistentExecutable", "dotnet", Environment.CurrentDirectory, "run", "--project", stressEmptyProjectPath, "--no-build")
     .WithPersistentLifetime();
 
@@ -171,23 +128,3 @@ builder.AddProject<Projects.Stress_Empty>("empty-profile-2", launchProfileName: 
 builder.AddNoStatusResource("no-status-resource");
 
 builder.Build().Run();
-
-static async Task PromptForEnvironmentValueAsync(
-    EnvironmentCallbackContext context,
-    string environmentVariableName,
-    string title,
-    string message)
-{
-    var interactionService = context.ExecutionContext.ServiceProvider.GetRequiredService<IInteractionService>();
-    var result = await interactionService.PromptInputAsync(
-        title: title,
-        message: message,
-        inputLabel: "Environment value",
-        placeHolder: "Value from WithEnvironment callback",
-        cancellationToken: context.CancellationToken);
-
-    if (!result.Canceled && result.Data.Value is { } value)
-    {
-        context.EnvironmentVariables[environmentVariableName] = value;
-    }
-}


### PR DESCRIPTION
## Description

Reverts stress apphost playground changes introduced in two PRs:

**From #17825:**
- Removed interaction-based examples (`manual-environment-interaction`, `persistent-environment-interaction`, `manual-container-environment-interaction`, `persistent-container-environment-interaction`)
- Removed `PromptForEnvironmentValueAsync` helper method
- Removed `ASPIREINTERACTION001` pragma disable
- Removed `interactionContainerImage`, `interactionContainerEntrypoint`, `interactionContainerArgs` variables

**From #17112:**
- Removed `persistentExecutable` resource
- Removed `stressEmptyProjectPath` variable
- Removed `ASPIREPERSISTENCE001` pragma disable

The core DCP and hosting logic from those PRs remains intact — only the stress apphost playground examples are reverted.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No