### PR TITLE
Fix flaky Qdrant health check test by using HTTP readiness wait strategy

### DIFF
--- a/tests/Aspire.Qdrant.Client.Tests/QdrantContainerFixture.cs
+++ b/tests/Aspire.Qdrant.Client.Tests/QdrantContainerFixture.cs
@@ -15,6 +15,7 @@ public sealed class QdrantContainerFixture : IAsyncLifetime
     public IContainer? Container { get; private set; }
 
     private const int GrpcPort = 6334;
+    private const int HttpPort = 6333;
 
     public string GetConnectionString()
     {
@@ -33,7 +34,9 @@ public sealed class QdrantContainerFixture : IAsyncLifetime
             Container = new ContainerBuilder()
               .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{QdrantContainerImageTags.Image}:{QdrantContainerImageTags.Tag}")
               .WithPortBinding(GrpcPort, true)
-              .WithWaitStrategy(Wait.ForUnixContainer().UntilExternalTcpPortIsAvailable(GrpcPort))
+              .WithPortBinding(HttpPort, true)
+              .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
+                  request.ForPort((ushort)HttpPort).ForPath("/healthz")))
               .Build();
 
             await Container.StartAsync();


### PR DESCRIPTION
## Summary

Fixes the frequently flaky test `Aspire.Qdrant.Client.Tests.ConformanceTests.HealthCheckReportsExpectedStatus(key: null)`.

## Problem

The `QdrantContainerFixture` was using `UntilExternalTcpPortIsAvailable(GrpcPort)` as its wait strategy, which only waits for the TCP port to accept connections. Qdrant can start accepting TCP connections on port 6334 before its gRPC service is fully initialized and ready to respond to health check calls. This caused intermittent test failures:

```
Assert.Equal() Failure: Values differ
Expected: Healthy
Actual:   Unhealthy
```

The failure was most commonly seen on net9.0/ubuntu-latest but could occur on any platform.

## Fix

Changed the wait strategy to `UntilHttpRequestIsSucceeded` against Qdrant's `/healthz` HTTP endpoint on port 6333. This ensures the Qdrant service is fully ready before tests proceed, eliminating the race condition.

## Validation

- Test passes consistently locally across all TFMs (net8.0, net9.0, net10.0)

Fixes #17999