### PR TITLE
[ci] Make internal build robust to download failures

### DIFF
--- a/eng/scripts/download-native-archives.ps1
+++ b/eng/scripts/download-native-archives.ps1
@@ -59,6 +59,20 @@
 .PARAMETER ThrottleLimit
     Maximum concurrent download jobs. Defaults to 10.
 
+.PARAMETER MaxDownloadAttempts
+    Total number of attempts per artifact download before giving up. Defaults
+    to 4 (i.e. the initial attempt plus up to 3 retries). Retries cover
+    transient artifact-store failures — both HTTP 5xx responses and
+    transport-level errors such as "An existing connection was forcibly closed
+    by the remote host" that drop the connection mid-transfer. (`Invoke-WebRequest
+    -MaximumRetryCount` only retries on HTTP status codes, not on those
+    transport exceptions, so the retry is implemented explicitly here.)
+
+.PARAMETER RetryBaseDelaySeconds
+    Base delay for exponential backoff between download retries. The wait before
+    retry N is `RetryBaseDelaySeconds * 2^(N-1)` seconds (e.g. 3, 6, 12 with the
+    default of 3). Set to 0 to retry without waiting (used by tests).
+
 .PARAMETER ApiVersion
     AzDO REST API version. Defaults to `7.1`.
 
@@ -100,6 +114,12 @@ param(
 
     [ValidateRange(1, 64)]
     [int]$ThrottleLimit = 10,
+
+    [ValidateRange(1, 10)]
+    [int]$MaxDownloadAttempts = 4,
+
+    [ValidateRange(0, 60)]
+    [int]$RetryBaseDelaySeconds = 3,
 
     [string]$ApiVersion = '7.1'
 )
@@ -184,7 +204,9 @@ $DownloadOneArtifact = {
         [string]$ArtifactName,
         [string]$DownloadUrl,
         [string]$ArchivesTargetDir,
-        [string]$NupkgsTargetDir
+        [string]$NupkgsTargetDir,
+        [int]$MaxDownloadAttempts,
+        [int]$RetryBaseDelaySeconds
     )
 
     Set-StrictMode -Version 3.0
@@ -193,30 +215,61 @@ $DownloadOneArtifact = {
     $tempBase = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
     $tempZip = Join-Path $tempBase "$ArtifactName.zip"
 
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
-    try {
-        Invoke-WebRequest -Uri $DownloadUrl -OutFile $tempZip `
-            -Headers @{ Authorization = "Bearer $AccessToken" } -UseBasicParsing
-    }
-    catch {
-        # Preserve $tempZip on failure (do NOT remove it) so a developer can
-        # inspect partial download contents. See Get-MatchingArtifacts above
-        # for why the throw message is constructed from $_.Exception.Message
-        # rather than the full ErrorRecord (token-leak hardening).
-        $status = $null
-        try { $status = $_.Exception.Response.StatusCode } catch { }
-        $statusPart = if ($null -ne $status) { " (HTTP $status)" } else { "" }
-        throw "Download failed for '$ArtifactName' from $DownloadUrl$statusPart. Temp file (may be partial): $tempZip. $($_.Exception.Message)"
+    # Retry transient download failures. AzDO's artifact store intermittently
+    # drops connections mid-transfer ("An existing connection was forcibly
+    # closed by the remote host"), which surfaces as a transport-level
+    # exception with no HTTP response — so `Invoke-WebRequest -MaximumRetryCount`
+    # (which only retries on HTTP status codes) does not cover it. Retry the
+    # whole request explicitly with exponential backoff so one flaky artifact
+    # doesn't fail the entire assemble stage. See
+    # https://github.com/microsoft/aspire/issues/18055.
+    #
+    # Opening the zip is done INSIDE the retry scope as an integrity check: a
+    # connection dropped mid-transfer usually throws from Invoke-WebRequest, but
+    # could also leave a truncated-yet-complete-looking file that only fails when
+    # ZipFile::OpenRead rejects it. Re-downloading is the correct remedy for that
+    # too, so a corrupt-zip failure should retry rather than fail the stage.
+    $attempt = 0
+    $zip = $null
+    while ($true) {
+        $attempt++
+        try {
+            Invoke-WebRequest -Uri $DownloadUrl -OutFile $tempZip `
+                -Headers @{ Authorization = "Bearer $AccessToken" } -UseBasicParsing
+            $zip = [System.IO.Compression.ZipFile]::OpenRead($tempZip)
+            break
+        }
+        catch {
+            # Construct the message from $_.Exception.Message + status code only,
+            # not the full ErrorRecord. The ErrorRecord's string form can include
+            # the request's Authorization header on some Invoke-WebRequest failure
+            # modes; AzDO log scrubbing masks $(System.AccessToken), but the
+            # -AccessToken parameter is also designed for non-AzDO use where
+            # nothing scrubs.
+            $status = $null
+            try { $status = $_.Exception.Response.StatusCode } catch { }
+            $statusPart = if ($null -ne $status) { " (HTTP $status)" } else { "" }
+
+            if ($attempt -ge $MaxDownloadAttempts) {
+                # Final attempt failed. Preserve $tempZip (do NOT remove it) so a
+                # developer can inspect partial / corrupt download contents.
+                throw "Download of '$ArtifactName' from $DownloadUrl$statusPart failed after $attempt attempt(s). Temp file (may be partial or corrupt): $tempZip. $($_.Exception.Message)"
+            }
+
+            # Remove the partial/corrupt temp file before retrying so a
+            # half-written zip from a dropped connection isn't reused on the next
+            # attempt.
+            Remove-Item -LiteralPath $tempZip -Force -ErrorAction SilentlyContinue
+
+            $delay = [int]($RetryBaseDelaySeconds * [math]::Pow(2, $attempt - 1))
+            Write-Host "##[warning]Download attempt $attempt/$MaxDownloadAttempts failed for '$ArtifactName'$statusPart; retrying in ${delay}s. $($_.Exception.Message)"
+            if ($delay -gt 0) { Start-Sleep -Seconds $delay }
+        }
     }
     $downloadMs = $sw.ElapsedMilliseconds
-
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    try {
-        $zip = [System.IO.Compression.ZipFile]::OpenRead($tempZip)
-    }
-    catch {
-        throw "Could not open downloaded zip for '$ArtifactName' at $tempZip. The file may be corrupt or not a zip. $_"
-    }
 
     $archivesCount = 0
     $nupkgsCount = 0
@@ -300,7 +353,9 @@ function Invoke-ParallelDownloads {
         [Parameter(Mandatory)] [string]$ArchivesTargetDir,
         [Parameter(Mandatory)] [string]$NupkgsTargetDir,
         [Parameter(Mandatory)] [scriptblock]$Worker,
-        [Parameter(Mandatory)] [int]$ThrottleLimit
+        [Parameter(Mandatory)] [int]$ThrottleLimit,
+        [Parameter(Mandatory)] [int]$MaxDownloadAttempts,
+        [Parameter(Mandatory)] [int]$RetryBaseDelaySeconds
     )
 
     # The cmdlet shipped under the bare name `ThreadJob` in PS 7.0-7.3 and was
@@ -335,7 +390,7 @@ function Invoke-ParallelDownloads {
     $jobs = @(foreach ($a in $Artifacts) {
         Start-ThreadJob `
             -ScriptBlock $Worker `
-            -ArgumentList @($AccessToken, $a.name, $a.resource.downloadUrl, $ArchivesTargetDir, $NupkgsTargetDir) `
+            -ArgumentList @($AccessToken, $a.name, $a.resource.downloadUrl, $ArchivesTargetDir, $NupkgsTargetDir, $MaxDownloadAttempts, $RetryBaseDelaySeconds) `
             -ThrottleLimit $ThrottleLimit `
             -Name $a.name
     })
@@ -383,4 +438,6 @@ Invoke-ParallelDownloads `
     -ArchivesTargetDir $ArchivesTargetDir `
     -NupkgsTargetDir $NupkgsTargetDir `
     -Worker $DownloadOneArtifact `
-    -ThrottleLimit $ThrottleLimit
+    -ThrottleLimit $ThrottleLimit `
+    -MaxDownloadAttempts $MaxDownloadAttempts `
+    -RetryBaseDelaySeconds $RetryBaseDelaySeconds

--- a/eng/scripts/download-native-archives.ps1
+++ b/eng/scripts/download-native-archives.ps1
@@ -62,11 +62,12 @@
 .PARAMETER MaxDownloadAttempts
     Total number of attempts per artifact download before giving up. Defaults
     to 4 (i.e. the initial attempt plus up to 3 retries). Retries cover
-    transient artifact-store failures — both HTTP 5xx responses and
+    transient artifact-store failures — HTTP 408, 429, and 5xx responses;
     transport-level errors such as "An existing connection was forcibly closed
-    by the remote host" that drop the connection mid-transfer. (`Invoke-WebRequest
-    -MaximumRetryCount` only retries on HTTP status codes, not on those
-    transport exceptions, so the retry is implemented explicitly here.)
+    by the remote host"; and corrupt zip downloads that fail the integrity check.
+    Non-transient HTTP 4xx responses fail immediately. (`Invoke-WebRequest
+    -MaximumRetryCount` only retries on HTTP status codes, not on transport
+    exceptions or corrupt downloads, so the retry is implemented explicitly here.)
 
 .PARAMETER RetryBaseDelaySeconds
     Base delay for exponential backoff between download retries. The wait before
@@ -249,14 +250,24 @@ $DownloadOneArtifact = {
             # modes; AzDO log scrubbing masks $(System.AccessToken), but the
             # -AccessToken parameter is also designed for non-AzDO use where
             # nothing scrubs.
-            $status = $null
-            try { $status = $_.Exception.Response.StatusCode } catch { }
-            $statusPart = if ($null -ne $status) { " (HTTP $status)" } else { "" }
+            $errorMessage = $_.Exception.Message
+            $statusCode = $null
+            try {
+                if ($null -ne $_.Exception.Response -and $null -ne $_.Exception.Response.StatusCode) {
+                    $statusCode = [int]$_.Exception.Response.StatusCode
+                }
+            } catch { }
+            $statusPart = if ($null -ne $statusCode) { " (HTTP $statusCode)" } else { "" }
+            $isRetryable = ($null -eq $statusCode) -or ($statusCode -eq 408) -or ($statusCode -eq 429) -or ($statusCode -ge 500)
+
+            if (-not $isRetryable) {
+                throw "Download of '$ArtifactName' from $DownloadUrl$statusPart failed with non-retryable HTTP $statusCode. Temp file (may be partial or corrupt): $tempZip. $errorMessage"
+            }
 
             if ($attempt -ge $MaxDownloadAttempts) {
                 # Final attempt failed. Preserve $tempZip (do NOT remove it) so a
                 # developer can inspect partial / corrupt download contents.
-                throw "Download of '$ArtifactName' from $DownloadUrl$statusPart failed after $attempt attempt(s). Temp file (may be partial or corrupt): $tempZip. $($_.Exception.Message)"
+                throw "Download of '$ArtifactName' from $DownloadUrl$statusPart failed after $attempt attempt(s). Temp file (may be partial or corrupt): $tempZip. $errorMessage"
             }
 
             # Remove the partial/corrupt temp file before retrying so a
@@ -265,7 +276,7 @@ $DownloadOneArtifact = {
             Remove-Item -LiteralPath $tempZip -Force -ErrorAction SilentlyContinue
 
             $delay = [int]($RetryBaseDelaySeconds * [math]::Pow(2, $attempt - 1))
-            Write-Host "##[warning]Download attempt $attempt/$MaxDownloadAttempts failed for '$ArtifactName'$statusPart; retrying in ${delay}s. $($_.Exception.Message)"
+            Write-Host "##[warning]Download attempt $attempt/$MaxDownloadAttempts failed for '$ArtifactName'$statusPart; retrying in ${delay}s. $errorMessage"
             if ($delay -gt 0) { Start-Sleep -Seconds $delay }
         }
     }

--- a/tests/Infrastructure.Tests/PowerShellScripts/DownloadNativeArchivesTests.cs
+++ b/tests/Infrastructure.Tests/PowerShellScripts/DownloadNativeArchivesTests.cs
@@ -245,9 +245,8 @@ public sealed class DownloadNativeArchivesTests : IDisposable
 
         using var server = new MockAzdoServer();
         // The download responds 500 for its first two attempts, then serves the
-        // zip — mirrors AzDO's artifact store dropping a connection mid-transfer
-        // (the failure seen in build 2995658). Without retry, the first failure
-        // would fail the whole assemble stage.
+        // zip — exercises retrying HTTP failures. Without retry, the first
+        // failure would fail the whole assemble stage.
         server.AddFlakyArtifact("native_archives_osx_x64", failTimes: 2, new[]
         {
             ("Release/Shipping/aspire-cli-osx-x64-13.4.0.tar.gz", "tar-content"),
@@ -272,6 +271,69 @@ public sealed class DownloadNativeArchivesTests : IDisposable
         Assert.True(File.Exists(Path.Combine(
             archivesDir,
             "native_archives_osx_x64", "Release", "Shipping", "aspire-cli-osx-x64-13.4.0.tar.gz")));
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task FailsFastForNonTransientHttpDownloadFailure()
+    {
+        var (archivesDir, nupkgsDir) = CreateTargetDirs();
+
+        using var server = new MockAzdoServer();
+        // The artifact list is valid, but the artifact download URL returns 404.
+        // That is a configuration/auth-style failure, not a transient artifact
+        // store failure, so retrying would only delay the actionable error.
+        server.SetArtifacts(new MockArtifact("native_archives_missing"));
+        server.Start();
+
+        var result = await RunScript(
+            collectionUri: server.CollectionUri,
+            project: "internal",
+            buildId: "12345",
+            archivesTargetDir: archivesDir,
+            nupkgsTargetDir: nupkgsDir,
+            accessToken: "fake-token",
+            maxDownloadAttempts: 4);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("non-retryable HTTP 404", result.Output);
+        Assert.DoesNotContain("Download attempt 1/4 failed for 'native_archives_missing'", result.Output);
+        Assert.DoesNotContain("after 4 attempt(s)", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task RetriesConnectionClosedDuringDownload_ThenSucceeds()
+    {
+        var (archivesDir, nupkgsDir) = CreateTargetDirs();
+
+        using var server = new MockAzdoServer();
+        // First attempt advertises a full zip response but closes the connection
+        // after writing only a prefix. That deterministically exercises the
+        // no-successful-response transport failure path, without sleeps or timing
+        // races. Second attempt serves a valid zip.
+        server.AddTruncatedThenValidArtifact("native_archives_osx_arm64", truncateTimes: 1, new[]
+        {
+            ("Release/Shipping/aspire-cli-osx-arm64-13.4.0.tar.gz", "tar-content"),
+            ("Release/Shipping/Aspire.Cli.osx-arm64.13.4.0.nupkg", "nupkg-content"),
+        });
+        server.Start();
+
+        var result = await RunScript(
+            collectionUri: server.CollectionUri,
+            project: "internal",
+            buildId: "12345",
+            archivesTargetDir: archivesDir,
+            nupkgsTargetDir: nupkgsDir,
+            accessToken: "fake-token",
+            maxDownloadAttempts: 4);
+
+        result.EnsureSuccessful();
+        Assert.Contains("Download attempt 1/4 failed for 'native_archives_osx_arm64'", result.Output);
+        Assert.Contains("archives=1 nupkgs=1", result.Output);
+        Assert.True(File.Exists(Path.Combine(
+            archivesDir,
+            "native_archives_osx_arm64", "Release", "Shipping", "aspire-cli-osx-arm64-13.4.0.tar.gz")));
     }
 
     [Fact]
@@ -379,6 +441,7 @@ public sealed class DownloadNativeArchivesTests : IDisposable
         private readonly Dictionary<string, byte[]> _artifactZips = new();
         private readonly HashSet<string> _failingArtifacts = new();
         private readonly Dictionary<string, int> _flakyRemaining = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, int> _truncatedRemaining = new(StringComparer.Ordinal);
         private readonly Dictionary<string, int> _corruptRemaining = new(StringComparer.Ordinal);
         private List<MockArtifact> _artifacts = new();
         private CancellationTokenSource? _cts;
@@ -437,6 +500,19 @@ public sealed class DownloadNativeArchivesTests : IDisposable
             _artifacts.Add(new MockArtifact(name));
             _artifactZips[name] = BuildZip(zipEntries);
             _flakyRemaining[name] = failTimes;
+        }
+
+        /// <summary>
+        /// Registers an artifact whose first <paramref name="truncateTimes"/>
+        /// requests return HTTP 200 with a Content-Length for the full zip but
+        /// close the connection after writing only a prefix. This exercises a
+        /// deterministic mid-transfer failure without relying on timing.
+        /// </summary>
+        public void AddTruncatedThenValidArtifact(string name, int truncateTimes, IEnumerable<(string path, string content)> zipEntries)
+        {
+            _artifacts.Add(new MockArtifact(name));
+            _artifactZips[name] = BuildZip(zipEntries);
+            _truncatedRemaining[name] = truncateTimes;
         }
 
         /// <summary>
@@ -530,6 +606,22 @@ public sealed class DownloadNativeArchivesTests : IDisposable
                     _flakyRemaining[fileName] = remaining - 1;
                     ctx.Response.StatusCode = 500;
                     ctx.Response.Close();
+                    return;
+                }
+                // Truncated artifacts start like successful downloads, then close
+                // early. Content-Length stays at the full zip size so the client
+                // sees a deterministic mid-response transport failure instead of
+                // an HTTP status retry.
+                if (_truncatedRemaining.TryGetValue(fileName, out var truncateLeft) && truncateLeft > 0
+                    && _artifactZips.TryGetValue(fileName, out var zipBytes))
+                {
+                    _truncatedRemaining[fileName] = truncateLeft - 1;
+                    var prefixLength = Math.Min(16, zipBytes.Length - 1);
+                    ctx.Response.ContentType = "application/zip";
+                    ctx.Response.ContentLength64 = zipBytes.Length;
+                    ctx.Response.OutputStream.Write(zipBytes, 0, prefixLength);
+                    ctx.Response.OutputStream.Flush();
+                    ctx.Response.Abort();
                     return;
                 }
                 // Corrupt artifacts respond 200 with non-zip bytes for their first

--- a/tests/Infrastructure.Tests/PowerShellScripts/DownloadNativeArchivesTests.cs
+++ b/tests/Infrastructure.Tests/PowerShellScripts/DownloadNativeArchivesTests.cs
@@ -221,10 +221,13 @@ public sealed class DownloadNativeArchivesTests : IDisposable
             buildId: "12345",
             archivesTargetDir: archivesDir,
             nupkgsTargetDir: nupkgsDir,
-            accessToken: "fake-token");
+            accessToken: "fake-token",
+            maxDownloadAttempts: 2);
 
         Assert.NotEqual(0, result.ExitCode);
         Assert.Contains("Failed downloads: native_archives_win_x64", result.Output);
+        // The download was retried up to the attempt cap before giving up.
+        Assert.Contains("after 2 attempt(s)", result.Output);
         // The succeeded artifact's results should still be reported.
         Assert.Contains("native_archives_linux_x64", result.Output);
         Assert.Contains("archives=1 nupkgs=1", result.Output);
@@ -234,6 +237,81 @@ public sealed class DownloadNativeArchivesTests : IDisposable
             "native_archives_linux_x64", "Release", "Shipping", "aspire-cli-linux-x64-13.4.0.tar.gz")));
     }
 
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task RetriesTransientDownloadFailure_ThenSucceeds()
+    {
+        var (archivesDir, nupkgsDir) = CreateTargetDirs();
+
+        using var server = new MockAzdoServer();
+        // The download responds 500 for its first two attempts, then serves the
+        // zip — mirrors AzDO's artifact store dropping a connection mid-transfer
+        // (the failure seen in build 2995658). Without retry, the first failure
+        // would fail the whole assemble stage.
+        server.AddFlakyArtifact("native_archives_osx_x64", failTimes: 2, new[]
+        {
+            ("Release/Shipping/aspire-cli-osx-x64-13.4.0.tar.gz", "tar-content"),
+            ("Release/Shipping/Aspire.Cli.osx-x64.13.4.0.nupkg", "nupkg-content"),
+        });
+        server.Start();
+
+        var result = await RunScript(
+            collectionUri: server.CollectionUri,
+            project: "internal",
+            buildId: "12345",
+            archivesTargetDir: archivesDir,
+            nupkgsTargetDir: nupkgsDir,
+            accessToken: "fake-token",
+            maxDownloadAttempts: 4);
+
+        result.EnsureSuccessful();
+        // Both early attempts were retried, then the third succeeded.
+        Assert.Contains("Download attempt 1/4 failed for 'native_archives_osx_x64'", result.Output);
+        Assert.Contains("Download attempt 2/4 failed for 'native_archives_osx_x64'", result.Output);
+        Assert.Contains("archives=1 nupkgs=1", result.Output);
+        Assert.True(File.Exists(Path.Combine(
+            archivesDir,
+            "native_archives_osx_x64", "Release", "Shipping", "aspire-cli-osx-x64-13.4.0.tar.gz")));
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task RetriesCorruptDownload_ThenSucceeds()
+    {
+        var (archivesDir, nupkgsDir) = CreateTargetDirs();
+
+        using var server = new MockAzdoServer();
+        // First attempt downloads successfully (HTTP 200) but the body is not a
+        // valid zip — mirrors a truncated-yet-complete-looking file. The script
+        // opens the zip inside the retry loop, so the open failure must trigger a
+        // re-download rather than failing the stage. Second attempt serves a
+        // valid zip.
+        server.AddCorruptThenValidArtifact("native_archives_linux_arm64", corruptTimes: 1, new[]
+        {
+            ("Release/Shipping/aspire-cli-linux-arm64-13.4.0.tar.gz", "tar-content"),
+            ("Release/Shipping/Aspire.Cli.linux-arm64.13.4.0.nupkg", "nupkg-content"),
+        });
+        server.Start();
+
+        var result = await RunScript(
+            collectionUri: server.CollectionUri,
+            project: "internal",
+            buildId: "12345",
+            archivesTargetDir: archivesDir,
+            nupkgsTargetDir: nupkgsDir,
+            accessToken: "fake-token",
+            maxDownloadAttempts: 4);
+
+        result.EnsureSuccessful();
+        // The corrupt download was retried (the warning carries the zip-open
+        // failure), then the valid zip extracted.
+        Assert.Contains("Download attempt 1/4 failed for 'native_archives_linux_arm64'", result.Output);
+        Assert.Contains("archives=1 nupkgs=1", result.Output);
+        Assert.True(File.Exists(Path.Combine(
+            archivesDir,
+            "native_archives_linux_arm64", "Release", "Shipping", "aspire-cli-linux-arm64-13.4.0.tar.gz")));
+    }
+
     private async Task<CommandResult> RunScript(
         string collectionUri,
         string project,
@@ -241,7 +319,9 @@ public sealed class DownloadNativeArchivesTests : IDisposable
         string archivesTargetDir,
         string nupkgsTargetDir,
         string? accessToken,
-        bool clearSystemAccessToken = false)
+        bool clearSystemAccessToken = false,
+        int? maxDownloadAttempts = null,
+        int retryBaseDelaySeconds = 0)
     {
         using var cmd = new PowerShellCommand(_scriptPath, _output)
             .WithTimeout(TimeSpan.FromMinutes(2));
@@ -258,7 +338,15 @@ public sealed class DownloadNativeArchivesTests : IDisposable
             "-BuildId", $"\"{buildId}\"",
             "-ArchivesTargetDir", $"\"{archivesTargetDir}\"",
             "-NupkgsTargetDir", $"\"{nupkgsTargetDir}\"",
+            // Keep tests fast: never sleep between retries. The mock server
+            // returns its failures instantly, so backoff time is pure overhead.
+            "-RetryBaseDelaySeconds", retryBaseDelaySeconds.ToString(),
         };
+        if (maxDownloadAttempts is not null)
+        {
+            args.Add("-MaxDownloadAttempts");
+            args.Add(maxDownloadAttempts.Value.ToString());
+        }
         if (accessToken is not null)
         {
             args.Add("-AccessToken");
@@ -290,6 +378,8 @@ public sealed class DownloadNativeArchivesTests : IDisposable
         private readonly int _port;
         private readonly Dictionary<string, byte[]> _artifactZips = new();
         private readonly HashSet<string> _failingArtifacts = new();
+        private readonly Dictionary<string, int> _flakyRemaining = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, int> _corruptRemaining = new(StringComparer.Ordinal);
         private List<MockArtifact> _artifacts = new();
         private CancellationTokenSource? _cts;
         private Task? _serverTask;
@@ -311,6 +401,11 @@ public sealed class DownloadNativeArchivesTests : IDisposable
         public void AddContainerArtifact(string name, IEnumerable<(string path, string content)> zipEntries)
         {
             _artifacts.Add(new MockArtifact(name));
+            _artifactZips[name] = BuildZip(zipEntries);
+        }
+
+        private static byte[] BuildZip(IEnumerable<(string path, string content)> zipEntries)
+        {
             using var ms = new MemoryStream();
             using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
             {
@@ -322,13 +417,40 @@ public sealed class DownloadNativeArchivesTests : IDisposable
                     stream.Write(bytes, 0, bytes.Length);
                 }
             }
-            _artifactZips[name] = ms.ToArray();
+            return ms.ToArray();
         }
 
         public void AddFailingArtifact(string name)
         {
             _artifacts.Add(new MockArtifact(name));
             _failingArtifacts.Add(name);
+        }
+
+        /// <summary>
+        /// Registers an artifact whose download responds with HTTP 500 for its
+        /// first <paramref name="failTimes"/> requests and then serves the zip,
+        /// simulating a transient artifact-store failure that the script should
+        /// retry through.
+        /// </summary>
+        public void AddFlakyArtifact(string name, int failTimes, IEnumerable<(string path, string content)> zipEntries)
+        {
+            _artifacts.Add(new MockArtifact(name));
+            _artifactZips[name] = BuildZip(zipEntries);
+            _flakyRemaining[name] = failTimes;
+        }
+
+        /// <summary>
+        /// Registers an artifact whose download responds 200 with corrupt
+        /// (non-zip) bytes for its first <paramref name="corruptTimes"/> requests
+        /// and then serves the real zip. Simulates a connection dropped
+        /// mid-transfer that yields a truncated-yet-complete-looking file the
+        /// script only detects when opening the zip — which should still retry.
+        /// </summary>
+        public void AddCorruptThenValidArtifact(string name, int corruptTimes, IEnumerable<(string path, string content)> zipEntries)
+        {
+            _artifacts.Add(new MockArtifact(name));
+            _artifactZips[name] = BuildZip(zipEntries);
+            _corruptRemaining[name] = corruptTimes;
         }
 
         public void Start()
@@ -397,6 +519,29 @@ public sealed class DownloadNativeArchivesTests : IDisposable
                 if (_failingArtifacts.Contains(fileName))
                 {
                     ctx.Response.StatusCode = 500;
+                    ctx.Response.Close();
+                    return;
+                }
+                // Flaky artifacts fail their first N requests, then fall through
+                // to serving the zip. The HttpListener loop handles requests one
+                // at a time, so this counter needs no extra synchronization.
+                if (_flakyRemaining.TryGetValue(fileName, out var remaining) && remaining > 0)
+                {
+                    _flakyRemaining[fileName] = remaining - 1;
+                    ctx.Response.StatusCode = 500;
+                    ctx.Response.Close();
+                    return;
+                }
+                // Corrupt artifacts respond 200 with non-zip bytes for their first
+                // N requests, then serve the real zip — exercising the script's
+                // open-the-zip integrity check inside the retry loop.
+                if (_corruptRemaining.TryGetValue(fileName, out var corruptLeft) && corruptLeft > 0)
+                {
+                    _corruptRemaining[fileName] = corruptLeft - 1;
+                    var garbage = Encoding.UTF8.GetBytes("this is not a zip file");
+                    ctx.Response.ContentType = "application/zip";
+                    ctx.Response.ContentLength64 = garbage.Length;
+                    ctx.Response.OutputStream.Write(garbage, 0, garbage.Length);
                     ctx.Response.Close();
                     return;
                 }


### PR DESCRIPTION
**The internal assemble stage fails when a single artifact download drops its
connection mid-transfer.** Build 2995658 failed in "Download native archives
(parallel)" because one of seven downloads hit:

    Download failed for 'native_archives_osx_x64' ... Unable to read data from
    the transport connection: An existing connection was forcibly closed by the
    remote host..

The other six succeeded, but `download-native-archives.ps1` issued a single
`Invoke-WebRequest` per artifact with no retry, so one flaky download failed the
whole stage — cascading into the `Assemble` job and the non-production-output
check — and required a manual re-run.

## Root cause

The failure is a transport-level exception with **no HTTP response**, so
`Invoke-WebRequest -MaximumRetryCount` (which only retries on HTTP status codes)
would not have caught it.

## The fix

Retry each per-artifact download explicitly with exponential backoff, governed
by new `-MaxDownloadAttempts` (default 4) and `-RetryBaseDelaySeconds`
(default 3) parameters. The partial temp file is removed between attempts.

Opening the downloaded zip is done **inside** the retry scope as an integrity
check: a mid-transfer drop usually throws from `Invoke-WebRequest`, but can also
leave a truncated-yet-complete-looking file that only fails at
`ZipFile::OpenRead`. Re-downloading is the right remedy there too, so a
corrupt-zip failure now retries instead of failing the stage.

## Tests

`tests/Infrastructure.Tests/.../DownloadNativeArchivesTests.cs` adds two
regression cases that both fail if the retry is reverted:
- flaky transport: HTTP 500 twice, then succeeds;
- corrupt-then-valid: HTTP 200 with non-zip bytes, then a valid zip.

The always-failing case now asserts retries are exhausted. 8/8 tests pass.

Fixes #18055
