### PR TITLE
ci: file deduplicated GitHub issues for failing CI, scheduled, nightly, outerloop & quarantine runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,3 +208,44 @@ jobs:
         run: |
           echo "One or more dependent jobs failed."
           exit 1
+
+  # Track red-main: file/update one deduplicated issue per branch when a push to a
+  # protected branch (main, release/**) is red, and close it when a later push to
+  # the same branch is green. One job handles both — it runs on every push
+  # (if: always()) and the script opens or closes based on the aggregate CI result
+  # passed in CI_RED / CI_GREEN. Runs only on push; PR failures live in the PR's own
+  # checks and are owned by the author.
+  #
+  # CI_RED / CI_GREEN are derived from explicit needs.*.result checks rather than
+  # failure()/success() because tests/stabilization_check are *skipped* on the
+  # no-relevant-changes path (skip_workflow): a skipped run is neither red nor green,
+  # so the script leaves any open issue untouched (no CI signal). Requiring all
+  # three to have *succeeded* for CI_GREEN means a docs-only push never closes a
+  # still-red issue without actually re-running CI.
+  ci_failure_tracker:
+    name: Track CI Failure
+    needs: [prepare_for_ci, tests, stabilization_check]
+    if: ${{ always() && github.event_name == 'push' && github.repository_owner == 'microsoft' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read   # checkout to require the local .js modules
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: File or close the red-main issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REF: ${{ github.ref_name }}
+          CI_RED: ${{ contains(needs.*.result, 'failure') }}
+          CI_GREEN: >-
+            ${{ needs.prepare_for_ci.result == 'success' &&
+                needs.tests.result == 'success' &&
+                needs.stabilization_check.result == 'success' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await require('./.github/workflows/report-ci-failure.js').track({ github, context, core });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: main
           persist-credentials: false
 
       - name: File or close the red-main issue

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -319,96 +319,36 @@ jobs:
           echo "::error::Deployment test ${{ matrix.shortname }} failed. Check the test results artifact for details."
           exit 1
 
-  # Create GitHub issue on nightly failure
+  # File/append a single deduplicated issue on a scheduled-run failure. One issue
+  # is kept open per workflow and a row is appended per failed run; a human closes
+  # it once fixed. See docs/ci/pipeline-failure-issues.md.
   create_issue_on_failure:
     name: Create Issue on Failure
     needs: [deploy-test]
     runs-on: ubuntu-latest
-    if: ${{ failure() && github.event_name == 'schedule' }}
+    if: ${{ failure() && github.event_name == 'schedule' && github.repository_owner == 'microsoft' }}
     permissions:
+      contents: read   # checkout to require the local .js modules
       issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          persist-credentials: false
 
-      - name: Create GitHub Issue
+      - name: File or update failure issue
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          WORKFLOW_FILE: deployment-tests.yml
+          DISPLAY_NAME: Deployment E2E Tests
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const date = new Date().toISOString().split('T')[0];
-
-            const issueTitle = `[Deployment E2E] Nightly test failure - ${date}`;
-            const issueBody = `## Deployment E2E Test Failure
-
-            The nightly deployment E2E tests failed on ${date}.
-
-            **Workflow Run:** ${runUrl}
-
-            ### Investigation Checklist
-
-            - [ ] Review workflow logs for error details
-            - [ ] Check if failures are timeout-related or deployment failures
-            - [ ] Download test artifacts (logs, asciinema recordings)
-            - [ ] Identify common failure patterns across tests
-            - [ ] Check Azure authentication and resource provisioning status
-
-            ### Resources
-
-            - **Workflow Logs:** See link above for detailed test output
-            - **Test Artifacts:** Download recordings and logs from the workflow run (testresults/recordings, testresults/logs)
-            - **Deployment E2E Tests:** \`tests/Aspire.Deployment.EndToEnd.Tests/\`
-            - **Test Helpers:** \`tests/Shared/Hex1bAutomatorTestHelpers.cs\`
-
-            ### Next Steps
-
-            1. Check the workflow run for detailed error logs
-            2. Download test artifacts for asciinema recordings and error logs
-            3. Investigate which specific tests are failing
-            4. Determine if this is a timeout, deployment, or test automation issue
-            5. Implement fix and verify with local test run
-
-            ### Labels
-
-            This issue was automatically created by the deployment E2E test workflow.
-
-            /cc @microsoft/aspire-team
-            `;
-
-            // Check if a similar issue already exists (created today)
-            const existingIssues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'area-testing,deployment-e2e',
-              per_page: 10
+            await require('./.github/workflows/report-pipeline-failure.js').report({
+              github, context, core,
+              labels: ['automation-broken', 'area-testing', 'deployment-e2e'],
+              cc: '@microsoft/aspire-team',
             });
-
-            const todayIssue = existingIssues.data.find(issue =>
-              issue.title.includes(date) && issue.title.includes('[Deployment E2E]')
-            );
-
-            if (todayIssue) {
-              console.log(`Issue already exists for today: ${todayIssue.html_url}`);
-              // Add a comment instead
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: todayIssue.number,
-                body: `Another failure occurred. See: ${runUrl}`
-              });
-            } else {
-              // Create new issue
-              const issue = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: issueTitle,
-                body: issueBody,
-                labels: ['area-testing', 'area-deployment', 'deployment-e2e'],
-                assignees: ['mitchdenny']
-              });
-              console.log(`Created issue: ${issue.data.html_url}`);
-            }
 
   # Post completion comment back to PR when triggered via /deployment-test command
   post_pr_comment:

--- a/.github/workflows/monitor-scheduled-workflows.config.json
+++ b/.github/workflows/monitor-scheduled-workflows.config.json
@@ -1,0 +1,22 @@
+{
+  "$schema-note": "Watch list for the scheduled-workflow failure watchdog (monitor-scheduled-workflows.yml). One entry per scheduled/automation workflow whose failure should file an automation-broken issue. Entries are watched by default; set enabled:false (optionally with a reason) to stop watching one without deleting it. Set selfReports:true for workflows that file their OWN normal failures in-pipeline (via an if:failure() reporter): the watchdog then ONLY backstops startup_failure and timed_out (the conclusions that in-pipeline reporter cannot catch), never plain failure (which would double-file). Optional per-entry labels[] are added to the filed issue alongside automation-broken. See docs/ci/monitor-scheduled-workflows.md.",
+  "watched": [
+    { "file": "generate-api-diffs.yml", "name": "Generate API Diffs" },
+    { "file": "generate-ats-diffs.yml", "name": "Generate ATS Diffs" },
+    { "file": "refresh-manifests.yml", "name": "Refresh Manifests" },
+    { "file": "update-dependencies.yml", "name": "Update Dependencies" },
+    { "file": "update-ai-foundry-models.yml", "name": "Update AI Foundry Models" },
+    { "file": "update-azure-vm-sizes.yml", "name": "Update Azure VM Sizes" },
+    { "file": "update-aspire-skills-bundle.yml", "name": "Update Aspire Skills Bundle" },
+    { "file": "deployment-cleanup.yml", "name": "Deployment Cleanup" },
+    { "file": "labeler-cache-retention.yml", "name": "Labeler Cache Retention" },
+    { "file": "warm-cli-e2e-image-cache.yml", "name": "Warm CLI E2E Image Cache" },
+    { "file": "locker.yml", "name": "Lock Threads" },
+    { "file": "backmerge-release.yml", "name": "Backmerge Release to Main" },
+
+    { "file": "tests-outerloop.yml", "name": "Outerloop Tests", "selfReports": true, "labels": ["failing-test"] },
+    { "file": "tests-quarantine.yml", "name": "Quarantined Tests", "selfReports": true },
+    { "file": "tests-daily-smoke.yml", "name": "Daily CLI Smoke Tests", "selfReports": true, "labels": ["area-cli", "failing-test"] },
+    { "file": "deployment-tests.yml", "name": "Deployment E2E Tests", "selfReports": true, "labels": ["area-testing", "deployment-e2e"] }
+  ]
+}

--- a/.github/workflows/monitor-scheduled-workflows.config.json
+++ b/.github/workflows/monitor-scheduled-workflows.config.json
@@ -14,9 +14,9 @@
     { "file": "locker.yml", "name": "Lock Threads" },
     { "file": "backmerge-release.yml", "name": "Backmerge Release to Main" },
 
-    { "file": "tests-outerloop.yml", "name": "Outerloop Tests", "selfReports": true, "labels": ["failing-test"] },
+    { "file": "tests-outerloop.yml", "name": "Outerloop Tests", "selfReports": true },
     { "file": "tests-quarantine.yml", "name": "Quarantined Tests", "selfReports": true },
-    { "file": "tests-daily-smoke.yml", "name": "Daily CLI Smoke Tests", "selfReports": true, "labels": ["area-cli", "failing-test"] },
+    { "file": "tests-daily-smoke.yml", "name": "Daily CLI Smoke Tests", "selfReports": true, "labels": ["area-cli"] },
     { "file": "deployment-tests.yml", "name": "Deployment E2E Tests", "selfReports": true, "labels": ["area-testing", "deployment-e2e"] }
   ]
 }

--- a/.github/workflows/monitor-scheduled-workflows.js
+++ b/.github/workflows/monitor-scheduled-workflows.js
@@ -152,7 +152,10 @@ async function run({ github, context, core, dryRun = false }) {
 
     // List once and reuse across watched workflows; each workflow's marker is
     // distinct, so a fresh issue filed for one cannot affect another's lookup.
-    const openIssues = await tracking.listOpenIssuesByLabel(github, owner, repo, label);
+    // Failure recording must include closed issues so a recurring failure reopens
+    // the canonical tracker instead of filing a duplicate.
+    const issues = await tracking.listIssuesByLabel(github, owner, repo, label);
+    const openIssues = issues.filter(issue => issue.state === 'open');
 
     for (const wf of watched) {
         let latest;
@@ -191,7 +194,8 @@ async function run({ github, context, core, dryRun = false }) {
                 runUrl: latest.html_url, runNumber: latest.run_number, sha: latest.head_sha, conclusion,
             });
             if (dryRun) {
-                log(`would RECORD failure for ${wf.file} on ${issue ? `issue #${issue.number}` : 'a new issue'}`);
+                const recordingIssue = tracking.findOpenIssueForMarker(issues, marker) ?? tracking.findIssueForMarker(issues, marker);
+                log(`would RECORD failure for ${wf.file} on ${recordingIssue ? `issue #${recordingIssue.number}` : 'a new issue'}`);
                 continue;
             }
             // Optional per-entry labels (e.g. area-cli, deployment-e2e) ride alongside
@@ -201,7 +205,7 @@ async function run({ github, context, core, dryRun = false }) {
                 label, labels: issueLabels, marker, title: buildIssueTitle(wf.name),
                 runId: latest.id,
                 buildBody: () => buildIssueBody({ marker, displayName: wf.name, workflowFile: wf.file, selfReports: wf.selfReports === true }),
-                comment, openIssues,
+                comment, issues,
             });
             if (!result.skipped) {
                 core.info(`${result.created ? 'Filed' : 'Updated'} #${result.number} for ${wf.file}`);
@@ -214,9 +218,14 @@ async function run({ github, context, core, dryRun = false }) {
                 log(`would CLOSE issue #${issue.number} (${wf.file})`);
                 continue;
             }
+            const autoClose = tracking.readAutoClose(issue.body);
+            if (autoClose !== true) {
+                core.info(`Issue #${issue.number} for ${wf.file} does not opt into auto-close; leaving it open.`);
+                continue;
+            }
+            await tracking.closeIssue(github, owner, repo, issue.number);
             await tracking.addComment(github, owner, repo, issue.number,
                 `Latest run succeeded ([run #${latest.run_number}](${latest.html_url})). Closing automatically.`);
-            await tracking.closeIssue(github, owner, repo, issue.number);
             core.info(`Closed #${issue.number} for ${wf.file}`);
         }
     }

--- a/.github/workflows/monitor-scheduled-workflows.js
+++ b/.github/workflows/monitor-scheduled-workflows.js
@@ -30,6 +30,10 @@ const MARKER_PREFIX = 'automation-broken:';
 // hits its timeout is treated as broken (see BACKSTOP_CONCLUSIONS below).
 const FAILURE_CONCLUSIONS = new Set(['failure', 'timed_out', 'startup_failure']);
 const SUCCESS_CONCLUSIONS = new Set(['success']);
+const WORKFLOW_RUN_PAGE_SIZE = 100;
+// The watchdog runs every two hours. Look back three hours so ordinary GitHub
+// schedule/queue delay cannot create a gap where a completed run is never seen.
+const POLLING_WINDOW_MS = 3 * 60 * 60 * 1000;
 
 // Backstop set for `selfReports` entries: workflows that file their own failure
 // issues in-pipeline via an `if: failure()` reporter job. That reporter cannot
@@ -96,8 +100,33 @@ function formatComment({ runUrl, runNumber, sha, conclusion }) {
     return `The scheduled run concluded \`${conclusion}\` in ${runLink}${shaPart}.`;
 }
 
-// Decides what the watchdog should do for one workflow given its latest completed
-// run conclusion and any existing open issue for it. Dedup of an already-recorded
+function getRunTimestamp(run) {
+    const value = run?.updated_at ?? run?.run_started_at ?? run?.created_at;
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const timestamp = Date.parse(value);
+    return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function selectRunsForPollingWindow(runs, { now = new Date(), pollingWindowMs = POLLING_WINDOW_MS } = {}) {
+    const nowTimestamp = now.getTime();
+    const cutoff = nowTimestamp - pollingWindowMs;
+    return (runs ?? [])
+        .filter(run => {
+            const timestamp = getRunTimestamp(run);
+            return timestamp !== null && timestamp >= cutoff && timestamp <= nowTimestamp;
+        })
+        .sort((left, right) => getRunTimestamp(left) - getRunTimestamp(right));
+}
+
+function formatIssueReference(issue) {
+    return issue?.dryRunPlaceholder ? 'the new issue' : `issue #${issue.number}`;
+}
+
+// Decides what the watchdog should do for one workflow run conclusion and any
+// existing open issue for it. Dedup of an already-recorded
 // run is handled downstream by the shared engine (recordRun scans comments), so a
 // still-failing run consistently resolves to 'record' and is then skipped if its
 // comment already exists.
@@ -128,10 +157,10 @@ function decideAction({ conclusion, issue, failureConclusions = FAILURE_CONCLUSI
 }
 
 // Orchestrator. Reads the watch list next to this file, polls each workflow's
-// latest completed scheduled run, and files/comments/closes its issue. Invoked
+// recently completed scheduled runs, and files/comments/closes its issue. Invoked
 // from an actions/github-script step. dryRun logs intended actions without
 // mutating GitHub.
-async function run({ github, context, core, dryRun = false }) {
+async function run({ github, context, core, dryRun = false, now = new Date() }) {
     const { owner, repo } = context.repo;
     const label = AUTOMATION_BROKEN_LABEL;
     const log = msg => core.info(`${dryRun ? '[dry-run] ' : ''}${msg}`);
@@ -155,77 +184,125 @@ async function run({ github, context, core, dryRun = false }) {
     // Failure recording must include closed issues so a recurring failure reopens
     // the canonical tracker instead of filing a duplicate.
     const issues = await tracking.listIssuesByLabel(github, owner, repo, label);
-    const openIssues = issues.filter(issue => issue.state === 'open');
-
     for (const wf of watched) {
-        let latest;
+        let recentRuns;
         try {
             // event: 'schedule' is required. Watched workflows commonly also have
             // workflow_dispatch (and some, e.g. warm-cli-e2e-image-cache.yml, a
-            // push: trigger). Without this filter the "latest completed run" could
-            // be a manual or push run, so a manual/push success would auto-close a
-            // real scheduled-failure issue (masking the silent failure this watchdog
-            // exists to catch), and a manual/push failure would file a false issue.
+            // push: trigger). Without this filter a completed run in the polling
+            // window could be a manual or push run, so a manual/push success would
+            // auto-close a real scheduled-failure issue (masking the silent failure
+            // this watchdog exists to catch), and a manual/push failure would file
+            // a false issue.
             const runs = await github.rest.actions.listWorkflowRuns({
-                owner, repo, workflow_id: wf.file, branch: 'main', event: 'schedule', status: 'completed', per_page: 1,
+                owner, repo, workflow_id: wf.file, branch: 'main', event: 'schedule', status: 'completed', per_page: WORKFLOW_RUN_PAGE_SIZE,
             });
-            latest = runs.data.workflow_runs[0];
+            recentRuns = selectRunsForPollingWindow(runs.data.workflow_runs, { now });
         } catch (error) {
             core.warning(`Could not list runs for ${wf.file}: ${error.message}`);
             continue;
         }
 
         const marker = buildMarker(wf.file);
-        const issue = tracking.findOpenIssueForMarker(openIssues, marker);
-        const conclusion = latest ? latest.conclusion : null;
-        // `selfReports` entries own their plain failures in-pipeline; the watchdog
-        // only backstops the conclusions that reporter cannot catch.
-        const failureConclusions = wf.selfReports ? BACKSTOP_CONCLUSIONS : FAILURE_CONCLUSIONS;
-        const { action, reason } = decideAction({ conclusion, issue, failureConclusions });
-
-        core.info(`${wf.file}: conclusion=${conclusion ?? 'none'} -> ${action} (${reason})`);
-
-        if (action === 'noop') {
+        if (recentRuns.length === 0) {
+            const { action, reason } = decideAction({ conclusion: null, issue: tracking.findOpenIssueForMarker(issues, marker) });
+            core.info(`${wf.file}: conclusion=none -> ${action} (${reason})`);
             continue;
         }
 
-        if (action === 'record') {
-            const comment = formatComment({
-                runUrl: latest.html_url, runNumber: latest.run_number, sha: latest.head_sha, conclusion,
-            });
-            if (dryRun) {
-                const recordingIssue = tracking.findOpenIssueForMarker(issues, marker) ?? tracking.findIssueForMarker(issues, marker);
-                log(`would RECORD failure for ${wf.file} on ${recordingIssue ? `issue #${recordingIssue.number}` : 'a new issue'}`);
+        const newest = recentRuns[recentRuns.length - 1];
+        for (const latest of recentRuns) {
+            const normalizedConclusion = typeof latest.conclusion === 'string' ? latest.conclusion.toLowerCase() : null;
+            if (normalizedConclusion !== null && SUCCESS_CONCLUSIONS.has(normalizedConclusion)) {
                 continue;
             }
-            // Optional per-entry labels (e.g. area-cli, deployment-e2e) ride alongside
-            // the lookup label; dedup keeps automation-broken single if also listed.
-            const issueLabels = [...new Set([label, ...(wf.labels ?? [])])];
-            const result = await tracking.recordRun(github, context, core, {
-                label, labels: issueLabels, marker, title: buildIssueTitle(wf.name),
-                runId: latest.id,
-                buildBody: () => buildIssueBody({ marker, displayName: wf.name, workflowFile: wf.file, selfReports: wf.selfReports === true }),
-                comment, issues,
-            });
-            if (!result.skipped) {
-                core.info(`${result.created ? 'Filed' : 'Updated'} #${result.number} for ${wf.file}`);
+
+            const issue = tracking.findOpenIssueForMarker(issues, marker);
+            const conclusion = latest.conclusion;
+            // `selfReports` entries own their plain failures in-pipeline; the watchdog
+            // only backstops the conclusions that reporter cannot catch.
+            const failureConclusions = wf.selfReports ? BACKSTOP_CONCLUSIONS : FAILURE_CONCLUSIONS;
+            const { action, reason } = decideAction({ conclusion, issue, failureConclusions });
+
+            core.info(`${wf.file}: run=${latest.id ?? '?'} conclusion=${conclusion ?? 'none'} -> ${action} (${reason})`);
+
+            if (action === 'noop') {
+                continue;
             }
-            continue;
+
+            if (action === 'record') {
+                const comment = formatComment({
+                    runUrl: latest.html_url, runNumber: latest.run_number, sha: latest.head_sha, conclusion,
+                });
+                // Optional per-entry labels (e.g. area-cli, deployment-e2e) ride alongside
+                // the lookup label; dedup keeps automation-broken single if also listed.
+                const issueLabels = [...new Set([label, ...(wf.labels ?? [])])];
+                const issueBody = buildIssueBody({ marker, displayName: wf.name, workflowFile: wf.file, selfReports: wf.selfReports === true });
+                if (dryRun) {
+                    const recordingIssue = tracking.findOpenIssueForMarker(issues, marker) ?? tracking.findIssueForMarker(issues, marker);
+                    if (recordingIssue !== null &&
+                        !recordingIssue.dryRunPlaceholder &&
+                        await tracking.hasCommentForRun(github, owner, repo, recordingIssue.number, tracking.runMarker(latest.id))) {
+                        core.info(`Run ${latest.id} already recorded in #${recordingIssue.number}; skipping duplicate comment.`);
+                        continue;
+                    }
+
+                    log(`would RECORD failure for ${wf.file} on ${recordingIssue ? formatIssueReference(recordingIssue) : 'a new issue'}`);
+                    if (recordingIssue === null) {
+                        issues.push({ number: 0, body: issueBody, labels: issueLabels, state: 'open', dryRunPlaceholder: true });
+                    } else if (recordingIssue.state === 'closed') {
+                        recordingIssue.state = 'open';
+                    }
+                    continue;
+                }
+                const result = await tracking.recordRun(github, context, core, {
+                    label, labels: issueLabels, marker, title: buildIssueTitle(wf.name),
+                    runId: latest.id,
+                    buildBody: () => issueBody,
+                    comment, issues,
+                });
+                if (result.created) {
+                    issues.push({ number: result.number, body: issueBody, labels: issueLabels, state: 'open' });
+                } else if (result.reopened) {
+                    const recordedIssue = tracking.findIssueForMarker(issues, marker);
+                    if (recordedIssue !== null) {
+                        recordedIssue.state = 'open';
+                    }
+                }
+
+                if (!result.skipped) {
+                    core.info(`${result.created ? 'Filed' : 'Updated'} #${result.number} for ${wf.file}`);
+                }
+                continue;
+            }
         }
 
-        if (action === 'close') {
-            if (dryRun) {
-                log(`would CLOSE issue #${issue.number} (${wf.file})`);
+        const newestConclusion = typeof newest.conclusion === 'string' ? newest.conclusion.toLowerCase() : null;
+        if (newestConclusion !== null && SUCCESS_CONCLUSIONS.has(newestConclusion)) {
+            const issue = tracking.findOpenIssueForMarker(issues, marker);
+            const failureConclusions = wf.selfReports ? BACKSTOP_CONCLUSIONS : FAILURE_CONCLUSIONS;
+            const { action, reason } = decideAction({ conclusion: newest.conclusion, issue, failureConclusions });
+            core.info(`${wf.file}: newest run=${newest.id ?? '?'} conclusion=${newest.conclusion ?? 'none'} -> ${action} (${reason})`);
+
+            if (action !== 'close') {
                 continue;
             }
+
             const autoClose = tracking.readAutoClose(issue.body);
             if (autoClose !== true) {
                 core.info(`Issue #${issue.number} for ${wf.file} does not opt into auto-close; leaving it open.`);
                 continue;
             }
+
+            if (dryRun) {
+                log(`would CLOSE ${formatIssueReference(issue)} (${wf.file})`);
+                issue.state = 'closed';
+                continue;
+            }
             await tracking.closeIssue(github, owner, repo, issue.number);
             await tracking.addComment(github, owner, repo, issue.number,
-                `Latest run succeeded ([run #${latest.run_number}](${latest.html_url})). Closing automatically.`);
+                `Latest run succeeded ([run #${newest.run_number}](${newest.html_url})). Closing automatically.`);
+            issue.state = 'closed';
             core.info(`Closed #${issue.number} for ${wf.file}`);
         }
     }
@@ -242,6 +319,7 @@ module.exports = {
     selectEnabled,
     buildIssueBody,
     formatComment,
+    selectRunsForPollingWindow,
     decideAction,
     run,
 };

--- a/.github/workflows/monitor-scheduled-workflows.js
+++ b/.github/workflows/monitor-scheduled-workflows.js
@@ -1,0 +1,238 @@
+// Scheduled-workflow failure watchdog (.github/workflows/monitor-scheduled-workflows.yml).
+//
+// The reusable issue mechanics (marker dedup, the per-run comment-recording loop,
+// octokit primitives) live in ./tracking-issue.js. This module owns the
+// watchdog-specific bits: the marker namespace, issue title/body, the per-run
+// failure comment, the record/close/noop decision (all pure), and the run()
+// orchestrator that reads the watch list, polls each workflow, and files/closes
+// issues. The pure helpers are unit-tested; run() is integration-tested via a fake.
+//
+// Contract: one dedup'd issue per *workflow file*, marker-based lookup, a failure
+// comment per newly-observed failed run, and close-on-green.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const tracking = require('./tracking-issue.js');
+
+const AUTOMATION_BROKEN_LABEL = 'automation-broken';
+
+// First line of every managed issue body. Used to map an issue back to the
+// workflow it tracks without relying on the (eventually-consistent) Search API.
+//   <!-- automation-broken:generate-api-diffs.yml -->
+const MARKER_PREFIX = 'automation-broken:';
+
+// Conclusions that count as "the workflow is broken". `cancelled` is excluded:
+// operator cancellation (and concurrency-superseded runs) is not a workflow defect,
+// and firing on it would create noise. `timed_out` is NOT excluded — a run that
+// hits its timeout is treated as broken (see BACKSTOP_CONCLUSIONS below).
+const FAILURE_CONCLUSIONS = new Set(['failure', 'timed_out', 'startup_failure']);
+const SUCCESS_CONCLUSIONS = new Set(['success']);
+
+// Backstop set for `selfReports` entries: workflows that file their own failure
+// issues in-pipeline via an `if: failure()` reporter job. That reporter cannot
+// catch two conclusions, so the watchdog backstops exactly these:
+//   - startup_failure: the run never started a job, so the reporter job never ran.
+//   - timed_out: a job-level timeout is *cancelled-class*, so `failure()` is false
+//     and the reporter job does not run (see GitHub's status-check functions docs).
+// Plain `failure` is deliberately EXCLUDED: the in-pipeline reporter owns it under
+// its own `ci-failure:<file>:…` marker, so recording it here would file a second,
+// duplicate issue under the watchdog's `automation-broken:<file>` marker.
+const BACKSTOP_CONCLUSIONS = new Set(['startup_failure', 'timed_out']);
+
+function buildMarker(workflowFile) {
+    return `<!-- ${MARKER_PREFIX}${workflowFile} -->`;
+}
+
+// Parses the watch-list config (the parsed JSON object) and returns the entries
+// that are enabled (missing `enabled` defaults to enabled). Disabled entries are
+// dropped so an operator can stop watching a workflow by flipping one flag.
+function selectEnabled(config) {
+    const watched = Array.isArray(config?.watched) ? config.watched : [];
+    return watched.filter(entry => entry && typeof entry.file === 'string' && entry.enabled !== false);
+}
+
+function buildIssueTitle(displayName) {
+    return `Scheduled workflow failing: ${displayName}`;
+}
+
+// Builds the static issue body. Each failed run is recorded as a comment (see the
+// runner), so the body is a fixed description written once at filing; the marker
+// is embedded so the issue can be found again. The body is stamped autoClose:true
+// — a watchdog-filed issue tracks "is this workflow currently broken", so a later
+// green run resolves it (the watchdog closes it; the stamp also lets any future
+// cross-producer closer do so).
+//
+// `selfReports` entries are backstop-only (startup_failure / timed_out): their
+// normal failures are filed in-pipeline, so the body says so to avoid confusion
+// with the in-pipeline issue.
+function buildIssueBody({ marker, displayName, workflowFile, selfReports = false }) {
+    const link = `[\`${workflowFile}\`](../../actions/workflows/${workflowFile})`;
+    const lead = selfReports
+        ? `The scheduled workflow ${link} (**${displayName}**) had a run that **failed to start or timed out**. Its normal failures are reported separately by an in-pipeline job; this issue backstops runs that never produced a result.`
+        : `The scheduled workflow ${link} (**${displayName}**) is failing.`;
+
+    return tracking.buildBody({
+        marker,
+        autoClose: true,
+        lead,
+        note: [
+            'Filed and updated automatically by the scheduled-workflow watchdog. Each',
+            'failed run is added as a comment below, and the issue is **closed',
+            'automatically** on the next successful run.',
+            'See [docs/ci/monitor-scheduled-workflows.md](../../blob/main/docs/ci/monitor-scheduled-workflows.md).',
+        ],
+    });
+}
+
+// Comment recorded per newly-observed failed run.
+// failure: { runUrl, runNumber, sha, conclusion }
+function formatComment({ runUrl, runNumber, sha, conclusion }) {
+    const runLink = runUrl ? `[run #${runNumber ?? '?'}](${runUrl})` : `run #${runNumber ?? '?'}`;
+    const shaPart = sha ? ` (commit \`${String(sha).slice(0, 8)}\`)` : '';
+
+    return `The scheduled run concluded \`${conclusion}\` in ${runLink}${shaPart}.`;
+}
+
+// Decides what the watchdog should do for one workflow given its latest completed
+// run conclusion and any existing open issue for it. Dedup of an already-recorded
+// run is handled downstream by the shared engine (recordRun scans comments), so a
+// still-failing run consistently resolves to 'record' and is then skipped if its
+// comment already exists.
+//
+// `failureConclusions` selects which conclusions count as "broken": the full set
+// for normal entries, or BACKSTOP_CONCLUSIONS for `selfReports` entries (which
+// own their plain failures in-pipeline). A conclusion not in the failure set and
+// not 'success' is a no-op — so for a `selfReports` entry a plain `failure` does
+// nothing here (the in-pipeline reporter handles it).
+//   action: 'record' | 'close' | 'noop'
+function decideAction({ conclusion, issue, failureConclusions = FAILURE_CONCLUSIONS }) {
+    const normalized = typeof conclusion === 'string' ? conclusion.toLowerCase() : null;
+
+    if (normalized !== null && failureConclusions.has(normalized)) {
+        return issue
+            ? { action: 'record', reason: `latest run concluded '${normalized}'; recording on issue #${issue.number}` }
+            : { action: 'record', reason: `latest run concluded '${normalized}'; no open issue` };
+    }
+
+    if (normalized !== null && SUCCESS_CONCLUSIONS.has(normalized)) {
+        return issue
+            ? { action: 'close', reason: `latest run concluded 'success'; closing issue #${issue.number}` }
+            : { action: 'noop', reason: 'latest run succeeded; nothing open' };
+    }
+
+    // null (no completed run yet), 'cancelled', 'skipped', 'neutral', etc.
+    return { action: 'noop', reason: `latest conclusion '${normalized ?? 'none'}' is not actionable` };
+}
+
+// Orchestrator. Reads the watch list next to this file, polls each workflow's
+// latest completed scheduled run, and files/comments/closes its issue. Invoked
+// from an actions/github-script step. dryRun logs intended actions without
+// mutating GitHub.
+async function run({ github, context, core, dryRun = false }) {
+    const { owner, repo } = context.repo;
+    const label = AUTOMATION_BROKEN_LABEL;
+    const log = msg => core.info(`${dryRun ? '[dry-run] ' : ''}${msg}`);
+
+    // Resolve the config next to this file so the read is independent of cwd.
+    const configPath = path.join(__dirname, 'monitor-scheduled-workflows.config.json');
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    const watched = selectEnabled(config);
+    core.info(`Watching ${watched.length} workflow(s) from ${path.basename(configPath)}.`);
+
+    if (dryRun) {
+        log(`would ENSURE label '${label}' exists`);
+    } else {
+        await tracking.ensureLabel(github, owner, repo, {
+            name: label, color: 'B60205', description: 'A scheduled/automation workflow is failing',
+        });
+    }
+
+    // List once and reuse across watched workflows; each workflow's marker is
+    // distinct, so a fresh issue filed for one cannot affect another's lookup.
+    const openIssues = await tracking.listOpenIssuesByLabel(github, owner, repo, label);
+
+    for (const wf of watched) {
+        let latest;
+        try {
+            // event: 'schedule' is required. Watched workflows commonly also have
+            // workflow_dispatch (and some, e.g. warm-cli-e2e-image-cache.yml, a
+            // push: trigger). Without this filter the "latest completed run" could
+            // be a manual or push run, so a manual/push success would auto-close a
+            // real scheduled-failure issue (masking the silent failure this watchdog
+            // exists to catch), and a manual/push failure would file a false issue.
+            const runs = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: wf.file, branch: 'main', event: 'schedule', status: 'completed', per_page: 1,
+            });
+            latest = runs.data.workflow_runs[0];
+        } catch (error) {
+            core.warning(`Could not list runs for ${wf.file}: ${error.message}`);
+            continue;
+        }
+
+        const marker = buildMarker(wf.file);
+        const issue = tracking.findOpenIssueForMarker(openIssues, marker);
+        const conclusion = latest ? latest.conclusion : null;
+        // `selfReports` entries own their plain failures in-pipeline; the watchdog
+        // only backstops the conclusions that reporter cannot catch.
+        const failureConclusions = wf.selfReports ? BACKSTOP_CONCLUSIONS : FAILURE_CONCLUSIONS;
+        const { action, reason } = decideAction({ conclusion, issue, failureConclusions });
+
+        core.info(`${wf.file}: conclusion=${conclusion ?? 'none'} -> ${action} (${reason})`);
+
+        if (action === 'noop') {
+            continue;
+        }
+
+        if (action === 'record') {
+            const comment = formatComment({
+                runUrl: latest.html_url, runNumber: latest.run_number, sha: latest.head_sha, conclusion,
+            });
+            if (dryRun) {
+                log(`would RECORD failure for ${wf.file} on ${issue ? `issue #${issue.number}` : 'a new issue'}`);
+                continue;
+            }
+            // Optional per-entry labels (e.g. area-cli, deployment-e2e) ride alongside
+            // the lookup label; dedup keeps automation-broken single if also listed.
+            const issueLabels = [...new Set([label, ...(wf.labels ?? [])])];
+            const result = await tracking.recordRun(github, context, core, {
+                label, labels: issueLabels, marker, title: buildIssueTitle(wf.name),
+                runId: latest.id,
+                buildBody: () => buildIssueBody({ marker, displayName: wf.name, workflowFile: wf.file, selfReports: wf.selfReports === true }),
+                comment, openIssues,
+            });
+            if (!result.skipped) {
+                core.info(`${result.created ? 'Filed' : 'Updated'} #${result.number} for ${wf.file}`);
+            }
+            continue;
+        }
+
+        if (action === 'close') {
+            if (dryRun) {
+                log(`would CLOSE issue #${issue.number} (${wf.file})`);
+                continue;
+            }
+            await tracking.addComment(github, owner, repo, issue.number,
+                `Latest run succeeded ([run #${latest.run_number}](${latest.html_url})). Closing automatically.`);
+            await tracking.closeIssue(github, owner, repo, issue.number);
+            core.info(`Closed #${issue.number} for ${wf.file}`);
+        }
+    }
+}
+
+module.exports = {
+    AUTOMATION_BROKEN_LABEL,
+    MARKER_PREFIX,
+    FAILURE_CONCLUSIONS,
+    BACKSTOP_CONCLUSIONS,
+    SUCCESS_CONCLUSIONS,
+    buildMarker,
+    buildIssueTitle,
+    selectEnabled,
+    buildIssueBody,
+    formatComment,
+    decideAction,
+    run,
+};

--- a/.github/workflows/monitor-scheduled-workflows.yml
+++ b/.github/workflows/monitor-scheduled-workflows.yml
@@ -1,0 +1,50 @@
+name: Monitor Scheduled Workflows
+
+# Watches the currently-silent scheduled/automation workflows and files, updates,
+# or closes a single deduplicated `automation-broken` GitHub issue per workflow.
+# A scheduled workflow that fails (generate/refresh/update/cleanup) otherwise has
+# no visibility — GitHub only emails the last person to touch the workflow file.
+#
+# Logic lives in ./.github/workflows/monitor-scheduled-workflows.js (pure, tested
+# by tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsTests.cs).
+# Full contract: docs/ci/monitor-scheduled-workflows.md.
+
+on:
+  schedule:
+    - cron: '0 */2 * * *' # every 2 hours
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Inspect and log intended issue actions without mutating GitHub'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read   # checkout to require the local .js module
+  actions: read    # list workflow runs / conclusions
+  issues: write    # file / comment / close automation-broken issues
+
+# One watchdog run at a time; a backlog would only re-evaluate the same state.
+concurrency:
+  group: monitor-scheduled-workflows
+  cancel-in-progress: false
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'microsoft' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Evaluate scheduled workflows
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        with:
+          script: |
+            const dryRun = process.env.DRY_RUN === 'true';
+            await require('./.github/workflows/monitor-scheduled-workflows.js').run({ github, context, core, dryRun });

--- a/.github/workflows/report-ci-failure.js
+++ b/.github/workflows/report-ci-failure.js
@@ -126,10 +126,16 @@ async function resolveSuccess({ github, context, core }) {
         return;
     }
 
+    const autoClose = tracking.readAutoClose(issue.body);
+    if (autoClose !== true) {
+        core.info(`CI-failure issue #${issue.number} for ${ref} does not opt into auto-close; leaving it open.`);
+        return;
+    }
+
     const run = runContext(context);
+    await tracking.closeIssue(github, owner, repo, issue.number);
     await tracking.addComment(github, owner, repo, issue.number,
         `CI is green again on \`${ref}\` ([run #${run.runNumber}](${run.runUrl})). Closing automatically.`);
-    await tracking.closeIssue(github, owner, repo, issue.number);
     core.info(`Closed #${issue.number} for ci.yml on ${ref}`);
 }
 

--- a/.github/workflows/report-ci-failure.js
+++ b/.github/workflows/report-ci-failure.js
@@ -1,0 +1,168 @@
+// Red-main CI reporter, used by ci.yml. Files/updates a single deduplicated issue
+// when a push to a protected branch (main, release/**) fails CI, and closes that
+// issue again when a later push to the same branch is green.
+//
+// Self-closing by design: ci.yml runs on every push, so a green push is the most
+// timely signal that the branch is no longer red — there is no need to wait for an
+// external 2h poll. The issue still carries an autoClose:true stamp (see
+// tracking-issue.js) so the scheduled watchdog can also close it as a backstop.
+//
+// Per-branch keying: a red `main` and a red `release/13.3` are different problems,
+// so the marker embeds the ref and each branch gets its own issue. Example markers:
+//   <!-- ci-failure:ci.yml:push:main -->
+//   <!-- ci-failure:ci.yml:push:release/13.3 -->
+//
+// The reusable find-or-create + comment-dedup loop and the octokit primitives live
+// in ./tracking-issue.js. The pure helpers here are unit-tested by
+// tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureTests.cs; reportFailure()
+// and resolveSuccess() are covered through report-ci-failure.integration.harness.js.
+
+'use strict';
+
+const tracking = require('./tracking-issue.js');
+
+// All red-main issues carry this label; it is also the lookup key used to narrow
+// the strongly-consistent issue list before the marker filter. Shared with the
+// scanner and the nightly-pipeline reporter — the per-branch marker keeps the
+// issues from being managed by each other.
+const AUTOMATION_BROKEN_LABEL = 'automation-broken';
+
+// Per-branch dedup marker; the ref segment makes main and release/** distinct.
+const MARKER_PREFIX = 'ci-failure:ci.yml:push:';
+
+function buildMarker(ref) {
+    return `<!-- ${MARKER_PREFIX}${ref} -->`;
+}
+
+function buildIssueTitle(ref) {
+    return `CI failing on \`${ref}\``;
+}
+
+// Builds the static issue body, stamped autoClose:true (a green push closes it).
+// Each failed run is recorded as a comment (see reportFailure), so the body is a
+// fixed description written once at filing.
+function buildIssueBody({ marker, ref }) {
+    return tracking.buildBody({
+        marker,
+        autoClose: true,
+        lead: `CI (\`ci.yml\`) is failing on push to \`${ref}\`. The branch is red.`,
+        note: [
+            'Filed automatically when a push to this branch fails CI. Each failed run is',
+            'recorded as a comment below. The issue is **closed automatically** when a',
+            'later push to the same branch passes CI.',
+            'See [docs/ci/ci-failure-issues.md](../../blob/main/docs/ci/ci-failure-issues.md).',
+        ],
+    });
+}
+
+// Comment recorded per failed run. Intentionally does NOT parse test results:
+// a push can fail for non-test reasons (setup, build, a non-TRX job), so the
+// comment links the run rather than asserting a failing-test list.
+function formatComment({ run }) {
+    const runLink = `[run #${run.runNumber ?? '?'}](${run.runUrl})`;
+    const shaPart = run.sha ? ` (commit \`${String(run.sha).slice(0, 8)}\`)` : '';
+
+    return `CI failed in ${runLink}${shaPart}.`;
+}
+
+// The branch under test, from github.ref_name (e.g. `main`, `release/13.3`).
+function readRef() {
+    const ref = process.env.REF;
+    if (!ref) {
+        throw new Error('REF env var is required (set it to github.ref_name).');
+    }
+
+    return ref;
+}
+
+function runContext(context) {
+    const { owner, repo } = context.repo;
+
+    return {
+        runUrl: `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`,
+        runNumber: context.runNumber,
+        sha: context.sha,
+    };
+}
+
+// Files or updates the branch's red-main issue. Required env: REF.
+async function reportFailure({ github, context, core }) {
+    const ref = readRef();
+    const { owner, repo } = context.repo;
+
+    await tracking.ensureLabel(github, owner, repo, {
+        name: AUTOMATION_BROKEN_LABEL, color: 'B60205',
+        description: 'A scheduled/automation workflow is failing',
+    });
+
+    const marker = buildMarker(ref);
+    const result = await tracking.recordRun(github, context, core, {
+        label: AUTOMATION_BROKEN_LABEL,
+        labels: [AUTOMATION_BROKEN_LABEL],
+        marker,
+        title: buildIssueTitle(ref),
+        runId: context.runId,
+        buildBody: () => buildIssueBody({ marker, ref }),
+        comment: formatComment({ run: runContext(context) }),
+    });
+
+    if (!result.skipped) {
+        core.info(`${result.created ? 'Filed' : 'Updated'} #${result.number} for ci.yml on ${ref}`);
+    }
+}
+
+// Closes the branch's red-main issue when a later push is green. A no-op when no
+// issue is open for the branch. Required env: REF.
+async function resolveSuccess({ github, context, core }) {
+    const ref = readRef();
+    const { owner, repo } = context.repo;
+
+    const marker = buildMarker(ref);
+    const open = await tracking.listOpenIssuesByLabel(github, owner, repo, AUTOMATION_BROKEN_LABEL);
+    const issue = tracking.findOpenIssueForMarker(open, marker);
+
+    if (issue === null) {
+        core.info(`No open CI-failure issue for ${ref}; nothing to close.`);
+        return;
+    }
+
+    const run = runContext(context);
+    await tracking.addComment(github, owner, repo, issue.number,
+        `CI is green again on \`${ref}\` ([run #${run.runNumber}](${run.runUrl})). Closing automatically.`);
+    await tracking.closeIssue(github, owner, repo, issue.number);
+    core.info(`Closed #${issue.number} for ci.yml on ${ref}`);
+}
+
+// Single entry point for ci.yml's tracker job, which runs on every push
+// (if: always()). The workflow computes the aggregate CI result from
+// needs.*.result and passes it in env:
+//   CI_RED   = 'true' when any dependency failed (the branch is red).
+//   CI_GREEN = 'true' when every dependency succeeded (the branch is green).
+// A run that is neither (a skipped no-relevant-changes push, or a cancelled run)
+// is a no-op: there is no CI signal, so an open issue is left untouched. CI_RED is
+// checked first so a genuine failure is always reported even if env is malformed.
+async function track({ github, context, core }) {
+    if (process.env.CI_RED === 'true') {
+        await reportFailure({ github, context, core });
+        return;
+    }
+
+    if (process.env.CI_GREEN === 'true') {
+        await resolveSuccess({ github, context, core });
+        return;
+    }
+
+    core.info('CI run is neither cleanly red nor green (skipped or cancelled); nothing to do.');
+}
+
+module.exports = {
+    AUTOMATION_BROKEN_LABEL,
+    MARKER_PREFIX,
+    buildMarker,
+    buildIssueTitle,
+    buildIssueBody,
+    formatComment,
+    reportFailure,
+    resolveSuccess,
+    track,
+};

--- a/.github/workflows/report-pipeline-failure.js
+++ b/.github/workflows/report-pipeline-failure.js
@@ -1,0 +1,123 @@
+// Nightly-pipeline failure reporter, used by deployment-tests.yml and
+// tests-daily-smoke.yml. Invoked from an actions/github-script step via report().
+//
+// These scheduled pipelines otherwise fail silently — GitHub only emails whoever
+// last edited the workflow file. This reporter files a single deduplicated issue
+// per workflow and records each failed run as a comment; a human closes the issue
+// once the problem is fixed (no auto-close-on-green, mirroring the specialized-test
+// reporter — a green run mid-triage should not close the issue out from under a
+// dev).
+//
+// Unlike the specialized-test reporter, a failed run here is NOT classified into
+// test-vs-infra: these pipelines report "the scheduled run failed" with a link to
+// the run. Any per-run detail a caller wants to surface (e.g. the smoke suite's
+// per-route CLI versions) rides on the comment.
+//
+// The reusable find-or-create + comment-dedup loop and the octokit primitives live
+// in ./tracking-issue.js. The pure helpers here are unit-tested by
+// tests/Infrastructure.Tests/WorkflowScripts/ReportPipelineFailureTests.cs; report()
+// is covered through report-pipeline-failure.integration.harness.js.
+
+'use strict';
+
+const tracking = require('./tracking-issue.js');
+
+// All pipeline-failure issues carry this label; it is also the lookup key used to
+// narrow the strongly-consistent issue list before the marker filter. Shared with
+// the scanner and the specialized reporter's infra issues — the per-workflow
+// marker keeps the issues from being managed by each other.
+const AUTOMATION_BROKEN_LABEL = 'automation-broken';
+
+// Per-workflow dedup marker, e.g.
+//   <!-- ci-failure:deployment-tests.yml:scheduled -->
+// Shares the `ci-failure:` namespace with the specialized-test reporter; the
+// workflow-file segment keeps each pipeline's marker distinct, so the two
+// reporters never edit or close each other's issues even though both query the
+// `automation-broken` label.
+const MARKER_PREFIX = 'ci-failure:';
+const KIND = 'scheduled';
+
+function buildMarker(workflowFile) {
+    return `<!-- ${MARKER_PREFIX}${workflowFile}:${KIND} -->`;
+}
+
+function buildIssueTitle(displayName) {
+    return `Nightly run failing: ${displayName}`;
+}
+
+// Builds the static issue body. Each failed run is recorded as a comment (see
+// report()), so the body is a fixed description written once at filing.
+function buildIssueBody({ marker, displayName, workflowFile, cc = '' }) {
+    const lead = `The scheduled workflow [\`${workflowFile}\`](../../actions/workflows/${workflowFile}) (**${displayName}**) is failing on its nightly run.`;
+
+    return tracking.buildBody({
+        marker,
+        lead: cc ? `${lead} /cc ${cc}` : lead,
+        note: [
+            'Filed automatically when a scheduled run fails. Each failed run is added as a',
+            'comment below; close this issue once the underlying problem is fixed.',
+            'See [docs/ci/pipeline-failure-issues.md](../../blob/main/docs/ci/pipeline-failure-issues.md).',
+        ],
+    });
+}
+
+// Comment recorded per failed run. `detail` carries optional caller-specific
+// per-run context (e.g. the smoke suite's per-route CLI versions); it is rendered
+// verbatim below the run line.
+function formatComment({ run, detail = '' }) {
+    const runLink = `[run #${run.runNumber ?? '?'}](${run.runUrl})`;
+    const shaPart = run.sha ? ` (commit \`${String(run.sha).slice(0, 8)}\`)` : '';
+    const head = `The scheduled run failed in ${runLink}${shaPart}.`;
+
+    return detail ? `${head}\n\n${detail}` : head;
+}
+
+// Orchestrator. Required env: WORKFLOW_FILE, DISPLAY_NAME. Call options:
+//   labels        - extra labels for a newly-filed issue (automation-broken is
+//                   always added, in lockstep with the lookup key, so a created
+//                   issue is always findable on the next run).
+//   cc            - optional @mention added to the body lead (first filing only).
+//   commentDetail - optional per-run markdown appended to the failure comment.
+async function report({ github, context, core, labels, cc = '', commentDetail = '' }) {
+    const workflowFile = process.env.WORKFLOW_FILE;
+    const displayName = process.env.DISPLAY_NAME;
+    const { owner, repo } = context.repo;
+
+    await tracking.ensureLabel(github, owner, repo, {
+        name: AUTOMATION_BROKEN_LABEL, color: 'B60205',
+        description: 'A scheduled/automation workflow is failing',
+    });
+
+    const run = {
+        runUrl: `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`,
+        runNumber: context.runNumber,
+        sha: context.sha,
+    };
+    const marker = buildMarker(workflowFile);
+    const issueLabels = [...new Set([AUTOMATION_BROKEN_LABEL, ...(labels ?? [])])];
+
+    const result = await tracking.recordRun(github, context, core, {
+        label: AUTOMATION_BROKEN_LABEL,
+        labels: issueLabels,
+        marker,
+        title: buildIssueTitle(displayName),
+        runId: context.runId,
+        buildBody: () => buildIssueBody({ marker, displayName, workflowFile, cc }),
+        comment: formatComment({ run, detail: commentDetail }),
+    });
+
+    if (!result.skipped) {
+        core.info(`${result.created ? 'Filed' : 'Updated'} #${result.number} for ${workflowFile}`);
+    }
+}
+
+module.exports = {
+    AUTOMATION_BROKEN_LABEL,
+    MARKER_PREFIX,
+    KIND,
+    buildMarker,
+    buildIssueTitle,
+    buildIssueBody,
+    formatComment,
+    report,
+};

--- a/.github/workflows/report-specialized-test-failures.js
+++ b/.github/workflows/report-specialized-test-failures.js
@@ -1,0 +1,154 @@
+// Pure decision/formatting helpers for the embedded test-failure reporter used by
+// tests-outerloop.yml and tests-quarantine.yml
+// (.github/workflows/specialized-test-failure-runner.js).
+//
+// These scheduled test workflows otherwise fail silently. This reporter files a
+// single deduplicated GitHub issue per (workflow, failure-kind) and records each
+// failed run as a comment; a human closes the issue once fixed (no
+// auto-close-on-green).
+//
+// Two failure kinds:
+//   - 'test-failures' : outerloop tests failed. Each failed run's comment lists
+//     the failing tests; a dev can split them into per-test issues later.
+//   - 'infra'         : the run broke before/around test execution (build/setup,
+//     missing TRX). Quarantine runs swallow test failures (ignoreTestFailures),
+//     so a *failed* quarantine run is always infra.
+//
+// This module performs NO network I/O; the shared engine (./tracking-issue.js)
+// does the octokit calls and calls these helpers. It is unit-tested by
+// tests/Infrastructure.Tests/WorkflowScripts/ReportSpecializedTestFailuresTests.cs.
+
+'use strict';
+
+const tracking = require('./tracking-issue.js');
+
+const AUTOMATION_BROKEN_LABEL = 'automation-broken';
+const FAILING_TEST_LABEL = 'failing-test';
+
+const KIND_INFRA = 'infra';
+const KIND_TEST_FAILURES = 'test-failures';
+
+// Per-(workflow, kind) dedup marker, e.g.
+//   <!-- ci-failure:tests-outerloop.yml:test-failures -->
+// Distinct from the scheduled-workflow scanner's `automation-broken:<file>`
+// marker so the two mechanisms never manage each other's issues.
+const MARKER_PREFIX = 'ci-failure:';
+
+// Cap inline test names in a comment so a large outerloop break doesn't post a
+// multi-hundred-line comment; the full set is always in the run's TRX artifacts.
+const DEFAULT_MAX_LISTED_TESTS = 50;
+
+function buildMarker(workflowFile, kind) {
+    return `<!-- ${MARKER_PREFIX}${workflowFile}:${kind} -->`;
+}
+
+function labelForKind(kind) {
+    return kind === KIND_TEST_FAILURES ? FAILING_TEST_LABEL : AUTOMATION_BROKEN_LABEL;
+}
+
+function buildIssueTitle(displayName, kind) {
+    return kind === KIND_TEST_FAILURES
+        ? `Test failures: ${displayName}`
+        : `CI infrastructure failing: ${displayName}`;
+}
+
+// Decides what a failed scheduled run represents.
+//   ignoreTestFailures (quarantine): a failed run is always infra, because test
+//   failures are swallowed upstream (run-tests.yml) and never red the run.
+//   Otherwise (outerloop):
+//     - failed tests extracted        => 'test-failures'
+//     - extraction failed/unknown     => 'test-failures' (we can't prove it was
+//       infra, and misfiling a red run as infra loses the failing-test signal —
+//       prefer the test-failures issue with a "could not enumerate" note)
+//     - clean extraction, zero failed => 'infra' (the run broke before/around
+//       test execution; no test produced a failed result)
+function classifyFailure({ result, failedCount = 0, ignoreTestFailures = false, extractionFailed = false }) {
+    if (result !== 'failure') {
+        return 'none';
+    }
+    if (ignoreTestFailures) {
+        return KIND_INFRA;
+    }
+    if (extractionFailed) {
+        return KIND_TEST_FAILURES;
+    }
+
+    return failedCount > 0 ? KIND_TEST_FAILURES : KIND_INFRA;
+}
+
+// Builds the static issue body. Each failed run is recorded as a comment (see the
+// runner), so the body is a fixed description written once at filing; the marker
+// is embedded so the issue can be found again.
+function buildIssueBody({ marker, displayName, workflowFile, kind }) {
+    const lead = kind === KIND_TEST_FAILURES
+        ? `Outerloop tests are failing in [\`${workflowFile}\`](../../actions/workflows/${workflowFile}) (**${displayName}**). The failing tests for each run are listed in the comments below; split them into per-test issues as needed.`
+        : `The scheduled workflow [\`${workflowFile}\`](../../actions/workflows/${workflowFile}) (**${displayName}**) is failing for an infrastructure reason (build/setup, or no test results were produced).`;
+
+    return tracking.buildBody({
+        marker,
+        lead,
+        note: [
+            'Filed automatically by the specialized-test failure reporter. Each failed run',
+            'is added as a comment below; close this issue once the underlying problem is',
+            'fixed.',
+            'See [docs/ci/specialized-test-failure-issues.md](../../blob/main/docs/ci/specialized-test-failure-issues.md).',
+        ],
+    });
+}
+
+// Normalizes a failed test name for safe inclusion inside a Markdown inline code
+// span. Real test display names can contain backticks (e.g. interpolated theory
+// data) and, rarely, newlines; left raw they can break out of the code span and
+// inject arbitrary Markdown (headings, @mentions). Collapse CR/LF to spaces and
+// wrap with a backtick fence longer than any backtick run in the name, padding
+// with spaces when the name starts/ends with a backtick (CommonMark rule).
+function toInlineCode(name) {
+    const normalized = String(name).replace(/\r?\n/g, ' ');
+    const longestRun = (normalized.match(/`+/g) ?? []).reduce((max, run) => Math.max(max, run.length), 0);
+    const fence = '`'.repeat(longestRun + 1);
+    const pad = normalized.startsWith('`') || normalized.endsWith('`') ? ' ' : '';
+
+    return `${fence}${pad}${normalized}${pad}${fence}`;
+}
+
+// Comment recorded per failed run. For test failures it lists the failing tests
+// (capped). When the kind is test-failures but no names were extracted (extraction
+// failed on a genuinely-red run), it points at the run artifacts instead of
+// claiming zero.
+function formatComment({ kind, run, failedTests = [], maxListed = DEFAULT_MAX_LISTED_TESTS }) {
+    const runLink = `[run #${run.runNumber ?? '?'}](${run.runUrl})`;
+    if (kind !== KIND_TEST_FAILURES) {
+        return `Infrastructure failure again in ${runLink}. See the run for build/setup logs.`;
+    }
+
+    if (failedTests.length === 0) {
+        return `Tests failed in ${runLink}, but the failing test names could not be ` +
+            `extracted from the run's results. See the run's test artifacts.`;
+    }
+
+    const shown = failedTests.slice(0, maxListed);
+    const lines = [`${failedTests.length} test(s) failed in ${runLink}:`, ''];
+    for (const test of shown) {
+        lines.push(`- ${toInlineCode(test)}`);
+    }
+    if (failedTests.length > shown.length) {
+        lines.push(`- _…and ${failedTests.length - shown.length} more (see run artifacts)_`);
+    }
+
+    return lines.join('\n');
+}
+
+module.exports = {
+    AUTOMATION_BROKEN_LABEL,
+    FAILING_TEST_LABEL,
+    KIND_INFRA,
+    KIND_TEST_FAILURES,
+    MARKER_PREFIX,
+    DEFAULT_MAX_LISTED_TESTS,
+    buildMarker,
+    labelForKind,
+    buildIssueTitle,
+    classifyFailure,
+    buildIssueBody,
+    formatComment,
+};

--- a/.github/workflows/report-specialized-test-failures.js
+++ b/.github/workflows/report-specialized-test-failures.js
@@ -118,7 +118,7 @@ function toInlineCode(name) {
 function formatComment({ kind, run, failedTests = [], maxListed = DEFAULT_MAX_LISTED_TESTS }) {
     const runLink = `[run #${run.runNumber ?? '?'}](${run.runUrl})`;
     if (kind !== KIND_TEST_FAILURES) {
-        return `Infrastructure failure again in ${runLink}. See the run for build/setup logs.`;
+        return `Infrastructure failure in ${runLink}. See the run for build/setup logs.`;
     }
 
     if (failedTests.length === 0) {

--- a/.github/workflows/specialized-test-failure-runner.js
+++ b/.github/workflows/specialized-test-failure-runner.js
@@ -1,0 +1,91 @@
+// Network orchestration for the specialized-test failure reporter, shared by
+// tests-outerloop.yml and tests-quarantine.yml. Invoked from an
+// actions/github-script step; all pure logic lives in (and is unit-tested via)
+// report-specialized-test-failures.js, and the find-or-create + comment-dedup
+// loop lives in the shared engine ./tracking-issue.js. This file reads the run's
+// results, classifies the failure, and delegates, so it is thin and covered
+// through specialized-test-failure-runner.harness.js.
+//
+// Required env:
+//   WORKFLOW_FILE        - e.g. 'tests-outerloop.yml' (dedup key + links)
+//   DISPLAY_NAME         - human label used in the issue title
+//   IGNORE_TEST_FAILURES - 'true' for quarantine (a failed run is always infra)
+//   FAILED_TESTS_PATH    - optional path to GenerateTestSummary --failed-tests-json output
+
+'use strict';
+
+const fs = require('node:fs');
+
+const tracking = require('./tracking-issue.js');
+
+module.exports = async function reportSpecializedTestFailure({ github, context, core, reporter }) {
+    const { owner, repo } = context.repo;
+    const workflowFile = process.env.WORKFLOW_FILE;
+    const displayName = process.env.DISPLAY_NAME;
+    const ignoreTestFailures = process.env.IGNORE_TEST_FAILURES === 'true';
+
+    // The reporter job is gated on failure(), so the upstream run concluded 'failure'.
+    let failedTests = [];
+    let extractionFailed = false;
+    const failedTestsPath = process.env.FAILED_TESTS_PATH;
+    if (failedTestsPath && fs.existsSync(failedTestsPath)) {
+        try {
+            const parsed = JSON.parse(fs.readFileSync(failedTestsPath, 'utf8'));
+            failedTests = Array.isArray(parsed.failedTests) ? parsed.failedTests : [];
+            extractionFailed = parsed.extractionFailed === true;
+        } catch (error) {
+            // We were handed a results path but couldn't read it — treat as an
+            // extraction failure rather than "zero failures" so a genuinely-red
+            // outerloop run is not misfiled as infra.
+            core.warning(`Could not parse failed-tests JSON: ${error.message}`);
+            extractionFailed = true;
+        }
+    } else if (!ignoreTestFailures) {
+        // The outerloop reporter expects a results file, but the extract step can
+        // crash before emitting its path output (leaving FAILED_TESTS_PATH empty).
+        // The run is red; treat unreadable results as a test failure, not infra, so
+        // the failing-test signal is not silently dropped. (Quarantine sets
+        // ignoreTestFailures and never inspects results, so this branch is skipped
+        // there.)
+        core.warning('No failed-tests results path was provided; treating as an extraction failure.');
+        extractionFailed = true;
+    }
+
+    const kind = reporter.classifyFailure({
+        result: 'failure',
+        failedCount: failedTests.length,
+        ignoreTestFailures,
+        extractionFailed,
+    });
+    if (kind === 'none') {
+        core.info('Run did not fail; nothing to report.');
+        return;
+    }
+
+    const marker = reporter.buildMarker(workflowFile, kind);
+    const label = reporter.labelForKind(kind);
+
+    await tracking.ensureLabel(github, owner, repo, {
+        name: label, color: 'B60205',
+        description: kind === reporter.KIND_TEST_FAILURES ? 'A failing test' : 'A scheduled/automation workflow is failing',
+    });
+
+    const run = {
+        runUrl: `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`,
+        runNumber: context.runNumber,
+    };
+
+    const result = await tracking.recordRun(github, context, core, {
+        label,
+        marker,
+        title: reporter.buildIssueTitle(displayName, kind),
+        runId: context.runId,
+        buildBody: () => reporter.buildIssueBody({ marker, displayName, workflowFile, kind }),
+        comment: reporter.formatComment({ kind, run, failedTests }),
+    });
+
+    if (result.skipped) {
+        return;
+    }
+    core.info(`${result.created ? 'Filed' : 'Updated'} #${result.number} (${kind}) for ${workflowFile}`);
+};

--- a/.github/workflows/tests-daily-smoke.yml
+++ b/.github/workflows/tests-daily-smoke.yml
@@ -243,15 +243,25 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # File/append a single deduplicated issue on a scheduled-run failure. One issue
+  # is kept open per workflow and a row is appended per failed run; a human closes
+  # it once fixed. The per-run CLI versions ride on the notification comment. See
+  # docs/ci/pipeline-failure-issues.md.
   create-issue-on-failure:
     name: Create Issue on Failure
     needs: [smoke-test]
     runs-on: ubuntu-latest
-    if: ${{ failure() && github.event_name == 'schedule' }}
+    if: ${{ failure() && github.event_name == 'schedule' && github.repository_owner == 'microsoft' }}
     permissions:
-      actions: read
+      contents: read   # checkout to require the local .js modules
+      actions: read    # download-artifact
       issues: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          persist-credentials: false
+
       - name: Download smoke test results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
@@ -259,88 +269,31 @@ jobs:
           name: smoke-test-results-${{ inputs.quality || 'dev' }}
           path: smoke-test-results
 
-      - name: Create GitHub Issue
+      - name: File or update failure issue
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          WORKFLOW_FILE: tests-daily-smoke.yml
+          DISPLAY_NAME: Daily CLI Smoke Tests
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('node:fs');
             const path = require('node:path');
 
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const quality = context.payload.inputs?.quality ?? 'dev';
-            const date = new Date().toISOString().split('T')[0];
-            const cliVersionSummary = getCliVersionSummary(process.env.GITHUB_WORKSPACE, message => core.warning(message));
-
-            const issueTitle = `[Daily Smoke] CLI smoke test failure - ${date}`;
-            const issueBody = [
-              '## Daily CLI Smoke Test Failure',
-              '',
-              `The daily CLI smoke tests failed on ${date}.`,
-              '',
-              `**Workflow Run:** ${runUrl}`,
+            // The per-route CLI versions (parsed from the smoke artifact) are per-run
+            // detail, so they ride on the notification comment rather than the body.
+            const commentDetail = [
               `**Quality:** ${quality} (daily build)`,
               '',
-              cliVersionSummary,
-              '',
-              '### Next Steps',
-              '1. Check the workflow run for detailed error logs',
-              '2. Download test recordings from artifacts',
-              '3. Compare with the latest daily build changes',
-              '4. Investigate and fix the regression',
-              '',
-              'This issue was automatically created by the daily CLI smoke test workflow.'
+              getCliVersionSummary(process.env.GITHUB_WORKSPACE),
             ].join('\n');
 
-            let todayIssue = null;
-            try {
-              const existingIssues = await github.rest.issues.listForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                labels: 'area-cli,failing-test',
-                per_page: 10
-              });
-
-              todayIssue = existingIssues.data.find(issue =>
-                issue.title.includes(date) && issue.title.includes('[Daily Smoke]')
-              );
-            }
-            catch (error) {
-              core.warning(`Could not query existing daily smoke issues; creating a new issue to avoid losing the failure report. ${getErrorMessage(error)}`);
-            }
-
-            if (todayIssue) {
-              core.info(`Issue already exists for today: ${todayIssue.html_url}`);
-              const body = [
-                `Another failure occurred. See: ${runUrl}`,
-                '',
-                cliVersionSummary
-              ].join('\n');
-
-              try {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: todayIssue.number,
-                  body
-                });
-                return;
-              }
-              catch (error) {
-                core.warning(`Failed to comment on the existing daily smoke issue; creating a new issue instead. ${getErrorMessage(error)}`);
-              }
-            }
-
-            const issue = await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: issueTitle,
-              body: issueBody,
-              labels: ['area-cli', 'failing-test']
+            await require('./.github/workflows/report-pipeline-failure.js').report({
+              github, context, core,
+              labels: ['automation-broken', 'area-cli', 'failing-test'],
+              commentDetail,
             });
-
-            core.info(`Created issue: ${issue.data.html_url}`);
 
             function getCliVersionSummary(workspace) {
               const noVersionRecordsSummary = [

--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -43,3 +43,75 @@ jobs:
       extraRunSheetBuilderArgs: "-p:RunOuterloopTests=true"
       extraTestArgs: "--filter-trait outerloop=true"
       enablePlaywrightInstall: true
+
+  # On a scheduled failure, file/append a single deduplicated issue: a
+  # 'failing-test' issue listing the failed outerloop tests, or an
+  # 'automation-broken' infra issue when the run broke before producing test
+  # results. PR-triggered runs (paths filter) are excluded so workflow edits
+  # don't file issues. See docs/ci/specialized-test-failure-issues.md.
+  report_failures:
+    name: Report failures
+    needs: [outerloop_tests]
+    if: ${{ failure() && github.event_name == 'schedule' && github.repository_owner == 'microsoft' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read   # checkout to require the local .js modules
+      actions: read
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          persist-credentials: false
+
+      # The runner uploads per-job test logs (incl. .trx) as 'logs-*' artifacts.
+      - name: Download test result artifacts
+        id: download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          pattern: 'logs-*'
+          path: ${{ github.workspace }}/all-logs
+
+      - name: Extract failed test names
+        id: failed
+        continue-on-error: true
+        env:
+          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/out"
+          OUT="$RUNNER_TEMP/out/failed-tests.json"
+          # extractionFailed distinguishes "we could not read the results" from
+          # "the run produced zero failed tests". The reporter classifies a
+          # genuinely-red run with unknown results as a test failure (not infra),
+          # so a transient download/tool flake doesn't silently misfile the issue
+          # or drop the failing-test list.
+          if [ -d "$GITHUB_WORKSPACE/all-logs" ]; then
+            if ./dotnet.sh run --project tools/GenerateTestSummary/GenerateTestSummary.csproj -- \
+                 "$GITHUB_WORKSPACE/all-logs" --failed-tests-json "$OUT"; then
+              :  # tool wrote $OUT (with or without failures)
+            else
+              echo '{"failedTests":[],"count":0,"extractionFailed":true}' > "$OUT"
+            fi
+          elif [ "$DOWNLOAD_OUTCOME" = "failure" ]; then
+            # No artifacts directory AND the download step errored — a download
+            # flake, not a clean "no results". A real build break still uploads
+            # logs-runsheet, so a present-but-empty result set stays infra below.
+            echo '{"failedTests":[],"count":0,"extractionFailed":true}' > "$OUT"
+          else
+            echo '{"failedTests":[],"count":0}' > "$OUT"
+          fi
+          echo "path=$OUT" >> "$GITHUB_OUTPUT"
+
+      - name: File or update failure issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          WORKFLOW_FILE: tests-outerloop.yml
+          DISPLAY_NAME: Outerloop Tests
+          IGNORE_TEST_FAILURES: 'false'
+          FAILED_TESTS_PATH: ${{ steps.failed.outputs.path }}
+        with:
+          script: |
+            const reporter = require('./.github/workflows/report-specialized-test-failures.js');
+            await require('./.github/workflows/specialized-test-failure-runner.js')({ github, context, core, reporter });
+

--- a/.github/workflows/tests-quarantine.yml
+++ b/.github/workflows/tests-quarantine.yml
@@ -45,3 +45,38 @@ jobs:
       extraTestArgs: "--filter-trait quarantined=true"
       enablePlaywrightInstall: true
       ignoreTestFailures: true
+
+  # Quarantine passes ignoreTestFailures, so failing quarantined tests do NOT red
+  # the run (run-tests.yml swallows them and only checks that TRX were produced).
+  # A failed quarantine run therefore means infrastructure broke — file/append a
+  # single deduplicated 'automation-broken' issue. No test-failure issues are
+  # filed here. PR-triggered runs are excluded.
+  # See docs/ci/specialized-test-failure-issues.md.
+  report_infra_failure:
+    name: Report infra failure
+    needs: [quarantine_tests]
+    if: ${{ failure() && github.event_name == 'schedule' && github.repository_owner == 'microsoft' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read   # checkout to require the local .js modules
+      actions: read
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: File or update infra issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          WORKFLOW_FILE: tests-quarantine.yml
+          DISPLAY_NAME: Quarantined Tests
+          # A failed quarantine run is always infra (see comment above), so the
+          # reporter never inspects TRX here.
+          IGNORE_TEST_FAILURES: 'true'
+        with:
+          script: |
+            const reporter = require('./.github/workflows/report-specialized-test-failures.js');
+            await require('./.github/workflows/specialized-test-failure-runner.js')({ github, context, core, reporter });
+

--- a/.github/workflows/tracking-issue.js
+++ b/.github/workflows/tracking-issue.js
@@ -1,0 +1,207 @@
+// Generic helpers for "tracking issues": a single deduplicated GitHub issue per
+// subject, identified by a hidden HTML-comment marker, whose failures accrue as
+// one comment per event (a failed run, a broken build, ...). The issue body is a
+// fixed description written once at creation; every subsequent failure is a new
+// comment. The comment both fires @notifications and — via a hidden per-run
+// marker — is the dedup key, so there is no body rewriting and no ordering window.
+//
+// This module owns the reusable *mechanics* — marker-based dedup lookup, the
+// per-run comment-recording loop, and the octokit primitives to
+// create/comment/close an issue. Callers own the *content and policy*: they build
+// the marker text, title, body, comments, and labels, and decide what action to
+// take. Nothing here is specific to any repository, label, workflow, or product —
+// keep it that way.
+//
+// The pure helpers (no network) are unit-tested via
+// tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs. The octokit
+// primitives and recordRun are exercised by the consumers' integration paths.
+
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Pure: marker mechanics
+// ---------------------------------------------------------------------------
+
+// Returns the oldest open issue (lowest number) whose body carries the marker.
+// "Oldest wins" gives a deterministic canonical issue. Concurrent double-filing is
+// already unlikely — most consumer workflows serialize via a `concurrency` group,
+// and the rest only file on their (infrequent) scheduled run — but if a duplicate
+// is ever filed (e.g. one created manually) the older one stays canonical and the
+// duplicate has to be closed by hand.
+function findOpenIssueForMarker(issues, marker) {
+    const matches = (issues ?? []).filter(
+        issue => typeof issue?.body === 'string' && issue.body.includes(marker));
+    if (matches.length === 0) {
+        return null;
+    }
+
+    return matches.reduce((oldest, issue) => (issue.number < oldest.number ? issue : oldest));
+}
+
+// Hidden marker embedded in each failure comment, e.g.
+//   <!-- run:12345678 -->
+// `runId` is stable across re-runs of the same run, so this is the dedup key that
+// stops a poller (or a re-run) from posting a second comment for a run already
+// recorded. Kept in an HTML comment so it never renders in the issue thread.
+function runMarker(runId) {
+    return `<!-- run:${runId} -->`;
+}
+
+// Builds a standard tracking-issue body: the hidden marker, an optional hidden
+// auto-close stamp, a one-line lead, then a short explanatory note (closing
+// policy + docs link). Consumers supply only the parts that differ; the skeleton
+// (marker placement, spacing) is shared so every tracking issue reads the same.
+// The body is static — failures are recorded as comments, not appended here.
+//
+// `autoClose` (optional) embeds a hidden close-policy stamp right after the
+// marker (see autoCloseStamp). Pass `true` for issues a green run should close
+// automatically (infra/automation), `false` for issues a human must close after
+// triage (test failures). Omit it when the body carries no close policy.
+function buildBody({ marker, lead, note, autoClose }) {
+    const head = autoClose === undefined ? [marker] : [marker, autoCloseStamp(autoClose)];
+    return [
+        ...head,
+        '',
+        lead,
+        '',
+        ...note,
+        '',
+    ].join('\n');
+}
+
+// Hidden close-policy stamp embedded in an issue body, e.g.
+//   <!-- autoclose:true -->
+// `true`  => a watchdog may close the issue when the subject's latest run is green.
+// `false` => the issue must be closed by a human (e.g. a flaky test where a single
+//            green run does not prove the problem is fixed).
+// Kept in an HTML comment so it never renders in the issue.
+function autoCloseStamp(autoClose) {
+    return `<!-- autoclose:${autoClose ? 'true' : 'false'} -->`;
+}
+
+// Reads the close-policy stamp from an issue body. Returns `true`/`false` when a
+// stamp is present, or `null` when it is missing or unparseable. Callers MUST
+// treat `null` conservatively (do not auto-close) so a human-edited body or an
+// issue filed before stamping was introduced is never closed out from under a
+// triager. Matches the autoCloseStamp shape, tolerant of surrounding whitespace:
+//   <!-- autoclose:true -->  /  <!--autoclose:false-->
+function readAutoClose(body) {
+    if (typeof body !== 'string') {
+        return null;
+    }
+
+    const match = /<!--\s*autoclose:(true|false)\s*-->/i.exec(body);
+    if (match === null) {
+        return null;
+    }
+
+    return match[1].toLowerCase() === 'true';
+}
+
+// ---------------------------------------------------------------------------
+// Octokit primitives (network). Thin wrappers; no policy.
+// ---------------------------------------------------------------------------
+
+// Idempotently ensures a label exists. A 422 means it already exists.
+async function ensureLabel(github, owner, repo, { name, color, description }) {
+    try {
+        await github.rest.issues.createLabel({ owner, repo, name, color, description });
+    } catch (error) {
+        if (error.status !== 422) {
+            throw error;
+        }
+    }
+}
+
+// Lists all open issues carrying a label. Uses the (strongly-consistent) list
+// API rather than Search, whose eventual-consistency window would let
+// near-simultaneous pollers each see "0 hits" and file duplicates.
+async function listOpenIssuesByLabel(github, owner, repo, label) {
+    const items = await github.paginate(github.rest.issues.listForRepo, {
+        owner, repo, labels: label, state: 'open', per_page: 100,
+    });
+    // listForRepo returns pull requests too (they are issues in the REST model).
+    // Exclude them so a labeled PR whose body happens to carry a tracking marker is
+    // never mistaken for the managed issue and then commented/closed in its place.
+    return items.filter(item => !item.pull_request);
+}
+
+async function createIssue(github, owner, repo, { title, body, labels }) {
+    const created = await github.rest.issues.create({ owner, repo, title, body, labels });
+    return created.data;
+}
+
+async function addComment(github, owner, repo, issueNumber, body) {
+    await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+}
+
+async function closeIssue(github, owner, repo, issueNumber, { stateReason = 'completed' } = {}) {
+    await github.rest.issues.update({ owner, repo, issue_number: issueNumber, state: 'closed', state_reason: stateReason });
+}
+
+// True when a comment carrying `marker` already exists on the issue. The marker is
+// the hidden per-run token (see runMarker); scanning comments — never collapsed or
+// truncated — reliably detects "already recorded this exact run".
+async function hasCommentForRun(github, owner, repo, issueNumber, marker) {
+    const comments = await github.paginate(github.rest.issues.listComments, {
+        owner, repo, issue_number: issueNumber, per_page: 100,
+    });
+    return comments.some(comment => typeof comment?.body === 'string' && comment.body.includes(marker));
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration: find-or-create the tracking issue, then record this run as a
+// comment unless it is already recorded. This is the one place the dedup contract
+// lives, so every consumer shares identical semantics.
+// ---------------------------------------------------------------------------
+
+// Options:
+//   label       - the lookup label; the issue is found and (by default) filed with it.
+//   labels      - full label set for a newly-filed issue (defaults to [label]).
+//   marker      - per-subject body marker used to find the canonical issue.
+//   title       - title for a newly-filed issue.
+//   runId       - stable run identifier; the dedup key (see runMarker).
+//   buildBody   - () => string, the static issue body for a fresh issue.
+//   comment     - the failure comment text; the run marker is appended to it.
+//   openIssues  - optional pre-fetched open-issue list (a multi-subject caller,
+//                 e.g. the watchdog, lists once and reuses it across subjects).
+// Returns { number, created } when a comment was posted, or { number, skipped }
+// when the run was already recorded.
+async function recordRun(github, context, core, { label, labels, marker, title, runId, buildBody, comment, openIssues }) {
+    const { owner, repo } = context.repo;
+    const list = openIssues ?? await listOpenIssuesByLabel(github, owner, repo, label);
+    const issue = findOpenIssueForMarker(list, marker);
+    const runComment = runMarker(runId);
+    const commentBody = `${comment}\n\n${runComment}`;
+
+    if (issue === null) {
+        const created = await createIssue(github, owner, repo, { title, body: buildBody(), labels: labels ?? [label] });
+        // A fresh issue has no comments, so the first failure is always posted
+        // without a dedup check; the comment is what notifies subscribers.
+        await addComment(github, owner, repo, created.number, commentBody);
+        return { number: created.number, created: true };
+    }
+
+    if (await hasCommentForRun(github, owner, repo, issue.number, runComment)) {
+        core.info(`Run ${runId} already recorded in #${issue.number}; skipping duplicate comment.`);
+        return { number: issue.number, skipped: true };
+    }
+
+    await addComment(github, owner, repo, issue.number, commentBody);
+    return { number: issue.number, created: false };
+}
+
+module.exports = {
+    findOpenIssueForMarker,
+    runMarker,
+    buildBody,
+    autoCloseStamp,
+    readAutoClose,
+    ensureLabel,
+    listOpenIssuesByLabel,
+    createIssue,
+    addComment,
+    closeIssue,
+    hasCommentForRun,
+    recordRun,
+};

--- a/.github/workflows/tracking-issue.js
+++ b/.github/workflows/tracking-issue.js
@@ -22,13 +22,13 @@
 // Pure: marker mechanics
 // ---------------------------------------------------------------------------
 
-// Returns the oldest open issue (lowest number) whose body carries the marker.
+// Returns the oldest issue (lowest number) whose body carries the marker.
 // "Oldest wins" gives a deterministic canonical issue. Concurrent double-filing is
 // already unlikely — most consumer workflows serialize via a `concurrency` group,
 // and the rest only file on their (infrequent) scheduled run — but if a duplicate
 // is ever filed (e.g. one created manually) the older one stays canonical and the
 // duplicate has to be closed by hand.
-function findOpenIssueForMarker(issues, marker) {
+function findIssueForMarker(issues, marker) {
     const matches = (issues ?? []).filter(
         issue => typeof issue?.body === 'string' && issue.body.includes(marker));
     if (matches.length === 0) {
@@ -36,6 +36,10 @@ function findOpenIssueForMarker(issues, marker) {
     }
 
     return matches.reduce((oldest, issue) => (issue.number < oldest.number ? issue : oldest));
+}
+
+function findOpenIssueForMarker(issues, marker) {
+    return findIssueForMarker((issues ?? []).filter(issue => issue?.state === undefined || issue.state === 'open'), marker);
 }
 
 // Hidden marker embedded in each failure comment, e.g.
@@ -113,17 +117,21 @@ async function ensureLabel(github, owner, repo, { name, color, description }) {
     }
 }
 
-// Lists all open issues carrying a label. Uses the (strongly-consistent) list
+// Lists issues carrying a label. Uses the (strongly-consistent) list
 // API rather than Search, whose eventual-consistency window would let
 // near-simultaneous pollers each see "0 hits" and file duplicates.
-async function listOpenIssuesByLabel(github, owner, repo, label) {
+async function listIssuesByLabel(github, owner, repo, label, { state = 'all' } = {}) {
     const items = await github.paginate(github.rest.issues.listForRepo, {
-        owner, repo, labels: label, state: 'open', per_page: 100,
+        owner, repo, labels: label, state, per_page: 100,
     });
     // listForRepo returns pull requests too (they are issues in the REST model).
     // Exclude them so a labeled PR whose body happens to carry a tracking marker is
     // never mistaken for the managed issue and then commented/closed in its place.
     return items.filter(item => !item.pull_request);
+}
+
+async function listOpenIssuesByLabel(github, owner, repo, label) {
+    return await listIssuesByLabel(github, owner, repo, label, { state: 'open' });
 }
 
 async function createIssue(github, owner, repo, { title, body, labels }) {
@@ -137,6 +145,10 @@ async function addComment(github, owner, repo, issueNumber, body) {
 
 async function closeIssue(github, owner, repo, issueNumber, { stateReason = 'completed' } = {}) {
     await github.rest.issues.update({ owner, repo, issue_number: issueNumber, state: 'closed', state_reason: stateReason });
+}
+
+async function reopenIssue(github, owner, repo, issueNumber) {
+    await github.rest.issues.update({ owner, repo, issue_number: issueNumber, state: 'open' });
 }
 
 // True when a comment carrying `marker` already exists on the issue. The marker is
@@ -163,14 +175,14 @@ async function hasCommentForRun(github, owner, repo, issueNumber, marker) {
 //   runId       - stable run identifier; the dedup key (see runMarker).
 //   buildBody   - () => string, the static issue body for a fresh issue.
 //   comment     - the failure comment text; the run marker is appended to it.
-//   openIssues  - optional pre-fetched open-issue list (a multi-subject caller,
+//   issues      - optional pre-fetched all-state issue list (a multi-subject caller,
 //                 e.g. the watchdog, lists once and reuses it across subjects).
 // Returns { number, created } when a comment was posted, or { number, skipped }
 // when the run was already recorded.
-async function recordRun(github, context, core, { label, labels, marker, title, runId, buildBody, comment, openIssues }) {
+async function recordRun(github, context, core, { label, labels, marker, title, runId, buildBody, comment, issues }) {
     const { owner, repo } = context.repo;
-    const list = openIssues ?? await listOpenIssuesByLabel(github, owner, repo, label);
-    const issue = findOpenIssueForMarker(list, marker);
+    const list = issues ?? await listIssuesByLabel(github, owner, repo, label);
+    const issue = findOpenIssueForMarker(list, marker) ?? findIssueForMarker(list, marker);
     const runComment = runMarker(runId);
     const commentBody = `${comment}\n\n${runComment}`;
 
@@ -187,21 +199,29 @@ async function recordRun(github, context, core, { label, labels, marker, title, 
         return { number: issue.number, skipped: true };
     }
 
+    const reopened = issue.state === 'closed';
+    if (reopened) {
+        await reopenIssue(github, owner, repo, issue.number);
+    }
+
     await addComment(github, owner, repo, issue.number, commentBody);
-    return { number: issue.number, created: false };
+    return { number: issue.number, created: false, reopened };
 }
 
 module.exports = {
+    findIssueForMarker,
     findOpenIssueForMarker,
     runMarker,
     buildBody,
     autoCloseStamp,
     readAutoClose,
     ensureLabel,
+    listIssuesByLabel,
     listOpenIssuesByLabel,
     createIssue,
     addComment,
     closeIssue,
+    reopenIssue,
     hasCommentForRun,
     recordRun,
 };

--- a/docs/ci/ci-failure-issues.md
+++ b/docs/ci/ci-failure-issues.md
@@ -1,0 +1,101 @@
+# Red-main CI failure issues
+
+The `CI` workflow ([`ci.yml`](../../.github/workflows/ci.yml)) runs on every push
+to a protected branch (`main`, `release/**`). When such a push fails CI the branch
+is "red", and — unlike a PR failure, which the author sees in their own checks —
+nobody necessarily owns it. This mechanism files a single deduplicated GitHub
+issue per branch when a push is red, and **closes it automatically** when a later
+push to the same branch is green.
+
+It is a consumer of the shared, repo-agnostic tracking-issue engine
+([`tracking-issue.js`](../../.github/workflows/tracking-issue.js)), alongside the
+[scheduled-workflow scanner](monitor-scheduled-workflows.md), the
+[specialized-test failure reporter](specialized-test-failure-issues.md), and the
+[nightly-pipeline failure reporter](pipeline-failure-issues.md).
+
+## Push only — PR failures are excluded
+
+The reporter runs only on `push` events. A failing **pull request** is the
+author's to fix and already surfaces in the PR's checks, so filing an issue for it
+would be noise. Per-test tracking issues are still created on demand via the
+[`/create-issue` command](../../.github/workflows/create-failing-test-issue.yml).
+
+## Per-branch keying
+
+A red `main` and a red `release/13.3` are different problems, so the dedup marker
+embeds the ref and each branch gets its own issue:
+
+```text
+<!-- ci-failure:ci.yml:push:main -->
+<!-- ci-failure:ci.yml:push:release/13.3 -->
+```
+
+## What gets filed
+
+When a push to a protected branch fails CI:
+
+- **Title:** `CI failing on <ref>`, with the ref in backticks — for example, a
+  red `main` produces the title ``CI failing on `main` ``.
+- **Label:** `automation-broken`
+- **Body marker:** the per-branch marker above, on the first line.
+- **Close stamp:** a hidden `<!-- autoclose:true -->` stamp (see below).
+
+The body is a fixed description written once at filing; each failed run is recorded
+as a **comment** carrying the run link and commit. The comment intentionally does
+**not** assert a failing-test list — a push can fail for non-test reasons (setup,
+build, a non-TRX job), so it links the run rather than claiming specific tests.
+Each comment embeds a hidden `<!-- run:<id> -->` marker used to dedup re-runs of
+the same run.
+
+## Self-closing on green
+
+`ci.yml` runs on every push, so a green push to the branch is the most timely
+signal that it is no longer red — there is no need to wait for an external poll.
+The same `ci_failure_tracker` job that files the issue also closes the branch's
+open issue (with a "CI is green again" comment) when a later push to the same
+branch passes CI.
+
+The `autoClose:true` body stamp records this policy on the issue itself, so the
+scheduled [watchdog](monitor-scheduled-workflows.md) can also close it as a
+backstop. Test-failure issues that should **not** auto-close (e.g. the specialized
+reporter's, where a single green run does not prove a flaky test fixed) carry no
+such stamp.
+
+### Why explicit `needs.*.result` checks
+
+A single job (`ci_failure_tracker`) handles both filing and closing: it runs on
+every push (`if: always()`) and the script opens or closes based on the aggregate
+CI result the workflow passes in env:
+
+- `CI_RED` = `contains(needs.*.result, 'failure')` — file/update the issue.
+- `CI_GREEN` = `prepare_for_ci`, `tests`, and `stabilization_check` all `success`
+  — close the issue.
+
+These are derived from explicit `needs.*.result` checks rather than
+`failure()`/`success()` because `tests`/`stabilization_check` are **skipped** on
+the no-relevant-changes path (`skip_workflow`). A skipped run is neither red nor
+green, so the script leaves any open issue untouched — requiring all-`success` for
+`CI_GREEN` avoids closing a still-red issue on a docs-only push, and the failure
+check avoids filing on a skip.
+
+## Logic and tests
+
+The reusable issue mechanics (marker dedup, the comment-recording loop with
+per-run dedup, octokit primitives) live in the generic engine
+[`tracking-issue.js`](../../.github/workflows/tracking-issue.js), unit-tested by
+[`TrackingIssueTests`](../../tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs).
+
+The reporter logic — the pure helpers (marker, title, body, comment) and the
+`reportFailure()` / `resolveSuccess()` orchestrators (dispatched by `track()` from
+the workflow) — lives in
+[`report-ci-failure.js`](../../.github/workflows/report-ci-failure.js). The pure
+helpers are unit-tested by
+[`ReportCiFailureTests`](../../tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureTests.cs);
+the orchestrators are driven against an in-memory octokit fake by
+[`ReportCiFailureIntegrationTests`](../../tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureIntegrationTests.cs)
+via the Node harness
+[`report-ci-failure.integration.harness.js`](../../tests/Infrastructure.Tests/WorkflowScripts/report-ci-failure.integration.harness.js).
+
+When changing the workflow job/step names or the module's exported contract, keep
+the workflow YAML, the `.js` modules, the harnesses, the tests, and this doc
+aligned.

--- a/docs/ci/monitor-scheduled-workflows.md
+++ b/docs/ci/monitor-scheduled-workflows.md
@@ -1,0 +1,165 @@
+# Scheduled-workflow failure notifications
+
+Several scheduled GitHub Actions workflows in this repo run unattended
+(generate diffs, refresh manifests/SDKs, update models/dependencies, clean up
+deployments, retrain the labeler, backmerge releases). When one of them fails,
+GitHub only emails the last person who edited the workflow file — so a broken
+scheduled job can sit unnoticed for days.
+
+[`monitor-scheduled-workflows.yml`](../../.github/workflows/monitor-scheduled-workflows.yml)
+watches those workflows and files, updates, or closes a single deduplicated
+GitHub issue per workflow.
+
+This is the GitHub Actions counterpart to the internal AzDO build notifier.
+It reuses the same file → update → close-on-green contract, keyed per *workflow*
+instead of per branch.
+
+## Schedule
+
+Runs every 2 hours (`cron: '0 */2 * * *'`) and on `workflow_dispatch`. The
+manual dispatch accepts a `dry_run` boolean that logs the issue actions it
+*would* take without mutating anything on GitHub.
+
+## What it watches
+
+The watch-list lives in
+[`monitor-scheduled-workflows.config.json`](../../.github/workflows/monitor-scheduled-workflows.config.json)
+(not in the workflow script), as an array of
+`{ file, name, enabled, selfReports?, labels? }` entries.
+
+**Full-watch entries** — workflows whose `failure` conclusion *unambiguously*
+means "broken". The watchdog files an issue on any failure conclusion:
+
+- `generate-api-diffs`, `generate-ats-diffs`
+- `refresh-manifests`
+- `update-dependencies`, `update-ai-foundry-models`,
+  `update-azure-vm-sizes`, `update-aspire-skills-bundle`
+- `deployment-cleanup`
+- `labeler-cache-retention`
+- `warm-cli-e2e-image-cache`
+- `locker`
+- `backmerge-release`
+
+**Backstop entries (`selfReports: true`)** — workflows that file their *own*
+normal failures in-pipeline via an `if: failure()` reporter. For these the
+watchdog records **only** `startup_failure` and `timed_out` — the two
+conclusions that in-pipeline reporter cannot catch (see below) — and **never**
+plain `failure` (which the reporter owns; recording it would double-file under a
+second marker):
+
+- `tests-outerloop`, `tests-quarantine` (see
+  [specialized-test-failure-issues.md](specialized-test-failure-issues.md))
+- `tests-daily-smoke`, `deployment-tests` (see
+  [pipeline-failure-issues.md](pipeline-failure-issues.md))
+
+- **To add a full-watch workflow:** add a `{ "file", "name" }` entry (entries
+  are watched by default).
+- **To add a backstop for a self-reporting workflow:** add
+  `"selfReports": true`.
+- **To add labels** to the filed issue (beyond `automation-broken`): add a
+  `"labels": [ ... ]` array.
+- **To stop watching one** (without deleting it): set `"enabled": false`.
+  Disabled entries are skipped and logged.
+
+### Why backstop entries record only `startup_failure` / `timed_out`
+
+An in-pipeline reporter is a job gated on `if: failure()`. Two conclusions slip
+past it:
+
+- **`startup_failure`** — the run never started a job (bad YAML, an unresolvable
+  `uses:`, a dead runner), so the reporter job itself never runs.
+- **`timed_out`** — a job-level timeout is *cancelled-class*, so
+  [`failure()` is false](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#failure)
+  and the reporter job does not run.
+
+Plain `failure` (including step-level timeouts, which surface as `failure`) *does*
+trigger the reporter, so the watchdog leaves those to it.
+
+### Deliberately excluded
+
+- **`backmerge-release` infra** is full-watched here; it also files a "merge
+  conflicts" issue on a *green* run (handled in its own workflow).
+- **`workflow_call` building blocks** (e.g. `tests.yml`, `run-tests.yml`) —
+  their failures surface in the caller, which is where the signal belongs.
+- **`ci.yml`** — red-main push failures are filed (and self-closed) by ci.yml
+  itself; see [ci-failure-issues.md](ci-failure-issues.md).
+- **Agentic `*.lock.yml` workflows** — `gh-aw` has its own error reporting.
+
+## What gets filed
+
+When a watched workflow's latest completed run on `main` concluded `failure`,
+`timed_out`, or `startup_failure`:
+
+- **Title:** `Scheduled workflow failing: <display name>`
+- **Label:** `automation-broken` (created idempotently by the workflow)
+- **Body marker:** the first line is a hidden HTML comment
+  `<!-- automation-broken:<workflow-file> -->`, used for dedup.
+
+Only one open issue per workflow exists at a time. The body is a fixed
+description written once at filing (the hidden marker plus prose); each failed
+run is recorded as a **comment** carrying the run link, commit, and conclusion.
+The comment is what fires notifications.
+
+Comments are deduplicated by run: the scanner runs every 2h but most watched
+workflows run less often, so the same still-latest failed run is observed on many
+ticks. Each comment embeds a hidden `<!-- run:<id> -->` marker; a run whose
+comment already exists is a no-op (no duplicate comment) until a newer run
+completes.
+
+`cancelled` and `skipped` conclusions are intentionally ignored — operator
+cancellation and skipped runs are not workflow defects. A `timed_out` run, by
+contrast, is treated as a failure and files an issue. For **backstop entries**
+(`selfReports: true`) a plain `failure` is also ignored (its in-pipeline reporter
+owns it); only `startup_failure` and `timed_out` file an issue, and the body says
+so to distinguish it from the in-pipeline issue. Issues carry `automation-broken`
+plus any per-entry `labels`, and are stamped `autoClose:true`.
+
+## What gets closed
+
+When a watched workflow's latest completed run concludes `success`, any open
+`automation-broken` issue for that workflow gets a "latest run succeeded"
+comment and is closed with `state_reason: completed`.
+
+## Dedup
+
+Issue lookup uses `GET /issues?labels=automation-broken&state=open` (strongly
+consistent) plus a local body-marker filter — the Search API is avoided because
+its eventual-consistency window could let near-simultaneous runs each see
+"0 hits". If two open issues ever carry the same marker, the oldest (lowest
+number) is treated as canonical.
+
+## Permissions and auth
+
+The job uses the default `GITHUB_TOKEN` with `actions: read` (list runs) and
+`issues: write` (file/comment/close). No app token is needed — issues are
+created in the same repo and the watchdog deliberately does *not* trigger
+downstream automation.
+
+## Why it never fails noisily
+
+Per-workflow run lookups are wrapped so a single unreadable workflow logs a
+warning and is skipped rather than failing the whole watchdog run.
+
+## Logic and tests
+
+The reusable issue mechanics (marker dedup, the comment-recording loop with
+per-run dedup, octokit primitives) live in the generic, repo-agnostic engine
+[`tracking-issue.js`](../../.github/workflows/tracking-issue.js), shared with the
+[specialized-test failure reporter](specialized-test-failure-issues.md), the
+[nightly-pipeline failure reporter](pipeline-failure-issues.md), the
+[red-main CI reporter](ci-failure-issues.md), and
+unit-tested by
+[`TrackingIssueTests`](../../tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs).
+
+The watchdog-specific content (markers, titles, body/comment formatting, the
+record/close/noop decision) and the `run()` orchestrator that reads the config,
+loops, and drives the engine live in
+[`monitor-scheduled-workflows.js`](../../.github/workflows/monitor-scheduled-workflows.js),
+invoked from the workflow's `github-script` step. The pure helpers are unit-tested by
+[`MonitorScheduledWorkflowsTests`](../../tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsTests.cs)
+via the Node harness
+[`monitor-scheduled-workflows.harness.js`](../../tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.harness.js).
+
+When changing the workflow's job/step names or the module's exported contract,
+keep the workflow YAML, the `.js` module, the harness, the test, and this doc
+aligned.

--- a/docs/ci/monitor-scheduled-workflows.md
+++ b/docs/ci/monitor-scheduled-workflows.md
@@ -20,6 +20,11 @@ Runs every 2 hours (`cron: '0 */2 * * *'`) and on `workflow_dispatch`. The
 manual dispatch accepts a `dry_run` boolean that logs the issue actions it
 *would* take without mutating anything on GitHub.
 
+Each run fetches recent completed scheduled runs and processes the runs updated
+in a three-hour polling window, oldest to newest. That prevents an hourly
+workflow failure from being hidden by a later success before the next watchdog
+tick; the per-run comment marker still deduplicates repeat observations.
+
 ## What it watches
 
 The watch-list lives in
@@ -87,8 +92,8 @@ trigger the reporter, so the watchdog leaves those to it.
 
 ## What gets filed
 
-When a watched workflow's latest completed run on `main` concluded `failure`,
-`timed_out`, or `startup_failure`:
+When a watched workflow has a completed scheduled run on `main` in the watchdog
+polling window that concluded `failure`, `timed_out`, or `startup_failure`:
 
 - **Title:** `Scheduled workflow failing: <display name>`
 - **Label:** `automation-broken` (created idempotently by the workflow)
@@ -100,10 +105,9 @@ description written once at filing (the hidden marker plus prose); each failed
 run is recorded as a **comment** carrying the run link, commit, and conclusion.
 The comment is what fires notifications.
 
-Comments are deduplicated by run: the scanner runs every 2h but most watched
-workflows run less often, so the same still-latest failed run is observed on many
-ticks. Each comment embeds a hidden `<!-- run:<id> -->` marker; a run whose
-comment already exists is a no-op (no duplicate comment) until a newer run
+Comments are deduplicated by run: the scanner can observe the same failed run on
+multiple ticks. Each comment embeds a hidden `<!-- run:<id> -->` marker; a run
+whose comment already exists is a no-op (no duplicate comment) until a newer run
 completes.
 
 `cancelled` and `skipped` conclusions are intentionally ignored — operator
@@ -116,9 +120,9 @@ plus any per-entry `labels`, and are stamped `autoClose:true`.
 
 ## What gets closed
 
-When a watched workflow's latest completed run concludes `success`, any open
-`automation-broken` issue for that workflow gets a "latest run succeeded"
-comment and is closed with `state_reason: completed`.
+When the newest completed scheduled run in the polling window concludes
+`success`, any open `automation-broken` issue for that workflow gets a "latest
+run succeeded" comment and is closed with `state_reason: completed`.
 
 ## Dedup
 

--- a/docs/ci/pipeline-failure-issues.md
+++ b/docs/ci/pipeline-failure-issues.md
@@ -1,0 +1,101 @@
+# Nightly-pipeline failure issues (deployment E2E & daily smoke)
+
+The scheduled `Deployment E2E Tests` (`deployment-tests.yml`) and
+`Daily CLI Smoke Tests` (`tests-daily-smoke.yml`) workflows run unattended and
+otherwise fail silently — GitHub only emails whoever last edited the workflow
+file. Each workflow files a GitHub issue when a **scheduled** run fails.
+
+This is a consumer of the shared, repo-agnostic tracking-issue engine
+([`tracking-issue.js`](../../.github/workflows/tracking-issue.js)), alongside the
+[scheduled-workflow scanner](monitor-scheduled-workflows.md), the
+[specialized-test failure reporter](specialized-test-failure-issues.md), and the
+[red-main CI reporter](ci-failure-issues.md). Like the
+specialized reporter it runs *inside* the pipeline (so it has the run context),
+but unlike it, a failure here is **not** classified into test-vs-infra: a nightly
+deployment/smoke failure can be either, and these pipelines do not inspect results
+to tell them apart. The issue just records "the scheduled run failed" with a link
+to the run.
+
+## What gets filed
+
+When a scheduled run fails:
+
+- **Title:** `Nightly run failing: <display name>`
+- **Labels:** the workflow's existing labels **plus** `automation-broken`:
+  - deployment: `automation-broken`, `area-testing`, `deployment-e2e`
+  - smoke: `automation-broken`, `area-cli`, `failing-test`
+- **Body marker:** a hidden HTML comment `<!-- ci-failure:<workflow-file>:scheduled -->`
+  on the first line, used for dedup.
+
+The body is a fixed description written once at filing (the hidden marker plus
+prose); each failed run is recorded as a **comment** carrying the run link and
+commit. Each comment embeds a hidden `<!-- run:<id> -->` marker used to dedup
+re-runs of the same run.
+
+## How a run is reported
+
+Each workflow's reporter job runs only on
+`failure() && github.event_name == 'schedule' && github.repository_owner == 'microsoft'`
+(so PR/manual runs never file issues and forks stay quiet). Because the job is
+gated on `failure()`, it cannot run for a `startup_failure` (no job runs) or a
+`timed_out` run (cancelled-class); the scheduled-workflow scanner **backstops**
+those two conclusions — see
+[monitor-scheduled-workflows.md](monitor-scheduled-workflows.md). It checks out
+`main` to load the local `.js` modules and calls
+[`report-pipeline-failure.js#report()`](../../.github/workflows/report-pipeline-failure.js),
+which:
+
+1. Ensures the `automation-broken` label exists.
+2. Finds the open issue carrying the per-workflow marker.
+3. **No open issue** → creates one (static body with the marker) and posts the
+   failure comment.
+4. **Open issue exists** → posts the failure comment, unless this run's comment is
+   already present (dedup), in which case it is a no-op.
+
+The **comment** is what fires notifications. The first filing notifies a team via
+a `/cc` `@mention` in the body (deployment cc's `@microsoft/aspire-team`);
+subsequent failures notify via comment.
+
+### Per-run detail on the comment
+
+The smoke reporter parses the per-route Aspire CLI versions from its uploaded
+artifact and passes them as `commentDetail`, so they appear on each run's
+failure comment rather than being baked into the body. The artifact-parsing
+helpers stay inline in `tests-daily-smoke.yml` — they are smoke-specific and not
+part of the reusable engine.
+
+## Dedup and lifecycle
+
+One open issue is kept per workflow — subsequent failed runs add a comment rather
+than filing a new issue (replacing the previous *per-day* issue behaviour). Issues
+are **closed by a human** once the underlying problem is fixed; there is no
+auto-close-on-green (a dev mid-triage should not have the issue closed out from
+under them by a transient green run).
+
+Issue lookup uses `GET /issues?labels=automation-broken&state=open` (strongly
+consistent) plus a local marker filter. The query is a superset — it also returns
+the scanner's and specialized reporter's `automation-broken` issues — but the
+per-workflow marker (`ci-failure:<file>:scheduled`) selects only this pipeline's
+issue, so the three mechanisms never manage each other's issues. Pull requests
+returned by the list API are excluded.
+
+## Logic and tests
+
+The reusable issue mechanics (marker dedup, the comment-recording loop with
+per-run dedup, octokit primitives) live in the generic engine
+[`tracking-issue.js`](../../.github/workflows/tracking-issue.js), unit-tested by
+[`TrackingIssueTests`](../../tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs).
+
+Reporter logic — the pure helpers (marker, title, body/comment formatting) and the
+`report()` orchestrator — lives in
+[`report-pipeline-failure.js`](../../.github/workflows/report-pipeline-failure.js).
+The pure helpers are unit-tested by
+[`ReportPipelineFailureTests`](../../tests/Infrastructure.Tests/WorkflowScripts/ReportPipelineFailureTests.cs);
+`report()` is driven against an in-memory octokit fake by
+[`ReportPipelineFailureIntegrationTests`](../../tests/Infrastructure.Tests/WorkflowScripts/ReportPipelineFailureIntegrationTests.cs)
+via the Node harness
+[`report-pipeline-failure.integration.harness.js`](../../tests/Infrastructure.Tests/WorkflowScripts/report-pipeline-failure.integration.harness.js).
+
+When changing the workflow job/step names or the module's exported contract, keep
+the workflow YAML, the `.js` modules, the harnesses, the tests, and this doc
+aligned.

--- a/docs/ci/specialized-test-failure-issues.md
+++ b/docs/ci/specialized-test-failure-issues.md
@@ -1,0 +1,127 @@
+# Specialized-test failure issues (outerloop & quarantine)
+
+The scheduled `Outerloop Tests` (`tests-outerloop.yml`) and `Quarantined Tests`
+(`tests-quarantine.yml`) workflows run unattended and otherwise fail silently —
+GitHub only emails whoever last edited the workflow file. Each workflow files a
+GitHub issue when a **scheduled** run fails.
+
+This is the test-workflow counterpart to the scheduled-workflow scanner
+([monitor-scheduled-workflows.md](monitor-scheduled-workflows.md)). It lives
+*inside* the test pipelines because, unlike the scanner, it needs the run's test
+results to tell a test failure from an infrastructure break. The scanner does,
+however, **backstop** these workflows for `startup_failure` and `timed_out` — the
+two conclusions where no job (and so no in-pipeline reporter) runs.
+
+## Two failure kinds
+
+| Kind | When | Issue label | Title |
+|------|------|-------------|-------|
+| `test-failures` | outerloop tests failed | `failing-test` | `Test failures: Outerloop Tests` |
+| `infra` | the run broke before/around test execution (build/setup, no TRX) | `automation-broken` | `CI infrastructure failing: <name>` |
+
+### Why quarantine is infra-only
+
+`tests-quarantine.yml` passes `ignoreTestFailures: true`. In `run-tests.yml` that
+appends `|| true` to the test step and then only checks that `.trx` files with a
+nonzero test count were produced. So **failing quarantined tests never red the
+run** — they are flaky by definition. A *failed* quarantine run therefore always
+means infrastructure broke, and only an `infra` issue is filed.
+
+`tests-outerloop.yml` does not ignore test failures, so a failed outerloop run is
+classified by inspecting the produced `.trx`:
+
+- failed test names present → `test-failures`
+- clean extraction, zero failed → `infra` (the run broke before/around test
+  execution; no test produced a failed result)
+- results could not be extracted (download/tool flake on a genuinely-red run) →
+  `test-failures`, with a "could not enumerate — see artifacts" comment. A red run
+  with unknown results is never downgraded to `infra`, so the failing-test signal
+  is not lost.
+
+The classification logic is `classifyFailure()` in
+[`report-specialized-test-failures.js`](../../.github/workflows/report-specialized-test-failures.js).
+
+## How a run is reported
+
+The reporter job runs only on `failure() && github.event_name == 'schedule'` (so
+PR-triggered runs from the `paths:` filter never file issues), and only for
+`microsoft/aspire`.
+
+For outerloop it downloads the runner's `logs-*` artifacts (which contain the
+`.trx` files) and runs:
+
+```bash
+GenerateTestSummary <all-logs> --failed-tests-json <out>
+```
+
+which writes `{ "failedTests": [...], "count": N, "extractionFailed": bool }`
+(outcomes `Failed`, `Error`, `Timeout`, `Aborted`). `extractionFailed` is `true`
+when at least one `.trx` was unreadable and no failures were collected, so a red run
+with entirely-corrupt results is reported as a test failure rather than infra. The
+orchestrator also synthesizes `extractionFailed: true` if the tool itself errors,
+the artifact download fails, or the extract step crashes before producing a results
+path. Quarantine skips this step entirely.
+
+An `actions/github-script` step then calls the shared orchestrator
+[`specialized-test-failure-runner.js`](../../.github/workflows/specialized-test-failure-runner.js),
+which:
+
+1. Classifies the failure and picks the label.
+2. Finds the open issue carrying the per-(workflow, kind) marker
+   `<!-- ci-failure:<workflow-file>:<kind> -->`.
+3. **No open issue** → creates one (static body with the marker) and posts the
+   failure comment.
+4. **Open issue exists** → posts the failure comment, unless this run's comment is
+   already present (dedup), in which case it is a no-op.
+
+The **comment** is what fires notifications; for `test-failures` it lists the
+failing tests (capped at 50, the rest are in the run artifacts). The issue body is
+a fixed description; each failed run is recorded as a comment carrying a hidden
+`<!-- run:<id> -->` marker used to dedup re-runs.
+
+## Dedup and lifecycle
+
+One open issue is kept per `(workflow, kind)` — subsequent failed runs add a
+comment rather than filing a new issue. Issues are **closed by a human** once the
+underlying problem is fixed; there is no auto-close-on-green (a dev mid-triage
+should not have the issue closed out from under them by a transient green run).
+
+Issue lookup uses `GET /issues?labels=<label>&state=open` (strongly consistent)
+plus a local marker filter, mirroring the scanner. The markers use a distinct
+`ci-failure:` prefix so the scanner and this reporter never manage each other's
+issues.
+
+## Why `failing-test` for outerloop test failures
+
+Outerloop test-failure issues use the existing `failing-test` label so they show
+up alongside other failing-test issues and tooling. Infra issues reuse
+`automation-broken` (shared with the scanner) because an infra break in a
+scheduled pipeline is the same class of problem the scanner reports.
+
+## Logic and tests
+
+The reusable issue mechanics (marker dedup, the comment-recording loop with
+per-run dedup, octokit primitives) live in the generic, repo-agnostic engine
+[`tracking-issue.js`](../../.github/workflows/tracking-issue.js), shared with the
+[scheduled-workflow scanner](monitor-scheduled-workflows.md), the
+[nightly-pipeline failure reporter](pipeline-failure-issues.md), and the
+[red-main CI reporter](ci-failure-issues.md), and unit-tested by
+[`TrackingIssueTests`](../../tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs).
+
+Reporter-specific pure logic (markers, titles, classification, body/comment
+formatting) is in
+[`report-specialized-test-failures.js`](../../.github/workflows/report-specialized-test-failures.js)
+and unit-tested by
+[`ReportSpecializedTestFailuresTests`](../../tests/Infrastructure.Tests/WorkflowScripts/ReportSpecializedTestFailuresTests.cs).
+The `--failed-tests-json` extraction is covered by
+[`GenerateTestSummaryToolTests`](../../tests/Infrastructure.Tests/GenerateTestSummary/GenerateTestSummaryToolTests.cs).
+The network orchestrator (`specialized-test-failure-runner.js`) is a thin wiring
+layer over the engine. Its results-read/classify preamble and the
+find-or-create + comment-dedup branching it delegates to the engine are covered
+by integration tests in
+[`SpecializedTestFailureRunnerTests`](../../tests/Infrastructure.Tests/WorkflowScripts/SpecializedTestFailureRunnerTests.cs),
+driven against an in-memory octokit fake via
+`specialized-test-failure-runner.harness.js`.
+
+When changing the workflow job/step names or the module's exported contract, keep
+the workflow YAML, the `.js` modules, the tests, and this doc aligned.

--- a/tests/Infrastructure.Tests/GenerateTestSummary/GenerateTestSummaryToolTests.cs
+++ b/tests/Infrastructure.Tests/GenerateTestSummary/GenerateTestSummaryToolTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json;
 using Xunit;
 
 namespace Infrastructure.Tests;
@@ -45,7 +46,195 @@ public sealed class GenerateTestSummaryToolTests : IClassFixture<GenerateTestSum
         Assert.Contains("### StdOut", result.Output, StringComparison.Ordinal);
     }
 
-    private async Task<ToolResult> RunToolAsync(string trxPath)
+    [Fact]
+    public async Task FailedTestsJsonListsOnlyFailedTestNames()
+    {
+        var trxPath = Path.Combine(_tempDirectory.Path, "mixed.trx");
+        TestTrxBuilder.CreateTrxFile(
+            trxPath,
+            new TestTrxCase("Tests.Type.PassingMethod", "Tests.Type.PassingMethod", "Passed"),
+            new TestTrxCase("Tests.Type.FailingMethod", "Tests.Type.FailingMethod", "Failed", ErrorMessage: "boom"),
+            new TestTrxCase("Tests.Type.ErroredMethod", "Tests.Type.ErroredMethod", "Error", ErrorMessage: "kaboom"));
+
+        var jsonPath = Path.Combine(_tempDirectory.Path, "failed.json");
+        var result = await RunToolAsync(trxPath, "--failed-tests-json", jsonPath);
+
+        Assert.Equal(0, result.ExitCode);
+        var payload = JsonSerializer.Deserialize<FailedTestsPayload>(
+            await File.ReadAllTextAsync(jsonPath),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.NotNull(payload);
+        Assert.Equal(2, payload!.Count);
+        Assert.Contains("Tests.Type.FailingMethod", payload.FailedTests);
+        Assert.Contains("Tests.Type.ErroredMethod", payload.FailedTests);
+        Assert.DoesNotContain("Tests.Type.PassingMethod", payload.FailedTests);
+    }
+
+    [Fact]
+    public async Task FailedTestsJsonTreatsAbortedAsFailure()
+    {
+        // Aborted is a failed outcome (matches CreateFailingTestIssue). Without it,
+        // a red run whose only failures aborted would report zero failures and be
+        // misfiled as infra, dropping the failing-test signal.
+        var trxPath = Path.Combine(_tempDirectory.Path, "aborted.trx");
+        TestTrxBuilder.CreateTrxFile(
+            trxPath,
+            new TestTrxCase("Tests.Type.AbortedMethod", "Tests.Type.AbortedMethod", "Aborted", ErrorMessage: "aborted"),
+            new TestTrxCase("Tests.Type.PassingMethod", "Tests.Type.PassingMethod", "Passed"));
+
+        var jsonPath = Path.Combine(_tempDirectory.Path, "failed.json");
+        var result = await RunToolAsync(trxPath, "--failed-tests-json", jsonPath);
+
+        Assert.Equal(0, result.ExitCode);
+        var payload = JsonSerializer.Deserialize<FailedTestsPayload>(
+            await File.ReadAllTextAsync(jsonPath),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.NotNull(payload);
+        Assert.Equal(1, payload!.Count);
+        Assert.Contains("Tests.Type.AbortedMethod", payload.FailedTests);
+        Assert.DoesNotContain("Tests.Type.PassingMethod", payload.FailedTests);
+    }
+
+    [Fact]
+    public async Task FailedTestsJsonIsEmptyWhenAllPass()
+    {
+        var trxPath = Path.Combine(_tempDirectory.Path, "allpass.trx");
+        TestTrxBuilder.CreateTrxFile(
+            trxPath,
+            new TestTrxCase("Tests.Type.A", "Tests.Type.A", "Passed"),
+            new TestTrxCase("Tests.Type.B", "Tests.Type.B", "Passed"));
+
+        var jsonPath = Path.Combine(_tempDirectory.Path, "failed.json");
+        var result = await RunToolAsync(trxPath, "--failed-tests-json", jsonPath);
+
+        Assert.Equal(0, result.ExitCode);
+        var payload = JsonSerializer.Deserialize<FailedTestsPayload>(
+            await File.ReadAllTextAsync(jsonPath),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.NotNull(payload);
+        Assert.Equal(0, payload!.Count);
+        Assert.Empty(payload.FailedTests);
+        // A clean read with zero failures is trustworthy infra, not lost results.
+        Assert.False(payload.ExtractionFailed);
+    }
+
+    [Fact]
+    public async Task FailedTestsJsonSetsExtractionFailedWhenAllTrxUnreadable()
+    {
+        // A genuinely-red run whose only .trx files are corrupt must not be
+        // reported as zero failures: the reporter would file that as infra and
+        // drop the failing-test signal. extractionFailed flags it as a test
+        // failure instead. Falsifiable: without the flag the payload is
+        // indistinguishable from a clean zero-failure run.
+        var trxDir = Path.Combine(_tempDirectory.Path, "corrupt");
+        Directory.CreateDirectory(trxDir);
+        await File.WriteAllTextAsync(Path.Combine(trxDir, "broken.trx"), "this is not valid trx xml <<<");
+
+        var jsonPath = Path.Combine(_tempDirectory.Path, "failed.json");
+        var result = await RunToolAsync(trxDir, "--failed-tests-json", jsonPath);
+
+        Assert.Equal(0, result.ExitCode);
+        var payload = JsonSerializer.Deserialize<FailedTestsPayload>(
+            await File.ReadAllTextAsync(jsonPath),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.NotNull(payload);
+        Assert.Equal(0, payload!.Count);
+        Assert.Empty(payload.FailedTests);
+        Assert.True(payload.ExtractionFailed);
+    }
+
+    [Fact]
+    public async Task FailedTestsJsonSetsExtractionFailedWhenSomeTrxUnreadableAndNoFailuresFound()
+    {
+        // Partial-corrupt: one .trx reads cleanly with only passing tests, another
+        // cannot be read. A "zero failures" result is not trustworthy here — the
+        // unreadable file may have held the failures — so extractionFailed is set
+        // and the reporter files a test-failure issue rather than dropping the
+        // signal as infra. Falsifiable: if the flag only considered the
+        // all-unreadable case, this would report a clean zero and be misfiled.
+        var trxDir = Path.Combine(_tempDirectory.Path, "partial");
+        Directory.CreateDirectory(trxDir);
+        TestTrxBuilder.CreateTrxFile(
+            Path.Combine(trxDir, "clean.trx"),
+            new TestTrxCase("Tests.Type.PassingMethod", "Tests.Type.PassingMethod", "Passed"));
+        await File.WriteAllTextAsync(Path.Combine(trxDir, "broken.trx"), "this is not valid trx xml <<<");
+
+        var jsonPath = Path.Combine(_tempDirectory.Path, "failed.json");
+        var result = await RunToolAsync(trxDir, "--failed-tests-json", jsonPath);
+
+        Assert.Equal(0, result.ExitCode);
+        var payload = JsonSerializer.Deserialize<FailedTestsPayload>(
+            await File.ReadAllTextAsync(jsonPath),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.NotNull(payload);
+        Assert.Equal(0, payload!.Count);
+        Assert.Empty(payload.FailedTests);
+        Assert.True(payload.ExtractionFailed);
+    }
+
+    [Fact]
+    public async Task FailedTestsJsonDoesNotSetExtractionFailedWhenFailuresFoundDespiteUnreadableTrx()
+    {
+        // A readable .trx with a real failure plus an unreadable .trx: the collected
+        // failure is trustworthy, so extractionFailed stays false even though one
+        // file could not be read. The failing test name is still reported.
+        var trxDir = Path.Combine(_tempDirectory.Path, "partial-with-failure");
+        Directory.CreateDirectory(trxDir);
+        TestTrxBuilder.CreateTrxFile(
+            Path.Combine(trxDir, "failed.trx"),
+            new TestTrxCase("Tests.Type.FailingMethod", "Tests.Type.FailingMethod", "Failed", ErrorMessage: "boom"));
+        await File.WriteAllTextAsync(Path.Combine(trxDir, "broken.trx"), "this is not valid trx xml <<<");
+
+        var jsonPath = Path.Combine(_tempDirectory.Path, "failed.json");
+        var result = await RunToolAsync(trxDir, "--failed-tests-json", jsonPath);
+
+        Assert.Equal(0, result.ExitCode);
+        var payload = JsonSerializer.Deserialize<FailedTestsPayload>(
+            await File.ReadAllTextAsync(jsonPath),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.NotNull(payload);
+        Assert.Equal(1, payload!.Count);
+        Assert.Contains("Tests.Type.FailingMethod", payload.FailedTests);
+        Assert.False(payload.ExtractionFailed);
+    }
+
+    [Fact]
+    public async Task FailedTestsJsonHandlesRealTrxTimestamps()
+    {
+        // Regression: real MTP `--report-trx` files stamp startTime/endTime as
+        // ISO-8601 DateTimeOffset. The previous implementation read TRX via
+        // TrxReader.GetTestResultsFromTrx, which TimeSpan.Parse-es those attributes
+        // and throws FormatException — silently skipping every real .trx and
+        // reporting zero failures.
+        var trxPath = Path.Combine(_tempDirectory.Path, "timestamped.trx");
+        TestTrxBuilder.CreateTrxFile(
+            trxPath,
+            new TestTrxCase(
+                "Tests.Type.TimedFailure", "Tests.Type.TimedFailure", "Failed",
+                ErrorMessage: "boom",
+                StartTime: "2026-06-08T18:34:22.1234567+00:00",
+                EndTime: "2026-06-08T18:34:25.7654321+00:00"));
+
+        var jsonPath = Path.Combine(_tempDirectory.Path, "failed.json");
+        var result = await RunToolAsync(trxPath, "--failed-tests-json", jsonPath);
+
+        Assert.Equal(0, result.ExitCode);
+        var payload = JsonSerializer.Deserialize<FailedTestsPayload>(
+            await File.ReadAllTextAsync(jsonPath),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.NotNull(payload);
+        Assert.Equal(1, payload!.Count);
+        Assert.Contains("Tests.Type.TimedFailure", payload.FailedTests);
+    }
+
+    private async Task<ToolResult> RunToolAsync(string trxPath, params string[] extraArgs)
     {
         ProcessStartInfo processStartInfo = new()
         {
@@ -62,6 +251,11 @@ public sealed class GenerateTestSummaryToolTests : IClassFixture<GenerateTestSum
         processStartInfo.ArgumentList.Add(_fixture.ToolProjectPath);
         processStartInfo.ArgumentList.Add("--");
         processStartInfo.ArgumentList.Add(trxPath);
+
+        foreach (var extraArg in extraArgs)
+        {
+            processStartInfo.ArgumentList.Add(extraArg);
+        }
 
         // Prevent the tool from writing sample data to the real GitHub Actions job summary.
         processStartInfo.Environment.Remove("GITHUB_STEP_SUMMARY");
@@ -100,4 +294,6 @@ public sealed class GenerateTestSummaryToolTests : IClassFixture<GenerateTestSum
     }
 
     private sealed record ToolResult(int ExitCode, string Output, string Error);
+
+    private sealed record FailedTestsPayload(string[] FailedTests, int Count, bool ExtractionFailed);
 }

--- a/tests/Infrastructure.Tests/Shared/TestTrxBuilder.cs
+++ b/tests/Infrastructure.Tests/Shared/TestTrxBuilder.cs
@@ -108,6 +108,11 @@ public static class TestTrxBuilder
             new XAttribute("testId", $"test-{index}"),
             new XAttribute("testName", testCase.DisplayName),
             new XAttribute("outcome", testCase.Outcome),
+            // Real MTP `--report-trx` files stamp startTime/endTime as ISO-8601
+            // DateTimeOffset. Emit them when supplied so tests can exercise readers
+            // against the real attribute shape (e.g. TimeSpan.Parse pitfalls).
+            testCase.StartTime is null ? null : new XAttribute("startTime", testCase.StartTime),
+            testCase.EndTime is null ? null : new XAttribute("endTime", testCase.EndTime),
             new XElement(
                 s_namespace + "Output",
                 CreateErrorInfoElement(testCase),
@@ -135,4 +140,6 @@ public sealed record TestTrxCase(
     string ErrorMessage = "",
     string StackTrace = "",
     string StdOut = "",
-    string? TestMethodName = null);
+    string? TestMethodName = null,
+    string? StartTime = null,
+    string? EndTime = null);

--- a/tests/Infrastructure.Tests/WorkflowScripts/CiWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/CiWorkflowTests.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+public sealed class CiWorkflowTests
+{
+    [Fact]
+    public void CiFailureTrackerCheckoutDoesNotPinMain()
+    {
+        var workflow = File.ReadAllText(Path.Combine(RepoRoot.Path, ".github", "workflows", "ci.yml"));
+        var job = System.Text.RegularExpressions.Regex.Match(workflow, "(?ms)^  ci_failure_tracker:\\n(?<body>.*?)(?=^  [A-Za-z0-9_-]+:\\n|\\z)");
+        Assert.True(job.Success, "Could not find the ci_failure_tracker job in ci.yml.");
+
+        var checkout = System.Text.RegularExpressions.Regex.Match(job.Value, "(?ms)^      - uses: actions/checkout@.*?(?=^      - |\\z)");
+        Assert.True(checkout.Success, "Could not find the ci_failure_tracker checkout step.");
+
+        // Push CI also runs on release/**. Pinning this checkout to main makes the
+        // tracker execute main's reporter instead of the workflow code from the branch
+        // whose run is being evaluated.
+        Assert.DoesNotContain("ref: main", checkout.Value);
+    }
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
@@ -142,14 +142,57 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
             runsByFile = new Dictionary<string, object> { [WatchedFile] = SucceedingRun() },
             issues = new[]
             {
-                new { number = 55, body = Marker, state = "open", comments = Array.Empty<string>() },
+                new { number = 55, body = $"{Marker}\n<!-- autoclose:true -->", state = "open", comments = Array.Empty<string>() },
             },
         });
 
-        Assert.Contains("createComment", result.Calls);
-        Assert.Contains("update", result.Calls);
+        Assert.False(result.Threw);
+        Assert.Equal(["createLabel", "update", "createComment"], result.Calls);
         var issue = Assert.Single(result.Issues);
         Assert.Equal("closed", issue.State);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task LeavesIssueOpenWhenAutoCloseStampIsFalse()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object> { [WatchedFile] = SucceedingRun() },
+            issues = new[]
+            {
+                new { number = 55, body = $"{Marker}\n<!-- autoclose:false -->", state = "open", comments = Array.Empty<string>() },
+            },
+        });
+
+        Assert.False(result.Threw);
+        Assert.Equal(["createLabel"], result.Calls);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("open", issue.State);
+        Assert.Empty(issue.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DoesNotCommentWhenCloseFails()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            failUpdate = true,
+            runsByFile = new Dictionary<string, object> { [WatchedFile] = SucceedingRun() },
+            issues = new[]
+            {
+                new { number = 55, body = $"{Marker}\n<!-- autoclose:true -->", state = "open", comments = Array.Empty<string>() },
+            },
+        });
+
+        Assert.True(result.Threw);
+        Assert.Equal(["createLabel", "update"], result.Calls);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("open", issue.State);
+        Assert.Empty(issue.Comments);
     }
 
     [Fact]
@@ -206,7 +249,7 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     private sealed record HarnessResponse(MonitorResult Result);
 
-    private sealed record MonitorResult(string[] Calls, MonitorIssue[] Issues);
+    private sealed record MonitorResult(bool Threw, string[] Calls, MonitorIssue[] Issues);
 
     private sealed record MonitorIssue(int Number, string State, string Body, string[] Labels, string[] Comments);
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
@@ -41,35 +41,37 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
     public void Dispose() => _tempDirectory.Dispose();
 
     // `id` is the stable run identifier the runner uses as the comment dedup key.
-    private static object FailingRun() => new
+    private static object FailingRun(int id = 9, int runNumber = 9, string? updatedAt = null) => new
     {
-        id = 9,
+        id,
         conclusion = "failure",
-        html_url = "https://github.com/microsoft/aspire/actions/runs/9",
-        run_number = 9,
+        html_url = $"https://github.com/microsoft/aspire/actions/runs/{id}",
+        run_number = runNumber,
         head_sha = "abcdef1234567890",
-        updated_at = "2026-01-01T00:00:00Z",
+        updated_at = updatedAt ?? MinutesAgo(30),
     };
 
-    private static object SucceedingRun() => new
+    private static object SucceedingRun(int id = 10, int runNumber = 10, string? updatedAt = null) => new
     {
-        id = 10,
+        id,
         conclusion = "success",
-        html_url = "https://github.com/microsoft/aspire/actions/runs/10",
-        run_number = 10,
+        html_url = $"https://github.com/microsoft/aspire/actions/runs/{id}",
+        run_number = runNumber,
         head_sha = "0123456789abcdef",
-        updated_at = "2026-01-02T00:00:00Z",
+        updated_at = updatedAt ?? MinutesAgo(30),
     };
 
-    private static object StartupFailureRun() => new
+    private static object StartupFailureRun(int id = 11, int runNumber = 11, string? updatedAt = null) => new
     {
-        id = 11,
+        id,
         conclusion = "startup_failure",
-        html_url = "https://github.com/microsoft/aspire/actions/runs/11",
-        run_number = 11,
+        html_url = $"https://github.com/microsoft/aspire/actions/runs/{id}",
+        run_number = runNumber,
         head_sha = "fedcba9876543210",
-        updated_at = "2026-01-03T00:00:00Z",
+        updated_at = updatedAt ?? MinutesAgo(30),
     };
+
+    private static string MinutesAgo(int minutes) => DateTimeOffset.UtcNow.AddMinutes(-minutes).ToString("O");
 
     [Fact]
     [RequiresTools(["node"])]
@@ -132,6 +134,26 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task DryRunDoesNotLogRecordWhenFailedRunAlreadyRecorded()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = true,
+            runsByFile = new Dictionary<string, object> { [WatchedFile] = FailingRun(updatedAt: MinutesAgo(30)) },
+            issues = new[]
+            {
+                new { number = 55, body = Marker, state = "open", comments = new[] { "earlier <!-- run:9 -->" } },
+            },
+        });
+
+        Assert.DoesNotContain(result.Logs, log => log.Contains("would RECORD", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Calls, call => call is "create" or "update" or "createComment");
+        var issue = Assert.Single(result.Issues);
+        Assert.Single(issue.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task ClosesIssueWhenLatestRunIsGreen()
     {
         // A successful latest run with an open issue closes it automatically, with a
@@ -175,6 +197,73 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task DryRunDoesNotLogCloseWhenAutoCloseStampIsFalse()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = true,
+            runsByFile = new Dictionary<string, object> { [WatchedFile] = SucceedingRun(updatedAt: MinutesAgo(30)) },
+            issues = new[]
+            {
+                new { number = 55, body = $"{Marker}\n<!-- autoclose:false -->", state = "open", comments = Array.Empty<string>() },
+            },
+        });
+
+        Assert.DoesNotContain(result.Logs, log => log.Contains("would CLOSE", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Calls, call => call is "update" or "createComment");
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("open", issue.State);
+        Assert.Empty(issue.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DryRunLogsCloseAfterWouldRecordWhenNewestRunSucceeded()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = true,
+            runsByFile = new Dictionary<string, object>
+            {
+                [WatchedFile] = new[]
+                {
+                    FailingRun(id: 9, runNumber: 9, updatedAt: MinutesAgo(75)),
+                    SucceedingRun(id: 10, runNumber: 10, updatedAt: MinutesAgo(15)),
+                },
+            },
+        });
+
+        Assert.Contains(result.Logs, log => log.Contains("would RECORD failure", StringComparison.Ordinal));
+        Assert.Contains(result.Logs, log => log.Contains("would CLOSE", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Calls, call => call is "create" or "update" or "createComment");
+        Assert.Empty(result.Issues);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DryRunRecordsMultipleFailuresInWindowWithoutReadingPlaceholderComments()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = true,
+            runsByFile = new Dictionary<string, object>
+            {
+                [WatchedFile] = new[]
+                {
+                    FailingRun(id: 9, runNumber: 9, updatedAt: MinutesAgo(75)),
+                    FailingRun(id: 10, runNumber: 10, updatedAt: MinutesAgo(15)),
+                },
+            },
+        });
+
+        Assert.False(result.Threw);
+        Assert.Equal(2, result.Logs.Count(log => log.Contains("would RECORD failure", StringComparison.Ordinal)));
+        Assert.DoesNotContain(result.Calls, call => call is "create" or "update" or "createComment");
+        Assert.Empty(result.Issues);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task DoesNotCommentWhenCloseFails()
     {
         var result = await InvokeAsync(new
@@ -197,6 +286,56 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task ProcessesRecentFailureEvenWhenNewerRunSucceeded()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object>
+            {
+                [WatchedFile] = new[]
+                {
+                    SucceedingRun(id: 10, runNumber: 10, updatedAt: MinutesAgo(15)),
+                    FailingRun(id: 9, runNumber: 9, updatedAt: MinutesAgo(75)),
+                },
+            },
+        });
+
+        Assert.All(result.ListRunRequests, request => Assert.True(request.PerPage > 1, "The watchdog must fetch more than one run per workflow."));
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("closed", issue.State);
+        Assert.Contains(issue.Comments, comment => comment.Contains("<!-- run:9 -->", StringComparison.Ordinal));
+        Assert.Contains(issue.Comments, comment => comment.Contains("Latest run succeeded", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DoesNotCloseWhenNewestRunInPollingWindowIsRecordedFailure()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object>
+            {
+                [WatchedFile] = new[]
+                {
+                    SucceedingRun(id: 9, runNumber: 9, updatedAt: MinutesAgo(75)),
+                    FailingRun(id: 10, runNumber: 10, updatedAt: MinutesAgo(15)),
+                },
+            },
+            issues = new[]
+            {
+                new { number = 55, body = $"{Marker}\n<!-- autoclose:true -->", state = "open", comments = new[] { "earlier <!-- run:10 -->" } },
+            },
+        });
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("open", issue.State);
+        Assert.DoesNotContain(issue.Comments, comment => comment.Contains("Latest run succeeded", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task SelfReportsEntryFilesBackstopIssueWithPerEntryLabelsOnStartupFailure()
     {
         // deployment-tests.yml is a selfReports entry with per-entry labels. A
@@ -213,6 +352,22 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
         Assert.Contains("automation-broken", issue.Labels);
         Assert.Contains("area-testing", issue.Labels);
         Assert.Contains("deployment-e2e", issue.Labels);
+    }
+
+    [Theory]
+    [InlineData("tests-outerloop.yml")]
+    [InlineData("tests-daily-smoke.yml")]
+    [RequiresTools(["node"])]
+    public async Task SelfReportsBackstopIssueDoesNotUseFailingTestLabel(string workflowFile)
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object> { [workflowFile] = StartupFailureRun(updatedAt: MinutesAgo(30)) },
+        });
+
+        var issue = Assert.Single(result.Issues);
+        Assert.DoesNotContain("failing-test", issue.Labels);
     }
 
     [Fact]
@@ -249,7 +404,9 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     private sealed record HarnessResponse(MonitorResult Result);
 
-    private sealed record MonitorResult(bool Threw, string[] Calls, MonitorIssue[] Issues);
+    private sealed record MonitorResult(bool Threw, string[] Calls, MonitorIssue[] Issues, string[] Logs, ListRunRequest[] ListRunRequests);
 
     private sealed record MonitorIssue(int Number, string State, string Body, string[] Labels, string[] Comments);
+
+    private sealed record ListRunRequest(string WorkflowId, int? PerPage);
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
@@ -1,0 +1,212 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Integration tests for the run() orchestrator in
+/// .github/workflows/monitor-scheduled-workflows.js, driven against an
+/// in-memory octokit fake via monitor-scheduled-workflows.integration.harness.js. These
+/// cover the dry-run no-mutation contract, comment-based dedup, and close-on-green,
+/// which the pure-helper tests cannot reach.
+/// </summary>
+public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
+    // Serialize the request verbatim so the Web camelCase policy does not rename the
+    // run fields (html_url, run_number, ...) the runner reads.
+    private static readonly JsonSerializerOptions s_requestOptions = new();
+
+    // A watched workflow (see .github/workflows/monitor-scheduled-workflows.config.json).
+    private const string WatchedFile = "generate-api-diffs.yml";
+    private const string Marker = "<!-- automation-broken:generate-api-diffs.yml -->";
+
+    private readonly TestTempDirectory _tempDirectory = new();
+    private readonly string _repoRoot;
+    private readonly string _harnessPath;
+    private readonly ITestOutputHelper _output;
+
+    public MonitorScheduledWorkflowsIntegrationTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _repoRoot = RepoRoot.Path;
+        _harnessPath = Path.Combine(_repoRoot, "tests", "Infrastructure.Tests", "WorkflowScripts", "monitor-scheduled-workflows.integration.harness.js");
+    }
+
+    public void Dispose() => _tempDirectory.Dispose();
+
+    // `id` is the stable run identifier the runner uses as the comment dedup key.
+    private static object FailingRun() => new
+    {
+        id = 9,
+        conclusion = "failure",
+        html_url = "https://github.com/microsoft/aspire/actions/runs/9",
+        run_number = 9,
+        head_sha = "abcdef1234567890",
+        updated_at = "2026-01-01T00:00:00Z",
+    };
+
+    private static object SucceedingRun() => new
+    {
+        id = 10,
+        conclusion = "success",
+        html_url = "https://github.com/microsoft/aspire/actions/runs/10",
+        run_number = 10,
+        head_sha = "0123456789abcdef",
+        updated_at = "2026-01-02T00:00:00Z",
+    };
+
+    private static object StartupFailureRun() => new
+    {
+        id = 11,
+        conclusion = "startup_failure",
+        html_url = "https://github.com/microsoft/aspire/actions/runs/11",
+        run_number = 11,
+        head_sha = "fedcba9876543210",
+        updated_at = "2026-01-03T00:00:00Z",
+    };
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DryRunDoesNotMutateGitHub()
+    {
+        // The workflow_dispatch dry_run input promises no GitHub mutation. Even with
+        // a workflow failing (which would otherwise file an issue), nothing — not
+        // even the label — may be created.
+        var result = await InvokeAsync(new
+        {
+            dryRun = true,
+            runsByFile = new Dictionary<string, object> { [WatchedFile] = FailingRun() },
+        });
+
+        Assert.DoesNotContain("createLabel", result.Calls);
+        Assert.DoesNotContain("create", result.Calls);
+        Assert.DoesNotContain("update", result.Calls);
+        Assert.DoesNotContain("createComment", result.Calls);
+        Assert.Empty(result.Issues);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RealRunFilesIssueAndRecordsFailureComment()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object> { [WatchedFile] = FailingRun() },
+        });
+
+        Assert.Contains("createLabel", result.Calls);
+        var issue = Assert.Single(result.Issues);
+        Assert.Contains(Marker, issue.Body);
+        var comment = Assert.Single(issue.Comments);
+        Assert.Contains("<!-- run:9 -->", comment);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DedupsWhenLatestFailedRunAlreadyRecorded()
+    {
+        // The scanner runs every 2h but watched workflows run less often, so the same
+        // still-latest failed run is seen repeatedly. A run whose comment already
+        // exists must not be re-commented on each tick.
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object> { [WatchedFile] = FailingRun() },
+            issues = new[]
+            {
+                new { number = 55, body = Marker, state = "open", comments = new[] { "earlier <!-- run:9 -->" } },
+            },
+        });
+
+        Assert.DoesNotContain("createComment", result.Calls);
+        var issue = Assert.Single(result.Issues);
+        Assert.Single(issue.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ClosesIssueWhenLatestRunIsGreen()
+    {
+        // A successful latest run with an open issue closes it automatically, with a
+        // closing comment.
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object> { [WatchedFile] = SucceedingRun() },
+            issues = new[]
+            {
+                new { number = 55, body = Marker, state = "open", comments = Array.Empty<string>() },
+            },
+        });
+
+        Assert.Contains("createComment", result.Calls);
+        Assert.Contains("update", result.Calls);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("closed", issue.State);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task SelfReportsEntryFilesBackstopIssueWithPerEntryLabelsOnStartupFailure()
+    {
+        // deployment-tests.yml is a selfReports entry with per-entry labels. A
+        // startup_failure (the in-pipeline reporter never ran) files the backstop
+        // issue, carrying automation-broken PLUS the configured labels.
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object> { ["deployment-tests.yml"] = StartupFailureRun() },
+        });
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Contains("<!-- automation-broken:deployment-tests.yml -->", issue.Body);
+        Assert.Contains("automation-broken", issue.Labels);
+        Assert.Contains("area-testing", issue.Labels);
+        Assert.Contains("deployment-e2e", issue.Labels);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task SelfReportsEntryDoesNotFileOnPlainFailure()
+    {
+        // tests-outerloop.yml is a selfReports entry. A plain failure is owned by its
+        // in-pipeline reporter, so the watchdog must NOT file a (duplicate) issue.
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object> { ["tests-outerloop.yml"] = FailingRun() },
+        });
+
+        Assert.DoesNotContain("create", result.Calls);
+        Assert.Empty(result.Issues);
+    }
+
+    private async Task<MonitorResult> InvokeAsync(object scenario)
+    {
+        var requestPath = Path.Combine(_tempDirectory.Path, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(requestPath, JsonSerializer.Serialize(scenario, s_requestOptions));
+
+        using var command = new NodeCommand(_output, "monitor-scheduled-workflows-integration");
+        command.WithWorkingDirectory(_repoRoot);
+
+        var result = await command.ExecuteScriptAsync(_harnessPath, requestPath);
+        Assert.Equal(0, result.ExitCode);
+
+        var response = JsonSerializer.Deserialize<HarnessResponse>(result.Output, s_jsonOptions);
+        Assert.NotNull(response);
+        return response!.Result;
+    }
+
+    private sealed record HarnessResponse(MonitorResult Result);
+
+    private sealed record MonitorResult(string[] Calls, MonitorIssue[] Issues);
+
+    private sealed record MonitorIssue(int Number, string State, string Body, string[] Labels, string[] Comments);
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsTests.cs
@@ -1,0 +1,263 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Tests for the pure decision/formatting helpers in
+/// .github/workflows/monitor-scheduled-workflows.js.
+/// </summary>
+public sealed class MonitorScheduledWorkflowsTests : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly TestTempDirectory _tempDirectory = new();
+    private readonly string _repoRoot;
+    private readonly string _harnessPath;
+    private readonly ITestOutputHelper _output;
+
+    public MonitorScheduledWorkflowsTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _repoRoot = RepoRoot.Path;
+        _harnessPath = Path.Combine(_repoRoot, "tests", "Infrastructure.Tests", "WorkflowScripts", "monitor-scheduled-workflows.harness.js");
+    }
+
+    public void Dispose() => _tempDirectory.Dispose();
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildMarkerEmbedsWorkflowFile()
+    {
+        var marker = await InvokeHarnessAsync<string>("buildMarker", new { workflowFile = "generate-api-diffs.yml" });
+
+        Assert.Equal("<!-- automation-broken:generate-api-diffs.yml -->", marker);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task SelectEnabledDropsDisabledEntries()
+    {
+        var enabled = await InvokeHarnessAsync<WatchEntry[]>(
+            "selectEnabled",
+            new
+            {
+                config = new
+                {
+                    watched = new object[]
+                    {
+                        new { file = "a.yml", name = "A", enabled = true },
+                        new { file = "b.yml", name = "B", enabled = false },
+                        new { file = "c.yml", name = "C" },
+                    }
+                }
+            });
+
+        Assert.Equal(2, enabled.Length);
+        Assert.Contains(enabled, e => e.File == "a.yml");
+        Assert.Contains(enabled, e => e.File == "c.yml");
+        Assert.DoesNotContain(enabled, e => e.File == "b.yml");
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildIssueTitleIncludesDisplayName()
+    {
+        var title = await InvokeHarnessAsync<string>("buildIssueTitle", new { displayName = "Generate API Diffs" });
+
+        Assert.Equal("Scheduled workflow failing: Generate API Diffs", title);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DecideActionRecordsWhenFailingWithoutIssue()
+    {
+        var result = await InvokeHarnessAsync<DecideActionResult>(
+            "decideAction",
+            new { conclusion = "failure", issue = (object?)null });
+
+        Assert.Equal("record", result.Action);
+    }
+
+    [Theory]
+    [InlineData("failure")]
+    [InlineData("timed_out")]
+    [InlineData("startup_failure")]
+    [RequiresTools(["node"])]
+    public async Task DecideActionRecordsWhenFailingWithExistingIssue(string conclusion)
+    {
+        // Dedup of an already-recorded run is handled downstream (recordRun scans
+        // comments), so a still-failing run always resolves to 'record' here.
+        var result = await InvokeHarnessAsync<DecideActionResult>(
+            "decideAction",
+            new { conclusion, issue = new { number = 7 } });
+
+        Assert.Equal("record", result.Action);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DecideActionClosesWhenSucceedingWithExistingIssue()
+    {
+        var result = await InvokeHarnessAsync<DecideActionResult>(
+            "decideAction",
+            new { conclusion = "success", issue = new { number = 7 } });
+
+        Assert.Equal("close", result.Action);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DecideActionNoopsWhenSucceedingWithoutIssue()
+    {
+        var result = await InvokeHarnessAsync<DecideActionResult>(
+            "decideAction",
+            new { conclusion = "success", issue = (object?)null });
+
+        Assert.Equal("noop", result.Action);
+    }
+
+    [Theory]
+    [InlineData("cancelled")]
+    [InlineData("skipped")]
+    [InlineData(null)]
+    [RequiresTools(["node"])]
+    public async Task DecideActionNoopsForNonActionableConclusions(string? conclusion)
+    {
+        var result = await InvokeHarnessAsync<DecideActionResult>(
+            "decideAction",
+            new { conclusion, issue = new { number = 7 } });
+
+        Assert.Equal("noop", result.Action);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildIssueBodyIsStaticDescriptionWithMarker()
+    {
+        // Each failed run is recorded as a comment, so the body is a fixed
+        // description: the marker (for lookup) plus prose, with no per-run table.
+        var body = await InvokeHarnessAsync<string>(
+            "buildIssueBody",
+            new
+            {
+                marker = "<!-- automation-broken:locker.yml -->",
+                displayName = "Lock Threads",
+                workflowFile = "locker.yml",
+            });
+
+        Assert.StartsWith("<!-- automation-broken:locker.yml -->", body);
+        Assert.Contains("is failing", body);
+        Assert.Contains("closed", body);
+        Assert.DoesNotContain("automation-broken-failures:begin", body);
+        Assert.DoesNotContain("[run #", body);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FormatCommentDescribesRunAndConclusion()
+    {
+        var comment = await InvokeHarnessAsync<string>(
+            "formatComment",
+            new
+            {
+                runUrl = "https://github.com/microsoft/aspire/actions/runs/123",
+                runNumber = 42,
+                sha = "abcdef1234567890",
+                conclusion = "failure",
+            });
+
+        Assert.Contains("[run #42](https://github.com/microsoft/aspire/actions/runs/123)", comment);
+        Assert.Contains("`abcdef12`", comment);
+        Assert.Contains("`failure`", comment);
+    }
+
+    [Theory]
+    [InlineData("startup_failure", "record")]
+    [InlineData("timed_out", "record")]
+    [InlineData("failure", "noop")]
+    [RequiresTools(["node"])]
+    public async Task DecideActionForSelfReportsBackstopsStartupAndTimeoutButNotFailure(string conclusion, string expected)
+    {
+        // selfReports entries own their plain failures in-pipeline, so the watchdog
+        // records only startup_failure/timed_out (which the in-pipeline if:failure()
+        // reporter cannot catch) and no-ops on a plain failure to avoid double-filing.
+        var result = await InvokeHarnessAsync<DecideActionResult>(
+            "decideAction",
+            new { conclusion, issue = new { number = 7 }, selfReports = true });
+
+        Assert.Equal(expected, result.Action);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DecideActionForSelfReportsClosesOnGreen()
+    {
+        var result = await InvokeHarnessAsync<DecideActionResult>(
+            "decideAction",
+            new { conclusion = "success", issue = new { number = 7 }, selfReports = true });
+
+        Assert.Equal("close", result.Action);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildIssueBodyStampsAutoCloseTrue()
+    {
+        var body = await InvokeHarnessAsync<string>(
+            "buildIssueBody",
+            new
+            {
+                marker = "<!-- automation-broken:locker.yml -->",
+                displayName = "Lock Threads",
+                workflowFile = "locker.yml",
+            });
+
+        // Watchdog issues close on green, so they carry the auto-close stamp.
+        Assert.Contains("<!-- autoclose:true -->", body);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildIssueBodyForSelfReportsExplainsBackstopScope()
+    {
+        var body = await InvokeHarnessAsync<string>(
+            "buildIssueBody",
+            new
+            {
+                marker = "<!-- automation-broken:tests-outerloop.yml -->",
+                displayName = "Outerloop Tests",
+                workflowFile = "tests-outerloop.yml",
+                selfReports = true,
+            });
+
+        Assert.Contains("failed to start or timed out", body);
+        Assert.Contains("reported separately", body);
+    }
+
+    private async Task<T> InvokeHarnessAsync<T>(string operation, object payload)
+    {
+        var requestPath = Path.Combine(_tempDirectory.Path, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(requestPath, JsonSerializer.Serialize(new { operation, payload }, s_jsonOptions));
+
+        using var command = new NodeCommand(_output, "monitor-scheduled-workflows");
+        command.WithWorkingDirectory(_repoRoot);
+
+        var result = await command.ExecuteScriptAsync(_harnessPath, requestPath);
+        Assert.Equal(0, result.ExitCode);
+
+        var response = JsonSerializer.Deserialize<HarnessResponse<T>>(result.Output, s_jsonOptions);
+        Assert.NotNull(response);
+        return response!.Result;
+    }
+
+    private sealed record HarnessResponse<T>(T Result);
+
+    private sealed record DecideActionResult(string Action, string Reason);
+
+    private sealed record WatchEntry(string File, string? Name, bool? Enabled);
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureIntegrationTests.cs
@@ -1,0 +1,259 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Integration tests for the reportFailure() and resolveSuccess() orchestrators in
+/// .github/workflows/report-ci-failure.js, driven against an in-memory octokit fake
+/// via report-ci-failure.integration.harness.js. These cover the find-or-create +
+/// comment-dedup branching (reportFailure) and the find-and-close branching
+/// (resolveSuccess) that the pure-helper tests cannot reach.
+/// </summary>
+public sealed class ReportCiFailureIntegrationTests : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
+    // The harness reads the exact env-var name (REF); serialize the request verbatim
+    // so the Web camelCase policy does not rename it.
+    private static readonly JsonSerializerOptions s_requestOptions = new();
+
+    private readonly TestTempDirectory _tempDirectory = new();
+    private readonly string _repoRoot;
+    private readonly string _harnessPath;
+    private readonly ITestOutputHelper _output;
+
+    public ReportCiFailureIntegrationTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _repoRoot = RepoRoot.Path;
+        _harnessPath = Path.Combine(_repoRoot, "tests", "Infrastructure.Tests", "WorkflowScripts", "report-ci-failure.integration.harness.js");
+    }
+
+    public void Dispose() => _tempDirectory.Dispose();
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ReportFailureFilesAutoCloseIssueAndRecordsRunAsComment()
+    {
+        var result = await InvokeAsync(new
+        {
+            operation = "reportFailure",
+            env = new { REF = "main" },
+        });
+
+        Assert.False(result.Threw);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("CI failing on `main`", issue.Title);
+        Assert.Contains("ci-failure:ci.yml:push:main", issue.Body);
+        Assert.Contains("<!-- autoclose:true -->", issue.Body);
+        Assert.Equal(["automation-broken"], issue.Labels);
+
+        var comment = Assert.Single(issue.Comments);
+        Assert.Contains("/actions/runs/12345", comment);
+        Assert.Contains("<!-- run:12345 -->", comment);
+        Assert.DoesNotContain("/actions/runs/12345", issue.Body);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ReportFailureKeysSeparateIssuesPerBranch()
+    {
+        // A red `release/13.3` must not comment on `main`'s issue: the per-branch
+        // marker keeps them distinct, so a fresh issue is filed.
+        var result = await InvokeAsync(new
+        {
+            operation = "reportFailure",
+            env = new { REF = "release/13.3" },
+            issues = new[]
+            {
+                new { number = 4242, body = "<!-- ci-failure:ci.yml:push:main -->", state = "open" },
+            },
+        });
+
+        Assert.Contains("create", result.Calls);
+        var created = Assert.Single(result.Issues, issue => issue.Number != 4242);
+        Assert.Contains("ci-failure:ci.yml:push:release/13.3", created.Body);
+        var mainIssue = Assert.Single(result.Issues, issue => issue.Number == 4242);
+        Assert.Empty(mainIssue.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ReportFailureCommentsOnExistingIssueForNewRun()
+    {
+        var first = await InvokeAsync(new { operation = "reportFailure", env = new { REF = "main" } });
+        var issue = Assert.Single(first.Issues);
+
+        var second = await InvokeAsync(new
+        {
+            operation = "reportFailure",
+            env = new { REF = "main" },
+            issues = new[] { new { number = issue.Number, body = issue.Body, state = "open", comments = issue.Comments } },
+            runId = 67890,
+            runNumber = 8,
+        });
+
+        var updated = Assert.Single(second.Issues);
+        Assert.DoesNotContain("create", second.Calls);
+        Assert.Equal(2, updated.Comments.Length);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ReportFailureCommentFailureLeavesRunUnrecorded()
+    {
+        var result = await InvokeAsync(new
+        {
+            operation = "reportFailure",
+            env = new { REF = "main" },
+            failComment = true,
+        });
+
+        Assert.True(result.Threw);
+        var issue = Assert.Single(result.Issues);
+        Assert.Empty(issue.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ResolveSuccessClosesTheBranchIssue()
+    {
+        var result = await InvokeAsync(new
+        {
+            operation = "resolveSuccess",
+            env = new { REF = "main" },
+            issues = new[]
+            {
+                new { number = 7, body = "lead <!-- ci-failure:ci.yml:push:main -->", state = "open" },
+            },
+        });
+
+        Assert.False(result.Threw);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("closed", issue.State);
+        Assert.Equal("completed", issue.StateReason);
+        // A closing comment is posted so the thread records why it closed.
+        var comment = Assert.Single(issue.Comments);
+        Assert.Contains("green again", comment);
+        Assert.Contains("update", result.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ResolveSuccessIsNoopWhenNoIssueOpen()
+    {
+        var result = await InvokeAsync(new
+        {
+            operation = "resolveSuccess",
+            env = new { REF = "main" },
+        });
+
+        Assert.False(result.Threw);
+        Assert.Empty(result.Issues);
+        Assert.DoesNotContain("update", result.Calls);
+        Assert.DoesNotContain("createComment", result.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ResolveSuccessLeavesAnotherBranchIssueOpen()
+    {
+        // A green `main` push must not close `release/13.3`'s open issue.
+        var result = await InvokeAsync(new
+        {
+            operation = "resolveSuccess",
+            env = new { REF = "main" },
+            issues = new[]
+            {
+                new { number = 9, body = "<!-- ci-failure:ci.yml:push:release/13.3 -->", state = "open" },
+            },
+        });
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("open", issue.State);
+        Assert.DoesNotContain("update", result.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task TrackOpensIssueWhenCiRed()
+    {
+        var result = await InvokeAsync(new
+        {
+            operation = "track",
+            env = new { REF = "main", CI_RED = "true", CI_GREEN = "false" },
+        });
+
+        Assert.False(result.Threw);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("CI failing on `main`", issue.Title);
+        Assert.Contains("create", result.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task TrackClosesIssueWhenCiGreen()
+    {
+        var result = await InvokeAsync(new
+        {
+            operation = "track",
+            env = new { REF = "main", CI_RED = "false", CI_GREEN = "true" },
+            issues = new[]
+            {
+                new { number = 7, body = "lead <!-- ci-failure:ci.yml:push:main -->", state = "open" },
+            },
+        });
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("closed", issue.State);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task TrackIsNoopWhenNeitherRedNorGreen()
+    {
+        // A skipped (no-relevant-changes) push: CI_RED and CI_GREEN both false, so a
+        // still-open red-main issue must be left untouched (no CI signal).
+        var result = await InvokeAsync(new
+        {
+            operation = "track",
+            env = new { REF = "main", CI_RED = "false", CI_GREEN = "false" },
+            issues = new[]
+            {
+                new { number = 7, body = "lead <!-- ci-failure:ci.yml:push:main -->", state = "open" },
+            },
+        });
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("open", issue.State);
+        Assert.DoesNotContain("update", result.Calls);
+        Assert.DoesNotContain("createComment", result.Calls);
+    }
+
+    private async Task<RunnerResult> InvokeAsync(object scenario)
+    {
+        var requestPath = Path.Combine(_tempDirectory.Path, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(requestPath, JsonSerializer.Serialize(scenario, s_requestOptions));
+
+        using var command = new NodeCommand(_output, "report-ci-failure-integration");
+        command.WithWorkingDirectory(_repoRoot);
+
+        var result = await command.ExecuteScriptAsync(_harnessPath, requestPath);
+        Assert.Equal(0, result.ExitCode);
+
+        var response = JsonSerializer.Deserialize<HarnessResponse>(result.Output, s_jsonOptions);
+        Assert.NotNull(response);
+        return response!.Result;
+    }
+
+    private sealed record HarnessResponse(RunnerResult Result);
+
+    private sealed record RunnerResult(bool Threw, string[] Calls, RunnerIssue[] Issues);
+
+    private sealed record RunnerIssue(int Number, string? Title, string State, string? StateReason, string Body, string[] Labels, string[] Comments);
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureIntegrationTests.cs
@@ -129,7 +129,7 @@ public sealed class ReportCiFailureIntegrationTests : IDisposable
             env = new { REF = "main" },
             issues = new[]
             {
-                new { number = 7, body = "lead <!-- ci-failure:ci.yml:push:main -->", state = "open" },
+                new { number = 7, body = "lead <!-- ci-failure:ci.yml:push:main -->\n<!-- autoclose:true -->", state = "open" },
             },
         });
 
@@ -140,7 +140,50 @@ public sealed class ReportCiFailureIntegrationTests : IDisposable
         // A closing comment is posted so the thread records why it closed.
         var comment = Assert.Single(issue.Comments);
         Assert.Contains("green again", comment);
-        Assert.Contains("update", result.Calls);
+        Assert.Equal(["update", "createComment"], result.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ResolveSuccessLeavesIssueOpenWhenAutoCloseStampIsMissing()
+    {
+        var result = await InvokeAsync(new
+        {
+            operation = "resolveSuccess",
+            env = new { REF = "main" },
+            issues = new[]
+            {
+                new { number = 7, body = "lead <!-- ci-failure:ci.yml:push:main -->", state = "open" },
+            },
+        });
+
+        Assert.False(result.Threw);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("open", issue.State);
+        Assert.Empty(issue.Comments);
+        Assert.Empty(result.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ResolveSuccessDoesNotCommentWhenCloseFails()
+    {
+        var result = await InvokeAsync(new
+        {
+            operation = "resolveSuccess",
+            env = new { REF = "main" },
+            failUpdate = true,
+            issues = new[]
+            {
+                new { number = 7, body = "lead <!-- ci-failure:ci.yml:push:main -->\n<!-- autoclose:true -->", state = "open" },
+            },
+        });
+
+        Assert.True(result.Threw);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("open", issue.State);
+        Assert.Empty(issue.Comments);
+        Assert.Equal(["update"], result.Calls);
     }
 
     [Fact]
@@ -205,7 +248,7 @@ public sealed class ReportCiFailureIntegrationTests : IDisposable
             env = new { REF = "main", CI_RED = "false", CI_GREEN = "true" },
             issues = new[]
             {
-                new { number = 7, body = "lead <!-- ci-failure:ci.yml:push:main -->", state = "open" },
+                new { number = 7, body = "lead <!-- ci-failure:ci.yml:push:main -->\n<!-- autoclose:true -->", state = "open" },
             },
         });
 

--- a/tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureTests.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Tests for the pure decision/formatting helpers in
+/// .github/workflows/report-ci-failure.js: the per-branch dedup marker, issue
+/// title/body (autoClose:true stamped), and the per-run failure comment.
+/// </summary>
+public sealed class ReportCiFailureTests : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly TestTempDirectory _tempDirectory = new();
+    private readonly string _repoRoot;
+    private readonly string _harnessPath;
+    private readonly ITestOutputHelper _output;
+
+    public ReportCiFailureTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _repoRoot = RepoRoot.Path;
+        _harnessPath = Path.Combine(_repoRoot, "tests", "Infrastructure.Tests", "WorkflowScripts", "report-ci-failure.harness.js");
+    }
+
+    public void Dispose() => _tempDirectory.Dispose();
+
+    [Theory]
+    [InlineData("main", "<!-- ci-failure:ci.yml:push:main -->")]
+    [InlineData("release/13.3", "<!-- ci-failure:ci.yml:push:release/13.3 -->")]
+    [RequiresTools(["node"])]
+    public async Task BuildMarkerEmbedsRef(string @ref, string expected)
+    {
+        var marker = await InvokeHarnessAsync<string>("buildMarker", new { @ref });
+
+        Assert.Equal(expected, marker);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildIssueTitleNamesTheBranch()
+    {
+        var title = await InvokeHarnessAsync<string>("buildIssueTitle", new { @ref = "release/13.3" });
+
+        Assert.Equal("CI failing on `release/13.3`", title);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildIssueBodyStampsAutoCloseTrueAndCarriesMarker()
+    {
+        var marker = "<!-- ci-failure:ci.yml:push:main -->";
+        var body = await InvokeHarnessAsync<string>("buildIssueBody", new { marker, @ref = "main" });
+
+        Assert.Contains(marker, body);
+        // Self-closing on green, so the watchdog may also close it as a backstop.
+        Assert.Contains("<!-- autoclose:true -->", body);
+        Assert.Contains("on push to `main`", body);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FormatCommentLinksTheRunAndCommit()
+    {
+        var comment = await InvokeHarnessAsync<string>(
+            "formatComment",
+            new { run = new { runNumber = 42, runUrl = "https://github.com/microsoft/aspire/actions/runs/42", sha = "abcdef0123456789" } });
+
+        Assert.Contains("[run #42](https://github.com/microsoft/aspire/actions/runs/42)", comment);
+        Assert.Contains("`abcdef01`", comment);
+    }
+
+    private async Task<T> InvokeHarnessAsync<T>(string operation, object payload)
+    {
+        var requestPath = Path.Combine(_tempDirectory.Path, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(requestPath, JsonSerializer.Serialize(new { operation, payload }, s_jsonOptions));
+
+        using var command = new NodeCommand(_output, "report-ci-failure");
+        command.WithWorkingDirectory(_repoRoot);
+
+        var result = await command.ExecuteScriptAsync(_harnessPath, requestPath);
+        Assert.Equal(0, result.ExitCode);
+
+        var response = JsonSerializer.Deserialize<HarnessResponse<T>>(result.Output, s_jsonOptions);
+        Assert.NotNull(response);
+        return response!.Result;
+    }
+
+    private sealed record HarnessResponse<T>(T Result);
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/ReportPipelineFailureIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ReportPipelineFailureIntegrationTests.cs
@@ -1,0 +1,273 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Integration tests for the report() orchestrator in
+/// .github/workflows/report-pipeline-failure.js, driven against an in-memory
+/// octokit fake via report-pipeline-failure.integration.harness.js. These cover the
+/// find-or-create + comment-dedup branching (delegated to the shared engine) that
+/// the pure-helper tests cannot reach.
+/// </summary>
+public sealed class ReportPipelineFailureIntegrationTests : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
+    // The harness reads exact env-var names (WORKFLOW_FILE, ...); serialize the
+    // request verbatim so the Web camelCase policy does not rename them.
+    private static readonly JsonSerializerOptions s_requestOptions = new();
+
+    private readonly TestTempDirectory _tempDirectory = new();
+    private readonly string _repoRoot;
+    private readonly string _harnessPath;
+    private readonly ITestOutputHelper _output;
+
+    public ReportPipelineFailureIntegrationTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _repoRoot = RepoRoot.Path;
+        _harnessPath = Path.Combine(_repoRoot, "tests", "Infrastructure.Tests", "WorkflowScripts", "report-pipeline-failure.integration.harness.js");
+    }
+
+    public void Dispose() => _tempDirectory.Dispose();
+
+    private static object DeploymentEnv() => new
+    {
+        WORKFLOW_FILE = "deployment-tests.yml",
+        DISPLAY_NAME = "Deployment E2E Tests",
+    };
+
+    private static readonly string[] s_deploymentLabels = ["automation-broken", "area-testing", "deployment-e2e"];
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FilesIssueWithAllLabelsAndRecordsRunAsComment()
+    {
+        var result = await InvokeAsync(new
+        {
+            env = DeploymentEnv(),
+            labels = s_deploymentLabels,
+            cc = "@microsoft/aspire-team",
+        });
+
+        Assert.False(result.Threw);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("Nightly run failing: Deployment E2E Tests", issue.Title);
+        Assert.Contains("ci-failure:deployment-tests.yml:scheduled", issue.Body);
+        // Carries the existing labels PLUS automation-broken.
+        Assert.Equal(s_deploymentLabels, issue.Labels);
+        Assert.Contains("/cc @microsoft/aspire-team", issue.Body);
+
+        // The run is recorded as a comment, not in the body; the comment carries the
+        // run link and the hidden dedup marker.
+        var comment = Assert.Single(issue.Comments);
+        Assert.Contains("/actions/runs/12345", comment);
+        Assert.Contains("<!-- run:12345 -->", comment);
+        Assert.DoesNotContain("/actions/runs/12345", issue.Body);
+        Assert.Contains("create", result.Calls);
+        Assert.Contains("createComment", result.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task CommentDetailRidesOnTheComment()
+    {
+        var result = await InvokeAsync(new
+        {
+            env = new { WORKFLOW_FILE = "tests-daily-smoke.yml", DISPLAY_NAME = "Daily CLI Smoke Tests" },
+            labels = new[] { "automation-broken", "area-cli", "failing-test" },
+            commentDetail = "### Aspire CLI versions tested\n\n- 9.0.0",
+        });
+
+        var issue = Assert.Single(result.Issues);
+        var comment = Assert.Single(issue.Comments);
+        Assert.Contains("### Aspire CLI versions tested", comment);
+        // Per-run detail goes on the comment, not baked into the issue body.
+        Assert.DoesNotContain("### Aspire CLI versions tested", issue.Body);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ForcesAutomationBrokenLabelEvenIfCallerOmitsIt()
+    {
+        // The runner looks issues up by automation-broken, so it must also file with
+        // it. A caller that passes only its own labels must still get automation-broken
+        // added, or the next run would not find the issue and would file a duplicate.
+        var result = await InvokeAsync(new
+        {
+            env = DeploymentEnv(),
+            labels = new[] { "area-testing", "deployment-e2e" },
+        });
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Contains("automation-broken", issue.Labels);
+        Assert.Contains("deployment-e2e", issue.Labels);
+        // Added once, not duplicated.
+        Assert.Single(issue.Labels, label => label == "automation-broken");
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task CommentFailureLeavesRunUnrecorded()
+    {
+        // If the comment fails, no comment is recorded, so the dedup guard cannot
+        // suppress the notification on the next run for this run.
+        var result = await InvokeAsync(new
+        {
+            env = DeploymentEnv(),
+            labels = s_deploymentLabels,
+            failComment = true,
+        });
+
+        Assert.True(result.Threw);
+        var issue = Assert.Single(result.Issues);
+        Assert.Empty(issue.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RetryAfterCommentFailurePostsExactlyOnceThenDedups()
+    {
+        var first = await InvokeAsync(new
+        {
+            env = DeploymentEnv(),
+            labels = s_deploymentLabels,
+            failComment = true,
+        });
+        var stranded = Assert.Single(first.Issues);
+        Assert.Empty(stranded.Comments);
+
+        // Re-run (same runId, comment succeeds): notified once and the run is recorded
+        // as a comment.
+        var second = await InvokeAsync(new
+        {
+            env = DeploymentEnv(),
+            labels = s_deploymentLabels,
+            issues = new[] { new { number = stranded.Number, body = stranded.Body, state = "open", comments = stranded.Comments } },
+        });
+        var recorded = Assert.Single(second.Issues);
+        Assert.Single(recorded.Comments);
+        Assert.Contains("<!-- run:12345 -->", recorded.Comments[0]);
+
+        // A further tick for the same run must not re-notify (the comment already
+        // carries the run marker).
+        var third = await InvokeAsync(new
+        {
+            env = DeploymentEnv(),
+            labels = s_deploymentLabels,
+            issues = new[] { new { number = recorded.Number, body = recorded.Body, state = "open", comments = recorded.Comments } },
+        });
+        Assert.DoesNotContain("createComment", third.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task CommentsOnExistingIssueForNewRun()
+    {
+        var first = await InvokeAsync(new { env = DeploymentEnv(), labels = s_deploymentLabels });
+        var issue = Assert.Single(first.Issues);
+
+        // A later scheduled run (new runId) adds a second comment to the same issue
+        // rather than filing a new one.
+        var second = await InvokeAsync(new
+        {
+            env = DeploymentEnv(),
+            labels = s_deploymentLabels,
+            issues = new[] { new { number = issue.Number, body = issue.Body, state = "open", comments = issue.Comments } },
+            runId = 67890,
+            runNumber = 8,
+        });
+
+        var updated = Assert.Single(second.Issues);
+        Assert.DoesNotContain("create", second.Calls);
+        Assert.Equal(2, updated.Comments.Length);
+        Assert.Contains(updated.Comments, c => c.Contains("/actions/runs/12345"));
+        Assert.Contains(updated.Comments, c => c.Contains("/actions/runs/67890"));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DoesNotManageAnotherWorkflowsAutomationBrokenIssue()
+    {
+        // Both pipelines and the scanner/specialized reporter carry automation-broken,
+        // so the label query is a superset. The per-workflow marker must keep this
+        // reporter from commenting on a different workflow's issue: it files its own.
+        var result = await InvokeAsync(new
+        {
+            env = DeploymentEnv(),
+            labels = s_deploymentLabels,
+            issues = new[]
+            {
+                new
+                {
+                    number = 4242,
+                    body = "<!-- ci-failure:tests-outerloop.yml:infra -->",
+                    state = "open",
+                },
+            },
+        });
+
+        Assert.Contains("create", result.Calls);
+        var created = Assert.Single(result.Issues, issue => issue.Number != 4242);
+        Assert.Contains("ci-failure:deployment-tests.yml:scheduled", created.Body);
+        var other = Assert.Single(result.Issues, issue => issue.Number == 4242);
+        Assert.Empty(other.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task PullRequestCarryingMarkerIsIgnored()
+    {
+        // listForRepo returns PRs too. A PR labelled automation-broken whose body
+        // happens to contain the marker must not be mistaken for the managed issue:
+        // the runner files a fresh issue instead of commenting on the PR.
+        var result = await InvokeAsync(new
+        {
+            env = DeploymentEnv(),
+            labels = s_deploymentLabels,
+            issues = new[]
+            {
+                new
+                {
+                    number = 4242,
+                    body = "<!-- ci-failure:deployment-tests.yml:scheduled -->",
+                    state = "open",
+                    pull_request = new { url = "https://api.github.com/pr/4242" },
+                },
+            },
+        });
+
+        Assert.Contains("create", result.Calls);
+        var created = Assert.Single(result.Issues, issue => issue.Number != 4242);
+        Assert.Contains(created.Comments, c => c.Contains("/actions/runs/12345"));
+        var pr = Assert.Single(result.Issues, issue => issue.Number == 4242);
+        Assert.Empty(pr.Comments);
+    }
+
+    private async Task<RunnerResult> InvokeAsync(object scenario)
+    {
+        var requestPath = Path.Combine(_tempDirectory.Path, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(requestPath, JsonSerializer.Serialize(scenario, s_requestOptions));
+
+        using var command = new NodeCommand(_output, "report-pipeline-failure-integration");
+        command.WithWorkingDirectory(_repoRoot);
+
+        var result = await command.ExecuteScriptAsync(_harnessPath, requestPath);
+        Assert.Equal(0, result.ExitCode);
+
+        var response = JsonSerializer.Deserialize<HarnessResponse>(result.Output, s_jsonOptions);
+        Assert.NotNull(response);
+        return response!.Result;
+    }
+
+    private sealed record HarnessResponse(RunnerResult Result);
+
+    private sealed record RunnerResult(bool Threw, string[] Calls, RunnerIssue[] Issues);
+
+    private sealed record RunnerIssue(int Number, string? Title, string State, string Body, string[] Labels, string[] Comments);
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/ReportPipelineFailureIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ReportPipelineFailureIntegrationTests.cs
@@ -192,6 +192,41 @@ public sealed class ReportPipelineFailureIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task ReopensClosedIssueForNewRun()
+    {
+        var result = await InvokeAsync(new
+        {
+            env = DeploymentEnv(),
+            labels = s_deploymentLabels,
+            issues = new[]
+            {
+                new
+                {
+                    number = 4242,
+                    body = "<!-- ci-failure:deployment-tests.yml:scheduled -->\n\nExisting closed issue.",
+                    state = "closed",
+                    comments = Array.Empty<string>(),
+                },
+            },
+            runId = 67890,
+            runNumber = 8,
+        });
+
+        Assert.DoesNotContain("create", result.Calls);
+        Assert.Contains("update", result.Calls);
+        Assert.Contains("createComment", result.Calls);
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal(4242, issue.Number);
+        Assert.Equal("open", issue.State);
+
+        var comment = Assert.Single(issue.Comments);
+        Assert.Contains("/actions/runs/67890", comment);
+        Assert.Contains("<!-- run:67890 -->", comment);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task DoesNotManageAnotherWorkflowsAutomationBrokenIssue()
     {
         // Both pipelines and the scanner/specialized reporter carry automation-broken,

--- a/tests/Infrastructure.Tests/WorkflowScripts/ReportPipelineFailureTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ReportPipelineFailureTests.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Tests for the pure helpers in
+/// .github/workflows/report-pipeline-failure.js.
+/// </summary>
+public sealed class ReportPipelineFailureTests : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly TestTempDirectory _tempDirectory = new();
+    private readonly string _repoRoot;
+    private readonly string _harnessPath;
+    private readonly ITestOutputHelper _output;
+
+    public ReportPipelineFailureTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _repoRoot = RepoRoot.Path;
+        _harnessPath = Path.Combine(_repoRoot, "tests", "Infrastructure.Tests", "WorkflowScripts", "report-pipeline-failure.harness.js");
+    }
+
+    public void Dispose() => _tempDirectory.Dispose();
+
+    [Theory]
+    [InlineData("deployment-tests.yml", "<!-- ci-failure:deployment-tests.yml:scheduled -->")]
+    [InlineData("tests-daily-smoke.yml", "<!-- ci-failure:tests-daily-smoke.yml:scheduled -->")]
+    [RequiresTools(["node"])]
+    public async Task BuildMarkerEmbedsWorkflowFile(string file, string expected)
+    {
+        var marker = await InvokeHarnessAsync<string>("buildMarker", new { workflowFile = file });
+
+        Assert.Equal(expected, marker);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildIssueTitleIsNeutral()
+    {
+        // The title must not pre-classify the failure as test-vs-infra: a nightly
+        // deployment/smoke failure can be either, and these pipelines do not inspect
+        // results to tell them apart.
+        var title = await InvokeHarnessAsync<string>("buildIssueTitle", new { displayName = "Deployment E2E Tests" });
+
+        Assert.Equal("Nightly run failing: Deployment E2E Tests", title);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildIssueBodyIsStaticDescriptionWithMarker()
+    {
+        // Each failed run is recorded as a comment, so the body is a fixed
+        // description: the marker (for lookup) plus prose, with no per-run table.
+        var body = await InvokeHarnessAsync<string>(
+            "buildIssueBody",
+            new
+            {
+                marker = "<!-- ci-failure:deployment-tests.yml:scheduled -->",
+                displayName = "Deployment E2E Tests",
+                workflowFile = "deployment-tests.yml",
+            });
+
+        Assert.Contains("<!-- ci-failure:deployment-tests.yml:scheduled -->", body);
+        Assert.Contains("is failing on its nightly run", body);
+        Assert.Contains("comment below", body);
+        Assert.DoesNotContain("ci-failure-runs:begin", body);
+        Assert.DoesNotContain("[run #", body);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildIssueBodyEmbedsCcWhenProvided()
+    {
+        // The first filing notifies a team via an @mention in the body; subsequent
+        // failures notify via comment.
+        var withCc = await InvokeHarnessAsync<string>(
+            "buildIssueBody",
+            new
+            {
+                marker = "<!-- ci-failure:deployment-tests.yml:scheduled -->",
+                displayName = "Deployment E2E Tests",
+                workflowFile = "deployment-tests.yml",
+                cc = "@microsoft/aspire-team",
+            });
+        Assert.Contains("/cc @microsoft/aspire-team", withCc);
+
+        var withoutCc = await InvokeHarnessAsync<string>(
+            "buildIssueBody",
+            new
+            {
+                marker = "<!-- ci-failure:tests-daily-smoke.yml:scheduled -->",
+                displayName = "Daily CLI Smoke Tests",
+                workflowFile = "tests-daily-smoke.yml",
+            });
+        Assert.DoesNotContain("/cc", withoutCc);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FormatCommentReferencesRunAndCommit()
+    {
+        var comment = await InvokeHarnessAsync<string>(
+            "formatComment",
+            new { run = new { runNumber = 7, runUrl = "https://x/runs/7", sha = "abcdef0123456789" } });
+
+        Assert.Contains("[run #7](https://x/runs/7)", comment);
+        Assert.Contains("`abcdef01`", comment);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FormatCommentAppendsDetailWhenProvided()
+    {
+        // Per-run caller detail (e.g. the smoke suite's CLI versions) rides on the
+        // failure comment that records the run.
+        var comment = await InvokeHarnessAsync<string>(
+            "formatComment",
+            new
+            {
+                run = new { runNumber = 7, runUrl = "https://x/runs/7", sha = "abcdef0123456789" },
+                detail = "### Aspire CLI versions tested\n\n- 9.0.0"
+            });
+
+        Assert.Contains("[run #7](https://x/runs/7)", comment);
+        Assert.Contains("### Aspire CLI versions tested", comment);
+        Assert.Contains("- 9.0.0", comment);
+    }
+
+    private async Task<T> InvokeHarnessAsync<T>(string operation, object payload)
+    {
+        var requestPath = Path.Combine(_tempDirectory.Path, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(requestPath, JsonSerializer.Serialize(new { operation, payload }, s_jsonOptions));
+
+        using var command = new NodeCommand(_output, "report-pipeline-failure");
+        command.WithWorkingDirectory(_repoRoot);
+
+        var result = await command.ExecuteScriptAsync(_harnessPath, requestPath);
+        Assert.Equal(0, result.ExitCode);
+
+        var response = JsonSerializer.Deserialize<HarnessResponse<T>>(result.Output, s_jsonOptions);
+        Assert.NotNull(response);
+        return response!.Result;
+    }
+
+    private sealed record HarnessResponse<T>(T Result);
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/ReportSpecializedTestFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ReportSpecializedTestFailuresTests.cs
@@ -1,0 +1,242 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Tests for the pure helpers in
+/// .github/workflows/report-specialized-test-failures.js.
+/// </summary>
+public sealed class ReportSpecializedTestFailuresTests : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly TestTempDirectory _tempDirectory = new();
+    private readonly string _repoRoot;
+    private readonly string _harnessPath;
+    private readonly ITestOutputHelper _output;
+
+    public ReportSpecializedTestFailuresTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _repoRoot = RepoRoot.Path;
+        _harnessPath = Path.Combine(_repoRoot, "tests", "Infrastructure.Tests", "WorkflowScripts", "report-specialized-test-failures.harness.js");
+    }
+
+    public void Dispose() => _tempDirectory.Dispose();
+
+    [Theory]
+    [InlineData("test-failures", "<!-- ci-failure:tests-outerloop.yml:test-failures -->")]
+    [InlineData("infra", "<!-- ci-failure:tests-quarantine.yml:infra -->")]
+    [RequiresTools(["node"])]
+    public async Task BuildMarkerEmbedsWorkflowAndKind(string kind, string expected)
+    {
+        var file = kind == "infra" ? "tests-quarantine.yml" : "tests-outerloop.yml";
+        var marker = await InvokeHarnessAsync<string>("buildMarker", new { workflowFile = file, kind });
+
+        Assert.Equal(expected, marker);
+    }
+
+    [Theory]
+    [InlineData("test-failures", "failing-test")]
+    [InlineData("infra", "automation-broken")]
+    [RequiresTools(["node"])]
+    public async Task LabelForKindMapsCorrectly(string kind, string expected)
+    {
+        var label = await InvokeHarnessAsync<string>("labelForKind", new { kind });
+
+        Assert.Equal(expected, label);
+    }
+
+    [Theory]
+    [InlineData("test-failures", "Test failures: Outerloop Tests")]
+    [InlineData("infra", "CI infrastructure failing: Outerloop Tests")]
+    [RequiresTools(["node"])]
+    public async Task BuildIssueTitleVariesByKind(string kind, string expected)
+    {
+        var title = await InvokeHarnessAsync<string>("buildIssueTitle", new { displayName = "Outerloop Tests", kind });
+
+        Assert.Equal(expected, title);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ClassifyFailureTreatsQuarantineFailureAsInfra()
+    {
+        // ignoreTestFailures (quarantine): even with failed tests reported, a failed
+        // run is infra because run-tests.yml swallows test failures.
+        var kind = await InvokeHarnessAsync<string>(
+            "classifyFailure",
+            new { result = "failure", failedCount = 5, ignoreTestFailures = true });
+
+        Assert.Equal("infra", kind);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ClassifyFailureIsTestFailuresWhenOuterloopTestsFailed()
+    {
+        var kind = await InvokeHarnessAsync<string>(
+            "classifyFailure",
+            new { result = "failure", failedCount = 3, ignoreTestFailures = false });
+
+        Assert.Equal("test-failures", kind);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ClassifyFailureIsInfraWhenOuterloopFailedWithNoTestFailures()
+    {
+        var kind = await InvokeHarnessAsync<string>(
+            "classifyFailure",
+            new { result = "failure", failedCount = 0, ignoreTestFailures = false });
+
+        Assert.Equal("infra", kind);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ClassifyFailureIsNoneWhenRunSucceeded()
+    {
+        var kind = await InvokeHarnessAsync<string>(
+            "classifyFailure",
+            new { result = "success", failedCount = 0, ignoreTestFailures = false });
+
+        Assert.Equal("none", kind);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ClassifyFailureIsTestFailuresWhenExtractionFailedOnRedOuterloopRun()
+    {
+        // A genuinely-red outerloop run whose results could not be extracted
+        // (download/tool flake) must not be misfiled as infra — that would lose
+        // the failing-test signal and open a second, mismatched issue.
+        var kind = await InvokeHarnessAsync<string>(
+            "classifyFailure",
+            new { result = "failure", failedCount = 0, ignoreTestFailures = false, extractionFailed = true });
+
+        Assert.Equal("test-failures", kind);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildIssueBodyIsStaticDescriptionWithMarker()
+    {
+        // Each failed run is recorded as a comment, so the body is a fixed
+        // description: the marker (for lookup) plus kind-specific prose, no table.
+        var body = await InvokeHarnessAsync<string>(
+            "buildIssueBody",
+            new
+            {
+                marker = "<!-- ci-failure:tests-outerloop.yml:test-failures -->",
+                displayName = "Outerloop Tests",
+                workflowFile = "tests-outerloop.yml",
+                kind = "test-failures",
+            });
+
+        Assert.StartsWith("<!-- ci-failure:tests-outerloop.yml:test-failures -->", body);
+        Assert.Contains("Outerloop tests are failing", body);
+        Assert.Contains("added as a comment", body);
+        Assert.DoesNotContain("ci-failure-runs:begin", body);
+        Assert.DoesNotContain("[run #", body);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FormatCommentForTestFailuresWithNoNamesPointsAtArtifacts()
+    {
+        var comment = await InvokeHarnessAsync<string>(
+            "formatComment",
+            new
+            {
+                kind = "test-failures",
+                run = new { runNumber = 7, runUrl = "https://x/runs/7" },
+                failedTests = Array.Empty<string>()
+            });
+
+        Assert.Contains("could not be extracted", comment);
+        Assert.Contains("[run #7](https://x/runs/7)", comment);
+        Assert.DoesNotContain("0 test(s) failed", comment);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FormatCommentEscapesBacktickInTestName()
+    {
+        // A test display name containing a backtick must not break out of the
+        // inline code span (Markdown/mention injection).
+        var comment = await InvokeHarnessAsync<string>(
+            "formatComment",
+            new
+            {
+                kind = "test-failures",
+                run = new { runNumber = 7, runUrl = "https://x/runs/7" },
+                failedTests = new[] { "Tests.Type.Method(arg: `evil`)" }
+            });
+
+        Assert.Contains("Tests.Type.Method(arg: `evil`)", comment);
+        // Wrapped in a longer fence so the embedded backtick cannot close the span.
+        Assert.Contains("``", comment);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FormatCommentListsFailedTestsCapped()
+    {
+        var comment = await InvokeHarnessAsync<string>(
+            "formatComment",
+            new
+            {
+                kind = "test-failures",
+                run = new { runNumber = 7, runUrl = "https://x/runs/7" },
+                failedTests = new[] { "A.B.C", "D.E.F", "G.H.I" },
+                maxListed = 2
+            });
+
+        Assert.Contains("3 test(s) failed in [run #7](https://x/runs/7)", comment);
+        Assert.Contains("`A.B.C`", comment);
+        Assert.Contains("`D.E.F`", comment);
+        Assert.Contains("and 1 more", comment);
+        Assert.DoesNotContain("`G.H.I`", comment);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FormatCommentForInfraReferencesRunOnly()
+    {
+        var comment = await InvokeHarnessAsync<string>(
+            "formatComment",
+            new
+            {
+                kind = "infra",
+                run = new { runNumber = 7, runUrl = "https://x/runs/7" },
+                failedTests = Array.Empty<string>()
+            });
+
+        Assert.Contains("Infrastructure failure", comment);
+        Assert.Contains("[run #7](https://x/runs/7)", comment);
+    }
+
+    private async Task<T> InvokeHarnessAsync<T>(string operation, object payload)
+    {
+        var requestPath = Path.Combine(_tempDirectory.Path, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(requestPath, JsonSerializer.Serialize(new { operation, payload }, s_jsonOptions));
+
+        using var command = new NodeCommand(_output, "report-specialized-test-failures");
+        command.WithWorkingDirectory(_repoRoot);
+
+        var result = await command.ExecuteScriptAsync(_harnessPath, requestPath);
+        Assert.Equal(0, result.ExitCode);
+
+        var response = JsonSerializer.Deserialize<HarnessResponse<T>>(result.Output, s_jsonOptions);
+        Assert.NotNull(response);
+        return response!.Result;
+    }
+
+    private sealed record HarnessResponse<T>(T Result);
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/SpecializedTestFailureRunnerTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/SpecializedTestFailureRunnerTests.cs
@@ -122,6 +122,42 @@ public sealed class SpecializedTestFailureRunnerTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task ReopensClosedIssueForNewRun()
+    {
+        var result = await InvokeAsync(new
+        {
+            env = OuterloopEnv(),
+            failedTests = new[] { "Tests.Type.A" },
+            issues = new[]
+            {
+                new
+                {
+                    number = 4242,
+                    body = "<!-- ci-failure:tests-outerloop.yml:test-failures -->\n\nExisting closed issue.",
+                    state = "closed",
+                    comments = Array.Empty<string>(),
+                },
+            },
+            runId = 67890,
+            runNumber = 8,
+        });
+
+        Assert.DoesNotContain("create", result.Calls);
+        Assert.Contains("update", result.Calls);
+        Assert.Contains("createComment", result.Calls);
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal(4242, issue.Number);
+        Assert.Equal("open", issue.State);
+
+        var comment = Assert.Single(issue.Comments);
+        Assert.Contains("`Tests.Type.A`", comment);
+        Assert.Contains("/actions/runs/67890", comment);
+        Assert.Contains("<!-- run:67890 -->", comment);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task MissingResultsPathIsClassifiedAsTestFailures()
     {
         // The extract step crashed before emitting its path (FAILED_TESTS_PATH

--- a/tests/Infrastructure.Tests/WorkflowScripts/SpecializedTestFailureRunnerTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/SpecializedTestFailureRunnerTests.cs
@@ -1,0 +1,210 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Integration tests for the network orchestration in
+/// .github/workflows/specialized-test-failure-runner.js, driven against an
+/// in-memory octokit fake via specialized-test-failure-runner.harness.js. These
+/// cover the results-read/classify preamble plus the find-or-create + comment-dedup
+/// branching (delegated to the shared engine) that the pure-helper tests cannot reach.
+/// </summary>
+public sealed class SpecializedTestFailureRunnerTests : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
+    // The harness reads exact env-var names (WORKFLOW_FILE, ...) and helper keys
+    // (failedTests, ...); serialize the request verbatim so the Web camelCase policy
+    // does not rename them.
+    private static readonly JsonSerializerOptions s_requestOptions = new();
+
+    private readonly TestTempDirectory _tempDirectory = new();
+    private readonly string _repoRoot;
+    private readonly string _harnessPath;
+    private readonly ITestOutputHelper _output;
+
+    public SpecializedTestFailureRunnerTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _repoRoot = RepoRoot.Path;
+        _harnessPath = Path.Combine(_repoRoot, "tests", "Infrastructure.Tests", "WorkflowScripts", "specialized-test-failure-runner.harness.js");
+    }
+
+    public void Dispose() => _tempDirectory.Dispose();
+
+    private static object OuterloopEnv() => new
+    {
+        WORKFLOW_FILE = "tests-outerloop.yml",
+        DISPLAY_NAME = "Outerloop Tests",
+        IGNORE_TEST_FAILURES = "false",
+    };
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FilesTestFailuresIssueAndRecordsRunAsComment()
+    {
+        var result = await InvokeAsync(new
+        {
+            env = OuterloopEnv(),
+            failedTests = new[] { "Tests.Type.A", "Tests.Type.B" },
+        });
+
+        Assert.False(result.Threw);
+        var issue = Assert.Single(result.Issues);
+        Assert.Contains("ci-failure:tests-outerloop.yml:test-failures", issue.Body);
+
+        // The failing-test list and run link ride on the comment, with the hidden
+        // dedup marker; the body is a static description.
+        var comment = Assert.Single(issue.Comments);
+        Assert.Contains("`Tests.Type.A`", comment);
+        Assert.Contains("/actions/runs/12345", comment);
+        Assert.Contains("<!-- run:12345 -->", comment);
+        Assert.DoesNotContain("/actions/runs/12345", issue.Body);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task CommentFailureLeavesRunUnrecorded()
+    {
+        // If the comment (which carries the failing-test list) fails, no comment is
+        // recorded, so the dedup guard cannot suppress the list on the next run.
+        var result = await InvokeAsync(new
+        {
+            env = OuterloopEnv(),
+            failedTests = new[] { "Tests.Type.A" },
+            failComment = true,
+        });
+
+        Assert.True(result.Threw);
+        var issue = Assert.Single(result.Issues);
+        Assert.Empty(issue.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RetryAfterCommentFailurePostsExactlyOnceThenDedups()
+    {
+        var first = await InvokeAsync(new
+        {
+            env = OuterloopEnv(),
+            failedTests = new[] { "Tests.Type.A" },
+            failComment = true,
+        });
+        var stranded = Assert.Single(first.Issues);
+        Assert.Empty(stranded.Comments);
+
+        // Re-run (same runId, comment succeeds): the list is posted once and recorded
+        // as a comment.
+        var second = await InvokeAsync(new
+        {
+            env = OuterloopEnv(),
+            failedTests = new[] { "Tests.Type.A" },
+            issues = new[] { new { number = stranded.Number, body = stranded.Body, state = "open", comments = stranded.Comments } },
+        });
+        var recorded = Assert.Single(second.Issues);
+        Assert.Single(recorded.Comments);
+        Assert.Contains("<!-- run:12345 -->", recorded.Comments[0]);
+
+        // A further tick for the same run must not re-notify.
+        var third = await InvokeAsync(new
+        {
+            env = OuterloopEnv(),
+            failedTests = new[] { "Tests.Type.A" },
+            issues = new[] { new { number = recorded.Number, body = recorded.Body, state = "open", comments = recorded.Comments } },
+        });
+        Assert.DoesNotContain("createComment", third.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task MissingResultsPathIsClassifiedAsTestFailures()
+    {
+        // The extract step crashed before emitting its path (FAILED_TESTS_PATH
+        // empty). A red outerloop run must be filed as a test failure, not infra.
+        var result = await InvokeAsync(new
+        {
+            env = OuterloopEnv(),
+            omitFailedTestsPath = true,
+        });
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Contains("ci-failure:tests-outerloop.yml:test-failures", issue.Body);
+        Assert.Contains("could not be extracted", Assert.Single(issue.Comments));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task QuarantineFailureFilesInfraIssue()
+    {
+        var result = await InvokeAsync(new
+        {
+            env = new
+            {
+                WORKFLOW_FILE = "tests-quarantine.yml",
+                DISPLAY_NAME = "Quarantined Tests",
+                IGNORE_TEST_FAILURES = "true",
+            },
+        });
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Contains("ci-failure:tests-quarantine.yml:infra", issue.Body);
+        Assert.Contains("Infrastructure failure", Assert.Single(issue.Comments));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task PullRequestCarryingMarkerIsIgnored()
+    {
+        // listForRepo returns PRs too. A PR labelled automation-broken/failing-test
+        // whose body happens to contain the marker must not be mistaken for the
+        // managed issue: the runner files a fresh issue instead of commenting on the PR.
+        var result = await InvokeAsync(new
+        {
+            env = OuterloopEnv(),
+            failedTests = new[] { "Tests.Type.A" },
+            issues = new[]
+            {
+                new
+                {
+                    number = 4242,
+                    body = "<!-- ci-failure:tests-outerloop.yml:test-failures -->",
+                    state = "open",
+                    pull_request = new { url = "https://api.github.com/pr/4242" },
+                },
+            },
+        });
+
+        Assert.Contains("create", result.Calls);
+        var created = Assert.Single(result.Issues, issue => issue.Number != 4242);
+        Assert.Contains(created.Comments, c => c.Contains("/actions/runs/12345"));
+        var pr = Assert.Single(result.Issues, issue => issue.Number == 4242);
+        Assert.Empty(pr.Comments);
+    }
+
+    private async Task<RunnerResult> InvokeAsync(object scenario)
+    {
+        var requestPath = Path.Combine(_tempDirectory.Path, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(requestPath, JsonSerializer.Serialize(scenario, s_requestOptions));
+
+        using var command = new NodeCommand(_output, "specialized-test-failure-runner");
+        command.WithWorkingDirectory(_repoRoot);
+
+        var result = await command.ExecuteScriptAsync(_harnessPath, requestPath);
+        Assert.Equal(0, result.ExitCode);
+
+        var response = JsonSerializer.Deserialize<HarnessResponse>(result.Output, s_jsonOptions);
+        Assert.NotNull(response);
+        return response!.Result;
+    }
+
+    private sealed record HarnessResponse(RunnerResult Result);
+
+    private sealed record RunnerResult(bool Threw, string[] Calls, RunnerIssue[] Issues);
+
+    private sealed record RunnerIssue(int Number, string? Title, string State, string Body, string[] Comments);
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs
@@ -1,0 +1,251 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Tests for the generic, repo-agnostic tracking-issue engine in
+/// .github/workflows/tracking-issue.js: marker dedup and the comment-based
+/// recordRun loop (find-or-create the issue, then record each run as a comment,
+/// deduping on the hidden per-run marker).
+/// </summary>
+public sealed class TrackingIssueTests : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly TestTempDirectory _tempDirectory = new();
+    private readonly string _repoRoot;
+    private readonly string _harnessPath;
+    private readonly ITestOutputHelper _output;
+
+    public TrackingIssueTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _repoRoot = RepoRoot.Path;
+        _harnessPath = Path.Combine(_repoRoot, "tests", "Infrastructure.Tests", "WorkflowScripts", "tracking-issue.harness.js");
+    }
+
+    public void Dispose() => _tempDirectory.Dispose();
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FindOpenIssueForMarkerReturnsOldestMatch()
+    {
+        var marker = "<!-- x -->";
+        var result = await InvokeHarnessAsync<FindIssueResult>(
+            "findOpenIssueForMarker",
+            new
+            {
+                marker,
+                issues = new object[]
+                {
+                    new { number = 40, body = $"a {marker}" },
+                    new { number = 11, body = marker },
+                    new { number = 88, body = "other" },
+                }
+            });
+
+        Assert.Equal(11, result.Number);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task FindOpenIssueForMarkerReturnsNullWhenNoMatch()
+    {
+        var result = await InvokeHarnessAsync<FindIssueResult>(
+            "findOpenIssueForMarker",
+            new { marker = "<!-- x -->", issues = new object[] { new { number = 1, body = "nope" } } });
+
+        Assert.Null(result.Number);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RunMarkerEmbedsRunIdAsHtmlComment()
+    {
+        var marker = await InvokeHarnessAsync<string>("runMarker", new { runId = 1234 });
+
+        Assert.Equal("<!-- run:1234 -->", marker);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RecordRunFilesIssueAndCommentsWhenNoneExists()
+    {
+        var result = await InvokeHarnessAsync<RecordRunResult>(
+            "recordRun",
+            new { marker = "<!-- m -->", runId = 9, comment = "boom" });
+
+        Assert.True(result.Result.Created);
+        Assert.False(result.Result.Skipped);
+        Assert.Contains("create", result.Calls);
+        Assert.Contains("createComment", result.Calls);
+
+        var issue = Assert.Single(result.Issues);
+        var comment = Assert.Single(issue.Comments);
+        Assert.Contains("boom", comment);
+        Assert.Contains("<!-- run:9 -->", comment);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RecordRunCommentsOnExistingIssueForNewRun()
+    {
+        var result = await InvokeHarnessAsync<RecordRunResult>(
+            "recordRun",
+            new
+            {
+                marker = "<!-- m -->",
+                runId = 7,
+                comment = "again",
+                issues = new object[]
+                {
+                    new { number = 5, body = "lead <!-- m -->", comments = new[] { "first <!-- run:6 -->" } },
+                }
+            });
+
+        Assert.False(result.Result.Created);
+        Assert.False(result.Result.Skipped);
+        Assert.DoesNotContain("create", result.Calls);
+        Assert.Contains("createComment", result.Calls);
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal(2, issue.Comments.Length);
+        Assert.Contains(issue.Comments, c => c.Contains("<!-- run:7 -->"));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RecordRunSkipsWhenRunAlreadyRecorded()
+    {
+        var result = await InvokeHarnessAsync<RecordRunResult>(
+            "recordRun",
+            new
+            {
+                marker = "<!-- m -->",
+                runId = 6,
+                comment = "dup",
+                issues = new object[]
+                {
+                    new { number = 5, body = "lead <!-- m -->", comments = new[] { "first <!-- run:6 -->" } },
+                }
+            });
+
+        Assert.True(result.Result.Skipped);
+        Assert.False(result.Result.Created);
+        Assert.DoesNotContain("createComment", result.Calls);
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Single(issue.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildBodyEmbedsAutoCloseStampWhenTrue()
+    {
+        var body = await InvokeHarnessAsync<string>(
+            "buildBody",
+            new { marker = "<!-- m -->", autoClose = true });
+
+        Assert.Contains("<!-- m -->", body);
+        Assert.Contains("<!-- autoclose:true -->", body);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildBodyEmbedsAutoCloseStampWhenFalse()
+    {
+        var body = await InvokeHarnessAsync<string>(
+            "buildBody",
+            new { marker = "<!-- m -->", autoClose = false });
+
+        Assert.Contains("<!-- autoclose:false -->", body);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task BuildBodyOmitsAutoCloseStampWhenUnset()
+    {
+        var body = await InvokeHarnessAsync<string>(
+            "buildBody",
+            new { marker = "<!-- m -->" });
+
+        Assert.DoesNotContain("autoclose", body);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ReadAutoCloseReturnsTrueForTrueStamp()
+    {
+        var result = await InvokeHarnessAsync<ReadAutoCloseResult>(
+            "readAutoClose",
+            new { body = "lead\n<!-- autoclose:true -->\nmore" });
+
+        Assert.True(result.Value);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ReadAutoCloseReturnsFalseForFalseStamp()
+    {
+        var result = await InvokeHarnessAsync<ReadAutoCloseResult>(
+            "readAutoClose",
+            new { body = "<!--autoclose:false-->" });
+
+        Assert.False(result.Value);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ReadAutoCloseReturnsNullWhenStampMissing()
+    {
+        var result = await InvokeHarnessAsync<ReadAutoCloseResult>(
+            "readAutoClose",
+            new { body = "a body with no stamp" });
+
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ReadAutoCloseReturnsNullWhenStampUnparseable()
+    {
+        var result = await InvokeHarnessAsync<ReadAutoCloseResult>(
+            "readAutoClose",
+            new { body = "<!-- autoclose:maybe -->" });
+
+        Assert.Null(result.Value);
+    }
+
+    private async Task<T> InvokeHarnessAsync<T>(string operation, object payload)
+    {
+        var requestPath = Path.Combine(_tempDirectory.Path, $"{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(requestPath, JsonSerializer.Serialize(new { operation, payload }, s_jsonOptions));
+
+        using var command = new NodeCommand(_output, "tracking-issue");
+        command.WithWorkingDirectory(_repoRoot);
+
+        var result = await command.ExecuteScriptAsync(_harnessPath, requestPath);
+        Assert.Equal(0, result.ExitCode);
+
+        var response = JsonSerializer.Deserialize<HarnessResponse<T>>(result.Output, s_jsonOptions);
+        Assert.NotNull(response);
+        return response!.Result;
+    }
+
+    private sealed record HarnessResponse<T>(T Result);
+
+    private sealed record FindIssueResult(int? Number);
+
+    private sealed record ReadAutoCloseResult(bool? Value);
+
+    private sealed record RecordRunResult(RecordResult Result, string[] Calls, IssueState[] Issues);
+
+    private sealed record RecordResult(int Number, bool Created, bool Skipped);
+
+    private sealed record IssueState(int Number, string State, string Body, string[] Labels, string[] Comments);
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs
@@ -145,6 +145,65 @@ public sealed class TrackingIssueTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task RecordRunReopensClosedIssueForNewRun()
+    {
+        var result = await InvokeHarnessAsync<RecordRunResult>(
+            "recordRun",
+            new
+            {
+                marker = "<!-- m -->",
+                runId = 7,
+                comment = "again",
+                issues = new object[]
+                {
+                    new { number = 5, body = "lead <!-- m -->", state = "closed", comments = new[] { "first <!-- run:6 -->" } },
+                }
+            });
+
+        Assert.False(result.Result.Created);
+        Assert.False(result.Result.Skipped);
+        Assert.Equal(["update", "createComment"], result.Calls);
+
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("open", issue.State);
+        Assert.Equal(2, issue.Comments.Length);
+        Assert.Contains(issue.Comments, c => c.Contains("<!-- run:7 -->"));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RecordRunPrefersOpenIssueOverOlderClosedDuplicate()
+    {
+        var result = await InvokeHarnessAsync<RecordRunResult>(
+            "recordRun",
+            new
+            {
+                marker = "<!-- m -->",
+                runId = 7,
+                comment = "again",
+                issues = new object[]
+                {
+                    new { number = 5, body = "lead <!-- m -->", state = "closed", comments = new[] { "first <!-- run:6 -->" } },
+                    new { number = 8, body = "lead <!-- m -->", state = "open", comments = Array.Empty<string>() },
+                }
+            });
+
+        Assert.False(result.Result.Created);
+        Assert.False(result.Result.Skipped);
+        Assert.Equal(["createComment"], result.Calls);
+
+        var closedIssue = Assert.Single(result.Issues, issue => issue.Number == 5);
+        Assert.Equal("closed", closedIssue.State);
+        Assert.Single(closedIssue.Comments);
+
+        var openIssue = Assert.Single(result.Issues, issue => issue.Number == 8);
+        Assert.Equal("open", openIssue.State);
+        var comment = Assert.Single(openIssue.Comments);
+        Assert.Contains("<!-- run:7 -->", comment);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task BuildBodyEmbedsAutoCloseStampWhenTrue()
     {
         var body = await InvokeHarnessAsync<string>(

--- a/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.harness.js
@@ -1,0 +1,57 @@
+const fs = require('node:fs/promises');
+const helper = require('../../../.github/workflows/monitor-scheduled-workflows.js');
+
+async function main() {
+    const inputPath = process.argv[2];
+    if (!inputPath) {
+        throw new Error('Expected the input payload file path as the first argument.');
+    }
+
+    const request = JSON.parse(await fs.readFile(inputPath, 'utf8'));
+    const result = await dispatch(request.operation, request.payload ?? {});
+    process.stdout.write(JSON.stringify({ result }));
+}
+
+async function dispatch(operation, payload) {
+    switch (operation) {
+        case 'buildMarker':
+            return helper.buildMarker(payload.workflowFile);
+
+        case 'buildIssueTitle':
+            return helper.buildIssueTitle(payload.displayName);
+
+        case 'decideAction':
+            return helper.decideAction({
+                conclusion: payload.conclusion ?? null,
+                issue: payload.issue ?? null,
+                failureConclusions: payload.selfReports ? helper.BACKSTOP_CONCLUSIONS : undefined,
+            });
+
+        case 'selectEnabled':
+            return helper.selectEnabled(payload.config);
+
+        case 'buildIssueBody':
+            return helper.buildIssueBody({
+                marker: payload.marker,
+                displayName: payload.displayName,
+                workflowFile: payload.workflowFile,
+                selfReports: payload.selfReports === true,
+            });
+
+        case 'formatComment':
+            return helper.formatComment({
+                runUrl: payload.runUrl ?? null,
+                runNumber: payload.runNumber ?? null,
+                sha: payload.sha ?? null,
+                conclusion: payload.conclusion,
+            });
+
+        default:
+            throw new Error(`Unsupported operation '${operation}'.`);
+    }
+}
+
+main().catch(error => {
+    process.stderr.write(`${error.stack ?? error}\n`);
+    process.exitCode = 1;
+});

--- a/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
@@ -1,0 +1,111 @@
+// Integration harness for the scheduled-workflow watchdog's run() orchestrator
+// (.github/workflows/monitor-scheduled-workflows.js). Drives run() against an
+// in-memory octokit fake so the dry-run no-mutation contract, comment-based
+// dedup, and close-on-green — all outside the reach of the pure-helper tests —
+// are exercised directly.
+//
+// Input payload (JSON, first argv):
+//   {
+//     "dryRun": true,
+//     "runsByFile": { "generate-api-diffs.yml": { "conclusion": "failure", "html_url": "...", "run_number": 9, "head_sha": "abcd", "updated_at": "..." } },
+//     "issues": [ { "number": 1, "body": "...", "state": "open" } ]
+//   }
+// A workflow file absent from runsByFile yields no completed run (noop). Output:
+//   { calls, issues: [ { number, state, body, labels, comments } ] }
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const monitor = require('../../../.github/workflows/monitor-scheduled-workflows.js');
+
+function makeGithub(store, runsByFile) {
+    const calls = [];
+    return {
+        calls,
+        paginate: async (fn, params) => (await fn(params)).data,
+        rest: {
+            issues: {
+                createLabel: async () => { calls.push('createLabel'); },
+                listForRepo: async ({ labels }) => {
+                    // Production narrows by the lookup label before the marker filter
+                    // (tracking-issue.js listOpenIssuesByLabel). Fail loudly if that
+                    // narrowing is ever dropped so the regression is caught here
+                    // rather than masked by the fake returning every open issue.
+                    if (!labels) {
+                        throw new Error('listForRepo must be called with a label filter');
+                    }
+                    return { data: store.issues.filter(issue => issue.state === 'open') };
+                },
+                create: async ({ title, body, labels }) => {
+                    calls.push('create');
+                    const issue = { number: store.next++, title, body, labels, state: 'open', comments: [] };
+                    store.issues.push(issue);
+                    return { data: issue };
+                },
+                update: async ({ issue_number, body, state }) => {
+                    calls.push('update');
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    if (body !== undefined) { issue.body = body; }
+                    if (state) { issue.state = state; }
+                },
+                listComments: async ({ issue_number }) => {
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    return { data: (issue?.comments ?? []).map(body => ({ body })) };
+                },
+                createComment: async ({ issue_number, body }) => {
+                    calls.push('createComment');
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    (issue.comments ??= []).push(body);
+                },
+            },
+            actions: {
+                listWorkflowRuns: async ({ workflow_id, branch, event, status }) => {
+                    // The watchdog must scan only completed scheduled runs on main.
+                    // A manual or push run leaking in would let a non-scheduled
+                    // success auto-close a real scheduled-failure issue (or a
+                    // non-scheduled failure file a false one). Fail loudly if any of
+                    // those filters is ever dropped so the regression is caught here.
+                    if (branch !== 'main' || event !== 'schedule' || status !== 'completed') {
+                        throw new Error(`listWorkflowRuns called without the scheduled-run filters (branch=${branch}, event=${event}, status=${status})`);
+                    }
+                    const run = runsByFile[workflow_id];
+                    return { data: { workflow_runs: run ? [run] : [] } };
+                },
+            },
+        },
+    };
+}
+
+async function main() {
+    const input = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+
+    const store = {
+        issues: (input.issues ?? []).map(issue => ({ comments: [], state: 'open', ...issue })),
+        next: input.nextNumber ?? 1000,
+    };
+    const github = makeGithub(store, input.runsByFile ?? {});
+    const core = { info: () => {}, warning: () => {} };
+    const context = { repo: { owner: 'microsoft', repo: 'aspire' } };
+
+    await monitor.run({ github, context, core, dryRun: input.dryRun === true });
+
+    process.stdout.write(JSON.stringify({
+        result: {
+            calls: github.calls,
+            issues: store.issues.map(issue => ({
+                number: issue.number,
+                state: issue.state,
+                body: issue.body,
+                labels: issue.labels ?? [],
+                comments: issue.comments ?? [],
+            })),
+        },
+    }));
+}
+
+main().catch(error => {
+    process.stderr.write(`${error.stack ?? error}\n`);
+    process.exitCode = 1;
+});

--- a/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
@@ -23,8 +23,10 @@ const monitor = require('../../../.github/workflows/monitor-scheduled-workflows.
 
 function makeGithub(store, runsByFile, { failUpdate }) {
     const calls = [];
+    const listRunRequests = [];
     return {
         calls,
+        listRunRequests,
         paginate: async (fn, params) => (await fn(params)).data,
         rest: {
             issues: {
@@ -59,6 +61,12 @@ function makeGithub(store, runsByFile, { failUpdate }) {
                 },
                 listComments: async ({ issue_number }) => {
                     const issue = store.issues.find(i => i.number === issue_number);
+                    if (!issue) {
+                        const error = new Error(`issue #${issue_number} not found`);
+                        error.status = 404;
+                        throw error;
+                    }
+
                     return { data: (issue?.comments ?? []).map(body => ({ body })) };
                 },
                 createComment: async ({ issue_number, body }) => {
@@ -68,7 +76,8 @@ function makeGithub(store, runsByFile, { failUpdate }) {
                 },
             },
             actions: {
-                listWorkflowRuns: async ({ workflow_id, branch, event, status }) => {
+                listWorkflowRuns: async ({ workflow_id, branch, event, status, per_page }) => {
+                    listRunRequests.push({ workflowId: workflow_id, perPage: per_page });
                     // The watchdog must scan only completed scheduled runs on main.
                     // A manual or push run leaking in would let a non-scheduled
                     // success auto-close a real scheduled-failure issue (or a
@@ -77,8 +86,8 @@ function makeGithub(store, runsByFile, { failUpdate }) {
                     if (branch !== 'main' || event !== 'schedule' || status !== 'completed') {
                         throw new Error(`listWorkflowRuns called without the scheduled-run filters (branch=${branch}, event=${event}, status=${status})`);
                     }
-                    const run = runsByFile[workflow_id];
-                    return { data: { workflow_runs: run ? [run] : [] } };
+                    const runs = runsByFile[workflow_id];
+                    return { data: { workflow_runs: Array.isArray(runs) ? runs : (runs ? [runs] : []) } };
                 },
             },
         },
@@ -93,12 +102,23 @@ async function main() {
         next: input.nextNumber ?? 1000,
     };
     const github = makeGithub(store, input.runsByFile ?? {}, { failUpdate: input.failUpdate === true });
-    const core = { info: () => {}, warning: () => {} };
+    const logs = [];
+    const warnings = [];
+    const core = {
+        info: message => logs.push(String(message)),
+        warning: message => warnings.push(String(message)),
+    };
     const context = { repo: { owner: 'microsoft', repo: 'aspire' } };
 
     let threw = false;
     try {
-        await monitor.run({ github, context, core, dryRun: input.dryRun === true });
+        await monitor.run({
+            github,
+            context,
+            core,
+            dryRun: input.dryRun === true,
+            now: input.now ? new Date(input.now) : undefined,
+        });
     } catch {
         threw = true;
     }
@@ -107,6 +127,9 @@ async function main() {
         result: {
             threw,
             calls: github.calls,
+            logs,
+            warnings,
+            listRunRequests: github.listRunRequests,
             issues: store.issues.map(issue => ({
                 number: issue.number,
                 state: issue.state,

--- a/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
@@ -8,10 +8,11 @@
 //   {
 //     "dryRun": true,
 //     "runsByFile": { "generate-api-diffs.yml": { "conclusion": "failure", "html_url": "...", "run_number": 9, "head_sha": "abcd", "updated_at": "..." } },
-//     "issues": [ { "number": 1, "body": "...", "state": "open" } ]
+//     "issues": [ { "number": 1, "body": "...", "state": "open" } ],
+//     "failUpdate": false
 //   }
 // A workflow file absent from runsByFile yields no completed run (noop). Output:
-//   { calls, issues: [ { number, state, body, labels, comments } ] }
+//   { threw, calls, issues: [ { number, state, body, labels, comments } ] }
 
 'use strict';
 
@@ -20,7 +21,7 @@ const path = require('node:path');
 
 const monitor = require('../../../.github/workflows/monitor-scheduled-workflows.js');
 
-function makeGithub(store, runsByFile) {
+function makeGithub(store, runsByFile, { failUpdate }) {
     const calls = [];
     return {
         calls,
@@ -28,7 +29,7 @@ function makeGithub(store, runsByFile) {
         rest: {
             issues: {
                 createLabel: async () => { calls.push('createLabel'); },
-                listForRepo: async ({ labels }) => {
+                listForRepo: async ({ labels, state }) => {
                     // Production narrows by the lookup label before the marker filter
                     // (tracking-issue.js listOpenIssuesByLabel). Fail loudly if that
                     // narrowing is ever dropped so the regression is caught here
@@ -36,7 +37,10 @@ function makeGithub(store, runsByFile) {
                     if (!labels) {
                         throw new Error('listForRepo must be called with a label filter');
                     }
-                    return { data: store.issues.filter(issue => issue.state === 'open') };
+                    const requestedState = state ?? 'open';
+                    return {
+                        data: store.issues.filter(issue => requestedState === 'all' || issue.state === requestedState),
+                    };
                 },
                 create: async ({ title, body, labels }) => {
                     calls.push('create');
@@ -46,6 +50,9 @@ function makeGithub(store, runsByFile) {
                 },
                 update: async ({ issue_number, body, state }) => {
                     calls.push('update');
+                    if (failUpdate) {
+                        throw new Error('transient update failure');
+                    }
                     const issue = store.issues.find(i => i.number === issue_number);
                     if (body !== undefined) { issue.body = body; }
                     if (state) { issue.state = state; }
@@ -85,14 +92,20 @@ async function main() {
         issues: (input.issues ?? []).map(issue => ({ comments: [], state: 'open', ...issue })),
         next: input.nextNumber ?? 1000,
     };
-    const github = makeGithub(store, input.runsByFile ?? {});
+    const github = makeGithub(store, input.runsByFile ?? {}, { failUpdate: input.failUpdate === true });
     const core = { info: () => {}, warning: () => {} };
     const context = { repo: { owner: 'microsoft', repo: 'aspire' } };
 
-    await monitor.run({ github, context, core, dryRun: input.dryRun === true });
+    let threw = false;
+    try {
+        await monitor.run({ github, context, core, dryRun: input.dryRun === true });
+    } catch {
+        threw = true;
+    }
 
     process.stdout.write(JSON.stringify({
         result: {
+            threw,
             calls: github.calls,
             issues: store.issues.map(issue => ({
                 number: issue.number,

--- a/tests/Infrastructure.Tests/WorkflowScripts/report-ci-failure.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/report-ci-failure.harness.js
@@ -1,0 +1,37 @@
+const fs = require('node:fs/promises');
+const helper = require('../../../.github/workflows/report-ci-failure.js');
+
+async function main() {
+    const inputPath = process.argv[2];
+    if (!inputPath) {
+        throw new Error('Expected the input payload file path as the first argument.');
+    }
+
+    const request = JSON.parse(await fs.readFile(inputPath, 'utf8'));
+    const result = await dispatch(request.operation, request.payload ?? {});
+    process.stdout.write(JSON.stringify({ result }));
+}
+
+async function dispatch(operation, payload) {
+    switch (operation) {
+        case 'buildMarker':
+            return helper.buildMarker(payload.ref);
+
+        case 'buildIssueTitle':
+            return helper.buildIssueTitle(payload.ref);
+
+        case 'buildIssueBody':
+            return helper.buildIssueBody({ marker: payload.marker, ref: payload.ref });
+
+        case 'formatComment':
+            return helper.formatComment({ run: payload.run });
+
+        default:
+            throw new Error(`Unsupported operation '${operation}'.`);
+    }
+}
+
+main().catch(error => {
+    process.stderr.write(`${error.stack ?? error}\n`);
+    process.exitCode = 1;
+});

--- a/tests/Infrastructure.Tests/WorkflowScripts/report-ci-failure.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/report-ci-failure.integration.harness.js
@@ -11,6 +11,7 @@
 //     "env": { "REF": "main", "CI_RED": "true", "CI_GREEN": "false" },
 //     "issues": [ { "number": 1, "body": "...", "state": "open" } ],
 //     "failComment": false,            // make createComment throw (transient failure)
+//     "failUpdate": false,             // make issues.update throw (transient failure)
 //     "runId": 12345, "runNumber": 7, "sha": "abcdef..."
 //   }
 // Output: { threw, calls, issues: [ { number, title, state, state_reason, body, labels, comments } ] }
@@ -21,7 +22,7 @@ const fs = require('node:fs');
 
 const reporter = require('../../../.github/workflows/report-ci-failure.js');
 
-function makeGithub(store, { failComment }) {
+function makeGithub(store, { failComment, failUpdate }) {
     const calls = [];
     return {
         calls,
@@ -29,7 +30,7 @@ function makeGithub(store, { failComment }) {
         rest: {
             issues: {
                 createLabel: async () => { calls.push('createLabel'); },
-                listForRepo: async ({ labels }) => {
+                listForRepo: async ({ labels, state }) => {
                     // Production narrows by the lookup label before the marker filter
                     // (tracking-issue.js listOpenIssuesByLabel). Fail loudly if that
                     // narrowing is ever dropped so the regression is caught here
@@ -37,7 +38,10 @@ function makeGithub(store, { failComment }) {
                     if (!labels) {
                         throw new Error('listForRepo must be called with a label filter');
                     }
-                    return { data: store.issues.filter(issue => issue.state === 'open') };
+                    const requestedState = state ?? 'open';
+                    return {
+                        data: store.issues.filter(issue => requestedState === 'all' || issue.state === requestedState),
+                    };
                 },
                 create: async ({ title, body, labels }) => {
                     calls.push('create');
@@ -47,6 +51,9 @@ function makeGithub(store, { failComment }) {
                 },
                 update: async ({ issue_number, body, state, state_reason }) => {
                     calls.push('update');
+                    if (failUpdate) {
+                        throw new Error('transient update failure');
+                    }
                     const issue = store.issues.find(i => i.number === issue_number);
                     if (body !== undefined) { issue.body = body; }
                     if (state) { issue.state = state; }
@@ -80,7 +87,7 @@ async function main() {
         issues: (input.issues ?? []).map(issue => ({ comments: [], state: 'open', ...issue })),
         next: input.nextNumber ?? 1000,
     };
-    const github = makeGithub(store, { failComment: input.failComment === true });
+    const github = makeGithub(store, { failComment: input.failComment === true, failUpdate: input.failUpdate === true });
     const core = { info: () => {}, warning: () => {} };
     const context = {
         repo: { owner: 'microsoft', repo: 'aspire' },

--- a/tests/Infrastructure.Tests/WorkflowScripts/report-ci-failure.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/report-ci-failure.integration.harness.js
@@ -1,0 +1,120 @@
+// Integration harness for the red-main reporter's reportFailure() and
+// resolveSuccess() orchestrators (.github/workflows/report-ci-failure.js). These
+// own the find-or-create + comment-dedup branching (reportFailure) and the
+// find-and-close branching (resolveSuccess) that the pure-helper tests cannot
+// reach, so this harness drives them against an in-memory fake of the octokit
+// surface they use and reports the resulting state.
+//
+// Input payload (JSON, first argv):
+//   {
+//     "operation": "reportFailure" | "resolveSuccess" | "track",
+//     "env": { "REF": "main", "CI_RED": "true", "CI_GREEN": "false" },
+//     "issues": [ { "number": 1, "body": "...", "state": "open" } ],
+//     "failComment": false,            // make createComment throw (transient failure)
+//     "runId": 12345, "runNumber": 7, "sha": "abcdef..."
+//   }
+// Output: { threw, calls, issues: [ { number, title, state, state_reason, body, labels, comments } ] }
+
+'use strict';
+
+const fs = require('node:fs');
+
+const reporter = require('../../../.github/workflows/report-ci-failure.js');
+
+function makeGithub(store, { failComment }) {
+    const calls = [];
+    return {
+        calls,
+        paginate: async (fn, params) => (await fn(params)).data,
+        rest: {
+            issues: {
+                createLabel: async () => { calls.push('createLabel'); },
+                listForRepo: async ({ labels }) => {
+                    // Production narrows by the lookup label before the marker filter
+                    // (tracking-issue.js listOpenIssuesByLabel). Fail loudly if that
+                    // narrowing is ever dropped so the regression is caught here
+                    // rather than masked by the fake returning every open issue.
+                    if (!labels) {
+                        throw new Error('listForRepo must be called with a label filter');
+                    }
+                    return { data: store.issues.filter(issue => issue.state === 'open') };
+                },
+                create: async ({ title, body, labels }) => {
+                    calls.push('create');
+                    const issue = { number: store.next++, title, body, labels, state: 'open', comments: [] };
+                    store.issues.push(issue);
+                    return { data: issue };
+                },
+                update: async ({ issue_number, body, state, state_reason }) => {
+                    calls.push('update');
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    if (body !== undefined) { issue.body = body; }
+                    if (state) { issue.state = state; }
+                    if (state_reason) { issue.state_reason = state_reason; }
+                },
+                listComments: async ({ issue_number }) => {
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    return { data: (issue?.comments ?? []).map(body => ({ body })) };
+                },
+                createComment: async ({ issue_number, body }) => {
+                    calls.push('createComment');
+                    if (failComment) {
+                        throw new Error('transient comment failure');
+                    }
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    (issue.comments ??= []).push(body);
+                },
+            },
+        },
+    };
+}
+
+async function main() {
+    const input = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+
+    for (const [key, value] of Object.entries(input.env ?? {})) {
+        process.env[key] = value;
+    }
+
+    const store = {
+        issues: (input.issues ?? []).map(issue => ({ comments: [], state: 'open', ...issue })),
+        next: input.nextNumber ?? 1000,
+    };
+    const github = makeGithub(store, { failComment: input.failComment === true });
+    const core = { info: () => {}, warning: () => {} };
+    const context = {
+        repo: { owner: 'microsoft', repo: 'aspire' },
+        runId: input.runId ?? 12345,
+        runNumber: input.runNumber ?? 7,
+        sha: input.sha ?? 'abcdef0123456789',
+    };
+
+    const operation = input.operation ?? 'reportFailure';
+    let threw = false;
+    try {
+        await reporter[operation]({ github, context, core });
+    } catch {
+        threw = true;
+    }
+
+    process.stdout.write(JSON.stringify({
+        result: {
+            threw,
+            calls: github.calls,
+            issues: store.issues.map(issue => ({
+                number: issue.number,
+                title: issue.title ?? null,
+                state: issue.state,
+                stateReason: issue.state_reason ?? null,
+                body: issue.body,
+                labels: issue.labels ?? [],
+                comments: issue.comments ?? [],
+            })),
+        },
+    }));
+}
+
+main().catch(error => {
+    process.stderr.write(`${error.stack ?? error}\n`);
+    process.exitCode = 1;
+});

--- a/tests/Infrastructure.Tests/WorkflowScripts/report-pipeline-failure.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/report-pipeline-failure.harness.js
@@ -1,0 +1,45 @@
+const fs = require('node:fs/promises');
+const helper = require('../../../.github/workflows/report-pipeline-failure.js');
+
+async function main() {
+    const inputPath = process.argv[2];
+    if (!inputPath) {
+        throw new Error('Expected the input payload file path as the first argument.');
+    }
+
+    const request = JSON.parse(await fs.readFile(inputPath, 'utf8'));
+    const result = await dispatch(request.operation, request.payload ?? {});
+    process.stdout.write(JSON.stringify({ result }));
+}
+
+async function dispatch(operation, payload) {
+    switch (operation) {
+        case 'buildMarker':
+            return helper.buildMarker(payload.workflowFile);
+
+        case 'buildIssueTitle':
+            return helper.buildIssueTitle(payload.displayName);
+
+        case 'buildIssueBody':
+            return helper.buildIssueBody({
+                marker: payload.marker,
+                displayName: payload.displayName,
+                workflowFile: payload.workflowFile,
+                cc: payload.cc,
+            });
+
+        case 'formatComment':
+            return helper.formatComment({
+                run: payload.run,
+                detail: payload.detail,
+            });
+
+        default:
+            throw new Error(`Unsupported operation '${operation}'.`);
+    }
+}
+
+main().catch(error => {
+    process.stderr.write(`${error.stack ?? error}\n`);
+    process.exitCode = 1;
+});

--- a/tests/Infrastructure.Tests/WorkflowScripts/report-pipeline-failure.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/report-pipeline-failure.integration.harness.js
@@ -30,7 +30,7 @@ function makeGithub(store, { failComment }) {
         rest: {
             issues: {
                 createLabel: async () => { calls.push('createLabel'); },
-                listForRepo: async ({ labels }) => {
+                listForRepo: async ({ labels, state }) => {
                     // Production narrows by the lookup label before the marker filter
                     // (tracking-issue.js listOpenIssuesByLabel). Fail loudly if that
                     // narrowing is ever dropped so the regression is caught here
@@ -38,7 +38,10 @@ function makeGithub(store, { failComment }) {
                     if (!labels) {
                         throw new Error('listForRepo must be called with a label filter');
                     }
-                    return { data: store.issues.filter(issue => issue.state === 'open') };
+                    const requestedState = state ?? 'open';
+                    return {
+                        data: store.issues.filter(issue => requestedState === 'all' || issue.state === requestedState),
+                    };
                 },
                 create: async ({ title, body, labels }) => {
                     calls.push('create');

--- a/tests/Infrastructure.Tests/WorkflowScripts/report-pipeline-failure.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/report-pipeline-failure.integration.harness.js
@@ -1,0 +1,124 @@
+// Integration harness for the nightly-pipeline failure reporter's report()
+// orchestrator (.github/workflows/report-pipeline-failure.js). report() owns the
+// find-or-create + comment-dedup branching that the pure-helper tests cannot
+// reach, so this harness drives it against an in-memory fake of the octokit
+// surface it uses and reports the resulting state.
+//
+// Input payload (JSON, first argv):
+//   {
+//     "env": { "WORKFLOW_FILE": "...", "DISPLAY_NAME": "..." },
+//     "labels": ["automation-broken", "area-testing", "deployment-e2e"],
+//     "cc": "@microsoft/aspire-team",      // optional body @mention
+//     "commentDetail": "extra markdown",   // optional per-run comment detail
+//     "issues": [ { "number": 1, "body": "...", "state": "open" } ],
+//     "failComment": false,                // make createComment throw (transient failure)
+//     "runId": 12345, "runNumber": 7, "sha": "abcdef..."
+//   }
+// Output: { threw, calls, issues: [ { number, title, state, body, labels, comments } ] }
+
+'use strict';
+
+const fs = require('node:fs');
+
+const reporter = require('../../../.github/workflows/report-pipeline-failure.js');
+
+function makeGithub(store, { failComment }) {
+    const calls = [];
+    return {
+        calls,
+        paginate: async (fn, params) => (await fn(params)).data,
+        rest: {
+            issues: {
+                createLabel: async () => { calls.push('createLabel'); },
+                listForRepo: async ({ labels }) => {
+                    // Production narrows by the lookup label before the marker filter
+                    // (tracking-issue.js listOpenIssuesByLabel). Fail loudly if that
+                    // narrowing is ever dropped so the regression is caught here
+                    // rather than masked by the fake returning every open issue.
+                    if (!labels) {
+                        throw new Error('listForRepo must be called with a label filter');
+                    }
+                    return { data: store.issues.filter(issue => issue.state === 'open') };
+                },
+                create: async ({ title, body, labels }) => {
+                    calls.push('create');
+                    const issue = { number: store.next++, title, body, labels, state: 'open', comments: [] };
+                    store.issues.push(issue);
+                    return { data: issue };
+                },
+                update: async ({ issue_number, body, state, state_reason }) => {
+                    calls.push('update');
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    if (body !== undefined) { issue.body = body; }
+                    if (state) { issue.state = state; }
+                    if (state_reason) { issue.state_reason = state_reason; }
+                },
+                listComments: async ({ issue_number }) => {
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    return { data: (issue?.comments ?? []).map(body => ({ body })) };
+                },
+                createComment: async ({ issue_number, body }) => {
+                    calls.push('createComment');
+                    if (failComment) {
+                        throw new Error('transient comment failure');
+                    }
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    (issue.comments ??= []).push(body);
+                },
+            },
+        },
+    };
+}
+
+async function main() {
+    const input = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+
+    for (const [key, value] of Object.entries(input.env ?? {})) {
+        process.env[key] = value;
+    }
+
+    const store = {
+        issues: (input.issues ?? []).map(issue => ({ comments: [], state: 'open', ...issue })),
+        next: input.nextNumber ?? 1000,
+    };
+    const github = makeGithub(store, { failComment: input.failComment === true });
+    const core = { info: () => {}, warning: () => {} };
+    const context = {
+        repo: { owner: 'microsoft', repo: 'aspire' },
+        runId: input.runId ?? 12345,
+        runNumber: input.runNumber ?? 7,
+        sha: input.sha ?? 'abcdef0123456789',
+    };
+
+    let threw = false;
+    try {
+        await reporter.report({
+            github, context, core,
+            labels: input.labels ?? ['automation-broken'],
+            cc: input.cc ?? '',
+            commentDetail: input.commentDetail ?? '',
+        });
+    } catch {
+        threw = true;
+    }
+
+    process.stdout.write(JSON.stringify({
+        result: {
+            threw,
+            calls: github.calls,
+            issues: store.issues.map(issue => ({
+                number: issue.number,
+                title: issue.title ?? null,
+                state: issue.state,
+                body: issue.body,
+                labels: issue.labels ?? [],
+                comments: issue.comments ?? [],
+            })),
+        },
+    }));
+}
+
+main().catch(error => {
+    process.stderr.write(`${error.stack ?? error}\n`);
+    process.exitCode = 1;
+});

--- a/tests/Infrastructure.Tests/WorkflowScripts/report-specialized-test-failures.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/report-specialized-test-failures.harness.js
@@ -1,0 +1,58 @@
+const fs = require('node:fs/promises');
+const helper = require('../../../.github/workflows/report-specialized-test-failures.js');
+
+async function main() {
+    const inputPath = process.argv[2];
+    if (!inputPath) {
+        throw new Error('Expected the input payload file path as the first argument.');
+    }
+
+    const request = JSON.parse(await fs.readFile(inputPath, 'utf8'));
+    const result = await dispatch(request.operation, request.payload ?? {});
+    process.stdout.write(JSON.stringify({ result }));
+}
+
+async function dispatch(operation, payload) {
+    switch (operation) {
+        case 'buildMarker':
+            return helper.buildMarker(payload.workflowFile, payload.kind);
+
+        case 'labelForKind':
+            return helper.labelForKind(payload.kind);
+
+        case 'buildIssueTitle':
+            return helper.buildIssueTitle(payload.displayName, payload.kind);
+
+        case 'classifyFailure':
+            return helper.classifyFailure({
+                result: payload.result,
+                failedCount: payload.failedCount ?? 0,
+                ignoreTestFailures: payload.ignoreTestFailures ?? false,
+                extractionFailed: payload.extractionFailed ?? false,
+            });
+
+        case 'buildIssueBody':
+            return helper.buildIssueBody({
+                marker: payload.marker,
+                displayName: payload.displayName,
+                workflowFile: payload.workflowFile,
+                kind: payload.kind,
+            });
+
+        case 'formatComment':
+            return helper.formatComment({
+                kind: payload.kind,
+                run: payload.run,
+                failedTests: payload.failedTests ?? [],
+                maxListed: payload.maxListed,
+            });
+
+        default:
+            throw new Error(`Unsupported operation '${operation}'.`);
+    }
+}
+
+main().catch(error => {
+    process.stderr.write(`${error.stack ?? error}\n`);
+    process.exitCode = 1;
+});

--- a/tests/Infrastructure.Tests/WorkflowScripts/specialized-test-failure-runner.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/specialized-test-failure-runner.harness.js
@@ -32,7 +32,7 @@ function makeGithub(store, { failComment }) {
         rest: {
             issues: {
                 createLabel: async () => { calls.push('createLabel'); },
-                listForRepo: async ({ labels }) => {
+                listForRepo: async ({ labels, state }) => {
                     // Production narrows by the lookup label before the marker filter
                     // (tracking-issue.js listOpenIssuesByLabel). Fail loudly if that
                     // narrowing is ever dropped so the regression is caught here
@@ -40,7 +40,10 @@ function makeGithub(store, { failComment }) {
                     if (!labels) {
                         throw new Error('listForRepo must be called with a label filter');
                     }
-                    return { data: store.issues.filter(issue => issue.state === 'open') };
+                    const requestedState = state ?? 'open';
+                    return {
+                        data: store.issues.filter(issue => requestedState === 'all' || issue.state === requestedState),
+                    };
                 },
                 create: async ({ title, body, labels }) => {
                     calls.push('create');

--- a/tests/Infrastructure.Tests/WorkflowScripts/specialized-test-failure-runner.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/specialized-test-failure-runner.harness.js
@@ -1,0 +1,121 @@
+// Integration harness for the specialized-test failure reporter's network
+// orchestration (.github/workflows/specialized-test-failure-runner.js). The runner
+// owns the create-vs-append-vs-dedup branching and the comment/body ordering that
+// pure-helper tests cannot reach, so this harness drives it against an in-memory
+// fake of the octokit surface it uses and reports the resulting state.
+//
+// Input payload (JSON, first argv):
+//   {
+//     "env": { "WORKFLOW_FILE": "...", "DISPLAY_NAME": "...", "IGNORE_TEST_FAILURES": "false" },
+//     "failedTests": ["A.B.C"] | null,   // when set, written to a temp file referenced by FAILED_TESTS_PATH
+//     "omitFailedTestsPath": true,       // when true, FAILED_TESTS_PATH is left unset (extract-step crash)
+//     "issues": [ { "number": 1, "body": "...", "state": "open" } ],
+//     "failComment": false,              // make createComment throw (transient failure)
+//     "runId": 12345, "runNumber": 7
+//   }
+// Output: { threw, calls, issues: [ { number, title, state, body, comments } ] }
+
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const reporter = require('../../../.github/workflows/report-specialized-test-failures.js');
+const runner = require('../../../.github/workflows/specialized-test-failure-runner.js');
+
+function makeGithub(store, { failComment }) {
+    const calls = [];
+    return {
+        calls,
+        paginate: async (fn, params) => (await fn(params)).data,
+        rest: {
+            issues: {
+                createLabel: async () => { calls.push('createLabel'); },
+                listForRepo: async ({ labels }) => {
+                    // Production narrows by the lookup label before the marker filter
+                    // (tracking-issue.js listOpenIssuesByLabel). Fail loudly if that
+                    // narrowing is ever dropped so the regression is caught here
+                    // rather than masked by the fake returning every open issue.
+                    if (!labels) {
+                        throw new Error('listForRepo must be called with a label filter');
+                    }
+                    return { data: store.issues.filter(issue => issue.state === 'open') };
+                },
+                create: async ({ title, body, labels }) => {
+                    calls.push('create');
+                    const issue = { number: store.next++, title, body, labels, state: 'open', comments: [] };
+                    store.issues.push(issue);
+                    return { data: issue };
+                },
+                update: async ({ issue_number, body, state, state_reason }) => {
+                    calls.push('update');
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    if (body !== undefined) { issue.body = body; }
+                    if (state) { issue.state = state; }
+                    if (state_reason) { issue.state_reason = state_reason; }
+                },
+                listComments: async ({ issue_number }) => {
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    return { data: (issue?.comments ?? []).map(body => ({ body })) };
+                },
+                createComment: async ({ issue_number, body }) => {
+                    calls.push('createComment');
+                    if (failComment) {
+                        throw new Error('transient comment failure');
+                    }
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    (issue.comments ??= []).push(body);
+                },
+            },
+        },
+    };
+}
+
+async function main() {
+    const input = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+
+    for (const [key, value] of Object.entries(input.env ?? {})) {
+        process.env[key] = value;
+    }
+    delete process.env.FAILED_TESTS_PATH;
+    if (!input.omitFailedTestsPath && Array.isArray(input.failedTests)) {
+        const tempPath = path.join(os.tmpdir(), `failed-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+        fs.writeFileSync(tempPath, JSON.stringify({ failedTests: input.failedTests, count: input.failedTests.length }));
+        process.env.FAILED_TESTS_PATH = tempPath;
+    }
+
+    const store = {
+        issues: (input.issues ?? []).map(issue => ({ comments: [], state: 'open', ...issue })),
+        next: input.nextNumber ?? 1000,
+    };
+    const github = makeGithub(store, { failComment: input.failComment === true });
+    const core = { info: () => {}, warning: () => {} };
+    const context = { repo: { owner: 'microsoft', repo: 'aspire' }, runId: input.runId ?? 12345, runNumber: input.runNumber ?? 7 };
+
+    let threw = false;
+    try {
+        await runner({ github, context, core, reporter });
+    } catch {
+        threw = true;
+    }
+
+    process.stdout.write(JSON.stringify({
+        result: {
+            threw,
+            calls: github.calls,
+            issues: store.issues.map(issue => ({
+                number: issue.number,
+                title: issue.title ?? null,
+                state: issue.state,
+                body: issue.body,
+                comments: issue.comments ?? [],
+            })),
+        },
+    }));
+}
+
+main().catch(error => {
+    process.stderr.write(`${error.stack ?? error}\n`);
+    process.exitCode = 1;
+});

--- a/tests/Infrastructure.Tests/WorkflowScripts/tracking-issue.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/tracking-issue.harness.js
@@ -1,0 +1,116 @@
+const fs = require('node:fs/promises');
+const engine = require('../../../.github/workflows/tracking-issue.js');
+
+async function main() {
+    const inputPath = process.argv[2];
+    if (!inputPath) {
+        throw new Error('Expected the input payload file path as the first argument.');
+    }
+
+    const request = JSON.parse(await fs.readFile(inputPath, 'utf8'));
+    const result = await dispatch(request.operation, request.payload ?? {});
+    process.stdout.write(JSON.stringify({ result }));
+}
+
+// In-memory octokit fake mirroring the surface recordRun touches, so the
+// find-or-create + comment-dedup contract can be exercised without a network.
+// Comments are stored as plain strings; listComments adapts them to { body }.
+function makeGithub(store) {
+    const calls = [];
+    return {
+        calls,
+        paginate: async (fn, params) => (await fn(params)).data,
+        rest: {
+            issues: {
+                listForRepo: async ({ labels }) => {
+                    // Production narrows by the lookup label before the marker filter
+                    // (tracking-issue.js listOpenIssuesByLabel). Fail loudly if that
+                    // narrowing is ever dropped so the regression is caught here
+                    // rather than masked by the fake returning every open issue.
+                    if (!labels) {
+                        throw new Error('listForRepo must be called with a label filter');
+                    }
+                    return { data: store.issues.filter(issue => issue.state === 'open') };
+                },
+                create: async ({ title, body, labels }) => {
+                    calls.push('create');
+                    const issue = { number: store.next++, title, body, labels, state: 'open', comments: [] };
+                    store.issues.push(issue);
+                    return { data: issue };
+                },
+                listComments: async ({ issue_number }) => {
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    return { data: (issue?.comments ?? []).map(body => ({ body })) };
+                },
+                createComment: async ({ issue_number, body }) => {
+                    calls.push('createComment');
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    (issue.comments ??= []).push(body);
+                },
+            },
+        },
+    };
+}
+
+async function dispatch(operation, payload) {
+    switch (operation) {
+        case 'findOpenIssueForMarker': {
+            const issue = engine.findOpenIssueForMarker(payload.issues ?? [], payload.marker);
+            return { number: issue ? issue.number : null };
+        }
+
+        case 'runMarker':
+            return engine.runMarker(payload.runId);
+
+        case 'buildBody':
+            return engine.buildBody({
+                marker: payload.marker,
+                lead: payload.lead ?? 'lead',
+                note: payload.note ?? ['note'],
+                autoClose: payload.autoClose,
+            });
+
+        case 'readAutoClose':
+            return { value: engine.readAutoClose(payload.body) };
+
+        case 'recordRun': {
+            const store = {
+                issues: (payload.issues ?? []).map(issue => ({ comments: [], state: 'open', ...issue })),
+                next: payload.nextNumber ?? 1000,
+            };
+            const github = makeGithub(store);
+            const core = { info: () => {}, warning: () => {} };
+            const context = { repo: { owner: 'microsoft', repo: 'aspire' } };
+
+            const result = await engine.recordRun(github, context, core, {
+                label: payload.label ?? 'automation-broken',
+                labels: payload.labels,
+                marker: payload.marker,
+                title: payload.title ?? 'Tracking issue',
+                runId: payload.runId,
+                buildBody: () => payload.body ?? `${payload.marker}\n\nbody`,
+                comment: payload.comment ?? 'failure',
+            });
+
+            return {
+                result,
+                calls: github.calls,
+                issues: store.issues.map(issue => ({
+                    number: issue.number,
+                    state: issue.state,
+                    body: issue.body,
+                    labels: issue.labels ?? [],
+                    comments: issue.comments ?? [],
+                })),
+            };
+        }
+
+        default:
+            throw new Error(`Unsupported operation '${operation}'.`);
+    }
+}
+
+main().catch(error => {
+    process.stderr.write(`${error.stack ?? error}\n`);
+    process.exitCode = 1;
+});

--- a/tests/Infrastructure.Tests/WorkflowScripts/tracking-issue.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/tracking-issue.harness.js
@@ -22,7 +22,7 @@ function makeGithub(store) {
         paginate: async (fn, params) => (await fn(params)).data,
         rest: {
             issues: {
-                listForRepo: async ({ labels }) => {
+                listForRepo: async ({ labels, state }) => {
                     // Production narrows by the lookup label before the marker filter
                     // (tracking-issue.js listOpenIssuesByLabel). Fail loudly if that
                     // narrowing is ever dropped so the regression is caught here
@@ -30,13 +30,21 @@ function makeGithub(store) {
                     if (!labels) {
                         throw new Error('listForRepo must be called with a label filter');
                     }
-                    return { data: store.issues.filter(issue => issue.state === 'open') };
+                    const requestedState = state ?? 'open';
+                    return {
+                        data: store.issues.filter(issue => requestedState === 'all' || issue.state === requestedState),
+                    };
                 },
                 create: async ({ title, body, labels }) => {
                     calls.push('create');
                     const issue = { number: store.next++, title, body, labels, state: 'open', comments: [] };
                     store.issues.push(issue);
                     return { data: issue };
+                },
+                update: async ({ issue_number, state }) => {
+                    calls.push('update');
+                    const issue = store.issues.find(i => i.number === issue_number);
+                    if (state) { issue.state = state; }
                 },
                 listComments: async ({ issue_number }) => {
                     const issue = store.issues.find(i => i.number === issue_number);

--- a/tools/GenerateTestSummary/Program.cs
+++ b/tools/GenerateTestSummary/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using System.Text.Json;
 using System.CommandLine;
 using Aspire.TestTools;
 
@@ -13,13 +14,19 @@ var dirPathOrTrxFilePathArgument = new Argument<string>("dirPathOrTrxFilePath");
 var outputOption = new Option<string>("--output", "-o") { Description = "Output file path" };
 var combinedSummaryOption = new Option<bool>("--combined", "-c") { Description = "Generate combined summary report" };
 var urlOption = new Option<string>("--url", "-u") { Description = "URL for test links" };
+// Emits a machine-readable list of failed test names instead of the markdown
+// report. Consumed by the outerloop failure-issue reporter
+// (.github/workflows/report-specialized-test-failures.js) to decide whether a
+// failed run was a test failure (non-empty) or an infrastructure break (empty).
+var failedTestsJsonOption = new Option<string>("--failed-tests-json") { Description = "Write distinct failed test names as JSON to this path and exit" };
 
 var rootCommand = new RootCommand
 {
     dirPathOrTrxFilePathArgument,
     outputOption,
     combinedSummaryOption,
-    urlOption
+    urlOption,
+    failedTestsJsonOption
 };
 
 rootCommand.SetAction(result =>
@@ -28,6 +35,13 @@ rootCommand.SetAction(result =>
     if (string.IsNullOrEmpty(dirPathOrTrxFilePath))
     {
         Console.WriteLine("Error: Please provide a directory path with trx files or a trx file path.");
+        return;
+    }
+
+    var failedTestsJsonPath = result.GetValue<string>(failedTestsJsonOption);
+    if (!string.IsNullOrEmpty(failedTestsJsonPath))
+    {
+        WriteFailedTestsJson(dirPathOrTrxFilePath, failedTestsJsonPath);
         return;
     }
 
@@ -110,3 +124,70 @@ rootCommand.SetAction(result =>
 });
 
 return rootCommand.Parse(args).Invoke();
+
+// Collects distinct failed test names across every .trx under the given path and
+// writes them as JSON: { "failedTests": [...], "count": N, "extractionFailed": bool }.
+// "Failed", "Error", "Timeout", and "Aborted" all count as failures;
+// "Passed"/"NotExecuted" are ignored. The list is sorted for stable, diff-friendly
+// output.
+//
+// extractionFailed is true when at least one .trx could not be read AND no failures
+// were collected from the ones that did. In that case a "zero failures" result
+// cannot be trusted — an unreadable .trx may have held the failures — so the
+// reporter treats the red run as a test failure (not infra) rather than silently
+// dropping the failing-test signal. This includes the partial case: if some .trx
+// read cleanly with zero failures but another could not be read, the result is
+// still flagged. extractionFailed is false only when every .trx read without error
+// (any failure count, including zero, is then trustworthy) or when at least one
+// failure was collected.
+//
+// Uses GetDetailedTestResultsFromTrx, NOT GetTestResultsFromTrx: the latter calls
+// TimeSpan.Parse on the UnitTestResult startTime/endTime attributes, which real
+// MTP `--report-trx` files emit as ISO-8601 DateTimeOffset (e.g.
+// "2026-06-08T18:34:22.1234567+00:00"). TimeSpan.Parse throws FormatException on
+// those, which would make this path silently skip every real .trx. The detailed
+// reader does not parse timestamps and also resolves the fully-qualified
+// CanonicalName from the TRX TestDefinitions.
+static void WriteFailedTestsJson(string dirPathOrTrxFilePath, string outputPath)
+{
+    var trxFiles = Directory.Exists(dirPathOrTrxFilePath)
+        ? Directory.EnumerateFiles(dirPathOrTrxFilePath, "*.trx", SearchOption.AllDirectories).ToList()
+        : [dirPathOrTrxFilePath];
+
+    // Mirror the failed-outcome set used by the sibling failing-test tooling
+    // (tools/CreateFailingTestIssue/FailingTestIssueCommand.cs) so an aborted test
+    // is not silently dropped — a red run with only aborted results would otherwise
+    // report zero failures and be misfiled as infrastructure.
+    var failedOutcomes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Failed", "Error", "Timeout", "Aborted" };
+    var failedTests = new SortedSet<string>(StringComparer.Ordinal);
+    var readErrors = 0;
+
+    foreach (var trxFile in trxFiles)
+    {
+        IList<DetailedTestResult> results;
+        try
+        {
+            results = TrxReader.GetDetailedTestResultsFromTrx(trxFile, result => failedOutcomes.Contains(result.Outcome));
+        }
+        catch (Exception ex)
+        {
+            // A single malformed/partial .trx must not lose the failures recorded
+            // in the others — log and keep scanning. If every .trx fails this way
+            // (readErrors > 0 with zero collected failures), extractionFailed below
+            // flags the result as untrustworthy.
+            readErrors++;
+            Console.WriteLine($"Warning: could not read '{trxFile}': {ex.Message}");
+            continue;
+        }
+
+        foreach (var testResult in results)
+        {
+            failedTests.Add(testResult.CanonicalName);
+        }
+    }
+
+    var extractionFailed = readErrors > 0 && failedTests.Count == 0;
+    var payload = new { failedTests = failedTests.ToArray(), count = failedTests.Count, extractionFailed };
+    File.WriteAllText(outputPath, JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+    Console.WriteLine($"Wrote {failedTests.Count} failed test name(s) to {outputPath} (extractionFailed={extractionFailed}).");
+}


### PR DESCRIPTION
## What's broken / missing

**Scheduled GitHub Actions workflows fail silently.** GitHub only emails whoever last edited the workflow file, so a broken nightly automation job — or a failing **outerloop** / **quarantine** run — can sit unnoticed for days.

**Worse, the nightly Deployment E2E job actively spams duplicates.** Its inline issue script keyed the title on the date and deduped only against *today's* issues:

```js
const issueTitle = `[Deployment E2E] Nightly test failure - ${date}`;
// dedup: issue.title.includes(date) ...
```

So every failing day filed a **brand-new issue**, accumulating one duplicate per day instead of tracking a single ongoing failure.

## What this adds

A shared engine plus four reporters, all deterministic (plain Actions + JS, no model budget):

**Shared engine — `tracking-issue.js`** — one deduplicated issue per subject, identified by a hidden HTML-comment marker, carrying a fenced run-table that appends one row per failed run (cap 50). It owns the mechanics; callers own content + policy.

**Scheduled-automation watchdog — `monitor-scheduled-workflows.yml`** (every 2h) — watches a config-driven list of silent automations; files/appends one `automation-broken` issue per workflow and **auto-closes on the next green run**. Watch list in `monitor-scheduled-workflows.config.json`.

**Outerloop / quarantine reporter — `report-specialized-test-failures.js`** — on a scheduled failure files either a `failing-test` issue listing the failed tests, or an `automation-broken` infra issue when the run broke before producing results.

**Red-main reporter — `report-ci-failure.js`** (wired into `ci.yml`) — files/updates one issue per branch when a push to `main` / `release/**` is red, and closes it when a later push is green.

**Nightly pipeline reporter — `report-pipeline-failure.js`** (wired into `deployment-tests.yml`, `tests-daily-smoke.yml`) — replaces the duplicate-prone inline scripts with the shared engine: one deduplicated issue per workflow, one comment per failed run. **This is what fixes the Deployment E2E duplication above.**

**`GenerateTestSummary --failed-tests-json`** — extracts distinct failed test names from TRX (`{ failedTests, count, extractionFailed }`) so a reporter can tell a real test failure from an infra break.

## Why a watchdog *and* in-pipeline reporters

The external watchdog only knows *"the latest run failed."* Telling an infra break from a genuine test failure needs the run's TRX results, which only exist **inside** the pipeline. So outerloop/quarantine/nightly get in-pipeline reporters that read their own results; the remaining silent automations get the external watchdog.

## Design notes

- Pure decision/formatting logic is unit-tested via node harnesses invoked from xUnit (`tests/Infrastructure.Tests/WorkflowScripts/`); the network orchestrators are covered by integration tests against an in-memory octokit fake.
- Dedup is via hidden markers. The watchdog (`automation-broken:<file>`) and in-pipeline reporters (`ci-failure:<file>[:<kind>]`) use **disjoint** markers, so they never manage each other's issues.
- Only **scheduled** / protected-branch-push runs file issues — PR-triggered runs never do.

## Call-outs

- The `paths:` filters on the quarantine / outerloop / pipeline workflows mean **those workflows run on this PR** — verify they pass before merging.
