### PR TITLE
Fix MAUI OTLP dev tunnel endpoint resolution

### DIFF
--- a/src/Aspire.Hosting.Maui/Aspire.Hosting.Maui.csproj
+++ b/src/Aspire.Hosting.Maui/Aspire.Hosting.Maui.csproj
@@ -22,7 +22,6 @@
     <Compile Include="..\Shared\KnownEndpointNames.cs" Link="Shared\KnownEndpointNames.cs" />
     <Compile Include="..\Shared\KnownOtelConfigNames.cs" Link="Shared\KnownOtelConfigNames.cs" />
     <Compile Include="..\Shared\KnownResourceNames.cs" Link="Shared\KnownResourceNames.cs" />
-    <Compile Include="..\Shared\OtlpEndpointResolver.cs" Link="Shared\OtlpEndpointResolver.cs" />
     <Compile Include="..\Shared\PathNormalizer.cs" Link="Shared\PathNormalizer.cs" />
     <Compile Include="..\Shared\StringComparers.cs" Link="Shared\StringComparers.cs" />
     <Compile Include="..\Shared\EnvironmentVariableNameEncoder.cs" Link="Shared\EnvironmentVariableNameEncoder.cs" />

--- a/src/Aspire.Hosting.Maui/Aspire.Hosting.Maui.csproj
+++ b/src/Aspire.Hosting.Maui/Aspire.Hosting.Maui.csproj
@@ -19,7 +19,9 @@
   <ItemGroup>
     <Compile Include="..\Shared\IConfigurationExtensions.cs" Link="Shared\IConfigurationExtensions.cs" />
     <Compile Include="..\Shared\KnownConfigNames.cs" Link="Shared\KnownConfigNames.cs" />
+    <Compile Include="..\Shared\KnownEndpointNames.cs" Link="Shared\KnownEndpointNames.cs" />
     <Compile Include="..\Shared\KnownOtelConfigNames.cs" Link="Shared\KnownOtelConfigNames.cs" />
+    <Compile Include="..\Shared\KnownResourceNames.cs" Link="Shared\KnownResourceNames.cs" />
     <Compile Include="..\Shared\OtlpEndpointResolver.cs" Link="Shared\OtlpEndpointResolver.cs" />
     <Compile Include="..\Shared\PathNormalizer.cs" Link="Shared\PathNormalizer.cs" />
     <Compile Include="..\Shared\StringComparers.cs" Link="Shared\StringComparers.cs" />

--- a/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
@@ -6,6 +6,7 @@ using Aspire.Hosting.DevTunnels;
 using Aspire.Hosting.Maui;
 using Aspire.Hosting.Maui.Annotations;
 using Aspire.Hosting.Maui.Otlp;
+using Microsoft.Extensions.Configuration;
 
 namespace Aspire.Hosting;
 
@@ -81,12 +82,14 @@ public static class MauiOtlpExtensions
     /// </summary>
     private static OtlpDevTunnelConfigurationAnnotation CreateOtlpDevTunnelInfrastructure(
         IResourceBuilder<MauiProjectResource> parentBuilder,
-        Microsoft.Extensions.Configuration.IConfiguration configuration)
+        IConfiguration configuration)
     {
         var appBuilder = parentBuilder.ApplicationBuilder;
-
-        // Resolve OTLP scheme and port from configuration
-        var (otlpScheme, otlpPort) = OtlpEndpointResolver.ResolveSchemeAndPort(configuration);
+        var configuredOtlpEndpoint = ResolveConfiguredOtlpEndpoint(configuration);
+        // Dynamic dashboard endpoints start with a provisional scheme and no port. The actual
+        // scheme and port are copied from the dashboard allocation event before the dev tunnel
+        // can consume the endpoint.
+        var initialOtlpScheme = configuredOtlpEndpoint?.Scheme ?? ResolveDynamicDashboardOtlpScheme(configuration);
 
         // Create names for the tunnel infrastructure
         // Use a short random suffix to ensure uniqueness (similar to DCP naming strategy)
@@ -96,7 +99,7 @@ public static class MauiOtlpExtensions
         var stubName = $"t{randomSuffix}"; // Prefix with 't' to ensure valid resource name
 
         // Create OtlpLoopbackResource - a synthetic IResourceWithEndpoints for service discovery
-        var stubResource = new OtlpLoopbackResource(stubName, otlpPort, otlpScheme);
+        var stubResource = new OtlpLoopbackResource(stubName, configuredOtlpEndpoint?.Port, initialOtlpScheme);
 
         var stubBuilder = appBuilder.AddResource(stubResource)
             .ExcludeFromManifest();
@@ -108,25 +111,123 @@ public static class MauiOtlpExtensions
             Properties = []
         });
 
-        // Create dev tunnel with anonymous access for OTLP
+        if (configuredOtlpEndpoint is null)
+        {
+            appBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>((evt, _) =>
+            {
+                if (evt.Resource is DevTunnelResource devTunnelResource &&
+                    string.Equals(devTunnelResource.Name, tunnelName, StringComparisons.ResourceName) &&
+                    stubResource.OtlpEndpoint.AllocatedEndpoint is null)
+                {
+                    var hasDashboardResource = appBuilder.Resources.Any(resource => string.Equals(resource.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName));
+                    if (!hasDashboardResource)
+                    {
+                        throw new DistributedApplicationException($"The MAUI OTLP dev tunnel for resource '{parentBuilder.Resource.Name}' requires the Aspire dashboard to be enabled or an explicit OTLP endpoint URL to be configured.");
+                    }
+
+                    throw new DistributedApplicationException($"The Aspire dashboard resource '{KnownResourceNames.AspireDashboard}' does not have an allocated OTLP endpoint named '{KnownEndpointNames.OtlpGrpcEndpointName}' or '{KnownEndpointNames.OtlpHttpEndpointName}', so the MAUI OTLP dev tunnel for resource '{parentBuilder.Resource.Name}' cannot start. Ensure dashboard OTLP ingestion is enabled, or configure an explicit OTLP endpoint URL.");
+                }
+
+                return Task.CompletedTask;
+            });
+
+            appBuilder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>((evt, ct) =>
+            {
+                if (TryResolveDashboardOtlpEndpoint(evt.Resource, out var dashboardOtlpEndpoint))
+                {
+                    return AllocateOtlpStubEndpointAsync(stubResource, dashboardOtlpEndpoint, evt.Services, appBuilder.Eventing, ct);
+                }
+
+                return Task.CompletedTask;
+            });
+        }
+        else
+        {
+            appBuilder.OnBeforeStart((evt, ct) =>
+                appBuilder.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(stubResource, evt.Services), ct));
+        }
+
+        // Create dev tunnel with anonymous access for OTLP. The dynamic unresolved-endpoint guard above
+        // must be registered first so it can fail fast before the dev tunnel waits on the target endpoint.
         var devTunnel = appBuilder.AddDevTunnel(tunnelName)
             .WithAnonymousAccess()
             .WithReference(stubBuilder, new DevTunnelPortOptions { Protocol = "https" });
 
-        // Manually allocate the stub endpoint so dev tunnel can start
-        // Dev tunnels wait for ResourceEndpointsAllocatedEvent before starting
-        appBuilder.OnBeforeStart((evt, ct) =>
-        {
-            var endpoint = stubResource.Annotations.OfType<EndpointAnnotation>().FirstOrDefault();
-            if (endpoint is not null && endpoint.AllocatedEndpoint is null)
-            {
-                endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", otlpPort);
-                return appBuilder.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(stubResource, evt.Services), ct);
-            }
-            return Task.CompletedTask;
-        });
-
         return new OtlpDevTunnelConfigurationAnnotation(stubResource, stubBuilder, devTunnel);
+    }
+
+    private static OtlpEndpointTarget? ResolveConfiguredOtlpEndpoint(IConfiguration configuration)
+    {
+        var configuredGrpcUrl = configuration.GetString(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, KnownConfigNames.Legacy.DashboardOtlpGrpcEndpointUrl);
+        var configuredHttpUrl = configuration.GetString(KnownConfigNames.DashboardOtlpHttpEndpointUrl, KnownConfigNames.Legacy.DashboardOtlpHttpEndpointUrl);
+
+        if (string.IsNullOrWhiteSpace(configuredGrpcUrl) && string.IsNullOrWhiteSpace(configuredHttpUrl))
+        {
+            return null;
+        }
+
+        var (url, _) = OtlpEndpointResolver.ResolveOtlpEndpoint(configuration);
+        return Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            ? new OtlpEndpointTarget(uri.Scheme, uri.Port)
+            : null;
+    }
+
+    private static string ResolveDynamicDashboardOtlpScheme(IConfiguration configuration)
+        => configuration.GetBool(KnownConfigNames.AllowUnsecuredTransport) is true ? "http" : "https";
+
+    private static bool TryResolveDashboardOtlpEndpoint(IResource resource, out OtlpEndpointTarget target)
+    {
+        target = default;
+
+        if (!string.Equals(resource.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName) || resource is not IResourceWithEndpoints dashboardResource)
+        {
+            return false;
+        }
+
+        var grpcEndpoint = dashboardResource.GetEndpoint(KnownEndpointNames.OtlpGrpcEndpointName);
+        if (TryResolveEndpoint(grpcEndpoint, out target))
+        {
+            return true;
+        }
+
+        var httpEndpoint = dashboardResource.GetEndpoint(KnownEndpointNames.OtlpHttpEndpointName);
+        return TryResolveEndpoint(httpEndpoint, out target);
+    }
+
+    private static bool TryResolveEndpoint(EndpointReference endpointReference, out OtlpEndpointTarget target)
+    {
+        target = default;
+
+        if (!endpointReference.Exists || endpointReference.EndpointAnnotation.AllocatedEndpoint is not { } allocatedEndpoint)
+        {
+            return false;
+        }
+
+        target = new OtlpEndpointTarget(allocatedEndpoint.UriScheme, allocatedEndpoint.Port);
+        return true;
+    }
+
+    private static Task AllocateOtlpStubEndpointAsync(
+        OtlpLoopbackResource stubResource,
+        OtlpEndpointTarget target,
+        IServiceProvider services,
+        Aspire.Hosting.Eventing.IDistributedApplicationEventing eventing,
+        CancellationToken cancellationToken)
+    {
+        var endpoint = stubResource.OtlpEndpoint;
+        if (endpoint.AllocatedEndpoint is not null)
+        {
+            return Task.CompletedTask;
+        }
+
+        endpoint.UriScheme = target.Scheme;
+        endpoint.Port = target.Port;
+        endpoint.TargetPort = target.Port;
+        endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", target.Port);
+
+        // The stub endpoint is synthetic and not allocated by DCP. Publishing the event keeps
+        // endpoint consumers such as dev tunnel ports on the normal endpoint-allocation path.
+        return eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(stubResource, services), cancellationToken);
     }
 
     /// <summary>
@@ -147,4 +248,6 @@ public static class MauiOtlpExtensions
         // Set OTEL_EXPORTER_OTLP_ENDPOINT directly to the tunnel endpoint URL
         platformBuilder.WithEnvironment(KnownOtelConfigNames.ExporterOtlpEndpoint, tunnelEndpoint);
     }
+
+    private readonly record struct OtlpEndpointTarget(string Scheme, int Port);
 }

--- a/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.DevTunnels;
+using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Maui;
 using Aspire.Hosting.Maui.Annotations;
 using Aspire.Hosting.Maui.Otlp;
@@ -221,7 +222,7 @@ public static class MauiOtlpExtensions
         OtlpLoopbackResource stubResource,
         OtlpEndpointTarget target,
         IServiceProvider services,
-        Aspire.Hosting.Eventing.IDistributedApplicationEventing eventing,
+        IDistributedApplicationEventing eventing,
         CancellationToken cancellationToken)
     {
         var endpoint = stubResource.OtlpEndpoint;

--- a/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
@@ -158,18 +158,28 @@ public static class MauiOtlpExtensions
 
     private static OtlpEndpointTarget? ResolveConfiguredOtlpEndpoint(IConfiguration configuration)
     {
-        var configuredGrpcUrl = configuration.GetString(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, KnownConfigNames.Legacy.DashboardOtlpGrpcEndpointUrl);
-        var configuredHttpUrl = configuration.GetString(KnownConfigNames.DashboardOtlpHttpEndpointUrl, KnownConfigNames.Legacy.DashboardOtlpHttpEndpointUrl);
+        var configuredGrpcUrl = configuration.GetString(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, KnownConfigNames.Legacy.DashboardOtlpGrpcEndpointUrl, fallbackOnEmpty: true);
+        var configuredHttpUrl = configuration.GetString(KnownConfigNames.DashboardOtlpHttpEndpointUrl, KnownConfigNames.Legacy.DashboardOtlpHttpEndpointUrl, fallbackOnEmpty: true);
 
         if (string.IsNullOrWhiteSpace(configuredGrpcUrl) && string.IsNullOrWhiteSpace(configuredHttpUrl))
         {
             return null;
         }
 
-        var (url, _) = OtlpEndpointResolver.ResolveOtlpEndpoint(configuration);
-        return Uri.TryCreate(url, UriKind.Absolute, out var uri)
-            ? new OtlpEndpointTarget(uri.Scheme, uri.Port)
-            : null;
+        return !string.IsNullOrWhiteSpace(configuredGrpcUrl)
+            ? CreateConfiguredOtlpEndpointTarget(configuredGrpcUrl, KnownConfigNames.DashboardOtlpGrpcEndpointUrl)
+            : CreateConfiguredOtlpEndpointTarget(configuredHttpUrl!, KnownConfigNames.DashboardOtlpHttpEndpointUrl);
+    }
+
+    private static OtlpEndpointTarget CreateConfiguredOtlpEndpointTarget(string url, string configKey)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+            uri.Scheme is not ("http" or "https"))
+        {
+            throw new DistributedApplicationException($"The configured OTLP endpoint URL '{url}' from '{configKey}' must be an absolute HTTP or HTTPS URL.");
+        }
+
+        return new OtlpEndpointTarget(uri.Scheme, uri.Port);
     }
 
     private static string ResolveDynamicDashboardOtlpScheme(IConfiguration configuration)

--- a/src/Aspire.Hosting.Maui/Otlp/OtlpLoopbackResource.cs
+++ b/src/Aspire.Hosting.Maui/Otlp/OtlpLoopbackResource.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.Maui.Otlp;
 /// <remarks>
 /// This resource is used internally for MAUI OTLP configurations (especially with dev tunnels).
 /// It creates an endpoint annotation that can be referenced by MAUI platform resources through service discovery.
-/// The endpoint always points to localhost at the specified port and scheme, but can be tunneled externally.
+/// The endpoint points to localhost at a configured or dashboard-allocated port and can be tunneled externally.
 /// </remarks>
 internal sealed class OtlpLoopbackResource : Resource, IResourceWithEndpoints
 {
@@ -22,11 +22,13 @@ internal sealed class OtlpLoopbackResource : Resource, IResourceWithEndpoints
     /// <param name="name">The name of the resource.</param>
     /// <param name="port">The port number for the OTLP endpoint.</param>
     /// <param name="scheme">The URI scheme (http or https).</param>
-    public OtlpLoopbackResource(string name, int port, string scheme) : base(name)
+    public OtlpLoopbackResource(string name, int? port, string scheme) : base(name)
     {
-        // Create an endpoint annotation for service discovery
-        // This endpoint represents the OTLP collector endpoint that MAUI apps will connect to
-        Annotations.Add(new EndpointAnnotation(
+        // File-based AppHosts commonly use dynamic dashboard ports, so the port can start as
+        // null and be filled from ResourceEndpointsAllocatedEvent once the dashboard OTLP
+        // endpoint is known. Configured OTLP endpoint URLs are already concrete and can be
+        // allocated immediately.
+        OtlpEndpoint = new EndpointAnnotation(
             ProtocolType.Tcp,
             uriScheme: scheme,
             name: "otlp",
@@ -36,6 +38,18 @@ internal sealed class OtlpLoopbackResource : Resource, IResourceWithEndpoints
             // TargetHost = localhost means this resource is running on the local machine
             // When tunneled through dev tunnels, the service discovery will rewrite this to the tunnel URL
             TargetHost = "localhost"
-        });
+        };
+
+        if (port is int configuredPort)
+        {
+            OtlpEndpoint.AllocatedEndpoint = new AllocatedEndpoint(OtlpEndpoint, "localhost", configuredPort);
+        }
+
+        Annotations.Add(OtlpEndpoint);
     }
+
+    /// <summary>
+    /// Gets the synthetic endpoint that targets the local dashboard OTLP listener.
+    /// </summary>
+    internal EndpointAnnotation OtlpEndpoint { get; }
 }

--- a/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Maui;
 using Aspire.Hosting.Maui.Annotations;
 using Aspire.Hosting.Maui.Utilities;
 using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 using System.Text.Json;
@@ -668,6 +670,193 @@ public class MauiPlatformExtensionsTests
         var stubName = tunnelConfig.OtlpStub.Name;
         Assert.DoesNotContain(envVars.Keys, k => k.StartsWith($"services__{stubName}__"));
         Assert.DoesNotContain(envVars.Keys, k => k.StartsWith($"{EnvironmentVariableNameEncoder.Encode(stubName).ToUpperInvariant()}_"));
+    }
+
+    [Fact]
+    public async Task WithOtlpDevTunnel_AllocatesStubFromDynamicDashboardOtlpEndpoint()
+    {
+        var projectContent = CreateProjectContent("net10.0-ios");
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            var appBuilder = DistributedApplication.CreateBuilder();
+            var dashboard = appBuilder.AddResource(new ContainerResource(KnownResourceNames.AspireDashboard));
+            dashboard.Resource.Annotations.Add(new EndpointAnnotation(
+                ProtocolType.Tcp,
+                name: KnownEndpointNames.OtlpGrpcEndpointName,
+                uriScheme: "http",
+                isProxied: true,
+                transport: "http2"));
+
+            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+            var iosSimulator = maui.AddiOSSimulator()
+                .WithOtlpDevTunnel();
+
+            var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+            var stubEndpoint = tunnelConfig.OtlpStub.OtlpEndpoint;
+
+            Assert.Null(stubEndpoint.Port);
+            Assert.Null(stubEndpoint.TargetPort);
+            Assert.Null(stubEndpoint.AllocatedEndpoint);
+
+            await using var app = appBuilder.Build();
+
+            var dashboardEndpoint = dashboard.Resource.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == KnownEndpointNames.OtlpGrpcEndpointName);
+            dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(dashboardEndpoint, "localhost", 55075);
+            await appBuilder.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services), CancellationToken.None);
+
+            Assert.Equal("http", stubEndpoint.UriScheme);
+            Assert.Equal(55075, stubEndpoint.Port);
+            Assert.Equal(55075, stubEndpoint.TargetPort);
+            Assert.Equal("http://localhost:55075", stubEndpoint.AllocatedEndpoint?.UriString);
+
+            var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
+            tunnelEndpoint.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(tunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
+
+            var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+                iosSimulator.Resource,
+                DistributedApplicationOperation.Run,
+                app.Services);
+
+            Assert.Equal("https://mobile-otlp.devtunnels.ms:443", envVars[KnownOtelConfigNames.ExporterOtlpEndpoint]);
+            Assert.Equal("grpc", envVars[KnownOtelConfigNames.ExporterOtlpProtocol]);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task WithOtlpDevTunnel_AllocatesStubFromConfiguredOtlpEndpoint()
+    {
+        var projectContent = CreateProjectContent("net10.0-android");
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            using var appBuilder = TestDistributedApplicationBuilder.Create();
+            appBuilder.Configuration[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "http://localhost:18889";
+
+            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+            var androidEmulator = maui.AddAndroidEmulator()
+                .WithOtlpDevTunnel();
+            var dashboard = appBuilder.AddResource(new ContainerResource(KnownResourceNames.AspireDashboard));
+            var dashboardEndpoint = new EndpointAnnotation(
+                ProtocolType.Tcp,
+                name: KnownEndpointNames.OtlpGrpcEndpointName,
+                uriScheme: "https",
+                isProxied: true,
+                transport: "http2");
+            dashboard.Resource.Annotations.Add(dashboardEndpoint);
+
+            var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+            var stubEndpoint = tunnelConfig.OtlpStub.OtlpEndpoint;
+            var stubEndpointEventPublished = false;
+            appBuilder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>((evt, _) =>
+            {
+                if (ReferenceEquals(evt.Resource, tunnelConfig.OtlpStub))
+                {
+                    stubEndpointEventPublished = true;
+                }
+
+                return Task.CompletedTask;
+            });
+
+            Assert.Equal("http", stubEndpoint.UriScheme);
+            Assert.Equal(18889, stubEndpoint.Port);
+            Assert.Equal(18889, stubEndpoint.TargetPort);
+            Assert.Equal("http://localhost:18889", stubEndpoint.AllocatedEndpoint?.UriString);
+
+            await using var app = appBuilder.Build();
+
+            await appBuilder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()), CancellationToken.None);
+            Assert.True(stubEndpointEventPublished);
+
+            dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(dashboardEndpoint, "localhost", 55075);
+            await appBuilder.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services), CancellationToken.None);
+
+            Assert.Equal("http", stubEndpoint.UriScheme);
+            Assert.Equal(18889, stubEndpoint.Port);
+            Assert.Equal(18889, stubEndpoint.TargetPort);
+            Assert.Equal("http://localhost:18889", stubEndpoint.AllocatedEndpoint?.UriString);
+
+            var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
+            tunnelEndpoint.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(tunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
+
+            var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+                androidEmulator.Resource,
+                DistributedApplicationOperation.Run,
+                app.Services);
+
+            Assert.Equal("https://mobile-otlp.devtunnels.ms:443", envVars[KnownOtelConfigNames.ExporterOtlpEndpoint]);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task WithOtlpDevTunnel_ThrowsWhenDashboardDisabledAndNoConfiguredOtlpEndpoint()
+    {
+        var projectContent = CreateProjectContent("net10.0-android");
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            var appBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { DisableDashboard = true });
+
+            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+            maui.AddAndroidEmulator()
+                .WithOtlpDevTunnel();
+
+            var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+
+            await using var app = appBuilder.Build();
+
+            var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
+                appBuilder.Eventing.PublishAsync(new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services), CancellationToken.None));
+
+            Assert.Contains("requires the Aspire dashboard", exception.Message);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task WithOtlpDevTunnel_ThrowsWhenDashboardHasNoAllocatedOtlpEndpoint()
+    {
+        var projectContent = CreateProjectContent("net10.0-android");
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            var appBuilder = DistributedApplication.CreateBuilder();
+            appBuilder.AddResource(new ContainerResource(KnownResourceNames.AspireDashboard));
+
+            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+            maui.AddAndroidEmulator()
+                .WithOtlpDevTunnel();
+
+            var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+
+            await using var app = appBuilder.Build();
+
+            var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
+                appBuilder.Eventing.PublishAsync(new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services), CancellationToken.None));
+
+            Assert.Contains("does not have an allocated OTLP endpoint", exception.Message);
+            Assert.Contains(KnownEndpointNames.OtlpGrpcEndpointName, exception.Message);
+            Assert.Contains(KnownEndpointNames.OtlpHttpEndpointName, exception.Message);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
     }
 
     // Helper methods

--- a/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Maui;
@@ -11,6 +10,7 @@ using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Net.Sockets;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -676,217 +676,187 @@ public class MauiPlatformExtensionsTests
     [Fact]
     public async Task WithOtlpDevTunnel_AllocatesStubFromDynamicDashboardOtlpEndpoint()
     {
-        var projectContent = CreateProjectContent("net10.0-ios");
-        var tempFile = CreateTempProjectFile(projectContent);
+        using var dir = new TestTempDirectory();
+        var tempFile = Path.Combine(dir.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-ios"));
 
-        try
-        {
-            var appBuilder = DistributedApplication.CreateBuilder();
-            ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
+        var appBuilder = DistributedApplication.CreateBuilder();
+        ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
 
-            var dashboard = appBuilder.AddResource(new ContainerResource(KnownResourceNames.AspireDashboard));
-            dashboard.Resource.Annotations.Add(new EndpointAnnotation(
-                ProtocolType.Tcp,
-                name: KnownEndpointNames.OtlpGrpcEndpointName,
-                uriScheme: "http",
-                isProxied: true,
-                transport: "http2"));
+        var dashboard = appBuilder.AddResource(new ContainerResource(KnownResourceNames.AspireDashboard));
+        dashboard.Resource.Annotations.Add(new EndpointAnnotation(
+            ProtocolType.Tcp,
+            name: KnownEndpointNames.OtlpGrpcEndpointName,
+            uriScheme: "http",
+            isProxied: true,
+            transport: "http2"));
 
-            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
-            var iosSimulator = maui.AddiOSSimulator()
-                .WithOtlpDevTunnel();
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var iosSimulator = maui.AddiOSSimulator()
+            .WithOtlpDevTunnel();
 
-            var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
-            var stubEndpoint = tunnelConfig.OtlpStub.OtlpEndpoint;
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+        var stubEndpoint = tunnelConfig.OtlpStub.OtlpEndpoint;
 
-            Assert.Null(stubEndpoint.Port);
-            Assert.Null(stubEndpoint.TargetPort);
-            Assert.Null(stubEndpoint.AllocatedEndpoint);
+        Assert.Null(stubEndpoint.Port);
+        Assert.Null(stubEndpoint.TargetPort);
+        Assert.Null(stubEndpoint.AllocatedEndpoint);
 
-            await using var app = appBuilder.Build();
+        await using var app = appBuilder.Build();
 
-            var dashboardEndpoint = dashboard.Resource.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == KnownEndpointNames.OtlpGrpcEndpointName);
-            dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(dashboardEndpoint, "localhost", 55075);
-            await appBuilder.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services), CancellationToken.None);
+        var dashboardEndpoint = dashboard.Resource.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == KnownEndpointNames.OtlpGrpcEndpointName);
+        dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(dashboardEndpoint, "localhost", 55075);
+        await appBuilder.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services), CancellationToken.None);
 
-            Assert.Equal("http", stubEndpoint.UriScheme);
-            Assert.Equal(55075, stubEndpoint.Port);
-            Assert.Equal(55075, stubEndpoint.TargetPort);
-            Assert.Equal("http://localhost:55075", stubEndpoint.AllocatedEndpoint?.UriString);
+        Assert.Equal("http", stubEndpoint.UriScheme);
+        Assert.Equal(55075, stubEndpoint.Port);
+        Assert.Equal(55075, stubEndpoint.TargetPort);
+        Assert.Equal("http://localhost:55075", stubEndpoint.AllocatedEndpoint?.UriString);
 
-            var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
-            tunnelEndpoint.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(tunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
+        var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
+        tunnelEndpoint.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(tunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
 
-            var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
-                iosSimulator.Resource,
-                DistributedApplicationOperation.Run,
-                app.Services);
+        var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+            iosSimulator.Resource,
+            DistributedApplicationOperation.Run,
+            app.Services);
 
-            Assert.Equal("https://mobile-otlp.devtunnels.ms:443", envVars[KnownOtelConfigNames.ExporterOtlpEndpoint]);
-            Assert.Equal("grpc", envVars[KnownOtelConfigNames.ExporterOtlpProtocol]);
-        }
-        finally
-        {
-            CleanupTempFile(tempFile);
-        }
+        Assert.Equal("https://mobile-otlp.devtunnels.ms:443", envVars[KnownOtelConfigNames.ExporterOtlpEndpoint]);
+        Assert.Equal("grpc", envVars[KnownOtelConfigNames.ExporterOtlpProtocol]);
     }
 
     [Fact]
     public async Task WithOtlpDevTunnel_AllocatesStubFromConfiguredOtlpEndpoint()
     {
-        var projectContent = CreateProjectContent("net10.0-android");
-        var tempFile = CreateTempProjectFile(projectContent);
+        using var dir = new TestTempDirectory();
+        var tempFile = Path.Combine(dir.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-android"));
 
-        try
+        using var appBuilder = TestDistributedApplicationBuilder.Create();
+        appBuilder.Configuration[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "http://localhost:18889";
+
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var androidEmulator = maui.AddAndroidEmulator()
+            .WithOtlpDevTunnel();
+        var dashboard = appBuilder.AddResource(new ContainerResource(KnownResourceNames.AspireDashboard));
+        var dashboardEndpoint = new EndpointAnnotation(
+            ProtocolType.Tcp,
+            name: KnownEndpointNames.OtlpGrpcEndpointName,
+            uriScheme: "https",
+            isProxied: true,
+            transport: "http2");
+        dashboard.Resource.Annotations.Add(dashboardEndpoint);
+
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+        var stubEndpoint = tunnelConfig.OtlpStub.OtlpEndpoint;
+        var stubEndpointEventPublished = false;
+        appBuilder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>((evt, _) =>
         {
-            using var appBuilder = TestDistributedApplicationBuilder.Create();
-            appBuilder.Configuration[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "http://localhost:18889";
-
-            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
-            var androidEmulator = maui.AddAndroidEmulator()
-                .WithOtlpDevTunnel();
-            var dashboard = appBuilder.AddResource(new ContainerResource(KnownResourceNames.AspireDashboard));
-            var dashboardEndpoint = new EndpointAnnotation(
-                ProtocolType.Tcp,
-                name: KnownEndpointNames.OtlpGrpcEndpointName,
-                uriScheme: "https",
-                isProxied: true,
-                transport: "http2");
-            dashboard.Resource.Annotations.Add(dashboardEndpoint);
-
-            var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
-            var stubEndpoint = tunnelConfig.OtlpStub.OtlpEndpoint;
-            var stubEndpointEventPublished = false;
-            appBuilder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>((evt, _) =>
+            if (ReferenceEquals(evt.Resource, tunnelConfig.OtlpStub))
             {
-                if (ReferenceEquals(evt.Resource, tunnelConfig.OtlpStub))
-                {
-                    stubEndpointEventPublished = true;
-                }
+                stubEndpointEventPublished = true;
+            }
 
-                return Task.CompletedTask;
-            });
+            return Task.CompletedTask;
+        });
 
-            Assert.Equal("http", stubEndpoint.UriScheme);
-            Assert.Equal(18889, stubEndpoint.Port);
-            Assert.Equal(18889, stubEndpoint.TargetPort);
-            Assert.Equal("http://localhost:18889", stubEndpoint.AllocatedEndpoint?.UriString);
+        Assert.Equal("http", stubEndpoint.UriScheme);
+        Assert.Equal(18889, stubEndpoint.Port);
+        Assert.Equal(18889, stubEndpoint.TargetPort);
+        Assert.Equal("http://localhost:18889", stubEndpoint.AllocatedEndpoint?.UriString);
 
-            await using var app = appBuilder.Build();
+        await using var app = appBuilder.Build();
 
-            await appBuilder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()), CancellationToken.None);
-            Assert.True(stubEndpointEventPublished);
+        await appBuilder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()), CancellationToken.None);
+        Assert.True(stubEndpointEventPublished);
 
-            dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(dashboardEndpoint, "localhost", 55075);
-            await appBuilder.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services), CancellationToken.None);
+        dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(dashboardEndpoint, "localhost", 55075);
+        await appBuilder.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services), CancellationToken.None);
 
-            Assert.Equal("http", stubEndpoint.UriScheme);
-            Assert.Equal(18889, stubEndpoint.Port);
-            Assert.Equal(18889, stubEndpoint.TargetPort);
-            Assert.Equal("http://localhost:18889", stubEndpoint.AllocatedEndpoint?.UriString);
+        Assert.Equal("http", stubEndpoint.UriScheme);
+        Assert.Equal(18889, stubEndpoint.Port);
+        Assert.Equal(18889, stubEndpoint.TargetPort);
+        Assert.Equal("http://localhost:18889", stubEndpoint.AllocatedEndpoint?.UriString);
 
-            var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
-            tunnelEndpoint.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(tunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
+        var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
+        tunnelEndpoint.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(tunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
 
-            var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
-                androidEmulator.Resource,
-                DistributedApplicationOperation.Run,
-                app.Services);
+        var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+            androidEmulator.Resource,
+            DistributedApplicationOperation.Run,
+            app.Services);
 
-            Assert.Equal("https://mobile-otlp.devtunnels.ms:443", envVars[KnownOtelConfigNames.ExporterOtlpEndpoint]);
-        }
-        finally
-        {
-            CleanupTempFile(tempFile);
-        }
+        Assert.Equal("https://mobile-otlp.devtunnels.ms:443", envVars[KnownOtelConfigNames.ExporterOtlpEndpoint]);
     }
 
     [Fact]
     public async Task WithOtlpDevTunnel_ThrowsWhenDashboardDisabledAndNoConfiguredOtlpEndpoint()
     {
-        var projectContent = CreateProjectContent("net10.0-android");
-        var tempFile = CreateTempProjectFile(projectContent);
+        using var dir = new TestTempDirectory();
+        var tempFile = Path.Combine(dir.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-android"));
 
-        try
-        {
-            var appBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { DisableDashboard = true });
-            ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
+        var appBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { DisableDashboard = true });
+        ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
 
-            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
-            maui.AddAndroidEmulator()
-                .WithOtlpDevTunnel();
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        maui.AddAndroidEmulator()
+            .WithOtlpDevTunnel();
 
-            var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
 
-            await using var app = appBuilder.Build();
+        await using var app = appBuilder.Build();
 
-            var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
-                appBuilder.Eventing.PublishAsync(new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services), CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
+            appBuilder.Eventing.PublishAsync(new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services), CancellationToken.None));
 
-            Assert.Contains("requires the Aspire dashboard", exception.Message);
-        }
-        finally
-        {
-            CleanupTempFile(tempFile);
-        }
+        Assert.Contains("requires the Aspire dashboard", exception.Message);
     }
 
     [Fact]
     public async Task WithOtlpDevTunnel_ThrowsWhenDashboardHasNoAllocatedOtlpEndpoint()
     {
-        var projectContent = CreateProjectContent("net10.0-android");
-        var tempFile = CreateTempProjectFile(projectContent);
+        using var dir = new TestTempDirectory();
+        var tempFile = Path.Combine(dir.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-android"));
 
-        try
-        {
-            var appBuilder = DistributedApplication.CreateBuilder();
-            ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
-            appBuilder.AddResource(new ContainerResource(KnownResourceNames.AspireDashboard));
+        var appBuilder = DistributedApplication.CreateBuilder();
+        ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
+        appBuilder.AddResource(new ContainerResource(KnownResourceNames.AspireDashboard));
 
-            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
-            maui.AddAndroidEmulator()
-                .WithOtlpDevTunnel();
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        maui.AddAndroidEmulator()
+            .WithOtlpDevTunnel();
 
-            var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
 
-            await using var app = appBuilder.Build();
+        await using var app = appBuilder.Build();
 
-            var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
-                appBuilder.Eventing.PublishAsync(new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services), CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
+            appBuilder.Eventing.PublishAsync(new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services), CancellationToken.None));
 
-            Assert.Contains("does not have an allocated OTLP endpoint", exception.Message);
-            Assert.Contains(KnownEndpointNames.OtlpGrpcEndpointName, exception.Message);
-            Assert.Contains(KnownEndpointNames.OtlpHttpEndpointName, exception.Message);
-        }
-        finally
-        {
-            CleanupTempFile(tempFile);
-        }
+        Assert.Contains("does not have an allocated OTLP endpoint", exception.Message);
+        Assert.Contains(KnownEndpointNames.OtlpGrpcEndpointName, exception.Message);
+        Assert.Contains(KnownEndpointNames.OtlpHttpEndpointName, exception.Message);
     }
 
     [Fact]
     public void WithOtlpDevTunnel_ThrowsForInvalidConfiguredOtlpEndpoint()
     {
-        var projectContent = CreateProjectContent("net10.0-android");
-        var tempFile = CreateTempProjectFile(projectContent);
+        using var dir = new TestTempDirectory();
+        var tempFile = Path.Combine(dir.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-android"));
 
-        try
-        {
-            var appBuilder = DistributedApplication.CreateBuilder();
-            appBuilder.Configuration[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "not a url";
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.Configuration[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "not a url";
 
-            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
-            var androidEmulator = maui.AddAndroidEmulator();
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var androidEmulator = maui.AddAndroidEmulator();
 
-            var exception = Assert.Throws<DistributedApplicationException>(() => androidEmulator.WithOtlpDevTunnel());
+        var exception = Assert.Throws<DistributedApplicationException>(() => androidEmulator.WithOtlpDevTunnel());
 
-            Assert.Contains(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, exception.Message);
-            Assert.Contains("not a url", exception.Message);
-        }
-        finally
-        {
-            CleanupTempFile(tempFile);
-        }
+        Assert.Contains(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, exception.Message);
+        Assert.Contains("not a url", exception.Message);
     }
 
     // Helper methods

--- a/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
@@ -9,6 +9,7 @@ using Aspire.Hosting.Maui.Annotations;
 using Aspire.Hosting.Maui.Utilities;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 using System.Text.Json;
@@ -681,6 +682,8 @@ public class MauiPlatformExtensionsTests
         try
         {
             var appBuilder = DistributedApplication.CreateBuilder();
+            ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
+
             var dashboard = appBuilder.AddResource(new ContainerResource(KnownResourceNames.AspireDashboard));
             dashboard.Resource.Annotations.Add(new EndpointAnnotation(
                 ProtocolType.Tcp,
@@ -807,6 +810,7 @@ public class MauiPlatformExtensionsTests
         try
         {
             var appBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { DisableDashboard = true });
+            ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
 
             var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
             maui.AddAndroidEmulator()
@@ -836,6 +840,7 @@ public class MauiPlatformExtensionsTests
         try
         {
             var appBuilder = DistributedApplication.CreateBuilder();
+            ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
             appBuilder.AddResource(new ContainerResource(KnownResourceNames.AspireDashboard));
 
             var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
@@ -852,6 +857,31 @@ public class MauiPlatformExtensionsTests
             Assert.Contains("does not have an allocated OTLP endpoint", exception.Message);
             Assert.Contains(KnownEndpointNames.OtlpGrpcEndpointName, exception.Message);
             Assert.Contains(KnownEndpointNames.OtlpHttpEndpointName, exception.Message);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    [Fact]
+    public void WithOtlpDevTunnel_ThrowsForInvalidConfiguredOtlpEndpoint()
+    {
+        var projectContent = CreateProjectContent("net10.0-android");
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            var appBuilder = DistributedApplication.CreateBuilder();
+            appBuilder.Configuration[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "not a url";
+
+            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+            var androidEmulator = maui.AddAndroidEmulator();
+
+            var exception = Assert.Throws<DistributedApplicationException>(() => androidEmulator.WithOtlpDevTunnel());
+
+            Assert.Contains(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, exception.Message);
+            Assert.Contains("not a url", exception.Message);
         }
         finally
         {
@@ -927,6 +957,17 @@ public class MauiPlatformExtensionsTests
         annotator.DynamicInvoke(executable, "Debug");
 
         return Assert.Single(GetLaunchConfigurations<SerializedMauiLaunchConfiguration>(executable));
+    }
+
+    private static void ClearDashboardOtlpEndpointConfiguration(ConfigurationManager configuration)
+    {
+        configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "",
+            [KnownConfigNames.Legacy.DashboardOtlpGrpcEndpointUrl] = "",
+            [KnownConfigNames.DashboardOtlpHttpEndpointUrl] = "",
+            [KnownConfigNames.Legacy.DashboardOtlpHttpEndpointUrl] = ""
+        });
     }
 
     // Configuration class for platform-specific test data


### PR DESCRIPTION
## Description

Fixes MAUI OTLP dev tunnel endpoint resolution so mobile apps send telemetry to the actual Aspire dashboard OTLP endpoint when the dashboard uses dynamically allocated ports.

Previously, `WithOtlpDevTunnel()` resolved the tunnel target from configuration and could fall back to the default OTLP port (`18889`) when no static dashboard OTLP endpoint URL was configured. File-based AppHosts commonly use dynamic dashboard OTLP ports, so the MAUI app could receive a dev tunnel endpoint that targeted a stale/non-listening port and telemetry would not appear in the dashboard.

This change makes the MAUI OTLP dev tunnel:

- use the actual dashboard OTLP endpoint from `ResourceEndpointsAllocatedEvent` when no explicit OTLP endpoint URL is configured
- preserve configured/static OTLP endpoint URL behavior
- fail fast with a clear error if no configured OTLP endpoint exists and the dashboard is disabled or lacks an allocated OTLP endpoint
- share the canonical dashboard resource and OTLP endpoint names from `src/Shared`

### User-facing usage

The documented MAUI pattern continues to work without custom fixed-port workarounds:

```csharp
var mobile = builder.AddMauiProject("mobile", "./AspireWithMaui.Mobile/AspireWithMaui.Mobile.csproj");

mobile.AddiOSSimulator()
    .WithOtlpDevTunnel()
    .WithReference(apiService, publicDevTunnel);

mobile.AddAndroidEmulator()
    .WithOtlpDevTunnel()
    .WithReference(apiService, publicDevTunnel);
```

When the dashboard allocates OTLP/gRPC dynamically, the generated MAUI environment now points to a dev tunnel for that allocated port instead of the stale fallback `18889`.

Validation:

```bash
dotnet test --project tests/Aspire.Hosting.Maui.Tests/Aspire.Hosting.Maui.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Result: 76 passed.

Manual validation was also performed in `microsoft/aspire-samples` with local packages: the MAUI iOS simulator used a dev tunnel for the dynamic dashboard OTLP/gRPC port and the dashboard showed logs, traces, and metrics for `mobile-ios-simulator`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
