### PR TITLE
Allow Azure VNet subnet name to be a parameter

### DIFF
--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
@@ -5,6 +5,7 @@
 #pragma warning disable ASPIREAZURE001 // AzureEnvironmentResource.ProvisionInfrastructureStepName for pipeline ordering
 #pragma warning disable ASPIREAZURE003 // AzureSubnetResource used in WithSubnet extensions
 
+using System.Diagnostics;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Azure.Kubernetes;
@@ -763,7 +764,20 @@ public static class AzureKubernetesEnvironmentExtensions
                 {
                     existingSubnet = SubnetResource.FromExisting(subnetIdentifier);
                     existingSubnet.Parent = existingVnet;
-                    existingSubnet.Name = subnet.SubnetName;
+
+                    if (subnet.SubnetName is not null)
+                    {
+                        existingSubnet.Name = subnet.SubnetName;
+                    }
+                    else if (subnet.SubnetNameParameter is not null)
+                    {
+                        existingSubnet.Name = subnet.SubnetNameParameter.AsProvisioningParameter(infrastructure);
+                    }
+                    else
+                    {
+                        throw new UnreachableException("Subnet name must be set.");
+                    }
+
                     infrastructure.Add(existingSubnet);
                     subnetExistingByKey[subnetIdentifier] = existingSubnet;
                 }

--- a/src/Aspire.Hosting.Azure.Network/AzureSubnetResource.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureSubnetResource.cs
@@ -22,6 +22,7 @@ namespace Aspire.Hosting.Azure;
 public class AzureSubnetResource : Resource, IResourceWithParent<AzureVirtualNetworkResource>
 {
     // Backing field holds either string or ParameterResource
+    private readonly object _subnetName;
     private readonly object _addressPrefix;
 
     /// <summary>
@@ -34,7 +35,7 @@ public class AzureSubnetResource : Resource, IResourceWithParent<AzureVirtualNet
     public AzureSubnetResource(string name, string subnetName, string addressPrefix, AzureVirtualNetworkResource parent)
         : base(name)
     {
-        SubnetName = ThrowIfNullOrEmpty(subnetName);
+        _subnetName = ThrowIfNullOrEmpty(subnetName);
         _addressPrefix = ThrowIfNullOrEmpty(addressPrefix);
         Parent = parent ?? throw new ArgumentNullException(nameof(parent));
     }
@@ -49,20 +50,40 @@ public class AzureSubnetResource : Resource, IResourceWithParent<AzureVirtualNet
     public AzureSubnetResource(string name, string subnetName, ParameterResource addressPrefix, AzureVirtualNetworkResource parent)
         : base(name)
     {
-        SubnetName = ThrowIfNullOrEmpty(subnetName);
+        _subnetName = ThrowIfNullOrEmpty(subnetName);
         _addressPrefix = addressPrefix ?? throw new ArgumentNullException(nameof(addressPrefix));
         Parent = parent ?? throw new ArgumentNullException(nameof(parent));
     }
 
     /// <summary>
-    /// Gets the subnet name.
+    /// Initializes a new instance of the <see cref="AzureSubnetResource"/> class with parameterized subnet name and address prefix.
     /// </summary>
-    public string SubnetName { get; }
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="subnetName">The parameter resource containing the subnet name.</param>
+    /// <param name="addressPrefix">The parameter resource containing the address prefix for the subnet.</param>
+    /// <param name="parent">The parent Virtual Network resource.</param>
+    public AzureSubnetResource(string name, ParameterResource subnetName, ParameterResource addressPrefix, AzureVirtualNetworkResource parent)
+        : base(name)
+    {
+        _subnetName = subnetName ?? throw new ArgumentNullException(nameof(subnetName));
+        _addressPrefix = addressPrefix ?? throw new ArgumentNullException(nameof(addressPrefix));
+        Parent = parent ?? throw new ArgumentNullException(nameof(parent));
+    }
+
+    /// <summary>
+    /// Gets the subnet name, or <c>null</c> if the subnet name is provided via a <see cref="ParameterResource"/>.
+    /// </summary>
+    public string? SubnetName => _subnetName as string;
 
     /// <summary>
     /// Gets the address prefix for the subnet (e.g., "10.0.1.0/24"), or <c>null</c> if the address prefix is provided via a <see cref="ParameterResource"/>.
     /// </summary>
     public string? AddressPrefix => _addressPrefix as string;
+
+    /// <summary>
+    /// Gets the parameter resource containing the subnet name, or <c>null</c> if the subnet name is provided as a literal string.
+    /// </summary>
+    public ParameterResource? SubnetNameParameter => _subnetName as ParameterResource;
 
     /// <summary>
     /// Gets the parameter resource containing the address prefix for the subnet, or <c>null</c> if the address prefix is provided as a literal string.
@@ -97,10 +118,21 @@ public class AzureSubnetResource : Resource, IResourceWithParent<AzureVirtualNet
     /// </summary>
     internal SubnetResource ToProvisioningEntity(AzureResourceInfrastructure infra, ProvisionableResource? dependsOn)
     {
-        var subnet = new SubnetResource(Infrastructure.NormalizeBicepIdentifier(Name))
+        var subnet = new SubnetResource(Infrastructure.NormalizeBicepIdentifier(Name));
+
+        // Set the subnet name from either the literal string or the parameter
+        if (_subnetName is string subnetName)
         {
-            Name = SubnetName,
-        };
+            subnet.Name = subnetName;
+        }
+        else if (_subnetName is ParameterResource subnetNameParameter)
+        {
+            subnet.Name = subnetNameParameter.AsProvisioningParameter(infra);
+        }
+        else
+        {
+            throw new UnreachableException("SubnetName must be set either as a string or a ParameterResource.");
+        }
 
         // Set the address prefix from either the literal string or the parameter
         if (_addressPrefix is string addressPrefix)

--- a/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
@@ -240,6 +240,40 @@ public static class AzureVirtualNetworkExtensions
     }
 
     /// <summary>
+    /// Adds an Azure Subnet to the Virtual Network with parameterized address prefix and subnet name.
+    /// </summary>
+    /// <param name="builder">The Virtual Network resource builder.</param>
+    /// <param name="name">The name of the subnet resource.</param>
+    /// <param name="addressPrefix">The parameter resource containing the address prefix for the subnet (e.g., "10.0.1.0/24").</param>
+    /// <param name="subnetName">The parameter resource containing the subnet name in Azure.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{AzureSubnetResource}"/>.</returns>
+    /// <example>
+    /// This example adds a subnet with parameterized address prefix and subnet name:
+    /// <code>
+    /// var subnetName = builder.AddParameter("subnetName");
+    /// var subnetPrefix = builder.AddParameter("subnetPrefix");
+    /// var vnet = builder.AddAzureVirtualNetwork("vnet");
+    /// var subnet = vnet.AddSubnet("my-subnet", subnetPrefix, subnetName);
+    /// </code>
+    /// </example>
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the internal addSubnet dispatcher export.")]
+    public static IResourceBuilder<AzureSubnetResource> AddSubnet(
+        this IResourceBuilder<AzureVirtualNetworkResource> builder,
+        [ResourceName] string name,
+        IResourceBuilder<ParameterResource> addressPrefix,
+        IResourceBuilder<ParameterResource> subnetName)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNull(addressPrefix);
+        ArgumentNullException.ThrowIfNull(subnetName);
+
+        var subnet = new AzureSubnetResource(name, subnetName.Resource, addressPrefix.Resource, builder.Resource);
+
+        return AddSubnetCore(builder, subnet);
+    }
+
+    /// <summary>
     /// Adds an Azure subnet resource to an Azure Virtual Network resource.
     /// </summary>
     [AspireExport("addSubnet")]


### PR DESCRIPTION
## Description

This pull request enhances support for parameterized subnet names in Azure subnet resources, enabling more flexible and dynamic provisioning scenarios. The main changes include updating the `AzureSubnetResource` class to accept either a literal string or a `ParameterResource` for the subnet name, adding a new overload for `AddSubnet` that supports parameterized subnet names and prefixes, and updating infrastructure configuration logic to handle these cases robustly.

**Support for parameterized subnet names and address prefixes:**

- `AzureSubnetResource` now accepts either a string or a `ParameterResource` for the subnet name and address prefix, and exposes new properties (`SubnetNameParameter`, `AddressPrefixParameter`) for accessing them. The class logic and constructor overloads have been updated accordingly.
- The `ToProvisioningEntity` method in `AzureSubnetResource` is updated to set the subnet name and address prefix from either a string or a parameter, throwing an exception if neither is set.

**API surface improvements:**

- A new overload for `AddSubnet` in `AzureVirtualNetworkExtensions` allows adding a subnet with both parameterized address prefix and subnet name, making it easier to define subnets dynamically in code.

**Infrastructure configuration robustness:**

- The AKS infrastructure configuration in `AzureKubernetesEnvironmentExtensions` now checks for both literal and parameterized subnet names, throwing an exception if neither is set, to ensure correctness during provisioning.


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
