### PR TITLE
ci: Skip Homebrew validation by default in release pipeline

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -13,7 +13,7 @@ The Aspire release process uses two main automation components:
    - Publishes Aspire CLI npm packages through ESRP/MicroBuild.
    - Promotes the build to the GA channel via darc.
    - Submits WinGet manifest PRs.
-   - Validates the Homebrew cask against the live GitHub release (cask version bumps themselves are submitted by upstream autobump; see [Installer channels](#installer-channels)).
+   - Optionally validates the Homebrew cask against the live GitHub release when `SkipHomebrewValidation=false` (cask version bumps themselves are submitted by upstream autobump; see [Installer channels](#installer-channels)).
    - Optionally publishes the signed VS Code extension to the Visual Studio Marketplace.
    - Dispatches the GitHub Actions workflow below as the `aspire-repo-bot` GitHub App and waits for it to complete.
    - Uploads `aspire-cli-*` archives from the source build's `BlobArtifacts` onto the GitHub Release as the `aspire-repo-bot`.
@@ -38,7 +38,7 @@ Aspire ships through several channels. The release pipeline either submits the b
 |---------|------------------------------|------------------|
 | **NuGet** (libraries, AppHost SDK, `Aspire.Cli` tool packages) | `release-publish-nuget` pushes to NuGet.org | This document |
 | **WinGet** (`winget install Microsoft.Aspire`) | `release-publish-nuget` submits manifest PRs to `microsoft/winget-pkgs` via `wingetcreate` | [`eng/winget/README.md`](../eng/winget/README.md) |
-| **Homebrew cask** (`brew install --cask aspire`) | Upstream Homebrew/homebrew-cask's [autobump workflow](https://github.com/Homebrew/homebrew-cask/blob/master/.github/workflows/autobump.yml) opens the bump PR on a 3-hour schedule, detecting the new version via the cask's `livecheck` block. `release-publish-nuget` only validates the cask against the live GitHub release after asset upload. | [`eng/homebrew/README.md`](../eng/homebrew/README.md) |
+| **Homebrew cask** (`brew install --cask aspire`) | Upstream Homebrew/homebrew-cask's [autobump workflow](https://github.com/Homebrew/homebrew-cask/blob/master/.github/workflows/autobump.yml) opens the bump PR on a 3-hour schedule, detecting the new version via the cask's `livecheck` block. `release-publish-nuget` validates the cask against the live GitHub release after asset upload only when `SkipHomebrewValidation=false` (skipped by default). | [`eng/homebrew/README.md`](../eng/homebrew/README.md) |
 | **`dotnet tool install -g Aspire.Cli`** | `release-publish-nuget` pushes the per-RID `Aspire.Cli.*.nupkg` packages to NuGet.org alongside the libraries | [`docs/specs/install-routes.md`](specs/install-routes.md) |
 | **Install script** (`get-aspire-cli.sh` / `.ps1`) | No separate publication — the script downloads directly from the GitHub release assets attached in Step 1 | [`docs/specs/install-routes.md`](specs/install-routes.md), `eng/scripts/get-aspire-cli.*` |
 
@@ -342,7 +342,7 @@ Azure DevOps release-publish-nuget.yml
   -> GitHubTasks
      -> dispatch release-github-tasks.yml as aspire-repo-bot
      -> upload aspire-cli-* assets to the GitHub release
-     -> validate Homebrew cask against the live release
+     -> validate Homebrew cask against the live release (only when SkipHomebrewValidation=false)
 
 GitHub release-github-tasks.yml
   -> create tag

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -97,7 +97,7 @@ Before starting a release:
    | `SkipWinGetPublish` | Set `true` if re-running after WinGet success. | `true` |
    | `SkipGitHubTasks` | Set `true` to skip dispatching the GH workflow. | `false` |
    | `SkipReleaseAssets` | Set `true` to skip uploading `aspire-cli-*` assets to the GitHub release. | `false` |
-   | `SkipHomebrewValidation` | Set `true` if re-running after a successful Homebrew cask validation against the live GitHub release. | `false` |
+   | `SkipHomebrewValidation` | Set `false` to run Homebrew cask validation against the live GitHub release. | `true` |
    | `SkipVSCodeExtensionPublish` | Set `false` to publish the signed `aspire-vscode-extension` artifact to the Visual Studio Marketplace. | `true` |
    | `NpmPublishOwners` | Optional comma-separated ESRP owner aliases or emails. Leave empty for the repo default; overrides must still include the required owner aliases from `eng/pipelines/common-variables.yml`. | empty |
    | `NpmPublishApprovers` | Optional comma-separated ESRP approver aliases or emails. Leave empty for the repo default; overrides must still include the required approver aliases from `eng/pipelines/common-variables.yml` and must not overlap owners. | empty |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -74,7 +74,7 @@ Before starting a release:
 
 1. Navigate to the Azure DevOps pipeline: [release-publish-nuget](https://dev.azure.com/dnceng/internal/_build?definitionId=1600&_a=summary) (definition `1600` in `dnceng/internal`).
 2. Click **Run pipeline**.
-3. Fill in the parameters. Most should stay at their defaults; the ones flagged `[Advanced]` in the run-pipeline form are only for re-running after a partial failure or for testing pipeline changes on a topic branch.
+3. Fill in the parameters. Most should stay at their defaults; the ones flagged `[Advanced]` in the run-pipeline form are for re-running after a partial failure, opting in to currently-disabled release legs, or testing pipeline changes on a topic branch.
 
    **Common (you may set these every release):**
 
@@ -108,7 +108,7 @@ Before starting a release:
 4. Select the **Resources** button in the bottom right, then select the source build from the `aspire-build` dropdown.
    - The picker shows all recent builds from the `microsoft-aspire` pipeline regardless of branch. Pick the build that corresponds to the release branch and version you intend to ship.
    - Each build's tags are shown alongside its number. Verify the `release-version - X.Y.Z` tag matches the version you intend to ship before clicking **Run**. If the tag is missing, either re-run the source build after the tag-emitting change in `azure-pipelines.yml` is on that release branch or pass an explicit `ReleaseVersion` override.
-5. Click **Run** and monitor the pipeline. The final stage (`GitHubTasks`) dispatches `release-github-tasks.yml`, waits for it to complete, uploads the `aspire-cli-*` archives from the source build's `BlobArtifacts` onto the newly-created GitHub release, and validates the Homebrew cask against that live release. The AzDO pipeline only succeeds if the enabled GitHub tasks, asset upload, and Homebrew validation succeed.
+5. Click **Run** and monitor the pipeline. The final stage (`GitHubTasks`) dispatches `release-github-tasks.yml`, waits for it to complete, and uploads the `aspire-cli-*` archives from the source build's `BlobArtifacts` onto the newly-created GitHub release. If `SkipHomebrewValidation=false`, it also validates the Homebrew cask against that live release. The AzDO pipeline only succeeds if the enabled GitHub tasks, asset upload, and optional Homebrew validation succeed.
 6. Verify packages appear on NuGet.org and npm, and verify that the `aspire-cli-*` archives are attached to the GitHub release.
 
 To publish only the VS Code extension after merging an extension release PR, run the same `release-publish-nuget` pipeline, select the signed source build from that merge, and set:

--- a/eng/homebrew/README.md
+++ b/eng/homebrew/README.md
@@ -74,7 +74,7 @@ what `brew install` fetches from the GitHub release URL.
 |---|---|---|---|
 | `.github/workflows/tests.yml` | Prerelease casks (artifacts only) | — | — |
 | `azure-pipelines.yml` (prepare stage) | Stable or prerelease casks (artifacts only) | — | — |
-| `release-publish-nuget.yml` (release) | — | Stable cask, LiveRelease mode | — (autobump handles bumps; see below) |
+| `release-publish-nuget.yml` (release) | — | Stable cask, LiveRelease mode (only when `SkipHomebrewValidation=false`) | — (autobump handles bumps; see below) |
 
 The release pipeline's `HomebrewValidateJob` runs `validate-cask-artifact.sh`
 in LiveRelease mode against the cask emitted by the source build, after the
@@ -85,8 +85,9 @@ the source-build prepare stage can only validate offline because the
 GitHub release for the version being built does not exist yet. Failures
 in this job catch problems that would otherwise only surface to end
 users running `brew install aspire`, or block Homebrew/homebrew-cask's
-autobump PR a few hours later. Gated by `SkipHomebrewValidation` for
-partial-failure re-runs.
+autobump PR a few hours later. Gated by `SkipHomebrewValidation`, which
+defaults to `true`; the job only runs when `SkipHomebrewValidation=false`
+(opt in per release, or when re-running after a partial failure).
 
 ### Submission: upstream autobump
 

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -4,7 +4,8 @@
 # 1. Downloads signed packages from a specified build
 # 2. Publishes packages to NuGet.org and npm
 # 3. Promotes the build to the Aspire GA channel via darc
-# 4. Submits WinGet manifests and validates the Homebrew cask
+# 4. Submits WinGet manifests and, when SkipHomebrewValidation=false,
+#    validates the Homebrew cask
 # 5. Optionally publishes the signed VS Code extension to the Marketplace
 # 6. Dispatches the release-github-tasks GitHub Actions workflow as the
 #    aspire-repo-bot GitHub App (tag, GitHub Release, merge-back PR,

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -94,7 +94,7 @@ parameters:
     default: false
 
   - name: SkipHomebrewValidation
-    displayName: '[Advanced] Skip Homebrew cask validation against live GitHub release (re-run after success)'
+    displayName: '[Advanced] Skip Homebrew cask validation against live GitHub release (default; set false to opt in)'
     type: boolean
     default: true
 

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -96,7 +96,7 @@ parameters:
   - name: SkipHomebrewValidation
     displayName: '[Advanced] Skip Homebrew cask validation against live GitHub release (re-run after success)'
     type: boolean
-    default: false
+    default: true
 
   # Azure DevOps manual string parameters cannot be left blank. These defaults
   # must include the NPM_PUBLISH_REQUIRED_* aliases from common-variables.yml.
@@ -2274,14 +2274,15 @@ extends:
       # DryRun behavior: this stage still runs when DryRun=true. DryRun is
       # propagated to the GH workflow as dry_run=true (keeps it from
       # creating tags/releases/PRs) and to the asset script (downloads and
-      # verifies SHA512s but skips the gh release upload). HomebrewValidateJob
-      # also runs under DryRun — it does not publish anything, it only audits
-      # and `brew install`/`brew uninstall` against a public URL. If the
-      # release for the version being validated does not yet exist (DryRun,
-      # or a re-run after assets were already uploaded), the job is expected
-      # to surface that as a real failure rather than be silently skipped.
-      # This lets a release manager validate the full AzDO → GitHub path
-      # end-to-end without performing a real release.
+      # verifies SHA512s but skips the gh release upload). When
+      # SkipHomebrewValidation=false, HomebrewValidateJob also runs under DryRun
+      # — it does not publish anything, it only audits and `brew install`/
+      # `brew uninstall` against a public URL. If the release for the version
+      # being validated does not yet exist (DryRun, or a re-run after assets
+      # were already uploaded), the job is expected to surface that as a real
+      # failure rather than be silently skipped. This lets a release manager
+      # validate the full AzDO → GitHub path end-to-end without performing a
+      # real release.
       - stage: GitHubTasks
         displayName: 'Dispatch GitHub Release Tasks'
         # PrepareArtifacts is listed explicitly (in addition to Release) so the


### PR DESCRIPTION
## Description

The release pipeline currently runs Homebrew cask validation by default after GitHub release asset upload. Homebrew publishing and bump work is currently handled manually, so the default release run should avoid the Homebrew leg unless a release manager opts in.

This changes `SkipHomebrewValidation` from `false` to `true` in `eng/pipelines/release-publish-nuget.yml`. The `HomebrewValidateJob` condition already runs only when the parameter is `false`, so the effective default is now to skip Homebrew validation; setting `SkipHomebrewValidation=false` opts back in.

`docs/release-process.md` now documents the new default.

Validation performed:

```bash
git --no-pager diff --check -- eng/pipelines/release-publish-nuget.yml docs/release-process.md
```

I also inspected the `SkipHomebrewValidation` references in the release pipeline, release docs, `.github/workflows/release-github-tasks.yml`, and `eng/homebrew/README.md`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
