### PR TITLE
Obsolete PublishAsConnectionString

### DIFF
--- a/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/AppHost.cs
+++ b/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/AppHost.cs
@@ -15,11 +15,11 @@ var builder = DistributedApplication.CreateBuilder(args);
 // The expression below is a bit more complex than the average developer app would
 // probably have, but in our repo we'll probably want to experiment with seperately
 // deployed resources a little bit.
+var sql = builder.AddSqlServer("sql");
 #pragma warning disable CS0618 // This playground intentionally exercises obsolete manifest-only PublishAsConnectionString behavior.
-var db = builder.AddSqlServer("sql")
-                .PublishAsConnectionString()
-                .AddDatabase("db");
+sql.PublishAsConnectionString();
 #pragma warning restore CS0618
+var db = sql.AddDatabase("db");
 
 var insertionrows = builder.AddParameter("insertionrows")
     .WithDescription("The number of rows to insert into the database.");

--- a/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/AppHost.cs
+++ b/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/AppHost.cs
@@ -15,9 +15,11 @@ var builder = DistributedApplication.CreateBuilder(args);
 // The expression below is a bit more complex than the average developer app would
 // probably have, but in our repo we'll probably want to experiment with seperately
 // deployed resources a little bit.
+#pragma warning disable CS0618 // This playground intentionally exercises obsolete manifest-only PublishAsConnectionString behavior.
 var db = builder.AddSqlServer("sql")
                 .PublishAsConnectionString()
                 .AddDatabase("db");
+#pragma warning restore CS0618
 
 var insertionrows = builder.AddParameter("insertionrows")
     .WithDescription("The number of rows to insert into the database.");

--- a/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
@@ -18,7 +18,11 @@ public static class AzureResourceExtensions
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The resource builder.</param>
     /// <returns>The configured <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// This API only changes the manifest representation; it does not change the resource model used by other publishers.
+    /// </remarks>
     /// <ats-returns>The resource builder.</ats-returns>
+    [Obsolete("PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.")]
     [AspireExport]
     public static IResourceBuilder<T> PublishAsConnectionString<T>(this IResourceBuilder<T> builder)
         where T : IAzureResource, IResourceWithConnectionString

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -363,7 +363,11 @@ public static class ParameterResourceBuilderExtensions
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The resource builder.</param>
     /// <returns>The configured <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// This API only changes the manifest representation; it does not change the resource model used by other publishers.
+    /// </remarks>
     /// <ats-returns>The resource builder.</ats-returns>
+    [Obsolete("PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.")]
     [AspireExport]
     public static IResourceBuilder<T> PublishAsConnectionString<T>(this IResourceBuilder<T> builder)
         where T : ContainerResource, IResourceWithConnectionString

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -14067,7 +14067,10 @@ export interface ContainerResource {
     withOtlpExporter(options?: WithOtlpExporterOptions): ContainerResourcePromise;
     /**
      * Changes the resource to be published as a connection string reference in the manifest.
+     *
+     * This API only changes the manifest representation; it does not change the resource model used by other publishers.
      * @returns The resource builder.
+     * @deprecated PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.
      */
     publishAsConnectionString(): ContainerResourcePromise;
     /**
@@ -14808,7 +14811,10 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
     withOtlpExporter(options?: WithOtlpExporterOptions): ContainerResourcePromise;
     /**
      * Changes the resource to be published as a connection string reference in the manifest.
+     *
+     * This API only changes the manifest representation; it does not change the resource model used by other publishers.
      * @returns The resource builder.
+     * @deprecated PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.
      */
     publishAsConnectionString(): ContainerResourcePromise;
     /**
@@ -15909,7 +15915,10 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
 
     /**
      * Changes the resource to be published as a connection string reference in the manifest.
+     *
+     * This API only changes the manifest representation; it does not change the resource model used by other publishers.
      * @returns The resource builder.
+     * @deprecated PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.
      */
     publishAsConnectionString(): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._publishAsConnectionStringInternal(), this._client);
@@ -37423,7 +37432,10 @@ export interface TestDatabaseResource {
     withOtlpExporter(options?: WithOtlpExporterOptions): TestDatabaseResourcePromise;
     /**
      * Changes the resource to be published as a connection string reference in the manifest.
+     *
+     * This API only changes the manifest representation; it does not change the resource model used by other publishers.
      * @returns The resource builder.
+     * @deprecated PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.
      */
     publishAsConnectionString(): TestDatabaseResourcePromise;
     /**
@@ -38164,7 +38176,10 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
     withOtlpExporter(options?: WithOtlpExporterOptions): TestDatabaseResourcePromise;
     /**
      * Changes the resource to be published as a connection string reference in the manifest.
+     *
+     * This API only changes the manifest representation; it does not change the resource model used by other publishers.
      * @returns The resource builder.
+     * @deprecated PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.
      */
     publishAsConnectionString(): TestDatabaseResourcePromise;
     /**
@@ -39264,7 +39279,10 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
 
     /**
      * Changes the resource to be published as a connection string reference in the manifest.
+     *
+     * This API only changes the manifest representation; it does not change the resource model used by other publishers.
      * @returns The resource builder.
+     * @deprecated PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.
      */
     publishAsConnectionString(): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._publishAsConnectionStringInternal(), this._client);
@@ -41924,7 +41942,10 @@ export interface TestRedisResource {
     withOtlpExporter(options?: WithOtlpExporterOptions): TestRedisResourcePromise;
     /**
      * Changes the resource to be published as a connection string reference in the manifest.
+     *
+     * This API only changes the manifest representation; it does not change the resource model used by other publishers.
      * @returns The resource builder.
+     * @deprecated PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.
      */
     publishAsConnectionString(): TestRedisResourcePromise;
     /**
@@ -42729,7 +42750,10 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
     withOtlpExporter(options?: WithOtlpExporterOptions): TestRedisResourcePromise;
     /**
      * Changes the resource to be published as a connection string reference in the manifest.
+     *
+     * This API only changes the manifest representation; it does not change the resource model used by other publishers.
      * @returns The resource builder.
+     * @deprecated PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.
      */
     publishAsConnectionString(): TestRedisResourcePromise;
     /**
@@ -43893,7 +43917,10 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
 
     /**
      * Changes the resource to be published as a connection string reference in the manifest.
+     *
+     * This API only changes the manifest representation; it does not change the resource model used by other publishers.
      * @returns The resource builder.
+     * @deprecated PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.
      */
     publishAsConnectionString(): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._publishAsConnectionStringInternal(), this._client);
@@ -46860,7 +46887,10 @@ export interface TestVaultResource {
     withOtlpExporter(options?: WithOtlpExporterOptions): TestVaultResourcePromise;
     /**
      * Changes the resource to be published as a connection string reference in the manifest.
+     *
+     * This API only changes the manifest representation; it does not change the resource model used by other publishers.
      * @returns The resource builder.
+     * @deprecated PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.
      */
     publishAsConnectionString(): TestVaultResourcePromise;
     /**
@@ -47603,7 +47633,10 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
     withOtlpExporter(options?: WithOtlpExporterOptions): TestVaultResourcePromise;
     /**
      * Changes the resource to be published as a connection string reference in the manifest.
+     *
+     * This API only changes the manifest representation; it does not change the resource model used by other publishers.
      * @returns The resource builder.
+     * @deprecated PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.
      */
     publishAsConnectionString(): TestVaultResourcePromise;
     /**
@@ -48705,7 +48738,10 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
 
     /**
      * Changes the resource to be published as a connection string reference in the manifest.
+     *
+     * This API only changes the manifest representation; it does not change the resource model used by other publishers.
      * @returns The resource builder.
+     * @deprecated PublishAsConnectionString only works with the manifest publisher and is obsolete. Use AddConnectionString in publish-mode app model code instead.
      */
     publishAsConnectionString(): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._publishAsConnectionStringInternal(), this._client);

--- a/tests/Aspire.Hosting.Tests/PublishAsConnectionStringTests.cs
+++ b/tests/Aspire.Hosting.Tests/PublishAsConnectionStringTests.cs
@@ -14,7 +14,10 @@ public class PublishAsConnectionStringTests
     {
         var builder = DistributedApplication.CreateBuilder();
 
-        var redis = builder.AddRedis("redis").PublishAsConnectionString();
+#pragma warning disable CS0618 // Test intentionally covers obsolete PublishAsConnectionString manifest behavior.
+        var redis = builder.AddRedis("redis")
+            .PublishAsConnectionString();
+#pragma warning restore CS0618
 
         Assert.True(redis.Resource.TryGetLastAnnotation<ManifestPublishingCallbackAnnotation>(out _));
 


### PR DESCRIPTION
## Description

`PublishAsConnectionString` only changes the manifest representation of a resource. Current non-manifest publishers use the resource model directly, so callers can be misled into thinking this API converts the resource into a publish-time connection string parameter for all publishers.

This marks the Hosting and Azure `PublishAsConnectionString` extension methods obsolete with guidance to use `AddConnectionString` in publish-mode app model code instead. It also adds XML remarks describing the manifest-only behavior, updates the TypeScript generated snapshot so TS AppHost users see the same `@deprecated` guidance, and suppresses the obsolete warning only in existing test/playground code that intentionally covers the old behavior.

### Migration guidance

Existing callers will now get a CS0618 warning. Apps that need different run and publish behavior should model that explicitly, for example by adding a local resource in run mode and an `AddConnectionString` resource in publish mode.

### Breaking changes

This obsoletes the public `PublishAsConnectionString` APIs. Existing callers continue to compile, but will receive an obsolete API warning directing them away from the manifest-only API.

Fixes: #8409

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No