### PR TITLE
Add coding agent telemetry detection

### DIFF
--- a/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
@@ -46,6 +46,7 @@ internal sealed class AspireCliTelemetry : IHostedService
     private readonly ActivitySource _reportedActivitySource;
     private readonly IMachineInformationProvider _machineInformationProvider;
     private readonly ICIEnvironmentDetector _ciEnvironmentDetector;
+    private readonly ICodingAgentDetector _codingAgentDetector;
     private readonly ILogger<AspireCliTelemetry> _logger;
     private readonly List<KeyValuePair<string, object?>> _tagsList = [];
 
@@ -57,8 +58,9 @@ internal sealed class AspireCliTelemetry : IHostedService
     /// <param name="logger">The logger instance for recording errors.</param>
     /// <param name="machineInformationProvider">The machine information provider.</param>
     /// <param name="ciEnvironmentDetector">The CI environment detector.</param>
-    public AspireCliTelemetry(ILogger<AspireCliTelemetry> logger, IMachineInformationProvider machineInformationProvider, ICIEnvironmentDetector ciEnvironmentDetector)
-        : this(logger, machineInformationProvider, ciEnvironmentDetector, ReportedActivitySourceName, DiagnosticsActivitySourceName)
+    /// <param name="codingAgentDetector">The coding agent detector.</param>
+    public AspireCliTelemetry(ILogger<AspireCliTelemetry> logger, IMachineInformationProvider machineInformationProvider, ICIEnvironmentDetector ciEnvironmentDetector, ICodingAgentDetector codingAgentDetector)
+        : this(logger, machineInformationProvider, ciEnvironmentDetector, codingAgentDetector, ReportedActivitySourceName, DiagnosticsActivitySourceName)
     {
     }
 
@@ -69,13 +71,15 @@ internal sealed class AspireCliTelemetry : IHostedService
     /// <param name="logger">The logger instance for recording errors.</param>
     /// <param name="machineInformationProvider">The machine information provider.</param>
     /// <param name="ciEnvironmentDetector">The CI environment detector.</param>
+    /// <param name="codingAgentDetector">The coding agent detector.</param>
     /// <param name="reportedSourceName">The name for the reported activity source.</param>
     /// <param name="diagnosticsSourceName">The name for the diagnostics activity source.</param>
-    internal AspireCliTelemetry(ILogger<AspireCliTelemetry> logger, IMachineInformationProvider machineInformationProvider, ICIEnvironmentDetector ciEnvironmentDetector, string reportedSourceName, string diagnosticsSourceName)
+    internal AspireCliTelemetry(ILogger<AspireCliTelemetry> logger, IMachineInformationProvider machineInformationProvider, ICIEnvironmentDetector ciEnvironmentDetector, ICodingAgentDetector codingAgentDetector, string reportedSourceName, string diagnosticsSourceName)
     {
         _logger = logger;
         _machineInformationProvider = machineInformationProvider;
         _ciEnvironmentDetector = ciEnvironmentDetector;
+        _codingAgentDetector = codingAgentDetector;
         _reportedActivitySource = new ActivitySource(reportedSourceName);
         _diagnosticsActivitySource = new ActivitySource(diagnosticsSourceName);
     }
@@ -224,6 +228,12 @@ internal sealed class AspireCliTelemetry : IHostedService
             // This is consistent with dashboard version data.
             _tagsList.Add(new(TelemetryConstants.Tags.CliVersion, GetCliVersion()));
             _tagsList.Add(new(TelemetryConstants.Tags.CliBuildId, GetCliBuildId()));
+
+            var codingAgent = _codingAgentDetector.GetCodingAgent();
+            if (codingAgent is not null)
+            {
+                _tagsList.Add(new(TelemetryConstants.Tags.CodingAgent, codingAgent));
+            }
 
             _tagsList.Add(new(TelemetryConstants.Tags.DeploymentEnvironmentName, _ciEnvironmentDetector.IsCIEnvironment() ? "ci" : "local"));
 

--- a/src/Aspire.Cli/Telemetry/CodingAgentDetector.cs
+++ b/src/Aspire.Cli/Telemetry/CodingAgentDetector.cs
@@ -12,6 +12,7 @@ internal sealed class CodingAgentDetector(IConfiguration configuration) : ICodin
 {
     // Keep this in sync with the dotnet CLI's LLMEnvironmentDetectorForTelemetry detection
     // order so Aspire reports the same agent names when the same environment variables are set.
+    // https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
     private static readonly DetectionRule[] s_detectionRules =
     [
         new("cowork", ["CLAUDE_CODE_IS_COWORK"]),

--- a/src/Aspire.Cli/Telemetry/CodingAgentDetector.cs
+++ b/src/Aspire.Cli/Telemetry/CodingAgentDetector.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Aspire.Cli.Telemetry;
+
+/// <summary>
+/// Detects coding agents from known environment variables.
+/// </summary>
+internal sealed class CodingAgentDetector(IConfiguration configuration) : ICodingAgentDetector
+{
+    // Keep this in sync with the dotnet CLI's LLMEnvironmentDetectorForTelemetry detection
+    // order so Aspire reports the same agent names when the same environment variables are set.
+    private static readonly DetectionRule[] s_detectionRules =
+    [
+        new("cowork", ["CLAUDE_CODE_IS_COWORK"]),
+        new("claude", ["CLAUDECODE", "CLAUDE_CODE", "CLAUDE_CODE_ENTRYPOINT"]),
+        new("cursor", ["CURSOR_EDITOR", "CURSOR_AI", "CURSOR_TRACE_ID", "CURSOR_AGENT"]),
+        new("gemini", ["GEMINI_CLI"]),
+        new("copilot", ["GITHUB_COPILOT_CLI_MODE", "GH_COPILOT_WORKING_DIRECTORY", "COPILOT_CLI", "COPILOT_AGENT", "COPILOT_MODEL", "COPILOT_ALLOW_ALL", "COPILOT_GITHUB_TOKEN"]),
+        new("codex", ["CODEX_CLI", "CODEX_SANDBOX", "CODEX_CI", "CODEX_THREAD_ID"]),
+        new("aider", ["OR_APP_NAME"], "Aider"),
+        new("plandex", ["OR_APP_NAME"], "plandex"),
+        new("amp", ["AMP_HOME"]),
+        new("qwen", ["QWEN_CODE"]),
+        new("droid", ["DROID_CLI"]),
+        new("opencode", ["OPENCODE_AI"]),
+        new("zed", ["ZED_ENVIRONMENT", "ZED_TERM"]),
+        new("kimi", ["KIMI_CLI"]),
+        new("openhands", ["OR_APP_NAME"], "OpenHands"),
+        new("goose", ["GOOSE_TERMINAL", "GOOSE_PROVIDER"]),
+        new("cline", ["CLINE_TASK_ID"]),
+        new("roo", ["ROO_CODE_TASK_ID"]),
+        new("windsurf", ["WINDSURF_SESSION"]),
+        new("replit", ["REPL_ID"]),
+        new("augment", ["AUGMENT_AGENT"]),
+        new("antigravity", ["ANTIGRAVITY_AGENT"]),
+        new("generic_agent", ["AGENT_CLI"])
+    ];
+
+    private readonly IConfiguration _configuration = configuration;
+
+    /// <inheritdoc />
+    public string? GetCodingAgent()
+    {
+        List<string>? agentNames = null;
+
+        foreach (var rule in s_detectionRules)
+        {
+            if (rule.IsMatch(_configuration))
+            {
+                agentNames ??= [];
+                agentNames.Add(rule.AgentName);
+            }
+        }
+
+        return agentNames is { Count: > 0 } ? string.Join(", ", agentNames) : null;
+    }
+
+    private sealed class DetectionRule
+    {
+        private readonly string[] _variableNames;
+        private readonly string? _expectedValue;
+
+        public DetectionRule(string agentName, string[] variableNames, string? expectedValue = null)
+        {
+            AgentName = agentName;
+            _variableNames = variableNames;
+            _expectedValue = expectedValue;
+        }
+
+        public string AgentName { get; }
+
+        public bool IsMatch(IConfiguration configuration)
+        {
+            foreach (var variableName in _variableNames)
+            {
+                var value = configuration[variableName];
+                if (_expectedValue is null)
+                {
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        return true;
+                    }
+                }
+                else if (string.Equals(value, _expectedValue, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Aspire.Cli/Telemetry/ICodingAgentDetector.cs
+++ b/src/Aspire.Cli/Telemetry/ICodingAgentDetector.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Telemetry;
+
+/// <summary>
+/// Detects whether the CLI is running under a known coding agent.
+/// </summary>
+internal interface ICodingAgentDetector
+{
+    /// <summary>
+    /// Gets the detected coding agent name, or names, for the current environment.
+    /// </summary>
+    /// <returns>The detected coding agent names, or <see langword="null"/> when none are detected.</returns>
+    string? GetCodingAgent();
+}

--- a/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
@@ -74,6 +74,11 @@ internal static class TelemetryConstants
         public const string CliBuildId = "aspire.cli.build_id";
 
         /// <summary>
+        /// Tag for the detected coding agent that invoked the CLI process.
+        /// </summary>
+        public const string CodingAgent = "process.coding_agent";
+
+        /// <summary>
         /// Tag for the deployment environment name ("ci" or "local").
         /// </summary>
         public const string DeploymentEnvironmentName = "deployment.environment.name";

--- a/src/Aspire.Cli/Telemetry/TelemetryServiceCollectionExtensions.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ internal static class TelemetryServiceCollectionExtensions
         }
 
         services.AddSingleton<ICIEnvironmentDetector, CIEnvironmentDetector>();
+        services.AddSingleton<ICodingAgentDetector, CodingAgentDetector>();
         services.AddSingleton<AspireCliTelemetry>();
         services.AddSingleton<ProfilingTelemetry>();
         services.AddHostedService(sp => sp.GetRequiredService<AspireCliTelemetry>());

--- a/tests/Aspire.Cli.Tests/Telemetry/AspireCliTelemetryTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/AspireCliTelemetryTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.InternalTesting;
 using System.Diagnostics;
 using Aspire.Cli.Telemetry;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
@@ -239,6 +240,44 @@ public class AspireCliTelemetryTests
     }
 
     [Fact]
+    public void InitializeAsync_AddsCodingAgentTag_WhenCodingAgentIsDetected()
+    {
+        var codingAgentDetector = new TelemetryFixture.TestCodingAgentDetector
+        {
+            CodingAgent = "copilot"
+        };
+        using var fixture = new TelemetryFixture(codingAgentDetector: codingAgentDetector, sampleResult: ActivitySamplingResult.AllData);
+
+        using var activity = fixture.Telemetry.StartReportedActivity(TelemetryConstants.Activities.Main);
+
+        Assert.NotNull(activity);
+        Assert.Equal("copilot", activity.GetTagItem(TelemetryConstants.Tags.CodingAgent));
+    }
+
+    [Fact]
+    public void InitializeAsync_DoesNotAddCodingAgentTag_WhenCodingAgentIsNotDetected()
+    {
+        using var fixture = new TelemetryFixture();
+
+        var tags = fixture.Telemetry.GetDefaultTags();
+
+        Assert.DoesNotContain(tags, t => t.Key == TelemetryConstants.Tags.CodingAgent);
+    }
+
+    [Theory]
+    [MemberData(nameof(CodingAgentTelemetryTestCases))]
+    public void CodingAgentDetector_DetectsKnownCodingAgents(Dictionary<string, string?> environmentVariables, string? expectedCodingAgent)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(environmentVariables)
+            .Build();
+
+        var detector = new CodingAgentDetector(configuration);
+
+        Assert.Equal(expectedCodingAgent, detector.GetCodingAgent());
+    }
+
+    [Fact]
     public void StartReportedActivity_IncludesAllDefaultTags()
     {
         var machineInfoProvider = new TelemetryFixture.TestMachineInformationProvider
@@ -267,7 +306,8 @@ public class AspireCliTelemetryTests
     {
         var provider = new TelemetryFixture.TestMachineInformationProvider();
         var ciDetector = new TelemetryFixture.TestCIEnvironmentDetector();
-        var telemetry = new AspireCliTelemetry(NullLogger<AspireCliTelemetry>.Instance, provider, ciDetector);
+        var codingAgentDetector = new TelemetryFixture.TestCodingAgentDetector();
+        var telemetry = new AspireCliTelemetry(NullLogger<AspireCliTelemetry>.Instance, provider, ciDetector, codingAgentDetector);
 
         var exception = Assert.Throws<InvalidOperationException>(() => telemetry.StartReportedActivity("test"));
         Assert.Contains("not been initialized", exception.Message);
@@ -278,7 +318,8 @@ public class AspireCliTelemetryTests
     {
         var provider = new TelemetryFixture.TestMachineInformationProvider();
         var ciDetector = new TelemetryFixture.TestCIEnvironmentDetector();
-        var telemetry = new AspireCliTelemetry(NullLogger<AspireCliTelemetry>.Instance, provider, ciDetector);
+        var codingAgentDetector = new TelemetryFixture.TestCodingAgentDetector();
+        var telemetry = new AspireCliTelemetry(NullLogger<AspireCliTelemetry>.Instance, provider, ciDetector, codingAgentDetector);
 
         await telemetry.InitializeAsync().DefaultTimeout();
         var tagsAfterFirstInit = telemetry.GetDefaultTags().Count;
@@ -287,4 +328,66 @@ public class AspireCliTelemetryTests
         var tags = telemetry.GetDefaultTags();
         Assert.Equal(tagsAfterFirstInit, tags.Count); // Should have the same number of tags after second init
     }
+
+    public static TheoryData<Dictionary<string, string?>, string?> CodingAgentTelemetryTestCases => new()
+    {
+        { new Dictionary<string, string?> { { "CLAUDECODE", "1" } }, "claude" },
+        { new Dictionary<string, string?> { { "CLAUDE_CODE", "1" } }, "claude" },
+        { new Dictionary<string, string?> { { "CLAUDE_CODE_ENTRYPOINT", "some_value" } }, "claude" },
+        { new Dictionary<string, string?> { { "CLAUDE_CODE_IS_COWORK", "1" } }, "cowork" },
+        { new Dictionary<string, string?> { { "CURSOR_EDITOR", "1" } }, "cursor" },
+        { new Dictionary<string, string?> { { "CURSOR_AI", "1" } }, "cursor" },
+        { new Dictionary<string, string?> { { "CURSOR_TRACE_ID", "abc" } }, "cursor" },
+        { new Dictionary<string, string?> { { "CURSOR_AGENT", "1" } }, "cursor" },
+        { new Dictionary<string, string?> { { "GEMINI_CLI", "true" } }, "gemini" },
+        { new Dictionary<string, string?> { { "GEMINI_CLI", "0" } }, "gemini" },
+        { new Dictionary<string, string?> { { "GITHUB_COPILOT_CLI_MODE", "true" } }, "copilot" },
+        { new Dictionary<string, string?> { { "GH_COPILOT_WORKING_DIRECTORY", "/repo" } }, "copilot" },
+        { new Dictionary<string, string?> { { "COPILOT_CLI", "1" } }, "copilot" },
+        { new Dictionary<string, string?> { { "COPILOT_AGENT", "1" } }, "copilot" },
+        { new Dictionary<string, string?> { { "COPILOT_MODEL", "gpt" } }, "copilot" },
+        { new Dictionary<string, string?> { { "COPILOT_ALLOW_ALL", "1" } }, "copilot" },
+        { new Dictionary<string, string?> { { "COPILOT_GITHUB_TOKEN", "token" } }, "copilot" },
+        { new Dictionary<string, string?> { { "CODEX_CLI", "1" } }, "codex" },
+        { new Dictionary<string, string?> { { "CODEX_SANDBOX", "1" } }, "codex" },
+        { new Dictionary<string, string?> { { "CODEX_CI", "1" } }, "codex" },
+        { new Dictionary<string, string?> { { "CODEX_THREAD_ID", "thread1" } }, "codex" },
+        { new Dictionary<string, string?> { { "OR_APP_NAME", "Aider" } }, "aider" },
+        { new Dictionary<string, string?> { { "OR_APP_NAME", "aider" } }, "aider" },
+        { new Dictionary<string, string?> { { "OR_APP_NAME", "plandex" } }, "plandex" },
+        { new Dictionary<string, string?> { { "OR_APP_NAME", "Plandex" } }, "plandex" },
+        { new Dictionary<string, string?> { { "AMP_HOME", "/path/to/amp" } }, "amp" },
+        { new Dictionary<string, string?> { { "QWEN_CODE", "1" } }, "qwen" },
+        { new Dictionary<string, string?> { { "DROID_CLI", "true" } }, "droid" },
+        { new Dictionary<string, string?> { { "OPENCODE_AI", "1" } }, "opencode" },
+        { new Dictionary<string, string?> { { "ZED_ENVIRONMENT", "1" } }, "zed" },
+        { new Dictionary<string, string?> { { "ZED_TERM", "1" } }, "zed" },
+        { new Dictionary<string, string?> { { "KIMI_CLI", "true" } }, "kimi" },
+        { new Dictionary<string, string?> { { "OR_APP_NAME", "OpenHands" } }, "openhands" },
+        { new Dictionary<string, string?> { { "OR_APP_NAME", "openhands" } }, "openhands" },
+        { new Dictionary<string, string?> { { "GOOSE_TERMINAL", "1" } }, "goose" },
+        { new Dictionary<string, string?> { { "GOOSE_PROVIDER", "openai" } }, "goose" },
+        { new Dictionary<string, string?> { { "CLINE_TASK_ID", "task123" } }, "cline" },
+        { new Dictionary<string, string?> { { "ROO_CODE_TASK_ID", "task456" } }, "roo" },
+        { new Dictionary<string, string?> { { "WINDSURF_SESSION", "session789" } }, "windsurf" },
+        { new Dictionary<string, string?> { { "REPL_ID", "repl1" } }, "replit" },
+        { new Dictionary<string, string?> { { "AUGMENT_AGENT", "1" } }, "augment" },
+        { new Dictionary<string, string?> { { "ANTIGRAVITY_AGENT", "1" } }, "antigravity" },
+        { new Dictionary<string, string?> { { "AGENT_CLI", "true" } }, "generic_agent" },
+        { new Dictionary<string, string?> { { "CLAUDECODE", "1" }, { "CURSOR_EDITOR", "1" } }, "claude, cursor" },
+        { new Dictionary<string, string?> { { "GEMINI_CLI", "true" }, { "GITHUB_COPILOT_CLI_MODE", "true" } }, "gemini, copilot" },
+        { new Dictionary<string, string?> { { "CLAUDECODE", "1" }, { "GEMINI_CLI", "true" }, { "AGENT_CLI", "true" } }, "claude, gemini, generic_agent" },
+        { new Dictionary<string, string?> { { "CLAUDECODE", "1" }, { "CURSOR_EDITOR", "1" }, { "GEMINI_CLI", "true" }, { "GITHUB_COPILOT_CLI_MODE", "true" }, { "AGENT_CLI", "true" } }, "claude, cursor, gemini, copilot, generic_agent" },
+        { new Dictionary<string, string?> { { "OR_APP_NAME", "Aider" }, { "CLINE_TASK_ID", "task123" } }, "aider, cline" },
+        { new Dictionary<string, string?> { { "CODEX_CLI", "1" }, { "WINDSURF_SESSION", "session789" } }, "codex, windsurf" },
+        { new Dictionary<string, string?> { { "GOOSE_TERMINAL", "1" }, { "ROO_CODE_TASK_ID", "task456" } }, "goose, roo" },
+        { new Dictionary<string, string?> { { "GEMINI_CLI", "false" } }, "gemini" },
+        { new Dictionary<string, string?> { { "GITHUB_COPILOT_CLI_MODE", "false" } }, "copilot" },
+        { new Dictionary<string, string?> { { "AGENT_CLI", "false" } }, "generic_agent" },
+        { new Dictionary<string, string?> { { "DROID_CLI", "false" } }, "droid" },
+        { new Dictionary<string, string?> { { "KIMI_CLI", "false" } }, "kimi" },
+        { new Dictionary<string, string?> { { "CLAUDE_CODE_IS_COWORK", "1" }, { "CLAUDE_CODE", "1" } }, "cowork, claude" },
+        { new Dictionary<string, string?> { { "OR_APP_NAME", "SomeOtherApp" } }, null },
+        { new Dictionary<string, string?>(), null },
+    };
 }

--- a/tests/Aspire.Cli.Tests/Telemetry/TelemetryFixture.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TelemetryFixture.cs
@@ -21,11 +21,13 @@ internal sealed class TelemetryFixture : IDisposable
     /// </summary>
     /// <param name="machineInfoProvider">Optional machine information provider. Uses a default test provider if not specified.</param>
     /// <param name="ciEnvironmentDetector">Optional CI environment detector. Uses a default test detector if not specified.</param>
+    /// <param name="codingAgentDetector">Optional coding agent detector. Uses a default test detector if not specified.</param>
     /// <param name="logger">Optional logger. Uses <see cref="NullLogger"/> if not specified.</param>
     /// <param name="sampleResult">The sampling result for the activity listener. Defaults to <see cref="ActivitySamplingResult.AllDataAndRecorded"/>.</param>
     public TelemetryFixture(
         IMachineInformationProvider? machineInfoProvider = null,
         ICIEnvironmentDetector? ciEnvironmentDetector = null,
+        ICodingAgentDetector? codingAgentDetector = null,
         ILogger<AspireCliTelemetry>? logger = null,
         ActivitySamplingResult sampleResult = ActivitySamplingResult.AllDataAndRecorded)
     {
@@ -42,9 +44,10 @@ internal sealed class TelemetryFixture : IDisposable
 
         machineInfoProvider ??= new TestMachineInformationProvider();
         ciEnvironmentDetector ??= new TestCIEnvironmentDetector();
+        codingAgentDetector ??= new TestCodingAgentDetector();
         logger ??= NullLogger<AspireCliTelemetry>.Instance;
 
-        Telemetry = new AspireCliTelemetry(logger, machineInfoProvider, ciEnvironmentDetector, ReportedSourceName, DiagnosticsSourceName);
+        Telemetry = new AspireCliTelemetry(logger, machineInfoProvider, ciEnvironmentDetector, codingAgentDetector, ReportedSourceName, DiagnosticsSourceName);
         Telemetry.InitializeAsync().GetAwaiter().GetResult();
     }
 
@@ -93,5 +96,15 @@ internal sealed class TelemetryFixture : IDisposable
         public bool IsCIEnvironmentResult { get; set; }
 
         public bool IsCIEnvironment() => IsCIEnvironmentResult;
+    }
+
+    /// <summary>
+    /// A test implementation of <see cref="ICodingAgentDetector"/> with configurable result.
+    /// </summary>
+    internal sealed class TestCodingAgentDetector : ICodingAgentDetector
+    {
+        public string? CodingAgent { get; set; }
+
+        public string? GetCodingAgent() => CodingAgent;
     }
 }

--- a/tests/Aspire.Cli.Tests/Telemetry/TestTelemetryHelper.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TestTelemetryHelper.cs
@@ -18,7 +18,8 @@ internal static class TestTelemetryHelper
     {
         var provider = new TestMachineInformationProvider();
         var ciDetector = new TestCIEnvironmentDetector();
-        var telemetry = new AspireCliTelemetry(NullLogger<AspireCliTelemetry>.Instance, provider, ciDetector);
+        var codingAgentDetector = new TestCodingAgentDetector();
+        var telemetry = new AspireCliTelemetry(NullLogger<AspireCliTelemetry>.Instance, provider, ciDetector, codingAgentDetector);
         telemetry.InitializeAsync().GetAwaiter().GetResult();
         return telemetry;
     }
@@ -30,7 +31,8 @@ internal static class TestTelemetryHelper
     {
         var provider = new TestMachineInformationProvider();
         var ciDetector = new TestCIEnvironmentDetector();
-        var telemetry = new AspireCliTelemetry(NullLogger<AspireCliTelemetry>.Instance, provider, ciDetector, reportedSourceName, diagnosticsSourceName);
+        var codingAgentDetector = new TestCodingAgentDetector();
+        var telemetry = new AspireCliTelemetry(NullLogger<AspireCliTelemetry>.Instance, provider, ciDetector, codingAgentDetector, reportedSourceName, diagnosticsSourceName);
         telemetry.InitializeAsync().GetAwaiter().GetResult();
         return telemetry;
     }
@@ -44,5 +46,10 @@ internal static class TestTelemetryHelper
     private sealed class TestCIEnvironmentDetector : ICIEnvironmentDetector
     {
         public bool IsCIEnvironment() => false;
+    }
+
+    private sealed class TestCodingAgentDetector : ICodingAgentDetector
+    {
+        public string? GetCodingAgent() => null;
     }
 }


### PR DESCRIPTION
## Description

Adds Aspire CLI detection for known coding agents and includes the detected agent name in the existing `aspire/cli/main` telemetry activity as `process.coding_agent`.

The detection map mirrors the `dotnet` CLI logic from dotnet/sdk#54659, including presence-based environment variable detection, value-based `OR_APP_NAME` rules, rule ordering, and comma-separated names when multiple agents are detected. The telemetry property only records the known agent name(s), not environment variable values.

### Validation

```powershell
.\restore.cmd
dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.AspireCliTelemetryTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
