### PR TITLE
Use last 8 characters of GUID service.instance.id in resource display name

### DIFF
--- a/src/Shared/Otlp/OtlpHelpers.cs
+++ b/src/Shared/Otlp/OtlpHelpers.cs
@@ -106,10 +106,10 @@ public static partial class OtlpHelpers
                     if (instanceId != null && Guid.TryParse(instanceId, out var guid))
                     {
                         Span<char> chars = stackalloc char[32];
-                        var result = guid.TryFormat(chars, charsWritten: out _, format: "N");
+                        var result = guid.TryFormat(chars, out var charsWritten, format: "N");
                         Debug.Assert(result, "Guid.TryFormat not successful.");
 
-                        instanceId = chars.Slice(chars.Length - 8).ToString();
+                        instanceId = chars.Slice(charsWritten - 8, 8).ToString();
                     }
 
                     if (instanceId == null)

--- a/src/Shared/Otlp/OtlpHelpers.cs
+++ b/src/Shared/Otlp/OtlpHelpers.cs
@@ -99,15 +99,17 @@ public static partial class OtlpHelpers
                     var instanceId = resource.InstanceId;
 
                     // Convert long GUID into a shorter, more human friendly format.
+                    // The last characters are used because version 7 GUIDs created close
+                    // in time share the same leading characters, e.g. Guid.CreateVersion7().
                     // Before: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
-                    // After:  aaaaaaaa
+                    // After:  eeeeeeee
                     if (instanceId != null && Guid.TryParse(instanceId, out var guid))
                     {
                         Span<char> chars = stackalloc char[32];
                         var result = guid.TryFormat(chars, charsWritten: out _, format: "N");
                         Debug.Assert(result, "Guid.TryFormat not successful.");
 
-                        instanceId = chars.Slice(0, 8).ToString();
+                        instanceId = chars.Slice(chars.Length - 8).ToString();
                     }
 
                     if (instanceId == null)

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
@@ -202,8 +202,8 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
         yield return [MakeResource("apiservice", null), new IOtlpResource[] { new SimpleOtlpResource("apiservice", null) }, "apiservice"];
         // replicas with non-GUID instance id → name-instanceId
         yield return [MakeResource("frontend", "abc123"), new IOtlpResource[] { new SimpleOtlpResource("frontend", "abc123"), new SimpleOtlpResource("frontend", "xyz789") }, "frontend-abc123"];
-        // replicas with GUID instance id → name-shortened8chars
-        yield return [MakeResource("worker", guidStr), new IOtlpResource[] { new SimpleOtlpResource("worker", guidStr), new SimpleOtlpResource("worker", Guid.NewGuid().ToString()) }, $"worker-{guid:N}"[..15]];
+        // replicas with GUID instance id → name-last8chars
+        yield return [MakeResource("worker", guidStr), new IOtlpResource[] { new SimpleOtlpResource("worker", guidStr), new SimpleOtlpResource("worker", Guid.NewGuid().ToString()) }, $"worker-{guid.ToString("N")[^8..]}"];
     }
 
     [Theory]

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
@@ -112,11 +112,11 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
 
-        // Replicas get shortened GUID appended: apiservice-11111111 and apiservice-aaaaaaaa
+        // Replicas get shortened GUID appended: apiservice-55555555 and apiservice-eeeeeeee
         var logLines = outputWriter.Logs.Where(l => l.Contains("apiservice")).ToList();
         Assert.Equal(2, logLines.Count);
-        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime)} INFO apiservice-11111111 Hello from replica 1", logLines[0]);
-        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime.AddSeconds(1))} WARN apiservice-aaaaaaaa Slow response from replica 2", logLines[1]);
+        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime)} INFO apiservice-55555555 Hello from replica 1", logLines[0]);
+        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime.AddSeconds(1))} WARN apiservice-eeeeeeee Slow response from replica 2", logLines[1]);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
@@ -114,8 +114,8 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
         // Replicas get shortened GUID appended
         var spanLines = outputWriter.Logs.Where(l => l.Contains("apiservice")).ToList();
         Assert.Equal(2, spanLines.Count);
-        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime)} OK      75ms apiservice-11111111: GET /api/products span001 (http://localhost:18888/traces/detail/trace001?spanId=span001)", spanLines[0]);
-        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime.AddMilliseconds(10))} ERR     50ms apiservice-aaaaaaaa: POST /api/orders span002 (http://localhost:18888/traces/detail/trace001?spanId=span002)", spanLines[1]);
+        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime)} OK      75ms apiservice-55555555: GET /api/products span001 (http://localhost:18888/traces/detail/trace001?spanId=span001)", spanLines[0]);
+        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime.AddMilliseconds(10))} ERR     50ms apiservice-eeeeeeee: POST /api/orders span002 (http://localhost:18888/traces/detail/trace001?spanId=span002)", spanLines[1]);
     }
 
     private static string BuildSpansJson(params (string serviceName, string? instanceId, string spanId, string name, DateTime startTime, DateTime endTime, bool hasError)[] entries)

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
@@ -331,13 +331,13 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(2, dataRows.Length);
 
         Assert.Equal(FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime), dataRows[0][0]);
-        Assert.Equal("apiservice-11111111: GET /apiservice abc1234 (http://localhost:18888/traces/detail/abc1234567890def)", dataRows[0][1]);
+        Assert.Equal("apiservice-55555555: GET /apiservice abc1234 (http://localhost:18888/traces/detail/abc1234567890def)", dataRows[0][1]);
         Assert.Equal("1", dataRows[0][2]);
         Assert.Equal("75ms", dataRows[0][3]);
         Assert.Equal("OK", dataRows[0][4]);
 
         Assert.Equal(FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime.AddMilliseconds(10)), dataRows[1][0]);
-        Assert.Equal("apiservice-aaaaaaaa: GET /apiservice def9876 (http://localhost:18888/traces/detail/def9876543210abc)", dataRows[1][1]);
+        Assert.Equal("apiservice-eeeeeeee: GET /apiservice def9876 (http://localhost:18888/traces/detail/def9876543210abc)", dataRows[1][1]);
         Assert.Equal("1", dataRows[1][2]);
         Assert.Equal("50ms", dataRows[1][3]);
         Assert.Equal("ERR", dataRows[1][4]);

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ResourceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ResourceTests.cs
@@ -162,8 +162,11 @@ public class ResourceTests
         // Act
         var resources = repository.GetResources();
 
-        var instance1Name = OtlpHelpers.GetResourceName(resources[0], resources);
-        var instance2Name = OtlpHelpers.GetResourceName(resources[1], resources);
+        var instance1 = Assert.Single(resources, r => r.InstanceId == guid1);
+        var instance2 = Assert.Single(resources, r => r.InstanceId == guid2);
+
+        var instance1Name = OtlpHelpers.GetResourceName(instance1, resources);
+        var instance2Name = OtlpHelpers.GetResourceName(instance2, resources);
 
         // Assert
         Assert.Equal("app1-099a8057", instance1Name);

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ResourceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ResourceTests.cs
@@ -142,8 +142,32 @@ public class ResourceTests
         var instance2Name = OtlpHelpers.GetResourceName(resources[1], resources);
 
         // Assert
-        Assert.Equal("app1-19572b19", instance1Name);
-        Assert.Equal("app1-f66e2b1e", instance2Name);
+        Assert.Equal("app1-658f73d3", instance1Name);
+        Assert.Equal("app1-f6fcda86", instance2Name);
+    }
+
+    [Fact]
+    public void GetResourceName_Version7GuidInstanceId_ShortenedNamesDiffer()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        // Version 7 GUIDs created close in time share the same leading characters.
+        var guid1 = "01890a5d-ac96-774b-bcce-b302099a8057";
+        var guid2 = "01890a5d-ac96-7768-a3e2-34c4a0e9f6ad";
+
+        AddResource(repository, "app1", guid1);
+        AddResource(repository, "app1", guid2);
+
+        // Act
+        var resources = repository.GetResources();
+
+        var instance1Name = OtlpHelpers.GetResourceName(resources[0], resources);
+        var instance2Name = OtlpHelpers.GetResourceName(resources[1], resources);
+
+        // Assert
+        Assert.Equal("app1-099a8057", instance1Name);
+        Assert.Equal("app1-a0e9f6ad", instance2Name);
     }
 
     private static void AddResource(TelemetryRepository repository, string name, string? instanceId = null)


### PR DESCRIPTION
## Description

Fixes #10615

When multiple replicas of a resource report telemetry, the dashboard disambiguates them by appending a shortened `service.instance.id` to the resource name. The shortening took the **first** 8 characters of the GUID, but version 7 GUIDs (e.g. `Guid.CreateVersion7()`, supported since .NET 9) are time-ordered, so instances created close together share the same leading characters and rendered identical display names in the UI.

This change takes the **last** 8 characters of the "N"-formatted GUID instead, which differ between v7 instances:

- Before: `catalogservice-01890a5d` / `catalogservice-01890a5d`
- After: `catalogservice-099a8057` / `catalogservice-a0e9f6ad`

Non-GUID instance ids are unaffected (they were never truncated).

## Checklist

- Updated `GetResourceName_GuidInstanceId_Shorten` expectations
- Added `GetResourceName_Version7GuidInstanceId_ShortenedNamesDiffer` covering the v7 prefix-collision scenario from the issue
- `dotnet test tests/Aspire.Dashboard.Tests --filter-class "*ResourceTests"`: 5/5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)