### PR TITLE
Expose IServiceProvider and callback contexts to ATS polyglot hosts

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.Java/Resources/Transport.java
+++ b/src/Aspire.Hosting.CodeGeneration.Java/Resources/Transport.java
@@ -63,6 +63,37 @@ class CancellationToken {
     private volatile boolean cancelled = false;
     private final List<Runnable> listeners = new CopyOnWriteArrayList<>();
 
+    // Remote token id supplied by the AppHost when this token is materialized for a
+    // callback argument. Null for locally-created tokens. Retained so cancellation can
+    // be correlated back to the AppHost if needed.
+    private final String remoteTokenId;
+
+    CancellationToken() {
+        this.remoteTokenId = null;
+    }
+
+    private CancellationToken(String remoteTokenId) {
+        this.remoteTokenId = remoteTokenId;
+    }
+
+    /**
+     * Materializes a cancellation token from a transport value sent by the AppHost.
+     * When the AppHost invokes a callback that accepts a CancellationToken it passes a
+     * remote token id (a string); generated code calls this to turn that wire value into
+     * a CancellationToken instance. Mirrors the TypeScript/Go SDK behavior.
+     */
+    static CancellationToken fromValue(Object value) {
+        if (value instanceof CancellationToken token) {
+            return token;
+        }
+        if (value instanceof String tokenId) {
+            return new CancellationToken(tokenId);
+        }
+        return new CancellationToken();
+    }
+
+    String getRemoteTokenId() { return remoteTokenId; }
+
     void cancel() {
         cancelled = true;
         for (Runnable listener : listeners) {

--- a/src/Aspire.Hosting.CodeGeneration.Python/AtsPythonCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Python/AtsPythonCodeGenerator.cs
@@ -334,8 +334,14 @@ internal sealed class AtsPythonCodeGenerator : ICodeGenerator
             var capWithExtra = items.First(c => c.Parameters.Any(p => string.Equals(p.Name, extraParamName, StringComparison.Ordinal)));
             var extraParam = capWithExtra.Parameters.First(p => string.Equals(p.Name, extraParamName, StringComparison.Ordinal));
 
-            // Only merge if the extra param is required (not already optional)
-            if (extraParam.IsOptional || extraParam.IsNullable)
+            // Only merge if the extra param is required (not already optional).
+            // Never merge when the differing parameter is a callback: a callback cannot be represented as a
+            // positional tuple element, so merging would (a) change the option shape from the published
+            // `str | tuple[...]` shorthand to a TypedDict (a breaking change for the non-callback overload)
+            // and (b) require conditional capability dispatch that always registers the callback argument even
+            // when routing to the non-callback capability. Keeping the callback overload as its own separate
+            // option avoids both problems.
+            if (extraParam.IsOptional || extraParam.IsNullable || extraParam.IsCallback)
             {
                 result.AddRange(items);
                 continue;

--- a/src/Aspire.Hosting/ApplicationModel/ContainerBuildOptionsCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerBuildOptionsCallbackAnnotation.cs
@@ -37,6 +37,7 @@ public sealed class ContainerBuildOptionsCallbackAnnotation(Func<ContainerBuildO
 /// Context for configuring container build options via a callback.
 /// </summary>
 [Experimental("ASPIREPIPELINES003", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[AspireExport(ExposeProperties = true)]
 public sealed class ContainerBuildOptionsCallbackContext
 {
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
@@ -9,6 +9,12 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents a base class for file system entries in a container.
 /// </summary>
+/// <remarks>
+/// Exported to ATS as an opaque handle type. Polyglot app hosts never construct or inspect these
+/// directly; they create concrete entries through the factory methods on
+/// <see cref="ContainerFileSystemCallbackContext"/> and pass the resulting handles back via the callback.
+/// </remarks>
+[AspireExport]
 public abstract class ContainerFileSystemItem
 {
     private string? _name;
@@ -266,23 +272,152 @@ public sealed class ContainerFileSystemCallbackAnnotation : IResourceAnnotation
 /// <summary>
 /// Represents the context for a <see cref="ContainerFileSystemCallbackAnnotation"/> callback.
 /// </summary>
+[AspireExport]
 public sealed class ContainerFileSystemCallbackContext
 {
     /// <summary>
     /// A <see cref="IServiceProvider"/> that can be used to resolve services in the callback.
     /// </summary>
+    [AspireExport(MethodName = "services")]
     public required IServiceProvider ServiceProvider { get; init; }
 
     /// <summary>
     /// The app model resource the callback is associated with.
     /// </summary>
+    [AspireExport]
     public required IResource Model { get; init; }
 
     /// <summary>
     /// The path to the server authentication certificate file inside the container.
     /// </summary>
     [Experimental("ASPIRECERTIFICATES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [AspireExportIgnore(Reason = "HttpsCertificateContext is an experimental certificate-specific type that is not yet part of the ATS surface.")]
     public ContainerFileSystemCallbackHttpsCertificateContext? HttpsCertificateContext { get; set; }
+}
+
+// The CreateFile/CreateCertificateFile/CreateDirectory shims below exist ONLY so that polyglot app hosts can
+// construct ContainerFileSystemItem entries to return from the callback. In C# the callback creates the
+// concrete entry types (ContainerFile/ContainerOpenSSLCertificateFile/ContainerDirectory) directly via object
+// initializers, so there is no reason to surface these as public C# API. They are therefore kept as internal
+// static extension methods on the (exported) context — the same shim pattern used for the builder exports —
+// which keeps them out of the public C# surface while still being picked up by the ATS exporter. ATS cannot
+// represent the abstract, recursive, polymorphic entry hierarchy as DTOs, so each shim returns the abstract
+// base type as an opaque handle, which keeps entries assignable to the directory `entries` parameter and the
+// callback result across all guest languages.
+internal static class ContainerFileSystemCallbackContextExtensions
+{
+    /// <summary>
+    /// Creates a file entry to return from the callback.
+    /// </summary>
+    /// <param name="context">The callback context.</param>
+    /// <param name="name">The simple file name (no path separators).</param>
+    /// <param name="contents">The inline UTF-8 contents of the file. Mutually exclusive with <paramref name="sourcePath"/>.</param>
+    /// <param name="sourcePath">An absolute path to a file on the host to copy. Mutually exclusive with <paramref name="contents"/>.</param>
+    /// <param name="owner">The owner UID, or <see langword="null"/> to inherit.</param>
+    /// <param name="group">The group GID, or <see langword="null"/> to inherit.</param>
+    /// <param name="mode">The Unix file mode as an integer (for example <c>0o644</c>), or <see langword="null"/> to inherit.</param>
+    /// <param name="continueOnError">Whether to ignore errors creating this file.</param>
+    /// <returns>The created file entry.</returns>
+    /// <ats-summary>Creates a container file entry with inline contents or a host source path.</ats-summary>
+    /// <ats-returns>The created file entry.</ats-returns>
+    [AspireExport]
+    internal static ContainerFileSystemItem CreateFile(this ContainerFileSystemCallbackContext context, string name, string? contents = null, string? sourcePath = null, int? owner = null, int? group = null, int? mode = null, bool? continueOnError = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        return new ContainerFile
+        {
+            Name = name,
+            Contents = contents,
+            SourcePath = sourcePath,
+            Owner = owner,
+            Group = group,
+            Mode = ConvertMode(mode),
+            ContinueOnError = continueOnError,
+        };
+    }
+
+    /// <summary>
+    /// Creates an OpenSSL public certificate file entry to return from the callback. An OpenSSL-compatible
+    /// subject-hash symlink is created alongside it in the container.
+    /// </summary>
+    /// <param name="context">The callback context.</param>
+    /// <param name="name">The simple file name (no path separators).</param>
+    /// <param name="contents">The inline PEM-encoded contents of the certificate. Mutually exclusive with <paramref name="sourcePath"/>.</param>
+    /// <param name="sourcePath">An absolute path to a PEM file on the host to copy. Mutually exclusive with <paramref name="contents"/>.</param>
+    /// <param name="owner">The owner UID, or <see langword="null"/> to inherit.</param>
+    /// <param name="group">The group GID, or <see langword="null"/> to inherit.</param>
+    /// <param name="mode">The Unix file mode as an integer (for example <c>0o644</c>), or <see langword="null"/> to inherit.</param>
+    /// <param name="continueOnError">Whether to ignore errors creating this file.</param>
+    /// <returns>The created certificate file entry.</returns>
+    /// <ats-summary>Creates a PEM container certificate file entry with the OpenSSL subject-hash symlink.</ats-summary>
+    /// <ats-returns>The created certificate file entry.</ats-returns>
+    [AspireExport]
+    internal static ContainerFileSystemItem CreateCertificateFile(this ContainerFileSystemCallbackContext context, string name, string? contents = null, string? sourcePath = null, int? owner = null, int? group = null, int? mode = null, bool? continueOnError = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        return new ContainerOpenSSLCertificateFile
+        {
+            Name = name,
+            Contents = contents,
+            SourcePath = sourcePath,
+            Owner = owner,
+            Group = group,
+            Mode = ConvertMode(mode),
+            ContinueOnError = continueOnError,
+        };
+    }
+
+    /// <summary>
+    /// Creates a directory entry containing the specified child entries, to return from the callback.
+    /// </summary>
+    /// <param name="context">The callback context.</param>
+    /// <param name="name">The simple directory name (no path separators).</param>
+    /// <param name="entries">The child entries (files and/or directories) created via this context.</param>
+    /// <param name="owner">The owner UID, or <see langword="null"/> to inherit.</param>
+    /// <param name="group">The group GID, or <see langword="null"/> to inherit.</param>
+    /// <param name="mode">The Unix file mode as an integer (for example <c>0o755</c>), or <see langword="null"/> to inherit.</param>
+    /// <returns>The created directory entry.</returns>
+    /// <ats-summary>Creates a container directory entry containing the specified child entries.</ats-summary>
+    /// <ats-returns>The created directory entry.</ats-returns>
+    [AspireExport]
+    internal static ContainerFileSystemItem CreateDirectory(this ContainerFileSystemCallbackContext context, string name, IEnumerable<ContainerFileSystemItem> entries, int? owner = null, int? group = null, int? mode = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(entries);
+
+        return new ContainerDirectory
+        {
+            Name = name,
+            // Materialize so the caller-provided (possibly lazily-resolved handle) sequence is captured eagerly.
+            Entries = entries.ToList(),
+            Owner = owner,
+            Group = group,
+            Mode = ConvertMode(mode),
+        };
+    }
+
+    // Mode is supplied as an integer because ATS has no UnixFileMode type. A value of 0 (the default for
+    // ContainerFileSystemItem.Mode) means "inherit from the parent directory or defaults". Valid values use
+    // the low 12 bits (rwx for owner/group/other plus setuid/setgid/sticky), i.e. 0..0o7777.
+    private static UnixFileMode ConvertMode(int? mode)
+    {
+        if (mode is null)
+        {
+            return (UnixFileMode)0;
+        }
+
+        if (mode.Value is < 0 or > 0xFFF)
+        {
+            throw new ArgumentOutOfRangeException(nameof(mode), mode.Value, "File mode must be between 0 and 0o7777.");
+        }
+
+        return (UnixFileMode)mode.Value;
+    }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
@@ -325,6 +325,7 @@ internal static class ContainerFileSystemCallbackContextExtensions
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ThrowIfContentsAndSourcePathBothProvided(contents, sourcePath);
 
         return new ContainerFile
         {
@@ -358,6 +359,7 @@ internal static class ContainerFileSystemCallbackContextExtensions
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ThrowIfContentsAndSourcePathBothProvided(contents, sourcePath);
 
         return new ContainerOpenSSLCertificateFile
         {
@@ -417,6 +419,17 @@ internal static class ContainerFileSystemCallbackContextExtensions
         }
 
         return (UnixFileMode)mode.Value;
+    }
+
+    // contents and sourcePath are mutually exclusive: a file entry is sourced either from inline contents or
+    // from a host path, never both. Validate here so polyglot callers get a clear error at construction time
+    // instead of a harder-to-diagnose failure later during DCP conversion.
+    private static void ThrowIfContentsAndSourcePathBothProvided(string? contents, string? sourcePath)
+    {
+        if (contents is not null && sourcePath is not null)
+        {
+            throw new ArgumentException($"Only one of '{nameof(contents)}' or '{nameof(sourcePath)}' can be specified, not both.");
+        }
     }
 }
 

--- a/src/Aspire.Hosting/ApplicationModel/HttpsCertificateConfigurationCallbackAnnotaion.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HttpsCertificateConfigurationCallbackAnnotaion.cs
@@ -22,16 +22,19 @@ public sealed class HttpsCertificateConfigurationCallbackAnnotation(Func<HttpsCe
 /// Context provided to a <see cref="HttpsCertificateConfigurationCallbackAnnotation"/> callback.
 /// </summary>
 [Experimental("ASPIRECERTIFICATES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[AspireExport]
 public sealed class HttpsCertificateConfigurationCallbackAnnotationContext
 {
     /// <summary>
     /// Gets the <see cref="DistributedApplicationExecutionContext"/> for this session.
     /// </summary>
+    [AspireExport]
     public required DistributedApplicationExecutionContext ExecutionContext { get; init; }
 
     /// <summary>
     /// Gets the resource to which the annotation is applied.
     /// </summary>
+    [AspireExport]
     public required IResource Resource { get; init; }
 
     /// <summary>
@@ -78,25 +81,42 @@ public sealed class HttpsCertificateConfigurationCallbackAnnotationContext
     /// <summary>
     /// A value provider that will resolve to a path to the certificate file.
     /// </summary>
+    [AspireExport]
     public required ReferenceExpression CertificatePath { get; init; }
 
     /// <summary>
     /// A value provider that will resolve to a path to the private key for the certificate.
     /// </summary>
+    [AspireExport]
     public required ReferenceExpression KeyPath { get; init; }
 
     /// <summary>
     /// A value provider that will resolve to a path to a PFX file for the key pair.
     /// </summary>
+    [AspireExport]
     public required ReferenceExpression PfxPath { get; init; }
 
     /// <summary>
     /// A value provider that will resolve to the password for the private key, if applicable.
     /// </summary>
+    [AspireExportIgnore(Reason = "Password is typed as IValueProvider, which has no ATS-exported representation and no guaranteed concrete type to expose it as. The certificate paths (exposed as ReferenceExpression) cover the common configuration scenarios.")]
     public required IValueProvider? Password { get; init; }
 
     /// <summary>
     /// Gets the <see cref="CancellationToken"/> that can be used to cancel the operation.
     /// </summary>
+    [AspireExport]
     public required CancellationToken CancellationToken { get; init; }
+
+    /// <summary>
+    /// Gets the editor used to manipulate the command-line arguments in polyglot callbacks.
+    /// </summary>
+    [AspireExport("HttpsCertificateConfigurationCallbackAnnotationContext.arguments", MethodName = "arguments")]
+    internal CommandLineArgsEditor ArgumentsEditor => new(Arguments);
+
+    /// <summary>
+    /// Gets the editor used to set environment variables in polyglot callbacks.
+    /// </summary>
+    [AspireExport]
+    internal EnvironmentEditor Environment => new(EnvironmentVariables);
 }

--- a/src/Aspire.Hosting/ApplicationModel/HttpsEndpointUpdateCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HttpsEndpointUpdateCallbackContext.cs
@@ -10,6 +10,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// when an HTTPS certificate is determined to be available for the resource.
 /// </summary>
 [Experimental("ASPIRECERTIFICATES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[AspireExport(ExposeProperties = true)]
 public sealed class HttpsEndpointUpdateCallbackContext
 {
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/RequiredCommandValidationContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/RequiredCommandValidationContext.cs
@@ -12,6 +12,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="services">The service provider for accessing application services.</param>
 /// <param name="cancellationToken">A cancellation token that can be used to cancel the validation.</param>
 [Experimental("ASPIRECOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[AspireExport(ExposeProperties = true, ExposeMethods = true)]
 public sealed class RequiredCommandValidationContext(string resolvedPath, IServiceProvider services, CancellationToken cancellationToken)
 {
     /// <summary>
@@ -28,4 +29,17 @@ public sealed class RequiredCommandValidationContext(string resolvedPath, IServi
     /// Gets a cancellation token that can be used to cancel the validation.
     /// </summary>
     public CancellationToken CancellationToken { get; } = cancellationToken;
+
+    /// <summary>
+    /// Creates a successful validation result.
+    /// </summary>
+    /// <returns>A <see cref="RequiredCommandValidationResult"/> indicating the command is valid.</returns>
+    public RequiredCommandValidationResult Success() => RequiredCommandValidationResult.Success();
+
+    /// <summary>
+    /// Creates a failed validation result with the specified message.
+    /// </summary>
+    /// <param name="validationMessage">A message describing why validation failed.</param>
+    /// <returns>A <see cref="RequiredCommandValidationResult"/> indicating the command is invalid.</returns>
+    public RequiredCommandValidationResult Failure(string validationMessage) => RequiredCommandValidationResult.Failure(validationMessage);
 }

--- a/src/Aspire.Hosting/ApplicationModel/RequiredCommandValidationResult.cs
+++ b/src/Aspire.Hosting/ApplicationModel/RequiredCommandValidationResult.cs
@@ -9,6 +9,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// Represents the result of validating a required command.
 /// </summary>
 [Experimental("ASPIRECOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[AspireExport(ExposeProperties = true)]
 public sealed class RequiredCommandValidationResult
 {
     private RequiredCommandValidationResult(bool isValid, string? validationMessage)

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -375,7 +375,7 @@ public sealed class UpdateCommandStateContext
     /// The service provider.
     /// </summary>
     [Obsolete("Use Services instead.")]
-    [AspireExportIgnore(Reason = "IServiceProvider is not usable from polyglot command state callbacks.")]
+    [AspireExportIgnore(Reason = "Obsolete alias for Services. The service provider is exposed to polyglot hosts via Services (services).")]
     public IServiceProvider ServiceProvider
     {
         get => Services;
@@ -385,7 +385,6 @@ public sealed class UpdateCommandStateContext
     /// <summary>
     /// The service provider.
     /// </summary>
-    [AspireExportIgnore(Reason = "IServiceProvider is not usable from polyglot command state callbacks.")]
     public required IServiceProvider Services { get; init; }
 }
 
@@ -444,7 +443,7 @@ public sealed class ExecuteCommandContext
     /// The service provider.
     /// </summary>
     [Obsolete("Use Services instead.")]
-    [AspireExportIgnore(Reason = "IServiceProvider is not usable from polyglot command callbacks.")]
+    [AspireExportIgnore(Reason = "Obsolete alias for Services. The service provider is exposed to polyglot hosts via Services (services).")]
     public IServiceProvider ServiceProvider
     {
         get => Services;
@@ -454,7 +453,6 @@ public sealed class ExecuteCommandContext
     /// <summary>
     /// The service provider.
     /// </summary>
-    [AspireExportIgnore(Reason = "IServiceProvider is not usable from polyglot command callbacks.")]
     public required IServiceProvider Services { get; init; }
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -374,7 +374,7 @@ public sealed class UpdateCommandStateContext
     /// <summary>
     /// The service provider.
     /// </summary>
-    [AspireExportIgnore(Reason = "IServiceProvider is not usable from polyglot command state callbacks.")]
+    [AspireExport(MethodName = "services")]
     public required IServiceProvider ServiceProvider { get; init; }
 }
 
@@ -432,7 +432,7 @@ public sealed class ExecuteCommandContext
     /// <summary>
     /// The service provider.
     /// </summary>
-    [AspireExportIgnore(Reason = "IServiceProvider is not usable from polyglot command callbacks.")]
+    [AspireExport(MethodName = "services")]
     public required IServiceProvider ServiceProvider { get; init; }
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -491,9 +491,8 @@ public static class ResourceExtensions
     /// <param name="builder">The resource builder.</param>
     /// <param name="callback">A callback to configure container build options.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    /// <remarks>This method is not available in polyglot app hosts.</remarks>
     [Experimental("ASPIREPIPELINES003", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    [AspireExportIgnore(Reason = "ContainerBuildOptionsCallbackContext exposes IResource and IServiceProvider — .NET runtime types not usable from polyglot hosts.")]
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the async callback overload.")]
     public static IResourceBuilder<T> WithContainerBuildOptions<T>(
         this IResourceBuilder<T> builder,
         Action<ContainerBuildOptionsCallbackContext> callback)
@@ -512,9 +511,8 @@ public static class ResourceExtensions
     /// <param name="builder">The resource builder.</param>
     /// <param name="callback">An async callback to configure container build options.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    /// <remarks>This method is not available in polyglot app hosts.</remarks>
     [Experimental("ASPIREPIPELINES003", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    [AspireExportIgnore(Reason = "ContainerBuildOptionsCallbackContext exposes IResource and IServiceProvider — .NET runtime types not usable from polyglot hosts.")]
+    [AspireExport]
     public static IResourceBuilder<T> WithContainerBuildOptions<T>(
         this IResourceBuilder<T> builder,
         Func<ContainerBuildOptionsCallbackContext, Task> callback)

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -1457,7 +1457,6 @@ public static class ContainerResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    /// <remarks>This overload is exposed to polyglot app hosts via the <c>withContainerFilesCallback</c> shim, which constructs entries through factory methods on <see cref="ContainerFileSystemCallbackContext"/>.</remarks>
     [AspireExportIgnore(Reason = "Exposed to ATS via the WithContainerFilesCallbackExport shim, which accepts integer file-mode options and lets polyglot callbacks build the IEnumerable<ContainerFileSystemItem> result through ContainerFileSystemCallbackContext factory methods (createFile/createDirectory/createCertificateFile).")]
     public static IResourceBuilder<T> WithContainerFiles<T>(this IResourceBuilder<T> builder, string destinationPath, Func<ContainerFileSystemCallbackContext, CancellationToken, Task<IEnumerable<ContainerFileSystemItem>>> callback, int? defaultOwner = null, int? defaultGroup = null, UnixFileMode? umask = null) where T : ContainerResource
     {
@@ -1490,7 +1489,6 @@ public static class ContainerResourceBuilderExtensions
     /// <param name="defaultGroup">The default group ID for the created or updated file system. Defaults to 0 for root if not set.</param>
     /// <param name="umask">The umask <see cref="UnixFileMode"/> permissions to exclude from the default file and folder permissions. This takes away (rather than granting) default permissions to files and folders without an explicit mode permission set.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    /// <remarks>This overload is exposed to polyglot app hosts via the <c>withContainerFiles</c> shim, which accepts integer file-mode options.</remarks>
     [AspireExportIgnore(Reason = "Exposed to ATS via the WithContainerFilesExport shim overload, which accepts integer file-mode options (ContainerFilesOptions) in place of the UnixFileMode parameter.")]
     public static IResourceBuilder<T> WithContainerFiles<T>(this IResourceBuilder<T> builder, string destinationPath, string sourcePath, int? defaultOwner = null, int? defaultGroup = null, UnixFileMode? umask = null) where T : ContainerResource
     {

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -1457,8 +1457,8 @@ public static class ContainerResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    /// <remarks>This method is not available in polyglot app hosts.</remarks>
-    [AspireExportIgnore(Reason = "ContainerFileSystemCallbackContext exposes IServiceProvider and IResource — .NET runtime types not usable from polyglot hosts.")]
+    /// <remarks>This overload is exposed to polyglot app hosts via the <c>withContainerFilesCallback</c> shim, which constructs entries through factory methods on <see cref="ContainerFileSystemCallbackContext"/>.</remarks>
+    [AspireExportIgnore(Reason = "Exposed to ATS via the WithContainerFilesCallbackExport shim, which accepts integer file-mode options and lets polyglot callbacks build the IEnumerable<ContainerFileSystemItem> result through ContainerFileSystemCallbackContext factory methods (createFile/createDirectory/createCertificateFile).")]
     public static IResourceBuilder<T> WithContainerFiles<T>(this IResourceBuilder<T> builder, string destinationPath, Func<ContainerFileSystemCallbackContext, CancellationToken, Task<IEnumerable<ContainerFileSystemItem>>> callback, int? defaultOwner = null, int? defaultGroup = null, UnixFileMode? umask = null) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1490,8 +1490,8 @@ public static class ContainerResourceBuilderExtensions
     /// <param name="defaultGroup">The default group ID for the created or updated file system. Defaults to 0 for root if not set.</param>
     /// <param name="umask">The umask <see cref="UnixFileMode"/> permissions to exclude from the default file and folder permissions. This takes away (rather than granting) default permissions to files and folders without an explicit mode permission set.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    /// <remarks>This method is not available in polyglot app hosts.</remarks>
-    [AspireExportIgnore(Reason = "Uses UnixFileMode parameter which is not ATS-compatible.")]
+    /// <remarks>This overload is exposed to polyglot app hosts via the <c>withContainerFiles</c> shim, which accepts integer file-mode options.</remarks>
+    [AspireExportIgnore(Reason = "Exposed to ATS via the WithContainerFilesExport shim overload, which accepts integer file-mode options (ContainerFilesOptions) in place of the UnixFileMode parameter.")]
     public static IResourceBuilder<T> WithContainerFiles<T>(this IResourceBuilder<T> builder, string destinationPath, string sourcePath, int? defaultOwner = null, int? defaultGroup = null, UnixFileMode? umask = null) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1542,8 +1542,10 @@ public static class ContainerResourceBuilderExtensions
     /// In publish mode, Aspire creates a read-only bind mount and ignores those options.
     /// </para>
     /// <para>
-    /// Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-    /// polymorphic <see cref="ContainerFileSystemItem"/> hierarchy or callbacks that use .NET services.
+    /// To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+    /// use the <c>withContainerFilesCallback</c> overload and build the entries via the factory methods on
+    /// <see cref="ContainerFileSystemCallbackContext"/>. Passing a pre-built <see cref="ContainerFileSystemItem"/> collection
+    /// remains .NET-only.
     /// </para>
     /// </remarks>
     /// <ats-summary>Creates or updates files and folders in a container by copying them from a source path on the host.</ats-summary>
@@ -1583,6 +1585,57 @@ public static class ContainerResourceBuilderExtensions
         var umask = umaskValue is { } value ? (UnixFileMode)value : (UnixFileMode?)null;
 
         return builder.WithContainerFiles(destinationPath, sourcePath, defaultOwner, defaultGroup, umask);
+    }
+
+    /// <summary>
+    /// Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
+    /// </summary>
+    /// <typeparam name="T">The type of container resource.</typeparam>
+    /// <param name="builder">The resource builder for the container resource.</param>
+    /// <param name="destinationPath">The destination absolute path in the container.</param>
+    /// <param name="callback">
+    /// A callback that returns the file system entries to create or update. Use the factory methods on
+    /// <see cref="ContainerFileSystemCallbackContext"/> (createFile, createDirectory, createCertificateFile) to build the entries.
+    /// </param>
+    /// <param name="options">Options for the created or updated file system entries.</param>
+    /// <returns>The resource builder.</returns>
+    /// <ats-summary>Creates or updates files and folders in a container using entries produced by a callback.</ats-summary>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExport("withContainerFilesCallback", MethodName = "withContainerFilesCallback")]
+    internal static IResourceBuilder<T> WithContainerFilesCallbackExport<T>(
+        this IResourceBuilder<T> builder,
+        string destinationPath,
+        Func<ContainerFileSystemCallbackContext, CancellationToken, Task<IEnumerable<ContainerFileSystemItem>>> callback,
+        ContainerFilesOptions? options = null)
+        where T : ContainerResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(destinationPath);
+        ArgumentNullException.ThrowIfNull(callback);
+
+        if (options is null)
+        {
+            return builder.WithContainerFiles(destinationPath, callback);
+        }
+
+        var defaultOwner = GetIntegralContainerFilesOption(
+            options.DefaultOwner,
+            nameof(ContainerFilesOptions.DefaultOwner),
+            minValue: 0,
+            maxValue: int.MaxValue);
+        var defaultGroup = GetIntegralContainerFilesOption(
+            options.DefaultGroup,
+            nameof(ContainerFilesOptions.DefaultGroup),
+            minValue: 0,
+            maxValue: int.MaxValue);
+        var umaskValue = GetIntegralContainerFilesOption(
+            options.Umask,
+            nameof(ContainerFilesOptions.Umask),
+            minValue: 0,
+            maxValue: 0xFFF);
+        var umask = umaskValue is { } value ? (UnixFileMode)value : (UnixFileMode?)null;
+
+        return builder.WithContainerFiles(destinationPath, callback, defaultOwner, defaultGroup, umask);
     }
 
     private static int? GetIntegralContainerFilesOption(double? value, string paramName, int minValue, int maxValue)

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -1599,8 +1599,6 @@ public static class ContainerResourceBuilderExtensions
     /// </param>
     /// <param name="options">Options for the created or updated file system entries.</param>
     /// <returns>The resource builder.</returns>
-    /// <ats-summary>Creates or updates files and folders in a container using entries produced by a callback.</ats-summary>
-    /// <ats-returns>The resource builder.</ats-returns>
     [AspireExport("withContainerFilesCallback", MethodName = "withContainerFilesCallback")]
     internal static IResourceBuilder<T> WithContainerFilesCallbackExport<T>(
         this IResourceBuilder<T> builder,

--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -365,6 +365,7 @@ internal sealed class ContainerCreateFileSystem : IEquatable<ContainerCreateFile
 
 internal static class ContainerFileSystemItemExtensions
 {
+    [AspireExportIgnore(Reason = "Internal conversion to the DCP ContainerFileSystemEntry model, which is not part of the ATS surface.")]
     public static ContainerFileSystemEntry ToContainerFileSystemEntry(this ContainerFileSystemItem item)
     {
         var type = item switch

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -614,7 +614,6 @@ public sealed class InputsDialogValidationContext
     /// <summary>
     /// Gets the service provider for resolving services during validation.
     /// </summary>
-    [AspireExportIgnore(Reason = "IServiceProvider is not part of the polyglot validation surface.")]
     public required IServiceProvider Services { get; init; }
 
     /// <summary>

--- a/src/Aspire.Hosting/RequiredCommandResourceExtensions.cs
+++ b/src/Aspire.Hosting/RequiredCommandResourceExtensions.cs
@@ -55,13 +55,13 @@ public static class RequiredCommandResourceExtensions
     /// <param name="helpLink">An optional help link URL to guide users when the command is missing or fails validation.</param>
     /// <returns>The resource builder.</returns>
     /// <remarks>
-    /// <para>This method is not available in polyglot app hosts. Use the overload without validation callback instead.</para>
     /// The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
-    /// The callback should return a <see cref="RequiredCommandValidationResult"/> indicating whether the command is valid.
+    /// The callback should return a <see cref="RequiredCommandValidationResult"/> indicating whether the command is valid,
+    /// which can be created via <see cref="RequiredCommandValidationContext.Success"/> or <see cref="RequiredCommandValidationContext.Failure(string)"/>.
     /// If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
     /// </remarks>
     [Experimental("ASPIRECOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    [AspireExportIgnore(Reason = "RequiredCommandValidationContext exposes IServiceProvider — not usable from polyglot hosts.")]
+    [AspireExport("withRequiredCommandValidation", MethodName = "withRequiredCommandValidation")]
     public static IResourceBuilder<T> WithRequiredCommand<T>(
         this IResourceBuilder<T> builder,
         string command,

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -4273,10 +4273,9 @@ public static class ResourceBuilderExtensions
     ///     });
     /// </code>
     /// </example>
-    /// <para>This method is not available in polyglot app hosts.</para>
     /// </remarks>
     [Experimental("ASPIRECERTIFICATES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    [AspireExportIgnore(Reason = "HttpsCertificateConfigurationCallbackAnnotationContext exposes IServiceProvider and IResource — not usable from polyglot hosts.")]
+    [AspireExport]
     public static IResourceBuilder<TResource> WithHttpsCertificateConfiguration<TResource>(this IResourceBuilder<TResource> builder, Func<HttpsCertificateConfigurationCallbackAnnotationContext, Task> callback)
         where TResource : IResourceWithEnvironment, IResourceWithArgs
     {
@@ -4314,10 +4313,9 @@ public static class ResourceBuilderExtensions
     /// });
     /// </code>
     /// </example>
-    /// <para>This method is not available in polyglot app hosts.</para>
     /// </remarks>
     [Experimental("ASPIRECERTIFICATES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    [AspireExportIgnore(Reason = "HttpsEndpointUpdateCallbackContext exposes IServiceProvider and IResource — not usable from polyglot hosts.")]
+    [AspireExport]
     public static IResourceBuilder<TResource> SubscribeHttpsEndpointsUpdate<TResource>(this IResourceBuilder<TResource> builder, Action<HttpsEndpointUpdateCallbackContext> callback)
         where TResource : IResource
     {

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -1833,7 +1833,7 @@ func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithContainerF
 	return s
 }
 
-// WithContainerFilesCallback creates or updates files and folders in a container using entries produced by a callback.
+// WithContainerFilesCallback creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
 func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithContainerFilesCallback(destinationPath string, callback func(arg1 ContainerFileSystemCallbackContext, arg2 *CancellationToken) []ContainerFileSystemItem, options ...*WithContainerFilesCallbackOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource {
 	if s.err != nil { return s }
 	ctx := context.Background()
@@ -7893,7 +7893,7 @@ func (s *containerResource) WithContainerFiles(destinationPath string, sourcePat
 	return s
 }
 
-// WithContainerFilesCallback creates or updates files and folders in a container using entries produced by a callback.
+// WithContainerFilesCallback creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
 func (s *containerResource) WithContainerFilesCallback(destinationPath string, callback func(arg1 ContainerFileSystemCallbackContext, arg2 *CancellationToken) []ContainerFileSystemItem, options ...*WithContainerFilesCallbackOptions) ContainerResource {
 	if s.err != nil { return s }
 	ctx := context.Background()
@@ -23281,7 +23281,7 @@ func (s *testDatabaseResource) WithContainerFiles(destinationPath string, source
 	return s
 }
 
-// WithContainerFilesCallback creates or updates files and folders in a container using entries produced by a callback.
+// WithContainerFilesCallback creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
 func (s *testDatabaseResource) WithContainerFilesCallback(destinationPath string, callback func(arg1 ContainerFileSystemCallbackContext, arg2 *CancellationToken) []ContainerFileSystemItem, options ...*WithContainerFilesCallbackOptions) TestDatabaseResource {
 	if s.err != nil { return s }
 	ctx := context.Background()
@@ -25692,7 +25692,7 @@ func (s *testRedisResource) WithContainerFiles(destinationPath string, sourcePat
 	return s
 }
 
-// WithContainerFilesCallback creates or updates files and folders in a container using entries produced by a callback.
+// WithContainerFilesCallback creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
 func (s *testRedisResource) WithContainerFilesCallback(destinationPath string, callback func(arg1 ContainerFileSystemCallbackContext, arg2 *CancellationToken) []ContainerFileSystemItem, options ...*WithContainerFilesCallbackOptions) TestRedisResource {
 	if s.err != nil { return s }
 	ctx := context.Background()

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -15341,6 +15341,7 @@ type ExecuteCommandContext interface {
 	CancellationToken() (*CancellationToken, error)
 	Logger() Logger
 	ResourceName() (string, error)
+	Services() ServiceProvider
 	Err() error
 }
 
@@ -15420,6 +15421,25 @@ func (s *executeCommandContext) ResourceName() (string, error) {
 		return zero, err
 	}
 	return decodeAs[string](result)
+}
+
+// Services the service provider.
+func (s *executeCommandContext) Services() ServiceProvider {
+	if s.err != nil { return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ExecuteCommandContext.services", reqArgs)
+	if err != nil {
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/ExecuteCommandContext.services returned unexpected type %T", result)
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
 }
 
 // ExecutionConfigurationBuilder is the public interface for handle type ExecutionConfigurationBuilder.
@@ -27211,6 +27231,7 @@ func (s *testResourceContext) Value() (float64, error) {
 type UpdateCommandStateContext interface {
 	handleReference
 	ResourceSnapshot() (*UpdateCommandStateResourceSnapshot, error)
+	Services() ServiceProvider
 	Err() error
 }
 
@@ -27237,6 +27258,25 @@ func (s *updateCommandStateContext) ResourceSnapshot() (*UpdateCommandStateResou
 		return zero, err
 	}
 	return decodeAs[*UpdateCommandStateResourceSnapshot](result)
+}
+
+// Services the service provider.
+func (s *updateCommandStateContext) Services() ServiceProvider {
+	if s.err != nil { return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.services", reqArgs)
+	if err != nil {
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.services returned unexpected type %T", result)
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
 }
 
 // UserSecretsManager is the public interface for handle type UserSecretsManager.

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -132,6 +132,35 @@ const (
 	ProbeTypeLiveness ProbeType = "Liveness"
 )
 
+// ContainerImageDestination represents ContainerImageDestination.
+type ContainerImageDestination string
+
+const (
+	ContainerImageDestinationRegistry ContainerImageDestination = "Registry"
+	ContainerImageDestinationArchive ContainerImageDestination = "Archive"
+)
+
+// ContainerImageFormat represents ContainerImageFormat.
+type ContainerImageFormat string
+
+const (
+	ContainerImageFormatDocker ContainerImageFormat = "Docker"
+	ContainerImageFormatOci ContainerImageFormat = "Oci"
+)
+
+// ContainerTargetPlatform represents ContainerTargetPlatform.
+type ContainerTargetPlatform string
+
+const (
+	ContainerTargetPlatformLinuxAmd64 ContainerTargetPlatform = "LinuxAmd64"
+	ContainerTargetPlatformLinuxArm64 ContainerTargetPlatform = "LinuxArm64"
+	ContainerTargetPlatformAllLinux ContainerTargetPlatform = "AllLinux"
+	ContainerTargetPlatformLinuxArm ContainerTargetPlatform = "LinuxArm"
+	ContainerTargetPlatformLinux386 ContainerTargetPlatform = "Linux386"
+	ContainerTargetPlatformWindowsAmd64 ContainerTargetPlatform = "WindowsAmd64"
+	ContainerTargetPlatformWindowsArm64 ContainerTargetPlatform = "WindowsArm64"
+)
+
 // EndpointProperty represents EndpointProperty.
 type EndpointProperty string
 
@@ -1136,6 +1165,7 @@ type Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource interface {
 	OnResourceStopped(callback func(arg ResourceStoppedEvent)) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	PublishAsConnectionString() Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	PublishAsContainer() Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
+	SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	TestWaitFor(dependency Resource) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	TestWithEnvironmentCallback(callback func(arg TestEnvironmentContext)) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WaitFor(dependency Resource, options ...*WaitForOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
@@ -1152,8 +1182,10 @@ type Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource interface {
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithConfig(config *TestConfigDto) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
+	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithContainerCertificatePaths(options ...*WithContainerCertificatePathsOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithContainerFiles(destinationPath string, sourcePath string, options ...*WithContainerFilesOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
+	WithContainerFilesCallback(destinationPath string, callback func(arg1 ContainerFileSystemCallbackContext, arg2 *CancellationToken) []ContainerFileSystemItem, options ...*WithContainerFilesCallbackOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithContainerName(name string) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithContainerNetworkAlias(alias string) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithContainerRegistry(registry Resource) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
@@ -1184,6 +1216,7 @@ type Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource interface {
 	WithHttpEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpEndpointCallbackOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithHttpHealthCheck(options ...*WithHttpHealthCheckOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithHttpProbe(probeType ProbeType, options ...*WithHttpProbeOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
+	WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithHttpsDeveloperCertificate(options ...*WithHttpsDeveloperCertificateOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithHttpsEndpoint(options ...*WithHttpsEndpointOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithHttpsEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpsEndpointCallbackOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
@@ -1223,6 +1256,7 @@ type Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource interface {
 	WithRemoteImageName(remoteImageName string) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithRemoteImageTag(remoteImageTag string) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
+	WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithSessionLifetime() Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithStatus(status TestResourceStatus) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithUnionDependency(dependency any) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
@@ -1447,6 +1481,25 @@ func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) PublishAsConta
 		"builder": s.handle.ToJSON(),
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/publishAsContainer", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// SubscribeHttpsEndpointsUpdate subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsEndpointUpdateCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -1723,6 +1776,25 @@ func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithConfig(con
 	return s
 }
 
+// WithContainerBuildOptions configures container build options for a compute resource using an async callback.
+func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[ContainerBuildOptionsCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerBuildOptions", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithContainerCertificatePaths adds container certificate path overrides used for certificate trust at run time.
 func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithContainerCertificatePaths(options ...*WithContainerCertificatePathsOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource {
 	if s.err != nil { return s }
@@ -1758,6 +1830,32 @@ func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithContainerF
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerFiles", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithContainerFilesCallback creates or updates files and folders in a container using entries produced by a callback.
+func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithContainerFilesCallback(destinationPath string, callback func(arg1 ContainerFileSystemCallbackContext, arg2 *CancellationToken) []ContainerFileSystemItem, options ...*WithContainerFilesCallbackOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["destinationPath"] = serializeValue(destinationPath)
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			return cb(callbackArg[ContainerFileSystemCallbackContext](args, 0), callbackArg[*CancellationToken](args, 1))
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithContainerFilesCallbackOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerFilesCallback", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -2242,6 +2340,25 @@ func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithHttpProbe(
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpProbe", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithHttpsCertificateConfiguration adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsCertificateConfigurationCallbackAnnotationContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -2881,6 +2998,32 @@ func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithRequiredCo
 	return s
 }
 
+// WithRequiredCommandValidation declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["command"] = serializeValue(command)
+	if validationCallback != nil {
+		cb := validationCallback
+		shim := func(args ...any) any {
+			return cb(callbackArg[RequiredCommandValidationContext](args, 0))
+		}
+		reqArgs["validationCallback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithRequiredCommandValidationOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommandValidation", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithSessionLifetime configures a resource to use a session lifetime.
 func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithSessionLifetime() Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource {
 	if s.err != nil { return s }
@@ -3234,6 +3377,7 @@ type CSharpAppResource interface {
 	OnResourceStopped(callback func(arg ResourceStoppedEvent)) CSharpAppResource
 	PublishAsDockerFile(options ...*PublishAsDockerFileOptions) CSharpAppResource
 	PublishWithContainerFiles(source ResourceWithContainerFiles, destinationPath string) CSharpAppResource
+	SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) CSharpAppResource
 	TestWaitFor(dependency Resource) CSharpAppResource
 	TestWithEnvironmentCallback(callback func(arg TestEnvironmentContext)) CSharpAppResource
 	WaitFor(dependency Resource, options ...*WaitForOptions) CSharpAppResource
@@ -3247,6 +3391,7 @@ type CSharpAppResource interface {
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) CSharpAppResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) CSharpAppResource
 	WithConfig(config *TestConfigDto) CSharpAppResource
+	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) CSharpAppResource
 	WithContainerRegistry(registry Resource) CSharpAppResource
 	WithCorrelationId(correlationId string) CSharpAppResource
 	WithCreatedAt(createdAt string) CSharpAppResource
@@ -3271,6 +3416,7 @@ type CSharpAppResource interface {
 	WithHttpEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpEndpointCallbackOptions) CSharpAppResource
 	WithHttpHealthCheck(options ...*WithHttpHealthCheckOptions) CSharpAppResource
 	WithHttpProbe(probeType ProbeType, options ...*WithHttpProbeOptions) CSharpAppResource
+	WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) CSharpAppResource
 	WithHttpsDeveloperCertificate(options ...*WithHttpsDeveloperCertificateOptions) CSharpAppResource
 	WithHttpsEndpoint(options ...*WithHttpsEndpointOptions) CSharpAppResource
 	WithHttpsEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpsEndpointCallbackOptions) CSharpAppResource
@@ -3305,6 +3451,7 @@ type CSharpAppResource interface {
 	WithRemoteImageTag(remoteImageTag string) CSharpAppResource
 	WithReplicas(replicas float64) CSharpAppResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) CSharpAppResource
+	WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) CSharpAppResource
 	WithSessionLifetime() CSharpAppResource
 	WithStatus(status TestResourceStatus) CSharpAppResource
 	WithUnionDependency(dependency any) CSharpAppResource
@@ -3559,6 +3706,25 @@ func (s *cSharpAppResource) PublishWithContainerFiles(source ResourceWithContain
 	return s
 }
 
+// SubscribeHttpsEndpointsUpdate subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+func (s *cSharpAppResource) SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) CSharpAppResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsEndpointUpdateCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // TestWaitFor waits for another resource (test version)
 func (s *cSharpAppResource) TestWaitFor(dependency Resource) CSharpAppResource {
 	if s.err != nil { return s }
@@ -3775,6 +3941,25 @@ func (s *cSharpAppResource) WithConfig(config *TestConfigDto) CSharpAppResource 
 	}
 	if config != nil { reqArgs["config"] = serializeValue(config) }
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.CodeGeneration.Go.Tests/withConfig", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithContainerBuildOptions configures container build options for a compute resource using an async callback.
+func (s *cSharpAppResource) WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) CSharpAppResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[ContainerBuildOptionsCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerBuildOptions", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -4151,6 +4336,25 @@ func (s *cSharpAppResource) WithHttpProbe(probeType ProbeType, options ...*WithH
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpProbe", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithHttpsCertificateConfiguration adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+func (s *cSharpAppResource) WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) CSharpAppResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsCertificateConfigurationCallbackAnnotationContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -4723,6 +4927,32 @@ func (s *cSharpAppResource) WithRequiredCommand(command string, options ...*With
 	return s
 }
 
+// WithRequiredCommandValidation declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+func (s *cSharpAppResource) WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) CSharpAppResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["command"] = serializeValue(command)
+	if validationCallback != nil {
+		cb := validationCallback
+		shim := func(args ...any) any {
+			return cb(callbackArg[RequiredCommandValidationContext](args, 0))
+		}
+		reqArgs["validationCallback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithRequiredCommandValidationOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommandValidation", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithSessionLifetime configures a resource to use a session lifetime.
 func (s *cSharpAppResource) WithSessionLifetime() CSharpAppResource {
 	if s.err != nil { return s }
@@ -5227,6 +5457,445 @@ func (s *connectionStringAvailableEvent) Services() ServiceProvider {
 	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
 }
 
+// ContainerBuildOptionsCallbackContext is the public interface for handle type ContainerBuildOptionsCallbackContext.
+type ContainerBuildOptionsCallbackContext interface {
+	handleReference
+	CancellationToken() (*CancellationToken, error)
+	Destination() (ContainerImageDestination, error)
+	ExecutionContext() DistributedApplicationExecutionContext
+	ImageFormat() (ContainerImageFormat, error)
+	LocalImageName() (string, error)
+	LocalImageTag() (string, error)
+	Logger() Logger
+	OutputPath() (string, error)
+	Resource() Resource
+	Services() ServiceProvider
+	SetDestination(value ContainerImageDestination) ContainerBuildOptionsCallbackContext
+	SetImageFormat(value ContainerImageFormat) ContainerBuildOptionsCallbackContext
+	SetLocalImageName(value string) ContainerBuildOptionsCallbackContext
+	SetLocalImageTag(value string) ContainerBuildOptionsCallbackContext
+	SetOutputPath(value string) ContainerBuildOptionsCallbackContext
+	SetTargetPlatform(value ContainerTargetPlatform) ContainerBuildOptionsCallbackContext
+	TargetPlatform() (ContainerTargetPlatform, error)
+	Err() error
+}
+
+// containerBuildOptionsCallbackContext is the unexported impl of ContainerBuildOptionsCallbackContext.
+type containerBuildOptionsCallbackContext struct {
+	*resourceBuilderBase
+}
+
+// newContainerBuildOptionsCallbackContextFromHandle wraps an existing handle as ContainerBuildOptionsCallbackContext.
+func newContainerBuildOptionsCallbackContextFromHandle(h *handle, c *client) ContainerBuildOptionsCallbackContext {
+	return &containerBuildOptionsCallbackContext{resourceBuilderBase: newResourceBuilderBase(h, c)}
+}
+
+// CancellationToken gets the cancellation token.
+func (s *containerBuildOptionsCallbackContext) CancellationToken() (*CancellationToken, error) {
+	if s.err != nil { var zero *CancellationToken; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.cancellationToken", reqArgs)
+	if err != nil {
+		var zero *CancellationToken
+		return zero, err
+	}
+	return decodeAs[*CancellationToken](result)
+}
+
+// Destination gets or sets the destination for the container image.
+func (s *containerBuildOptionsCallbackContext) Destination() (ContainerImageDestination, error) {
+	if s.err != nil { var zero ContainerImageDestination; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.destination", reqArgs)
+	if err != nil {
+		var zero ContainerImageDestination
+		return zero, err
+	}
+	return decodeAs[ContainerImageDestination](result)
+}
+
+// ExecutionContext gets the distributed application execution context.
+func (s *containerBuildOptionsCallbackContext) ExecutionContext() DistributedApplicationExecutionContext {
+	if s.err != nil { return &distributedApplicationExecutionContext{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.executionContext", reqArgs)
+	if err != nil {
+		return &distributedApplicationExecutionContext{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.executionContext returned unexpected type %T", result)
+		return &distributedApplicationExecutionContext{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &distributedApplicationExecutionContext{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// ImageFormat gets or sets the container image format.
+func (s *containerBuildOptionsCallbackContext) ImageFormat() (ContainerImageFormat, error) {
+	if s.err != nil { var zero ContainerImageFormat; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.imageFormat", reqArgs)
+	if err != nil {
+		var zero ContainerImageFormat
+		return zero, err
+	}
+	return decodeAs[ContainerImageFormat](result)
+}
+
+// LocalImageName gets or sets the local image name for the built container.
+func (s *containerBuildOptionsCallbackContext) LocalImageName() (string, error) {
+	if s.err != nil { var zero string; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.localImageName", reqArgs)
+	if err != nil {
+		var zero string
+		return zero, err
+	}
+	return decodeAs[string](result)
+}
+
+// LocalImageTag gets or sets the local image tag for the built container.
+func (s *containerBuildOptionsCallbackContext) LocalImageTag() (string, error) {
+	if s.err != nil { var zero string; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.localImageTag", reqArgs)
+	if err != nil {
+		var zero string
+		return zero, err
+	}
+	return decodeAs[string](result)
+}
+
+// Logger gets the logger instance.
+func (s *containerBuildOptionsCallbackContext) Logger() Logger {
+	if s.err != nil { return &logger{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.logger", reqArgs)
+	if err != nil {
+		return &logger{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.logger returned unexpected type %T", result)
+		return &logger{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &logger{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// OutputPath gets or sets the output path for the container archive.
+func (s *containerBuildOptionsCallbackContext) OutputPath() (string, error) {
+	if s.err != nil { var zero string; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.outputPath", reqArgs)
+	if err != nil {
+		var zero string
+		return zero, err
+	}
+	return decodeAs[string](result)
+}
+
+// Resource gets the resource being built.
+func (s *containerBuildOptionsCallbackContext) Resource() Resource {
+	if s.err != nil { return nil }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.resource", reqArgs)
+	if err != nil { s.setErr(err); return nil }
+	typed, ok := result.(Resource)
+	if !ok {
+		s.setErr(fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.resource returned unexpected type %T", result))
+		return nil
+	}
+	return typed
+}
+
+// Services gets the service provider.
+func (s *containerBuildOptionsCallbackContext) Services() ServiceProvider {
+	if s.err != nil { return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.services", reqArgs)
+	if err != nil {
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.services returned unexpected type %T", result)
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// SetDestination sets the Destination property
+func (s *containerBuildOptionsCallbackContext) SetDestination(value ContainerImageDestination) ContainerBuildOptionsCallbackContext {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	reqArgs["value"] = serializeValue(value)
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setDestination", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// SetImageFormat sets the ImageFormat property
+func (s *containerBuildOptionsCallbackContext) SetImageFormat(value ContainerImageFormat) ContainerBuildOptionsCallbackContext {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	reqArgs["value"] = serializeValue(value)
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setImageFormat", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// SetLocalImageName sets the LocalImageName property
+func (s *containerBuildOptionsCallbackContext) SetLocalImageName(value string) ContainerBuildOptionsCallbackContext {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	reqArgs["value"] = serializeValue(value)
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setLocalImageName", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// SetLocalImageTag sets the LocalImageTag property
+func (s *containerBuildOptionsCallbackContext) SetLocalImageTag(value string) ContainerBuildOptionsCallbackContext {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	reqArgs["value"] = serializeValue(value)
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setLocalImageTag", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// SetOutputPath sets the OutputPath property
+func (s *containerBuildOptionsCallbackContext) SetOutputPath(value string) ContainerBuildOptionsCallbackContext {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	reqArgs["value"] = serializeValue(value)
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setOutputPath", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// SetTargetPlatform sets the TargetPlatform property
+func (s *containerBuildOptionsCallbackContext) SetTargetPlatform(value ContainerTargetPlatform) ContainerBuildOptionsCallbackContext {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	reqArgs["value"] = serializeValue(value)
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setTargetPlatform", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// TargetPlatform gets or sets the target platform for the container.
+func (s *containerBuildOptionsCallbackContext) TargetPlatform() (ContainerTargetPlatform, error) {
+	if s.err != nil { var zero ContainerTargetPlatform; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.targetPlatform", reqArgs)
+	if err != nil {
+		var zero ContainerTargetPlatform
+		return zero, err
+	}
+	return decodeAs[ContainerTargetPlatform](result)
+}
+
+// ContainerFileSystemCallbackContext is the public interface for handle type ContainerFileSystemCallbackContext.
+type ContainerFileSystemCallbackContext interface {
+	handleReference
+	CreateCertificateFile(name string, options ...*CreateCertificateFileOptions) ContainerFileSystemItem
+	CreateDirectory(name string, entries []ContainerFileSystemItem, options ...*CreateDirectoryOptions) ContainerFileSystemItem
+	CreateFile(name string, options ...*CreateFileOptions) ContainerFileSystemItem
+	Model() Resource
+	Services() ServiceProvider
+	Err() error
+}
+
+// containerFileSystemCallbackContext is the unexported impl of ContainerFileSystemCallbackContext.
+type containerFileSystemCallbackContext struct {
+	*resourceBuilderBase
+}
+
+// newContainerFileSystemCallbackContextFromHandle wraps an existing handle as ContainerFileSystemCallbackContext.
+func newContainerFileSystemCallbackContextFromHandle(h *handle, c *client) ContainerFileSystemCallbackContext {
+	return &containerFileSystemCallbackContext{resourceBuilderBase: newResourceBuilderBase(h, c)}
+}
+
+// CreateCertificateFile creates a PEM container certificate file entry with the OpenSSL subject-hash symlink.
+func (s *containerFileSystemCallbackContext) CreateCertificateFile(name string, options ...*CreateCertificateFileOptions) ContainerFileSystemItem {
+	if s.err != nil { return &containerFileSystemItem{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	reqArgs["name"] = serializeValue(name)
+	if len(options) > 0 {
+		merged := &CreateCertificateFileOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/createCertificateFile", reqArgs)
+	if err != nil {
+		return &containerFileSystemItem{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting/createCertificateFile returned unexpected type %T", result)
+		return &containerFileSystemItem{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &containerFileSystemItem{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// CreateDirectory creates a container directory entry containing the specified child entries.
+func (s *containerFileSystemCallbackContext) CreateDirectory(name string, entries []ContainerFileSystemItem, options ...*CreateDirectoryOptions) ContainerFileSystemItem {
+	if s.err != nil { return &containerFileSystemItem{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	reqArgs["name"] = serializeValue(name)
+	if entries != nil { reqArgs["entries"] = serializeValue(entries) }
+	if len(options) > 0 {
+		merged := &CreateDirectoryOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/createDirectory", reqArgs)
+	if err != nil {
+		return &containerFileSystemItem{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting/createDirectory returned unexpected type %T", result)
+		return &containerFileSystemItem{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &containerFileSystemItem{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// CreateFile creates a container file entry with inline contents or a host source path.
+func (s *containerFileSystemCallbackContext) CreateFile(name string, options ...*CreateFileOptions) ContainerFileSystemItem {
+	if s.err != nil { return &containerFileSystemItem{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	reqArgs["name"] = serializeValue(name)
+	if len(options) > 0 {
+		merged := &CreateFileOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/createFile", reqArgs)
+	if err != nil {
+		return &containerFileSystemItem{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting/createFile returned unexpected type %T", result)
+		return &containerFileSystemItem{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &containerFileSystemItem{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// Model the app model resource the callback is associated with.
+func (s *containerFileSystemCallbackContext) Model() Resource {
+	if s.err != nil { return nil }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerFileSystemCallbackContext.model", reqArgs)
+	if err != nil { s.setErr(err); return nil }
+	typed, ok := result.(Resource)
+	if !ok {
+		s.setErr(fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/ContainerFileSystemCallbackContext.model returned unexpected type %T", result))
+		return nil
+	}
+	return typed
+}
+
+// Services a `IServiceProvider` that can be used to resolve services in the callback.
+func (s *containerFileSystemCallbackContext) Services() ServiceProvider {
+	if s.err != nil { return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ContainerFileSystemCallbackContext.services", reqArgs)
+	if err != nil {
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/ContainerFileSystemCallbackContext.services returned unexpected type %T", result)
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// ContainerFileSystemItem is the public interface for handle type ContainerFileSystemItem.
+type ContainerFileSystemItem interface {
+	handleReference
+	Err() error
+}
+
+// containerFileSystemItem is the unexported impl of ContainerFileSystemItem.
+type containerFileSystemItem struct {
+	*resourceBuilderBase
+}
+
+// newContainerFileSystemItemFromHandle wraps an existing handle as ContainerFileSystemItem.
+func newContainerFileSystemItemFromHandle(h *handle, c *client) ContainerFileSystemItem {
+	return &containerFileSystemItem{resourceBuilderBase: newResourceBuilderBase(h, c)}
+}
+
 // ContainerImagePushOptions is the public interface for handle type ContainerImagePushOptions.
 type ContainerImagePushOptions interface {
 	handleReference
@@ -5562,11 +6231,13 @@ type ContainerRegistryResource interface {
 	OnInitializeResource(callback func(arg InitializeResourceEvent)) ContainerRegistryResource
 	OnResourceReady(callback func(arg ResourceReadyEvent)) ContainerRegistryResource
 	OnResourceStopped(callback func(arg ResourceStoppedEvent)) ContainerRegistryResource
+	SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) ContainerRegistryResource
 	TestWaitFor(dependency Resource) ContainerRegistryResource
 	WithCancellableOperation(operation func(arg *CancellationToken)) ContainerRegistryResource
 	WithChildRelationship(child Resource) ContainerRegistryResource
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) ContainerRegistryResource
 	WithConfig(config *TestConfigDto) ContainerRegistryResource
+	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ContainerRegistryResource
 	WithContainerRegistry(registry Resource) ContainerRegistryResource
 	WithCorrelationId(correlationId string) ContainerRegistryResource
 	WithCreatedAt(createdAt string) ContainerRegistryResource
@@ -5600,6 +6271,7 @@ type ContainerRegistryResource interface {
 	WithProcessCommandFactory(commandName string, displayName string, createProcessSpec func(arg ExecuteCommandContext) *ProcessCommandSpecExportData, options ...*WithProcessCommandFactoryOptions) ContainerRegistryResource
 	WithRelationship(resourceBuilder Resource, type_ string) ContainerRegistryResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) ContainerRegistryResource
+	WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) ContainerRegistryResource
 	WithSessionLifetime() ContainerRegistryResource
 	WithStatus(status TestResourceStatus) ContainerRegistryResource
 	WithUnionDependency(dependency any) ContainerRegistryResource
@@ -5752,6 +6424,25 @@ func (s *containerRegistryResource) OnResourceStopped(callback func(arg Resource
 	return s
 }
 
+// SubscribeHttpsEndpointsUpdate subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+func (s *containerRegistryResource) SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) ContainerRegistryResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsEndpointUpdateCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // TestWaitFor waits for another resource (test version)
 func (s *containerRegistryResource) TestWaitFor(dependency Resource) ContainerRegistryResource {
 	if s.err != nil { return s }
@@ -5833,6 +6524,25 @@ func (s *containerRegistryResource) WithConfig(config *TestConfigDto) ContainerR
 	}
 	if config != nil { reqArgs["config"] = serializeValue(config) }
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.CodeGeneration.Go.Tests/withConfig", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithContainerBuildOptions configures container build options for a compute resource using an async callback.
+func (s *containerRegistryResource) WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ContainerRegistryResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[ContainerBuildOptionsCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerBuildOptions", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -6346,6 +7056,32 @@ func (s *containerRegistryResource) WithRequiredCommand(command string, options 
 	return s
 }
 
+// WithRequiredCommandValidation declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+func (s *containerRegistryResource) WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) ContainerRegistryResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["command"] = serializeValue(command)
+	if validationCallback != nil {
+		cb := validationCallback
+		shim := func(args ...any) any {
+			return cb(callbackArg[RequiredCommandValidationContext](args, 0))
+		}
+		reqArgs["validationCallback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithRequiredCommandValidationOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommandValidation", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithSessionLifetime configures a resource to use a session lifetime.
 func (s *containerRegistryResource) WithSessionLifetime() ContainerRegistryResource {
 	if s.err != nil { return s }
@@ -6490,6 +7226,7 @@ type ContainerResource interface {
 	OnResourceStopped(callback func(arg ResourceStoppedEvent)) ContainerResource
 	PublishAsConnectionString() ContainerResource
 	PublishAsContainer() ContainerResource
+	SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) ContainerResource
 	TestWaitFor(dependency Resource) ContainerResource
 	TestWithEnvironmentCallback(callback func(arg TestEnvironmentContext)) ContainerResource
 	WaitFor(dependency Resource, options ...*WaitForOptions) ContainerResource
@@ -6506,8 +7243,10 @@ type ContainerResource interface {
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) ContainerResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) ContainerResource
 	WithConfig(config *TestConfigDto) ContainerResource
+	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ContainerResource
 	WithContainerCertificatePaths(options ...*WithContainerCertificatePathsOptions) ContainerResource
 	WithContainerFiles(destinationPath string, sourcePath string, options ...*WithContainerFilesOptions) ContainerResource
+	WithContainerFilesCallback(destinationPath string, callback func(arg1 ContainerFileSystemCallbackContext, arg2 *CancellationToken) []ContainerFileSystemItem, options ...*WithContainerFilesCallbackOptions) ContainerResource
 	WithContainerName(name string) ContainerResource
 	WithContainerNetworkAlias(alias string) ContainerResource
 	WithContainerRegistry(registry Resource) ContainerResource
@@ -6538,6 +7277,7 @@ type ContainerResource interface {
 	WithHttpEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpEndpointCallbackOptions) ContainerResource
 	WithHttpHealthCheck(options ...*WithHttpHealthCheckOptions) ContainerResource
 	WithHttpProbe(probeType ProbeType, options ...*WithHttpProbeOptions) ContainerResource
+	WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) ContainerResource
 	WithHttpsDeveloperCertificate(options ...*WithHttpsDeveloperCertificateOptions) ContainerResource
 	WithHttpsEndpoint(options ...*WithHttpsEndpointOptions) ContainerResource
 	WithHttpsEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpsEndpointCallbackOptions) ContainerResource
@@ -6577,6 +7317,7 @@ type ContainerResource interface {
 	WithRemoteImageName(remoteImageName string) ContainerResource
 	WithRemoteImageTag(remoteImageTag string) ContainerResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) ContainerResource
+	WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) ContainerResource
 	WithSessionLifetime() ContainerResource
 	WithStatus(status TestResourceStatus) ContainerResource
 	WithUnionDependency(dependency any) ContainerResource
@@ -6800,6 +7541,25 @@ func (s *containerResource) PublishAsContainer() ContainerResource {
 		"builder": s.handle.ToJSON(),
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/publishAsContainer", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// SubscribeHttpsEndpointsUpdate subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+func (s *containerResource) SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) ContainerResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsEndpointUpdateCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -7076,6 +7836,25 @@ func (s *containerResource) WithConfig(config *TestConfigDto) ContainerResource 
 	return s
 }
 
+// WithContainerBuildOptions configures container build options for a compute resource using an async callback.
+func (s *containerResource) WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ContainerResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[ContainerBuildOptionsCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerBuildOptions", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithContainerCertificatePaths adds container certificate path overrides used for certificate trust at run time.
 func (s *containerResource) WithContainerCertificatePaths(options ...*WithContainerCertificatePathsOptions) ContainerResource {
 	if s.err != nil { return s }
@@ -7111,6 +7890,32 @@ func (s *containerResource) WithContainerFiles(destinationPath string, sourcePat
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerFiles", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithContainerFilesCallback creates or updates files and folders in a container using entries produced by a callback.
+func (s *containerResource) WithContainerFilesCallback(destinationPath string, callback func(arg1 ContainerFileSystemCallbackContext, arg2 *CancellationToken) []ContainerFileSystemItem, options ...*WithContainerFilesCallbackOptions) ContainerResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["destinationPath"] = serializeValue(destinationPath)
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			return cb(callbackArg[ContainerFileSystemCallbackContext](args, 0), callbackArg[*CancellationToken](args, 1))
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithContainerFilesCallbackOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerFilesCallback", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -7595,6 +8400,25 @@ func (s *containerResource) WithHttpProbe(probeType ProbeType, options ...*WithH
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpProbe", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithHttpsCertificateConfiguration adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+func (s *containerResource) WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) ContainerResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsCertificateConfigurationCallbackAnnotationContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -8231,6 +9055,32 @@ func (s *containerResource) WithRequiredCommand(command string, options ...*With
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommand", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithRequiredCommandValidation declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+func (s *containerResource) WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) ContainerResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["command"] = serializeValue(command)
+	if validationCallback != nil {
+		cb := validationCallback
+		shim := func(args ...any) any {
+			return cb(callbackArg[RequiredCommandValidationContext](args, 0))
+		}
+		reqArgs["validationCallback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithRequiredCommandValidationOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommandValidation", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -9993,6 +10843,7 @@ type DotnetToolResource interface {
 	OnResourceReady(callback func(arg ResourceReadyEvent)) DotnetToolResource
 	OnResourceStopped(callback func(arg ResourceStoppedEvent)) DotnetToolResource
 	PublishAsDockerFile(configure func(obj ContainerResource)) DotnetToolResource
+	SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) DotnetToolResource
 	TestWaitFor(dependency Resource) DotnetToolResource
 	TestWithEnvironmentCallback(callback func(arg TestEnvironmentContext)) DotnetToolResource
 	WaitFor(dependency Resource, options ...*WaitForOptions) DotnetToolResource
@@ -10006,6 +10857,7 @@ type DotnetToolResource interface {
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) DotnetToolResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) DotnetToolResource
 	WithConfig(config *TestConfigDto) DotnetToolResource
+	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) DotnetToolResource
 	WithContainerRegistry(registry Resource) DotnetToolResource
 	WithCorrelationId(correlationId string) DotnetToolResource
 	WithCreatedAt(createdAt string) DotnetToolResource
@@ -10030,6 +10882,7 @@ type DotnetToolResource interface {
 	WithHttpEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpEndpointCallbackOptions) DotnetToolResource
 	WithHttpHealthCheck(options ...*WithHttpHealthCheckOptions) DotnetToolResource
 	WithHttpProbe(probeType ProbeType, options ...*WithHttpProbeOptions) DotnetToolResource
+	WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) DotnetToolResource
 	WithHttpsDeveloperCertificate(options ...*WithHttpsDeveloperCertificateOptions) DotnetToolResource
 	WithHttpsEndpoint(options ...*WithHttpsEndpointOptions) DotnetToolResource
 	WithHttpsEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpsEndpointCallbackOptions) DotnetToolResource
@@ -10063,6 +10916,7 @@ type DotnetToolResource interface {
 	WithRemoteImageName(remoteImageName string) DotnetToolResource
 	WithRemoteImageTag(remoteImageTag string) DotnetToolResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) DotnetToolResource
+	WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) DotnetToolResource
 	WithSessionLifetime() DotnetToolResource
 	WithStatus(status TestResourceStatus) DotnetToolResource
 	WithToolIgnoreExistingFeeds() DotnetToolResource
@@ -10292,6 +11146,25 @@ func (s *dotnetToolResource) PublishAsDockerFile(configure func(obj ContainerRes
 	return s
 }
 
+// SubscribeHttpsEndpointsUpdate subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+func (s *dotnetToolResource) SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) DotnetToolResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsEndpointUpdateCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // TestWaitFor waits for another resource (test version)
 func (s *dotnetToolResource) TestWaitFor(dependency Resource) DotnetToolResource {
 	if s.err != nil { return s }
@@ -10508,6 +11381,25 @@ func (s *dotnetToolResource) WithConfig(config *TestConfigDto) DotnetToolResourc
 	}
 	if config != nil { reqArgs["config"] = serializeValue(config) }
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.CodeGeneration.Go.Tests/withConfig", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithContainerBuildOptions configures container build options for a compute resource using an async callback.
+func (s *dotnetToolResource) WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) DotnetToolResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[ContainerBuildOptionsCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerBuildOptions", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -10884,6 +11776,25 @@ func (s *dotnetToolResource) WithHttpProbe(probeType ProbeType, options ...*With
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpProbe", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithHttpsCertificateConfiguration adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+func (s *dotnetToolResource) WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) DotnetToolResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsCertificateConfigurationCallbackAnnotationContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -11441,6 +12352,32 @@ func (s *dotnetToolResource) WithRequiredCommand(command string, options ...*Wit
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommand", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithRequiredCommandValidation declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+func (s *dotnetToolResource) WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) DotnetToolResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["command"] = serializeValue(command)
+	if validationCallback != nil {
+		cb := validationCallback
+		shim := func(args ...any) any {
+			return cb(callbackArg[RequiredCommandValidationContext](args, 0))
+		}
+		reqArgs["validationCallback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithRequiredCommandValidationOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommandValidation", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -12694,6 +13631,7 @@ type ExecutableResource interface {
 	OnResourceReady(callback func(arg ResourceReadyEvent)) ExecutableResource
 	OnResourceStopped(callback func(arg ResourceStoppedEvent)) ExecutableResource
 	PublishAsDockerFile(configure func(obj ContainerResource)) ExecutableResource
+	SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) ExecutableResource
 	TestWaitFor(dependency Resource) ExecutableResource
 	TestWithEnvironmentCallback(callback func(arg TestEnvironmentContext)) ExecutableResource
 	WaitFor(dependency Resource, options ...*WaitForOptions) ExecutableResource
@@ -12707,6 +13645,7 @@ type ExecutableResource interface {
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) ExecutableResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) ExecutableResource
 	WithConfig(config *TestConfigDto) ExecutableResource
+	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ExecutableResource
 	WithContainerRegistry(registry Resource) ExecutableResource
 	WithCorrelationId(correlationId string) ExecutableResource
 	WithCreatedAt(createdAt string) ExecutableResource
@@ -12731,6 +13670,7 @@ type ExecutableResource interface {
 	WithHttpEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpEndpointCallbackOptions) ExecutableResource
 	WithHttpHealthCheck(options ...*WithHttpHealthCheckOptions) ExecutableResource
 	WithHttpProbe(probeType ProbeType, options ...*WithHttpProbeOptions) ExecutableResource
+	WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) ExecutableResource
 	WithHttpsDeveloperCertificate(options ...*WithHttpsDeveloperCertificateOptions) ExecutableResource
 	WithHttpsEndpoint(options ...*WithHttpsEndpointOptions) ExecutableResource
 	WithHttpsEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpsEndpointCallbackOptions) ExecutableResource
@@ -12764,6 +13704,7 @@ type ExecutableResource interface {
 	WithRemoteImageName(remoteImageName string) ExecutableResource
 	WithRemoteImageTag(remoteImageTag string) ExecutableResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) ExecutableResource
+	WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) ExecutableResource
 	WithSessionLifetime() ExecutableResource
 	WithStatus(status TestResourceStatus) ExecutableResource
 	WithUnionDependency(dependency any) ExecutableResource
@@ -12987,6 +13928,25 @@ func (s *executableResource) PublishAsDockerFile(configure func(obj ContainerRes
 	return s
 }
 
+// SubscribeHttpsEndpointsUpdate subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+func (s *executableResource) SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) ExecutableResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsEndpointUpdateCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // TestWaitFor waits for another resource (test version)
 func (s *executableResource) TestWaitFor(dependency Resource) ExecutableResource {
 	if s.err != nil { return s }
@@ -13203,6 +14163,25 @@ func (s *executableResource) WithConfig(config *TestConfigDto) ExecutableResourc
 	}
 	if config != nil { reqArgs["config"] = serializeValue(config) }
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.CodeGeneration.Go.Tests/withConfig", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithContainerBuildOptions configures container build options for a compute resource using an async callback.
+func (s *executableResource) WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ExecutableResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[ContainerBuildOptionsCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerBuildOptions", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -13579,6 +14558,25 @@ func (s *executableResource) WithHttpProbe(probeType ProbeType, options ...*With
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpProbe", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithHttpsCertificateConfiguration adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+func (s *executableResource) WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) ExecutableResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsCertificateConfigurationCallbackAnnotationContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -14139,6 +15137,32 @@ func (s *executableResource) WithRequiredCommand(command string, options ...*Wit
 	return s
 }
 
+// WithRequiredCommandValidation declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+func (s *executableResource) WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) ExecutableResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["command"] = serializeValue(command)
+	if validationCallback != nil {
+		cb := validationCallback
+		shim := func(args ...any) any {
+			return cb(callbackArg[RequiredCommandValidationContext](args, 0))
+		}
+		reqArgs["validationCallback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithRequiredCommandValidationOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommandValidation", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithSessionLifetime configures a resource to use a session lifetime.
 func (s *executableResource) WithSessionLifetime() ExecutableResource {
 	if s.err != nil { return s }
@@ -14297,6 +15321,7 @@ type ExecuteCommandContext interface {
 	CancellationToken() (*CancellationToken, error)
 	Logger() Logger
 	ResourceName() (string, error)
+	Services() ServiceProvider
 	Err() error
 }
 
@@ -14376,6 +15401,25 @@ func (s *executeCommandContext) ResourceName() (string, error) {
 		return zero, err
 	}
 	return decodeAs[string](result)
+}
+
+// Services the service provider.
+func (s *executeCommandContext) Services() ServiceProvider {
+	if s.err != nil { return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/ExecuteCommandContext.services", reqArgs)
+	if err != nil {
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/ExecuteCommandContext.services returned unexpected type %T", result)
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
 }
 
 // ExecutionConfigurationBuilder is the public interface for handle type ExecutionConfigurationBuilder.
@@ -14550,11 +15594,13 @@ type ExternalServiceResource interface {
 	OnInitializeResource(callback func(arg InitializeResourceEvent)) ExternalServiceResource
 	OnResourceReady(callback func(arg ResourceReadyEvent)) ExternalServiceResource
 	OnResourceStopped(callback func(arg ResourceStoppedEvent)) ExternalServiceResource
+	SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) ExternalServiceResource
 	TestWaitFor(dependency Resource) ExternalServiceResource
 	WithCancellableOperation(operation func(arg *CancellationToken)) ExternalServiceResource
 	WithChildRelationship(child Resource) ExternalServiceResource
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) ExternalServiceResource
 	WithConfig(config *TestConfigDto) ExternalServiceResource
+	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ExternalServiceResource
 	WithContainerRegistry(registry Resource) ExternalServiceResource
 	WithCorrelationId(correlationId string) ExternalServiceResource
 	WithCreatedAt(createdAt string) ExternalServiceResource
@@ -14589,6 +15635,7 @@ type ExternalServiceResource interface {
 	WithProcessCommandFactory(commandName string, displayName string, createProcessSpec func(arg ExecuteCommandContext) *ProcessCommandSpecExportData, options ...*WithProcessCommandFactoryOptions) ExternalServiceResource
 	WithRelationship(resourceBuilder Resource, type_ string) ExternalServiceResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) ExternalServiceResource
+	WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) ExternalServiceResource
 	WithSessionLifetime() ExternalServiceResource
 	WithStatus(status TestResourceStatus) ExternalServiceResource
 	WithUnionDependency(dependency any) ExternalServiceResource
@@ -14741,6 +15788,25 @@ func (s *externalServiceResource) OnResourceStopped(callback func(arg ResourceSt
 	return s
 }
 
+// SubscribeHttpsEndpointsUpdate subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+func (s *externalServiceResource) SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) ExternalServiceResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsEndpointUpdateCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // TestWaitFor waits for another resource (test version)
 func (s *externalServiceResource) TestWaitFor(dependency Resource) ExternalServiceResource {
 	if s.err != nil { return s }
@@ -14822,6 +15888,25 @@ func (s *externalServiceResource) WithConfig(config *TestConfigDto) ExternalServ
 	}
 	if config != nil { reqArgs["config"] = serializeValue(config) }
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.CodeGeneration.Go.Tests/withConfig", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithContainerBuildOptions configures container build options for a compute resource using an async callback.
+func (s *externalServiceResource) WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ExternalServiceResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[ContainerBuildOptionsCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerBuildOptions", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -15353,6 +16438,32 @@ func (s *externalServiceResource) WithRequiredCommand(command string, options ..
 	return s
 }
 
+// WithRequiredCommandValidation declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+func (s *externalServiceResource) WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) ExternalServiceResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["command"] = serializeValue(command)
+	if validationCallback != nil {
+		cb := validationCallback
+		shim := func(args ...any) any {
+			return cb(callbackArg[RequiredCommandValidationContext](args, 0))
+		}
+		reqArgs["validationCallback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithRequiredCommandValidationOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommandValidation", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithSessionLifetime configures a resource to use a session lifetime.
 func (s *externalServiceResource) WithSessionLifetime() ExternalServiceResource {
 	if s.err != nil { return s }
@@ -15737,6 +16848,260 @@ func (s *httpCommandPrepareRequestContext) ResourceName() (string, error) {
 	return decodeAs[string](result)
 }
 
+// HttpsCertificateConfigurationCallbackAnnotationContext is the public interface for handle type HttpsCertificateConfigurationCallbackAnnotationContext.
+type HttpsCertificateConfigurationCallbackAnnotationContext interface {
+	handleReference
+	Arguments() CommandLineArgsEditor
+	CancellationToken() (*CancellationToken, error)
+	CertificatePath() *ReferenceExpression
+	Environment() EnvironmentEditor
+	ExecutionContext() DistributedApplicationExecutionContext
+	KeyPath() *ReferenceExpression
+	PfxPath() *ReferenceExpression
+	Resource() Resource
+	Err() error
+}
+
+// httpsCertificateConfigurationCallbackAnnotationContext is the unexported impl of HttpsCertificateConfigurationCallbackAnnotationContext.
+type httpsCertificateConfigurationCallbackAnnotationContext struct {
+	*resourceBuilderBase
+}
+
+// newHttpsCertificateConfigurationCallbackAnnotationContextFromHandle wraps an existing handle as HttpsCertificateConfigurationCallbackAnnotationContext.
+func newHttpsCertificateConfigurationCallbackAnnotationContextFromHandle(h *handle, c *client) HttpsCertificateConfigurationCallbackAnnotationContext {
+	return &httpsCertificateConfigurationCallbackAnnotationContext{resourceBuilderBase: newResourceBuilderBase(h, c)}
+}
+
+// Arguments gets the editor used to manipulate the command-line arguments in polyglot callbacks.
+func (s *httpsCertificateConfigurationCallbackAnnotationContext) Arguments() CommandLineArgsEditor {
+	if s.err != nil { return &commandLineArgsEditor{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.arguments", reqArgs)
+	if err != nil {
+		return &commandLineArgsEditor{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.arguments returned unexpected type %T", result)
+		return &commandLineArgsEditor{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &commandLineArgsEditor{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// CancellationToken gets the `CancellationToken` that can be used to cancel the operation.
+func (s *httpsCertificateConfigurationCallbackAnnotationContext) CancellationToken() (*CancellationToken, error) {
+	if s.err != nil { var zero *CancellationToken; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.cancellationToken", reqArgs)
+	if err != nil {
+		var zero *CancellationToken
+		return zero, err
+	}
+	return decodeAs[*CancellationToken](result)
+}
+
+// CertificatePath a value provider that will resolve to a path to the certificate file.
+func (s *httpsCertificateConfigurationCallbackAnnotationContext) CertificatePath() *ReferenceExpression {
+	if s.err != nil { return nil }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.certificatePath", reqArgs)
+	if err != nil { s.setErr(err); return nil }
+	typed, ok := result.(*ReferenceExpression)
+	if !ok {
+		s.setErr(fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.certificatePath returned unexpected type %T", result))
+		return nil
+	}
+	return typed
+}
+
+// Environment gets the editor used to set environment variables in polyglot callbacks.
+func (s *httpsCertificateConfigurationCallbackAnnotationContext) Environment() EnvironmentEditor {
+	if s.err != nil { return &environmentEditor{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.environment", reqArgs)
+	if err != nil {
+		return &environmentEditor{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.environment returned unexpected type %T", result)
+		return &environmentEditor{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &environmentEditor{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// ExecutionContext gets the `DistributedApplicationExecutionContext` for this session.
+func (s *httpsCertificateConfigurationCallbackAnnotationContext) ExecutionContext() DistributedApplicationExecutionContext {
+	if s.err != nil { return &distributedApplicationExecutionContext{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.executionContext", reqArgs)
+	if err != nil {
+		return &distributedApplicationExecutionContext{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.executionContext returned unexpected type %T", result)
+		return &distributedApplicationExecutionContext{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &distributedApplicationExecutionContext{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// KeyPath a value provider that will resolve to a path to the private key for the certificate.
+func (s *httpsCertificateConfigurationCallbackAnnotationContext) KeyPath() *ReferenceExpression {
+	if s.err != nil { return nil }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.keyPath", reqArgs)
+	if err != nil { s.setErr(err); return nil }
+	typed, ok := result.(*ReferenceExpression)
+	if !ok {
+		s.setErr(fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.keyPath returned unexpected type %T", result))
+		return nil
+	}
+	return typed
+}
+
+// PfxPath a value provider that will resolve to a path to a PFX file for the key pair.
+func (s *httpsCertificateConfigurationCallbackAnnotationContext) PfxPath() *ReferenceExpression {
+	if s.err != nil { return nil }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.pfxPath", reqArgs)
+	if err != nil { s.setErr(err); return nil }
+	typed, ok := result.(*ReferenceExpression)
+	if !ok {
+		s.setErr(fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.pfxPath returned unexpected type %T", result))
+		return nil
+	}
+	return typed
+}
+
+// Resource gets the resource to which the annotation is applied.
+func (s *httpsCertificateConfigurationCallbackAnnotationContext) Resource() Resource {
+	if s.err != nil { return nil }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.resource", reqArgs)
+	if err != nil { s.setErr(err); return nil }
+	typed, ok := result.(Resource)
+	if !ok {
+		s.setErr(fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.resource returned unexpected type %T", result))
+		return nil
+	}
+	return typed
+}
+
+// HttpsEndpointUpdateCallbackContext is the public interface for handle type HttpsEndpointUpdateCallbackContext.
+type HttpsEndpointUpdateCallbackContext interface {
+	handleReference
+	CancellationToken() (*CancellationToken, error)
+	Model() DistributedApplicationModel
+	Resource() Resource
+	Services() ServiceProvider
+	Err() error
+}
+
+// httpsEndpointUpdateCallbackContext is the unexported impl of HttpsEndpointUpdateCallbackContext.
+type httpsEndpointUpdateCallbackContext struct {
+	*resourceBuilderBase
+}
+
+// newHttpsEndpointUpdateCallbackContextFromHandle wraps an existing handle as HttpsEndpointUpdateCallbackContext.
+func newHttpsEndpointUpdateCallbackContextFromHandle(h *handle, c *client) HttpsEndpointUpdateCallbackContext {
+	return &httpsEndpointUpdateCallbackContext{resourceBuilderBase: newResourceBuilderBase(h, c)}
+}
+
+// CancellationToken gets the `CancellationToken` for the operation.
+func (s *httpsEndpointUpdateCallbackContext) CancellationToken() (*CancellationToken, error) {
+	if s.err != nil { var zero *CancellationToken; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.cancellationToken", reqArgs)
+	if err != nil {
+		var zero *CancellationToken
+		return zero, err
+	}
+	return decodeAs[*CancellationToken](result)
+}
+
+// Model gets the `DistributedApplicationModel` instance.
+func (s *httpsEndpointUpdateCallbackContext) Model() DistributedApplicationModel {
+	if s.err != nil { return &distributedApplicationModel{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.model", reqArgs)
+	if err != nil {
+		return &distributedApplicationModel{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.model returned unexpected type %T", result)
+		return &distributedApplicationModel{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &distributedApplicationModel{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// Resource gets the `IResource` that is being configured for HTTPS.
+func (s *httpsEndpointUpdateCallbackContext) Resource() Resource {
+	if s.err != nil { return nil }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.resource", reqArgs)
+	if err != nil { s.setErr(err); return nil }
+	typed, ok := result.(Resource)
+	if !ok {
+		s.setErr(fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.resource returned unexpected type %T", result))
+		return nil
+	}
+	return typed
+}
+
+// Services gets the `IServiceProvider` instance from the application.
+func (s *httpsEndpointUpdateCallbackContext) Services() ServiceProvider {
+	if s.err != nil { return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.services", reqArgs)
+	if err != nil {
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.services returned unexpected type %T", result)
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
 // IComputeResource is the public interface for handle type IComputeResource.
 type IComputeResource interface {
 	handleReference
@@ -15889,6 +17254,7 @@ type InputsDialogValidationContext interface {
 	AddValidationError(inputName string, errorMessage string) error
 	CancellationToken() (*CancellationToken, error)
 	Inputs() InteractionInputCollection
+	Services() ServiceProvider
 	Err() error
 }
 
@@ -15947,6 +17313,25 @@ func (s *inputsDialogValidationContext) Inputs() InteractionInputCollection {
 		return &interactionInputCollection{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
 	}
 	return &interactionInputCollection{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// Services gets the service provider for resolving services during validation.
+func (s *inputsDialogValidationContext) Services() ServiceProvider {
+	if s.err != nil { return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting/InputsDialogValidationContext.services", reqArgs)
+	if err != nil {
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting/InputsDialogValidationContext.services returned unexpected type %T", result)
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
 }
 
 // InteractionInputCollection is the public interface for handle type InteractionInputCollection.
@@ -16179,11 +17564,13 @@ type ParameterResource interface {
 	OnInitializeResource(callback func(arg InitializeResourceEvent)) ParameterResource
 	OnResourceReady(callback func(arg ResourceReadyEvent)) ParameterResource
 	OnResourceStopped(callback func(arg ResourceStoppedEvent)) ParameterResource
+	SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) ParameterResource
 	TestWaitFor(dependency Resource) ParameterResource
 	WithCancellableOperation(operation func(arg *CancellationToken)) ParameterResource
 	WithChildRelationship(child Resource) ParameterResource
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) ParameterResource
 	WithConfig(config *TestConfigDto) ParameterResource
+	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ParameterResource
 	WithContainerRegistry(registry Resource) ParameterResource
 	WithCorrelationId(correlationId string) ParameterResource
 	WithCreatedAt(createdAt string) ParameterResource
@@ -16219,6 +17606,7 @@ type ParameterResource interface {
 	WithProcessCommandFactory(commandName string, displayName string, createProcessSpec func(arg ExecuteCommandContext) *ProcessCommandSpecExportData, options ...*WithProcessCommandFactoryOptions) ParameterResource
 	WithRelationship(resourceBuilder Resource, type_ string) ParameterResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) ParameterResource
+	WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) ParameterResource
 	WithSessionLifetime() ParameterResource
 	WithStatus(status TestResourceStatus) ParameterResource
 	WithUnionDependency(dependency any) ParameterResource
@@ -16371,6 +17759,25 @@ func (s *parameterResource) OnResourceStopped(callback func(arg ResourceStoppedE
 	return s
 }
 
+// SubscribeHttpsEndpointsUpdate subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+func (s *parameterResource) SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) ParameterResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsEndpointUpdateCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // TestWaitFor waits for another resource (test version)
 func (s *parameterResource) TestWaitFor(dependency Resource) ParameterResource {
 	if s.err != nil { return s }
@@ -16452,6 +17859,25 @@ func (s *parameterResource) WithConfig(config *TestConfigDto) ParameterResource 
 	}
 	if config != nil { reqArgs["config"] = serializeValue(config) }
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.CodeGeneration.Go.Tests/withConfig", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithContainerBuildOptions configures container build options for a compute resource using an async callback.
+func (s *parameterResource) WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ParameterResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[ContainerBuildOptionsCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerBuildOptions", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -16993,6 +18419,32 @@ func (s *parameterResource) WithRequiredCommand(command string, options ...*With
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommand", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithRequiredCommandValidation declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+func (s *parameterResource) WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) ParameterResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["command"] = serializeValue(command)
+	if validationCallback != nil {
+		cb := validationCallback
+		shim := func(args ...any) any {
+			return cb(callbackArg[RequiredCommandValidationContext](args, 0))
+		}
+		reqArgs["validationCallback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithRequiredCommandValidationOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommandValidation", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -17807,6 +19259,7 @@ type ProjectResource interface {
 	OnResourceStopped(callback func(arg ResourceStoppedEvent)) ProjectResource
 	PublishAsDockerFile(options ...*PublishAsDockerFileOptions) ProjectResource
 	PublishWithContainerFiles(source ResourceWithContainerFiles, destinationPath string) ProjectResource
+	SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) ProjectResource
 	TestWaitFor(dependency Resource) ProjectResource
 	TestWithEnvironmentCallback(callback func(arg TestEnvironmentContext)) ProjectResource
 	WaitFor(dependency Resource, options ...*WaitForOptions) ProjectResource
@@ -17820,6 +19273,7 @@ type ProjectResource interface {
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) ProjectResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) ProjectResource
 	WithConfig(config *TestConfigDto) ProjectResource
+	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ProjectResource
 	WithContainerRegistry(registry Resource) ProjectResource
 	WithCorrelationId(correlationId string) ProjectResource
 	WithCreatedAt(createdAt string) ProjectResource
@@ -17844,6 +19298,7 @@ type ProjectResource interface {
 	WithHttpEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpEndpointCallbackOptions) ProjectResource
 	WithHttpHealthCheck(options ...*WithHttpHealthCheckOptions) ProjectResource
 	WithHttpProbe(probeType ProbeType, options ...*WithHttpProbeOptions) ProjectResource
+	WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) ProjectResource
 	WithHttpsDeveloperCertificate(options ...*WithHttpsDeveloperCertificateOptions) ProjectResource
 	WithHttpsEndpoint(options ...*WithHttpsEndpointOptions) ProjectResource
 	WithHttpsEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpsEndpointCallbackOptions) ProjectResource
@@ -17878,6 +19333,7 @@ type ProjectResource interface {
 	WithRemoteImageTag(remoteImageTag string) ProjectResource
 	WithReplicas(replicas float64) ProjectResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) ProjectResource
+	WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) ProjectResource
 	WithSessionLifetime() ProjectResource
 	WithStatus(status TestResourceStatus) ProjectResource
 	WithUnionDependency(dependency any) ProjectResource
@@ -18132,6 +19588,25 @@ func (s *projectResource) PublishWithContainerFiles(source ResourceWithContainer
 	return s
 }
 
+// SubscribeHttpsEndpointsUpdate subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+func (s *projectResource) SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) ProjectResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsEndpointUpdateCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // TestWaitFor waits for another resource (test version)
 func (s *projectResource) TestWaitFor(dependency Resource) ProjectResource {
 	if s.err != nil { return s }
@@ -18348,6 +19823,25 @@ func (s *projectResource) WithConfig(config *TestConfigDto) ProjectResource {
 	}
 	if config != nil { reqArgs["config"] = serializeValue(config) }
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting.CodeGeneration.Go.Tests/withConfig", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithContainerBuildOptions configures container build options for a compute resource using an async callback.
+func (s *projectResource) WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ProjectResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[ContainerBuildOptionsCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerBuildOptions", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -18724,6 +20218,25 @@ func (s *projectResource) WithHttpProbe(probeType ProbeType, options ...*WithHtt
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpProbe", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithHttpsCertificateConfiguration adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+func (s *projectResource) WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) ProjectResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsCertificateConfigurationCallbackAnnotationContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -19293,6 +20806,32 @@ func (s *projectResource) WithRequiredCommand(command string, options ...*WithRe
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommand", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithRequiredCommandValidation declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+func (s *projectResource) WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) ProjectResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["command"] = serializeValue(command)
+	if validationCallback != nil {
+		cb := validationCallback
+		shim := func(args ...any) any {
+			return cb(callbackArg[RequiredCommandValidationContext](args, 0))
+		}
+		reqArgs["validationCallback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithRequiredCommandValidationOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommandValidation", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -19922,6 +21461,163 @@ func (s *reportingTask) UpdateTaskMarkdown(markdownString string, options ...*Up
 	}
 	_, err := s.client.invokeCapability(ctx, "Aspire.Hosting/updateTaskMarkdown", reqArgs)
 	return err
+}
+
+// RequiredCommandValidationContext is the public interface for handle type RequiredCommandValidationContext.
+type RequiredCommandValidationContext interface {
+	handleReference
+	CancellationToken() (*CancellationToken, error)
+	Failure(validationMessage string) RequiredCommandValidationResult
+	ResolvedPath() (string, error)
+	Services() ServiceProvider
+	Success() RequiredCommandValidationResult
+	Err() error
+}
+
+// requiredCommandValidationContext is the unexported impl of RequiredCommandValidationContext.
+type requiredCommandValidationContext struct {
+	*resourceBuilderBase
+}
+
+// newRequiredCommandValidationContextFromHandle wraps an existing handle as RequiredCommandValidationContext.
+func newRequiredCommandValidationContextFromHandle(h *handle, c *client) RequiredCommandValidationContext {
+	return &requiredCommandValidationContext{resourceBuilderBase: newResourceBuilderBase(h, c)}
+}
+
+// CancellationToken gets a cancellation token that can be used to cancel the validation.
+func (s *requiredCommandValidationContext) CancellationToken() (*CancellationToken, error) {
+	if s.err != nil { var zero *CancellationToken; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.cancellationToken", reqArgs)
+	if err != nil {
+		var zero *CancellationToken
+		return zero, err
+	}
+	return decodeAs[*CancellationToken](result)
+}
+
+// Failure creates a failed validation result with the specified message.
+func (s *requiredCommandValidationContext) Failure(validationMessage string) RequiredCommandValidationResult {
+	if s.err != nil { return &requiredCommandValidationResult{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	reqArgs["validationMessage"] = serializeValue(validationMessage)
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.failure", reqArgs)
+	if err != nil {
+		return &requiredCommandValidationResult{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.failure returned unexpected type %T", result)
+		return &requiredCommandValidationResult{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &requiredCommandValidationResult{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// ResolvedPath gets the resolved full path to the command executable.
+func (s *requiredCommandValidationContext) ResolvedPath() (string, error) {
+	if s.err != nil { var zero string; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.resolvedPath", reqArgs)
+	if err != nil {
+		var zero string
+		return zero, err
+	}
+	return decodeAs[string](result)
+}
+
+// Services gets the service provider for accessing application services.
+func (s *requiredCommandValidationContext) Services() ServiceProvider {
+	if s.err != nil { return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.services", reqArgs)
+	if err != nil {
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.services returned unexpected type %T", result)
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// Success creates a successful validation result.
+func (s *requiredCommandValidationContext) Success() RequiredCommandValidationResult {
+	if s.err != nil { return &requiredCommandValidationResult{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.success", reqArgs)
+	if err != nil {
+		return &requiredCommandValidationResult{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.success returned unexpected type %T", result)
+		return &requiredCommandValidationResult{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &requiredCommandValidationResult{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
+}
+
+// RequiredCommandValidationResult is the public interface for handle type RequiredCommandValidationResult.
+type RequiredCommandValidationResult interface {
+	handleReference
+	IsValid() (bool, error)
+	ValidationMessage() (string, error)
+	Err() error
+}
+
+// requiredCommandValidationResult is the unexported impl of RequiredCommandValidationResult.
+type requiredCommandValidationResult struct {
+	*resourceBuilderBase
+}
+
+// newRequiredCommandValidationResultFromHandle wraps an existing handle as RequiredCommandValidationResult.
+func newRequiredCommandValidationResultFromHandle(h *handle, c *client) RequiredCommandValidationResult {
+	return &requiredCommandValidationResult{resourceBuilderBase: newResourceBuilderBase(h, c)}
+}
+
+// IsValid gets a value indicating whether the command validation succeeded.
+func (s *requiredCommandValidationResult) IsValid() (bool, error) {
+	if s.err != nil { var zero bool; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/RequiredCommandValidationResult.isValid", reqArgs)
+	if err != nil {
+		var zero bool
+		return zero, err
+	}
+	return decodeAs[bool](result)
+}
+
+// ValidationMessage gets an optional validation message describing why validation failed.
+func (s *requiredCommandValidationResult) ValidationMessage() (string, error) {
+	if s.err != nil { var zero string; return zero, s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/RequiredCommandValidationResult.validationMessage", reqArgs)
+	if err != nil {
+		var zero string
+		return zero, err
+	}
+	return decodeAs[string](result)
 }
 
 // ResourceCommandService is the public interface for handle type ResourceCommandService.
@@ -20898,6 +22594,7 @@ type TestDatabaseResource interface {
 	OnResourceStopped(callback func(arg ResourceStoppedEvent)) TestDatabaseResource
 	PublishAsConnectionString() TestDatabaseResource
 	PublishAsContainer() TestDatabaseResource
+	SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) TestDatabaseResource
 	TestWaitFor(dependency Resource) TestDatabaseResource
 	TestWithEnvironmentCallback(callback func(arg TestEnvironmentContext)) TestDatabaseResource
 	WaitFor(dependency Resource, options ...*WaitForOptions) TestDatabaseResource
@@ -20914,8 +22611,10 @@ type TestDatabaseResource interface {
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) TestDatabaseResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) TestDatabaseResource
 	WithConfig(config *TestConfigDto) TestDatabaseResource
+	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) TestDatabaseResource
 	WithContainerCertificatePaths(options ...*WithContainerCertificatePathsOptions) TestDatabaseResource
 	WithContainerFiles(destinationPath string, sourcePath string, options ...*WithContainerFilesOptions) TestDatabaseResource
+	WithContainerFilesCallback(destinationPath string, callback func(arg1 ContainerFileSystemCallbackContext, arg2 *CancellationToken) []ContainerFileSystemItem, options ...*WithContainerFilesCallbackOptions) TestDatabaseResource
 	WithContainerName(name string) TestDatabaseResource
 	WithContainerNetworkAlias(alias string) TestDatabaseResource
 	WithContainerRegistry(registry Resource) TestDatabaseResource
@@ -20946,6 +22645,7 @@ type TestDatabaseResource interface {
 	WithHttpEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpEndpointCallbackOptions) TestDatabaseResource
 	WithHttpHealthCheck(options ...*WithHttpHealthCheckOptions) TestDatabaseResource
 	WithHttpProbe(probeType ProbeType, options ...*WithHttpProbeOptions) TestDatabaseResource
+	WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) TestDatabaseResource
 	WithHttpsDeveloperCertificate(options ...*WithHttpsDeveloperCertificateOptions) TestDatabaseResource
 	WithHttpsEndpoint(options ...*WithHttpsEndpointOptions) TestDatabaseResource
 	WithHttpsEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpsEndpointCallbackOptions) TestDatabaseResource
@@ -20985,6 +22685,7 @@ type TestDatabaseResource interface {
 	WithRemoteImageName(remoteImageName string) TestDatabaseResource
 	WithRemoteImageTag(remoteImageTag string) TestDatabaseResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) TestDatabaseResource
+	WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) TestDatabaseResource
 	WithSessionLifetime() TestDatabaseResource
 	WithStatus(status TestResourceStatus) TestDatabaseResource
 	WithUnionDependency(dependency any) TestDatabaseResource
@@ -21208,6 +22909,25 @@ func (s *testDatabaseResource) PublishAsContainer() TestDatabaseResource {
 		"builder": s.handle.ToJSON(),
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/publishAsContainer", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// SubscribeHttpsEndpointsUpdate subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+func (s *testDatabaseResource) SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) TestDatabaseResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsEndpointUpdateCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -21484,6 +23204,25 @@ func (s *testDatabaseResource) WithConfig(config *TestConfigDto) TestDatabaseRes
 	return s
 }
 
+// WithContainerBuildOptions configures container build options for a compute resource using an async callback.
+func (s *testDatabaseResource) WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) TestDatabaseResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[ContainerBuildOptionsCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerBuildOptions", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithContainerCertificatePaths adds container certificate path overrides used for certificate trust at run time.
 func (s *testDatabaseResource) WithContainerCertificatePaths(options ...*WithContainerCertificatePathsOptions) TestDatabaseResource {
 	if s.err != nil { return s }
@@ -21519,6 +23258,32 @@ func (s *testDatabaseResource) WithContainerFiles(destinationPath string, source
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerFiles", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithContainerFilesCallback creates or updates files and folders in a container using entries produced by a callback.
+func (s *testDatabaseResource) WithContainerFilesCallback(destinationPath string, callback func(arg1 ContainerFileSystemCallbackContext, arg2 *CancellationToken) []ContainerFileSystemItem, options ...*WithContainerFilesCallbackOptions) TestDatabaseResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["destinationPath"] = serializeValue(destinationPath)
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			return cb(callbackArg[ContainerFileSystemCallbackContext](args, 0), callbackArg[*CancellationToken](args, 1))
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithContainerFilesCallbackOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerFilesCallback", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -22003,6 +23768,25 @@ func (s *testDatabaseResource) WithHttpProbe(probeType ProbeType, options ...*Wi
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpProbe", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithHttpsCertificateConfiguration adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+func (s *testDatabaseResource) WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) TestDatabaseResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsCertificateConfigurationCallbackAnnotationContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -22642,6 +24426,32 @@ func (s *testDatabaseResource) WithRequiredCommand(command string, options ...*W
 	return s
 }
 
+// WithRequiredCommandValidation declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+func (s *testDatabaseResource) WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) TestDatabaseResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["command"] = serializeValue(command)
+	if validationCallback != nil {
+		cb := validationCallback
+		shim := func(args ...any) any {
+			return cb(callbackArg[RequiredCommandValidationContext](args, 0))
+		}
+		reqArgs["validationCallback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithRequiredCommandValidationOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommandValidation", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithSessionLifetime configures a resource to use a session lifetime.
 func (s *testDatabaseResource) WithSessionLifetime() TestDatabaseResource {
 	if s.err != nil { return s }
@@ -22986,6 +24796,7 @@ type TestRedisResource interface {
 	OnResourceStopped(callback func(arg ResourceStoppedEvent)) TestRedisResource
 	PublishAsConnectionString() TestRedisResource
 	PublishAsContainer() TestRedisResource
+	SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) TestRedisResource
 	TestWaitFor(dependency Resource) TestRedisResource
 	TestWithEnvironmentCallback(callback func(arg TestEnvironmentContext)) TestRedisResource
 	WaitFor(dependency Resource, options ...*WaitForOptions) TestRedisResource
@@ -23006,8 +24817,10 @@ type TestRedisResource interface {
 	WithConnectionProperty(name string, value any) TestRedisResource
 	WithConnectionString(connectionString *ReferenceExpression) TestRedisResource
 	WithConnectionStringDirect(connectionString string) TestRedisResource
+	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) TestRedisResource
 	WithContainerCertificatePaths(options ...*WithContainerCertificatePathsOptions) TestRedisResource
 	WithContainerFiles(destinationPath string, sourcePath string, options ...*WithContainerFilesOptions) TestRedisResource
+	WithContainerFilesCallback(destinationPath string, callback func(arg1 ContainerFileSystemCallbackContext, arg2 *CancellationToken) []ContainerFileSystemItem, options ...*WithContainerFilesCallbackOptions) TestRedisResource
 	WithContainerName(name string) TestRedisResource
 	WithContainerNetworkAlias(alias string) TestRedisResource
 	WithContainerRegistry(registry Resource) TestRedisResource
@@ -23039,6 +24852,7 @@ type TestRedisResource interface {
 	WithHttpEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpEndpointCallbackOptions) TestRedisResource
 	WithHttpHealthCheck(options ...*WithHttpHealthCheckOptions) TestRedisResource
 	WithHttpProbe(probeType ProbeType, options ...*WithHttpProbeOptions) TestRedisResource
+	WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) TestRedisResource
 	WithHttpsDeveloperCertificate(options ...*WithHttpsDeveloperCertificateOptions) TestRedisResource
 	WithHttpsEndpoint(options ...*WithHttpsEndpointOptions) TestRedisResource
 	WithHttpsEndpointCallback(callback func(obj EndpointUpdateContext), options ...*WithHttpsEndpointCallbackOptions) TestRedisResource
@@ -23081,6 +24895,7 @@ type TestRedisResource interface {
 	WithRemoteImageName(remoteImageName string) TestRedisResource
 	WithRemoteImageTag(remoteImageTag string) TestRedisResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) TestRedisResource
+	WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) TestRedisResource
 	WithSessionLifetime() TestRedisResource
 	WithStatus(status TestResourceStatus) TestRedisResource
 	WithUnionDependency(dependency any) TestRedisResource
@@ -23434,6 +25249,25 @@ func (s *testRedisResource) PublishAsContainer() TestRedisResource {
 	return s
 }
 
+// SubscribeHttpsEndpointsUpdate subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+func (s *testRedisResource) SubscribeHttpsEndpointsUpdate(callback func(obj HttpsEndpointUpdateCallbackContext)) TestRedisResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsEndpointUpdateCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // TestWaitFor waits for another resource (test version)
 func (s *testRedisResource) TestWaitFor(dependency Resource) TestRedisResource {
 	if s.err != nil { return s }
@@ -23781,6 +25615,25 @@ func (s *testRedisResource) WithConnectionStringDirect(connectionString string) 
 	return s
 }
 
+// WithContainerBuildOptions configures container build options for a compute resource using an async callback.
+func (s *testRedisResource) WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) TestRedisResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[ContainerBuildOptionsCallbackContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerBuildOptions", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithContainerCertificatePaths adds container certificate path overrides used for certificate trust at run time.
 func (s *testRedisResource) WithContainerCertificatePaths(options ...*WithContainerCertificatePathsOptions) TestRedisResource {
 	if s.err != nil { return s }
@@ -23816,6 +25669,32 @@ func (s *testRedisResource) WithContainerFiles(destinationPath string, sourcePat
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerFiles", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithContainerFilesCallback creates or updates files and folders in a container using entries produced by a callback.
+func (s *testRedisResource) WithContainerFilesCallback(destinationPath string, callback func(arg1 ContainerFileSystemCallbackContext, arg2 *CancellationToken) []ContainerFileSystemItem, options ...*WithContainerFilesCallbackOptions) TestRedisResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["destinationPath"] = serializeValue(destinationPath)
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			return cb(callbackArg[ContainerFileSystemCallbackContext](args, 0), callbackArg[*CancellationToken](args, 1))
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithContainerFilesCallbackOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withContainerFilesCallback", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -24318,6 +26197,25 @@ func (s *testRedisResource) WithHttpProbe(probeType ProbeType, options ...*WithH
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpProbe", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithHttpsCertificateConfiguration adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+func (s *testRedisResource) WithHttpsCertificateConfiguration(callback func(arg HttpsCertificateConfigurationCallbackAnnotationContext)) TestRedisResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if callback != nil {
+		cb := callback
+		shim := func(args ...any) any {
+			cb(callbackArg[HttpsCertificateConfigurationCallbackAnnotationContext](args, 0))
+			return nil
+		}
+		reqArgs["callback"] = s.client.registerCallback(shim)
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -25006,6 +26904,32 @@ func (s *testRedisResource) WithRequiredCommand(command string, options ...*With
 	return s
 }
 
+// WithRequiredCommandValidation declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+func (s *testRedisResource) WithRequiredCommandValidation(command string, validationCallback func(arg RequiredCommandValidationContext) RequiredCommandValidationResult, options ...*WithRequiredCommandValidationOptions) TestRedisResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["command"] = serializeValue(command)
+	if validationCallback != nil {
+		cb := validationCallback
+		shim := func(args ...any) any {
+			return cb(callbackArg[RequiredCommandValidationContext](args, 0))
+		}
+		reqArgs["validationCallback"] = s.client.registerCallback(shim)
+	}
+	if len(options) > 0 {
+		merged := &WithRequiredCommandValidationOptions{}
+		for _, opt := range options {
+			if opt != nil { merged = deepUpdate(merged, opt) }
+		}
+		for k, v := range merged.ToMap() { reqArgs[k] = v }
+	}
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withRequiredCommandValidation", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithSessionLifetime configures a resource to use a session lifetime.
 func (s *testRedisResource) WithSessionLifetime() TestRedisResource {
 	if s.err != nil { return s }
@@ -25287,6 +27211,7 @@ func (s *testResourceContext) Value() (float64, error) {
 type UpdateCommandStateContext interface {
 	handleReference
 	ResourceSnapshot() (*UpdateCommandStateResourceSnapshot, error)
+	Services() ServiceProvider
 	Err() error
 }
 
@@ -25313,6 +27238,25 @@ func (s *updateCommandStateContext) ResourceSnapshot() (*UpdateCommandStateResou
 		return zero, err
 	}
 	return decodeAs[*UpdateCommandStateResourceSnapshot](result)
+}
+
+// Services the service provider.
+func (s *updateCommandStateContext) Services() ServiceProvider {
+	if s.err != nil { return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(s.err, s.client)} }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	result, err := s.client.invokeCapability(ctx, "Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.services", reqArgs)
+	if err != nil {
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	href, ok := result.(handleReference)
+	if !ok {
+		err := fmt.Errorf("aspire: Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.services returned unexpected type %T", result)
+		return &serviceProvider{resourceBuilderBase: newErroredResourceBuilder(err, s.client)}
+	}
+	return &serviceProvider{resourceBuilderBase: newResourceBuilderBase(href.getHandle(), s.client)}
 }
 
 // UserSecretsManager is the public interface for handle type UserSecretsManager.
@@ -25572,6 +27516,18 @@ func (o *WithContainerFilesOptions) ToMap() map[string]any {
 	return m
 }
 
+// WithContainerFilesCallbackOptions carries optional parameters for WithContainerFilesCallback.
+type WithContainerFilesCallbackOptions struct {
+	Options *ContainerFilesOptions `json:"options,omitempty"`
+}
+
+func (o *WithContainerFilesCallbackOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if o == nil { return m }
+	if o.Options != nil { m["options"] = serializeValue(o.Options) }
+	return m
+}
+
 // WithDockerfileBuilderOptions carries optional parameters for WithDockerfileBuilder.
 type WithDockerfileBuilderOptions struct {
 	Stage *string `json:"stage,omitempty"`
@@ -25758,6 +27714,18 @@ type WithRequiredCommandOptions struct {
 }
 
 func (o *WithRequiredCommandOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if o == nil { return m }
+	if o.HelpLink != nil { m["helpLink"] = serializeValue(o.HelpLink) }
+	return m
+}
+
+// WithRequiredCommandValidationOptions carries optional parameters for WithRequiredCommandValidation.
+type WithRequiredCommandValidationOptions struct {
+	HelpLink *string `json:"helpLink,omitempty"`
+}
+
+func (o *WithRequiredCommandValidationOptions) ToMap() map[string]any {
 	m := map[string]any{}
 	if o == nil { return m }
 	if o.HelpLink != nil { m["helpLink"] = serializeValue(o.HelpLink) }
@@ -26322,6 +28290,66 @@ func (o *SaveStateJsonOptions) ToMap() map[string]any {
 	return m
 }
 
+// CreateFileOptions carries optional parameters for CreateFile.
+type CreateFileOptions struct {
+	Contents *string `json:"contents,omitempty"`
+	SourcePath *string `json:"sourcePath,omitempty"`
+	Owner *float64 `json:"owner,omitempty"`
+	Group *float64 `json:"group,omitempty"`
+	Mode *float64 `json:"mode,omitempty"`
+	ContinueOnError *bool `json:"continueOnError,omitempty"`
+}
+
+func (o *CreateFileOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if o == nil { return m }
+	if o.Contents != nil { m["contents"] = serializeValue(o.Contents) }
+	if o.SourcePath != nil { m["sourcePath"] = serializeValue(o.SourcePath) }
+	if o.Owner != nil { m["owner"] = serializeValue(o.Owner) }
+	if o.Group != nil { m["group"] = serializeValue(o.Group) }
+	if o.Mode != nil { m["mode"] = serializeValue(o.Mode) }
+	if o.ContinueOnError != nil { m["continueOnError"] = serializeValue(o.ContinueOnError) }
+	return m
+}
+
+// CreateCertificateFileOptions carries optional parameters for CreateCertificateFile.
+type CreateCertificateFileOptions struct {
+	Contents *string `json:"contents,omitempty"`
+	SourcePath *string `json:"sourcePath,omitempty"`
+	Owner *float64 `json:"owner,omitempty"`
+	Group *float64 `json:"group,omitempty"`
+	Mode *float64 `json:"mode,omitempty"`
+	ContinueOnError *bool `json:"continueOnError,omitempty"`
+}
+
+func (o *CreateCertificateFileOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if o == nil { return m }
+	if o.Contents != nil { m["contents"] = serializeValue(o.Contents) }
+	if o.SourcePath != nil { m["sourcePath"] = serializeValue(o.SourcePath) }
+	if o.Owner != nil { m["owner"] = serializeValue(o.Owner) }
+	if o.Group != nil { m["group"] = serializeValue(o.Group) }
+	if o.Mode != nil { m["mode"] = serializeValue(o.Mode) }
+	if o.ContinueOnError != nil { m["continueOnError"] = serializeValue(o.ContinueOnError) }
+	return m
+}
+
+// CreateDirectoryOptions carries optional parameters for CreateDirectory.
+type CreateDirectoryOptions struct {
+	Owner *float64 `json:"owner,omitempty"`
+	Group *float64 `json:"group,omitempty"`
+	Mode *float64 `json:"mode,omitempty"`
+}
+
+func (o *CreateDirectoryOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	if o == nil { return m }
+	if o.Owner != nil { m["owner"] = serializeValue(o.Owner) }
+	if o.Group != nil { m["group"] = serializeValue(o.Group) }
+	if o.Mode != nil { m["mode"] = serializeValue(o.Mode) }
+	return m
+}
+
 // GetValueAsyncOptions carries optional parameters for GetValueAsync.
 type GetValueAsyncOptions struct {
 	CancellationToken *CancellationToken `json:"-"`
@@ -26553,6 +28581,15 @@ func registerWrappers(c *client) {
 	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent", func(h *handle, c *client) any {
 		return newConnectionStringAvailableEventFromHandle(h, c)
 	})
+	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerBuildOptionsCallbackContext", func(h *handle, c *client) any {
+		return newContainerBuildOptionsCallbackContextFromHandle(h, c)
+	})
+	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemCallbackContext", func(h *handle, c *client) any {
+		return newContainerFileSystemCallbackContextFromHandle(h, c)
+	})
+	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemItem", func(h *handle, c *client) any {
+		return newContainerFileSystemItemFromHandle(h, c)
+	})
 	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions", func(h *handle, c *client) any {
 		return newContainerImagePushOptionsFromHandle(h, c)
 	})
@@ -26655,6 +28692,12 @@ func registerWrappers(c *client) {
 	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpCommandPrepareRequestContext", func(h *handle, c *client) any {
 		return newHttpCommandPrepareRequestContextFromHandle(h, c)
 	})
+	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext", func(h *handle, c *client) any {
+		return newHttpsCertificateConfigurationCallbackAnnotationContextFromHandle(h, c)
+	})
+	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsEndpointUpdateCallbackContext", func(h *handle, c *client) any {
+		return newHttpsEndpointUpdateCallbackContextFromHandle(h, c)
+	})
 	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IComputeResource", func(h *handle, c *client) any {
 		return newIComputeResourceFromHandle(h, c)
 	})
@@ -26717,6 +28760,12 @@ func registerWrappers(c *client) {
 	})
 	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingTask", func(h *handle, c *client) any {
 		return newReportingTaskFromHandle(h, c)
+	})
+	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationContext", func(h *handle, c *client) any {
+		return newRequiredCommandValidationContextFromHandle(h, c)
+	})
+	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationResult", func(h *handle, c *client) any {
+		return newRequiredCommandValidationResultFromHandle(h, c)
 	})
 	c.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceCommandService", func(h *handle, c *client) any {
 		return newResourceCommandServiceFromHandle(h, c)

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AtsGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AtsGeneratedAspire.verified.java
@@ -1,4 +1,4 @@
-// ===== Aspire.java =====
+﻿// ===== Aspire.java =====
 // Aspire.java - GENERATED CODE - DO NOT EDIT
 
 package aspire;
@@ -1216,6 +1216,37 @@ import java.util.function.*;
 public class CancellationToken {
     private volatile boolean cancelled = false;
     private final List<Runnable> listeners = new CopyOnWriteArrayList<>();
+
+    // Remote token id supplied by the AppHost when this token is materialized for a
+    // callback argument. Null for locally-created tokens. Retained so cancellation can
+    // be correlated back to the AppHost if needed.
+    private final String remoteTokenId;
+
+    CancellationToken() {
+        this.remoteTokenId = null;
+    }
+
+    private CancellationToken(String remoteTokenId) {
+        this.remoteTokenId = remoteTokenId;
+    }
+
+    /**
+     * Materializes a cancellation token from a transport value sent by the AppHost.
+     * When the AppHost invokes a callback that accepts a CancellationToken it passes a
+     * remote token id (a string); generated code calls this to turn that wire value into
+     * a CancellationToken instance. Mirrors the TypeScript/Go SDK behavior.
+     */
+    static CancellationToken fromValue(Object value) {
+        if (value instanceof CancellationToken token) {
+            return token;
+        }
+        if (value instanceof String tokenId) {
+            return new CancellationToken(tokenId);
+        }
+        return new CancellationToken();
+    }
+
+    String getRemoteTokenId() { return remoteTokenId; }
 
     void cancel() {
         cancelled = true;

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1377,6 +1377,9 @@ public class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext", (h, c) -> new CommandLineArgsCallbackContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsEditor", (h, c) -> new CommandLineArgsEditor(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent", (h, c) -> new ConnectionStringAvailableEvent(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerBuildOptionsCallbackContext", (h, c) -> new ContainerBuildOptionsCallbackContext(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemItem", (h, c) -> new ContainerFileSystemItem(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemCallbackContext", (h, c) -> new ContainerFileSystemCallbackContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions", (h, c) -> new ContainerImagePushOptions(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext", (h, c) -> new ContainerImagePushOptionsCallbackContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.DistributedApplicationModel", (h, c) -> new DistributedApplicationModel(h, c));
@@ -1387,10 +1390,14 @@ public class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext", (h, c) -> new EnvironmentCallbackContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentEditor", (h, c) -> new EnvironmentEditor(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpCommandPrepareRequestContext", (h, c) -> new HttpCommandPrepareRequestContext(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext", (h, c) -> new HttpsCertificateConfigurationCallbackAnnotationContext(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsEndpointUpdateCallbackContext", (h, c) -> new HttpsEndpointUpdateCallbackContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IExpressionValue", (h, c) -> new IExpressionValue(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent", (h, c) -> new InitializeResourceEvent(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.LogFacade", (h, c) -> new LogFacade(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpressionBuilder", (h, c) -> new ReferenceExpressionBuilder(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationContext", (h, c) -> new RequiredCommandValidationContext(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationResult", (h, c) -> new RequiredCommandValidationResult(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.UpdateCommandStateContext", (h, c) -> new UpdateCommandStateContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext", (h, c) -> new ExecuteCommandContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceEndpointsAllocatedEvent", (h, c) -> new ResourceEndpointsAllocatedEvent(h, c));
@@ -1765,6 +1772,29 @@ public class CSharpAppResource extends ProjectResource {
             reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
         }
         getClient().invokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs);
+        return this;
+    }
+
+    public CSharpAppResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback) {
+        return withRequiredCommandValidation(command, validationCallback, null);
+    }
+
+    /** Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic. */
+    public CSharpAppResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback, String helpLink) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("command", AspireClient.serializeValue(command));
+        var validationCallbackId = getClient().registerCallback(args -> {
+            var arg = (RequiredCommandValidationContext) args[0];
+            return AspireClient.awaitValue(validationCallback.invoke(arg));
+        });
+        if (validationCallbackId != null) {
+            reqArgs.put("validationCallback", validationCallbackId);
+        }
+        if (helpLink != null) {
+            reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withRequiredCommandValidation", reqArgs);
         return this;
     }
 
@@ -2521,6 +2551,38 @@ public class CSharpAppResource extends ProjectResource {
         return this;
     }
 
+    /** Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication. */
+    public CSharpAppResource withHttpsCertificateConfiguration(AspireAction1<HttpsCertificateConfigurationCallbackAnnotationContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (HttpsCertificateConfigurationCallbackAnnotationContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs);
+        return this;
+    }
+
+    /** Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup. */
+    public CSharpAppResource subscribeHttpsEndpointsUpdate(AspireAction1<HttpsEndpointUpdateCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (HttpsEndpointUpdateCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs);
+        return this;
+    }
+
     /** Adds a relationship to another resource using its builder. */
     public CSharpAppResource withRelationship(IResource resourceBuilder, String type) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -2872,6 +2934,22 @@ public class CSharpAppResource extends ProjectResource {
         reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
         return (IExecutionConfigurationBuilder) result;
+    }
+
+    /** Configures container build options for a compute resource using an async callback. */
+    public CSharpAppResource withContainerBuildOptions(AspireAction1<ContainerBuildOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (ContainerBuildOptionsCallbackContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerBuildOptions", reqArgs);
+        return this;
     }
 
     /** Adds an optional string parameter */
@@ -3800,6 +3878,327 @@ public class ConnectionStringAvailableEvent extends HandleWrapperBase {
 
 }
 
+// ===== ContainerBuildOptionsCallbackContext.java =====
+// ContainerBuildOptionsCallbackContext.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerBuildOptionsCallbackContext. */
+public class ContainerBuildOptionsCallbackContext extends HandleWrapperBase {
+    ContainerBuildOptionsCallbackContext(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Gets the resource being built. */
+    public IResource resource() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.resource", reqArgs);
+        return (IResource) result;
+    }
+
+    /** Gets the service provider. */
+    public IServiceProvider services() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.services", reqArgs);
+        return (IServiceProvider) result;
+    }
+
+    /** Gets the logger instance. */
+    public ILogger logger() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.logger", reqArgs);
+        return (ILogger) result;
+    }
+
+    /** Gets the cancellation token. */
+    public CancellationToken cancellationToken() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.cancellationToken", reqArgs);
+        return (CancellationToken) result;
+    }
+
+    /** Gets the distributed application execution context. */
+    public DistributedApplicationExecutionContext executionContext() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.executionContext", reqArgs);
+        return (DistributedApplicationExecutionContext) result;
+    }
+
+    /** Gets or sets the destination for the container image. */
+    public ContainerImageDestination destination() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.destination", reqArgs);
+        return result == null ? null : ContainerImageDestination.fromValue((String) result);
+    }
+
+    /** Sets the Destination property */
+    public ContainerBuildOptionsCallbackContext setDestination(ContainerImageDestination value) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("value", AspireClient.serializeValue(value));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setDestination", reqArgs);
+        return (ContainerBuildOptionsCallbackContext) result;
+    }
+
+    /** Gets or sets the output path for the container archive. */
+    public String outputPath() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.outputPath", reqArgs);
+        return result == null ? null : (String) result;
+    }
+
+    /** Sets the OutputPath property */
+    public ContainerBuildOptionsCallbackContext setOutputPath(String value) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("value", AspireClient.serializeValue(value));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setOutputPath", reqArgs);
+        return (ContainerBuildOptionsCallbackContext) result;
+    }
+
+    /** Gets or sets the container image format. */
+    public ContainerImageFormat imageFormat() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.imageFormat", reqArgs);
+        return result == null ? null : ContainerImageFormat.fromValue((String) result);
+    }
+
+    /** Sets the ImageFormat property */
+    public ContainerBuildOptionsCallbackContext setImageFormat(ContainerImageFormat value) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("value", AspireClient.serializeValue(value));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setImageFormat", reqArgs);
+        return (ContainerBuildOptionsCallbackContext) result;
+    }
+
+    /** Gets or sets the target platform for the container. */
+    public ContainerTargetPlatform targetPlatform() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.targetPlatform", reqArgs);
+        return result == null ? null : ContainerTargetPlatform.fromValue((String) result);
+    }
+
+    /** Sets the TargetPlatform property */
+    public ContainerBuildOptionsCallbackContext setTargetPlatform(ContainerTargetPlatform value) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("value", AspireClient.serializeValue(value));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setTargetPlatform", reqArgs);
+        return (ContainerBuildOptionsCallbackContext) result;
+    }
+
+    /** Gets or sets the local image name for the built container. */
+    public String localImageName() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.localImageName", reqArgs);
+        return result == null ? null : (String) result;
+    }
+
+    /** Sets the LocalImageName property */
+    public ContainerBuildOptionsCallbackContext setLocalImageName(String value) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("value", AspireClient.serializeValue(value));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setLocalImageName", reqArgs);
+        return (ContainerBuildOptionsCallbackContext) result;
+    }
+
+    /** Gets or sets the local image tag for the built container. */
+    public String localImageTag() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.localImageTag", reqArgs);
+        return result == null ? null : (String) result;
+    }
+
+    /** Sets the LocalImageTag property */
+    public ContainerBuildOptionsCallbackContext setLocalImageTag(String value) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("value", AspireClient.serializeValue(value));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setLocalImageTag", reqArgs);
+        return (ContainerBuildOptionsCallbackContext) result;
+    }
+
+}
+
+// ===== ContainerFileSystemCallbackContext.java =====
+// ContainerFileSystemCallbackContext.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemCallbackContext. */
+public class ContainerFileSystemCallbackContext extends HandleWrapperBase {
+    ContainerFileSystemCallbackContext(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** A `IServiceProvider` that can be used to resolve services in the callback. */
+    public IServiceProvider services() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerFileSystemCallbackContext.services", reqArgs);
+        return (IServiceProvider) result;
+    }
+
+    /** The app model resource the callback is associated with. */
+    public IResource model() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ContainerFileSystemCallbackContext.model", reqArgs);
+        return (IResource) result;
+    }
+
+    /** Creates a container file entry with inline contents or a host source path. */
+    public ContainerFileSystemItem createFile(String name, CreateFileOptions options) {
+        var contents = options == null ? null : options.getContents();
+        var sourcePath = options == null ? null : options.getSourcePath();
+        var owner = options == null ? null : options.getOwner();
+        var group = options == null ? null : options.getGroup();
+        var mode = options == null ? null : options.getMode();
+        var continueOnError = options == null ? null : options.getContinueOnError();
+        return createFileImpl(name, contents, sourcePath, owner, group, mode, continueOnError);
+    }
+
+    public ContainerFileSystemItem createFile(String name) {
+        return createFile(name, null);
+    }
+
+    /** Creates a container file entry with inline contents or a host source path. */
+    private ContainerFileSystemItem createFileImpl(String name, String contents, String sourcePath, Double owner, Double group, Double mode, Boolean continueOnError) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("name", AspireClient.serializeValue(name));
+        if (contents != null) {
+            reqArgs.put("contents", AspireClient.serializeValue(contents));
+        }
+        if (sourcePath != null) {
+            reqArgs.put("sourcePath", AspireClient.serializeValue(sourcePath));
+        }
+        if (owner != null) {
+            reqArgs.put("owner", AspireClient.serializeValue(owner));
+        }
+        if (group != null) {
+            reqArgs.put("group", AspireClient.serializeValue(group));
+        }
+        if (mode != null) {
+            reqArgs.put("mode", AspireClient.serializeValue(mode));
+        }
+        if (continueOnError != null) {
+            reqArgs.put("continueOnError", AspireClient.serializeValue(continueOnError));
+        }
+        var result = getClient().invokeCapability("Aspire.Hosting/createFile", reqArgs);
+        return (ContainerFileSystemItem) result;
+    }
+
+    /** Creates a PEM container certificate file entry with the OpenSSL subject-hash symlink. */
+    public ContainerFileSystemItem createCertificateFile(String name, CreateCertificateFileOptions options) {
+        var contents = options == null ? null : options.getContents();
+        var sourcePath = options == null ? null : options.getSourcePath();
+        var owner = options == null ? null : options.getOwner();
+        var group = options == null ? null : options.getGroup();
+        var mode = options == null ? null : options.getMode();
+        var continueOnError = options == null ? null : options.getContinueOnError();
+        return createCertificateFileImpl(name, contents, sourcePath, owner, group, mode, continueOnError);
+    }
+
+    public ContainerFileSystemItem createCertificateFile(String name) {
+        return createCertificateFile(name, null);
+    }
+
+    /** Creates a PEM container certificate file entry with the OpenSSL subject-hash symlink. */
+    private ContainerFileSystemItem createCertificateFileImpl(String name, String contents, String sourcePath, Double owner, Double group, Double mode, Boolean continueOnError) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("name", AspireClient.serializeValue(name));
+        if (contents != null) {
+            reqArgs.put("contents", AspireClient.serializeValue(contents));
+        }
+        if (sourcePath != null) {
+            reqArgs.put("sourcePath", AspireClient.serializeValue(sourcePath));
+        }
+        if (owner != null) {
+            reqArgs.put("owner", AspireClient.serializeValue(owner));
+        }
+        if (group != null) {
+            reqArgs.put("group", AspireClient.serializeValue(group));
+        }
+        if (mode != null) {
+            reqArgs.put("mode", AspireClient.serializeValue(mode));
+        }
+        if (continueOnError != null) {
+            reqArgs.put("continueOnError", AspireClient.serializeValue(continueOnError));
+        }
+        var result = getClient().invokeCapability("Aspire.Hosting/createCertificateFile", reqArgs);
+        return (ContainerFileSystemItem) result;
+    }
+
+    /** Creates a container directory entry containing the specified child entries. */
+    public ContainerFileSystemItem createDirectory(String name, ContainerFileSystemItem[] entries, CreateDirectoryOptions options) {
+        var owner = options == null ? null : options.getOwner();
+        var group = options == null ? null : options.getGroup();
+        var mode = options == null ? null : options.getMode();
+        return createDirectoryImpl(name, entries, owner, group, mode);
+    }
+
+    public ContainerFileSystemItem createDirectory(String name, ContainerFileSystemItem[] entries) {
+        return createDirectory(name, entries, null);
+    }
+
+    /** Creates a container directory entry containing the specified child entries. */
+    private ContainerFileSystemItem createDirectoryImpl(String name, ContainerFileSystemItem[] entries, Double owner, Double group, Double mode) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("name", AspireClient.serializeValue(name));
+        reqArgs.put("entries", AspireClient.serializeValue(entries));
+        if (owner != null) {
+            reqArgs.put("owner", AspireClient.serializeValue(owner));
+        }
+        if (group != null) {
+            reqArgs.put("group", AspireClient.serializeValue(group));
+        }
+        if (mode != null) {
+            reqArgs.put("mode", AspireClient.serializeValue(mode));
+        }
+        var result = getClient().invokeCapability("Aspire.Hosting/createDirectory", reqArgs);
+        return (ContainerFileSystemItem) result;
+    }
+
+}
+
+// ===== ContainerFileSystemItem.java =====
+// ContainerFileSystemItem.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemItem. */
+public class ContainerFileSystemItem extends HandleWrapperBase {
+    ContainerFileSystemItem(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+}
+
 // ===== ContainerFilesOptions.java =====
 // ContainerFilesOptions.java - GENERATED CODE - DO NOT EDIT
 
@@ -3839,6 +4238,64 @@ public class ContainerFilesOptions implements JsonSerializable {
         map.put("DefaultGroup", AspireClient.serializeValue(defaultGroup));
         map.put("Umask", AspireClient.serializeValue(umask));
         return map;
+    }
+}
+
+// ===== ContainerImageDestination.java =====
+// ContainerImageDestination.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** ContainerImageDestination enum. */
+public enum ContainerImageDestination implements WireValueEnum {
+    REGISTRY("Registry"),
+    ARCHIVE("Archive");
+
+    private final String value;
+
+    ContainerImageDestination(String value) {
+        this.value = value;
+    }
+
+    public String getValue() { return value; }
+
+    public static ContainerImageDestination fromValue(String value) {
+        for (ContainerImageDestination e : values()) {
+            if (e.value.equals(value)) return e;
+        }
+        throw new IllegalArgumentException("Unknown value: " + value);
+    }
+}
+
+// ===== ContainerImageFormat.java =====
+// ContainerImageFormat.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** ContainerImageFormat enum. */
+public enum ContainerImageFormat implements WireValueEnum {
+    DOCKER("Docker"),
+    OCI("Oci");
+
+    private final String value;
+
+    ContainerImageFormat(String value) {
+        this.value = value;
+    }
+
+    public String getValue() { return value; }
+
+    public static ContainerImageFormat fromValue(String value) {
+        for (ContainerImageFormat e : values()) {
+            if (e.value.equals(value)) return e;
+        }
+        throw new IllegalArgumentException("Unknown value: " + value);
     }
 }
 
@@ -4170,6 +4627,29 @@ public class ContainerRegistryResource extends ResourceBuilderBase {
         return this;
     }
 
+    public ContainerRegistryResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback) {
+        return withRequiredCommandValidation(command, validationCallback, null);
+    }
+
+    /** Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic. */
+    public ContainerRegistryResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback, String helpLink) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("command", AspireClient.serializeValue(command));
+        var validationCallbackId = getClient().registerCallback(args -> {
+            var arg = (RequiredCommandValidationContext) args[0];
+            return AspireClient.awaitValue(validationCallback.invoke(arg));
+        });
+        if (validationCallbackId != null) {
+            reqArgs.put("validationCallback", validationCallbackId);
+        }
+        if (helpLink != null) {
+            reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withRequiredCommandValidation", reqArgs);
+        return this;
+    }
+
     /** Configures a resource to use a session lifetime. */
     public ContainerRegistryResource withSessionLifetime() {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -4346,6 +4826,22 @@ public class ContainerRegistryResource extends ResourceBuilderBase {
             reqArgs.put("options", AspireClient.serializeValue(options));
         }
         getClient().invokeCapability("Aspire.Hosting/withProcessCommandFactory", reqArgs);
+        return this;
+    }
+
+    /** Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup. */
+    public ContainerRegistryResource subscribeHttpsEndpointsUpdate(AspireAction1<HttpsEndpointUpdateCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (HttpsEndpointUpdateCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs);
         return this;
     }
 
@@ -4582,6 +5078,22 @@ public class ContainerRegistryResource extends ResourceBuilderBase {
         reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
         return (IExecutionConfigurationBuilder) result;
+    }
+
+    /** Configures container build options for a compute resource using an async callback. */
+    public ContainerRegistryResource withContainerBuildOptions(AspireAction1<ContainerBuildOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (ContainerBuildOptionsCallbackContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerBuildOptions", reqArgs);
+        return this;
     }
 
     /** Adds an optional string parameter */
@@ -5153,6 +5665,30 @@ public class ContainerResource extends ResourceBuilderBase {
         return this;
     }
 
+    public ContainerResource withContainerFilesCallback(String destinationPath, AspireFunc2<ContainerFileSystemCallbackContext, CancellationToken, ContainerFileSystemItem[]> callback) {
+        return withContainerFilesCallback(destinationPath, callback, null);
+    }
+
+    /** Creates or updates files and folders in a container using entries produced by a callback. */
+    public ContainerResource withContainerFilesCallback(String destinationPath, AspireFunc2<ContainerFileSystemCallbackContext, CancellationToken, ContainerFileSystemItem[]> callback, ContainerFilesOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("destinationPath", AspireClient.serializeValue(destinationPath));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg1 = (ContainerFileSystemCallbackContext) args[0];
+            var arg2 = CancellationToken.fromValue(args[1]);
+            return AspireClient.awaitValue(callback.invoke(arg1, arg2));
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        if (options != null) {
+            reqArgs.put("options", AspireClient.serializeValue(options));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerFilesCallback", reqArgs);
+        return this;
+    }
+
     public ContainerResource withDockerfileBuilder(String contextPath, AspireAction1<DockerfileBuilderCallbackContext> callback) {
         return withDockerfileBuilder(contextPath, callback, null);
     }
@@ -5272,6 +5808,29 @@ public class ContainerResource extends ResourceBuilderBase {
             reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
         }
         getClient().invokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs);
+        return this;
+    }
+
+    public ContainerResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback) {
+        return withRequiredCommandValidation(command, validationCallback, null);
+    }
+
+    /** Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic. */
+    public ContainerResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback, String helpLink) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("command", AspireClient.serializeValue(command));
+        var validationCallbackId = getClient().registerCallback(args -> {
+            var arg = (RequiredCommandValidationContext) args[0];
+            return AspireClient.awaitValue(validationCallback.invoke(arg));
+        });
+        if (validationCallbackId != null) {
+            reqArgs.put("validationCallback", validationCallbackId);
+        }
+        if (helpLink != null) {
+            reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withRequiredCommandValidation", reqArgs);
         return this;
     }
 
@@ -6014,6 +6573,38 @@ public class ContainerResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication. */
+    public ContainerResource withHttpsCertificateConfiguration(AspireAction1<HttpsCertificateConfigurationCallbackAnnotationContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (HttpsCertificateConfigurationCallbackAnnotationContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs);
+        return this;
+    }
+
+    /** Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup. */
+    public ContainerResource subscribeHttpsEndpointsUpdate(AspireAction1<HttpsEndpointUpdateCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (HttpsEndpointUpdateCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs);
+        return this;
+    }
+
     /** Adds a relationship to another resource using its builder. */
     public ContainerResource withRelationship(IResource resourceBuilder, String type) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -6384,6 +6975,22 @@ public class ContainerResource extends ResourceBuilderBase {
         return (IExecutionConfigurationBuilder) result;
     }
 
+    /** Configures container build options for a compute resource using an async callback. */
+    public ContainerResource withContainerBuildOptions(AspireAction1<ContainerBuildOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (ContainerBuildOptionsCallbackContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerBuildOptions", reqArgs);
+        return this;
+    }
+
     /** Adds an optional string parameter */
     public ContainerResource withOptionalString(WithOptionalStringOptions options) {
         var value = options == null ? null : options.getValue();
@@ -6715,6 +7322,40 @@ public class ContainerResource extends ResourceBuilderBase {
 
 }
 
+// ===== ContainerTargetPlatform.java =====
+// ContainerTargetPlatform.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** ContainerTargetPlatform enum. */
+public enum ContainerTargetPlatform implements WireValueEnum {
+    LINUX_AMD64("LinuxAmd64"),
+    LINUX_ARM64("LinuxArm64"),
+    ALL_LINUX("AllLinux"),
+    LINUX_ARM("LinuxArm"),
+    LINUX386("Linux386"),
+    WINDOWS_AMD64("WindowsAmd64"),
+    WINDOWS_ARM64("WindowsArm64");
+
+    private final String value;
+
+    ContainerTargetPlatform(String value) {
+        this.value = value;
+    }
+
+    public String getValue() { return value; }
+
+    public static ContainerTargetPlatform fromValue(String value) {
+        for (ContainerTargetPlatform e : values()) {
+            if (e.value.equals(value)) return e;
+        }
+        throw new IllegalArgumentException("Unknown value: " + value);
+    }
+}
+
 // ===== CreateBuilderOptions.java =====
 // CreateBuilderOptions.java - GENERATED CODE - DO NOT EDIT
 
@@ -6785,6 +7426,150 @@ public class CreateBuilderOptions implements JsonSerializable {
         map.put("EnableResourceLogging", AspireClient.serializeValue(enableResourceLogging));
         return map;
     }
+}
+
+// ===== CreateCertificateFileOptions.java =====
+// CreateCertificateFileOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Options for CreateCertificateFile. */
+public final class CreateCertificateFileOptions {
+    private String contents;
+    private String sourcePath;
+    private Double owner;
+    private Double group;
+    private Double mode;
+    private Boolean continueOnError;
+
+    public String getContents() { return contents; }
+    public CreateCertificateFileOptions contents(String value) {
+        this.contents = value;
+        return this;
+    }
+
+    public String getSourcePath() { return sourcePath; }
+    public CreateCertificateFileOptions sourcePath(String value) {
+        this.sourcePath = value;
+        return this;
+    }
+
+    public Double getOwner() { return owner; }
+    public CreateCertificateFileOptions owner(Double value) {
+        this.owner = value;
+        return this;
+    }
+
+    public Double getGroup() { return group; }
+    public CreateCertificateFileOptions group(Double value) {
+        this.group = value;
+        return this;
+    }
+
+    public Double getMode() { return mode; }
+    public CreateCertificateFileOptions mode(Double value) {
+        this.mode = value;
+        return this;
+    }
+
+    public Boolean getContinueOnError() { return continueOnError; }
+    public CreateCertificateFileOptions continueOnError(Boolean value) {
+        this.continueOnError = value;
+        return this;
+    }
+
+}
+
+// ===== CreateDirectoryOptions.java =====
+// CreateDirectoryOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Options for CreateDirectory. */
+public final class CreateDirectoryOptions {
+    private Double owner;
+    private Double group;
+    private Double mode;
+
+    public Double getOwner() { return owner; }
+    public CreateDirectoryOptions owner(Double value) {
+        this.owner = value;
+        return this;
+    }
+
+    public Double getGroup() { return group; }
+    public CreateDirectoryOptions group(Double value) {
+        this.group = value;
+        return this;
+    }
+
+    public Double getMode() { return mode; }
+    public CreateDirectoryOptions mode(Double value) {
+        this.mode = value;
+        return this;
+    }
+
+}
+
+// ===== CreateFileOptions.java =====
+// CreateFileOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Options for CreateFile. */
+public final class CreateFileOptions {
+    private String contents;
+    private String sourcePath;
+    private Double owner;
+    private Double group;
+    private Double mode;
+    private Boolean continueOnError;
+
+    public String getContents() { return contents; }
+    public CreateFileOptions contents(String value) {
+        this.contents = value;
+        return this;
+    }
+
+    public String getSourcePath() { return sourcePath; }
+    public CreateFileOptions sourcePath(String value) {
+        this.sourcePath = value;
+        return this;
+    }
+
+    public Double getOwner() { return owner; }
+    public CreateFileOptions owner(Double value) {
+        this.owner = value;
+        return this;
+    }
+
+    public Double getGroup() { return group; }
+    public CreateFileOptions group(Double value) {
+        this.group = value;
+        return this;
+    }
+
+    public Double getMode() { return mode; }
+    public CreateFileOptions mode(Double value) {
+        this.mode = value;
+        return this;
+    }
+
+    public Boolean getContinueOnError() { return continueOnError; }
+    public CreateFileOptions continueOnError(Boolean value) {
+        this.continueOnError = value;
+        return this;
+    }
+
 }
 
 // ===== DistributedApplication.java =====
@@ -7547,6 +8332,29 @@ public class DotnetToolResource extends ExecutableResource {
         return this;
     }
 
+    public DotnetToolResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback) {
+        return withRequiredCommandValidation(command, validationCallback, null);
+    }
+
+    /** Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic. */
+    public DotnetToolResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback, String helpLink) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("command", AspireClient.serializeValue(command));
+        var validationCallbackId = getClient().registerCallback(args -> {
+            var arg = (RequiredCommandValidationContext) args[0];
+            return AspireClient.awaitValue(validationCallback.invoke(arg));
+        });
+        if (validationCallbackId != null) {
+            reqArgs.put("validationCallback", validationCallbackId);
+        }
+        if (helpLink != null) {
+            reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withRequiredCommandValidation", reqArgs);
+        return this;
+    }
+
     /** Configures a resource to use a session lifetime. */
     public DotnetToolResource withSessionLifetime() {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -8286,6 +9094,38 @@ public class DotnetToolResource extends ExecutableResource {
         return this;
     }
 
+    /** Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication. */
+    public DotnetToolResource withHttpsCertificateConfiguration(AspireAction1<HttpsCertificateConfigurationCallbackAnnotationContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (HttpsCertificateConfigurationCallbackAnnotationContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs);
+        return this;
+    }
+
+    /** Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup. */
+    public DotnetToolResource subscribeHttpsEndpointsUpdate(AspireAction1<HttpsEndpointUpdateCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (HttpsEndpointUpdateCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs);
+        return this;
+    }
+
     /** Adds a relationship to another resource using its builder. */
     public DotnetToolResource withRelationship(IResource resourceBuilder, String type) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -8628,6 +9468,22 @@ public class DotnetToolResource extends ExecutableResource {
         reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
         return (IExecutionConfigurationBuilder) result;
+    }
+
+    /** Configures container build options for a compute resource using an async callback. */
+    public DotnetToolResource withContainerBuildOptions(AspireAction1<ContainerBuildOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (ContainerBuildOptionsCallbackContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerBuildOptions", reqArgs);
+        return this;
     }
 
     /** Adds an optional string parameter */
@@ -9743,6 +10599,29 @@ public class ExecutableResource extends ResourceBuilderBase {
         return this;
     }
 
+    public ExecutableResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback) {
+        return withRequiredCommandValidation(command, validationCallback, null);
+    }
+
+    /** Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic. */
+    public ExecutableResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback, String helpLink) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("command", AspireClient.serializeValue(command));
+        var validationCallbackId = getClient().registerCallback(args -> {
+            var arg = (RequiredCommandValidationContext) args[0];
+            return AspireClient.awaitValue(validationCallback.invoke(arg));
+        });
+        if (validationCallbackId != null) {
+            reqArgs.put("validationCallback", validationCallbackId);
+        }
+        if (helpLink != null) {
+            reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withRequiredCommandValidation", reqArgs);
+        return this;
+    }
+
     /** Configures a resource to use a session lifetime. */
     public ExecutableResource withSessionLifetime() {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -10482,6 +11361,38 @@ public class ExecutableResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication. */
+    public ExecutableResource withHttpsCertificateConfiguration(AspireAction1<HttpsCertificateConfigurationCallbackAnnotationContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (HttpsCertificateConfigurationCallbackAnnotationContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs);
+        return this;
+    }
+
+    /** Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup. */
+    public ExecutableResource subscribeHttpsEndpointsUpdate(AspireAction1<HttpsEndpointUpdateCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (HttpsEndpointUpdateCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs);
+        return this;
+    }
+
     /** Adds a relationship to another resource using its builder. */
     public ExecutableResource withRelationship(IResource resourceBuilder, String type) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -10824,6 +11735,22 @@ public class ExecutableResource extends ResourceBuilderBase {
         reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
         return (IExecutionConfigurationBuilder) result;
+    }
+
+    /** Configures container build options for a compute resource using an async callback. */
+    public ExecutableResource withContainerBuildOptions(AspireAction1<ContainerBuildOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (ContainerBuildOptionsCallbackContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerBuildOptions", reqArgs);
+        return this;
     }
 
     /** Adds an optional string parameter */
@@ -11198,6 +12125,14 @@ public class ExecuteCommandContext extends HandleWrapperBase {
         super(handle, client);
     }
 
+    /** The service provider. */
+    public IServiceProvider services() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ExecuteCommandContext.services", reqArgs);
+        return (IServiceProvider) result;
+    }
+
     /** The resource name. */
     public String resourceName() {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -11383,6 +12318,29 @@ public class ExternalServiceResource extends ResourceBuilderBase {
         return this;
     }
 
+    public ExternalServiceResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback) {
+        return withRequiredCommandValidation(command, validationCallback, null);
+    }
+
+    /** Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic. */
+    public ExternalServiceResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback, String helpLink) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("command", AspireClient.serializeValue(command));
+        var validationCallbackId = getClient().registerCallback(args -> {
+            var arg = (RequiredCommandValidationContext) args[0];
+            return AspireClient.awaitValue(validationCallback.invoke(arg));
+        });
+        if (validationCallbackId != null) {
+            reqArgs.put("validationCallback", validationCallbackId);
+        }
+        if (helpLink != null) {
+            reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withRequiredCommandValidation", reqArgs);
+        return this;
+    }
+
     /** Configures a resource to use a session lifetime. */
     public ExternalServiceResource withSessionLifetime() {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -11559,6 +12517,22 @@ public class ExternalServiceResource extends ResourceBuilderBase {
             reqArgs.put("options", AspireClient.serializeValue(options));
         }
         getClient().invokeCapability("Aspire.Hosting/withProcessCommandFactory", reqArgs);
+        return this;
+    }
+
+    /** Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup. */
+    public ExternalServiceResource subscribeHttpsEndpointsUpdate(AspireAction1<HttpsEndpointUpdateCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (HttpsEndpointUpdateCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs);
         return this;
     }
 
@@ -11795,6 +12769,22 @@ public class ExternalServiceResource extends ResourceBuilderBase {
         reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
         return (IExecutionConfigurationBuilder) result;
+    }
+
+    /** Configures container build options for a compute resource using an async callback. */
+    public ExternalServiceResource withContainerBuildOptions(AspireAction1<ContainerBuildOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (ContainerBuildOptionsCallbackContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerBuildOptions", reqArgs);
+        return this;
     }
 
     /** Adds an optional string parameter */
@@ -12539,6 +13529,86 @@ public enum HttpCommandResultMode implements WireValueEnum {
     }
 }
 
+// ===== HttpsCertificateConfigurationCallbackAnnotationContext.java =====
+// HttpsCertificateConfigurationCallbackAnnotationContext.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext. */
+public class HttpsCertificateConfigurationCallbackAnnotationContext extends HandleWrapperBase {
+    HttpsCertificateConfigurationCallbackAnnotationContext(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Gets the `DistributedApplicationExecutionContext` for this session. */
+    public DistributedApplicationExecutionContext executionContext() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.executionContext", reqArgs);
+        return (DistributedApplicationExecutionContext) result;
+    }
+
+    /** Gets the resource to which the annotation is applied. */
+    public IResource resource() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.resource", reqArgs);
+        return (IResource) result;
+    }
+
+    /** A value provider that will resolve to a path to the certificate file. */
+    public ReferenceExpression certificatePath() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.certificatePath", reqArgs);
+        return (ReferenceExpression) result;
+    }
+
+    /** A value provider that will resolve to a path to the private key for the certificate. */
+    public ReferenceExpression keyPath() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.keyPath", reqArgs);
+        return (ReferenceExpression) result;
+    }
+
+    /** A value provider that will resolve to a path to a PFX file for the key pair. */
+    public ReferenceExpression pfxPath() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.pfxPath", reqArgs);
+        return (ReferenceExpression) result;
+    }
+
+    /** Gets the `CancellationToken` that can be used to cancel the operation. */
+    public CancellationToken cancellationToken() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.cancellationToken", reqArgs);
+        return (CancellationToken) result;
+    }
+
+    /** Gets the editor used to manipulate the command-line arguments in polyglot callbacks. */
+    public CommandLineArgsEditor arguments() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.arguments", reqArgs);
+        return (CommandLineArgsEditor) result;
+    }
+
+    /** Gets the editor used to set environment variables in polyglot callbacks. */
+    public EnvironmentEditor environment() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.environment", reqArgs);
+        return (EnvironmentEditor) result;
+    }
+
+}
+
 // ===== HttpsCertificateExecutionConfigurationContext.java =====
 // HttpsCertificateExecutionConfigurationContext.java - GENERATED CODE - DO NOT EDIT
 
@@ -12687,6 +13757,54 @@ public class HttpsCertificateInfo implements JsonSerializable {
         map.put("Thumbprint", AspireClient.serializeValue(thumbprint));
         return map;
     }
+}
+
+// ===== HttpsEndpointUpdateCallbackContext.java =====
+// HttpsEndpointUpdateCallbackContext.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsEndpointUpdateCallbackContext. */
+public class HttpsEndpointUpdateCallbackContext extends HandleWrapperBase {
+    HttpsEndpointUpdateCallbackContext(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Gets the `IServiceProvider` instance from the application. */
+    public IServiceProvider services() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.services", reqArgs);
+        return (IServiceProvider) result;
+    }
+
+    /** Gets the `IResource` that is being configured for HTTPS. */
+    public IResource resource() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.resource", reqArgs);
+        return (IResource) result;
+    }
+
+    /** Gets the `DistributedApplicationModel` instance. */
+    public DistributedApplicationModel model() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.model", reqArgs);
+        return (DistributedApplicationModel) result;
+    }
+
+    /** Gets the `CancellationToken` for the operation. */
+    public CancellationToken cancellationToken() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.cancellationToken", reqArgs);
+        return (CancellationToken) result;
+    }
+
 }
 
 // ===== IAspireStore.java =====
@@ -14560,6 +15678,14 @@ public class InputsDialogValidationContext extends HandleWrapperBase {
         return (CancellationToken) result;
     }
 
+    /** Gets the service provider for resolving services during validation. */
+    public IServiceProvider services() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting/InputsDialogValidationContext.services", reqArgs);
+        return (IServiceProvider) result;
+    }
+
     /** Adds a validation error for the input with the specified name. */
     public void addValidationError(String inputName, String errorMessage) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -14969,6 +16095,29 @@ public class ParameterResource extends ResourceBuilderBase {
         return this;
     }
 
+    public ParameterResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback) {
+        return withRequiredCommandValidation(command, validationCallback, null);
+    }
+
+    /** Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic. */
+    public ParameterResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback, String helpLink) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("command", AspireClient.serializeValue(command));
+        var validationCallbackId = getClient().registerCallback(args -> {
+            var arg = (RequiredCommandValidationContext) args[0];
+            return AspireClient.awaitValue(validationCallback.invoke(arg));
+        });
+        if (validationCallbackId != null) {
+            reqArgs.put("validationCallback", validationCallbackId);
+        }
+        if (helpLink != null) {
+            reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withRequiredCommandValidation", reqArgs);
+        return this;
+    }
+
     /** Configures a resource to use a session lifetime. */
     public ParameterResource withSessionLifetime() {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -15145,6 +16294,22 @@ public class ParameterResource extends ResourceBuilderBase {
             reqArgs.put("options", AspireClient.serializeValue(options));
         }
         getClient().invokeCapability("Aspire.Hosting/withProcessCommandFactory", reqArgs);
+        return this;
+    }
+
+    /** Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup. */
+    public ParameterResource subscribeHttpsEndpointsUpdate(AspireAction1<HttpsEndpointUpdateCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (HttpsEndpointUpdateCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs);
         return this;
     }
 
@@ -15381,6 +16546,22 @@ public class ParameterResource extends ResourceBuilderBase {
         reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
         return (IExecutionConfigurationBuilder) result;
+    }
+
+    /** Configures container build options for a compute resource using an async callback. */
+    public ParameterResource withContainerBuildOptions(AspireAction1<ContainerBuildOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (ContainerBuildOptionsCallbackContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerBuildOptions", reqArgs);
+        return this;
     }
 
     /** Adds an optional string parameter */
@@ -16452,6 +17633,29 @@ public class ProjectResource extends ResourceBuilderBase {
         return this;
     }
 
+    public ProjectResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback) {
+        return withRequiredCommandValidation(command, validationCallback, null);
+    }
+
+    /** Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic. */
+    public ProjectResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback, String helpLink) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("command", AspireClient.serializeValue(command));
+        var validationCallbackId = getClient().registerCallback(args -> {
+            var arg = (RequiredCommandValidationContext) args[0];
+            return AspireClient.awaitValue(validationCallback.invoke(arg));
+        });
+        if (validationCallbackId != null) {
+            reqArgs.put("validationCallback", validationCallbackId);
+        }
+        if (helpLink != null) {
+            reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withRequiredCommandValidation", reqArgs);
+        return this;
+    }
+
     /** Configures a resource to use a session lifetime. */
     public ProjectResource withSessionLifetime() {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -17205,6 +18409,38 @@ public class ProjectResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication. */
+    public ProjectResource withHttpsCertificateConfiguration(AspireAction1<HttpsCertificateConfigurationCallbackAnnotationContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (HttpsCertificateConfigurationCallbackAnnotationContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs);
+        return this;
+    }
+
+    /** Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup. */
+    public ProjectResource subscribeHttpsEndpointsUpdate(AspireAction1<HttpsEndpointUpdateCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (HttpsEndpointUpdateCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs);
+        return this;
+    }
+
     /** Adds a relationship to another resource using its builder. */
     public ProjectResource withRelationship(IResource resourceBuilder, String type) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -17556,6 +18792,22 @@ public class ProjectResource extends ResourceBuilderBase {
         reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
         return (IExecutionConfigurationBuilder) result;
+    }
+
+    /** Configures container build options for a compute resource using an async callback. */
+    public ProjectResource withContainerBuildOptions(AspireAction1<ContainerBuildOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (ContainerBuildOptionsCallbackContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerBuildOptions", reqArgs);
+        return this;
     }
 
     /** Adds an optional string parameter */
@@ -18277,6 +19529,95 @@ public class ReferenceExpressionBuilder extends HandleWrapperBase {
         reqArgs.put("context", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/build", reqArgs);
         return (ReferenceExpression) result;
+    }
+
+}
+
+// ===== RequiredCommandValidationContext.java =====
+// RequiredCommandValidationContext.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationContext. */
+public class RequiredCommandValidationContext extends HandleWrapperBase {
+    RequiredCommandValidationContext(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Gets the resolved full path to the command executable. */
+    public String resolvedPath() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.resolvedPath", reqArgs);
+        return (String) result;
+    }
+
+    /** Gets the service provider for accessing application services. */
+    public IServiceProvider services() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.services", reqArgs);
+        return (IServiceProvider) result;
+    }
+
+    /** Gets a cancellation token that can be used to cancel the validation. */
+    public CancellationToken cancellationToken() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.cancellationToken", reqArgs);
+        return (CancellationToken) result;
+    }
+
+    /** Creates a successful validation result. */
+    public RequiredCommandValidationResult success() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.success", reqArgs);
+        return (RequiredCommandValidationResult) result;
+    }
+
+    /** Creates a failed validation result with the specified message. */
+    public RequiredCommandValidationResult failure(String validationMessage) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("validationMessage", AspireClient.serializeValue(validationMessage));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.failure", reqArgs);
+        return (RequiredCommandValidationResult) result;
+    }
+
+}
+
+// ===== RequiredCommandValidationResult.java =====
+// RequiredCommandValidationResult.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationResult. */
+public class RequiredCommandValidationResult extends HandleWrapperBase {
+    RequiredCommandValidationResult(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+    /** Gets a value indicating whether the command validation succeeded. */
+    public boolean isValid() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationResult.isValid", reqArgs);
+        return (Boolean) result;
+    }
+
+    /** Gets an optional validation message describing why validation failed. */
+    public String validationMessage() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationResult.validationMessage", reqArgs);
+        return result == null ? null : (String) result;
     }
 
 }
@@ -19332,6 +20673,30 @@ public class TestDatabaseResource extends ContainerResource {
         return this;
     }
 
+    public TestDatabaseResource withContainerFilesCallback(String destinationPath, AspireFunc2<ContainerFileSystemCallbackContext, CancellationToken, ContainerFileSystemItem[]> callback) {
+        return withContainerFilesCallback(destinationPath, callback, null);
+    }
+
+    /** Creates or updates files and folders in a container using entries produced by a callback. */
+    public TestDatabaseResource withContainerFilesCallback(String destinationPath, AspireFunc2<ContainerFileSystemCallbackContext, CancellationToken, ContainerFileSystemItem[]> callback, ContainerFilesOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("destinationPath", AspireClient.serializeValue(destinationPath));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg1 = (ContainerFileSystemCallbackContext) args[0];
+            var arg2 = CancellationToken.fromValue(args[1]);
+            return AspireClient.awaitValue(callback.invoke(arg1, arg2));
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        if (options != null) {
+            reqArgs.put("options", AspireClient.serializeValue(options));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerFilesCallback", reqArgs);
+        return this;
+    }
+
     public TestDatabaseResource withDockerfileBuilder(String contextPath, AspireAction1<DockerfileBuilderCallbackContext> callback) {
         return withDockerfileBuilder(contextPath, callback, null);
     }
@@ -19451,6 +20816,29 @@ public class TestDatabaseResource extends ContainerResource {
             reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
         }
         getClient().invokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs);
+        return this;
+    }
+
+    public TestDatabaseResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback) {
+        return withRequiredCommandValidation(command, validationCallback, null);
+    }
+
+    /** Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic. */
+    public TestDatabaseResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback, String helpLink) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("command", AspireClient.serializeValue(command));
+        var validationCallbackId = getClient().registerCallback(args -> {
+            var arg = (RequiredCommandValidationContext) args[0];
+            return AspireClient.awaitValue(validationCallback.invoke(arg));
+        });
+        if (validationCallbackId != null) {
+            reqArgs.put("validationCallback", validationCallbackId);
+        }
+        if (helpLink != null) {
+            reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withRequiredCommandValidation", reqArgs);
         return this;
     }
 
@@ -20193,6 +21581,38 @@ public class TestDatabaseResource extends ContainerResource {
         return this;
     }
 
+    /** Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication. */
+    public TestDatabaseResource withHttpsCertificateConfiguration(AspireAction1<HttpsCertificateConfigurationCallbackAnnotationContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (HttpsCertificateConfigurationCallbackAnnotationContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs);
+        return this;
+    }
+
+    /** Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup. */
+    public TestDatabaseResource subscribeHttpsEndpointsUpdate(AspireAction1<HttpsEndpointUpdateCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (HttpsEndpointUpdateCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs);
+        return this;
+    }
+
     /** Adds a relationship to another resource using its builder. */
     public TestDatabaseResource withRelationship(IResource resourceBuilder, String type) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -20561,6 +21981,22 @@ public class TestDatabaseResource extends ContainerResource {
         reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
         return (IExecutionConfigurationBuilder) result;
+    }
+
+    /** Configures container build options for a compute resource using an async callback. */
+    public TestDatabaseResource withContainerBuildOptions(AspireAction1<ContainerBuildOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (ContainerBuildOptionsCallbackContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerBuildOptions", reqArgs);
+        return this;
     }
 
     /** Adds an optional string parameter */
@@ -21390,6 +22826,30 @@ public class TestRedisResource extends ContainerResource {
         return this;
     }
 
+    public TestRedisResource withContainerFilesCallback(String destinationPath, AspireFunc2<ContainerFileSystemCallbackContext, CancellationToken, ContainerFileSystemItem[]> callback) {
+        return withContainerFilesCallback(destinationPath, callback, null);
+    }
+
+    /** Creates or updates files and folders in a container using entries produced by a callback. */
+    public TestRedisResource withContainerFilesCallback(String destinationPath, AspireFunc2<ContainerFileSystemCallbackContext, CancellationToken, ContainerFileSystemItem[]> callback, ContainerFilesOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("destinationPath", AspireClient.serializeValue(destinationPath));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg1 = (ContainerFileSystemCallbackContext) args[0];
+            var arg2 = CancellationToken.fromValue(args[1]);
+            return AspireClient.awaitValue(callback.invoke(arg1, arg2));
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        if (options != null) {
+            reqArgs.put("options", AspireClient.serializeValue(options));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerFilesCallback", reqArgs);
+        return this;
+    }
+
     public TestRedisResource withDockerfileBuilder(String contextPath, AspireAction1<DockerfileBuilderCallbackContext> callback) {
         return withDockerfileBuilder(contextPath, callback, null);
     }
@@ -21509,6 +22969,29 @@ public class TestRedisResource extends ContainerResource {
             reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
         }
         getClient().invokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs);
+        return this;
+    }
+
+    public TestRedisResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback) {
+        return withRequiredCommandValidation(command, validationCallback, null);
+    }
+
+    /** Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic. */
+    public TestRedisResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback, String helpLink) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("command", AspireClient.serializeValue(command));
+        var validationCallbackId = getClient().registerCallback(args -> {
+            var arg = (RequiredCommandValidationContext) args[0];
+            return AspireClient.awaitValue(validationCallback.invoke(arg));
+        });
+        if (validationCallbackId != null) {
+            reqArgs.put("validationCallback", validationCallbackId);
+        }
+        if (helpLink != null) {
+            reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withRequiredCommandValidation", reqArgs);
         return this;
     }
 
@@ -22278,6 +23761,38 @@ public class TestRedisResource extends ContainerResource {
         return this;
     }
 
+    /** Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication. */
+    public TestRedisResource withHttpsCertificateConfiguration(AspireAction1<HttpsCertificateConfigurationCallbackAnnotationContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (HttpsCertificateConfigurationCallbackAnnotationContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs);
+        return this;
+    }
+
+    /** Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup. */
+    public TestRedisResource subscribeHttpsEndpointsUpdate(AspireAction1<HttpsEndpointUpdateCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (HttpsEndpointUpdateCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs);
+        return this;
+    }
+
     /** Adds a relationship to another resource using its builder. */
     public TestRedisResource withRelationship(IResource resourceBuilder, String type) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -22662,6 +24177,22 @@ public class TestRedisResource extends ContainerResource {
         reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting/createExecutionConfiguration", reqArgs);
         return (IExecutionConfigurationBuilder) result;
+    }
+
+    /** Configures container build options for a compute resource using an async callback. */
+    public TestRedisResource withContainerBuildOptions(AspireAction1<ContainerBuildOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (ContainerBuildOptionsCallbackContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerBuildOptions", reqArgs);
+        return this;
     }
 
     public TestDatabaseResource addTestChildDatabase(String name) {
@@ -23520,6 +25051,30 @@ public class TestVaultResource extends ContainerResource {
         return this;
     }
 
+    public TestVaultResource withContainerFilesCallback(String destinationPath, AspireFunc2<ContainerFileSystemCallbackContext, CancellationToken, ContainerFileSystemItem[]> callback) {
+        return withContainerFilesCallback(destinationPath, callback, null);
+    }
+
+    /** Creates or updates files and folders in a container using entries produced by a callback. */
+    public TestVaultResource withContainerFilesCallback(String destinationPath, AspireFunc2<ContainerFileSystemCallbackContext, CancellationToken, ContainerFileSystemItem[]> callback, ContainerFilesOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("destinationPath", AspireClient.serializeValue(destinationPath));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg1 = (ContainerFileSystemCallbackContext) args[0];
+            var arg2 = CancellationToken.fromValue(args[1]);
+            return AspireClient.awaitValue(callback.invoke(arg1, arg2));
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        if (options != null) {
+            reqArgs.put("options", AspireClient.serializeValue(options));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerFilesCallback", reqArgs);
+        return this;
+    }
+
     public TestVaultResource withDockerfileBuilder(String contextPath, AspireAction1<DockerfileBuilderCallbackContext> callback) {
         return withDockerfileBuilder(contextPath, callback, null);
     }
@@ -23639,6 +25194,29 @@ public class TestVaultResource extends ContainerResource {
             reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
         }
         getClient().invokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs);
+        return this;
+    }
+
+    public TestVaultResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback) {
+        return withRequiredCommandValidation(command, validationCallback, null);
+    }
+
+    /** Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic. */
+    public TestVaultResource withRequiredCommandValidation(String command, AspireFunc1<RequiredCommandValidationContext, RequiredCommandValidationResult> validationCallback, String helpLink) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("command", AspireClient.serializeValue(command));
+        var validationCallbackId = getClient().registerCallback(args -> {
+            var arg = (RequiredCommandValidationContext) args[0];
+            return AspireClient.awaitValue(validationCallback.invoke(arg));
+        });
+        if (validationCallbackId != null) {
+            reqArgs.put("validationCallback", validationCallbackId);
+        }
+        if (helpLink != null) {
+            reqArgs.put("helpLink", AspireClient.serializeValue(helpLink));
+        }
+        getClient().invokeCapability("Aspire.Hosting/withRequiredCommandValidation", reqArgs);
         return this;
     }
 
@@ -24381,6 +25959,38 @@ public class TestVaultResource extends ContainerResource {
         return this;
     }
 
+    /** Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication. */
+    public TestVaultResource withHttpsCertificateConfiguration(AspireAction1<HttpsCertificateConfigurationCallbackAnnotationContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (HttpsCertificateConfigurationCallbackAnnotationContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withHttpsCertificateConfiguration", reqArgs);
+        return this;
+    }
+
+    /** Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup. */
+    public TestVaultResource subscribeHttpsEndpointsUpdate(AspireAction1<HttpsEndpointUpdateCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var obj = (HttpsEndpointUpdateCallbackContext) args[0];
+            callback.invoke(obj);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", reqArgs);
+        return this;
+    }
+
     /** Adds a relationship to another resource using its builder. */
     public TestVaultResource withRelationship(IResource resourceBuilder, String type) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -24751,6 +26361,22 @@ public class TestVaultResource extends ContainerResource {
         return (IExecutionConfigurationBuilder) result;
     }
 
+    /** Configures container build options for a compute resource using an async callback. */
+    public TestVaultResource withContainerBuildOptions(AspireAction1<ContainerBuildOptionsCallbackContext> callback) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        var callbackId = getClient().registerCallback(args -> {
+            var arg = (ContainerBuildOptionsCallbackContext) args[0];
+            callback.invoke(arg);
+            return null;
+        });
+        if (callbackId != null) {
+            reqArgs.put("callback", callbackId);
+        }
+        getClient().invokeCapability("Aspire.Hosting/withContainerBuildOptions", reqArgs);
+        return this;
+    }
+
     /** Adds an optional string parameter */
     public TestVaultResource withOptionalString(WithOptionalStringOptions options) {
         var value = options == null ? null : options.getValue();
@@ -25111,6 +26737,14 @@ public class UpdateCommandStateContext extends HandleWrapperBase {
         reqArgs.put("context", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.resourceSnapshot", reqArgs);
         return UpdateCommandStateResourceSnapshot.fromMap((Map<String, Object>) result);
+    }
+
+    /** The service provider. */
+    public IServiceProvider services() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.services", reqArgs);
+        return (IServiceProvider) result;
     }
 
 }
@@ -26036,7 +27670,12 @@ public final class WithVolumeOptions {
 .aspire/modules/CompleteTaskMarkdownOptions.java
 .aspire/modules/CompleteTaskOptions.java
 .aspire/modules/ConnectionStringAvailableEvent.java
+.aspire/modules/ContainerBuildOptionsCallbackContext.java
+.aspire/modules/ContainerFileSystemCallbackContext.java
+.aspire/modules/ContainerFileSystemItem.java
 .aspire/modules/ContainerFilesOptions.java
+.aspire/modules/ContainerImageDestination.java
+.aspire/modules/ContainerImageFormat.java
 .aspire/modules/ContainerImagePushOptions.java
 .aspire/modules/ContainerImagePushOptionsCallbackContext.java
 .aspire/modules/ContainerImageReference.java
@@ -26046,7 +27685,11 @@ public final class WithVolumeOptions {
 .aspire/modules/ContainerPortReference.java
 .aspire/modules/ContainerRegistryResource.java
 .aspire/modules/ContainerResource.java
+.aspire/modules/ContainerTargetPlatform.java
 .aspire/modules/CreateBuilderOptions.java
+.aspire/modules/CreateCertificateFileOptions.java
+.aspire/modules/CreateDirectoryOptions.java
+.aspire/modules/CreateFileOptions.java
 .aspire/modules/DistributedApplication.java
 .aspire/modules/DistributedApplicationEventSubscription.java
 .aspire/modules/DistributedApplicationExecutionContext.java
@@ -26080,9 +27723,11 @@ public final class WithVolumeOptions {
 .aspire/modules/HttpCommandPrepareRequestContext.java
 .aspire/modules/HttpCommandRequestExportData.java
 .aspire/modules/HttpCommandResultMode.java
+.aspire/modules/HttpsCertificateConfigurationCallbackAnnotationContext.java
 .aspire/modules/HttpsCertificateExecutionConfigurationContext.java
 .aspire/modules/HttpsCertificateExecutionConfigurationExportData.java
 .aspire/modules/HttpsCertificateInfo.java
+.aspire/modules/HttpsEndpointUpdateCallbackContext.java
 .aspire/modules/IAspireStore.java
 .aspire/modules/IComputeEnvironmentResource.java
 .aspire/modules/IComputeResource.java
@@ -26143,6 +27788,8 @@ public final class WithVolumeOptions {
 .aspire/modules/ReferenceEnvironmentInjectionOptions.java
 .aspire/modules/ReferenceExpression.java
 .aspire/modules/ReferenceExpressionBuilder.java
+.aspire/modules/RequiredCommandValidationContext.java
+.aspire/modules/RequiredCommandValidationResult.java
 .aspire/modules/ResourceBuilderBase.java
 .aspire/modules/ResourceCommandService.java
 .aspire/modules/ResourceCommandState.java

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -12133,6 +12133,14 @@ public class ExecuteCommandContext extends HandleWrapperBase {
         super(handle, client);
     }
 
+    /** The service provider. */
+    public IServiceProvider services() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/ExecuteCommandContext.services", reqArgs);
+        return (IServiceProvider) result;
+    }
+
     /** The resource name. */
     public String resourceName() {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -26737,6 +26745,14 @@ public class UpdateCommandStateContext extends HandleWrapperBase {
         reqArgs.put("context", AspireClient.serializeValue(getHandle()));
         var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.resourceSnapshot", reqArgs);
         return UpdateCommandStateResourceSnapshot.fromMap((Map<String, Object>) result);
+    }
+
+    /** The service provider. */
+    public IServiceProvider services() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        var result = getClient().invokeCapability("Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.services", reqArgs);
+        return (IServiceProvider) result;
     }
 
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -5700,7 +5700,7 @@ public class ContainerResource extends ResourceBuilderBase {
         return withContainerFilesCallback(destinationPath, callback, null);
     }
 
-    /** Creates or updates files and folders in a container using entries produced by a callback. */
+    /** Creates or updates files and/or folders at the destination path in the container using entries produced by a callback. */
     public ContainerResource withContainerFilesCallback(String destinationPath, AspireFunc2<ContainerFileSystemCallbackContext, CancellationToken, ContainerFileSystemItem[]> callback, ContainerFilesOptions options) {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
@@ -20716,7 +20716,7 @@ public class TestDatabaseResource extends ContainerResource {
         return withContainerFilesCallback(destinationPath, callback, null);
     }
 
-    /** Creates or updates files and folders in a container using entries produced by a callback. */
+    /** Creates or updates files and/or folders at the destination path in the container using entries produced by a callback. */
     public TestDatabaseResource withContainerFilesCallback(String destinationPath, AspireFunc2<ContainerFileSystemCallbackContext, CancellationToken, ContainerFileSystemItem[]> callback, ContainerFilesOptions options) {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
@@ -22869,7 +22869,7 @@ public class TestRedisResource extends ContainerResource {
         return withContainerFilesCallback(destinationPath, callback, null);
     }
 
-    /** Creates or updates files and folders in a container using entries produced by a callback. */
+    /** Creates or updates files and/or folders at the destination path in the container using entries produced by a callback. */
     public TestRedisResource withContainerFilesCallback(String destinationPath, AspireFunc2<ContainerFileSystemCallbackContext, CancellationToken, ContainerFileSystemItem[]> callback, ContainerFilesOptions options) {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
@@ -25094,7 +25094,7 @@ public class TestVaultResource extends ContainerResource {
         return withContainerFilesCallback(destinationPath, callback, null);
     }
 
-    /** Creates or updates files and folders in a container using entries produced by a callback. */
+    /** Creates or updates files and/or folders at the destination path in the container using entries produced by a callback. */
     public TestVaultResource withContainerFilesCallback(String destinationPath, AspireFunc2<ContainerFileSystemCallbackContext, CancellationToken, ContainerFileSystemItem[]> callback, ContainerFilesOptions options) {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -3303,6 +3303,37 @@ public class CancellationToken {
     private volatile boolean cancelled = false;
     private final List<Runnable> listeners = new CopyOnWriteArrayList<>();
 
+    // Remote token id supplied by the AppHost when this token is materialized for a
+    // callback argument. Null for locally-created tokens. Retained so cancellation can
+    // be correlated back to the AppHost if needed.
+    private final String remoteTokenId;
+
+    CancellationToken() {
+        this.remoteTokenId = null;
+    }
+
+    private CancellationToken(String remoteTokenId) {
+        this.remoteTokenId = remoteTokenId;
+    }
+
+    /**
+     * Materializes a cancellation token from a transport value sent by the AppHost.
+     * When the AppHost invokes a callback that accepts a CancellationToken it passes a
+     * remote token id (a string); generated code calls this to turn that wire value into
+     * a CancellationToken instance. Mirrors the TypeScript/Go SDK behavior.
+     */
+    static CancellationToken fromValue(Object value) {
+        if (value instanceof CancellationToken token) {
+            return token;
+        }
+        if (value instanceof String tokenId) {
+            return new CancellationToken(tokenId);
+        }
+        return new CancellationToken();
+    }
+
+    String getRemoteTokenId() { return remoteTokenId; }
+
     void cancel() {
         cancelled = true;
         for (Runnable listener : listeners) {

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -5092,6 +5092,15 @@ class ExecuteCommandContext:
         return self._handle
 
     @_cached_property
+    def services(self) -> AbstractServiceProvider:
+        """The service provider."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.services',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractServiceProvider, result)
+
+    @_cached_property
     def resource_name(self) -> str:
         """The resource name."""
         result = self._client.invoke_capability(
@@ -6792,6 +6801,15 @@ class UpdateCommandStateContext:
             {'context': self._handle}
         )
         return typing.cast(UpdateCommandStateResourceSnapshot, result)
+
+    @_cached_property
+    def services(self) -> AbstractServiceProvider:
+        """The service provider."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.services',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractServiceProvider, result)
 
 
 # ============================================================================

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -8685,7 +8685,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         return self
 
     def with_container_files_callback(self, destination_path: str, callback: typing.Callable[[ContainerFileSystemCallbackContext, CancellationToken], typing.Iterable[ContainerFileSystemItem]], *, options: ContainerFilesOptions | None = None) -> typing.Self:
-        """Creates or updates files and folders in a container using entries produced by a callback."""
+        """Creates or updates files and/or folders at the destination path in the container using entries produced by a callback."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['destinationPath'] = destination_path
         rpc_args['callback'] = self._client.register_callback(callback)

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1561,9 +1561,9 @@ class DockerfileBaseImageParameters(typing.TypedDict, total=False):
     runtime_image: str
 
 
-class RequiredCommandParameters(typing.TypedDict, total=False):
+class RequiredCommandValidationParameters(typing.TypedDict, total=False):
     command: typing.Required[str]
-    validation_callback: typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult]
+    validation_callback: typing.Required[typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult]]
     help_link: str
 
 
@@ -6819,8 +6819,12 @@ class AbstractResource(abc.ABC):
         """Configures custom base images for generated Dockerfiles."""
 
     @abc.abstractmethod
-    def with_required_command(self, command: str, *, validation_callback: typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult] | None = None, help_link: str | None = None) -> typing.Self:
+    def with_required_command(self, command: str, *, help_link: str | None = None) -> typing.Self:
         """Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start."""
+
+    @abc.abstractmethod
+    def with_required_command_validation(self, command: str, validation_callback: typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult], *, help_link: str | None = None) -> typing.Self:
+        """Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic."""
 
     @abc.abstractmethod
     def with_session_lifetime(self) -> typing.Self:
@@ -7252,7 +7256,8 @@ class _BaseResourceKwargs(typing.TypedDict, total=False):
 
     container_registry: AbstractResource
     dockerfile_base_image: DockerfileBaseImageParameters | typing.Literal[True]
-    required_command: str | RequiredCommandParameters
+    required_command: str | tuple[str, str]
+    required_command_validation: tuple[str, typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult]] | RequiredCommandValidationParameters
     session_lifetime: typing.Literal[True]
     persistent_lifetime: typing.Literal[True]
     lifetime_of: AbstractResource
@@ -7338,17 +7343,28 @@ class _BaseResource(AbstractResource):
         self._handle = self._wrap_builder(result)
         return self
 
-    def with_required_command(self, command: str, *, validation_callback: typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult] | None = None, help_link: str | None = None) -> typing.Self:
+    def with_required_command(self, command: str, *, help_link: str | None = None) -> typing.Self:
         """Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['command'] = command
-        if validation_callback is not None:
-            rpc_args['validationCallback'] = self._client.register_callback(validation_callback)
         if help_link is not None:
             rpc_args['helpLink'] = help_link
-        capability_id = 'Aspire.Hosting/withRequiredCommandValidation' if validation_callback is not None else 'Aspire.Hosting/withRequiredCommand'
         result = self._client.invoke_capability(
-            capability_id,
+            'Aspire.Hosting/withRequiredCommand',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
+    def with_required_command_validation(self, command: str, validation_callback: typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult], *, help_link: str | None = None) -> typing.Self:
+        """Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic."""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['command'] = command
+        rpc_args['validationCallback'] = self._client.register_callback(validation_callback)
+        if help_link is not None:
+            rpc_args['helpLink'] = help_link
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withRequiredCommandValidation',
             rpc_args,
         )
         self._handle = self._wrap_builder(result)
@@ -7948,15 +7964,27 @@ class _BaseResource(AbstractResource):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["command"] = typing.cast(str, _required_command)
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withRequiredCommand', rpc_args))
-            elif _validate_dict_types(_required_command, RequiredCommandParameters):
+            elif _validate_tuple_types(_required_command, (str, str)):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["command"] = typing.cast(RequiredCommandParameters, _required_command)["command"]
-                rpc_args["validationCallback"] = client.register_callback(typing.cast(RequiredCommandParameters, _required_command).get("validation_callback"))
-                rpc_args["helpLink"] = typing.cast(RequiredCommandParameters, _required_command).get("help_link")
-                capability_id = 'Aspire.Hosting/withRequiredCommandValidation' if "validation_callback" in _required_command else 'Aspire.Hosting/withRequiredCommand'
-                handle = self._wrap_builder(client.invoke_capability(capability_id, rpc_args))
+                rpc_args["command"] = typing.cast(tuple[str, str], _required_command)[0]
+                rpc_args["helpLink"] = typing.cast(tuple[str, str], _required_command)[1]
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withRequiredCommand', rpc_args))
             else:
-                raise TypeError("Invalid type for option 'required_command'. Expected: str or RequiredCommandParameters")
+                raise TypeError("Invalid type for option 'required_command'. Expected: str or (str, str)")
+        if _required_command_validation := kwargs.pop("required_command_validation", None):
+            if _validate_tuple_types(_required_command_validation, (str, typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult])):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["command"] = typing.cast(tuple[str, typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult]], _required_command_validation)[0]
+                rpc_args["validationCallback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult]], _required_command_validation)[1])
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withRequiredCommandValidation', rpc_args))
+            elif _validate_dict_types(_required_command_validation, RequiredCommandValidationParameters):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["command"] = typing.cast(RequiredCommandValidationParameters, _required_command_validation)["command"]
+                rpc_args["validationCallback"] = client.register_callback(typing.cast(RequiredCommandValidationParameters, _required_command_validation)["validation_callback"])
+                rpc_args["helpLink"] = typing.cast(RequiredCommandValidationParameters, _required_command_validation).get("help_link")
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withRequiredCommandValidation', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'required_command_validation'. Expected: (str, Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult]) or RequiredCommandValidationParameters")
         if _session_lifetime := kwargs.pop("session_lifetime", None):
             if _session_lifetime is True:
                 rpc_args: dict[str, typing.Any] = {"builder": handle}

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1508,9 +1508,15 @@ CertificateTrustScope = typing.Literal["None", "Append", "Override", "System"]
 
 CommandResultFormat = typing.Literal["Text", "Json", "Markdown"]
 
+ContainerImageDestination = typing.Literal["Registry", "Archive"]
+
+ContainerImageFormat = typing.Literal["Docker", "Oci"]
+
 ContainerLifetime = typing.Literal["Session", "Persistent"]
 
 ContainerMountType = typing.Literal["BindMount", "Volume"]
+
+ContainerTargetPlatform = typing.Literal["LinuxAmd64", "LinuxArm64", "AllLinux", "LinuxArm", "Linux386", "WindowsAmd64", "WindowsArm64"]
 
 DistributedApplicationOperation = typing.Literal["Run", "Publish"]
 
@@ -1553,6 +1559,12 @@ WaitBehavior = typing.Literal["WaitOnResourceUnavailable", "StopOnResourceUnavai
 class DockerfileBaseImageParameters(typing.TypedDict, total=False):
     build_image: str
     runtime_image: str
+
+
+class RequiredCommandParameters(typing.TypedDict, total=False):
+    command: typing.Required[str]
+    validation_callback: typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult]
+    help_link: str
 
 
 class CommandParameters(typing.TypedDict, total=False):
@@ -1636,6 +1648,12 @@ class ContainerCertificatePathsParameters(typing.TypedDict, total=False):
 class ContainerFilesParameters(typing.TypedDict, total=False):
     destination_path: typing.Required[str]
     source_path: typing.Required[str]
+    options: ContainerFilesOptions
+
+
+class ContainerFilesCallbackParameters(typing.TypedDict, total=False):
+    destination_path: typing.Required[str]
+    callback: typing.Required[typing.Callable[[ContainerFileSystemCallbackContext, CancellationToken], typing.Iterable[ContainerFileSystemItem]]]
     options: ContainerFilesOptions
 
 
@@ -3549,6 +3567,279 @@ class ConnectionStringAvailableEvent:
         return typing.cast(AbstractServiceProvider, result)
 
 
+class ContainerBuildOptionsCallbackContext:
+    """Type class for ContainerBuildOptionsCallbackContext."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"ContainerBuildOptionsCallbackContext(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    @_cached_property
+    def resource(self) -> AbstractResource:
+        """Gets the resource being built."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.resource',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractResource, result)
+
+    @_cached_property
+    def services(self) -> AbstractServiceProvider:
+        """Gets the service provider."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.services',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractServiceProvider, result)
+
+    @_cached_property
+    def logger(self) -> AbstractLogger:
+        """Gets the logger instance."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.logger',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractLogger, result)
+
+    def cancel(self) -> None:
+        """Cancel the operation."""
+        token: CancellationToken = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.cancellationToken',
+            {'context': self._handle}
+        )
+        token.cancel()
+
+    @_cached_property
+    def execution_context(self) -> DistributedApplicationExecutionContext:
+        """Gets the distributed application execution context."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.executionContext',
+            {'context': self._handle}
+        )
+        return typing.cast(DistributedApplicationExecutionContext, result)
+
+    @_uncached_property
+    def destination(self) -> ContainerImageDestination | None:
+        """Gets or sets the destination for the container image."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.destination',
+            {'context': self._handle}
+        )
+        return typing.cast(ContainerImageDestination | None, result)
+
+    @destination.setter
+    def destination(self, value: ContainerImageDestination | None) -> None:
+        """Sets the Destination property"""
+        self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setDestination',
+            {'context': self._handle, 'value': value}
+        )
+
+    @_uncached_property
+    def output_path(self) -> str | None:
+        """Gets or sets the output path for the container archive."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.outputPath',
+            {'context': self._handle}
+        )
+        return typing.cast(str | None, result)
+
+    @output_path.setter
+    def output_path(self, value: str | None) -> None:
+        """Sets the OutputPath property"""
+        self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setOutputPath',
+            {'context': self._handle, 'value': value}
+        )
+
+    @_uncached_property
+    def image_format(self) -> ContainerImageFormat | None:
+        """Gets or sets the container image format."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.imageFormat',
+            {'context': self._handle}
+        )
+        return typing.cast(ContainerImageFormat | None, result)
+
+    @image_format.setter
+    def image_format(self, value: ContainerImageFormat | None) -> None:
+        """Sets the ImageFormat property"""
+        self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setImageFormat',
+            {'context': self._handle, 'value': value}
+        )
+
+    @_uncached_property
+    def target_platform(self) -> ContainerTargetPlatform | None:
+        """Gets or sets the target platform for the container."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.targetPlatform',
+            {'context': self._handle}
+        )
+        return typing.cast(ContainerTargetPlatform | None, result)
+
+    @target_platform.setter
+    def target_platform(self, value: ContainerTargetPlatform | None) -> None:
+        """Sets the TargetPlatform property"""
+        self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setTargetPlatform',
+            {'context': self._handle, 'value': value}
+        )
+
+    @_uncached_property
+    def local_image_name(self) -> str | None:
+        """Gets or sets the local image name for the built container."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.localImageName',
+            {'context': self._handle}
+        )
+        return typing.cast(str | None, result)
+
+    @local_image_name.setter
+    def local_image_name(self, value: str | None) -> None:
+        """Sets the LocalImageName property"""
+        self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setLocalImageName',
+            {'context': self._handle, 'value': value}
+        )
+
+    @_uncached_property
+    def local_image_tag(self) -> str | None:
+        """Gets or sets the local image tag for the built container."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.localImageTag',
+            {'context': self._handle}
+        )
+        return typing.cast(str | None, result)
+
+    @local_image_tag.setter
+    def local_image_tag(self, value: str | None) -> None:
+        """Sets the LocalImageTag property"""
+        self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setLocalImageTag',
+            {'context': self._handle, 'value': value}
+        )
+
+
+class ContainerFileSystemCallbackContext:
+    """Type class for ContainerFileSystemCallbackContext."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"ContainerFileSystemCallbackContext(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    @_cached_property
+    def services(self) -> AbstractServiceProvider:
+        """A `IServiceProvider` that can be used to resolve services in the callback."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerFileSystemCallbackContext.services',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractServiceProvider, result)
+
+    @_cached_property
+    def model(self) -> AbstractResource:
+        """The app model resource the callback is associated with."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ContainerFileSystemCallbackContext.model',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractResource, result)
+
+    def create_file(self, name: str, *, contents: str | None = None, source_path: str | None = None, owner: int | None = None, group: int | None = None, mode: int | None = None, continue_on_error: bool | None = None) -> ContainerFileSystemItem:
+        """Creates a container file entry with inline contents or a host source path."""
+        rpc_args: dict[str, typing.Any] = {'context': self._handle}
+        rpc_args['name'] = name
+        if contents is not None:
+            rpc_args['contents'] = contents
+        if source_path is not None:
+            rpc_args['sourcePath'] = source_path
+        if owner is not None:
+            rpc_args['owner'] = owner
+        if group is not None:
+            rpc_args['group'] = group
+        if mode is not None:
+            rpc_args['mode'] = mode
+        if continue_on_error is not None:
+            rpc_args['continueOnError'] = continue_on_error
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/createFile',
+            rpc_args,
+        )
+        return typing.cast(ContainerFileSystemItem, result)
+
+    def create_certificate_file(self, name: str, *, contents: str | None = None, source_path: str | None = None, owner: int | None = None, group: int | None = None, mode: int | None = None, continue_on_error: bool | None = None) -> ContainerFileSystemItem:
+        """Creates a PEM container certificate file entry with the OpenSSL subject-hash symlink."""
+        rpc_args: dict[str, typing.Any] = {'context': self._handle}
+        rpc_args['name'] = name
+        if contents is not None:
+            rpc_args['contents'] = contents
+        if source_path is not None:
+            rpc_args['sourcePath'] = source_path
+        if owner is not None:
+            rpc_args['owner'] = owner
+        if group is not None:
+            rpc_args['group'] = group
+        if mode is not None:
+            rpc_args['mode'] = mode
+        if continue_on_error is not None:
+            rpc_args['continueOnError'] = continue_on_error
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/createCertificateFile',
+            rpc_args,
+        )
+        return typing.cast(ContainerFileSystemItem, result)
+
+    def create_dir(self, name: str, entries: typing.Iterable[ContainerFileSystemItem], *, owner: int | None = None, group: int | None = None, mode: int | None = None) -> ContainerFileSystemItem:
+        """Creates a container directory entry containing the specified child entries."""
+        rpc_args: dict[str, typing.Any] = {'context': self._handle}
+        rpc_args['name'] = name
+        rpc_args['entries'] = entries
+        if owner is not None:
+            rpc_args['owner'] = owner
+        if group is not None:
+            rpc_args['group'] = group
+        if mode is not None:
+            rpc_args['mode'] = mode
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/createDirectory',
+            rpc_args,
+        )
+        return typing.cast(ContainerFileSystemItem, result)
+
+
+class ContainerFileSystemItem:
+    """Type class for ContainerFileSystemItem."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"ContainerFileSystemItem(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+
 class ContainerImagePushOptions:
     """Type class for ContainerImagePushOptions."""
 
@@ -4792,6 +5083,15 @@ class ExecuteCommandContext:
         return self._handle
 
     @_cached_property
+    def services(self) -> AbstractServiceProvider:
+        """The service provider."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.services',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractServiceProvider, result)
+
+    @_cached_property
     def resource_name(self) -> str:
         """The resource name."""
         result = self._client.invoke_capability(
@@ -4876,6 +5176,144 @@ class HttpCommandPrepareRequestContext:
             {'context': self._handle}
         )
         return typing.cast(InteractionInputCollection, result)
+
+
+class HttpsCertificateConfigurationCallbackAnnotationContext:
+    """Type class for HttpsCertificateConfigurationCallbackAnnotationContext."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"HttpsCertificateConfigurationCallbackAnnotationContext(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    @_cached_property
+    def execution_context(self) -> DistributedApplicationExecutionContext:
+        """Gets the `DistributedApplicationExecutionContext` for this session."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.executionContext',
+            {'context': self._handle}
+        )
+        return typing.cast(DistributedApplicationExecutionContext, result)
+
+    @_cached_property
+    def resource(self) -> AbstractResource:
+        """Gets the resource to which the annotation is applied."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.resource',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractResource, result)
+
+    @_cached_property
+    def certificate_path(self) -> ReferenceExpression:
+        """A value provider that will resolve to a path to the certificate file."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.certificatePath',
+            {'context': self._handle}
+        )
+        return typing.cast(ReferenceExpression, result)
+
+    @_cached_property
+    def key_path(self) -> ReferenceExpression:
+        """A value provider that will resolve to a path to the private key for the certificate."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.keyPath',
+            {'context': self._handle}
+        )
+        return typing.cast(ReferenceExpression, result)
+
+    @_cached_property
+    def pfx_path(self) -> ReferenceExpression:
+        """A value provider that will resolve to a path to a PFX file for the key pair."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.pfxPath',
+            {'context': self._handle}
+        )
+        return typing.cast(ReferenceExpression, result)
+
+    def cancel(self) -> None:
+        """Cancel the operation."""
+        token: CancellationToken = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.cancellationToken',
+            {'context': self._handle}
+        )
+        token.cancel()
+
+    @_cached_property
+    def arguments(self) -> CommandLineArgsEditor:
+        """Gets the editor used to manipulate the command-line arguments in polyglot callbacks."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.arguments',
+            {'context': self._handle}
+        )
+        return typing.cast(CommandLineArgsEditor, result)
+
+    @_cached_property
+    def env(self) -> EnvironmentEditor:
+        """Gets the editor used to set environment variables in polyglot callbacks."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.environment',
+            {'context': self._handle}
+        )
+        return typing.cast(EnvironmentEditor, result)
+
+
+class HttpsEndpointUpdateCallbackContext:
+    """Type class for HttpsEndpointUpdateCallbackContext."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"HttpsEndpointUpdateCallbackContext(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    @_cached_property
+    def services(self) -> AbstractServiceProvider:
+        """Gets the `IServiceProvider` instance from the application."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.services',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractServiceProvider, result)
+
+    @_cached_property
+    def resource(self) -> AbstractResource:
+        """Gets the `IResource` that is being configured for HTTPS."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.resource',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractResource, result)
+
+    @_cached_property
+    def model(self) -> DistributedApplicationModel:
+        """Gets the `DistributedApplicationModel` instance."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.model',
+            {'context': self._handle}
+        )
+        return typing.cast(DistributedApplicationModel, result)
+
+    def cancel(self) -> None:
+        """Cancel the operation."""
+        token: CancellationToken = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.cancellationToken',
+            {'context': self._handle}
+        )
+        token.cancel()
 
 
 class InitializeResourceEvent:
@@ -4970,6 +5408,15 @@ class InputsDialogValidationContext:
             {'context': self._handle}
         )
         token.cancel()
+
+    @_cached_property
+    def services(self) -> AbstractServiceProvider:
+        """Gets the service provider for resolving services during validation."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/InputsDialogValidationContext.services',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractServiceProvider, result)
 
     def add_validation_error(self, input_name: str, error_message: str) -> None:
         """Adds a validation error for the input with the specified name."""
@@ -5582,6 +6029,101 @@ class ReferenceExpressionBuilder:
             rpc_args,
         )
         return typing.cast(ReferenceExpression, result)
+
+
+class RequiredCommandValidationContext:
+    """Type class for RequiredCommandValidationContext."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"RequiredCommandValidationContext(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    @_cached_property
+    def resolved_path(self) -> str:
+        """Gets the resolved full path to the command executable."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.resolvedPath',
+            {'context': self._handle}
+        )
+        return typing.cast(str, result)
+
+    @_cached_property
+    def services(self) -> AbstractServiceProvider:
+        """Gets the service provider for accessing application services."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.services',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractServiceProvider, result)
+
+    def cancel(self) -> None:
+        """Cancel the operation."""
+        token: CancellationToken = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.cancellationToken',
+            {'context': self._handle}
+        )
+        token.cancel()
+
+    def success(self) -> RequiredCommandValidationResult:
+        """Creates a successful validation result."""
+        rpc_args: dict[str, typing.Any] = {'context': self._handle}
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.success',
+            rpc_args,
+        )
+        return typing.cast(RequiredCommandValidationResult, result)
+
+    def failure(self, validation_message: str) -> RequiredCommandValidationResult:
+        """Creates a failed validation result with the specified message."""
+        rpc_args: dict[str, typing.Any] = {'context': self._handle}
+        rpc_args['validationMessage'] = validation_message
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.failure',
+            rpc_args,
+        )
+        return typing.cast(RequiredCommandValidationResult, result)
+
+
+class RequiredCommandValidationResult:
+    """Type class for RequiredCommandValidationResult."""
+
+    def __init__(self, handle: Handle, client: AspireClient) -> None:
+        self._handle = handle
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"RequiredCommandValidationResult(handle={self._handle.handle_id})"
+
+    @_uncached_property
+    def handle(self) -> Handle:
+        """The underlying object reference handle."""
+        return self._handle
+
+    @_cached_property
+    def is_valid(self) -> bool:
+        """Gets a value indicating whether the command validation succeeded."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationResult.isValid',
+            {'context': self._handle}
+        )
+        return typing.cast(bool, result)
+
+    @_cached_property
+    def validation_message(self) -> str | None:
+        """Gets an optional validation message describing why validation failed."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationResult.validationMessage',
+            {'context': self._handle}
+        )
+        return typing.cast(str | None, result)
 
 
 class ResourceCommandService:
@@ -6251,6 +6793,15 @@ class UpdateCommandStateContext:
         )
         return typing.cast(UpdateCommandStateResourceSnapshot, result)
 
+    @_cached_property
+    def services(self) -> AbstractServiceProvider:
+        """The service provider."""
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.services',
+            {'context': self._handle}
+        )
+        return typing.cast(AbstractServiceProvider, result)
+
 
 # ============================================================================
 # Interface Classes
@@ -6268,7 +6819,7 @@ class AbstractResource(abc.ABC):
         """Configures custom base images for generated Dockerfiles."""
 
     @abc.abstractmethod
-    def with_required_command(self, command: str, *, help_link: str | None = None) -> typing.Self:
+    def with_required_command(self, command: str, *, validation_callback: typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult] | None = None, help_link: str | None = None) -> typing.Self:
         """Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start."""
 
     @abc.abstractmethod
@@ -6322,6 +6873,10 @@ class AbstractResource(abc.ABC):
     @abc.abstractmethod
     def with_process_command_factory(self, command_name: str, display_name: str, create_process_spec: typing.Callable[[ExecuteCommandContext], ProcessCommandSpecExportData], *, options: ProcessCommandResultExportOptions | None = None) -> typing.Self:
         """Adds a command to the resource that starts a local process created by a callback when invoked."""
+
+    @abc.abstractmethod
+    def subscribe_https_endpoints_update(self, callback: typing.Callable[[HttpsEndpointUpdateCallbackContext], None]) -> typing.Self:
+        """Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup."""
 
     @abc.abstractmethod
     def with_relationship(self, resource_builder: AbstractResource, type: str) -> typing.Self:
@@ -6382,6 +6937,10 @@ class AbstractResource(abc.ABC):
     @abc.abstractmethod
     def create_execution_config(self) -> AbstractExecutionConfigurationBuilder:
         """Creates an execution configuration builder for the specified resource."""
+
+    @abc.abstractmethod
+    def with_container_build_options(self, callback: typing.Callable[[ContainerBuildOptionsCallbackContext], None]) -> typing.Self:
+        """Configures container build options for a compute resource using an async callback."""
 
     @abc.abstractmethod
     def with_optional_string(self, *, value: str | None = None, enabled: bool = True) -> typing.Self:
@@ -6640,6 +7199,10 @@ class AbstractResourceWithEnvironment(AbstractResource):
         """Disable HTTPS/TLS server certificate configuration for the resource. No HTTPS/TLS termination configuration will be applied."""
 
     @abc.abstractmethod
+    def with_https_certificate_config(self, callback: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]) -> typing.Self:
+        """Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication."""
+
+    @abc.abstractmethod
     def test_with_env_callback(self, callback: typing.Callable[[TestEnvironmentContext], None]) -> typing.Self:
         """Configures environment with callback (test version)"""
 
@@ -6689,7 +7252,7 @@ class _BaseResourceKwargs(typing.TypedDict, total=False):
 
     container_registry: AbstractResource
     dockerfile_base_image: DockerfileBaseImageParameters | typing.Literal[True]
-    required_command: str | tuple[str, str]
+    required_command: str | RequiredCommandParameters
     session_lifetime: typing.Literal[True]
     persistent_lifetime: typing.Literal[True]
     lifetime_of: AbstractResource
@@ -6703,6 +7266,7 @@ class _BaseResourceKwargs(typing.TypedDict, total=False):
     command: tuple[str, str, typing.Callable[[ExecuteCommandContext], ExecuteCommandResult]] | CommandParameters
     process_command: tuple[str, str, ProcessCommandExportOptions]
     process_command_factory: tuple[str, str, typing.Callable[[ExecuteCommandContext], ProcessCommandSpecExportData]] | ProcessCommandFactoryParameters
+    subscribe_https_endpoints_update: typing.Callable[[HttpsEndpointUpdateCallbackContext], None]
     relationship: tuple[AbstractResource, str]
     parent_relationship: AbstractResource
     child_relationship: AbstractResource
@@ -6716,6 +7280,7 @@ class _BaseResourceKwargs(typing.TypedDict, total=False):
     on_resource_stopped: typing.Callable[[ResourceStoppedEvent], None]
     on_initialize_resource: typing.Callable[[InitializeResourceEvent], None]
     on_resource_ready: typing.Callable[[ResourceReadyEvent], None]
+    container_build_options: typing.Callable[[ContainerBuildOptionsCallbackContext], None]
     optional_string: OptionalStringParameters | typing.Literal[True]
     config: TestConfigDto
     created_at: datetime.datetime
@@ -6773,14 +7338,17 @@ class _BaseResource(AbstractResource):
         self._handle = self._wrap_builder(result)
         return self
 
-    def with_required_command(self, command: str, *, help_link: str | None = None) -> typing.Self:
+    def with_required_command(self, command: str, *, validation_callback: typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult] | None = None, help_link: str | None = None) -> typing.Self:
         """Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['command'] = command
+        if validation_callback is not None:
+            rpc_args['validationCallback'] = self._client.register_callback(validation_callback)
         if help_link is not None:
             rpc_args['helpLink'] = help_link
+        capability_id = 'Aspire.Hosting/withRequiredCommandValidation' if validation_callback is not None else 'Aspire.Hosting/withRequiredCommand'
         result = self._client.invoke_capability(
-            'Aspire.Hosting/withRequiredCommand',
+            capability_id,
             rpc_args,
         )
         self._handle = self._wrap_builder(result)
@@ -6933,6 +7501,17 @@ class _BaseResource(AbstractResource):
             rpc_args['options'] = options
         result = self._client.invoke_capability(
             'Aspire.Hosting/withProcessCommandFactory',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
+    def subscribe_https_endpoints_update(self, callback: typing.Callable[[HttpsEndpointUpdateCallbackContext], None]) -> typing.Self:
+        """Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup."""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['callback'] = self._client.register_callback(callback)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
             rpc_args,
         )
         self._handle = self._wrap_builder(result)
@@ -7111,6 +7690,17 @@ class _BaseResource(AbstractResource):
             rpc_args,
         )
         return typing.cast(AbstractExecutionConfigurationBuilder, result)
+
+    def with_container_build_options(self, callback: typing.Callable[[ContainerBuildOptionsCallbackContext], None]) -> typing.Self:
+        """Configures container build options for a compute resource using an async callback."""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['callback'] = self._client.register_callback(callback)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
 
     def with_optional_string(self, *, value: str | None = None, enabled: bool = True) -> typing.Self:
         """Adds an optional string parameter"""
@@ -7358,13 +7948,15 @@ class _BaseResource(AbstractResource):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["command"] = typing.cast(str, _required_command)
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withRequiredCommand', rpc_args))
-            elif _validate_tuple_types(_required_command, (str, str)):
+            elif _validate_dict_types(_required_command, RequiredCommandParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["command"] = typing.cast(tuple[str, str], _required_command)[0]
-                rpc_args["helpLink"] = typing.cast(tuple[str, str], _required_command)[1]
-                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withRequiredCommand', rpc_args))
+                rpc_args["command"] = typing.cast(RequiredCommandParameters, _required_command)["command"]
+                rpc_args["validationCallback"] = client.register_callback(typing.cast(RequiredCommandParameters, _required_command).get("validation_callback"))
+                rpc_args["helpLink"] = typing.cast(RequiredCommandParameters, _required_command).get("help_link")
+                capability_id = 'Aspire.Hosting/withRequiredCommandValidation' if "validation_callback" in _required_command else 'Aspire.Hosting/withRequiredCommand'
+                handle = self._wrap_builder(client.invoke_capability(capability_id, rpc_args))
             else:
-                raise TypeError("Invalid type for option 'required_command'. Expected: str or (str, str)")
+                raise TypeError("Invalid type for option 'required_command'. Expected: str or RequiredCommandParameters")
         if _session_lifetime := kwargs.pop("session_lifetime", None):
             if _session_lifetime is True:
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -7478,6 +8070,13 @@ class _BaseResource(AbstractResource):
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withProcessCommandFactory', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'process_command_factory'. Expected: (str, str, Callable[[ExecuteCommandContext], ProcessCommandSpecExportData]) or ProcessCommandFactoryParameters")
+        if _subscribe_https_endpoints_update := kwargs.pop("subscribe_https_endpoints_update", None):
+            if _validate_type(_subscribe_https_endpoints_update, typing.Callable[[HttpsEndpointUpdateCallbackContext], None]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[HttpsEndpointUpdateCallbackContext], None], _subscribe_https_endpoints_update))
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/subscribeHttpsEndpointsUpdate', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'subscribe_https_endpoints_update'. Expected: Callable[[HttpsEndpointUpdateCallbackContext], None]")
         if _relationship := kwargs.pop("relationship", None):
             if _validate_tuple_types(_relationship, (AbstractResource, str)):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -7587,6 +8186,13 @@ class _BaseResource(AbstractResource):
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/onResourceReady', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'on_resource_ready'. Expected: Callable[[ResourceReadyEvent], None]")
+        if _container_build_options := kwargs.pop("container_build_options", None):
+            if _validate_type(_container_build_options, typing.Callable[[ContainerBuildOptionsCallbackContext], None]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ContainerBuildOptionsCallbackContext], None], _container_build_options))
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withContainerBuildOptions', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'container_build_options'. Expected: Callable[[ContainerBuildOptionsCallbackContext], None]")
         if _optional_string := kwargs.pop("optional_string", None):
             if _validate_dict_types(_optional_string, OptionalStringParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -7786,6 +8392,7 @@ class ContainerResourceKwargs(_BaseResourceKwargs, total=False):
     build_secret: tuple[str, ParameterResource]
     container_certificate_paths: ContainerCertificatePathsParameters | typing.Literal[True]
     container_files: tuple[str, str] | ContainerFilesParameters
+    container_files_callback: tuple[str, typing.Callable[[ContainerFileSystemCallbackContext, CancellationToken], typing.Iterable[ContainerFileSystemItem]]] | ContainerFilesCallbackParameters
     dockerfile_builder: tuple[str, typing.Callable[[DockerfileBuilderCallbackContext], None]] | DockerfileBuilderParameters
     container_network_alias: str
     mcp_server: McpServerParameters | typing.Literal[True]
@@ -7815,6 +8422,7 @@ class ContainerResourceKwargs(_BaseResourceKwargs, total=False):
     certificate_trust_scope: CertificateTrustScope
     https_developer_certificate: ParameterResource | typing.Literal[True]
     without_https_certificate: typing.Literal[True]
+    https_certificate_config: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]
     compute_env: AbstractComputeEnvironmentResource
     http_probe: ProbeType | HttpProbeParameters
     image_push_options: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]
@@ -8034,6 +8642,20 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
             rpc_args['options'] = options
         result = self._client.invoke_capability(
             'Aspire.Hosting/withContainerFiles',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
+    def with_container_files_callback(self, destination_path: str, callback: typing.Callable[[ContainerFileSystemCallbackContext, CancellationToken], typing.Iterable[ContainerFileSystemItem]], *, options: ContainerFilesOptions | None = None) -> typing.Self:
+        """Creates or updates files and folders in a container using entries produced by a callback."""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['destinationPath'] = destination_path
+        rpc_args['callback'] = self._client.register_callback(callback)
+        if options is not None:
+            rpc_args['options'] = options
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withContainerFilesCallback',
             rpc_args,
         )
         self._handle = self._wrap_builder(result)
@@ -8437,6 +9059,17 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         self._handle = self._wrap_builder(result)
         return self
 
+    def with_https_certificate_config(self, callback: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]) -> typing.Self:
+        """Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication."""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['callback'] = self._client.register_callback(callback)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withHttpsCertificateConfiguration',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
     def with_compute_env(self, compute_env_resource: AbstractComputeEnvironmentResource) -> typing.Self:
         """Configures the compute environment for the compute resource."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
@@ -8712,6 +9345,20 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withContainerFiles', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'container_files'. Expected: (str, str) or ContainerFilesParameters")
+        if _container_files_callback := kwargs.pop("container_files_callback", None):
+            if _validate_tuple_types(_container_files_callback, (str, typing.Callable[[ContainerFileSystemCallbackContext, CancellationToken], typing.Iterable[ContainerFileSystemItem]])):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["destinationPath"] = typing.cast(tuple[str, typing.Callable[[ContainerFileSystemCallbackContext, CancellationToken], typing.Iterable[ContainerFileSystemItem]]], _container_files_callback)[0]
+                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[ContainerFileSystemCallbackContext, CancellationToken], typing.Iterable[ContainerFileSystemItem]]], _container_files_callback)[1])
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withContainerFilesCallback', rpc_args))
+            elif _validate_dict_types(_container_files_callback, ContainerFilesCallbackParameters):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["destinationPath"] = typing.cast(ContainerFilesCallbackParameters, _container_files_callback)["destination_path"]
+                rpc_args["callback"] = client.register_callback(typing.cast(ContainerFilesCallbackParameters, _container_files_callback)["callback"])
+                rpc_args["options"] = typing.cast(ContainerFilesCallbackParameters, _container_files_callback).get("options")
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withContainerFilesCallback', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'container_files_callback'. Expected: (str, Callable[[ContainerFileSystemCallbackContext, CancellationToken], Iterable[ContainerFileSystemItem]]) or ContainerFilesCallbackParameters")
         if _dockerfile_builder := kwargs.pop("dockerfile_builder", None):
             if _validate_tuple_types(_dockerfile_builder, (str, typing.Callable[[DockerfileBuilderCallbackContext], None])):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -9006,6 +9653,13 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withoutHttpsCertificate', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'without_https_certificate'. Expected: Literal[True]")
+        if _https_certificate_config := kwargs.pop("https_certificate_config", None):
+            if _validate_type(_https_certificate_config, typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None], _https_certificate_config))
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpsCertificateConfiguration', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'https_certificate_config'. Expected: Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]")
         if _compute_env := kwargs.pop("compute_env", None):
             if _validate_type(_compute_env, AbstractComputeEnvironmentResource):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -9122,6 +9776,7 @@ class ProjectResourceKwargs(_BaseResourceKwargs, total=False):
     certificate_trust_scope: CertificateTrustScope
     https_developer_certificate: ParameterResource | typing.Literal[True]
     without_https_certificate: typing.Literal[True]
+    https_certificate_config: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]
     compute_env: AbstractComputeEnvironmentResource
     http_probe: ProbeType | HttpProbeParameters
     image_push_options: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]
@@ -9546,6 +10201,17 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         self._handle = self._wrap_builder(result)
         return self
 
+    def with_https_certificate_config(self, callback: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]) -> typing.Self:
+        """Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication."""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['callback'] = self._client.register_callback(callback)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withHttpsCertificateConfiguration',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
     def with_compute_env(self, compute_env_resource: AbstractComputeEnvironmentResource) -> typing.Self:
         """Configures the compute environment for the compute resource."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
@@ -9958,6 +10624,13 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withoutHttpsCertificate', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'without_https_certificate'. Expected: Literal[True]")
+        if _https_certificate_config := kwargs.pop("https_certificate_config", None):
+            if _validate_type(_https_certificate_config, typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None], _https_certificate_config))
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpsCertificateConfiguration', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'https_certificate_config'. Expected: Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]")
         if _compute_env := kwargs.pop("compute_env", None):
             if _validate_type(_compute_env, AbstractComputeEnvironmentResource):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -10081,6 +10754,7 @@ class ExecutableResourceKwargs(_BaseResourceKwargs, total=False):
     certificate_trust_scope: CertificateTrustScope
     https_developer_certificate: ParameterResource | typing.Literal[True]
     without_https_certificate: typing.Literal[True]
+    https_certificate_config: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]
     compute_env: AbstractComputeEnvironmentResource
     http_probe: ProbeType | HttpProbeParameters
     image_push_options: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]
@@ -10492,6 +11166,17 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         self._handle = self._wrap_builder(result)
         return self
 
+    def with_https_certificate_config(self, callback: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]) -> typing.Self:
+        """Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication."""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['callback'] = self._client.register_callback(callback)
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withHttpsCertificateConfiguration',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
     def with_compute_env(self, compute_env_resource: AbstractComputeEnvironmentResource) -> typing.Self:
         """Configures the compute environment for the compute resource."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
@@ -10883,6 +11568,13 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withoutHttpsCertificate', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'without_https_certificate'. Expected: Literal[True]")
+        if _https_certificate_config := kwargs.pop("https_certificate_config", None):
+            if _validate_type(_https_certificate_config, typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None], _https_certificate_config))
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpsCertificateConfiguration', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'https_certificate_config'. Expected: Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]")
         if _compute_env := kwargs.pop("compute_env", None):
             if _validate_type(_compute_env, AbstractComputeEnvironmentResource):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -11608,6 +12300,9 @@ _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeS
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext", CommandLineArgsCallbackContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsEditor", CommandLineArgsEditor)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent", ConnectionStringAvailableEvent)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerBuildOptionsCallbackContext", ContainerBuildOptionsCallbackContext)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemCallbackContext", ContainerFileSystemCallbackContext)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemItem", ContainerFileSystemItem)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions", ContainerImagePushOptions)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext", ContainerImagePushOptionsCallbackContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference", ContainerImageReference)
@@ -11629,6 +12324,8 @@ _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.Environ
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext", EventingSubscriberRegistrationContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext", ExecuteCommandContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpCommandPrepareRequestContext", HttpCommandPrepareRequestContext)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext", HttpsCertificateConfigurationCallbackAnnotationContext)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsEndpointUpdateCallbackContext", HttpsEndpointUpdateCallbackContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent", InitializeResourceEvent)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.InputsDialogValidationContext", InputsDialogValidationContext)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.InteractionInputCollection", InteractionInputCollection)
@@ -11642,6 +12339,8 @@ _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineStepFa
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineSummary", PipelineSummary)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ProjectResourceOptions", ProjectResourceOptions)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpressionBuilder", ReferenceExpressionBuilder)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationContext", RequiredCommandValidationContext)
+_register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationResult", RequiredCommandValidationResult)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceCommandService", ResourceCommandService)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceEndpointsAllocatedEvent", ResourceEndpointsAllocatedEvent)
 _register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceLoggerService", ResourceLoggerService)

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -9605,6 +9605,15 @@ impl ExecuteCommandContext {
         &self.client
     }
 
+    /// The service provider.
+    pub fn services(&self) -> Result<IServiceProvider, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ExecuteCommandContext.services", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IServiceProvider::new(handle, self.client.clone()))
+    }
+
     /// The resource name.
     pub fn resource_name(&self) -> Result<String, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -20497,6 +20506,15 @@ impl UpdateCommandStateContext {
         args.insert("context".to_string(), self.handle.to_json());
         let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.resourceSnapshot", args)?;
         Ok(serde_json::from_value(result)?)
+    }
+
+    /// The service provider.
+    pub fn services(&self) -> Result<IServiceProvider, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.services", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IServiceProvider::new(handle, self.client.clone()))
     }
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -4711,7 +4711,7 @@ impl ContainerResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
-    /// Creates or updates files and folders in a container using entries produced by a callback.
+    /// Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
     pub fn with_container_files_callback(&self, destination_path: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, options: Option<ContainerFilesOptions>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
@@ -16027,7 +16027,7 @@ impl TestDatabaseResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
-    /// Creates or updates files and folders in a container using entries produced by a callback.
+    /// Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
     pub fn with_container_files_callback(&self, destination_path: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, options: Option<ContainerFilesOptions>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
@@ -17595,7 +17595,7 @@ impl TestRedisResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
-    /// Creates or updates files and folders in a container using entries produced by a callback.
+    /// Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
     pub fn with_container_files_callback(&self, destination_path: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, options: Option<ContainerFilesOptions>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
@@ -19269,7 +19269,7 @@ impl TestVaultResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
-    /// Creates or updates files and folders in a container using entries produced by a callback.
+    /// Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
     pub fn with_container_files_callback(&self, destination_path: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, options: Option<ContainerFilesOptions>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -297,6 +297,78 @@ impl std::fmt::Display for ProbeType {
     }
 }
 
+/// ContainerImageDestination
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ContainerImageDestination {
+    #[default]
+    #[serde(rename = "Registry")]
+    Registry,
+    #[serde(rename = "Archive")]
+    Archive,
+}
+
+impl std::fmt::Display for ContainerImageDestination {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Registry => write!(f, "Registry"),
+            Self::Archive => write!(f, "Archive"),
+        }
+    }
+}
+
+/// ContainerImageFormat
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ContainerImageFormat {
+    #[default]
+    #[serde(rename = "Docker")]
+    Docker,
+    #[serde(rename = "Oci")]
+    Oci,
+}
+
+impl std::fmt::Display for ContainerImageFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Docker => write!(f, "Docker"),
+            Self::Oci => write!(f, "Oci"),
+        }
+    }
+}
+
+/// ContainerTargetPlatform
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ContainerTargetPlatform {
+    #[default]
+    #[serde(rename = "LinuxAmd64")]
+    LinuxAmd64,
+    #[serde(rename = "LinuxArm64")]
+    LinuxArm64,
+    #[serde(rename = "AllLinux")]
+    AllLinux,
+    #[serde(rename = "LinuxArm")]
+    LinuxArm,
+    #[serde(rename = "Linux386")]
+    Linux386,
+    #[serde(rename = "WindowsAmd64")]
+    WindowsAmd64,
+    #[serde(rename = "WindowsArm64")]
+    WindowsArm64,
+}
+
+impl std::fmt::Display for ContainerTargetPlatform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LinuxAmd64 => write!(f, "LinuxAmd64"),
+            Self::LinuxArm64 => write!(f, "LinuxArm64"),
+            Self::AllLinux => write!(f, "AllLinux"),
+            Self::LinuxArm => write!(f, "LinuxArm"),
+            Self::Linux386 => write!(f, "Linux386"),
+            Self::WindowsAmd64 => write!(f, "WindowsAmd64"),
+            Self::WindowsArm64 => write!(f, "WindowsArm64"),
+        }
+    }
+}
+
 /// EndpointProperty
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EndpointProperty {
@@ -1908,6 +1980,21 @@ impl CSharpAppResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+    pub fn with_required_command_validation(&self, command: &str, validation_callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, help_link: Option<&str>) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("command".to_string(), serde_json::to_value(&command).unwrap_or(Value::Null));
+        let callback_id = register_callback(validation_callback);
+        args.insert("validationCallback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = help_link {
+            args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommandValidation", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Configures a resource to use a session lifetime.
     pub fn with_session_lifetime(&self) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -2417,6 +2504,28 @@ impl CSharpAppResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
+    /// Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+    pub fn with_https_certificate_configuration(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsCertificateConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+    pub fn subscribe_https_endpoints_update(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Adds a relationship to another resource using its builder.
     pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -2681,6 +2790,17 @@ impl CSharpAppResource {
         let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Configures container build options for a compute resource using an async callback.
+    pub fn with_container_build_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerBuildOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -3098,6 +3218,332 @@ impl ConnectionStringAvailableEvent {
     }
 }
 
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerBuildOptionsCallbackContext
+pub struct ContainerBuildOptionsCallbackContext {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for ContainerBuildOptionsCallbackContext {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl ContainerBuildOptionsCallbackContext {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Gets the resource being built.
+    pub fn resource(&self) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.resource", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Gets the service provider.
+    pub fn services(&self) -> Result<IServiceProvider, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.services", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IServiceProvider::new(handle, self.client.clone()))
+    }
+
+    /// Gets the logger instance.
+    pub fn logger(&self) -> Result<ILogger, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.logger", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ILogger::new(handle, self.client.clone()))
+    }
+
+    /// Gets the cancellation token.
+    pub fn cancellation_token(&self) -> Result<CancellationToken, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.cancellationToken", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(CancellationToken::new(handle, self.client.clone()))
+    }
+
+    /// Gets the distributed application execution context.
+    pub fn execution_context(&self) -> Result<DistributedApplicationExecutionContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.executionContext", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(DistributedApplicationExecutionContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets or sets the destination for the container image.
+    pub fn destination(&self) -> Result<ContainerImageDestination, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.destination", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the Destination property
+    pub fn set_destination(&self, value: ContainerImageDestination) -> Result<ContainerBuildOptionsCallbackContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setDestination", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerBuildOptionsCallbackContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets or sets the output path for the container archive.
+    pub fn output_path(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.outputPath", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the OutputPath property
+    pub fn set_output_path(&self, value: &str) -> Result<ContainerBuildOptionsCallbackContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setOutputPath", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerBuildOptionsCallbackContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets or sets the container image format.
+    pub fn image_format(&self) -> Result<ContainerImageFormat, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.imageFormat", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the ImageFormat property
+    pub fn set_image_format(&self, value: ContainerImageFormat) -> Result<ContainerBuildOptionsCallbackContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setImageFormat", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerBuildOptionsCallbackContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets or sets the target platform for the container.
+    pub fn target_platform(&self) -> Result<ContainerTargetPlatform, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.targetPlatform", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the TargetPlatform property
+    pub fn set_target_platform(&self, value: ContainerTargetPlatform) -> Result<ContainerBuildOptionsCallbackContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setTargetPlatform", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerBuildOptionsCallbackContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets or sets the local image name for the built container.
+    pub fn local_image_name(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.localImageName", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the LocalImageName property
+    pub fn set_local_image_name(&self, value: &str) -> Result<ContainerBuildOptionsCallbackContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setLocalImageName", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerBuildOptionsCallbackContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets or sets the local image tag for the built container.
+    pub fn local_image_tag(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.localImageTag", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Sets the LocalImageTag property
+    pub fn set_local_image_tag(&self, value: &str) -> Result<ContainerBuildOptionsCallbackContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setLocalImageTag", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerBuildOptionsCallbackContext::new(handle, self.client.clone()))
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemCallbackContext
+pub struct ContainerFileSystemCallbackContext {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for ContainerFileSystemCallbackContext {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl ContainerFileSystemCallbackContext {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// A `IServiceProvider` that can be used to resolve services in the callback.
+    pub fn services(&self) -> Result<IServiceProvider, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerFileSystemCallbackContext.services", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IServiceProvider::new(handle, self.client.clone()))
+    }
+
+    /// The app model resource the callback is associated with.
+    pub fn model(&self) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ContainerFileSystemCallbackContext.model", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Creates a container file entry with inline contents or a host source path.
+    pub fn create_file(&self, name: &str, contents: Option<&str>, source_path: Option<&str>, owner: Option<f64>, group: Option<f64>, mode: Option<f64>, continue_on_error: Option<bool>) -> Result<ContainerFileSystemItem, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
+        if let Some(ref v) = contents {
+            args.insert("contents".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = source_path {
+            args.insert("sourcePath".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = owner {
+            args.insert("owner".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = group {
+            args.insert("group".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = mode {
+            args.insert("mode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = continue_on_error {
+            args.insert("continueOnError".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/createFile", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerFileSystemItem::new(handle, self.client.clone()))
+    }
+
+    /// Creates a PEM container certificate file entry with the OpenSSL subject-hash symlink.
+    pub fn create_certificate_file(&self, name: &str, contents: Option<&str>, source_path: Option<&str>, owner: Option<f64>, group: Option<f64>, mode: Option<f64>, continue_on_error: Option<bool>) -> Result<ContainerFileSystemItem, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
+        if let Some(ref v) = contents {
+            args.insert("contents".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = source_path {
+            args.insert("sourcePath".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = owner {
+            args.insert("owner".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = group {
+            args.insert("group".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = mode {
+            args.insert("mode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = continue_on_error {
+            args.insert("continueOnError".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/createCertificateFile", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerFileSystemItem::new(handle, self.client.clone()))
+    }
+
+    /// Creates a container directory entry containing the specified child entries.
+    pub fn create_directory(&self, name: &str, entries: Vec<ContainerFileSystemItem>, owner: Option<f64>, group: Option<f64>, mode: Option<f64>) -> Result<ContainerFileSystemItem, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
+        let handles: Vec<Value> = entries.iter().map(|item| item.handle().to_json()).collect();
+        args.insert("entries".to_string(), Value::Array(handles));
+        if let Some(ref v) = owner {
+            args.insert("owner".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = group {
+            args.insert("group".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = mode {
+            args.insert("mode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/createDirectory", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerFileSystemItem::new(handle, self.client.clone()))
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemItem
+pub struct ContainerFileSystemItem {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for ContainerFileSystemItem {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl ContainerFileSystemItem {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+}
+
 /// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions
 pub struct ContainerImagePushOptions {
     handle: Handle,
@@ -3420,6 +3866,21 @@ impl ContainerRegistryResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+    pub fn with_required_command_validation(&self, command: &str, validation_callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, help_link: Option<&str>) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("command".to_string(), serde_json::to_value(&command).unwrap_or(Value::Null));
+        let callback_id = register_callback(validation_callback);
+        args.insert("validationCallback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = help_link {
+            args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommandValidation", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Configures a resource to use a session lifetime.
     pub fn with_session_lifetime(&self) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -3562,6 +4023,17 @@ impl ContainerRegistryResource {
             args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommandFactory", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+    pub fn subscribe_https_endpoints_update(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -3737,6 +4209,17 @@ impl ContainerRegistryResource {
         let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Configures container build options for a compute resource using an async callback.
+    pub fn with_container_build_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerBuildOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -4228,6 +4711,21 @@ impl ContainerResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
+    /// Creates or updates files and folders in a container using entries produced by a callback.
+    pub fn with_container_files_callback(&self, destination_path: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, options: Option<ContainerFilesOptions>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("destinationPath".to_string(), serde_json::to_value(&destination_path).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerFilesCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerResource::new(handle, self.client.clone()))
+    }
+
     /// Configures the resource to use a programmatically generated Dockerfile
     pub fn with_dockerfile_builder(&self, context_path: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, stage: Option<&str>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -4313,6 +4811,21 @@ impl ContainerResource {
             args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+    pub fn with_required_command_validation(&self, command: &str, validation_callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, help_link: Option<&str>) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("command".to_string(), serde_json::to_value(&command).unwrap_or(Value::Null));
+        let callback_id = register_callback(validation_callback);
+        args.insert("validationCallback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = help_link {
+            args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommandValidation", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -4815,6 +5328,28 @@ impl ContainerResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
+    /// Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+    pub fn with_https_certificate_configuration(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsCertificateConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+    pub fn subscribe_https_endpoints_update(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Adds a relationship to another resource using its builder.
     pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -5085,6 +5620,17 @@ impl ContainerResource {
         let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Configures container build options for a compute resource using an async callback.
+    pub fn with_container_build_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerBuildOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -6122,6 +6668,21 @@ impl DotnetToolResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+    pub fn with_required_command_validation(&self, command: &str, validation_callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, help_link: Option<&str>) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("command".to_string(), serde_json::to_value(&command).unwrap_or(Value::Null));
+        let callback_id = register_callback(validation_callback);
+        args.insert("validationCallback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = help_link {
+            args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommandValidation", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Configures a resource to use a session lifetime.
     pub fn with_session_lifetime(&self) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -6620,6 +7181,28 @@ impl DotnetToolResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
+    /// Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+    pub fn with_https_certificate_configuration(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsCertificateConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+    pub fn subscribe_https_endpoints_update(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Adds a relationship to another resource using its builder.
     pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -6874,6 +7457,17 @@ impl DotnetToolResource {
         let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Configures container build options for a compute resource using an async callback.
+    pub fn with_container_build_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerBuildOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -7901,6 +8495,21 @@ impl ExecutableResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+    pub fn with_required_command_validation(&self, command: &str, validation_callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, help_link: Option<&str>) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("command".to_string(), serde_json::to_value(&command).unwrap_or(Value::Null));
+        let callback_id = register_callback(validation_callback);
+        args.insert("validationCallback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = help_link {
+            args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommandValidation", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Configures a resource to use a session lifetime.
     pub fn with_session_lifetime(&self) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -8399,6 +9008,28 @@ impl ExecutableResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
+    /// Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+    pub fn with_https_certificate_configuration(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsCertificateConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+    pub fn subscribe_https_endpoints_update(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Adds a relationship to another resource using its builder.
     pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -8653,6 +9284,17 @@ impl ExecutableResource {
         let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Configures container build options for a compute resource using an async callback.
+    pub fn with_container_build_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerBuildOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -8954,6 +9596,15 @@ impl ExecuteCommandContext {
         &self.client
     }
 
+    /// The service provider.
+    pub fn services(&self) -> Result<IServiceProvider, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/ExecuteCommandContext.services", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IServiceProvider::new(handle, self.client.clone()))
+    }
+
     /// The resource name.
     pub fn resource_name(&self) -> Result<String, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -9067,6 +9718,21 @@ impl ExternalServiceResource {
             args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+    pub fn with_required_command_validation(&self, command: &str, validation_callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, help_link: Option<&str>) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("command".to_string(), serde_json::to_value(&command).unwrap_or(Value::Null));
+        let callback_id = register_callback(validation_callback);
+        args.insert("validationCallback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = help_link {
+            args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommandValidation", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -9213,6 +9879,17 @@ impl ExternalServiceResource {
             args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommandFactory", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+    pub fn subscribe_https_endpoints_update(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -9388,6 +10065,17 @@ impl ExternalServiceResource {
         let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Configures container build options for a compute resource using an async callback.
+    pub fn with_container_build_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerBuildOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -9701,6 +10389,163 @@ impl HttpCommandPrepareRequestContext {
         let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpCommandPrepareRequestContext.arguments", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(InteractionInputCollection::new(handle, self.client.clone()))
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext
+pub struct HttpsCertificateConfigurationCallbackAnnotationContext {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for HttpsCertificateConfigurationCallbackAnnotationContext {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl HttpsCertificateConfigurationCallbackAnnotationContext {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Gets the `DistributedApplicationExecutionContext` for this session.
+    pub fn execution_context(&self) -> Result<DistributedApplicationExecutionContext, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.executionContext", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(DistributedApplicationExecutionContext::new(handle, self.client.clone()))
+    }
+
+    /// Gets the resource to which the annotation is applied.
+    pub fn resource(&self) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.resource", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// A value provider that will resolve to a path to the certificate file.
+    pub fn certificate_path(&self) -> Result<ReferenceExpression, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.certificatePath", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// A value provider that will resolve to a path to the private key for the certificate.
+    pub fn key_path(&self) -> Result<ReferenceExpression, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.keyPath", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// A value provider that will resolve to a path to a PFX file for the key pair.
+    pub fn pfx_path(&self) -> Result<ReferenceExpression, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.pfxPath", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Gets the `CancellationToken` that can be used to cancel the operation.
+    pub fn cancellation_token(&self) -> Result<CancellationToken, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.cancellationToken", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(CancellationToken::new(handle, self.client.clone()))
+    }
+
+    /// Gets the editor used to manipulate the command-line arguments in polyglot callbacks.
+    pub fn arguments(&self) -> Result<CommandLineArgsEditor, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.arguments", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(CommandLineArgsEditor::new(handle, self.client.clone()))
+    }
+
+    /// Gets the editor used to set environment variables in polyglot callbacks.
+    pub fn environment(&self) -> Result<EnvironmentEditor, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.environment", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(EnvironmentEditor::new(handle, self.client.clone()))
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsEndpointUpdateCallbackContext
+pub struct HttpsEndpointUpdateCallbackContext {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for HttpsEndpointUpdateCallbackContext {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl HttpsEndpointUpdateCallbackContext {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Gets the `IServiceProvider` instance from the application.
+    pub fn services(&self) -> Result<IServiceProvider, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.services", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IServiceProvider::new(handle, self.client.clone()))
+    }
+
+    /// Gets the `IResource` that is being configured for HTTPS.
+    pub fn resource(&self) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.resource", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Gets the `DistributedApplicationModel` instance.
+    pub fn model(&self) -> Result<DistributedApplicationModel, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.model", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(DistributedApplicationModel::new(handle, self.client.clone()))
+    }
+
+    /// Gets the `CancellationToken` for the operation.
+    pub fn cancellation_token(&self) -> Result<CancellationToken, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.cancellationToken", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(CancellationToken::new(handle, self.client.clone()))
     }
 }
 
@@ -11616,6 +12461,15 @@ impl InputsDialogValidationContext {
         Ok(CancellationToken::new(handle, self.client.clone()))
     }
 
+    /// Gets the service provider for resolving services during validation.
+    pub fn services(&self) -> Result<IServiceProvider, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/InputsDialogValidationContext.services", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IServiceProvider::new(handle, self.client.clone()))
+    }
+
     /// Adds a validation error for the input with the specified name.
     pub fn add_validation_error(&self, input_name: &str, error_message: &str) -> Result<(), Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -11809,6 +12663,21 @@ impl ParameterResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+    pub fn with_required_command_validation(&self, command: &str, validation_callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, help_link: Option<&str>) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("command".to_string(), serde_json::to_value(&command).unwrap_or(Value::Null));
+        let callback_id = register_callback(validation_callback);
+        args.insert("validationCallback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = help_link {
+            args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommandValidation", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Configures a resource to use a session lifetime.
     pub fn with_session_lifetime(&self) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -11951,6 +12820,17 @@ impl ParameterResource {
             args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommandFactory", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+    pub fn subscribe_https_endpoints_update(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -12126,6 +13006,17 @@ impl ParameterResource {
         let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Configures container build options for a compute resource using an async callback.
+    pub fn with_container_build_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerBuildOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -12965,6 +13856,21 @@ impl ProjectResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+    pub fn with_required_command_validation(&self, command: &str, validation_callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, help_link: Option<&str>) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("command".to_string(), serde_json::to_value(&command).unwrap_or(Value::Null));
+        let callback_id = register_callback(validation_callback);
+        args.insert("validationCallback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = help_link {
+            args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommandValidation", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Configures a resource to use a session lifetime.
     pub fn with_session_lifetime(&self) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -13474,6 +14380,28 @@ impl ProjectResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
+    /// Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+    pub fn with_https_certificate_configuration(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsCertificateConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+    pub fn subscribe_https_endpoints_update(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Adds a relationship to another resource using its builder.
     pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -13738,6 +14666,17 @@ impl ProjectResource {
         let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Configures container build options for a compute resource using an async callback.
+    pub fn with_container_build_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerBuildOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -14165,6 +15104,119 @@ impl ReferenceExpressionBuilder {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("context".to_string(), self.handle.to_json());
         let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/build", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationContext
+pub struct RequiredCommandValidationContext {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for RequiredCommandValidationContext {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl RequiredCommandValidationContext {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Gets the resolved full path to the command executable.
+    pub fn resolved_path(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.resolvedPath", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Gets the service provider for accessing application services.
+    pub fn services(&self) -> Result<IServiceProvider, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.services", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IServiceProvider::new(handle, self.client.clone()))
+    }
+
+    /// Gets a cancellation token that can be used to cancel the validation.
+    pub fn cancellation_token(&self) -> Result<CancellationToken, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.cancellationToken", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(CancellationToken::new(handle, self.client.clone()))
+    }
+
+    /// Creates a successful validation result.
+    pub fn success(&self) -> Result<RequiredCommandValidationResult, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.success", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(RequiredCommandValidationResult::new(handle, self.client.clone()))
+    }
+
+    /// Creates a failed validation result with the specified message.
+    pub fn failure(&self, validation_message: &str) -> Result<RequiredCommandValidationResult, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        args.insert("validationMessage".to_string(), serde_json::to_value(&validation_message).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.failure", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(RequiredCommandValidationResult::new(handle, self.client.clone()))
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationResult
+pub struct RequiredCommandValidationResult {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for RequiredCommandValidationResult {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl RequiredCommandValidationResult {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+
+    /// Gets a value indicating whether the command validation succeeded.
+    pub fn is_valid(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationResult.isValid", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
+    /// Gets an optional validation message describing why validation failed.
+    pub fn validation_message(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/RequiredCommandValidationResult.validationMessage", args)?;
         Ok(serde_json::from_value(result)?)
     }
 }
@@ -14966,6 +16018,21 @@ impl TestDatabaseResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
+    /// Creates or updates files and folders in a container using entries produced by a callback.
+    pub fn with_container_files_callback(&self, destination_path: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, options: Option<ContainerFilesOptions>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("destinationPath".to_string(), serde_json::to_value(&destination_path).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerFilesCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerResource::new(handle, self.client.clone()))
+    }
+
     /// Configures the resource to use a programmatically generated Dockerfile
     pub fn with_dockerfile_builder(&self, context_path: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, stage: Option<&str>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -15051,6 +16118,21 @@ impl TestDatabaseResource {
             args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+    pub fn with_required_command_validation(&self, command: &str, validation_callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, help_link: Option<&str>) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("command".to_string(), serde_json::to_value(&command).unwrap_or(Value::Null));
+        let callback_id = register_callback(validation_callback);
+        args.insert("validationCallback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = help_link {
+            args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommandValidation", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -15553,6 +16635,28 @@ impl TestDatabaseResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
+    /// Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+    pub fn with_https_certificate_configuration(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsCertificateConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+    pub fn subscribe_https_endpoints_update(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Adds a relationship to another resource using its builder.
     pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -15823,6 +16927,17 @@ impl TestDatabaseResource {
         let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Configures container build options for a compute resource using an async callback.
+    pub fn with_container_build_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerBuildOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -16471,6 +17586,21 @@ impl TestRedisResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
+    /// Creates or updates files and folders in a container using entries produced by a callback.
+    pub fn with_container_files_callback(&self, destination_path: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, options: Option<ContainerFilesOptions>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("destinationPath".to_string(), serde_json::to_value(&destination_path).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerFilesCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerResource::new(handle, self.client.clone()))
+    }
+
     /// Configures the resource to use a programmatically generated Dockerfile
     pub fn with_dockerfile_builder(&self, context_path: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, stage: Option<&str>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -16556,6 +17686,21 @@ impl TestRedisResource {
             args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+    pub fn with_required_command_validation(&self, command: &str, validation_callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, help_link: Option<&str>) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("command".to_string(), serde_json::to_value(&command).unwrap_or(Value::Null));
+        let callback_id = register_callback(validation_callback);
+        args.insert("validationCallback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = help_link {
+            args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommandValidation", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -17078,6 +18223,28 @@ impl TestRedisResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
+    /// Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+    pub fn with_https_certificate_configuration(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsCertificateConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+    pub fn subscribe_https_endpoints_update(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Adds a relationship to another resource using its builder.
     pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -17359,6 +18526,17 @@ impl TestRedisResource {
         let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Configures container build options for a compute resource using an async callback.
+    pub fn with_container_build_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerBuildOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Adds a child database to a test Redis resource
@@ -18082,6 +19260,21 @@ impl TestVaultResource {
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
 
+    /// Creates or updates files and folders in a container using entries produced by a callback.
+    pub fn with_container_files_callback(&self, destination_path: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, options: Option<ContainerFilesOptions>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("destinationPath".to_string(), serde_json::to_value(&destination_path).unwrap_or(Value::Null));
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = options {
+            args.insert("options".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerFilesCallback", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerResource::new(handle, self.client.clone()))
+    }
+
     /// Configures the resource to use a programmatically generated Dockerfile
     pub fn with_dockerfile_builder(&self, context_path: &str, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, stage: Option<&str>) -> Result<ContainerResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -18167,6 +19360,21 @@ impl TestVaultResource {
             args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+    pub fn with_required_command_validation(&self, command: &str, validation_callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, help_link: Option<&str>) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("command".to_string(), serde_json::to_value(&command).unwrap_or(Value::Null));
+        let callback_id = register_callback(validation_callback);
+        args.insert("validationCallback".to_string(), Value::String(callback_id));
+        if let Some(ref v) = help_link {
+            args.insert("helpLink".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/withRequiredCommandValidation", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -18669,6 +19877,28 @@ impl TestVaultResource {
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
 
+    /// Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+    pub fn with_https_certificate_configuration(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResourceWithEnvironment, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsCertificateConfiguration", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+    pub fn subscribe_https_endpoints_update(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/subscribeHttpsEndpointsUpdate", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Adds a relationship to another resource using its builder.
     pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -18939,6 +20169,17 @@ impl TestVaultResource {
         let result = self.client.invoke_capability("Aspire.Hosting/createExecutionConfiguration", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IExecutionConfigurationBuilder::new(handle, self.client.clone()))
+    }
+
+    /// Configures container build options for a compute resource using an async callback.
+    pub fn with_container_build_options(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let callback_id = register_callback(callback);
+        args.insert("callback".to_string(), Value::String(callback_id));
+        let result = self.client.invoke_capability("Aspire.Hosting/withContainerBuildOptions", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
     }
 
     /// Adds an optional string parameter
@@ -19256,6 +20497,15 @@ impl UpdateCommandStateContext {
         args.insert("context".to_string(), self.handle.to_json());
         let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.resourceSnapshot", args)?;
         Ok(serde_json::from_value(result)?)
+    }
+
+    /// The service provider.
+    pub fn services(&self) -> Result<IServiceProvider, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.services", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IServiceProvider::new(handle, self.client.clone()))
     }
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -5562,6 +5562,8 @@ class EventingSubscriberRegistrationContextPromiseImpl implements EventingSubscr
 /** Context for {@link ResourceCommandAnnotation.ExecuteCommand}. */
 export interface ExecuteCommandContext {
     toJSON(): MarshalledHandle;
+    /** The service provider. */
+    services(): ServiceProviderPromise;
     /** The resource name. */
     resourceName(): Promise<string>;
     /** The cancellation token. */
@@ -5579,6 +5581,8 @@ export interface ExecuteCommandContext {
 }
 
 export interface ExecuteCommandContextPromise extends PromiseLike<ExecuteCommandContext> {
+    /** The service provider. */
+    services(): ServiceProviderPromise;
     /** The resource name. */
     resourceName(): Promise<string>;
     /** The cancellation token. */
@@ -5605,6 +5609,17 @@ class ExecuteCommandContextImpl implements ExecuteCommandContext {
 
     /** Serialize for JSON-RPC transport */
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    services(): ServiceProviderPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IServiceProviderHandle>(
+                'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.services',
+                { context: this._handle }
+            );
+            return new ServiceProviderImpl(handle, this._client);
+        })();
+        return new ServiceProviderPromiseImpl(promise, this._client, false);
+    }
 
     async resourceName(): Promise<string> {
         return await this._client.invokeCapability<string>(
@@ -5654,6 +5669,10 @@ class ExecuteCommandContextPromiseImpl implements ExecuteCommandContextPromise {
         onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
     ): PromiseLike<TResult1 | TResult2> {
         return this._promise.then(onfulfilled, onrejected);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
     }
 
     resourceName(): Promise<string> {
@@ -9412,11 +9431,15 @@ export interface UpdateCommandStateContext {
     toJSON(): MarshalledHandle;
     /** Gets the resource snapshot data available to polyglot command state callbacks. */
     resourceSnapshot(): Promise<UpdateCommandStateResourceSnapshot>;
+    /** The service provider. */
+    services(): ServiceProviderPromise;
 }
 
 export interface UpdateCommandStateContextPromise extends PromiseLike<UpdateCommandStateContext> {
     /** Gets the resource snapshot data available to polyglot command state callbacks. */
     resourceSnapshot(): Promise<UpdateCommandStateResourceSnapshot>;
+    /** The service provider. */
+    services(): ServiceProviderPromise;
 }
 
 // ============================================================================
@@ -9435,6 +9458,17 @@ class UpdateCommandStateContextImpl implements UpdateCommandStateContext {
             'Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.resourceSnapshot',
             { context: this._handle }
         );
+    }
+
+    services(): ServiceProviderPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IServiceProviderHandle>(
+                'Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.services',
+                { context: this._handle }
+            );
+            return new ServiceProviderImpl(handle, this._client);
+        })();
+        return new ServiceProviderPromiseImpl(promise, this._client, false);
     }
 
 }
@@ -9456,6 +9490,10 @@ class UpdateCommandStateContextPromiseImpl implements UpdateCommandStateContextP
 
     resourceSnapshot(): Promise<UpdateCommandStateResourceSnapshot> {
         return this._promise.then(obj => obj.resourceSnapshot());
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
     }
 
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -15354,7 +15354,7 @@ export interface ContainerResource {
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): ContainerResourcePromise;
     /**
-     * Creates or updates files and folders in a container using entries produced by a callback.
+     * Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
      * @param destinationPath The destination absolute path in the container.
      * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
      * @param options Additional options.
@@ -16161,7 +16161,7 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): ContainerResourcePromise;
     /**
-     * Creates or updates files and folders in a container using entries produced by a callback.
+     * Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
      * @param destinationPath The destination absolute path in the container.
      * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
      * @param options Additional options.
@@ -17253,7 +17253,7 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
     }
 
     /**
-     * Creates or updates files and folders in a container using entries produced by a callback.
+     * Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
      * @param destinationPath The destination absolute path in the container.
      * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
      * @param options Additional options.
@@ -40370,7 +40370,7 @@ export interface TestDatabaseResource {
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestDatabaseResourcePromise;
     /**
-     * Creates or updates files and folders in a container using entries produced by a callback.
+     * Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
      * @param destinationPath The destination absolute path in the container.
      * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
      * @param options Additional options.
@@ -41177,7 +41177,7 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestDatabaseResourcePromise;
     /**
-     * Creates or updates files and folders in a container using entries produced by a callback.
+     * Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
      * @param destinationPath The destination absolute path in the container.
      * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
      * @param options Additional options.
@@ -42268,7 +42268,7 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
     }
 
     /**
-     * Creates or updates files and folders in a container using entries produced by a callback.
+     * Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
      * @param destinationPath The destination absolute path in the container.
      * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
      * @param options Additional options.
@@ -45183,7 +45183,7 @@ export interface TestRedisResource {
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestRedisResourcePromise;
     /**
-     * Creates or updates files and folders in a container using entries produced by a callback.
+     * Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
      * @param destinationPath The destination absolute path in the container.
      * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
      * @param options Additional options.
@@ -46054,7 +46054,7 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestRedisResourcePromise;
     /**
-     * Creates or updates files and folders in a container using entries produced by a callback.
+     * Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
      * @param destinationPath The destination absolute path in the container.
      * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
      * @param options Additional options.
@@ -47209,7 +47209,7 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
     }
 
     /**
-     * Creates or updates files and folders in a container using entries produced by a callback.
+     * Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
      * @param destinationPath The destination absolute path in the container.
      * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
      * @param options Additional options.
@@ -50431,7 +50431,7 @@ export interface TestVaultResource {
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestVaultResourcePromise;
     /**
-     * Creates or updates files and folders in a container using entries produced by a callback.
+     * Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
      * @param destinationPath The destination absolute path in the container.
      * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
      * @param options Additional options.
@@ -51240,7 +51240,7 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestVaultResourcePromise;
     /**
-     * Creates or updates files and folders in a container using entries produced by a callback.
+     * Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
      * @param destinationPath The destination absolute path in the container.
      * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
      * @param options Additional options.
@@ -52333,7 +52333,7 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
     }
 
     /**
-     * Creates or updates files and folders in a container using entries produced by a callback.
+     * Creates or updates files and/or folders at the destination path in the container using entries produced by a callback.
      * @param destinationPath The destination absolute path in the container.
      * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
      * @param options Additional options.

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -112,6 +112,21 @@ type CommandLineArgsEditorHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Applica
 /** The {@link ConnectionStringAvailableEvent} is raised when a connection string becomes available for a resource. */
 type ConnectionStringAvailableEventHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent'>;
 
+/** Context for configuring container build options via a callback. */
+type ContainerBuildOptionsCallbackContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerBuildOptionsCallbackContext'>;
+
+/** Represents the context for a `ContainerFileSystemCallbackAnnotation` callback. */
+type ContainerFileSystemCallbackContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemCallbackContext'>;
+
+/**
+ * Represents a base class for file system entries in a container.
+ *
+ * Exported to ATS as an opaque handle type. Polyglot app hosts never construct or inspect these
+ * directly; they create concrete entries through the factory methods on
+ * `ContainerFileSystemCallbackContext` and pass the resulting handles back via the callback.
+ */
+type ContainerFileSystemItemHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemItem'>;
+
 /**
  * Represents options for pushing container images to a registry.
  *
@@ -191,6 +206,12 @@ type ExecuteCommandContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Applica
 /** Provides context for HTTP command prepare-request callbacks in polyglot app hosts. */
 type HttpCommandPrepareRequestContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpCommandPrepareRequestContext'>;
 
+/** Context provided to a `HttpsCertificateConfigurationCallbackAnnotation` callback. */
+type HttpsCertificateConfigurationCallbackAnnotationContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext'>;
+
+/** Context provided to the callback of `SubscribeHttpsEndpointsUpdate``1` when an HTTPS certificate is determined to be available for the resource. */
+type HttpsEndpointUpdateCallbackContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsEndpointUpdateCallbackContext'>;
+
 /**
  * Represents a store for managing files in the Aspire hosting environment that can be reused across runs.
  *
@@ -269,6 +290,12 @@ type ReferenceExpressionHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Applicati
 
 /** A builder for creating {@link ReferenceExpression} instances. */
 type ReferenceExpressionBuilderHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpressionBuilder'>;
+
+/** Provides context for validating a required command. */
+type RequiredCommandValidationContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationContext'>;
+
+/** Represents the result of validating a required command. */
+type RequiredCommandValidationResultHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationResult'>;
 
 /** A service to execute resource commands. */
 type ResourceCommandServiceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceCommandService'>;
@@ -441,6 +468,22 @@ export enum CommandResultFormat {
     Markdown = "Markdown",
 }
 
+/** Specifies the destination for container images. */
+export enum ContainerImageDestination {
+    /** Image will be pushed to a container registry. */
+    Registry = "Registry",
+    /** Image will be saved as an archive file. */
+    Archive = "Archive",
+}
+
+/** Specifies the format for container images. */
+export enum ContainerImageFormat {
+    /** Docker format (default). */
+    Docker = "Docker",
+    /** OCI format. */
+    Oci = "Oci",
+}
+
 /** Lifetime modes for container resources. */
 export enum ContainerLifetime {
     /** Create the resource when the app host process starts and dispose of it when the app host process shuts down. */
@@ -464,6 +507,24 @@ export enum ContainerMountType {
     BindMount = "BindMount",
     /** A volume. */
     Volume = "Volume",
+}
+
+/** Specifies the target platform for container images. */
+export enum ContainerTargetPlatform {
+    /** Linux AMD64 (linux/amd64). */
+    LinuxAmd64 = "LinuxAmd64",
+    /** Linux ARM64 (linux/arm64). */
+    LinuxArm64 = "LinuxArm64",
+    /** All Linux platforms (AMD64 and ARM64). */
+    AllLinux = "AllLinux",
+    /** Linux ARM (linux/arm). */
+    LinuxArm = "LinuxArm",
+    /** Linux 386 (linux/386). */
+    Linux386 = "Linux386",
+    /** Windows AMD64 (windows/amd64). */
+    WindowsAmd64 = "WindowsAmd64",
+    /** Windows ARM64 (windows/arm64). */
+    WindowsArm64 = "WindowsArm64",
 }
 
 /** Describes the context in which the AppHost is being executed. */
@@ -1286,6 +1347,45 @@ export interface CopyOptions {
     chown?: string;
 }
 
+export interface CreateCertificateFileOptions {
+    /** The inline PEM-encoded contents of the certificate. Mutually exclusive with `sourcePath`. */
+    contents?: string;
+    /** An absolute path to a PEM file on the host to copy. Mutually exclusive with `contents`. */
+    sourcePath?: string;
+    /** The owner UID, or `null` to inherit. */
+    owner?: number;
+    /** The group GID, or `null` to inherit. */
+    group?: number;
+    /** The Unix file mode as an integer (for example `0o644`), or `null` to inherit. */
+    mode?: number;
+    /** Whether to ignore errors creating this file. */
+    continueOnError?: boolean;
+}
+
+export interface CreateDirectoryOptions {
+    /** The owner UID, or `null` to inherit. */
+    owner?: number;
+    /** The group GID, or `null` to inherit. */
+    group?: number;
+    /** The Unix file mode as an integer (for example `0o755`), or `null` to inherit. */
+    mode?: number;
+}
+
+export interface CreateFileOptions {
+    /** The inline UTF-8 contents of the file. Mutually exclusive with `sourcePath`. */
+    contents?: string;
+    /** An absolute path to a file on the host to copy. Mutually exclusive with `contents`. */
+    sourcePath?: string;
+    /** The owner UID, or `null` to inherit. */
+    owner?: number;
+    /** The group GID, or `null` to inherit. */
+    group?: number;
+    /** The Unix file mode as an integer (for example `0o644`), or `null` to inherit. */
+    mode?: number;
+    /** Whether to ignore errors creating this file. */
+    continueOnError?: boolean;
+}
+
 export interface CreateMarkdownTaskOptions {
     cancellationToken?: AbortSignal | CancellationToken;
 }
@@ -1569,6 +1669,11 @@ export interface WithReferenceOptions {
 
 export interface WithRequiredCommandOptions {
     /** An optional help link URL to guide users when the command is missing. */
+    helpLink?: string;
+}
+
+export interface WithRequiredCommandValidationOptions {
+    /** An optional help link URL to guide users when the command is missing or fails validation. */
     helpLink?: string;
 }
 
@@ -2296,6 +2401,481 @@ class ConnectionStringAvailableEventPromiseImpl implements ConnectionStringAvail
 
     services(): ServiceProviderPromise {
         return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+}
+
+// ============================================================================
+// ContainerBuildOptionsCallbackContext
+// ============================================================================
+
+/** Context for configuring container build options via a callback. */
+export interface ContainerBuildOptionsCallbackContext {
+    toJSON(): MarshalledHandle;
+    /** Gets the resource being built. */
+    resource(): ResourcePromise;
+    /** Gets the service provider. */
+    services(): ServiceProviderPromise;
+    /** Gets the logger instance. */
+    logger(): LoggerPromise;
+    /** Gets the cancellation token. */
+    cancellationToken(): Promise<CancellationToken>;
+    /**
+     * Gets the distributed application execution context.
+     *
+     * Use `IsPublishMode` or
+     * `IsRunMode` to vary build options
+     * (for example `TargetPlatform`) between local run and publish operations.
+     */
+    executionContext(): DistributedApplicationExecutionContextPromise;
+    /** Gets or sets the destination for the container image. */
+    destination: {
+        get: () => Promise<ContainerImageDestination | null>;
+        set: (value: ContainerImageDestination | null) => Promise<void>;
+    };
+    /** Gets or sets the output path for the container archive. */
+    outputPath: {
+        get: () => Promise<string | null>;
+        set: (value: string | null) => Promise<void>;
+    };
+    /** Gets or sets the container image format. */
+    imageFormat: {
+        get: () => Promise<ContainerImageFormat | null>;
+        set: (value: ContainerImageFormat | null) => Promise<void>;
+    };
+    /** Gets or sets the target platform for the container. */
+    targetPlatform: {
+        get: () => Promise<ContainerTargetPlatform | null>;
+        set: (value: ContainerTargetPlatform | null) => Promise<void>;
+    };
+    /** Gets or sets the local image name for the built container. */
+    localImageName: {
+        get: () => Promise<string | null>;
+        set: (value: string | null) => Promise<void>;
+    };
+    /** Gets or sets the local image tag for the built container. */
+    localImageTag: {
+        get: () => Promise<string | null>;
+        set: (value: string | null) => Promise<void>;
+    };
+}
+
+export interface ContainerBuildOptionsCallbackContextPromise extends PromiseLike<ContainerBuildOptionsCallbackContext> {
+    /** Gets the resource being built. */
+    resource(): ResourcePromise;
+    /** Gets the service provider. */
+    services(): ServiceProviderPromise;
+    /** Gets the logger instance. */
+    logger(): LoggerPromise;
+    /** Gets the cancellation token. */
+    cancellationToken(): Promise<CancellationToken>;
+    /**
+     * Gets the distributed application execution context.
+     *
+     * Use `IsPublishMode` or
+     * `IsRunMode` to vary build options
+     * (for example `TargetPlatform`) between local run and publish operations.
+     */
+    executionContext(): DistributedApplicationExecutionContextPromise;
+}
+
+// ============================================================================
+// ContainerBuildOptionsCallbackContextImpl
+// ============================================================================
+
+/** Context for configuring container build options via a callback. */
+class ContainerBuildOptionsCallbackContextImpl implements ContainerBuildOptionsCallbackContext {
+    constructor(private _handle: ContainerBuildOptionsCallbackContextHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    resource(): ResourcePromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IResourceHandle>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.resource',
+                { context: this._handle }
+            );
+            return new ResourceImpl(handle, this._client);
+        })();
+        return new ResourcePromiseImpl(promise, this._client, false);
+    }
+
+    services(): ServiceProviderPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IServiceProviderHandle>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.services',
+                { context: this._handle }
+            );
+            return new ServiceProviderImpl(handle, this._client);
+        })();
+        return new ServiceProviderPromiseImpl(promise, this._client, false);
+    }
+
+    logger(): LoggerPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<ILoggerHandle>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.logger',
+                { context: this._handle }
+            );
+            return new LoggerImpl(handle, this._client);
+        })();
+        return new LoggerPromiseImpl(promise, this._client, false);
+    }
+
+    async cancellationToken(): Promise<CancellationToken> {
+        const result = await this._client.invokeCapability<string | null>(
+            'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.cancellationToken',
+            { context: this._handle }
+        );
+        return CancellationToken.fromValue(result);
+    }
+
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.executionContext',
+                { context: this._handle }
+            );
+            return new DistributedApplicationExecutionContextImpl(handle, this._client);
+        })();
+        return new DistributedApplicationExecutionContextPromiseImpl(promise, this._client, false);
+    }
+
+    destination = {
+        get: async (): Promise<ContainerImageDestination | null> => {
+            return await this._client.invokeCapability<ContainerImageDestination | null>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.destination',
+                { context: this._handle }
+            );
+        },
+        set: async (value: ContainerImageDestination | null): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setDestination',
+                { context: this._handle, value }
+            );
+        }
+    };
+
+    outputPath = {
+        get: async (): Promise<string | null> => {
+            return await this._client.invokeCapability<string | null>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.outputPath',
+                { context: this._handle }
+            );
+        },
+        set: async (value: string | null): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setOutputPath',
+                { context: this._handle, value }
+            );
+        }
+    };
+
+    imageFormat = {
+        get: async (): Promise<ContainerImageFormat | null> => {
+            return await this._client.invokeCapability<ContainerImageFormat | null>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.imageFormat',
+                { context: this._handle }
+            );
+        },
+        set: async (value: ContainerImageFormat | null): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setImageFormat',
+                { context: this._handle, value }
+            );
+        }
+    };
+
+    targetPlatform = {
+        get: async (): Promise<ContainerTargetPlatform | null> => {
+            return await this._client.invokeCapability<ContainerTargetPlatform | null>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.targetPlatform',
+                { context: this._handle }
+            );
+        },
+        set: async (value: ContainerTargetPlatform | null): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setTargetPlatform',
+                { context: this._handle, value }
+            );
+        }
+    };
+
+    localImageName = {
+        get: async (): Promise<string | null> => {
+            return await this._client.invokeCapability<string | null>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.localImageName',
+                { context: this._handle }
+            );
+        },
+        set: async (value: string | null): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setLocalImageName',
+                { context: this._handle, value }
+            );
+        }
+    };
+
+    localImageTag = {
+        get: async (): Promise<string | null> => {
+            return await this._client.invokeCapability<string | null>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.localImageTag',
+                { context: this._handle }
+            );
+        },
+        set: async (value: string | null): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Aspire.Hosting.ApplicationModel/ContainerBuildOptionsCallbackContext.setLocalImageTag',
+                { context: this._handle, value }
+            );
+        }
+    };
+
+}
+
+/**
+ * Thenable wrapper for ContainerBuildOptionsCallbackContext that enables fluent chaining.
+ */
+class ContainerBuildOptionsCallbackContextPromiseImpl implements ContainerBuildOptionsCallbackContextPromise {
+    constructor(private _promise: Promise<ContainerBuildOptionsCallbackContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ContainerBuildOptionsCallbackContext, TResult2 = never>(
+        onfulfilled?: ((value: ContainerBuildOptionsCallbackContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+    logger(): LoggerPromise {
+        return new LoggerPromiseImpl(this._promise.then(obj => obj.logger()), this._client, false);
+    }
+
+    cancellationToken(): Promise<CancellationToken> {
+        return this._promise.then(obj => obj.cancellationToken());
+    }
+
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        return new DistributedApplicationExecutionContextPromiseImpl(this._promise.then(obj => obj.executionContext()), this._client, false);
+    }
+
+}
+
+// ============================================================================
+// ContainerFileSystemCallbackContext
+// ============================================================================
+
+/** Represents the context for a `ContainerFileSystemCallbackAnnotation` callback. */
+export interface ContainerFileSystemCallbackContext {
+    toJSON(): MarshalledHandle;
+    /** A `IServiceProvider` that can be used to resolve services in the callback. */
+    services(): ServiceProviderPromise;
+    /** The app model resource the callback is associated with. */
+    model(): ResourcePromise;
+    /**
+     * Creates a container file entry with inline contents or a host source path.
+     * @param name The simple file name (no path separators).
+     * @param options Additional options.
+     * @returns The created file entry.
+     */
+    createFile(name: string, options?: CreateFileOptions): Promise<ContainerFileSystemItemHandle>;
+    /**
+     * Creates a PEM container certificate file entry with the OpenSSL subject-hash symlink.
+     * @param name The simple file name (no path separators).
+     * @param options Additional options.
+     * @returns The created certificate file entry.
+     */
+    createCertificateFile(name: string, options?: CreateCertificateFileOptions): Promise<ContainerFileSystemItemHandle>;
+    /**
+     * Creates a container directory entry containing the specified child entries.
+     * @param name The simple directory name (no path separators).
+     * @param entries The child entries (files and/or directories) created via this context.
+     * @param options Additional options.
+     * @returns The created directory entry.
+     */
+    createDirectory(name: string, entries: ContainerFileSystemItemHandle[], options?: CreateDirectoryOptions): Promise<ContainerFileSystemItemHandle>;
+}
+
+export interface ContainerFileSystemCallbackContextPromise extends PromiseLike<ContainerFileSystemCallbackContext> {
+    /** A `IServiceProvider` that can be used to resolve services in the callback. */
+    services(): ServiceProviderPromise;
+    /** The app model resource the callback is associated with. */
+    model(): ResourcePromise;
+    /**
+     * Creates a container file entry with inline contents or a host source path.
+     * @param name The simple file name (no path separators).
+     * @param options Additional options.
+     * @returns The created file entry.
+     */
+    createFile(name: string, options?: CreateFileOptions): Promise<ContainerFileSystemItemHandle>;
+    /**
+     * Creates a PEM container certificate file entry with the OpenSSL subject-hash symlink.
+     * @param name The simple file name (no path separators).
+     * @param options Additional options.
+     * @returns The created certificate file entry.
+     */
+    createCertificateFile(name: string, options?: CreateCertificateFileOptions): Promise<ContainerFileSystemItemHandle>;
+    /**
+     * Creates a container directory entry containing the specified child entries.
+     * @param name The simple directory name (no path separators).
+     * @param entries The child entries (files and/or directories) created via this context.
+     * @param options Additional options.
+     * @returns The created directory entry.
+     */
+    createDirectory(name: string, entries: ContainerFileSystemItemHandle[], options?: CreateDirectoryOptions): Promise<ContainerFileSystemItemHandle>;
+}
+
+// ============================================================================
+// ContainerFileSystemCallbackContextImpl
+// ============================================================================
+
+/** Represents the context for a `ContainerFileSystemCallbackAnnotation` callback. */
+class ContainerFileSystemCallbackContextImpl implements ContainerFileSystemCallbackContext {
+    constructor(private _handle: ContainerFileSystemCallbackContextHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    services(): ServiceProviderPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IServiceProviderHandle>(
+                'Aspire.Hosting.ApplicationModel/ContainerFileSystemCallbackContext.services',
+                { context: this._handle }
+            );
+            return new ServiceProviderImpl(handle, this._client);
+        })();
+        return new ServiceProviderPromiseImpl(promise, this._client, false);
+    }
+
+    model(): ResourcePromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IResourceHandle>(
+                'Aspire.Hosting.ApplicationModel/ContainerFileSystemCallbackContext.model',
+                { context: this._handle }
+            );
+            return new ResourceImpl(handle, this._client);
+        })();
+        return new ResourcePromiseImpl(promise, this._client, false);
+    }
+
+    /**
+     * Creates a container file entry with inline contents or a host source path.
+     * @param name The simple file name (no path separators).
+     * @param options Additional options.
+     * @returns The created file entry.
+     */
+    async createFile(name: string, options?: CreateFileOptions): Promise<ContainerFileSystemItemHandle> {
+        const contents = options?.contents;
+        const sourcePath = options?.sourcePath;
+        const owner = options?.owner;
+        const group = options?.group;
+        const mode = options?.mode;
+        const continueOnError = options?.continueOnError;
+        const rpcArgs: Record<string, unknown> = { context: this._handle, name };
+        if (contents !== undefined) rpcArgs.contents = contents;
+        if (sourcePath !== undefined) rpcArgs.sourcePath = sourcePath;
+        if (owner !== undefined) rpcArgs.owner = owner;
+        if (group !== undefined) rpcArgs.group = group;
+        if (mode !== undefined) rpcArgs.mode = mode;
+        if (continueOnError !== undefined) rpcArgs.continueOnError = continueOnError;
+        return await this._client.invokeCapability<ContainerFileSystemItemHandle>(
+            'Aspire.Hosting/createFile',
+            rpcArgs
+        );
+    }
+
+    /**
+     * Creates a PEM container certificate file entry with the OpenSSL subject-hash symlink.
+     * @param name The simple file name (no path separators).
+     * @param options Additional options.
+     * @returns The created certificate file entry.
+     */
+    async createCertificateFile(name: string, options?: CreateCertificateFileOptions): Promise<ContainerFileSystemItemHandle> {
+        const contents = options?.contents;
+        const sourcePath = options?.sourcePath;
+        const owner = options?.owner;
+        const group = options?.group;
+        const mode = options?.mode;
+        const continueOnError = options?.continueOnError;
+        const rpcArgs: Record<string, unknown> = { context: this._handle, name };
+        if (contents !== undefined) rpcArgs.contents = contents;
+        if (sourcePath !== undefined) rpcArgs.sourcePath = sourcePath;
+        if (owner !== undefined) rpcArgs.owner = owner;
+        if (group !== undefined) rpcArgs.group = group;
+        if (mode !== undefined) rpcArgs.mode = mode;
+        if (continueOnError !== undefined) rpcArgs.continueOnError = continueOnError;
+        return await this._client.invokeCapability<ContainerFileSystemItemHandle>(
+            'Aspire.Hosting/createCertificateFile',
+            rpcArgs
+        );
+    }
+
+    /**
+     * Creates a container directory entry containing the specified child entries.
+     * @param name The simple directory name (no path separators).
+     * @param entries The child entries (files and/or directories) created via this context.
+     * @param options Additional options.
+     * @returns The created directory entry.
+     */
+    async createDirectory(name: string, entries: ContainerFileSystemItemHandle[], options?: CreateDirectoryOptions): Promise<ContainerFileSystemItemHandle> {
+        const owner = options?.owner;
+        const group = options?.group;
+        const mode = options?.mode;
+        const rpcArgs: Record<string, unknown> = { context: this._handle, name, entries };
+        if (owner !== undefined) rpcArgs.owner = owner;
+        if (group !== undefined) rpcArgs.group = group;
+        if (mode !== undefined) rpcArgs.mode = mode;
+        return await this._client.invokeCapability<ContainerFileSystemItemHandle>(
+            'Aspire.Hosting/createDirectory',
+            rpcArgs
+        );
+    }
+
+}
+
+/**
+ * Thenable wrapper for ContainerFileSystemCallbackContext that enables fluent chaining.
+ */
+class ContainerFileSystemCallbackContextPromiseImpl implements ContainerFileSystemCallbackContextPromise {
+    constructor(private _promise: Promise<ContainerFileSystemCallbackContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ContainerFileSystemCallbackContext, TResult2 = never>(
+        onfulfilled?: ((value: ContainerFileSystemCallbackContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+    model(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.model()), this._client, false);
+    }
+
+    createFile(name: string, options?: CreateFileOptions): Promise<ContainerFileSystemItemHandle> {
+        return this._promise.then(obj => obj.createFile(name, options));
+    }
+
+    createCertificateFile(name: string, options?: CreateCertificateFileOptions): Promise<ContainerFileSystemItemHandle> {
+        return this._promise.then(obj => obj.createCertificateFile(name, options));
+    }
+
+    createDirectory(name: string, entries: ContainerFileSystemItemHandle[], options?: CreateDirectoryOptions): Promise<ContainerFileSystemItemHandle> {
+        return this._promise.then(obj => obj.createDirectory(name, entries, options));
     }
 
 }
@@ -4963,6 +5543,8 @@ class EventingSubscriberRegistrationContextPromiseImpl implements EventingSubscr
 /** Context for {@link ResourceCommandAnnotation.ExecuteCommand}. */
 export interface ExecuteCommandContext {
     toJSON(): MarshalledHandle;
+    /** The service provider. */
+    services(): ServiceProviderPromise;
     /** The resource name. */
     resourceName(): Promise<string>;
     /** The cancellation token. */
@@ -4980,6 +5562,8 @@ export interface ExecuteCommandContext {
 }
 
 export interface ExecuteCommandContextPromise extends PromiseLike<ExecuteCommandContext> {
+    /** The service provider. */
+    services(): ServiceProviderPromise;
     /** The resource name. */
     resourceName(): Promise<string>;
     /** The cancellation token. */
@@ -5006,6 +5590,17 @@ class ExecuteCommandContextImpl implements ExecuteCommandContext {
 
     /** Serialize for JSON-RPC transport */
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    services(): ServiceProviderPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IServiceProviderHandle>(
+                'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.services',
+                { context: this._handle }
+            );
+            return new ServiceProviderImpl(handle, this._client);
+        })();
+        return new ServiceProviderPromiseImpl(promise, this._client, false);
+    }
 
     async resourceName(): Promise<string> {
         return await this._client.invokeCapability<string>(
@@ -5055,6 +5650,10 @@ class ExecuteCommandContextPromiseImpl implements ExecuteCommandContextPromise {
         onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
     ): PromiseLike<TResult1 | TResult2> {
         return this._promise.then(onfulfilled, onrejected);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
     }
 
     resourceName(): Promise<string> {
@@ -5178,6 +5777,300 @@ class HttpCommandPrepareRequestContextPromiseImpl implements HttpCommandPrepareR
 
     arguments(): Promise<InteractionInputCollection> {
         return this._promise.then(obj => obj.arguments());
+    }
+
+}
+
+// ============================================================================
+// HttpsCertificateConfigurationCallbackAnnotationContext
+// ============================================================================
+
+/** Context provided to a `HttpsCertificateConfigurationCallbackAnnotation` callback. */
+export interface HttpsCertificateConfigurationCallbackAnnotationContext {
+    toJSON(): MarshalledHandle;
+    /** Gets the `DistributedApplicationExecutionContext` for this session. */
+    executionContext(): DistributedApplicationExecutionContextPromise;
+    /** Gets the resource to which the annotation is applied. */
+    resource(): ResourcePromise;
+    /** A value provider that will resolve to a path to the certificate file. */
+    certificatePath(): Promise<ReferenceExpression>;
+    /** A value provider that will resolve to a path to the private key for the certificate. */
+    keyPath(): Promise<ReferenceExpression>;
+    /** A value provider that will resolve to a path to a PFX file for the key pair. */
+    pfxPath(): Promise<ReferenceExpression>;
+    /** Gets the `CancellationToken` that can be used to cancel the operation. */
+    cancellationToken(): Promise<CancellationToken>;
+    /** Gets the editor used to manipulate the command-line arguments in polyglot callbacks. */
+    arguments(): CommandLineArgsEditorPromise;
+    /** Gets the editor used to set environment variables in polyglot callbacks. */
+    environment(): EnvironmentEditorPromise;
+}
+
+export interface HttpsCertificateConfigurationCallbackAnnotationContextPromise extends PromiseLike<HttpsCertificateConfigurationCallbackAnnotationContext> {
+    /** Gets the `DistributedApplicationExecutionContext` for this session. */
+    executionContext(): DistributedApplicationExecutionContextPromise;
+    /** Gets the resource to which the annotation is applied. */
+    resource(): ResourcePromise;
+    /** A value provider that will resolve to a path to the certificate file. */
+    certificatePath(): Promise<ReferenceExpression>;
+    /** A value provider that will resolve to a path to the private key for the certificate. */
+    keyPath(): Promise<ReferenceExpression>;
+    /** A value provider that will resolve to a path to a PFX file for the key pair. */
+    pfxPath(): Promise<ReferenceExpression>;
+    /** Gets the `CancellationToken` that can be used to cancel the operation. */
+    cancellationToken(): Promise<CancellationToken>;
+    /** Gets the editor used to manipulate the command-line arguments in polyglot callbacks. */
+    arguments(): CommandLineArgsEditorPromise;
+    /** Gets the editor used to set environment variables in polyglot callbacks. */
+    environment(): EnvironmentEditorPromise;
+}
+
+// ============================================================================
+// HttpsCertificateConfigurationCallbackAnnotationContextImpl
+// ============================================================================
+
+/** Context provided to a `HttpsCertificateConfigurationCallbackAnnotation` callback. */
+class HttpsCertificateConfigurationCallbackAnnotationContextImpl implements HttpsCertificateConfigurationCallbackAnnotationContext {
+    constructor(private _handle: HttpsCertificateConfigurationCallbackAnnotationContextHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
+                'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.executionContext',
+                { context: this._handle }
+            );
+            return new DistributedApplicationExecutionContextImpl(handle, this._client);
+        })();
+        return new DistributedApplicationExecutionContextPromiseImpl(promise, this._client, false);
+    }
+
+    resource(): ResourcePromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IResourceHandle>(
+                'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.resource',
+                { context: this._handle }
+            );
+            return new ResourceImpl(handle, this._client);
+        })();
+        return new ResourcePromiseImpl(promise, this._client, false);
+    }
+
+    async certificatePath(): Promise<ReferenceExpression> {
+        return await this._client.invokeCapability<ReferenceExpression>(
+            'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.certificatePath',
+            { context: this._handle }
+        );
+    }
+
+    async keyPath(): Promise<ReferenceExpression> {
+        return await this._client.invokeCapability<ReferenceExpression>(
+            'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.keyPath',
+            { context: this._handle }
+        );
+    }
+
+    async pfxPath(): Promise<ReferenceExpression> {
+        return await this._client.invokeCapability<ReferenceExpression>(
+            'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.pfxPath',
+            { context: this._handle }
+        );
+    }
+
+    async cancellationToken(): Promise<CancellationToken> {
+        const result = await this._client.invokeCapability<string | null>(
+            'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.cancellationToken',
+            { context: this._handle }
+        );
+        return CancellationToken.fromValue(result);
+    }
+
+    arguments(): CommandLineArgsEditorPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<CommandLineArgsEditorHandle>(
+                'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.arguments',
+                { context: this._handle }
+            );
+            return new CommandLineArgsEditorImpl(handle, this._client);
+        })();
+        return new CommandLineArgsEditorPromiseImpl(promise, this._client, false);
+    }
+
+    environment(): EnvironmentEditorPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<EnvironmentEditorHandle>(
+                'Aspire.Hosting.ApplicationModel/HttpsCertificateConfigurationCallbackAnnotationContext.environment',
+                { context: this._handle }
+            );
+            return new EnvironmentEditorImpl(handle, this._client);
+        })();
+        return new EnvironmentEditorPromiseImpl(promise, this._client, false);
+    }
+
+}
+
+/**
+ * Thenable wrapper for HttpsCertificateConfigurationCallbackAnnotationContext that enables fluent chaining.
+ */
+class HttpsCertificateConfigurationCallbackAnnotationContextPromiseImpl implements HttpsCertificateConfigurationCallbackAnnotationContextPromise {
+    constructor(private _promise: Promise<HttpsCertificateConfigurationCallbackAnnotationContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = HttpsCertificateConfigurationCallbackAnnotationContext, TResult2 = never>(
+        onfulfilled?: ((value: HttpsCertificateConfigurationCallbackAnnotationContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        return new DistributedApplicationExecutionContextPromiseImpl(this._promise.then(obj => obj.executionContext()), this._client, false);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    certificatePath(): Promise<ReferenceExpression> {
+        return this._promise.then(obj => obj.certificatePath());
+    }
+
+    keyPath(): Promise<ReferenceExpression> {
+        return this._promise.then(obj => obj.keyPath());
+    }
+
+    pfxPath(): Promise<ReferenceExpression> {
+        return this._promise.then(obj => obj.pfxPath());
+    }
+
+    cancellationToken(): Promise<CancellationToken> {
+        return this._promise.then(obj => obj.cancellationToken());
+    }
+
+    arguments(): CommandLineArgsEditorPromise {
+        return new CommandLineArgsEditorPromiseImpl(this._promise.then(obj => obj.arguments()), this._client, false);
+    }
+
+    environment(): EnvironmentEditorPromise {
+        return new EnvironmentEditorPromiseImpl(this._promise.then(obj => obj.environment()), this._client, false);
+    }
+
+}
+
+// ============================================================================
+// HttpsEndpointUpdateCallbackContext
+// ============================================================================
+
+/** Context provided to the callback of `SubscribeHttpsEndpointsUpdate``1` when an HTTPS certificate is determined to be available for the resource. */
+export interface HttpsEndpointUpdateCallbackContext {
+    toJSON(): MarshalledHandle;
+    /** Gets the `IServiceProvider` instance from the application. */
+    services(): ServiceProviderPromise;
+    /** Gets the `IResource` that is being configured for HTTPS. */
+    resource(): ResourcePromise;
+    /** Gets the `DistributedApplicationModel` instance. */
+    model(): DistributedApplicationModelPromise;
+    /** Gets the `CancellationToken` for the operation. */
+    cancellationToken(): Promise<CancellationToken>;
+}
+
+export interface HttpsEndpointUpdateCallbackContextPromise extends PromiseLike<HttpsEndpointUpdateCallbackContext> {
+    /** Gets the `IServiceProvider` instance from the application. */
+    services(): ServiceProviderPromise;
+    /** Gets the `IResource` that is being configured for HTTPS. */
+    resource(): ResourcePromise;
+    /** Gets the `DistributedApplicationModel` instance. */
+    model(): DistributedApplicationModelPromise;
+    /** Gets the `CancellationToken` for the operation. */
+    cancellationToken(): Promise<CancellationToken>;
+}
+
+// ============================================================================
+// HttpsEndpointUpdateCallbackContextImpl
+// ============================================================================
+
+/** Context provided to the callback of `SubscribeHttpsEndpointsUpdate``1` when an HTTPS certificate is determined to be available for the resource. */
+class HttpsEndpointUpdateCallbackContextImpl implements HttpsEndpointUpdateCallbackContext {
+    constructor(private _handle: HttpsEndpointUpdateCallbackContextHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    services(): ServiceProviderPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IServiceProviderHandle>(
+                'Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.services',
+                { context: this._handle }
+            );
+            return new ServiceProviderImpl(handle, this._client);
+        })();
+        return new ServiceProviderPromiseImpl(promise, this._client, false);
+    }
+
+    resource(): ResourcePromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IResourceHandle>(
+                'Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.resource',
+                { context: this._handle }
+            );
+            return new ResourceImpl(handle, this._client);
+        })();
+        return new ResourcePromiseImpl(promise, this._client, false);
+    }
+
+    model(): DistributedApplicationModelPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<DistributedApplicationModelHandle>(
+                'Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.model',
+                { context: this._handle }
+            );
+            return new DistributedApplicationModelImpl(handle, this._client);
+        })();
+        return new DistributedApplicationModelPromiseImpl(promise, this._client, false);
+    }
+
+    async cancellationToken(): Promise<CancellationToken> {
+        const result = await this._client.invokeCapability<string | null>(
+            'Aspire.Hosting.ApplicationModel/HttpsEndpointUpdateCallbackContext.cancellationToken',
+            { context: this._handle }
+        );
+        return CancellationToken.fromValue(result);
+    }
+
+}
+
+/**
+ * Thenable wrapper for HttpsEndpointUpdateCallbackContext that enables fluent chaining.
+ */
+class HttpsEndpointUpdateCallbackContextPromiseImpl implements HttpsEndpointUpdateCallbackContextPromise {
+    constructor(private _promise: Promise<HttpsEndpointUpdateCallbackContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = HttpsEndpointUpdateCallbackContext, TResult2 = never>(
+        onfulfilled?: ((value: HttpsEndpointUpdateCallbackContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    model(): DistributedApplicationModelPromise {
+        return new DistributedApplicationModelPromiseImpl(this._promise.then(obj => obj.model()), this._client, false);
+    }
+
+    cancellationToken(): Promise<CancellationToken> {
+        return this._promise.then(obj => obj.cancellationToken());
     }
 
 }
@@ -5340,6 +6233,8 @@ export interface InputsDialogValidationContext {
     inputs(): Promise<InteractionInputCollection>;
     /** Gets the cancellation token for the validation operation. */
     cancellationToken(): Promise<CancellationToken>;
+    /** Gets the service provider for resolving services during validation. */
+    services(): ServiceProviderPromise;
     /**
      * Adds a validation error for the input with the specified name.
      * @param inputName The name of the input to add a validation error for.
@@ -5353,6 +6248,8 @@ export interface InputsDialogValidationContextPromise extends PromiseLike<Inputs
     inputs(): Promise<InteractionInputCollection>;
     /** Gets the cancellation token for the validation operation. */
     cancellationToken(): Promise<CancellationToken>;
+    /** Gets the service provider for resolving services during validation. */
+    services(): ServiceProviderPromise;
     /**
      * Adds a validation error for the input with the specified name.
      * @param inputName The name of the input to add a validation error for.
@@ -5385,6 +6282,17 @@ class InputsDialogValidationContextImpl implements InputsDialogValidationContext
             { context: this._handle }
         );
         return CancellationToken.fromValue(result);
+    }
+
+    services(): ServiceProviderPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IServiceProviderHandle>(
+                'Aspire.Hosting/InputsDialogValidationContext.services',
+                { context: this._handle }
+            );
+            return new ServiceProviderImpl(handle, this._client);
+        })();
+        return new ServiceProviderPromiseImpl(promise, this._client, false);
     }
 
     /** @internal */
@@ -5429,6 +6337,10 @@ class InputsDialogValidationContextPromiseImpl implements InputsDialogValidation
 
     cancellationToken(): Promise<CancellationToken> {
         return this._promise.then(obj => obj.cancellationToken());
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
     }
 
     addValidationError(inputName: string, errorMessage: string): InputsDialogValidationContextPromise {
@@ -6910,6 +7822,237 @@ class ReferenceExpressionBuilderPromiseImpl implements ReferenceExpressionBuilde
 }
 
 // ============================================================================
+// RequiredCommandValidationContext
+// ============================================================================
+
+/** Provides context for validating a required command. */
+export interface RequiredCommandValidationContext {
+    toJSON(): MarshalledHandle;
+    /** Gets the resolved full path to the command executable. */
+    resolvedPath(): Promise<string>;
+    /** Gets the service provider for accessing application services. */
+    services(): ServiceProviderPromise;
+    /** Gets a cancellation token that can be used to cancel the validation. */
+    cancellationToken(): Promise<CancellationToken>;
+    /**
+     * Creates a successful validation result.
+     * @returns A `RequiredCommandValidationResult` indicating the command is valid.
+     */
+    success(): RequiredCommandValidationResultPromise;
+    /**
+     * Creates a failed validation result with the specified message.
+     * @param validationMessage A message describing why validation failed.
+     * @returns A `RequiredCommandValidationResult` indicating the command is invalid.
+     */
+    failure(validationMessage: string): RequiredCommandValidationResultPromise;
+}
+
+export interface RequiredCommandValidationContextPromise extends PromiseLike<RequiredCommandValidationContext> {
+    /** Gets the resolved full path to the command executable. */
+    resolvedPath(): Promise<string>;
+    /** Gets the service provider for accessing application services. */
+    services(): ServiceProviderPromise;
+    /** Gets a cancellation token that can be used to cancel the validation. */
+    cancellationToken(): Promise<CancellationToken>;
+    /**
+     * Creates a successful validation result.
+     * @returns A `RequiredCommandValidationResult` indicating the command is valid.
+     */
+    success(): RequiredCommandValidationResultPromise;
+    /**
+     * Creates a failed validation result with the specified message.
+     * @param validationMessage A message describing why validation failed.
+     * @returns A `RequiredCommandValidationResult` indicating the command is invalid.
+     */
+    failure(validationMessage: string): RequiredCommandValidationResultPromise;
+}
+
+// ============================================================================
+// RequiredCommandValidationContextImpl
+// ============================================================================
+
+/** Provides context for validating a required command. */
+class RequiredCommandValidationContextImpl implements RequiredCommandValidationContext {
+    constructor(private _handle: RequiredCommandValidationContextHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    async resolvedPath(): Promise<string> {
+        return await this._client.invokeCapability<string>(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.resolvedPath',
+            { context: this._handle }
+        );
+    }
+
+    services(): ServiceProviderPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IServiceProviderHandle>(
+                'Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.services',
+                { context: this._handle }
+            );
+            return new ServiceProviderImpl(handle, this._client);
+        })();
+        return new ServiceProviderPromiseImpl(promise, this._client, false);
+    }
+
+    async cancellationToken(): Promise<CancellationToken> {
+        const result = await this._client.invokeCapability<string | null>(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.cancellationToken',
+            { context: this._handle }
+        );
+        return CancellationToken.fromValue(result);
+    }
+
+    /** @internal */
+    async _successInternal(): Promise<RequiredCommandValidationResult> {
+        const rpcArgs: Record<string, unknown> = { context: this._handle };
+        const result = await this._client.invokeCapability<RequiredCommandValidationResultHandle>(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.success',
+            rpcArgs
+        );
+        return new RequiredCommandValidationResultImpl(result, this._client);
+    }
+
+    /**
+     * Creates a successful validation result.
+     * @returns A `RequiredCommandValidationResult` indicating the command is valid.
+     */
+    success(): RequiredCommandValidationResultPromise {
+        return new RequiredCommandValidationResultPromiseImpl(this._successInternal(), this._client);
+    }
+
+    /** @internal */
+    async _failureInternal(validationMessage: string): Promise<RequiredCommandValidationResult> {
+        const rpcArgs: Record<string, unknown> = { context: this._handle, validationMessage };
+        const result = await this._client.invokeCapability<RequiredCommandValidationResultHandle>(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationContext.failure',
+            rpcArgs
+        );
+        return new RequiredCommandValidationResultImpl(result, this._client);
+    }
+
+    /**
+     * Creates a failed validation result with the specified message.
+     * @param validationMessage A message describing why validation failed.
+     * @returns A `RequiredCommandValidationResult` indicating the command is invalid.
+     */
+    failure(validationMessage: string): RequiredCommandValidationResultPromise {
+        return new RequiredCommandValidationResultPromiseImpl(this._failureInternal(validationMessage), this._client);
+    }
+
+}
+
+/**
+ * Thenable wrapper for RequiredCommandValidationContext that enables fluent chaining.
+ */
+class RequiredCommandValidationContextPromiseImpl implements RequiredCommandValidationContextPromise {
+    constructor(private _promise: Promise<RequiredCommandValidationContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = RequiredCommandValidationContext, TResult2 = never>(
+        onfulfilled?: ((value: RequiredCommandValidationContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resolvedPath(): Promise<string> {
+        return this._promise.then(obj => obj.resolvedPath());
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+    cancellationToken(): Promise<CancellationToken> {
+        return this._promise.then(obj => obj.cancellationToken());
+    }
+
+    success(): RequiredCommandValidationResultPromise {
+        return new RequiredCommandValidationResultPromiseImpl(this._promise.then(obj => obj.success()), this._client);
+    }
+
+    failure(validationMessage: string): RequiredCommandValidationResultPromise {
+        return new RequiredCommandValidationResultPromiseImpl(this._promise.then(obj => obj.failure(validationMessage)), this._client);
+    }
+
+}
+
+// ============================================================================
+// RequiredCommandValidationResult
+// ============================================================================
+
+/** Represents the result of validating a required command. */
+export interface RequiredCommandValidationResult {
+    toJSON(): MarshalledHandle;
+    /** Gets a value indicating whether the command validation succeeded. */
+    isValid(): Promise<boolean>;
+    /** Gets an optional validation message describing why validation failed. */
+    validationMessage(): Promise<string | null>;
+}
+
+export interface RequiredCommandValidationResultPromise extends PromiseLike<RequiredCommandValidationResult> {
+    /** Gets a value indicating whether the command validation succeeded. */
+    isValid(): Promise<boolean>;
+    /** Gets an optional validation message describing why validation failed. */
+    validationMessage(): Promise<string | null>;
+}
+
+// ============================================================================
+// RequiredCommandValidationResultImpl
+// ============================================================================
+
+/** Represents the result of validating a required command. */
+class RequiredCommandValidationResultImpl implements RequiredCommandValidationResult {
+    constructor(private _handle: RequiredCommandValidationResultHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    async isValid(): Promise<boolean> {
+        return await this._client.invokeCapability<boolean>(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationResult.isValid',
+            { context: this._handle }
+        );
+    }
+
+    async validationMessage(): Promise<string | null> {
+        return await this._client.invokeCapability<string | null>(
+            'Aspire.Hosting.ApplicationModel/RequiredCommandValidationResult.validationMessage',
+            { context: this._handle }
+        );
+    }
+
+}
+
+/**
+ * Thenable wrapper for RequiredCommandValidationResult that enables fluent chaining.
+ */
+class RequiredCommandValidationResultPromiseImpl implements RequiredCommandValidationResultPromise {
+    constructor(private _promise: Promise<RequiredCommandValidationResult>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = RequiredCommandValidationResult, TResult2 = never>(
+        onfulfilled?: ((value: RequiredCommandValidationResult) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    isValid(): Promise<boolean> {
+        return this._promise.then(obj => obj.isValid());
+    }
+
+    validationMessage(): Promise<string | null> {
+        return this._promise.then(obj => obj.validationMessage());
+    }
+
+}
+
+// ============================================================================
 // ResourceCommandService
 // ============================================================================
 
@@ -8269,11 +9412,15 @@ export interface UpdateCommandStateContext {
     toJSON(): MarshalledHandle;
     /** Gets the resource snapshot data available to polyglot command state callbacks. */
     resourceSnapshot(): Promise<UpdateCommandStateResourceSnapshot>;
+    /** The service provider. */
+    services(): ServiceProviderPromise;
 }
 
 export interface UpdateCommandStateContextPromise extends PromiseLike<UpdateCommandStateContext> {
     /** Gets the resource snapshot data available to polyglot command state callbacks. */
     resourceSnapshot(): Promise<UpdateCommandStateResourceSnapshot>;
+    /** The service provider. */
+    services(): ServiceProviderPromise;
 }
 
 // ============================================================================
@@ -8292,6 +9439,17 @@ class UpdateCommandStateContextImpl implements UpdateCommandStateContext {
             'Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.resourceSnapshot',
             { context: this._handle }
         );
+    }
+
+    services(): ServiceProviderPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<IServiceProviderHandle>(
+                'Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.services',
+                { context: this._handle }
+            );
+            return new ServiceProviderImpl(handle, this._client);
+        })();
+        return new ServiceProviderPromiseImpl(promise, this._client, false);
     }
 
 }
@@ -8313,6 +9471,10 @@ class UpdateCommandStateContextPromiseImpl implements UpdateCommandStateContextP
 
     resourceSnapshot(): Promise<UpdateCommandStateResourceSnapshot> {
         return this._promise.then(obj => obj.resourceSnapshot());
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
     }
 
 }
@@ -11918,6 +13080,19 @@ export interface ContainerRegistryResource {
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ContainerRegistryResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ContainerRegistryResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -11997,6 +13172,23 @@ export interface ContainerRegistryResource {
      * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ContainerRegistryResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ContainerRegistryResourcePromise;
     /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
@@ -12098,6 +13290,12 @@ export interface ContainerRegistryResource {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ContainerRegistryResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -12197,6 +13395,19 @@ export interface ContainerRegistryResourcePromise extends PromiseLike<ContainerR
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ContainerRegistryResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ContainerRegistryResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -12276,6 +13487,23 @@ export interface ContainerRegistryResourcePromise extends PromiseLike<ContainerR
      * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ContainerRegistryResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ContainerRegistryResourcePromise;
     /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
@@ -12377,6 +13605,12 @@ export interface ContainerRegistryResourcePromise extends PromiseLike<ContainerR
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ContainerRegistryResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -12527,6 +13761,39 @@ class ContainerRegistryResourceImpl extends ResourceBuilderBase<ContainerRegistr
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ContainerRegistryResourcePromise {
         const helpLink = options?.helpLink;
         return new ContainerRegistryResourcePromiseImpl(this._withRequiredCommandInternal(command, helpLink), this._client);
+    }
+
+    /** @internal */
+    private async _withRequiredCommandValidationInternal(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, helpLink?: string): Promise<ContainerRegistryResource> {
+        const validationCallbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as RequiredCommandValidationContextHandle;
+            const arg = new RequiredCommandValidationContextImpl(argHandle, this._client);
+            return await validationCallback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command, validationCallback: validationCallbackId };
+        if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
+        const result = await this._client.invokeCapability<ContainerRegistryResourceHandle>(
+            'Aspire.Hosting/withRequiredCommandValidation',
+            rpcArgs
+        );
+        return new ContainerRegistryResourceImpl(result, this._client);
+    }
+
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ContainerRegistryResourcePromise {
+        const helpLink = options?.helpLink;
+        return new ContainerRegistryResourcePromiseImpl(this._withRequiredCommandValidationInternal(command, validationCallback, helpLink), this._client);
     }
 
     /** @internal */
@@ -12891,6 +14158,41 @@ class ContainerRegistryResourceImpl extends ResourceBuilderBase<ContainerRegistr
     }
 
     /** @internal */
+    private async _subscribeHttpsEndpointsUpdateInternal(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): Promise<ContainerRegistryResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as HttpsEndpointUpdateCallbackContextHandle;
+            const obj = new HttpsEndpointUpdateCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ContainerRegistryResourceHandle>(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
+            rpcArgs
+        );
+        return new ContainerRegistryResourceImpl(result, this._client);
+    }
+
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ContainerRegistryResourcePromise {
+        return new ContainerRegistryResourcePromiseImpl(this._subscribeHttpsEndpointsUpdateInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withRelationshipInternal(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): Promise<ContainerRegistryResource> {
         resourceBuilder = isPromiseLike(resourceBuilder) ? await resourceBuilder : resourceBuilder;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, resourceBuilder, type };
@@ -13223,6 +14525,30 @@ class ContainerRegistryResourceImpl extends ResourceBuilderBase<ContainerRegistr
             return new ExecutionConfigurationBuilderImpl(handle, this._client);
         })();
         return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
+    }
+
+    /** @internal */
+    private async _withContainerBuildOptionsInternal(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): Promise<ContainerRegistryResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerBuildOptionsCallbackContextHandle;
+            const arg = new ContainerBuildOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ContainerRegistryResourceHandle>(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpcArgs
+        );
+        return new ContainerRegistryResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ContainerRegistryResourcePromise {
+        return new ContainerRegistryResourcePromiseImpl(this._withContainerBuildOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -13629,6 +14955,10 @@ class ContainerRegistryResourcePromiseImpl implements ContainerRegistryResourceP
         return new ContainerRegistryResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommand(command, options)), this._client);
     }
 
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ContainerRegistryResourcePromise {
+        return new ContainerRegistryResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommandValidation(command, validationCallback, options)), this._client);
+    }
+
     withSessionLifetime(): ContainerRegistryResourcePromise {
         return new ContainerRegistryResourcePromiseImpl(this._promise.then(obj => obj.withSessionLifetime()), this._client);
     }
@@ -13679,6 +15009,10 @@ class ContainerRegistryResourcePromiseImpl implements ContainerRegistryResourceP
 
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ContainerRegistryResourcePromise {
         return new ContainerRegistryResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommandFactory(commandName, displayName, createProcessSpec, options)), this._client);
+    }
+
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ContainerRegistryResourcePromise {
+        return new ContainerRegistryResourcePromiseImpl(this._promise.then(obj => obj.subscribeHttpsEndpointsUpdate(callback)), this._client);
     }
 
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ContainerRegistryResourcePromise {
@@ -13739,6 +15073,10 @@ class ContainerRegistryResourcePromiseImpl implements ContainerRegistryResourceP
 
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
         return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
+    }
+
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ContainerRegistryResourcePromise {
+        return new ContainerRegistryResourcePromiseImpl(this._promise.then(obj => obj.withContainerBuildOptions(callback)), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ContainerRegistryResourcePromise {
@@ -13986,14 +15324,24 @@ export interface ContainerResource {
      *
      * In run mode, Aspire copies the files into the container and applies owner, group, and umask options.
      * In publish mode, Aspire creates a read-only bind mount and ignores those options.
-     * Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-     * polymorphic `ContainerFileSystemItem` hierarchy or callbacks that use .NET services.
+     * To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+     * use the `withContainerFilesCallback` overload and build the entries via the factory methods on
+     * `ContainerFileSystemCallbackContext`. Passing a pre-built `ContainerFileSystemItem` collection
+     * remains .NET-only.
      * @param destinationPath The destination absolute path in the container.
      * @param sourcePath The source path on the host to copy files from.
      * @param options Additional options.
      * @returns The resource builder.
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): ContainerResourcePromise;
+    /**
+     * Creates or updates files and folders in a container using entries produced by a callback.
+     * @param destinationPath The destination absolute path in the container.
+     * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): ContainerResourcePromise;
     /**
      * Configures the resource to use a programmatically generated Dockerfile
      *
@@ -14085,6 +15433,19 @@ export interface ContainerResource {
      * @returns The resource builder.
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ContainerResourcePromise;
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ContainerResourcePromise;
     /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
@@ -14358,6 +15719,40 @@ export interface ContainerResource {
      */
     withoutHttpsCertificate(): ContainerResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ContainerResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ContainerResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -14519,6 +15914,12 @@ export interface ContainerResource {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ContainerResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -14730,14 +16131,24 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
      *
      * In run mode, Aspire copies the files into the container and applies owner, group, and umask options.
      * In publish mode, Aspire creates a read-only bind mount and ignores those options.
-     * Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-     * polymorphic `ContainerFileSystemItem` hierarchy or callbacks that use .NET services.
+     * To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+     * use the `withContainerFilesCallback` overload and build the entries via the factory methods on
+     * `ContainerFileSystemCallbackContext`. Passing a pre-built `ContainerFileSystemItem` collection
+     * remains .NET-only.
      * @param destinationPath The destination absolute path in the container.
      * @param sourcePath The source path on the host to copy files from.
      * @param options Additional options.
      * @returns The resource builder.
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): ContainerResourcePromise;
+    /**
+     * Creates or updates files and folders in a container using entries produced by a callback.
+     * @param destinationPath The destination absolute path in the container.
+     * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): ContainerResourcePromise;
     /**
      * Configures the resource to use a programmatically generated Dockerfile
      *
@@ -14829,6 +16240,19 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
      * @returns The resource builder.
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ContainerResourcePromise;
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ContainerResourcePromise;
     /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
@@ -15102,6 +16526,40 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
      */
     withoutHttpsCertificate(): ContainerResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ContainerResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ContainerResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -15263,6 +16721,12 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ContainerResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -15739,8 +17203,10 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
      *
      * In run mode, Aspire copies the files into the container and applies owner, group, and umask options.
      * In publish mode, Aspire creates a read-only bind mount and ignores those options.
-     * Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-     * polymorphic `ContainerFileSystemItem` hierarchy or callbacks that use .NET services.
+     * To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+     * use the `withContainerFilesCallback` overload and build the entries via the factory methods on
+     * `ContainerFileSystemCallbackContext`. Passing a pre-built `ContainerFileSystemItem` collection
+     * remains .NET-only.
      * @param destinationPath The destination absolute path in the container.
      * @param sourcePath The source path on the host to copy files from.
      * @param options Additional options.
@@ -15748,6 +17214,34 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._withContainerFilesInternal(destinationPath, sourcePath, options), this._client);
+    }
+
+    /** @internal */
+    private async _withContainerFilesCallbackInternal(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): Promise<ContainerResource> {
+        const callbackId = registerCallback(async (arg1Data: unknown, arg2Data: unknown) => {
+            const arg1Handle = wrapIfHandle(arg1Data) as ContainerFileSystemCallbackContextHandle;
+            const arg1 = new ContainerFileSystemCallbackContextImpl(arg1Handle, this._client);
+            const arg2 = CancellationToken.fromValue(arg2Data);
+            return await callback(arg1, arg2);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, destinationPath, callback: callbackId };
+        if (options !== undefined) rpcArgs.options = options;
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withContainerFilesCallback',
+            rpcArgs
+        );
+        return new ContainerResourceImpl(result, this._client);
+    }
+
+    /**
+     * Creates or updates files and folders in a container using entries produced by a callback.
+     * @param destinationPath The destination absolute path in the container.
+     * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._withContainerFilesCallbackInternal(destinationPath, callback, options), this._client);
     }
 
     /** @internal */
@@ -15949,6 +17443,39 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ContainerResourcePromise {
         const helpLink = options?.helpLink;
         return new ContainerResourcePromiseImpl(this._withRequiredCommandInternal(command, helpLink), this._client);
+    }
+
+    /** @internal */
+    private async _withRequiredCommandValidationInternal(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, helpLink?: string): Promise<ContainerResource> {
+        const validationCallbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as RequiredCommandValidationContextHandle;
+            const arg = new RequiredCommandValidationContextImpl(argHandle, this._client);
+            return await validationCallback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command, validationCallback: validationCallbackId };
+        if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withRequiredCommandValidation',
+            rpcArgs
+        );
+        return new ContainerResourceImpl(result, this._client);
+    }
+
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ContainerResourcePromise {
+        const helpLink = options?.helpLink;
+        return new ContainerResourcePromiseImpl(this._withRequiredCommandValidationInternal(command, validationCallback, helpLink), this._client);
     }
 
     /** @internal */
@@ -16963,6 +18490,76 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
     }
 
     /** @internal */
+    private async _withHttpsCertificateConfigurationInternal(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): Promise<ContainerResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as HttpsCertificateConfigurationCallbackAnnotationContextHandle;
+            const arg = new HttpsCertificateConfigurationCallbackAnnotationContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withHttpsCertificateConfiguration',
+            rpcArgs
+        );
+        return new ContainerResourceImpl(result, this._client);
+    }
+
+    /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._withHttpsCertificateConfigurationInternal(callback), this._client);
+    }
+
+    /** @internal */
+    private async _subscribeHttpsEndpointsUpdateInternal(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): Promise<ContainerResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as HttpsEndpointUpdateCallbackContextHandle;
+            const obj = new HttpsEndpointUpdateCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
+            rpcArgs
+        );
+        return new ContainerResourceImpl(result, this._client);
+    }
+
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._subscribeHttpsEndpointsUpdateInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withRelationshipInternal(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): Promise<ContainerResource> {
         resourceBuilder = isPromiseLike(resourceBuilder) ? await resourceBuilder : resourceBuilder;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, resourceBuilder, type };
@@ -17479,6 +19076,30 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
     }
 
     /** @internal */
+    private async _withContainerBuildOptionsInternal(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): Promise<ContainerResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerBuildOptionsCallbackContextHandle;
+            const arg = new ContainerBuildOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpcArgs
+        );
+        return new ContainerResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._withContainerBuildOptionsInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
@@ -17977,6 +19598,10 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withContainerFiles(destinationPath, sourcePath, options)), this._client);
     }
 
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withContainerFilesCallback(destinationPath, callback, options)), this._client);
+    }
+
     withDockerfileBuilder(contextPath: string, callback: (arg: DockerfileBuilderCallbackContext) => Promise<void>, options?: WithDockerfileBuilderOptions): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withDockerfileBuilder(contextPath, callback, options)), this._client);
     }
@@ -18003,6 +19628,10 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
 
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommand(command, options)), this._client);
+    }
+
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommandValidation(command, validationCallback, options)), this._client);
     }
 
     withSessionLifetime(): ContainerResourcePromise {
@@ -18157,6 +19786,14 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withoutHttpsCertificate()), this._client);
     }
 
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withHttpsCertificateConfiguration(callback)), this._client);
+    }
+
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.subscribeHttpsEndpointsUpdate(callback)), this._client);
+    }
+
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withRelationship(resourceBuilder, type)), this._client);
     }
@@ -18243,6 +19880,10 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
 
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
         return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
+    }
+
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withContainerBuildOptions(callback)), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ContainerResourcePromise {
@@ -18424,6 +20065,19 @@ export interface CSharpAppResource {
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): CSharpAppResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): CSharpAppResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -18702,6 +20356,40 @@ export interface CSharpAppResource {
      */
     withoutHttpsCertificate(): CSharpAppResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): CSharpAppResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): CSharpAppResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -18855,6 +20543,12 @@ export interface CSharpAppResource {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -18993,6 +20687,19 @@ export interface CSharpAppResourcePromise extends PromiseLike<CSharpAppResource>
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): CSharpAppResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): CSharpAppResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -19271,6 +20978,40 @@ export interface CSharpAppResourcePromise extends PromiseLike<CSharpAppResource>
      */
     withoutHttpsCertificate(): CSharpAppResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): CSharpAppResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): CSharpAppResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -19424,6 +21165,12 @@ export interface CSharpAppResourcePromise extends PromiseLike<CSharpAppResource>
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -19691,6 +21438,39 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): CSharpAppResourcePromise {
         const helpLink = options?.helpLink;
         return new CSharpAppResourcePromiseImpl(this._withRequiredCommandInternal(command, helpLink), this._client);
+    }
+
+    /** @internal */
+    private async _withRequiredCommandValidationInternal(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, helpLink?: string): Promise<CSharpAppResource> {
+        const validationCallbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as RequiredCommandValidationContextHandle;
+            const arg = new RequiredCommandValidationContextImpl(argHandle, this._client);
+            return await validationCallback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command, validationCallback: validationCallbackId };
+        if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
+        const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
+            'Aspire.Hosting/withRequiredCommandValidation',
+            rpcArgs
+        );
+        return new CSharpAppResourceImpl(result, this._client);
+    }
+
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): CSharpAppResourcePromise {
+        const helpLink = options?.helpLink;
+        return new CSharpAppResourcePromiseImpl(this._withRequiredCommandValidationInternal(command, validationCallback, helpLink), this._client);
     }
 
     /** @internal */
@@ -20725,6 +22505,76 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
     }
 
     /** @internal */
+    private async _withHttpsCertificateConfigurationInternal(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): Promise<CSharpAppResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as HttpsCertificateConfigurationCallbackAnnotationContextHandle;
+            const arg = new HttpsCertificateConfigurationCallbackAnnotationContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
+            'Aspire.Hosting/withHttpsCertificateConfiguration',
+            rpcArgs
+        );
+        return new CSharpAppResourceImpl(result, this._client);
+    }
+
+    /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._withHttpsCertificateConfigurationInternal(callback), this._client);
+    }
+
+    /** @internal */
+    private async _subscribeHttpsEndpointsUpdateInternal(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): Promise<CSharpAppResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as HttpsEndpointUpdateCallbackContextHandle;
+            const obj = new HttpsEndpointUpdateCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
+            rpcArgs
+        );
+        return new CSharpAppResourceImpl(result, this._client);
+    }
+
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._subscribeHttpsEndpointsUpdateInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withRelationshipInternal(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): Promise<CSharpAppResource> {
         resourceBuilder = isPromiseLike(resourceBuilder) ? await resourceBuilder : resourceBuilder;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, resourceBuilder, type };
@@ -21229,6 +23079,30 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
     }
 
     /** @internal */
+    private async _withContainerBuildOptionsInternal(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): Promise<CSharpAppResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerBuildOptionsCallbackContextHandle;
+            const arg = new ContainerBuildOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpcArgs
+        );
+        return new CSharpAppResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._withContainerBuildOptionsInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<CSharpAppResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
@@ -21687,6 +23561,10 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommand(command, options)), this._client);
     }
 
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommandValidation(command, validationCallback, options)), this._client);
+    }
+
     withSessionLifetime(): CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withSessionLifetime()), this._client);
     }
@@ -21843,6 +23721,14 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withoutHttpsCertificate()), this._client);
     }
 
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withHttpsCertificateConfiguration(callback)), this._client);
+    }
+
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.subscribeHttpsEndpointsUpdate(callback)), this._client);
+    }
+
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withRelationship(resourceBuilder, type)), this._client);
     }
@@ -21929,6 +23815,10 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
 
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
         return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
+    }
+
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withContainerBuildOptions(callback)), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): CSharpAppResourcePromise {
@@ -22144,6 +24034,19 @@ export interface DotnetToolResource {
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): DotnetToolResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): DotnetToolResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -22416,6 +24319,40 @@ export interface DotnetToolResource {
      */
     withoutHttpsCertificate(): DotnetToolResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): DotnetToolResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): DotnetToolResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -22563,6 +24500,12 @@ export interface DotnetToolResource {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -22735,6 +24678,19 @@ export interface DotnetToolResourcePromise extends PromiseLike<DotnetToolResourc
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): DotnetToolResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): DotnetToolResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -23007,6 +24963,40 @@ export interface DotnetToolResourcePromise extends PromiseLike<DotnetToolResourc
      */
     withoutHttpsCertificate(): DotnetToolResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): DotnetToolResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): DotnetToolResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -23154,6 +25144,12 @@ export interface DotnetToolResourcePromise extends PromiseLike<DotnetToolResourc
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -23531,6 +25527,39 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): DotnetToolResourcePromise {
         const helpLink = options?.helpLink;
         return new DotnetToolResourcePromiseImpl(this._withRequiredCommandInternal(command, helpLink), this._client);
+    }
+
+    /** @internal */
+    private async _withRequiredCommandValidationInternal(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, helpLink?: string): Promise<DotnetToolResource> {
+        const validationCallbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as RequiredCommandValidationContextHandle;
+            const arg = new RequiredCommandValidationContextImpl(argHandle, this._client);
+            return await validationCallback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command, validationCallback: validationCallbackId };
+        if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
+        const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
+            'Aspire.Hosting/withRequiredCommandValidation',
+            rpcArgs
+        );
+        return new DotnetToolResourceImpl(result, this._client);
+    }
+
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): DotnetToolResourcePromise {
+        const helpLink = options?.helpLink;
+        return new DotnetToolResourcePromiseImpl(this._withRequiredCommandValidationInternal(command, validationCallback, helpLink), this._client);
     }
 
     /** @internal */
@@ -24545,6 +26574,76 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
     }
 
     /** @internal */
+    private async _withHttpsCertificateConfigurationInternal(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): Promise<DotnetToolResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as HttpsCertificateConfigurationCallbackAnnotationContextHandle;
+            const arg = new HttpsCertificateConfigurationCallbackAnnotationContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
+            'Aspire.Hosting/withHttpsCertificateConfiguration',
+            rpcArgs
+        );
+        return new DotnetToolResourceImpl(result, this._client);
+    }
+
+    /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._withHttpsCertificateConfigurationInternal(callback), this._client);
+    }
+
+    /** @internal */
+    private async _subscribeHttpsEndpointsUpdateInternal(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): Promise<DotnetToolResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as HttpsEndpointUpdateCallbackContextHandle;
+            const obj = new HttpsEndpointUpdateCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
+            rpcArgs
+        );
+        return new DotnetToolResourceImpl(result, this._client);
+    }
+
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._subscribeHttpsEndpointsUpdateInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withRelationshipInternal(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): Promise<DotnetToolResource> {
         resourceBuilder = isPromiseLike(resourceBuilder) ? await resourceBuilder : resourceBuilder;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, resourceBuilder, type };
@@ -25030,6 +27129,30 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
     }
 
     /** @internal */
+    private async _withContainerBuildOptionsInternal(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): Promise<DotnetToolResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerBuildOptionsCallbackContextHandle;
+            const arg = new ContainerBuildOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpcArgs
+        );
+        return new DotnetToolResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._withContainerBuildOptionsInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<DotnetToolResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
@@ -25512,6 +27635,10 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommand(command, options)), this._client);
     }
 
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommandValidation(command, validationCallback, options)), this._client);
+    }
+
     withSessionLifetime(): DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withSessionLifetime()), this._client);
     }
@@ -25664,6 +27791,14 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withoutHttpsCertificate()), this._client);
     }
 
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withHttpsCertificateConfiguration(callback)), this._client);
+    }
+
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.subscribeHttpsEndpointsUpdate(callback)), this._client);
+    }
+
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withRelationship(resourceBuilder, type)), this._client);
     }
@@ -25746,6 +27881,10 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
 
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
         return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
+    }
+
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withContainerBuildOptions(callback)), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): DotnetToolResourcePromise {
@@ -25935,6 +28074,19 @@ export interface ExecutableResource {
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ExecutableResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ExecutableResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -26207,6 +28359,40 @@ export interface ExecutableResource {
      */
     withoutHttpsCertificate(): ExecutableResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ExecutableResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ExecutableResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -26354,6 +28540,12 @@ export interface ExecutableResource {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -26493,6 +28685,19 @@ export interface ExecutableResourcePromise extends PromiseLike<ExecutableResourc
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ExecutableResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ExecutableResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -26765,6 +28970,40 @@ export interface ExecutableResourcePromise extends PromiseLike<ExecutableResourc
      */
     withoutHttpsCertificate(): ExecutableResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ExecutableResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ExecutableResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -26912,6 +29151,12 @@ export interface ExecutableResourcePromise extends PromiseLike<ExecutableResourc
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -27185,6 +29430,39 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ExecutableResourcePromise {
         const helpLink = options?.helpLink;
         return new ExecutableResourcePromiseImpl(this._withRequiredCommandInternal(command, helpLink), this._client);
+    }
+
+    /** @internal */
+    private async _withRequiredCommandValidationInternal(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, helpLink?: string): Promise<ExecutableResource> {
+        const validationCallbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as RequiredCommandValidationContextHandle;
+            const arg = new RequiredCommandValidationContextImpl(argHandle, this._client);
+            return await validationCallback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command, validationCallback: validationCallbackId };
+        if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
+        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
+            'Aspire.Hosting/withRequiredCommandValidation',
+            rpcArgs
+        );
+        return new ExecutableResourceImpl(result, this._client);
+    }
+
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ExecutableResourcePromise {
+        const helpLink = options?.helpLink;
+        return new ExecutableResourcePromiseImpl(this._withRequiredCommandValidationInternal(command, validationCallback, helpLink), this._client);
     }
 
     /** @internal */
@@ -28199,6 +30477,76 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
     }
 
     /** @internal */
+    private async _withHttpsCertificateConfigurationInternal(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): Promise<ExecutableResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as HttpsCertificateConfigurationCallbackAnnotationContextHandle;
+            const arg = new HttpsCertificateConfigurationCallbackAnnotationContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
+            'Aspire.Hosting/withHttpsCertificateConfiguration',
+            rpcArgs
+        );
+        return new ExecutableResourceImpl(result, this._client);
+    }
+
+    /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._withHttpsCertificateConfigurationInternal(callback), this._client);
+    }
+
+    /** @internal */
+    private async _subscribeHttpsEndpointsUpdateInternal(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): Promise<ExecutableResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as HttpsEndpointUpdateCallbackContextHandle;
+            const obj = new HttpsEndpointUpdateCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
+            rpcArgs
+        );
+        return new ExecutableResourceImpl(result, this._client);
+    }
+
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._subscribeHttpsEndpointsUpdateInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withRelationshipInternal(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): Promise<ExecutableResource> {
         resourceBuilder = isPromiseLike(resourceBuilder) ? await resourceBuilder : resourceBuilder;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, resourceBuilder, type };
@@ -28684,6 +31032,30 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
     }
 
     /** @internal */
+    private async _withContainerBuildOptionsInternal(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): Promise<ExecutableResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerBuildOptionsCallbackContextHandle;
+            const arg = new ContainerBuildOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpcArgs
+        );
+        return new ExecutableResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._withContainerBuildOptionsInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
@@ -29142,6 +31514,10 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommand(command, options)), this._client);
     }
 
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommandValidation(command, validationCallback, options)), this._client);
+    }
+
     withSessionLifetime(): ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withSessionLifetime()), this._client);
     }
@@ -29294,6 +31670,14 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withoutHttpsCertificate()), this._client);
     }
 
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withHttpsCertificateConfiguration(callback)), this._client);
+    }
+
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.subscribeHttpsEndpointsUpdate(callback)), this._client);
+    }
+
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withRelationship(resourceBuilder, type)), this._client);
     }
@@ -29376,6 +31760,10 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
 
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
         return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
+    }
+
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withContainerBuildOptions(callback)), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ExecutableResourcePromise {
@@ -29527,6 +31915,19 @@ export interface ExternalServiceResource {
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ExternalServiceResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ExternalServiceResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -29606,6 +32007,23 @@ export interface ExternalServiceResource {
      * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ExternalServiceResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ExternalServiceResourcePromise;
     /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
@@ -29707,6 +32125,12 @@ export interface ExternalServiceResource {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ExternalServiceResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -29811,6 +32235,19 @@ export interface ExternalServiceResourcePromise extends PromiseLike<ExternalServ
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ExternalServiceResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ExternalServiceResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -29890,6 +32327,23 @@ export interface ExternalServiceResourcePromise extends PromiseLike<ExternalServ
      * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ExternalServiceResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ExternalServiceResourcePromise;
     /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
@@ -29991,6 +32445,12 @@ export interface ExternalServiceResourcePromise extends PromiseLike<ExternalServ
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ExternalServiceResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -30165,6 +32625,39 @@ class ExternalServiceResourceImpl extends ResourceBuilderBase<ExternalServiceRes
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ExternalServiceResourcePromise {
         const helpLink = options?.helpLink;
         return new ExternalServiceResourcePromiseImpl(this._withRequiredCommandInternal(command, helpLink), this._client);
+    }
+
+    /** @internal */
+    private async _withRequiredCommandValidationInternal(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, helpLink?: string): Promise<ExternalServiceResource> {
+        const validationCallbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as RequiredCommandValidationContextHandle;
+            const arg = new RequiredCommandValidationContextImpl(argHandle, this._client);
+            return await validationCallback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command, validationCallback: validationCallbackId };
+        if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
+        const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
+            'Aspire.Hosting/withRequiredCommandValidation',
+            rpcArgs
+        );
+        return new ExternalServiceResourceImpl(result, this._client);
+    }
+
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ExternalServiceResourcePromise {
+        const helpLink = options?.helpLink;
+        return new ExternalServiceResourcePromiseImpl(this._withRequiredCommandValidationInternal(command, validationCallback, helpLink), this._client);
     }
 
     /** @internal */
@@ -30529,6 +33022,41 @@ class ExternalServiceResourceImpl extends ResourceBuilderBase<ExternalServiceRes
     }
 
     /** @internal */
+    private async _subscribeHttpsEndpointsUpdateInternal(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): Promise<ExternalServiceResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as HttpsEndpointUpdateCallbackContextHandle;
+            const obj = new HttpsEndpointUpdateCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
+            rpcArgs
+        );
+        return new ExternalServiceResourceImpl(result, this._client);
+    }
+
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ExternalServiceResourcePromise {
+        return new ExternalServiceResourcePromiseImpl(this._subscribeHttpsEndpointsUpdateInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withRelationshipInternal(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): Promise<ExternalServiceResource> {
         resourceBuilder = isPromiseLike(resourceBuilder) ? await resourceBuilder : resourceBuilder;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, resourceBuilder, type };
@@ -30861,6 +33389,30 @@ class ExternalServiceResourceImpl extends ResourceBuilderBase<ExternalServiceRes
             return new ExecutionConfigurationBuilderImpl(handle, this._client);
         })();
         return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
+    }
+
+    /** @internal */
+    private async _withContainerBuildOptionsInternal(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): Promise<ExternalServiceResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerBuildOptionsCallbackContextHandle;
+            const arg = new ContainerBuildOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpcArgs
+        );
+        return new ExternalServiceResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ExternalServiceResourcePromise {
+        return new ExternalServiceResourcePromiseImpl(this._withContainerBuildOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -31271,6 +33823,10 @@ class ExternalServiceResourcePromiseImpl implements ExternalServiceResourcePromi
         return new ExternalServiceResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommand(command, options)), this._client);
     }
 
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ExternalServiceResourcePromise {
+        return new ExternalServiceResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommandValidation(command, validationCallback, options)), this._client);
+    }
+
     withSessionLifetime(): ExternalServiceResourcePromise {
         return new ExternalServiceResourcePromiseImpl(this._promise.then(obj => obj.withSessionLifetime()), this._client);
     }
@@ -31321,6 +33877,10 @@ class ExternalServiceResourcePromiseImpl implements ExternalServiceResourcePromi
 
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ExternalServiceResourcePromise {
         return new ExternalServiceResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommandFactory(commandName, displayName, createProcessSpec, options)), this._client);
+    }
+
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ExternalServiceResourcePromise {
+        return new ExternalServiceResourcePromiseImpl(this._promise.then(obj => obj.subscribeHttpsEndpointsUpdate(callback)), this._client);
     }
 
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ExternalServiceResourcePromise {
@@ -31381,6 +33941,10 @@ class ExternalServiceResourcePromiseImpl implements ExternalServiceResourcePromi
 
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
         return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
+    }
+
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ExternalServiceResourcePromise {
+        return new ExternalServiceResourcePromiseImpl(this._promise.then(obj => obj.withContainerBuildOptions(callback)), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ExternalServiceResourcePromise {
@@ -31533,6 +34097,19 @@ export interface ParameterResource {
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ParameterResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ParameterResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -31612,6 +34189,23 @@ export interface ParameterResource {
      * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ParameterResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ParameterResourcePromise;
     /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
@@ -31713,6 +34307,12 @@ export interface ParameterResource {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ParameterResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -31825,6 +34425,19 @@ export interface ParameterResourcePromise extends PromiseLike<ParameterResource>
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ParameterResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ParameterResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -31904,6 +34517,23 @@ export interface ParameterResourcePromise extends PromiseLike<ParameterResource>
      * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ParameterResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ParameterResourcePromise;
     /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
@@ -32005,6 +34635,12 @@ export interface ParameterResourcePromise extends PromiseLike<ParameterResource>
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ParameterResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -32197,6 +34833,39 @@ class ParameterResourceImpl extends ResourceBuilderBase<ParameterResourceHandle>
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ParameterResourcePromise {
         const helpLink = options?.helpLink;
         return new ParameterResourcePromiseImpl(this._withRequiredCommandInternal(command, helpLink), this._client);
+    }
+
+    /** @internal */
+    private async _withRequiredCommandValidationInternal(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, helpLink?: string): Promise<ParameterResource> {
+        const validationCallbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as RequiredCommandValidationContextHandle;
+            const arg = new RequiredCommandValidationContextImpl(argHandle, this._client);
+            return await validationCallback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command, validationCallback: validationCallbackId };
+        if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
+        const result = await this._client.invokeCapability<ParameterResourceHandle>(
+            'Aspire.Hosting/withRequiredCommandValidation',
+            rpcArgs
+        );
+        return new ParameterResourceImpl(result, this._client);
+    }
+
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ParameterResourcePromise {
+        const helpLink = options?.helpLink;
+        return new ParameterResourcePromiseImpl(this._withRequiredCommandValidationInternal(command, validationCallback, helpLink), this._client);
     }
 
     /** @internal */
@@ -32561,6 +35230,41 @@ class ParameterResourceImpl extends ResourceBuilderBase<ParameterResourceHandle>
     }
 
     /** @internal */
+    private async _subscribeHttpsEndpointsUpdateInternal(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): Promise<ParameterResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as HttpsEndpointUpdateCallbackContextHandle;
+            const obj = new HttpsEndpointUpdateCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ParameterResourceHandle>(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
+            rpcArgs
+        );
+        return new ParameterResourceImpl(result, this._client);
+    }
+
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ParameterResourcePromise {
+        return new ParameterResourcePromiseImpl(this._subscribeHttpsEndpointsUpdateInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withRelationshipInternal(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): Promise<ParameterResource> {
         resourceBuilder = isPromiseLike(resourceBuilder) ? await resourceBuilder : resourceBuilder;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, resourceBuilder, type };
@@ -32893,6 +35597,30 @@ class ParameterResourceImpl extends ResourceBuilderBase<ParameterResourceHandle>
             return new ExecutionConfigurationBuilderImpl(handle, this._client);
         })();
         return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
+    }
+
+    /** @internal */
+    private async _withContainerBuildOptionsInternal(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): Promise<ParameterResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerBuildOptionsCallbackContextHandle;
+            const arg = new ContainerBuildOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ParameterResourceHandle>(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpcArgs
+        );
+        return new ParameterResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ParameterResourcePromise {
+        return new ParameterResourcePromiseImpl(this._withContainerBuildOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -33307,6 +36035,10 @@ class ParameterResourcePromiseImpl implements ParameterResourcePromise {
         return new ParameterResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommand(command, options)), this._client);
     }
 
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ParameterResourcePromise {
+        return new ParameterResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommandValidation(command, validationCallback, options)), this._client);
+    }
+
     withSessionLifetime(): ParameterResourcePromise {
         return new ParameterResourcePromiseImpl(this._promise.then(obj => obj.withSessionLifetime()), this._client);
     }
@@ -33357,6 +36089,10 @@ class ParameterResourcePromiseImpl implements ParameterResourcePromise {
 
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ParameterResourcePromise {
         return new ParameterResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommandFactory(commandName, displayName, createProcessSpec, options)), this._client);
+    }
+
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ParameterResourcePromise {
+        return new ParameterResourcePromiseImpl(this._promise.then(obj => obj.subscribeHttpsEndpointsUpdate(callback)), this._client);
     }
 
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ParameterResourcePromise {
@@ -33417,6 +36153,10 @@ class ParameterResourcePromiseImpl implements ParameterResourcePromise {
 
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
         return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
+    }
+
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ParameterResourcePromise {
+        return new ParameterResourcePromiseImpl(this._promise.then(obj => obj.withContainerBuildOptions(callback)), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ParameterResourcePromise {
@@ -33591,6 +36331,19 @@ export interface ProjectResource {
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ProjectResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ProjectResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -33869,6 +36622,40 @@ export interface ProjectResource {
      */
     withoutHttpsCertificate(): ProjectResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ProjectResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ProjectResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -34022,6 +36809,12 @@ export interface ProjectResource {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ProjectResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -34160,6 +36953,19 @@ export interface ProjectResourcePromise extends PromiseLike<ProjectResource> {
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ProjectResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ProjectResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -34438,6 +37244,40 @@ export interface ProjectResourcePromise extends PromiseLike<ProjectResource> {
      */
     withoutHttpsCertificate(): ProjectResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ProjectResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ProjectResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -34591,6 +37431,12 @@ export interface ProjectResourcePromise extends PromiseLike<ProjectResource> {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ProjectResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -34859,6 +37705,39 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ProjectResourcePromise {
         const helpLink = options?.helpLink;
         return new ProjectResourcePromiseImpl(this._withRequiredCommandInternal(command, helpLink), this._client);
+    }
+
+    /** @internal */
+    private async _withRequiredCommandValidationInternal(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, helpLink?: string): Promise<ProjectResource> {
+        const validationCallbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as RequiredCommandValidationContextHandle;
+            const arg = new RequiredCommandValidationContextImpl(argHandle, this._client);
+            return await validationCallback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command, validationCallback: validationCallbackId };
+        if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
+        const result = await this._client.invokeCapability<ProjectResourceHandle>(
+            'Aspire.Hosting/withRequiredCommandValidation',
+            rpcArgs
+        );
+        return new ProjectResourceImpl(result, this._client);
+    }
+
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ProjectResourcePromise {
+        const helpLink = options?.helpLink;
+        return new ProjectResourcePromiseImpl(this._withRequiredCommandValidationInternal(command, validationCallback, helpLink), this._client);
     }
 
     /** @internal */
@@ -35893,6 +38772,76 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
     }
 
     /** @internal */
+    private async _withHttpsCertificateConfigurationInternal(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): Promise<ProjectResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as HttpsCertificateConfigurationCallbackAnnotationContextHandle;
+            const arg = new HttpsCertificateConfigurationCallbackAnnotationContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ProjectResourceHandle>(
+            'Aspire.Hosting/withHttpsCertificateConfiguration',
+            rpcArgs
+        );
+        return new ProjectResourceImpl(result, this._client);
+    }
+
+    /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._withHttpsCertificateConfigurationInternal(callback), this._client);
+    }
+
+    /** @internal */
+    private async _subscribeHttpsEndpointsUpdateInternal(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): Promise<ProjectResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as HttpsEndpointUpdateCallbackContextHandle;
+            const obj = new HttpsEndpointUpdateCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ProjectResourceHandle>(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
+            rpcArgs
+        );
+        return new ProjectResourceImpl(result, this._client);
+    }
+
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._subscribeHttpsEndpointsUpdateInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withRelationshipInternal(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): Promise<ProjectResource> {
         resourceBuilder = isPromiseLike(resourceBuilder) ? await resourceBuilder : resourceBuilder;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, resourceBuilder, type };
@@ -36397,6 +39346,30 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
     }
 
     /** @internal */
+    private async _withContainerBuildOptionsInternal(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): Promise<ProjectResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerBuildOptionsCallbackContextHandle;
+            const arg = new ContainerBuildOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<ProjectResourceHandle>(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpcArgs
+        );
+        return new ProjectResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._withContainerBuildOptionsInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
@@ -36855,6 +39828,10 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommand(command, options)), this._client);
     }
 
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommandValidation(command, validationCallback, options)), this._client);
+    }
+
     withSessionLifetime(): ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withSessionLifetime()), this._client);
     }
@@ -37011,6 +39988,14 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withoutHttpsCertificate()), this._client);
     }
 
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withHttpsCertificateConfiguration(callback)), this._client);
+    }
+
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.subscribeHttpsEndpointsUpdate(callback)), this._client);
+    }
+
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withRelationship(resourceBuilder, type)), this._client);
     }
@@ -37097,6 +40082,10 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
 
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
         return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
+    }
+
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withContainerBuildOptions(callback)), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ProjectResourcePromise {
@@ -37351,14 +40340,24 @@ export interface TestDatabaseResource {
      *
      * In run mode, Aspire copies the files into the container and applies owner, group, and umask options.
      * In publish mode, Aspire creates a read-only bind mount and ignores those options.
-     * Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-     * polymorphic `ContainerFileSystemItem` hierarchy or callbacks that use .NET services.
+     * To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+     * use the `withContainerFilesCallback` overload and build the entries via the factory methods on
+     * `ContainerFileSystemCallbackContext`. Passing a pre-built `ContainerFileSystemItem` collection
+     * remains .NET-only.
      * @param destinationPath The destination absolute path in the container.
      * @param sourcePath The source path on the host to copy files from.
      * @param options Additional options.
      * @returns The resource builder.
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestDatabaseResourcePromise;
+    /**
+     * Creates or updates files and folders in a container using entries produced by a callback.
+     * @param destinationPath The destination absolute path in the container.
+     * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): TestDatabaseResourcePromise;
     /**
      * Configures the resource to use a programmatically generated Dockerfile
      *
@@ -37450,6 +40449,19 @@ export interface TestDatabaseResource {
      * @returns The resource builder.
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestDatabaseResourcePromise;
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): TestDatabaseResourcePromise;
     /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
@@ -37723,6 +40735,40 @@ export interface TestDatabaseResource {
      */
     withoutHttpsCertificate(): TestDatabaseResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): TestDatabaseResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): TestDatabaseResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -37884,6 +40930,12 @@ export interface TestDatabaseResource {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -38095,14 +41147,24 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
      *
      * In run mode, Aspire copies the files into the container and applies owner, group, and umask options.
      * In publish mode, Aspire creates a read-only bind mount and ignores those options.
-     * Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-     * polymorphic `ContainerFileSystemItem` hierarchy or callbacks that use .NET services.
+     * To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+     * use the `withContainerFilesCallback` overload and build the entries via the factory methods on
+     * `ContainerFileSystemCallbackContext`. Passing a pre-built `ContainerFileSystemItem` collection
+     * remains .NET-only.
      * @param destinationPath The destination absolute path in the container.
      * @param sourcePath The source path on the host to copy files from.
      * @param options Additional options.
      * @returns The resource builder.
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestDatabaseResourcePromise;
+    /**
+     * Creates or updates files and folders in a container using entries produced by a callback.
+     * @param destinationPath The destination absolute path in the container.
+     * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): TestDatabaseResourcePromise;
     /**
      * Configures the resource to use a programmatically generated Dockerfile
      *
@@ -38194,6 +41256,19 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
      * @returns The resource builder.
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestDatabaseResourcePromise;
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): TestDatabaseResourcePromise;
     /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
@@ -38467,6 +41542,40 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
      */
     withoutHttpsCertificate(): TestDatabaseResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): TestDatabaseResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): TestDatabaseResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -38628,6 +41737,12 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -39103,8 +42218,10 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
      *
      * In run mode, Aspire copies the files into the container and applies owner, group, and umask options.
      * In publish mode, Aspire creates a read-only bind mount and ignores those options.
-     * Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-     * polymorphic `ContainerFileSystemItem` hierarchy or callbacks that use .NET services.
+     * To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+     * use the `withContainerFilesCallback` overload and build the entries via the factory methods on
+     * `ContainerFileSystemCallbackContext`. Passing a pre-built `ContainerFileSystemItem` collection
+     * remains .NET-only.
      * @param destinationPath The destination absolute path in the container.
      * @param sourcePath The source path on the host to copy files from.
      * @param options Additional options.
@@ -39112,6 +42229,34 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._withContainerFilesInternal(destinationPath, sourcePath, options), this._client);
+    }
+
+    /** @internal */
+    private async _withContainerFilesCallbackInternal(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): Promise<TestDatabaseResource> {
+        const callbackId = registerCallback(async (arg1Data: unknown, arg2Data: unknown) => {
+            const arg1Handle = wrapIfHandle(arg1Data) as ContainerFileSystemCallbackContextHandle;
+            const arg1 = new ContainerFileSystemCallbackContextImpl(arg1Handle, this._client);
+            const arg2 = CancellationToken.fromValue(arg2Data);
+            return await callback(arg1, arg2);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, destinationPath, callback: callbackId };
+        if (options !== undefined) rpcArgs.options = options;
+        const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
+            'Aspire.Hosting/withContainerFilesCallback',
+            rpcArgs
+        );
+        return new TestDatabaseResourceImpl(result, this._client);
+    }
+
+    /**
+     * Creates or updates files and folders in a container using entries produced by a callback.
+     * @param destinationPath The destination absolute path in the container.
+     * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._withContainerFilesCallbackInternal(destinationPath, callback, options), this._client);
     }
 
     /** @internal */
@@ -39313,6 +42458,39 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestDatabaseResourcePromise {
         const helpLink = options?.helpLink;
         return new TestDatabaseResourcePromiseImpl(this._withRequiredCommandInternal(command, helpLink), this._client);
+    }
+
+    /** @internal */
+    private async _withRequiredCommandValidationInternal(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, helpLink?: string): Promise<TestDatabaseResource> {
+        const validationCallbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as RequiredCommandValidationContextHandle;
+            const arg = new RequiredCommandValidationContextImpl(argHandle, this._client);
+            return await validationCallback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command, validationCallback: validationCallbackId };
+        if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
+        const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
+            'Aspire.Hosting/withRequiredCommandValidation',
+            rpcArgs
+        );
+        return new TestDatabaseResourceImpl(result, this._client);
+    }
+
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): TestDatabaseResourcePromise {
+        const helpLink = options?.helpLink;
+        return new TestDatabaseResourcePromiseImpl(this._withRequiredCommandValidationInternal(command, validationCallback, helpLink), this._client);
     }
 
     /** @internal */
@@ -40327,6 +43505,76 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
     }
 
     /** @internal */
+    private async _withHttpsCertificateConfigurationInternal(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): Promise<TestDatabaseResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as HttpsCertificateConfigurationCallbackAnnotationContextHandle;
+            const arg = new HttpsCertificateConfigurationCallbackAnnotationContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
+            'Aspire.Hosting/withHttpsCertificateConfiguration',
+            rpcArgs
+        );
+        return new TestDatabaseResourceImpl(result, this._client);
+    }
+
+    /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._withHttpsCertificateConfigurationInternal(callback), this._client);
+    }
+
+    /** @internal */
+    private async _subscribeHttpsEndpointsUpdateInternal(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): Promise<TestDatabaseResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as HttpsEndpointUpdateCallbackContextHandle;
+            const obj = new HttpsEndpointUpdateCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
+            rpcArgs
+        );
+        return new TestDatabaseResourceImpl(result, this._client);
+    }
+
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._subscribeHttpsEndpointsUpdateInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withRelationshipInternal(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): Promise<TestDatabaseResource> {
         resourceBuilder = isPromiseLike(resourceBuilder) ? await resourceBuilder : resourceBuilder;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, resourceBuilder, type };
@@ -40843,6 +44091,30 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
     }
 
     /** @internal */
+    private async _withContainerBuildOptionsInternal(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): Promise<TestDatabaseResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerBuildOptionsCallbackContextHandle;
+            const arg = new ContainerBuildOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpcArgs
+        );
+        return new TestDatabaseResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._withContainerBuildOptionsInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<TestDatabaseResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
@@ -41341,6 +44613,10 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withContainerFiles(destinationPath, sourcePath, options)), this._client);
     }
 
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withContainerFilesCallback(destinationPath, callback, options)), this._client);
+    }
+
     withDockerfileBuilder(contextPath: string, callback: (arg: DockerfileBuilderCallbackContext) => Promise<void>, options?: WithDockerfileBuilderOptions): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withDockerfileBuilder(contextPath, callback, options)), this._client);
     }
@@ -41367,6 +44643,10 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
 
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommand(command, options)), this._client);
+    }
+
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommandValidation(command, validationCallback, options)), this._client);
     }
 
     withSessionLifetime(): TestDatabaseResourcePromise {
@@ -41521,6 +44801,14 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withoutHttpsCertificate()), this._client);
     }
 
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withHttpsCertificateConfiguration(callback)), this._client);
+    }
+
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.subscribeHttpsEndpointsUpdate(callback)), this._client);
+    }
+
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withRelationship(resourceBuilder, type)), this._client);
     }
@@ -41607,6 +44895,10 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
 
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
         return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
+    }
+
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withContainerBuildOptions(callback)), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): TestDatabaseResourcePromise {
@@ -41861,14 +45153,24 @@ export interface TestRedisResource {
      *
      * In run mode, Aspire copies the files into the container and applies owner, group, and umask options.
      * In publish mode, Aspire creates a read-only bind mount and ignores those options.
-     * Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-     * polymorphic `ContainerFileSystemItem` hierarchy or callbacks that use .NET services.
+     * To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+     * use the `withContainerFilesCallback` overload and build the entries via the factory methods on
+     * `ContainerFileSystemCallbackContext`. Passing a pre-built `ContainerFileSystemItem` collection
+     * remains .NET-only.
      * @param destinationPath The destination absolute path in the container.
      * @param sourcePath The source path on the host to copy files from.
      * @param options Additional options.
      * @returns The resource builder.
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestRedisResourcePromise;
+    /**
+     * Creates or updates files and folders in a container using entries produced by a callback.
+     * @param destinationPath The destination absolute path in the container.
+     * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): TestRedisResourcePromise;
     /**
      * Configures the resource to use a programmatically generated Dockerfile
      *
@@ -41960,6 +45262,19 @@ export interface TestRedisResource {
      * @returns The resource builder.
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestRedisResourcePromise;
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): TestRedisResourcePromise;
     /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
@@ -42249,6 +45564,40 @@ export interface TestRedisResource {
      */
     withoutHttpsCertificate(): TestRedisResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): TestRedisResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): TestRedisResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -42416,6 +45765,12 @@ export interface TestRedisResource {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise;
     /**
      * Adds a child database to a test Redis resource
      *
@@ -42669,14 +46024,24 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
      *
      * In run mode, Aspire copies the files into the container and applies owner, group, and umask options.
      * In publish mode, Aspire creates a read-only bind mount and ignores those options.
-     * Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-     * polymorphic `ContainerFileSystemItem` hierarchy or callbacks that use .NET services.
+     * To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+     * use the `withContainerFilesCallback` overload and build the entries via the factory methods on
+     * `ContainerFileSystemCallbackContext`. Passing a pre-built `ContainerFileSystemItem` collection
+     * remains .NET-only.
      * @param destinationPath The destination absolute path in the container.
      * @param sourcePath The source path on the host to copy files from.
      * @param options Additional options.
      * @returns The resource builder.
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestRedisResourcePromise;
+    /**
+     * Creates or updates files and folders in a container using entries produced by a callback.
+     * @param destinationPath The destination absolute path in the container.
+     * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): TestRedisResourcePromise;
     /**
      * Configures the resource to use a programmatically generated Dockerfile
      *
@@ -42768,6 +46133,19 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
      * @returns The resource builder.
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestRedisResourcePromise;
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): TestRedisResourcePromise;
     /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
@@ -43057,6 +46435,40 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
      */
     withoutHttpsCertificate(): TestRedisResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): TestRedisResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): TestRedisResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -43224,6 +46636,12 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise;
     /**
      * Adds a child database to a test Redis resource
      *
@@ -43741,8 +47159,10 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
      *
      * In run mode, Aspire copies the files into the container and applies owner, group, and umask options.
      * In publish mode, Aspire creates a read-only bind mount and ignores those options.
-     * Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-     * polymorphic `ContainerFileSystemItem` hierarchy or callbacks that use .NET services.
+     * To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+     * use the `withContainerFilesCallback` overload and build the entries via the factory methods on
+     * `ContainerFileSystemCallbackContext`. Passing a pre-built `ContainerFileSystemItem` collection
+     * remains .NET-only.
      * @param destinationPath The destination absolute path in the container.
      * @param sourcePath The source path on the host to copy files from.
      * @param options Additional options.
@@ -43750,6 +47170,34 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._withContainerFilesInternal(destinationPath, sourcePath, options), this._client);
+    }
+
+    /** @internal */
+    private async _withContainerFilesCallbackInternal(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): Promise<TestRedisResource> {
+        const callbackId = registerCallback(async (arg1Data: unknown, arg2Data: unknown) => {
+            const arg1Handle = wrapIfHandle(arg1Data) as ContainerFileSystemCallbackContextHandle;
+            const arg1 = new ContainerFileSystemCallbackContextImpl(arg1Handle, this._client);
+            const arg2 = CancellationToken.fromValue(arg2Data);
+            return await callback(arg1, arg2);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, destinationPath, callback: callbackId };
+        if (options !== undefined) rpcArgs.options = options;
+        const result = await this._client.invokeCapability<TestRedisResourceHandle>(
+            'Aspire.Hosting/withContainerFilesCallback',
+            rpcArgs
+        );
+        return new TestRedisResourceImpl(result, this._client);
+    }
+
+    /**
+     * Creates or updates files and folders in a container using entries produced by a callback.
+     * @param destinationPath The destination absolute path in the container.
+     * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._withContainerFilesCallbackInternal(destinationPath, callback, options), this._client);
     }
 
     /** @internal */
@@ -43951,6 +47399,39 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestRedisResourcePromise {
         const helpLink = options?.helpLink;
         return new TestRedisResourcePromiseImpl(this._withRequiredCommandInternal(command, helpLink), this._client);
+    }
+
+    /** @internal */
+    private async _withRequiredCommandValidationInternal(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, helpLink?: string): Promise<TestRedisResource> {
+        const validationCallbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as RequiredCommandValidationContextHandle;
+            const arg = new RequiredCommandValidationContextImpl(argHandle, this._client);
+            return await validationCallback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command, validationCallback: validationCallbackId };
+        if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
+        const result = await this._client.invokeCapability<TestRedisResourceHandle>(
+            'Aspire.Hosting/withRequiredCommandValidation',
+            rpcArgs
+        );
+        return new TestRedisResourceImpl(result, this._client);
+    }
+
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): TestRedisResourcePromise {
+        const helpLink = options?.helpLink;
+        return new TestRedisResourcePromiseImpl(this._withRequiredCommandValidationInternal(command, validationCallback, helpLink), this._client);
     }
 
     /** @internal */
@@ -45001,6 +48482,76 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
     }
 
     /** @internal */
+    private async _withHttpsCertificateConfigurationInternal(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): Promise<TestRedisResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as HttpsCertificateConfigurationCallbackAnnotationContextHandle;
+            const arg = new HttpsCertificateConfigurationCallbackAnnotationContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<TestRedisResourceHandle>(
+            'Aspire.Hosting/withHttpsCertificateConfiguration',
+            rpcArgs
+        );
+        return new TestRedisResourceImpl(result, this._client);
+    }
+
+    /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._withHttpsCertificateConfigurationInternal(callback), this._client);
+    }
+
+    /** @internal */
+    private async _subscribeHttpsEndpointsUpdateInternal(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): Promise<TestRedisResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as HttpsEndpointUpdateCallbackContextHandle;
+            const obj = new HttpsEndpointUpdateCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<TestRedisResourceHandle>(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
+            rpcArgs
+        );
+        return new TestRedisResourceImpl(result, this._client);
+    }
+
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._subscribeHttpsEndpointsUpdateInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withRelationshipInternal(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): Promise<TestRedisResource> {
         resourceBuilder = isPromiseLike(resourceBuilder) ? await resourceBuilder : resourceBuilder;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, resourceBuilder, type };
@@ -45538,6 +49089,30 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
             return new ExecutionConfigurationBuilderImpl(handle, this._client);
         })();
         return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
+    }
+
+    /** @internal */
+    private async _withContainerBuildOptionsInternal(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): Promise<TestRedisResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerBuildOptionsCallbackContextHandle;
+            const arg = new ContainerBuildOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<TestRedisResourceHandle>(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpcArgs
+        );
+        return new TestRedisResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._withContainerBuildOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -46226,6 +49801,10 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withContainerFiles(destinationPath, sourcePath, options)), this._client);
     }
 
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withContainerFilesCallback(destinationPath, callback, options)), this._client);
+    }
+
     withDockerfileBuilder(contextPath: string, callback: (arg: DockerfileBuilderCallbackContext) => Promise<void>, options?: WithDockerfileBuilderOptions): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withDockerfileBuilder(contextPath, callback, options)), this._client);
     }
@@ -46252,6 +49831,10 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
 
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommand(command, options)), this._client);
+    }
+
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommandValidation(command, validationCallback, options)), this._client);
     }
 
     withSessionLifetime(): TestRedisResourcePromise {
@@ -46414,6 +49997,14 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withoutHttpsCertificate()), this._client);
     }
 
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withHttpsCertificateConfiguration(callback)), this._client);
+    }
+
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.subscribeHttpsEndpointsUpdate(callback)), this._client);
+    }
+
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withRelationship(resourceBuilder, type)), this._client);
     }
@@ -46504,6 +50095,10 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
 
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
         return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
+    }
+
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withContainerBuildOptions(callback)), this._client);
     }
 
     addTestChildDatabase(name: string, options?: AddTestChildDatabaseOptions): TestDatabaseResourcePromise {
@@ -46806,14 +50401,24 @@ export interface TestVaultResource {
      *
      * In run mode, Aspire copies the files into the container and applies owner, group, and umask options.
      * In publish mode, Aspire creates a read-only bind mount and ignores those options.
-     * Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-     * polymorphic `ContainerFileSystemItem` hierarchy or callbacks that use .NET services.
+     * To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+     * use the `withContainerFilesCallback` overload and build the entries via the factory methods on
+     * `ContainerFileSystemCallbackContext`. Passing a pre-built `ContainerFileSystemItem` collection
+     * remains .NET-only.
      * @param destinationPath The destination absolute path in the container.
      * @param sourcePath The source path on the host to copy files from.
      * @param options Additional options.
      * @returns The resource builder.
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestVaultResourcePromise;
+    /**
+     * Creates or updates files and folders in a container using entries produced by a callback.
+     * @param destinationPath The destination absolute path in the container.
+     * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): TestVaultResourcePromise;
     /**
      * Configures the resource to use a programmatically generated Dockerfile
      *
@@ -46905,6 +50510,19 @@ export interface TestVaultResource {
      * @returns The resource builder.
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestVaultResourcePromise;
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): TestVaultResourcePromise;
     /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
@@ -47178,6 +50796,40 @@ export interface TestVaultResource {
      */
     withoutHttpsCertificate(): TestVaultResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): TestVaultResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): TestVaultResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -47339,6 +50991,12 @@ export interface TestVaultResource {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -47552,14 +51210,24 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
      *
      * In run mode, Aspire copies the files into the container and applies owner, group, and umask options.
      * In publish mode, Aspire creates a read-only bind mount and ignores those options.
-     * Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-     * polymorphic `ContainerFileSystemItem` hierarchy or callbacks that use .NET services.
+     * To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+     * use the `withContainerFilesCallback` overload and build the entries via the factory methods on
+     * `ContainerFileSystemCallbackContext`. Passing a pre-built `ContainerFileSystemItem` collection
+     * remains .NET-only.
      * @param destinationPath The destination absolute path in the container.
      * @param sourcePath The source path on the host to copy files from.
      * @param options Additional options.
      * @returns The resource builder.
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestVaultResourcePromise;
+    /**
+     * Creates or updates files and folders in a container using entries produced by a callback.
+     * @param destinationPath The destination absolute path in the container.
+     * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): TestVaultResourcePromise;
     /**
      * Configures the resource to use a programmatically generated Dockerfile
      *
@@ -47651,6 +51319,19 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
      * @returns The resource builder.
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestVaultResourcePromise;
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): TestVaultResourcePromise;
     /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
@@ -47924,6 +51605,40 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
      */
     withoutHttpsCertificate(): TestVaultResourcePromise;
     /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): TestVaultResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): TestVaultResourcePromise;
+    /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
      * @param type The relationship type.
@@ -48085,6 +51800,12 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -48562,8 +52283,10 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
      *
      * In run mode, Aspire copies the files into the container and applies owner, group, and umask options.
      * In publish mode, Aspire creates a read-only bind mount and ignores those options.
-     * Inline file entries and callbacks are only available in .NET apphosts because ATS does not support the recursive,
-     * polymorphic `ContainerFileSystemItem` hierarchy or callbacks that use .NET services.
+     * To produce entries dynamically (including inline file contents and OpenSSL certificate files), polyglot app hosts
+     * use the `withContainerFilesCallback` overload and build the entries via the factory methods on
+     * `ContainerFileSystemCallbackContext`. Passing a pre-built `ContainerFileSystemItem` collection
+     * remains .NET-only.
      * @param destinationPath The destination absolute path in the container.
      * @param sourcePath The source path on the host to copy files from.
      * @param options Additional options.
@@ -48571,6 +52294,34 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
      */
     withContainerFiles(destinationPath: string, sourcePath: string, options?: ContainerFilesOptions): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._withContainerFilesInternal(destinationPath, sourcePath, options), this._client);
+    }
+
+    /** @internal */
+    private async _withContainerFilesCallbackInternal(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): Promise<TestVaultResource> {
+        const callbackId = registerCallback(async (arg1Data: unknown, arg2Data: unknown) => {
+            const arg1Handle = wrapIfHandle(arg1Data) as ContainerFileSystemCallbackContextHandle;
+            const arg1 = new ContainerFileSystemCallbackContextImpl(arg1Handle, this._client);
+            const arg2 = CancellationToken.fromValue(arg2Data);
+            return await callback(arg1, arg2);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, destinationPath, callback: callbackId };
+        if (options !== undefined) rpcArgs.options = options;
+        const result = await this._client.invokeCapability<TestVaultResourceHandle>(
+            'Aspire.Hosting/withContainerFilesCallback',
+            rpcArgs
+        );
+        return new TestVaultResourceImpl(result, this._client);
+    }
+
+    /**
+     * Creates or updates files and folders in a container using entries produced by a callback.
+     * @param destinationPath The destination absolute path in the container.
+     * @param callback A callback that returns the file system entries to create or update. Use the factory methods on `ContainerFileSystemCallbackContext` (createFile, createDirectory, createCertificateFile) to build the entries.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._withContainerFilesCallbackInternal(destinationPath, callback, options), this._client);
     }
 
     /** @internal */
@@ -48772,6 +52523,39 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestVaultResourcePromise {
         const helpLink = options?.helpLink;
         return new TestVaultResourcePromiseImpl(this._withRequiredCommandInternal(command, helpLink), this._client);
+    }
+
+    /** @internal */
+    private async _withRequiredCommandValidationInternal(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, helpLink?: string): Promise<TestVaultResource> {
+        const validationCallbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as RequiredCommandValidationContextHandle;
+            const arg = new RequiredCommandValidationContextImpl(argHandle, this._client);
+            return await validationCallback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command, validationCallback: validationCallbackId };
+        if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
+        const result = await this._client.invokeCapability<TestVaultResourceHandle>(
+            'Aspire.Hosting/withRequiredCommandValidation',
+            rpcArgs
+        );
+        return new TestVaultResourceImpl(result, this._client);
+    }
+
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): TestVaultResourcePromise {
+        const helpLink = options?.helpLink;
+        return new TestVaultResourcePromiseImpl(this._withRequiredCommandValidationInternal(command, validationCallback, helpLink), this._client);
     }
 
     /** @internal */
@@ -49786,6 +53570,76 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
     }
 
     /** @internal */
+    private async _withHttpsCertificateConfigurationInternal(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): Promise<TestVaultResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as HttpsCertificateConfigurationCallbackAnnotationContextHandle;
+            const arg = new HttpsCertificateConfigurationCallbackAnnotationContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<TestVaultResourceHandle>(
+            'Aspire.Hosting/withHttpsCertificateConfiguration',
+            rpcArgs
+        );
+        return new TestVaultResourceImpl(result, this._client);
+    }
+
+    /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._withHttpsCertificateConfigurationInternal(callback), this._client);
+    }
+
+    /** @internal */
+    private async _subscribeHttpsEndpointsUpdateInternal(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): Promise<TestVaultResource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as HttpsEndpointUpdateCallbackContextHandle;
+            const obj = new HttpsEndpointUpdateCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<TestVaultResourceHandle>(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
+            rpcArgs
+        );
+        return new TestVaultResourceImpl(result, this._client);
+    }
+
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._subscribeHttpsEndpointsUpdateInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withRelationshipInternal(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): Promise<TestVaultResource> {
         resourceBuilder = isPromiseLike(resourceBuilder) ? await resourceBuilder : resourceBuilder;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, resourceBuilder, type };
@@ -50302,6 +54156,30 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
     }
 
     /** @internal */
+    private async _withContainerBuildOptionsInternal(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): Promise<TestVaultResource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerBuildOptionsCallbackContextHandle;
+            const arg = new ContainerBuildOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<TestVaultResourceHandle>(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpcArgs
+        );
+        return new TestVaultResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._withContainerBuildOptionsInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<TestVaultResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
@@ -50815,6 +54693,10 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withContainerFiles(destinationPath, sourcePath, options)), this._client);
     }
 
+    withContainerFilesCallback(destinationPath: string, callback: (arg1: ContainerFileSystemCallbackContext, arg2: CancellationToken) => Promise<ContainerFileSystemItemHandle[]>, options?: ContainerFilesOptions): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withContainerFilesCallback(destinationPath, callback, options)), this._client);
+    }
+
     withDockerfileBuilder(contextPath: string, callback: (arg: DockerfileBuilderCallbackContext) => Promise<void>, options?: WithDockerfileBuilderOptions): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withDockerfileBuilder(contextPath, callback, options)), this._client);
     }
@@ -50841,6 +54723,10 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
 
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommand(command, options)), this._client);
+    }
+
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommandValidation(command, validationCallback, options)), this._client);
     }
 
     withSessionLifetime(): TestVaultResourcePromise {
@@ -50995,6 +54881,14 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withoutHttpsCertificate()), this._client);
     }
 
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withHttpsCertificateConfiguration(callback)), this._client);
+    }
+
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.subscribeHttpsEndpointsUpdate(callback)), this._client);
+    }
+
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withRelationship(resourceBuilder, type)), this._client);
     }
@@ -51081,6 +54975,10 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
 
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
         return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
+    }
+
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withContainerBuildOptions(callback)), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): TestVaultResourcePromise {
@@ -51551,6 +55449,19 @@ export interface Resource {
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -51630,6 +55541,23 @@ export interface Resource {
      * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ResourcePromise;
     /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
@@ -51731,6 +55659,12 @@ export interface Resource {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -51830,6 +55764,19 @@ export interface ResourcePromise extends PromiseLike<Resource> {
      */
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ResourcePromise;
     /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ResourcePromise;
+    /**
      * Configures a resource to use a session lifetime.
      * @returns The resource builder.
      */
@@ -51909,6 +55856,23 @@ export interface ResourcePromise extends PromiseLike<Resource> {
      * @deprecated Use withProcessCommand with createProcessSpec in the options object instead.
      */
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ResourcePromise;
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ResourcePromise;
     /**
      * Adds a relationship to another resource using its builder.
      * @param resourceBuilder The resource builder that the relationship is to.
@@ -52010,6 +55974,12 @@ export interface ResourcePromise extends PromiseLike<Resource> {
      * @returns The execution configuration builder.
      */
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ResourcePromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -52161,6 +56131,39 @@ class ResourceImpl extends ResourceBuilderBase<IResourceHandle> implements Resou
     withRequiredCommand(command: string, options?: WithRequiredCommandOptions): ResourcePromise {
         const helpLink = options?.helpLink;
         return new ResourcePromiseImpl(this._withRequiredCommandInternal(command, helpLink), this._client);
+    }
+
+    /** @internal */
+    private async _withRequiredCommandValidationInternal(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, helpLink?: string): Promise<Resource> {
+        const validationCallbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as RequiredCommandValidationContextHandle;
+            const arg = new RequiredCommandValidationContextImpl(argHandle, this._client);
+            return await validationCallback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command, validationCallback: validationCallbackId };
+        if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
+        const result = await this._client.invokeCapability<IResourceHandle>(
+            'Aspire.Hosting/withRequiredCommandValidation',
+            rpcArgs
+        );
+        return new ResourceImpl(result, this._client);
+    }
+
+    /**
+     * Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic.
+     *
+     * The command is first resolved to a full path. If found, the validation callback is invoked with the context containing the resolved path and service provider.
+     * The callback should return a `RequiredCommandValidationResult` indicating whether the command is valid,
+     * which can be created via `Success` or `Failure`.
+     * If the command is not found or fails validation, a warning message will be logged but the resource will be allowed to attempt to start.
+     * @param command The command string (file name or path) that should be validated.
+     * @param validationCallback A callback that validates the resolved command path. Receives a `RequiredCommandValidationContext` and returns a `RequiredCommandValidationResult`.
+     * @param options Additional options.
+     * @returns The resource builder.
+     */
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ResourcePromise {
+        const helpLink = options?.helpLink;
+        return new ResourcePromiseImpl(this._withRequiredCommandValidationInternal(command, validationCallback, helpLink), this._client);
     }
 
     /** @internal */
@@ -52525,6 +56528,41 @@ class ResourceImpl extends ResourceBuilderBase<IResourceHandle> implements Resou
     }
 
     /** @internal */
+    private async _subscribeHttpsEndpointsUpdateInternal(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): Promise<Resource> {
+        const callbackId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as HttpsEndpointUpdateCallbackContextHandle;
+            const obj = new HttpsEndpointUpdateCallbackContextImpl(objHandle, this._client);
+            await callback(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<IResourceHandle>(
+            'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
+            rpcArgs
+        );
+        return new ResourceImpl(result, this._client);
+    }
+
+    /**
+     * Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup.
+     *
+     * The callback is invoked when either:
+     * -
+     * -
+     * Switch an endpoint to HTTPS when a certificate is available:
+     * ```
+     * builder.SubscribeHttpsEndpointsUpdate(ctx =>
+     * {
+     * builder.WithEndpoint("http", ep => ep.UriScheme = "https");
+     * });
+     * ```
+     * @param callback The callback to invoke when HTTPS is enabled. Receives an `HttpsEndpointUpdateCallbackContext` providing access to the service provider, resource, and application model.
+     * @returns The updated resource builder.
+     */
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ResourcePromise {
+        return new ResourcePromiseImpl(this._subscribeHttpsEndpointsUpdateInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _withRelationshipInternal(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): Promise<Resource> {
         resourceBuilder = isPromiseLike(resourceBuilder) ? await resourceBuilder : resourceBuilder;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, resourceBuilder, type };
@@ -52857,6 +56895,30 @@ class ResourceImpl extends ResourceBuilderBase<IResourceHandle> implements Resou
             return new ExecutionConfigurationBuilderImpl(handle, this._client);
         })();
         return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
+    }
+
+    /** @internal */
+    private async _withContainerBuildOptionsInternal(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): Promise<Resource> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as ContainerBuildOptionsCallbackContextHandle;
+            const arg = new ContainerBuildOptionsCallbackContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<IResourceHandle>(
+            'Aspire.Hosting/withContainerBuildOptions',
+            rpcArgs
+        );
+        return new ResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures container build options for a compute resource using an async callback.
+     * @param callback An async callback to configure container build options.
+     * @returns A reference to the `IResourceBuilder`1`.
+     */
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ResourcePromise {
+        return new ResourcePromiseImpl(this._withContainerBuildOptionsInternal(callback), this._client);
     }
 
     /** @internal */
@@ -53263,6 +57325,10 @@ class ResourcePromiseImpl implements ResourcePromise {
         return new ResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommand(command, options)), this._client);
     }
 
+    withRequiredCommandValidation(command: string, validationCallback: (arg: RequiredCommandValidationContext) => Promise<RequiredCommandValidationResult>, options?: WithRequiredCommandValidationOptions): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.withRequiredCommandValidation(command, validationCallback, options)), this._client);
+    }
+
     withSessionLifetime(): ResourcePromise {
         return new ResourcePromiseImpl(this._promise.then(obj => obj.withSessionLifetime()), this._client);
     }
@@ -53313,6 +57379,10 @@ class ResourcePromiseImpl implements ResourcePromise {
 
     withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): ResourcePromise {
         return new ResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommandFactory(commandName, displayName, createProcessSpec, options)), this._client);
+    }
+
+    subscribeHttpsEndpointsUpdate(callback: (obj: HttpsEndpointUpdateCallbackContext) => Promise<void>): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.subscribeHttpsEndpointsUpdate(callback)), this._client);
     }
 
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeEnvironmentResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ResourcePromise {
@@ -53373,6 +57443,10 @@ class ResourcePromiseImpl implements ResourcePromise {
 
     createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
         return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
+    }
+
+    withContainerBuildOptions(callback: (arg: ContainerBuildOptionsCallbackContext) => Promise<void>): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.withContainerBuildOptions(callback)), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ResourcePromise {
@@ -54709,6 +58783,23 @@ export interface ResourceWithEnvironment {
      * @returns The resource builder.
      */
     withoutHttpsCertificate(): ResourceWithEnvironmentPromise;
+    /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ResourceWithEnvironmentPromise;
     /** Configures environment with callback (test version) */
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): ResourceWithEnvironmentPromise;
     /** Sets environment variables */
@@ -54807,6 +58898,23 @@ export interface ResourceWithEnvironmentPromise extends PromiseLike<ResourceWith
      * @returns The resource builder.
      */
     withoutHttpsCertificate(): ResourceWithEnvironmentPromise;
+    /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ResourceWithEnvironmentPromise;
     /** Configures environment with callback (test version) */
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): ResourceWithEnvironmentPromise;
     /** Sets environment variables */
@@ -55050,6 +59158,41 @@ class ResourceWithEnvironmentImpl extends ResourceBuilderBase<IResourceWithEnvir
     }
 
     /** @internal */
+    private async _withHttpsCertificateConfigurationInternal(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): Promise<ResourceWithEnvironment> {
+        const callbackId = registerCallback(async (argData: unknown) => {
+            const argHandle = wrapIfHandle(argData) as HttpsCertificateConfigurationCallbackAnnotationContextHandle;
+            const arg = new HttpsCertificateConfigurationCallbackAnnotationContextImpl(argHandle, this._client);
+            await callback(arg);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, callback: callbackId };
+        const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
+            'Aspire.Hosting/withHttpsCertificateConfiguration',
+            rpcArgs
+        );
+        return new ResourceWithEnvironmentImpl(result, this._client);
+    }
+
+    /**
+     * Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication.
+     *
+     * Pass the path to the PFX certificate file to the container arguments.
+     * ```
+     * builder.AddContainer("my-service", "my-image")
+     * .WithHttpsCertificateConfiguration(ctx =>
+     * {
+     * ctx.Arguments.Add("--https-certificate-path");
+     * ctx.Arguments.Add(ctx.PfxPath);
+     * return Task.CompletedTask;
+     * });
+     * ```
+     * @param callback The callback to configure the resource to use a certificate key pair.
+     * @returns The updated resource builder.
+     */
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ResourceWithEnvironmentPromise {
+        return new ResourceWithEnvironmentPromiseImpl(this._withHttpsCertificateConfigurationInternal(callback), this._client);
+    }
+
+    /** @internal */
     private async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<ResourceWithEnvironment> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestEnvironmentContextHandle;
@@ -55137,6 +59280,10 @@ class ResourceWithEnvironmentPromiseImpl implements ResourceWithEnvironmentPromi
 
     withoutHttpsCertificate(): ResourceWithEnvironmentPromise {
         return new ResourceWithEnvironmentPromiseImpl(this._promise.then(obj => obj.withoutHttpsCertificate()), this._client);
+    }
+
+    withHttpsCertificateConfiguration(callback: (arg: HttpsCertificateConfigurationCallbackAnnotationContext) => Promise<void>): ResourceWithEnvironmentPromise {
+        return new ResourceWithEnvironmentPromiseImpl(this._promise.then(obj => obj.withHttpsCertificateConfiguration(callback)), this._client);
     }
 
     testWithEnvironmentCallback(callback: (arg: TestEnvironmentContext) => Promise<void>): ResourceWithEnvironmentPromise {
@@ -55440,6 +59587,8 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeStar
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext', (handle, client) => new CommandLineArgsCallbackContextImpl(handle as CommandLineArgsCallbackContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsEditor', (handle, client) => new CommandLineArgsEditorImpl(handle as CommandLineArgsEditorHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent', (handle, client) => new ConnectionStringAvailableEventImpl(handle as ConnectionStringAvailableEventHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerBuildOptionsCallbackContext', (handle, client) => new ContainerBuildOptionsCallbackContextImpl(handle as ContainerBuildOptionsCallbackContextHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemCallbackContext', (handle, client) => new ContainerFileSystemCallbackContextImpl(handle as ContainerFileSystemCallbackContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptions', (handle, client) => new ContainerImagePushOptionsImpl(handle as ContainerImagePushOptionsHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext', (handle, client) => new ContainerImagePushOptionsCallbackContextImpl(handle as ContainerImagePushOptionsCallbackContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImageReference', (handle, client) => new ContainerImageReferenceImpl(handle as ContainerImageReferenceHandle, client));
@@ -55460,6 +59609,8 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.Environmen
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext', (handle, client) => new EventingSubscriberRegistrationContextImpl(handle as EventingSubscriberRegistrationContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext', (handle, client) => new ExecuteCommandContextImpl(handle as ExecuteCommandContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpCommandPrepareRequestContext', (handle, client) => new HttpCommandPrepareRequestContextImpl(handle as HttpCommandPrepareRequestContextHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext', (handle, client) => new HttpsCertificateConfigurationCallbackAnnotationContextImpl(handle as HttpsCertificateConfigurationCallbackAnnotationContextHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsEndpointUpdateCallbackContext', (handle, client) => new HttpsEndpointUpdateCallbackContextImpl(handle as HttpsEndpointUpdateCallbackContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent', (handle, client) => new InitializeResourceEventImpl(handle as InitializeResourceEventHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.InputsDialogValidationContext', (handle, client) => new InputsDialogValidationContextImpl(handle as InputsDialogValidationContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.LogFacade', (handle, client) => new LogFacadeImpl(handle as LogFacadeHandle, client));
@@ -55472,6 +59623,8 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineStepFacto
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineSummary', (handle, client) => new PipelineSummaryImpl(handle as PipelineSummaryHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ProjectResourceOptions', (handle, client) => new ProjectResourceOptionsImpl(handle as ProjectResourceOptionsHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpressionBuilder', (handle, client) => new ReferenceExpressionBuilderImpl(handle as ReferenceExpressionBuilderHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationContext', (handle, client) => new RequiredCommandValidationContextImpl(handle as RequiredCommandValidationContextHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationResult', (handle, client) => new RequiredCommandValidationResultImpl(handle as RequiredCommandValidationResultHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceCommandService', (handle, client) => new ResourceCommandServiceImpl(handle as ResourceCommandServiceHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceEndpointsAllocatedEvent', (handle, client) => new ResourceEndpointsAllocatedEventImpl(handle as ResourceEndpointsAllocatedEventHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceLoggerService', (handle, client) => new ResourceLoggerServiceImpl(handle as ResourceLoggerServiceHandle, client));

--- a/tests/Aspire.Hosting.Containers.Tests/ContainerFileSystemCallbackContextTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/ContainerFileSystemCallbackContextTests.cs
@@ -13,7 +13,7 @@ public class ContainerFileSystemCallbackContextTests
         return new ContainerFileSystemCallbackContext
         {
             Model = new ContainerResource("test"),
-            ServiceProvider = new ServiceCollection().BuildServiceProvider(),
+            Services = new ServiceCollection().BuildServiceProvider(),
         };
     }
 

--- a/tests/Aspire.Hosting.Containers.Tests/ContainerFileSystemCallbackContextTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/ContainerFileSystemCallbackContextTests.cs
@@ -134,4 +134,20 @@ public class ContainerFileSystemCallbackContextTests
 
         Assert.Throws<ArgumentNullException>(() => context.CreateDirectory("conf.d", entries: null!));
     }
+
+    [Fact]
+    public void CreateFileWithBothContentsAndSourcePathThrows()
+    {
+        var context = CreateContext();
+
+        Assert.Throws<ArgumentException>(() => context.CreateFile("app.conf", contents: "key=value", sourcePath: "/host/app.conf"));
+    }
+
+    [Fact]
+    public void CreateCertificateFileWithBothContentsAndSourcePathThrows()
+    {
+        var context = CreateContext();
+
+        Assert.Throws<ArgumentException>(() => context.CreateCertificateFile("server.pem", contents: "-----BEGIN CERTIFICATE-----", sourcePath: "/host/server.pem"));
+    }
 }

--- a/tests/Aspire.Hosting.Containers.Tests/ContainerFileSystemCallbackContextTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/ContainerFileSystemCallbackContextTests.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Containers.Tests;
+
+public class ContainerFileSystemCallbackContextTests
+{
+    private static ContainerFileSystemCallbackContext CreateContext()
+    {
+        return new ContainerFileSystemCallbackContext
+        {
+            Model = new ContainerResource("test"),
+            ServiceProvider = new ServiceCollection().BuildServiceProvider(),
+        };
+    }
+
+    [Fact]
+    public void CreateFileProducesContainerFileWithInlineContents()
+    {
+        var context = CreateContext();
+
+        var item = context.CreateFile("app.conf", contents: "key=value", mode: 420 /* 0o644 */, owner: 1000, group: 1000, continueOnError: true);
+
+        var file = Assert.IsType<ContainerFile>(item);
+        Assert.Equal("app.conf", file.Name);
+        Assert.Equal("key=value", file.Contents);
+        Assert.Null(file.SourcePath);
+        Assert.Equal((UnixFileMode)420 /* 0o644 */, file.Mode);
+        Assert.Equal(1000, file.Owner);
+        Assert.Equal(1000, file.Group);
+        Assert.True(file.ContinueOnError);
+    }
+
+    [Fact]
+    public void CreateFileProducesContainerFileWithSourcePath()
+    {
+        var context = CreateContext();
+
+        var item = context.CreateFile("app.conf", sourcePath: "/host/app.conf");
+
+        var file = Assert.IsType<ContainerFile>(item);
+        Assert.Equal("/host/app.conf", file.SourcePath);
+        Assert.Null(file.Contents);
+        // A null mode is converted to UnixFileMode 0, which means "inherit".
+        Assert.Equal((UnixFileMode)0, file.Mode);
+    }
+
+    [Fact]
+    public void CreateCertificateFileProducesContainerOpenSSLCertificateFile()
+    {
+        var context = CreateContext();
+
+        var item = context.CreateCertificateFile("server.pem", contents: "-----BEGIN CERTIFICATE-----");
+
+        var cert = Assert.IsType<ContainerOpenSSLCertificateFile>(item);
+        Assert.Equal("server.pem", cert.Name);
+        Assert.Equal("-----BEGIN CERTIFICATE-----", cert.Contents);
+    }
+
+    [Fact]
+    public void CreateDirectoryProducesContainerDirectoryWithEntries()
+    {
+        var context = CreateContext();
+
+        var child = context.CreateFile("nested.conf", contents: "nested=true");
+        var item = context.CreateDirectory("conf.d", [child], mode: 493 /* 0o755 */);
+
+        var directory = Assert.IsType<ContainerDirectory>(item);
+        Assert.Equal("conf.d", directory.Name);
+        Assert.Equal((UnixFileMode)493 /* 0o755 */, directory.Mode);
+        var entry = Assert.Single(directory.Entries);
+        Assert.Same(child, entry);
+    }
+
+    [Fact]
+    public void CreateDirectoryMaterializesLazyEntries()
+    {
+        var context = CreateContext();
+
+        var evaluationCount = 0;
+        IEnumerable<ContainerFileSystemItem> LazyEntries()
+        {
+            evaluationCount++;
+            yield return context.CreateFile("nested.conf", contents: "nested=true");
+        }
+
+        var item = context.CreateDirectory("conf.d", LazyEntries());
+
+        // The directory factory eagerly materializes the sequence so a lazily-resolved
+        // handle sequence is captured at call time rather than on later enumeration.
+        Assert.Equal(1, evaluationCount);
+        var directory = Assert.IsType<ContainerDirectory>(item);
+        Assert.Single(directory.Entries);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0x1000)]
+    public void CreateFileWithOutOfRangeModeThrows(int mode)
+    {
+        var context = CreateContext();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => context.CreateFile("app.conf", mode: mode));
+    }
+
+    [Fact]
+    public void CreateFileWithMaximumModeSucceeds()
+    {
+        var context = CreateContext();
+
+        var item = context.CreateFile("app.conf", mode: 4095 /* 0o7777 */);
+
+        var file = Assert.IsType<ContainerFile>(item);
+        Assert.Equal((UnixFileMode)4095 /* 0o7777 */, file.Mode);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void CreateFileWithInvalidNameThrows(string name)
+    {
+        var context = CreateContext();
+
+        Assert.Throws<ArgumentException>(() => context.CreateFile(name));
+    }
+
+    [Fact]
+    public void CreateDirectoryWithNullEntriesThrows()
+    {
+        var context = CreateContext();
+
+        Assert.Throws<ArgumentNullException>(() => context.CreateDirectory("conf.d", entries: null!));
+    }
+}

--- a/tests/Aspire.Hosting.Tests/RequiredCommandAnnotationTests.cs
+++ b/tests/Aspire.Hosting.Tests/RequiredCommandAnnotationTests.cs
@@ -468,6 +468,30 @@ public class RequiredCommandAnnotationTests
         Assert.False(testInteractionService.Interactions.Reader.TryRead(out _));
     }
 
+    [Fact]
+    public void RequiredCommandValidationContext_Success_ReturnsValidResult()
+    {
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var context = new RequiredCommandValidationContext("/usr/bin/test", services, CancellationToken.None);
+
+        var result = context.Success();
+
+        Assert.True(result.IsValid);
+        Assert.Null(result.ValidationMessage);
+    }
+
+    [Fact]
+    public void RequiredCommandValidationContext_Failure_ReturnsInvalidResultWithMessage()
+    {
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var context = new RequiredCommandValidationContext("/usr/bin/test", services, CancellationToken.None);
+
+        var result = context.Failure("command is too old");
+
+        Assert.False(result.IsValid);
+        Assert.Equal("command is too old", result.ValidationMessage);
+    }
+
     /// <summary>
     /// Helper method to subscribe all eventing subscribers (including RequiredCommandValidationEventingSubscriber)
     /// to the eventing system. This simulates what happens during app.StartAsync().

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Go/apphost.go
@@ -168,6 +168,26 @@ ENTRYPOINT ["dotnet", "App.dll"]
 		},
 	})
 
+	// WithContainerFilesCallback — build entries dynamically via the context factory methods
+	container.WithContainerFilesCallback("/usr/lib/aspire/container-files", func(filesCtx aspire.ContainerFileSystemCallbackContext, _ *aspire.CancellationToken) []aspire.ContainerFileSystemItem {
+		filesServices := filesCtx.Services()
+		filesLoggerFactory := filesServices.GetLoggerFactory()
+		filesLogger := filesLoggerFactory.CreateLogger("ValidationAppHost.ContainerFilesCallback")
+		_ = filesLogger.LogInformation("ContainerFilesCallback services")
+
+		appConfig := filesCtx.CreateFile("app.conf", &aspire.CreateFileOptions{Contents: aspire.StringPtr("key=value"), Mode: aspire.Float64Ptr(0o644)})
+		nestedConfig := filesCtx.CreateFile("nested.conf", &aspire.CreateFileOptions{Contents: aspire.StringPtr("nested=true")})
+		confDir := filesCtx.CreateDirectory("conf.d", []aspire.ContainerFileSystemItem{nestedConfig}, &aspire.CreateDirectoryOptions{Mode: aspire.Float64Ptr(0o755)})
+		cert := filesCtx.CreateCertificateFile("server.pem", &aspire.CreateCertificateFileOptions{Contents: aspire.StringPtr("-----BEGIN CERTIFICATE-----")})
+		return []aspire.ContainerFileSystemItem{appConfig, confDir, cert}
+	}, &aspire.WithContainerFilesCallbackOptions{
+		Options: &aspire.ContainerFilesOptions{
+			DefaultOwner: aspire.Float64Ptr(1000),
+			DefaultGroup: aspire.Float64Ptr(1000),
+			Umask:        aspire.Float64Ptr(0o022),
+		},
+	})
+
 	// WithImageRegistry
 	container.WithImageRegistry("docker.io")
 
@@ -281,6 +301,15 @@ ENTRYPOINT ["dotnet", "App.dll"]
 
 	// WithRequiredCommand
 	container.WithRequiredCommand("docker")
+
+	// WithRequiredCommandValidation
+	container.WithRequiredCommandValidation("docker", func(validationCtx aspire.RequiredCommandValidationContext) aspire.RequiredCommandValidationResult {
+		validationServices := validationCtx.Services()
+		validationLoggerFactory := validationServices.GetLoggerFactory()
+		validationLogger := validationLoggerFactory.CreateLogger("ValidationAppHost.RequiredCommandValidation")
+		_ = validationLogger.LogInformation("RequiredCommandValidation services")
+		return validationCtx.Success()
+	})
 
 	// ===================================================================
 	// DotnetToolResourceExtensions — all With-tool methods are fluent
@@ -550,6 +579,10 @@ ENTRYPOINT ["dotnet", "App.dll"]
 		if !ok {
 			return aspire.ResourceCommandStateDisabled
 		}
+		updateStateServices := ctx.Services()
+		updateStateLoggerFactory := updateStateServices.GetLoggerFactory()
+		updateStateLogger := updateStateLoggerFactory.CreateLogger("ValidationAppHost.UpdateCommandState")
+		_ = updateStateLogger.LogInformation("UpdateCommandState services")
 		snapshot, err := ctx.ResourceSnapshot()
 		if err != nil || snapshot.HealthStatus == nil {
 			return aspire.ResourceCommandStateDisabled
@@ -566,7 +599,25 @@ ENTRYPOINT ["dotnet", "App.dll"]
 			UpdateState: updateCommandState,
 		},
 	})
+	validateCommandArguments := func(args ...any) any {
+		if len(args) == 0 {
+			return nil
+		}
+		ctx, ok := args[0].(aspire.InputsDialogValidationContext)
+		if !ok {
+			return nil
+		}
+		validationServices := ctx.Services()
+		validationLoggerFactory := validationServices.GetLoggerFactory()
+		validationLogger := validationLoggerFactory.CreateLogger("ValidationAppHost.ValidateCommandArguments")
+		_ = validationLogger.LogInformation("Validate command arguments services")
+		return nil
+	}
 	_ = container.WithCommand("echo", "Echo", func(ctx aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
+		echoServices := ctx.Services()
+		echoLoggerFactory := echoServices.GetLoggerFactory()
+		echoLogger := echoLoggerFactory.CreateLogger("ValidationAppHost.EchoCommand")
+		_ = echoLogger.LogInformation("Echo command services")
 		commandArguments, err := ctx.Arguments().ToArray()
 		if err != nil {
 			return &aspire.ExecuteCommandResult{Success: false, ErrorMessage: aspire.StringPtr(aspire.FormatError(err))}
@@ -581,6 +632,7 @@ ENTRYPOINT ["dotnet", "App.dll"]
 					Required:  aspire.BoolPtr(true),
 				},
 			},
+			ValidateArguments: validateCommandArguments,
 		},
 	})
 	_ = container.WithCommand("restart", "Restart", func(ctx aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
@@ -594,6 +646,39 @@ ENTRYPOINT ["dotnet", "App.dll"]
 		}
 
 		return result
+	})
+
+	container.WithHttpsCertificateConfiguration(func(certCtx aspire.HttpsCertificateConfigurationCallbackAnnotationContext) {
+		certificatePath := certCtx.CertificatePath()
+		keyPath := certCtx.KeyPath()
+		certArgs := certCtx.Arguments()
+		_ = certArgs.Add("--certificate")
+		_ = certArgs.Add(certificatePath)
+		_ = certArgs.Add("--key")
+		_ = certArgs.Add(keyPath)
+		certEnv := certCtx.Environment()
+		_ = certEnv.Set("Kestrel__Certificates__Path", certificatePath)
+		_ = certEnv.Set("Kestrel__Certificates__KeyPath", keyPath)
+	})
+
+	_ = container.SubscribeHttpsEndpointsUpdate(func(httpsCtx aspire.HttpsEndpointUpdateCallbackContext) {
+		httpsServices := httpsCtx.Services()
+		httpsLoggerFactory := httpsServices.GetLoggerFactory()
+		httpsLogger := httpsLoggerFactory.CreateLogger("ValidationAppHost.HttpsEndpointsUpdate")
+		_ = httpsLogger.LogInformation("HttpsEndpointsUpdate services")
+	})
+
+	_ = container.WithContainerBuildOptions(func(buildCtx aspire.ContainerBuildOptionsCallbackContext) {
+		buildCtx.SetDestination(aspire.ContainerImageDestinationRegistry).
+			SetImageFormat(aspire.ContainerImageFormatOci).
+			SetTargetPlatform(aspire.ContainerTargetPlatformLinuxAmd64).
+			SetOutputPath("./artifacts/container-image").
+			SetLocalImageName("validation-image").
+			SetLocalImageTag("latest")
+		buildServices := buildCtx.Services()
+		buildLoggerFactory := buildServices.GetLoggerFactory()
+		buildLogger := buildLoggerFactory.CreateLogger("ValidationAppHost.ContainerBuildOptions")
+		_ = buildLogger.LogInformation("ContainerBuildOptions services")
 	})
 
 	app, err := builder.Build()

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
@@ -73,6 +73,21 @@ void main() throws Exception {
         containerFilesOptions.setDefaultGroup(1000.0);
         containerFilesOptions.setUmask(18.0);
         container.withContainerFiles("/usr/lib/aspire/container-files", ".", containerFilesOptions);
+        var callbackContainerFilesOptions = new ContainerFilesOptions();
+        callbackContainerFilesOptions.setDefaultOwner(1000.0);
+        callbackContainerFilesOptions.setDefaultGroup(1000.0);
+        callbackContainerFilesOptions.setUmask(18.0);
+        container.withContainerFilesCallback("/usr/lib/aspire/container-files", (filesCtx, filesCancellationToken) -> {
+            var filesServices = filesCtx.services();
+            var filesLoggerFactory = filesServices.getLoggerFactory();
+            var filesLogger = filesLoggerFactory.createLogger("ValidationAppHost.ContainerFilesCallback");
+            filesLogger.logInformation("ContainerFilesCallback services");
+            var appConfig = filesCtx.createFile("app.conf", new CreateFileOptions().contents("key=value").mode(420.0));
+            var nestedConfig = filesCtx.createFile("nested.conf", new CreateFileOptions().contents("nested=true"));
+            var confDir = filesCtx.createDirectory("conf.d", new ContainerFileSystemItem[] { nestedConfig }, new CreateDirectoryOptions().mode(493.0));
+            var cert = filesCtx.createCertificateFile("server.pem", new CreateCertificateFileOptions().contents("-----BEGIN CERTIFICATE-----"));
+            return new ContainerFileSystemItem[] { appConfig, confDir, cert };
+        }, callbackContainerFilesOptions);
         container.withImageRegistry("docker.io");
         dockerContainer.withHttpEndpoint(new WithHttpEndpointOptions().name("http").targetPort(80.0));
         dockerContainer.withHttpEndpointCallback((updateContext) -> { updateContext.setPort(8080.0); updateContext.setIsProxied(false); }, new WithHttpEndpointCallbackOptions().name("http").createIfNotExists(false));
@@ -129,6 +144,14 @@ void main() throws Exception {
         });
         container.withMcpServer(new WithMcpServerOptions().path("/mcp"));
         container.withRequiredCommand("docker");
+        container.withRequiredCommandValidation("docker", (validationCtx) -> {
+            var _validationResolvedPath = validationCtx.resolvedPath();
+            var validationServices = validationCtx.services();
+            var validationLoggerFactory = validationServices.getLoggerFactory();
+            var validationLogger = validationLoggerFactory.createLogger("ValidationAppHost.RequiredCommandValidation");
+            validationLogger.logInformation("RequiredCommandValidation services");
+            return validationCtx.success();
+        });
         tool.withToolIgnoreExistingFeeds();
         tool.withToolIgnoreFailedSources();
         tool.withToolPackage("dotnet-ef");
@@ -248,6 +271,10 @@ void main() throws Exception {
         var commandOptions = new CommandOptions();
         commandOptions.setUpdateState((Function<UpdateCommandStateContext, ResourceCommandState>) (ctx) -> {
             var snapshot = ctx.resourceSnapshot();
+            var updateStateServices = ctx.services();
+            var updateStateLoggerFactory = updateStateServices.getLoggerFactory();
+            var updateStateLogger = updateStateLoggerFactory.createLogger("ValidationAppHost.UpdateCommandState");
+            updateStateLogger.logInformation("UpdateCommandState services");
             return snapshot.getHealthStatus() == HealthStatus.HEALTHY ? ResourceCommandState.ENABLED : ResourceCommandState.DISABLED;
         });
         container.withCommand("noop", "Noop", (_ctx) -> {
@@ -261,8 +288,19 @@ void main() throws Exception {
         messageArgument.setInputType(InputType.TEXT);
         messageArgument.setRequired(true);
         echoCommandOptions.setArguments(new InteractionInput[] { messageArgument });
+        echoCommandOptions.setValidateArguments((Function<InputsDialogValidationContext, Object>) (ctx) -> {
+            var validationServices = ctx.services();
+            var validationLoggerFactory = validationServices.getLoggerFactory();
+            var validationLogger = validationLoggerFactory.createLogger("ValidationAppHost.ValidateCommandArguments");
+            validationLogger.logInformation("Validate command arguments services");
+            return null;
+        });
         container.withCommand("echo", "Echo", (ctx) -> {
             var commandArguments = ctx.arguments().toArray();
+            var echoServices = ctx.services();
+            var echoLoggerFactory = echoServices.getLoggerFactory();
+            var echoLogger = echoLoggerFactory.createLogger("ValidationAppHost.EchoCommand");
+            echoLogger.logInformation("Echo command services");
             var result = new ExecuteCommandResult();
             result.setSuccess("hello".equals(commandArguments[0].getValue()));
             return result;
@@ -277,6 +315,42 @@ void main() throws Exception {
                     .cancellationToken(cancellationToken));
         });
         container.withHealthCheck("custom_check");
+        container.withHttpsCertificateConfiguration((certCtx) -> {
+            var _certResource = certCtx.resource();
+            var _certIsRunMode = certCtx.executionContext().isRunMode();
+            var certificatePath = certCtx.certificatePath();
+            var keyPath = certCtx.keyPath();
+            var certArgs = certCtx.arguments();
+            certArgs.add("--certificate");
+            certArgs.add(certificatePath);
+            certArgs.add("--key");
+            certArgs.add(keyPath);
+            var certEnv = certCtx.environment();
+            certEnv.set("Kestrel__Certificates__Path", certificatePath);
+            certEnv.set("Kestrel__Certificates__KeyPath", keyPath);
+        });
+        container.subscribeHttpsEndpointsUpdate((httpsCtx) -> {
+            var _httpsResource = httpsCtx.resource();
+            var _httpsModel = httpsCtx.model();
+            var httpsServices = httpsCtx.services();
+            var httpsLoggerFactory = httpsServices.getLoggerFactory();
+            var httpsLogger = httpsLoggerFactory.createLogger("ValidationAppHost.HttpsEndpointsUpdate");
+            httpsLogger.logInformation("HttpsEndpointsUpdate services");
+        });
+        container.withContainerBuildOptions((buildCtx) -> {
+            buildCtx.setDestination(ContainerImageDestination.REGISTRY);
+            buildCtx.setImageFormat(ContainerImageFormat.OCI);
+            buildCtx.setTargetPlatform(ContainerTargetPlatform.LINUX_AMD64);
+            buildCtx.setOutputPath("./artifacts/container-image");
+            buildCtx.setLocalImageName("validation-image");
+            buildCtx.setLocalImageTag("latest");
+            var _buildResource = buildCtx.resource();
+            var _buildExecutionContext = buildCtx.executionContext();
+            var buildServices = buildCtx.services();
+            var buildLoggerFactory = buildServices.getLoggerFactory();
+            var buildLogger = buildLoggerFactory.createLogger("ValidationAppHost.ContainerBuildOptions");
+            buildLogger.logInformation("ContainerBuildOptions services");
+        });
         container.withHttpCommand("/health", "Health Check");
         var httpCmdOptions = new HttpCommandExportOptions();
         httpCmdOptions.setMethodName("POST");

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
@@ -300,7 +300,7 @@ ENTRYPOINT ["dotnet", "App.dll"]"""
         validation_logger.log_information("RequiredCommandValidation services")
         return validation_ctx.success()
 
-    container.with_required_command("docker", validation_callback=required_command_validation)
+    container.with_required_command_validation("docker", required_command_validation)
     # withToolIgnoreExistingFeeds
     tool.with_tool_ignore_existing_feeds()
     # withToolIgnoreFailedSources

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
@@ -150,6 +150,28 @@ ENTRYPOINT ["dotnet", "App.dll"]"""
             "Umask": 0o022,
         },
     )
+
+    # withContainerFilesCallback — build entries dynamically via the context factory methods
+    def container_files_callback(files_ctx, files_cancellation_token):
+        files_services = files_ctx.services
+        files_logger_factory = files_services.get_logger_factory()
+        files_logger = files_logger_factory.create_logger("ValidationAppHost.ContainerFilesCallback")
+        files_logger.log_information("ContainerFilesCallback services")
+        app_config = files_ctx.create_file("app.conf", contents="key=value", mode=0o644)
+        nested_config = files_ctx.create_file("nested.conf", contents="nested=true")
+        conf_dir = files_ctx.create_dir("conf.d", [nested_config], mode=0o755)
+        cert = files_ctx.create_certificate_file("server.pem", contents="-----BEGIN CERTIFICATE-----")
+        return [app_config, conf_dir, cert]
+
+    container.with_container_files_callback(
+        "/usr/lib/aspire/container-files",
+        container_files_callback,
+        options={
+            "DefaultOwner": 1000,
+            "DefaultGroup": 1000,
+            "Umask": 0o022,
+        },
+    )
     # withImageRegistry
     container.with_image_registry("docker.io")
     # ===================================================================
@@ -269,6 +291,16 @@ ENTRYPOINT ["dotnet", "App.dll"]"""
     container.with_mcp_server()
     # withRequiredCommand
     container.with_required_command("docker")
+
+    def required_command_validation(validation_ctx):
+        _validation_resolved_path = validation_ctx.resolved_path
+        validation_services = validation_ctx.services
+        validation_logger_factory = validation_services.get_logger_factory()
+        validation_logger = validation_logger_factory.create_logger("ValidationAppHost.RequiredCommandValidation")
+        validation_logger.log_information("RequiredCommandValidation services")
+        return validation_ctx.success()
+
+    container.with_required_command("docker", validation_callback=required_command_validation)
     # withToolIgnoreExistingFeeds
     tool.with_tool_ignore_existing_feeds()
     # withToolIgnoreFailedSources
@@ -426,11 +458,26 @@ ENTRYPOINT ["dotnet", "App.dll"]"""
     # withCommand
     def update_command_state(ctx):
         snapshot = ctx.resource_snapshot
+        update_state_services = ctx.services
+        update_state_logger_factory = update_state_services.get_logger_factory()
+        update_state_logger = update_state_logger_factory.create_logger("ValidationAppHost.UpdateCommandState")
+        update_state_logger.log_information("UpdateCommandState services")
         return "Enabled" if snapshot.get("HealthStatus") == "Healthy" else "Disabled"
 
     def echo_command(ctx):
         command_arguments = list(ctx.arguments.to_array())
+        echo_services = ctx.services
+        echo_logger_factory = echo_services.get_logger_factory()
+        echo_logger = echo_logger_factory.create_logger("ValidationAppHost.EchoCommand")
+        echo_logger.log_information("Echo command services")
         return {"success": command_arguments[0]["Value"] == "hello"}
+
+    def validate_command_arguments(ctx):
+        validation_services = ctx.services
+        validation_logger_factory = validation_services.get_logger_factory()
+        validation_logger = validation_logger_factory.create_logger("ValidationAppHost.ValidateCommandArguments")
+        validation_logger.log_information("Validate command arguments services")
+        return None
 
     container.with_command(
         "noop",
@@ -446,9 +493,48 @@ ENTRYPOINT ["dotnet", "App.dll"]"""
         "echo",
         "Echo",
         echo_command,
-        command_options={"Arguments": [{"Name": "message", "InputType": "Text", "Required": True}]}
+        command_options={"Arguments": [{"Name": "message", "InputType": "Text", "Required": True}], "ValidateArguments": validate_command_arguments}
     )
     container.with_command("restart", "Restart", restart_command)
+
+    def https_endpoints_update(https_ctx):
+        _https_resource = https_ctx.resource
+        _https_model = https_ctx.model
+        https_services = https_ctx.services
+        https_logger_factory = https_services.get_logger_factory()
+        https_logger = https_logger_factory.create_logger("ValidationAppHost.HttpsEndpointsUpdate")
+        https_logger.log_information("HttpsEndpointsUpdate services")
+
+    def https_certificate_configuration(cert_ctx):
+        _cert_resource = cert_ctx.resource
+        certificate_path = cert_ctx.certificate_path
+        key_path = cert_ctx.key_path
+        cert_ctx.arguments.add("--certificate")
+        cert_ctx.arguments.add(certificate_path)
+        cert_ctx.arguments.add("--key")
+        cert_ctx.arguments.add(key_path)
+        cert_ctx.env.set("Kestrel__Certificates__Path", certificate_path)
+        cert_ctx.env.set("Kestrel__Certificates__KeyPath", key_path)
+
+    container.with_https_certificate_config(https_certificate_configuration)
+
+    container.subscribe_https_endpoints_update(https_endpoints_update)
+
+    def container_build_options(build_ctx):
+        build_ctx.destination = "Registry"
+        build_ctx.image_format = "Oci"
+        build_ctx.target_platform = "LinuxAmd64"
+        build_ctx.output_path = "./artifacts/container-image"
+        build_ctx.local_image_name = "validation-image"
+        build_ctx.local_image_tag = "latest"
+        _build_resource = build_ctx.resource
+        _build_execution_context = build_ctx.execution_context
+        build_services = build_ctx.services
+        build_logger_factory = build_services.get_logger_factory()
+        build_logger = build_logger_factory.create_logger("ValidationAppHost.ContainerBuildOptions")
+        build_logger.log_information("ContainerBuildOptions services")
+
+    container.with_container_build_options(container_build_options)
     # withHttpCommand
     container.with_http_command("/health", "Health Check")
     container.with_http_command("/api/reset", "Reset", options={"MethodName": "POST", "ConfirmationMessage": "Are you sure?"})

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
@@ -5,6 +5,9 @@ import {
     WellKnownPipelineTags,
     createBuilder,
     CertificateTrustScope,
+    ContainerImageDestination,
+    ContainerImageFormat,
+    ContainerTargetPlatform,
     EndpointProperty,
     HealthStatus,
     IconVariant,
@@ -160,6 +163,20 @@ await container.withContainerFiles("/usr/lib/aspire/container-files", ".", {
     defaultGroup: 1000,
     umask: 0o022,
 });
+
+// withContainerFilesCallback — build entries dynamically via the context factory methods
+await container.withContainerFilesCallback("/usr/lib/aspire/container-files", async (filesCtx) => {
+    const filesServices = await filesCtx.services();
+    const filesLoggerFactory = await filesServices.getLoggerFactory();
+    const filesLogger = await filesLoggerFactory.createLogger("ValidationAppHost.ContainerFilesCallback");
+    await filesLogger.logInformation("ContainerFilesCallback services");
+
+    const appConfig = await filesCtx.createFile("app.conf", { contents: "key=value", mode: 0o644 });
+    const nestedConfig = await filesCtx.createFile("nested.conf", { contents: "nested=true" });
+    const confDir = await filesCtx.createDirectory("conf.d", [nestedConfig], { mode: 0o755 });
+    const cert = await filesCtx.createCertificateFile("server.pem", { contents: "-----BEGIN CERTIFICATE-----" });
+    return [appConfig, confDir, cert];
+}, { defaultOwner: 1000, defaultGroup: 1000, umask: 0o022 });
 
 // withImageRegistry
 await container.withImageRegistry("docker.io");
@@ -335,6 +352,16 @@ await container.withMcpServer({ path: "/mcp" });
 
 // withRequiredCommand
 await container.withRequiredCommand("docker");
+
+// withRequiredCommandValidation
+await container.withRequiredCommandValidation("docker", async (validationCtx) => {
+    const _validationResolvedPath = await validationCtx.resolvedPath();
+    const validationServices = await validationCtx.services();
+    const validationLoggerFactory = await validationServices.getLoggerFactory();
+    const validationLogger = await validationLoggerFactory.createLogger("ValidationAppHost.RequiredCommandValidation");
+    await validationLogger.logInformation("RequiredCommandValidation services");
+    return await validationCtx.success();
+});
 
 // ===================================================================
 // DotnetToolResourceExtensions.cs — NEW exports
@@ -728,6 +755,10 @@ await container.withCommand("noop", "Noop", async () => {
     commandOptions: {
         updateState: async (ctx) => {
             const snapshot = await ctx.resourceSnapshot();
+            const updateStateServices = await ctx.services();
+            const updateStateLoggerFactory = await updateStateServices.getLoggerFactory();
+            const updateStateLogger = await updateStateLoggerFactory.createLogger("ValidationAppHost.UpdateCommandState");
+            await updateStateLogger.logInformation("UpdateCommandState services");
 
             return snapshot.healthStatus === HealthStatus.Healthy
                 ? ResourceCommandState.Enabled
@@ -738,6 +769,10 @@ await container.withCommand("noop", "Noop", async () => {
 await container.withCommand("echo", "Echo", async (ctx) => {
     const commandInputs = await ctx.arguments();
     const commandArguments = await commandInputs.toArray();
+    const echoServices = await ctx.services();
+    const echoLoggerFactory = await echoServices.getLoggerFactory();
+    const echoLogger = await echoLoggerFactory.createLogger("ValidationAppHost.EchoCommand");
+    await echoLogger.logInformation("Echo command services");
 
     return { success: commandArguments[0]?.value === "hello" };
 }, {
@@ -748,7 +783,13 @@ await container.withCommand("echo", "Echo", async (ctx) => {
                 inputType: InputType.Text,
                 required: true
             }
-        ]
+        ],
+        validateArguments: async (ctx) => {
+            const validationServices = await ctx.services();
+            const validationLoggerFactory = await validationServices.getLoggerFactory();
+            const validationLogger = await validationLoggerFactory.createLogger("ValidationAppHost.ValidateCommandArguments");
+            await validationLogger.logInformation("Validate command arguments services");
+        }
     }
 });
 await container.withCommand("restart", "Restart", async (ctx) => {
@@ -758,6 +799,48 @@ await container.withCommand("restart", "Restart", async (ctx) => {
         arguments: { message: "hello" },
         cancellationToken
     });
+});
+
+// withHttpsCertificateConfiguration
+await container.withHttpsCertificateConfiguration(async (certCtx) => {
+    const _certResource = await certCtx.resource();
+    const _certIsRunMode: boolean = await certCtx.executionContext().isRunMode();
+    const certificatePath = await certCtx.certificatePath();
+    const keyPath = await certCtx.keyPath();
+    const certArgs = await certCtx.arguments();
+    await certArgs.add("--certificate");
+    await certArgs.add(certificatePath);
+    await certArgs.add("--key");
+    await certArgs.add(keyPath);
+    const certEnv = await certCtx.environment();
+    await certEnv.set("Kestrel__Certificates__Path", certificatePath);
+    await certEnv.set("Kestrel__Certificates__KeyPath", keyPath);
+});
+
+// subscribeHttpsEndpointsUpdate
+await container.subscribeHttpsEndpointsUpdate(async (httpsCtx) => {
+    const _httpsResource = await httpsCtx.resource();
+    const _httpsModel = await httpsCtx.model();
+    const httpsServices = await httpsCtx.services();
+    const httpsLoggerFactory = await httpsServices.getLoggerFactory();
+    const httpsLogger = await httpsLoggerFactory.createLogger("ValidationAppHost.HttpsEndpointsUpdate");
+    await httpsLogger.logInformation("HttpsEndpointsUpdate services");
+});
+
+// withContainerBuildOptions
+await container.withContainerBuildOptions(async (buildCtx) => {
+    await buildCtx.destination.set(ContainerImageDestination.Registry);
+    await buildCtx.imageFormat.set(ContainerImageFormat.Oci);
+    await buildCtx.targetPlatform.set(ContainerTargetPlatform.LinuxAmd64);
+    await buildCtx.outputPath.set("./artifacts/container-image");
+    await buildCtx.localImageName.set("validation-image");
+    await buildCtx.localImageTag.set("latest");
+    const _buildResource = await buildCtx.resource();
+    const _buildExecutionContext = await buildCtx.executionContext();
+    const buildServices = await buildCtx.services();
+    const buildLoggerFactory = await buildServices.getLoggerFactory();
+    const buildLogger = await buildLoggerFactory.createLogger("ValidationAppHost.ContainerBuildOptions");
+    await buildLogger.logInformation("ContainerBuildOptions services");
 });
 
 // withProcessCommand


### PR DESCRIPTION
## Description

Several callback contexts carried `[AspireExportIgnore]` on their `IServiceProvider` members, which forced the entire context (and its builder overloads) to be hidden from polyglot app hosts because `IServiceProvider` could not be consumed from ATS. Now that `IServiceProvider` is an exported ATS handle, those members can be exposed, and the contexts that wrap them become usable from TypeScript/Go/Java/Python.

This PR removes the now-unnecessary ignores, exposes the service provider consistently as `services`, and closes the `WithContainerFiles` callback gap so polyglot hosts can build container file-system entries (including inline contents and OpenSSL certificate files) through factory methods rather than the host-only polymorphic hierarchy.

### What changed

- **Expose `services`**: `ServiceProvider`/`Services` members on the command (`ExecuteCommandContext`, `UpdateCommandStateContext`), HTTPS endpoint update, container build options, required-command validation, and container-file callback contexts are now exported, named `services` on the newly exposed members. Properties already named `Services` map to `services` automatically; `ServiceProvider` properties use `MethodName = "services"`. Remaining ignores are only on `Func<IServiceProvider, ...>` parameters (lifecycle hooks, Kusto health check) and carry accurate reasons pointing to ATS-friendly alternatives.
- **Export builder overloads**: the async `WithContainerBuildOptions`, `WithHttpsCertificateConfiguration`, `SubscribeHttpsEndpointsUpdate`, and the validation-callback `WithRequiredCommand` overloads are now exported. The three `ContainerImage*` enums they depend on are exported too.
- **Close the container-files callback gap**: added internal static factory shims (`CreateFile` / `CreateCertificateFile` / `CreateDirectory`) on `ContainerFileSystemCallbackContext`, plus a `WithContainerFilesCallbackExport` shim that accepts integer file-mode options (`ContainerFilesOptions`) and forwards to the real `WithContainerFiles`. This lets polyglot callbacks construct the `IEnumerable<ContainerFileSystemItem>` result that was previously .NET-only.
- **Helpers**: added `Success()` / `Failure(string)` on `RequiredCommandValidationContext` so polyglot callbacks can return a result without a static factory reference.
- **Tests + app hosts**: wired all four polyglot app hosts (Go/Java/Python/TypeScript) to use real extension-method chains on `services` (e.g. `services().getLoggerFactory()`), regenerated the five codegen snapshots, and added unit tests for the new factories (`ConvertMode` range/validation, recursive entries) and the validation helpers.

### Notes for reviewers

- Per repo convention, ATS export-coverage changes are validated via the `tests/PolyglotAppHosts` apps and codegen snapshots rather than unit tests asserting generated shape.
- The factory methods are deliberately `internal static` extension methods (the established polyglot-only shim pattern) so they do not expand the public C# surface.
- `api/*.cs` baseline files are intentionally not regenerated here; that happens at release time.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No