### PR TITLE
Improve Aspire docs search relevance

### DIFF
--- a/benchmarks/Aspire.Cli.Benchmarks/QueryBenchmarks.cs
+++ b/benchmarks/Aspire.Cli.Benchmarks/QueryBenchmarks.cs
@@ -9,6 +9,7 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Perfolizer.Horology;
 
 namespace Aspire.Cli.Benchmarks;
 
@@ -146,7 +147,7 @@ public class QueryBenchmarks
                 .WithToolchain(InProcessNoEmitToolchain.Instance)
                 .WithWarmupCount(2)
                 .WithIterationCount(5)
-                .WithInvocationCount(16)
+                .WithMinIterationTime(TimeInterval.FromMilliseconds(150))
                 .WithUnrollFactor(1));
 
             AddDiagnoser(MemoryDiagnoser.Default);

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -1034,7 +1034,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
     private static partial Regex BlankLineAfterListRegex();
 
     /// <summary>
-    /// Pre-indexed document with lowercase text for faster searching.
+    /// Pre-indexed document with normalized search text for faster searching.
     /// </summary>
     private sealed class IndexedDocument
     {
@@ -1111,7 +1111,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         public string IdentitySearchableTextLower { get; }
 
         /// <summary>
-        /// Concatenated lowercase text of every searchable field (slug, title, summary,
+        /// Concatenated normalized text of every searchable field (slug, title, summary,
         /// each section heading + content), separated by single spaces. Used by
         /// <c>SearchAsync</c> as a fast reject filter: if none of the query tokens appear
         /// anywhere in this haystack, the document cannot score &gt; 0 and we skip the

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -267,7 +267,13 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         var documentCount = documents.Count;
         foreach (var (token, count) in documentFrequency)
         {
-            // Use the smoothed BM25-style IDF shape:
+            // In plain terms, IDF is a rarity multiplier. A term that appears in
+            // nearly every doc, like "new" or "azure", should not move the ranking
+            // much by itself. A rarer term, like "addredis" or "134", is stronger
+            // evidence that a document is the one the user meant.
+            //
+            // The formula below is the smoothed BM25-style way to turn that rarity
+            // into a small positive weight:
             //   log(1 + (N - df + 0.5) / (df + 0.5))
             // where N is the number of indexed docs and df is the number of docs that contain
             // the token. The 0.5 terms keep very small corpora from producing extreme weights,

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -384,6 +384,11 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         ];
     }
 
+    // SearchAsync calls this for every positive-scoring document. Keep `results` sorted and
+    // capped to topK as we scan so we never allocate/sort every matching document. A small
+    // sorted list is intentional here: the CLI default is topK = 10, so linear insertion is
+    // simple, preserves final score order and stable tie-breaking, and avoids the extra final
+    // sort a heap/priority queue would need. If topK ever becomes large, revisit this.
     private static void AddTopResult(List<SearchCandidate> results, SearchCandidate candidate, int topK)
     {
         var insertIndex = 0;

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -797,7 +797,9 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
            char.IsDigit(text[index + 1]);
 
     /// <summary>
-    /// Scores how well a normalized field matches the query tokens.
+    /// Scores one normalized field by finding each query token as a substring, rewarding the
+    /// first word-boundary match, adding a capped repeated-occurrence bonus, and multiplying
+    /// the token's contribution by its IDF weight so rarer query terms count more.
     /// </summary>
     private static float ScoreField(string lowerText, string[] queryTokens, float[] queryTokenWeights)
     {

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -267,6 +267,13 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         var documentCount = documents.Count;
         foreach (var (token, count) in documentFrequency)
         {
+            // Use the smoothed BM25-style IDF shape:
+            //   log(1 + (N - df + 0.5) / (df + 0.5))
+            // where N is the number of indexed docs and df is the number of docs that contain
+            // the token. The 0.5 terms keep very small corpora from producing extreme weights,
+            // while the +1 inside the log keeps terms that appear in every doc positive but tiny.
+            // We only use the result as a rarity multiplier in the existing field scorer; this is
+            // not a full BM25 implementation.
             idf[token] = MathF.Log(1.0f + (documentCount - count + 0.5f) / (count + 0.5f));
         }
 

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -644,6 +644,11 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
             return false;
         }
 
+        // Single-token queries like "new", "whats", or "what" are not specific enough
+        // to prove the user wants a release-note page. They only become release-note
+        // identity signals when paired with more context, such as "whats new 13.4".
+        // Otherwise a broad release-note page could avoid the context penalty for a
+        // generic query and outrank a dedicated doc that happens to contain the term.
         if (queryTokens.Length is 1 && IsReleaseNotesGenericToken(queryTokens[0]))
         {
             return false;

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -308,12 +308,18 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
             return [];
         }
 
+        if (topK <= 0)
+        {
+            return [];
+        }
+
         // Pre-compute queryAsSlug once to avoid repeated allocation in hot path
         var queryAsSlug = string.Join("-", queryTokens);
         var queryAsPhrase = queryTokens.Length > 1 ? string.Join(' ', queryTokens) : string.Empty;
         var queryTokenWeights = GetQueryTokenWeights(queryTokens);
 
-        var results = new List<DocsSearchResult>();
+        var results = new List<SearchCandidate>(Math.Min(topK, _indexedDocuments.Count));
+        var documentIndex = 0;
 
         foreach (var doc in _indexedDocuments)
         {
@@ -337,6 +343,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
 
             if (!anyTokenMatches)
             {
+                documentIndex++;
                 continue;
             }
 
@@ -344,24 +351,49 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
 
             if (score > 0)
             {
-                results.Add(new DocsSearchResult
-                {
-                    Title = doc.Source.Title,
-                    Slug = doc.Source.Slug,
-                    Summary = doc.Source.Summary,
-                    MatchedSection = matchedSection,
-                    Score = score
-                });
+                AddTopResult(results, new SearchCandidate(doc, matchedSection, score, documentIndex), topK);
             }
+
+            documentIndex++;
         }
 
         return
         [
             .. results
-                .OrderByDescending(static r => r.Score)
-                .Take(topK)
+                .Select(static r => new DocsSearchResult
+                {
+                    Title = r.Document.Source.Title,
+                    Slug = r.Document.Source.Slug,
+                    Summary = r.Document.Source.Summary,
+                    MatchedSection = r.MatchedSection,
+                    Score = r.Score
+                })
         ];
     }
+
+    private static void AddTopResult(List<SearchCandidate> results, SearchCandidate candidate, int topK)
+    {
+        var insertIndex = 0;
+        while (insertIndex < results.Count && !IsBetterCandidate(candidate, results[insertIndex]))
+        {
+            insertIndex++;
+        }
+
+        if (insertIndex >= topK)
+        {
+            return;
+        }
+
+        results.Insert(insertIndex, candidate);
+        if (results.Count > topK)
+        {
+            results.RemoveAt(results.Count - 1);
+        }
+    }
+
+    private static bool IsBetterCandidate(SearchCandidate candidate, SearchCandidate current)
+        => candidate.Score > current.Score ||
+           (candidate.Score == current.Score && candidate.DocumentIndex < current.DocumentIndex);
 
     public async ValueTask<DocsContent?> GetDocumentAsync(string slug, string? section = null, CancellationToken cancellationToken = default)
     {
@@ -408,14 +440,15 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         };
     }
 
-    private Dictionary<string, float> GetQueryTokenWeights(string[] queryTokens)
+    private float[] GetQueryTokenWeights(string[] queryTokens)
     {
         var tokenIdf = _tokenIdf;
-        var weights = new Dictionary<string, float>(queryTokens.Length, StringComparer.Ordinal);
+        var weights = new float[queryTokens.Length];
 
-        foreach (var token in queryTokens)
+        for (var i = 0; i < queryTokens.Length; i++)
         {
-            weights[token] = tokenIdf is not null && tokenIdf.TryGetValue(token, out var idf)
+            var token = queryTokens[i];
+            weights[i] = tokenIdf is not null && tokenIdf.TryGetValue(token, out var idf)
                 ? idf
                 : 1.0f;
         }
@@ -426,7 +459,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
     private static (float Score, string? MatchedSection) ScoreDocument(
         IndexedDocument doc,
         string[] queryTokens,
-        IReadOnlyDictionary<string, float> queryTokenWeights,
+        float[] queryTokenWeights,
         string queryAsSlug,
         string queryAsPhrase)
     {
@@ -479,17 +512,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
             contextScore *= WhatsNewPenaltyMultiplier;
         }
 
-        var score = identityScore + contextScore;
-        if (queryTokens.Length > 1)
-        {
-            // Multi-token queries should reward coverage, not just one common word.
-            // For "azure container apps environment", a page matching only "azure"
-            // should not outrank a page that matches the full phrase in its title.
-            var coverage = CountDistinctTokenMatches(doc.AllSearchableTextLower, queryTokens) / (float)queryTokens.Length;
-            score *= 0.5f + (coverage * 0.5f);
-        }
-
-        return (score, matchedSection);
+        return (identityScore + contextScore, matchedSection);
     }
 
     /// <summary>
@@ -700,22 +723,6 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         return false;
     }
 
-    private static int CountDistinctTokenMatches(string lowerText, string[] queryTokens)
-    {
-        var count = 0;
-        var textSpan = lowerText.AsSpan();
-
-        foreach (var token in queryTokens)
-        {
-            if (textSpan.IndexOf(token, StringComparison.Ordinal) >= 0)
-            {
-                count++;
-            }
-        }
-
-        return count;
-    }
-
     private static string NormalizeSearchText(string text)
     {
         if (string.IsNullOrEmpty(text))
@@ -758,7 +765,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
     /// <summary>
     /// Scores how well a normalized field matches the query tokens.
     /// </summary>
-    private static float ScoreField(string lowerText, string[] queryTokens, IReadOnlyDictionary<string, float> queryTokenWeights)
+    private static float ScoreField(string lowerText, string[] queryTokens, float[] queryTokenWeights)
     {
         if (string.IsNullOrEmpty(lowerText))
         {
@@ -769,8 +776,9 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         var textSpan = lowerText.AsSpan();
         var occurrenceLimit = MaxOccurrenceBonus + 1;
 
-        foreach (var token in queryTokens)
+        for (var i = 0; i < queryTokens.Length; i++)
         {
+            var token = queryTokens[i];
             var startIndex = 0;
             var firstMatchIndex = -1;
             var count = 0;
@@ -809,7 +817,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
                 tokenScore += Math.Min(count - 1, MaxOccurrenceBonus) * MultipleOccurrenceBonus;
             }
 
-            score += tokenScore * GetQueryTokenWeight(queryTokenWeights, token);
+            score += tokenScore * queryTokenWeights[i];
         }
 
         return score;
@@ -827,22 +835,23 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         IReadOnlyList<string> codeSpans,
         IReadOnlyList<string> identifiers,
         string[] queryTokens,
-        IReadOnlyDictionary<string, float> queryTokenWeights)
+        float[] queryTokenWeights)
     {
         var score = 0.0f;
 
-        foreach (var token in queryTokens)
+        for (var i = 0; i < queryTokens.Length; i++)
         {
+            var token = queryTokens[i];
             var codeSpanMatches = CountContainingTokens(codeSpans, token);
             if (codeSpanMatches > 0)
             {
-                score += ScoreRepeatedMatches(BaseMatchScore, codeSpanMatches) * GetQueryTokenWeight(queryTokenWeights, token);
+                score += ScoreRepeatedMatches(BaseMatchScore, codeSpanMatches) * queryTokenWeights[i];
             }
 
             var identifierMatches = CountContainingTokens(identifiers, token);
             if (identifierMatches > 0)
             {
-                score += ScoreRepeatedMatches(CodeIdentifierBonus, identifierMatches) * GetQueryTokenWeight(queryTokenWeights, token);
+                score += ScoreRepeatedMatches(CodeIdentifierBonus, identifierMatches) * queryTokenWeights[i];
             }
         }
 
@@ -870,9 +879,6 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
 
     private static float ScoreRepeatedMatches(float baseScore, int count)
         => baseScore + Math.Min(count - 1, MaxOccurrenceBonus) * MultipleOccurrenceBonus;
-
-    private static float GetQueryTokenWeight(IReadOnlyDictionary<string, float> queryTokenWeights, string token)
-        => queryTokenWeights.TryGetValue(token, out var weight) ? weight : 1.0f;
 
     /// <summary>
     /// Normalizes markdown content from llms.txt sources.
@@ -1032,6 +1038,8 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
 
     [GeneratedRegex(@"(?m)(^(?:\*\s|\d+\.\s)[^\n]*\n)(?!\n|\*\s|\d+\.\s|```)")]
     private static partial Regex BlankLineAfterListRegex();
+
+    private readonly record struct SearchCandidate(IndexedDocument Document, string? MatchedSection, float Score, int DocumentIndex);
 
     /// <summary>
     /// Pre-indexed document with normalized search text for faster searching.

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -788,7 +788,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         for (var i = 0; i < text.Length; i++)
         {
             var c = text[i];
-            if (IsApostropheLike(c))
+            if (IsIgnoredPunctuation(c))
             {
                 continue;
             }
@@ -806,7 +806,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         return builder.ToString();
     }
 
-    private static bool IsApostropheLike(char c)
+    private static bool IsIgnoredPunctuation(char c)
         => c is '\'' or '\u2019' or '\u2018' or '\u02BC' or '`';
 
     private static bool IsNumericVersionSeparator(string text, int index)

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -469,6 +469,13 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         return weights;
     }
 
+    // ScoreDocument combines two kinds of evidence:
+    //   1. Identity signals (slug + H1 title): strong proof that this is the page the user meant.
+    //   2. Context signals (summary + best matching section): useful supporting evidence, but
+    //      noisier because broad docs and release notes mention many unrelated terms.
+    // Field weights make matches in titles/headings/summaries count more than body text, IDF
+    // makes rarer query terms count more than common terms, and exact phrase bonuses help pages
+    // with the whole query in a title/heading beat pages with scattered incidental matches.
     private static (float Score, string? MatchedSection) ScoreDocument(
         IndexedDocument doc,
         string[] queryTokens,
@@ -495,7 +502,9 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
                 ScorePhraseMatch(doc.SummaryLower, queryAsPhrase, SummaryPhraseBonus);
         }
 
-        // Score each section (H2/H3 headings + content)
+        // Score every section, but only add the best one to the document score. This gives
+        // the result a useful MatchedSection without letting a long page win just because it
+        // has many sections that each contain a small incidental match.
         for (var i = 0; i < doc.Sections.Count; i++)
         {
             var section = doc.Sections[i];

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -821,6 +821,12 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
     /// first word-boundary match, adding a capped repeated-occurrence bonus, and multiplying
     /// the token's contribution by its IDF weight so rarer query terms count more.
     /// </summary>
+    // This is docs-search-specific instead of using LexicalScoring.ScoreField because docs
+    // search needs per-token weights. For example, in "whats new 13.4", "new" appears in
+    // many docs and should barely move ranking, while "134" is rare and should count more.
+    // In "service discovery", a word-boundary match for "discovery" should count more than
+    // a substring match inside another word; exact whole-phrase bonuses are added by the
+    // ScoreDocument caller for titles, summaries, and headings.
     private static float ScoreField(string lowerText, string[] queryTokens, float[] queryTokenWeights)
     {
         if (string.IsNullOrEmpty(lowerText))

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -139,10 +139,10 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
     private readonly string _llmsTxtUrl = DocsSourceConfiguration.GetLlmsTxtUrl(configuration);
     private readonly ILogger<DocsIndexService> _logger = logger;
 
-    // Volatile ensures the double-checked locking pattern works correctly by preventing
-    // instruction reordering that could expose a partially-constructed list to other threads.
+    // Volatile ensures the double-checked locking pattern publishes the fully initialized
+    // index data before any thread observes _indexedDocuments as non-null.
     private volatile List<IndexedDocument>? _indexedDocuments;
-    private Dictionary<string, float>? _tokenIdf;
+    private volatile Dictionary<string, float>? _tokenIdf;
     private readonly SemaphoreSlim _indexLock = new(1, 1);
 
     /// <inheritdoc />

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -721,10 +721,11 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         return token is "what" && ContainsWordBoundaryMatch(textSpan, "whats");
     }
 
-    // Search every occurrence of the token and accept only lexical word-boundary matches.
-    // For release-note identity checks this keeps "go" matching "Go updates" while rejecting
-    // the substring inside "changelog", so short feature names do not accidentally make a
-    // changelog page look like an explicit release-note query.
+    // ContainsIdentityToken uses this for release-note identity checks. Search every
+    // occurrence of the token and accept only lexical word-boundary matches, so "go"
+    // matches "Go updates" but not the substring inside "changelog". That keeps short
+    // feature names from accidentally making a changelog page look like an explicit
+    // release-note query.
     private static bool ContainsWordBoundaryMatch(ReadOnlySpan<char> textSpan, string token)
     {
         var startIndex = 0;

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -721,6 +721,10 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         return token is "what" && ContainsWordBoundaryMatch(textSpan, "whats");
     }
 
+    // Search every occurrence of the token and accept only lexical word-boundary matches.
+    // For release-note identity checks this keeps "go" matching "Go updates" while rejecting
+    // the substring inside "changelog", so short feature names do not accidentally make a
+    // changelog page look like an explicit release-note query.
     private static bool ContainsWordBoundaryMatch(ReadOnlySpan<char> textSpan, string token)
     {
         var startIndex = 0;

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -104,9 +104,9 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
     private const float HeadingWeight = 6.0f;     // H2/H3 headings
     private const float CodeWeight = 5.0f;        // Code identifiers
     private const float BodyWeight = 1.0f;        // Body text
-    private const float TitlePhraseBonus = 40.0f;
-    private const float SummaryPhraseBonus = 20.0f;
-    private const float HeadingPhraseBonus = 15.0f;
+    private const float TitlePhraseBonus = 40.0f;   // Exact query phrase in H1 title
+    private const float SummaryPhraseBonus = 20.0f; // Exact query phrase in blockquote summary
+    private const float HeadingPhraseBonus = 15.0f; // Exact query phrase in H2/H3 heading
 
     // Scoring constants
     private const float BaseMatchScore = 1.0f;
@@ -668,7 +668,17 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         => token is "new" or "whats" or "what";
 
     private static bool ContainsDigit(string token)
-        => token.Any(static c => char.IsDigit(c));
+    {
+        foreach (var c in token.AsSpan())
+        {
+            if (char.IsDigit(c))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     private static int CountDistinctIdentityTokenMatches(string lowerText, string[] queryTokens)
     {

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -750,6 +750,13 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         return false;
     }
 
+    // Apply the same lightweight normalization to indexed document fields and incoming
+    // queries before tokenization/scoring. This deliberately handles the cases where the
+    // live docs and user input use different spellings for the same intent:
+    //   "What's new" -> "whats new"
+    //   "13.4" / "13-4" -> "134"
+    // That lets a query like "whats new 13.4" line up with both the page title and the
+    // aspire.dev slug "whats-new-in-aspire-134" without changing unrelated punctuation.
     private static string NormalizeSearchText(string text)
     {
         if (string.IsNullOrEmpty(text))

--- a/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Documentation/Docs/DocsIndexService.cs
@@ -104,6 +104,9 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
     private const float HeadingWeight = 6.0f;     // H2/H3 headings
     private const float CodeWeight = 5.0f;        // Code identifiers
     private const float BodyWeight = 1.0f;        // Body text
+    private const float TitlePhraseBonus = 40.0f;
+    private const float SummaryPhraseBonus = 20.0f;
+    private const float HeadingPhraseBonus = 15.0f;
 
     // Scoring constants
     private const float BaseMatchScore = 1.0f;
@@ -139,6 +142,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
     // Volatile ensures the double-checked locking pattern works correctly by preventing
     // instruction reordering that could expose a partially-constructed list to other threads.
     private volatile List<IndexedDocument>? _indexedDocuments;
+    private Dictionary<string, float>? _tokenIdf;
     private readonly SemaphoreSlim _indexLock = new(1, 1);
 
     /// <inheritdoc />
@@ -172,7 +176,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
             {
                 if (cachedDocuments is not null)
                 {
-                    _indexedDocuments = [.. cachedDocuments.Select(static d => new IndexedDocument(d))];
+                    SetIndexedDocuments(cachedDocuments);
 
                     _logger.LogWarning(
                         "Failed to refresh Aspire documentation. Using cached index with {Count} documents.",
@@ -189,17 +193,17 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
             var currentFingerprint = SourceContentFingerprint.Compute(content, IndexSchemaVersion);
             if (cachedDocuments is not null && string.Equals(cachedFingerprint, currentFingerprint, StringComparison.Ordinal))
             {
-                _indexedDocuments = [.. cachedDocuments.Select(static d => new IndexedDocument(d))];
+                var indexedDocuments = SetIndexedDocuments(cachedDocuments);
 
                 var cacheElapsedTime = Stopwatch.GetElapsedTime(startTimestamp);
-                _logger.LogInformation("Loaded {Count} documents from cache in {ElapsedTime:ss\\.fff} seconds.", _indexedDocuments.Count, cacheElapsedTime);
+                _logger.LogInformation("Loaded {Count} documents from cache in {ElapsedTime:ss\\.fff} seconds.", indexedDocuments.Count, cacheElapsedTime);
                 return;
             }
 
             var documents = await LlmsTxtParser.ParseAsync(content, cancellationToken).ConfigureAwait(false);
 
-            // Pre-compute lowercase versions for faster searching
-            _indexedDocuments = [.. documents.Select(static d => new IndexedDocument(d))];
+            // Pre-compute normalized versions for faster searching
+            var indexedDocumentsFromSource = SetIndexedDocuments(documents);
 
             // Cache the parsed documents for next time
             await _docsCache.SetIndexAsync([.. documents], cancellationToken).ConfigureAwait(false);
@@ -207,12 +211,66 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
 
             var elapsedTime = Stopwatch.GetElapsedTime(startTimestamp);
 
-            _logger.LogInformation("Indexed {Count} documents from aspire.dev in {ElapsedTime:ss\\.fff} seconds.", _indexedDocuments.Count, elapsedTime);
+            _logger.LogInformation("Indexed {Count} documents from aspire.dev in {ElapsedTime:ss\\.fff} seconds.", indexedDocumentsFromSource.Count, elapsedTime);
         }
         finally
         {
             _indexLock.Release();
         }
+    }
+
+    private List<IndexedDocument> SetIndexedDocuments(IEnumerable<LlmsDocument> documents)
+    {
+        var indexedDocuments = documents.Select(static d => new IndexedDocument(d)).ToList();
+        _tokenIdf = BuildTokenIdf(indexedDocuments);
+        _indexedDocuments = indexedDocuments;
+        return indexedDocuments;
+    }
+
+    private static Dictionary<string, float> BuildTokenIdf(IReadOnlyList<IndexedDocument> documents)
+    {
+        var documentFrequency = new Dictionary<string, int>(StringComparer.Ordinal);
+        var documentTokens = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var document in documents)
+        {
+            documentTokens.Clear();
+
+            // IDF is based on whether a token appears in a document, not how many times
+            // it appears inside that document. That keeps noisy pages from dominating by
+            // repetition: "azure" or "new" appears almost everywhere and should carry a
+            // small multiplier, while rarer terms like "addredis" or "134" are stronger
+            // signals for queries such as "AddRedis" or "whats new 13.4".
+            foreach (var token in Tokenize(document.AllSearchableTextLower))
+            {
+                documentTokens.Add(token);
+            }
+
+            // Tokenize keeps hyphenated slugs as one token, so add slug segments too.
+            // For example, "service-discovery" should contribute weights for both
+            // "service" and "discovery" when scoring the query "service discovery".
+            foreach (var segment in document.SlugSegments)
+            {
+                if (segment.Length >= MinTokenLength)
+                {
+                    documentTokens.Add(segment);
+                }
+            }
+
+            foreach (var token in documentTokens)
+            {
+                documentFrequency[token] = documentFrequency.TryGetValue(token, out var count) ? count + 1 : 1;
+            }
+        }
+
+        var idf = new Dictionary<string, float>(documentFrequency.Count, StringComparer.Ordinal);
+        var documentCount = documents.Count;
+        foreach (var (token, count) in documentFrequency)
+        {
+            idf[token] = MathF.Log(1.0f + (documentCount - count + 0.5f) / (count + 0.5f));
+        }
+
+        return idf;
     }
 
     public async ValueTask<IReadOnlyList<DocsListItem>> ListDocumentsAsync(CancellationToken cancellationToken = default)
@@ -252,6 +310,8 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
 
         // Pre-compute queryAsSlug once to avoid repeated allocation in hot path
         var queryAsSlug = string.Join("-", queryTokens);
+        var queryAsPhrase = queryTokens.Length > 1 ? string.Join(' ', queryTokens) : string.Empty;
+        var queryTokenWeights = GetQueryTokenWeights(queryTokens);
 
         var results = new List<DocsSearchResult>();
 
@@ -280,7 +340,7 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
                 continue;
             }
 
-            var (score, matchedSection) = ScoreDocument(doc, queryTokens, queryAsSlug);
+            var (score, matchedSection) = ScoreDocument(doc, queryTokens, queryTokenWeights, queryAsSlug, queryAsPhrase);
 
             if (score > 0)
             {
@@ -348,32 +408,55 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         };
     }
 
-    private static (float Score, string? MatchedSection) ScoreDocument(IndexedDocument doc, string[] queryTokens, string queryAsSlug)
+    private Dictionary<string, float> GetQueryTokenWeights(string[] queryTokens)
     {
-        var score = 0.0f;
+        var tokenIdf = _tokenIdf;
+        var weights = new Dictionary<string, float>(queryTokens.Length, StringComparer.Ordinal);
+
+        foreach (var token in queryTokens)
+        {
+            weights[token] = tokenIdf is not null && tokenIdf.TryGetValue(token, out var idf)
+                ? idf
+                : 1.0f;
+        }
+
+        return weights;
+    }
+
+    private static (float Score, string? MatchedSection) ScoreDocument(
+        IndexedDocument doc,
+        string[] queryTokens,
+        IReadOnlyDictionary<string, float> queryTokenWeights,
+        string queryAsSlug,
+        string queryAsPhrase)
+    {
         string? matchedSection = null;
         var bestSectionScore = 0.0f;
 
         // Score slug matching - this is key for finding dedicated docs
         // e.g., query "service discovery" should match slug "service-discovery" with high score
-        score += ScoreSlugMatch(doc.SlugLower, doc.SlugSegments, queryTokens, queryAsSlug);
+        var slugScore = ScoreSlugMatch(doc.SlugLower, doc.SlugSegments, queryTokens, queryAsSlug);
 
         // Score H1 title
-        score += ScoreField(doc.TitleLower, queryTokens) * TitleWeight;
+        var titleScore = (ScoreField(doc.TitleLower, queryTokens, queryTokenWeights) * TitleWeight) +
+            ScorePhraseMatch(doc.TitleLower, queryAsPhrase, TitlePhraseBonus);
 
         // Score blockquote summary
+        var summaryScore = 0.0f;
         if (doc.SummaryLower is not null)
         {
-            score += ScoreField(doc.SummaryLower, queryTokens) * SummaryWeight;
+            summaryScore = (ScoreField(doc.SummaryLower, queryTokens, queryTokenWeights) * SummaryWeight) +
+                ScorePhraseMatch(doc.SummaryLower, queryAsPhrase, SummaryPhraseBonus);
         }
 
         // Score each section (H2/H3 headings + content)
         for (var i = 0; i < doc.Sections.Count; i++)
         {
             var section = doc.Sections[i];
-            var headingScore = ScoreField(section.HeadingLower, queryTokens) * HeadingWeight;
-            var codeScore = ScoreCodeIdentifiers(section.CodeSpans, section.Identifiers, queryTokens) * CodeWeight;
-            var bodyScore = ScoreField(section.ContentLower, queryTokens) * BodyWeight;
+            var headingScore = (ScoreField(section.HeadingLower, queryTokens, queryTokenWeights) * HeadingWeight) +
+                ScorePhraseMatch(section.HeadingLower, queryAsPhrase, HeadingPhraseBonus);
+            var codeScore = ScoreCodeIdentifiers(section.CodeSpans, section.Identifiers, queryTokens, queryTokenWeights) * CodeWeight;
+            var bodyScore = ScoreField(section.ContentLower, queryTokens, queryTokenWeights) * BodyWeight;
 
             var sectionScore = headingScore + codeScore + bodyScore;
 
@@ -384,18 +467,26 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
             }
         }
 
-        score += bestSectionScore;
+        var identityScore = slugScore + titleScore;
+        var contextScore = summaryScore + bestSectionScore;
 
-        // Apply penalty for "What's New" / changelog pages
-        // These pages mention many features and shouldn't outrank dedicated documentation
-        // BUT: Skip penalty when user is explicitly searching for changelog content
-        // Note: "what's" tokenizes to "what" due to apostrophe splitting, so we check for both "what" and "new" together
-        var hasChangelogToken = queryTokens.Any(static t => t is "changelog" or "whats-new");
-        var hasWhatsNewTokens = queryTokens.Contains("what") && queryTokens.Contains("new");
-        var queryIsAboutChangelog = hasChangelogToken || hasWhatsNewTokens;
-        if (!queryIsAboutChangelog && (doc.SlugLower.Contains("whats-new") || doc.SlugLower.Contains("changelog")))
+        // What's New and changelog pages contain broad feature lists, so a query like
+        // "javascript" or "go" should prefer dedicated docs over release-note context
+        // mentions. Keep title/slug identity unpenalized so explicit queries like
+        // "whats new 13.4" and "changelog" still find the release-note pages.
+        if (IsReleaseNotesDocument(doc) && !HasReleaseNotesIdentityMatch(doc, queryTokens, queryAsSlug, slugScore))
         {
-            score *= WhatsNewPenaltyMultiplier;
+            contextScore *= WhatsNewPenaltyMultiplier;
+        }
+
+        var score = identityScore + contextScore;
+        if (queryTokens.Length > 1)
+        {
+            // Multi-token queries should reward coverage, not just one common word.
+            // For "azure container apps environment", a page matching only "azure"
+            // should not outrank a page that matches the full phrase in its title.
+            var coverage = CountDistinctTokenMatches(doc.AllSearchableTextLower, queryTokens) / (float)queryTokens.Length;
+            score *= 0.5f + (coverage * 0.5f);
         }
 
         return (score, matchedSection);
@@ -510,53 +601,278 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
     /// Tokenizes a query string, preserving symbols like --flag, AddRedis, aspire.json.
     /// </summary>
     private static string[] Tokenize(string text)
-        => LexicalScoring.Tokenize(text, TokenSplitRegex(), MinTokenLength);
+        => LexicalScoring.Tokenize(NormalizeSearchText(text), TokenSplitRegex(), MinTokenLength);
+
+    private static bool IsReleaseNotesDocument(IndexedDocument doc)
+        => doc.SlugLower.Contains("whats-new", StringComparison.Ordinal) ||
+           doc.SlugLower.Contains("changelog", StringComparison.Ordinal);
+
+    private static bool HasReleaseNotesIdentityMatch(IndexedDocument doc, string[] queryTokens, string queryAsSlug, float slugScore)
+    {
+        if (queryTokens.Length is 0)
+        {
+            return false;
+        }
+
+        if (queryTokens.Length is 1 && IsReleaseNotesGenericToken(queryTokens[0]))
+        {
+            return false;
+        }
+
+        if (doc.SlugLower == queryAsSlug || slugScore >= FullPhraseInSlugBonus)
+        {
+            return true;
+        }
+
+        var matchedTokens = CountDistinctIdentityTokenMatches(doc.IdentitySearchableTextLower, queryTokens);
+        // Versioned release-note queries need all tokens so "whats new 13.4" does not
+        // rank "What's new in Aspire 13.2" just because "whats" and "new" match.
+        // Non-versioned queries allow a partial identity match for longer phrases, but
+        // still require token-boundary matches so "go" does not match inside "changelog".
+        var requiredMatches = queryTokens.Any(static token => ContainsDigit(token))
+            ? queryTokens.Length
+            : queryTokens.Length switch
+            {
+                1 => 1,
+                2 => 2,
+                _ => Math.Max(2, (queryTokens.Length * 2 + 2) / 3)
+            };
+
+        return matchedTokens >= requiredMatches;
+    }
+
+    private static bool IsReleaseNotesGenericToken(string token)
+        => token is "new" or "whats" or "what";
+
+    private static bool ContainsDigit(string token)
+        => token.Any(static c => char.IsDigit(c));
+
+    private static int CountDistinctIdentityTokenMatches(string lowerText, string[] queryTokens)
+    {
+        var count = 0;
+        var textSpan = lowerText.AsSpan();
+
+        foreach (var token in queryTokens)
+        {
+            if (ContainsIdentityToken(textSpan, token))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static bool ContainsIdentityToken(ReadOnlySpan<char> textSpan, string token)
+    {
+        if (ContainsWordBoundaryMatch(textSpan, token))
+        {
+            return true;
+        }
+
+        // The "What's new" title normalizes to "whats new", but users commonly type
+        // "what new" without the trailing s. Keep that release-note query working
+        // without allowing arbitrary substrings like "go" inside "changelog".
+        return token is "what" && ContainsWordBoundaryMatch(textSpan, "whats");
+    }
+
+    private static bool ContainsWordBoundaryMatch(ReadOnlySpan<char> textSpan, string token)
+    {
+        var startIndex = 0;
+
+        while (startIndex < textSpan.Length)
+        {
+            var nextIndex = textSpan[startIndex..].IndexOf(token, StringComparison.Ordinal);
+            if (nextIndex < 0)
+            {
+                return false;
+            }
+
+            var absoluteIndex = startIndex + nextIndex;
+            if (LexicalScoring.IsWordBoundaryMatch(textSpan, token, absoluteIndex))
+            {
+                return true;
+            }
+
+            startIndex = absoluteIndex + token.Length;
+        }
+
+        return false;
+    }
+
+    private static int CountDistinctTokenMatches(string lowerText, string[] queryTokens)
+    {
+        var count = 0;
+        var textSpan = lowerText.AsSpan();
+
+        foreach (var token in queryTokens)
+        {
+            if (textSpan.IndexOf(token, StringComparison.Ordinal) >= 0)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static string NormalizeSearchText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        var builder = new StringBuilder(text.Length);
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (IsApostropheLike(c))
+            {
+                continue;
+            }
+
+            // aspire.dev slugs strip numeric separators from versions, so normalize
+            // "13.4" and "13-4" to the same token shape as "134".
+            if (IsNumericVersionSeparator(text, i))
+            {
+                continue;
+            }
+
+            builder.Append(char.ToLowerInvariant(c));
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool IsApostropheLike(char c)
+        => c is '\'' or '\u2019' or '\u2018' or '\u02BC' or '`';
+
+    private static bool IsNumericVersionSeparator(string text, int index)
+        => (text[index] is '.' or '-') &&
+           index > 0 &&
+           index + 1 < text.Length &&
+           char.IsDigit(text[index - 1]) &&
+           char.IsDigit(text[index + 1]);
 
     /// <summary>
-    /// Scores how well a pre-lowercased field matches the query tokens.
+    /// Scores how well a normalized field matches the query tokens.
     /// </summary>
-    private static float ScoreField(string lowerText, string[] queryTokens)
-        => LexicalScoring.ScoreField(
-            lowerText,
-            queryTokens,
-            MaxOccurrenceBonus,
-            BaseMatchScore,
-            WordBoundaryBonus,
-            MultipleOccurrenceBonus);
+    private static float ScoreField(string lowerText, string[] queryTokens, IReadOnlyDictionary<string, float> queryTokenWeights)
+    {
+        if (string.IsNullOrEmpty(lowerText))
+        {
+            return 0;
+        }
+
+        var score = 0.0f;
+        var textSpan = lowerText.AsSpan();
+        var occurrenceLimit = MaxOccurrenceBonus + 1;
+
+        foreach (var token in queryTokens)
+        {
+            var startIndex = 0;
+            var firstMatchIndex = -1;
+            var count = 0;
+
+            while (startIndex < textSpan.Length && count < occurrenceLimit)
+            {
+                var nextIndex = textSpan[startIndex..].IndexOf(token, StringComparison.Ordinal);
+                if (nextIndex < 0)
+                {
+                    break;
+                }
+
+                var absoluteIndex = startIndex + nextIndex;
+                if (firstMatchIndex < 0)
+                {
+                    firstMatchIndex = absoluteIndex;
+                }
+
+                count++;
+                startIndex = absoluteIndex + token.Length;
+            }
+
+            if (count is 0)
+            {
+                continue;
+            }
+
+            var tokenScore = BaseMatchScore;
+            if (LexicalScoring.IsWordBoundaryMatch(textSpan, token, firstMatchIndex))
+            {
+                tokenScore += WordBoundaryBonus;
+            }
+
+            if (count > 1)
+            {
+                tokenScore += Math.Min(count - 1, MaxOccurrenceBonus) * MultipleOccurrenceBonus;
+            }
+
+            score += tokenScore * GetQueryTokenWeight(queryTokenWeights, token);
+        }
+
+        return score;
+    }
+
+    private static float ScorePhraseMatch(string lowerText, string queryAsPhrase, float bonus)
+        => queryAsPhrase.Length > 0 && lowerText.Contains(queryAsPhrase, StringComparison.Ordinal)
+            ? bonus
+            : 0;
 
     /// <summary>
     /// Scores pre-extracted code identifiers against query tokens.
     /// </summary>
-    private static float ScoreCodeIdentifiers(IReadOnlyList<string> codeSpans, IReadOnlyList<string> identifiers, string[] queryTokens)
+    private static float ScoreCodeIdentifiers(
+        IReadOnlyList<string> codeSpans,
+        IReadOnlyList<string> identifiers,
+        string[] queryTokens,
+        IReadOnlyDictionary<string, float> queryTokenWeights)
     {
         var score = 0.0f;
 
-        // Score backticked code spans
-        foreach (var code in codeSpans)
+        foreach (var token in queryTokens)
         {
-            foreach (var token in queryTokens)
+            var codeSpanMatches = CountContainingTokens(codeSpans, token);
+            if (codeSpanMatches > 0)
             {
-                if (code.Contains(token, StringComparison.Ordinal))
-                {
-                    score += BaseMatchScore;
-                }
+                score += ScoreRepeatedMatches(BaseMatchScore, codeSpanMatches) * GetQueryTokenWeight(queryTokenWeights, token);
             }
-        }
 
-        // Score PascalCase identifiers
-        foreach (var identifier in identifiers)
-        {
-            foreach (var token in queryTokens)
+            var identifierMatches = CountContainingTokens(identifiers, token);
+            if (identifierMatches > 0)
             {
-                if (identifier.Contains(token, StringComparison.Ordinal))
-                {
-                    score += CodeIdentifierBonus;
-                }
+                score += ScoreRepeatedMatches(CodeIdentifierBonus, identifierMatches) * GetQueryTokenWeight(queryTokenWeights, token);
             }
         }
 
         return score;
     }
+
+    private static int CountContainingTokens(IReadOnlyList<string> values, string token)
+    {
+        var count = 0;
+        var occurrenceLimit = MaxOccurrenceBonus + 1;
+        foreach (var value in values)
+        {
+            if (value.Contains(token, StringComparison.Ordinal))
+            {
+                count++;
+                if (count >= occurrenceLimit)
+                {
+                    break;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private static float ScoreRepeatedMatches(float baseScore, int count)
+        => baseScore + Math.Min(count - 1, MaxOccurrenceBonus) * MultipleOccurrenceBonus;
+
+    private static float GetQueryTokenWeight(IReadOnlyDictionary<string, float> queryTokenWeights, string token)
+        => queryTokenWeights.TryGetValue(token, out var weight) ? weight : 1.0f;
 
     /// <summary>
     /// Normalizes markdown content from llms.txt sources.
@@ -727,13 +1043,14 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
         public IndexedDocument(LlmsDocument source)
         {
             Source = source;
-            TitleLower = source.Title.ToLowerInvariant();
-            _slugLower = source.Slug.ToLowerInvariant();
+            TitleLower = NormalizeSearchText(source.Title);
+            _slugLower = NormalizeSearchText(source.Slug);
             SlugSegments = _slugLower.Split('-');
-            SummaryLower = source.Summary?.ToLowerInvariant();
+            SummaryLower = source.Summary is not null ? NormalizeSearchText(source.Summary) : null;
             Sections = [.. source.Sections.Select(static s => new IndexedSection(s))];
+            IdentitySearchableTextLower = $"{_slugLower} {TitleLower}";
 
-            // Build a single concatenated lowercase haystack used ONLY as an early-reject
+            // Build a single concatenated normalized haystack used ONLY as an early-reject
             // pre-filter in SearchAsync. Probing each query token against every section's
             // ContentLower scales with every section in every document; one per-doc haystack
             // check lets us skip the full per-section scoring for docs that can't possibly
@@ -791,6 +1108,8 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
 
         public IReadOnlyList<IndexedSection> Sections { get; }
 
+        public string IdentitySearchableTextLower { get; }
+
         /// <summary>
         /// Concatenated lowercase text of every searchable field (slug, title, summary,
         /// each section heading + content), separated by single spaces. Used by
@@ -806,22 +1125,22 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
     /// </summary>
     private sealed class IndexedSection(LlmsSection source)
     {
-        public string HeadingLower { get; } = source.Heading.ToLowerInvariant();
+        public string HeadingLower { get; } = NormalizeSearchText(source.Heading);
 
-        public string ContentLower { get; } = source.Content.ToLowerInvariant();
+        public string ContentLower { get; } = NormalizeSearchText(source.Content);
 
         public IReadOnlyList<string> CodeSpans { get; } =
         [
             .. CodeBlockRegex()
                 .Matches(source.Content)
-                .Select(static m => m.Groups[1].Value.ToLowerInvariant())
+                .Select(static m => NormalizeSearchText(m.Groups[1].Value))
         ];
 
         public IReadOnlyList<string> Identifiers { get; } =
         [
             .. IdentifierRegex()
                 .Matches(source.Content)
-                .Select(static m => m.Value.ToLowerInvariant())
+                .Select(static m => NormalizeSearchText(m.Value))
         ];
     }
 }

--- a/tests/Aspire.Cli.Tests/Mcp/Docs/DocsIndexServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/Docs/DocsIndexServiceTests.cs
@@ -1355,7 +1355,7 @@ public class DocsIndexServiceTests
     public async Task SearchAsync_VersionQuery_MatchesSlugWithCollapsedVersion(string query)
     {
         var content = """
-            # Aspire 134 Release Notes
+            # Aspire 13.4 Release Notes
             > Release notes for Aspire.
 
             Upgrade details.
@@ -1372,7 +1372,7 @@ public class DocsIndexServiceTests
         var results = await service.SearchAsync(query);
 
         Assert.NotEmpty(results);
-        Assert.Equal("Aspire 134 Release Notes", results[0].Title);
+        Assert.Equal("Aspire 13.4 Release Notes", results[0].Title);
     }
 
     private sealed class MockDocsFetcher(string? content) : IDocsFetcher

--- a/tests/Aspire.Cli.Tests/Mcp/Docs/DocsIndexServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/Docs/DocsIndexServiceTests.cs
@@ -993,6 +993,85 @@ public class DocsIndexServiceTests
     }
 
     [Fact]
+    public async Task SearchAsync_TitleAndSlugPhraseMatch_OutranksRepeatedBodyAndCodeMatches()
+    {
+        var content = """
+            # Service Discovery
+            > Learn about service discovery in Aspire.
+
+            Service discovery content.
+
+            # Connect to Azure Service Bus
+            > Connect to Azure Service Bus for messaging.
+
+            ## Troubleshooting
+            Service discovery is mentioned in troubleshooting. Service discovery appears again.
+            `ServiceDiscoveryOptions` `ServiceDiscoveryOptions` `ServiceDiscoveryOptions`
+            `ServiceDiscoveryOptions` `ServiceDiscoveryOptions` `ServiceDiscoveryOptions`
+            """;
+
+        var fetcher = CreateMockFetcher(content);
+        var service = CreateService(fetcher);
+
+        var results = await service.SearchAsync("service discovery");
+
+        Assert.NotEmpty(results);
+        Assert.Equal("Service Discovery", results[0].Title);
+    }
+
+    [Fact]
+    public async Task SearchAsync_CommandTitleAndSlug_OutrankReleaseNotesForCommonTerms()
+    {
+        var content = """
+            # aspire new command
+            > Learn about the aspire new command and its usage.
+
+            This command creates new Aspire projects or solutions.
+
+            # What's new in Aspire 13.2
+            > Aspire 13.2 is here with new CLI commands, TypeScript AppHost support, and new and improved integrations.
+
+            ## CLI enhancements
+            Aspire has new commands, new templates, new project creation, and new integration updates.
+            New Aspire experiences are easier to use with new command-line workflows.
+            """;
+
+        var fetcher = CreateMockFetcher(content);
+        var service = CreateService(fetcher);
+
+        var results = await service.SearchAsync("aspire new");
+
+        Assert.NotEmpty(results);
+        Assert.Equal("aspire new command", results[0].Title);
+    }
+
+    [Fact]
+    public async Task SearchAsync_TitlePhrase_OutranksRepeatedCommonAzureTerms()
+    {
+        var content = """
+            # Configure Azure Container Apps environments
+            > Learn how to configure Azure Container Apps environment settings, scaling rules, and ingress.
+
+            Configure environment details.
+
+            # Manage Azure role assignments
+            > Learn how to manage Azure role assignments.
+
+            Azure resources use Azure role assignments. Azure permissions can apply to Azure Container Apps.
+            Azure Container Apps environment names can appear in Azure role assignment examples.
+            Azure role assignment examples repeat Azure terms many times.
+            """;
+
+        var fetcher = CreateMockFetcher(content);
+        var service = CreateService(fetcher);
+
+        var results = await service.SearchAsync("azure container apps environment");
+
+        Assert.NotEmpty(results);
+        Assert.Equal("Configure Azure Container Apps environments", results[0].Title);
+    }
+
+    [Fact]
     public async Task SearchAsync_WhatsNewPenalty_RanksLower()
     {
         // "What's New" pages mention many features and should rank lower than dedicated docs
@@ -1069,6 +1148,31 @@ public class DocsIndexServiceTests
         Assert.NotEmpty(results);
         // The dedicated Redis doc should rank higher than the changelog
         Assert.Equal("Redis Integration", results[0].Title);
+    }
+
+    [Fact]
+    public async Task SearchAsync_ReleaseNotesIdentityMatch_RequiresTokenBoundaryMatch()
+    {
+        var content = """
+            # Set up Go apps
+            > Configure applications.
+
+            Basic setup.
+
+            # Changelog
+            > Complete changelog for Aspire.
+
+            ## Go updates
+            Go support was added. Go improvements. Go templates. Go resources.
+            """;
+
+        var fetcher = CreateMockFetcher(content);
+        var service = CreateService(fetcher);
+
+        var results = await service.SearchAsync("go");
+
+        Assert.NotEmpty(results);
+        Assert.Equal("Set up Go apps", results[0].Title);
     }
 
     [Fact]
@@ -1178,30 +1282,97 @@ public class DocsIndexServiceTests
         Assert.Equal("Changelog", results[0].Title);
     }
 
-    [Fact]
-    public async Task SearchAsync_WhatsNewQuery_DoesNotApplyPenalty()
+    [Theory]
+    [InlineData("whats new 13.4")]
+    [InlineData("what's new 13.4")]
+    [InlineData("what new 13.4")]
+    [InlineData("13-4 whats new")]
+    public async Task SearchAsync_WhatsNewQuery_RanksReleaseNotesAboveNoisyMatches(string query)
     {
-        // When user searches for "whats new", the whats-new page should NOT be penalized
         var content = """
-            # What's New in Aspire 1.3
-            > Release notes for Aspire 1.3.
+            # Configure Azure Container Apps environments
+            > Learn how to configure new Aspire 13.4 environment settings, scaling rules, and ingress.
 
-            New features and improvements.
+            ## Use an existing ACA environment
+            Aspire 13.4 includes new environment options. New projects can use new environment settings in 13.4.
 
-            # Other Documentation
-            > Some other docs.
+            # Create custom hosting integrations
+            > Learn how to create a new custom Aspire hosting integration for an existing containerized application.
 
-            Nothing new here.
+            ## Add a .NET service project to the AppHost for testing
+            New Aspire 13.4 hosting integration samples can test new service behavior with a new AppHost.
+
+            # What's new in Aspire 13.2
+            > Aspire 13.2 is here with new CLI commands, TypeScript AppHost support, and new and improved integrations.
+
+            ## CLI enhancements
+            New commands, new templates, and new integration updates make Aspire 13.2 easier to use.
+
+            # What's new in Aspire 13.4
+            > Explore Aspire 13.4: GA TypeScript AppHost, new Go, Blazor WebAssembly, and Bun hosting integrations, richer Kubernetes and AKS deployment APIs, AI agent readiness, process resource commands, CLI integration discovery, and dashboard updates.
+
+            ## Upgrade to Aspire 13.4
+            Aspire 13.4 includes breaking changes. Review the release notes before upgrading.
             """;
 
         var fetcher = CreateMockFetcher(content);
         var service = CreateService(fetcher);
 
-        var results = await service.SearchAsync("whats new");
+        var results = await service.SearchAsync(query);
 
         Assert.NotEmpty(results);
-        // The What's New page should rank highest when user searches for it
-        Assert.Equal("What's New in Aspire 1.3", results[0].Title);
+        Assert.Equal("What's new in Aspire 13.4", results[0].Title);
+    }
+
+    [Fact]
+    public async Task SearchAsync_ReleaseNotesPenalty_StillAppliesToIncidentalFeatureMatches()
+    {
+        var content = """
+            # JavaScript Integration
+            > How to use JavaScript with Aspire.
+
+            JavaScript integration details.
+
+            # What's new in Aspire 13.4
+            > Release notes for Aspire 13.4 with JavaScript updates.
+
+            JavaScript support was added. JavaScript is now fully supported.
+            JavaScript JavaScript JavaScript. We love JavaScript!
+            """;
+
+        var fetcher = CreateMockFetcher(content);
+        var service = CreateService(fetcher);
+
+        var results = await service.SearchAsync("javascript");
+
+        Assert.NotEmpty(results);
+        Assert.Equal("JavaScript Integration", results[0].Title);
+    }
+
+    [Theory]
+    [InlineData("13.4")]
+    [InlineData("13-4")]
+    public async Task SearchAsync_VersionQuery_MatchesSlugWithCollapsedVersion(string query)
+    {
+        var content = """
+            # Aspire 134 Release Notes
+            > Release notes for Aspire.
+
+            Upgrade details.
+
+            # Other Documentation
+            > Some other docs.
+
+            Nothing about the release here.
+            """;
+
+        var fetcher = CreateMockFetcher(content);
+        var service = CreateService(fetcher);
+
+        var results = await service.SearchAsync(query);
+
+        Assert.NotEmpty(results);
+        Assert.Equal("Aspire 134 Release Notes", results[0].Title);
     }
 
     private sealed class MockDocsFetcher(string? content) : IDocsFetcher


### PR DESCRIPTION
## Description

The docs search ranker could miss or under-rank the page users were asking for. For example, `aspire docs search "whats new 13.4"` did not prioritize the Aspire 13.4 What's New page because query and document text were normalized differently and broad release-note pages could dominate results through incidental matches.

This updates the lexical ranker so docs search normalizes user queries and indexed page text consistently, rewards more discriminating terms, and keeps What's New/changelog pages from outranking dedicated docs unless the query is explicitly targeting release notes.

Key changes:

- Normalize apostrophes and version separators so `what's`, `whats`, `13.4`, `13-4`, and `134` line up with aspire.dev titles and slugs.
- Add inverse document frequency weighting so common terms like `new` or `azure` count less than rarer, more useful terms.
- Add phrase scoring for title, summary, and headings so matches such as `service discovery` or `azure container apps environment` outrank noisy body mentions.
- Refine What's New/changelog handling so incidental feature matches are penalized, while explicit queries like `whats new 13.4` and `changelog` still rank release-note pages correctly.
- Require token-boundary identity matches for the release-note penalty exemption so short queries like `go` do not match inside `changelog`.
- Keep only the best top-K candidates during search instead of materializing every positive match before taking the top results.
- Keep hot-path helpers allocation-conscious, including replacing the digit check with a span-based loop.
- Make the docs index publication contract explicit by publishing the token IDF table with the same volatile pattern as the indexed documents.
- Improve the docs query benchmark configuration so BenchmarkDotNet runs long enough to avoid short-iteration warnings.

### User-facing usage

```bash
aspire docs search "whats new 13.4"
```

Ranks `What's new in Aspire 13.4` first, including variants such as `what's new 13.4`, `what new 13.4`, and `13-4 whats new`.

```bash
aspire docs search "service discovery"
aspire docs search "azure container apps environment"
```

Prioritizes exact title, slug, heading, and phrase matches over repeated common terms in body text or release notes.

### Validation

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.DocsIndexServiceTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Live checks for `whats new 13.4`, `service discovery`, `aspire new`, `typescript apphost`, `azure container apps environment`, and `go` with `aspire docs search --format json`
- Benchmark comparison against `origin/main` with the same 150ms minimum-iteration query benchmark configuration and the same `llms-full.txt` corpus. The final run had no BenchmarkDotNet warnings; multi-token searches were about 1.5-1.6ms slower in absolute terms while remaining under 10ms, and single-token/high-recall searches improved.
- Offline corpus evaluation against the real aspire.dev `llms-full.txt` corpus using the current `DocsIndexService`: 475 parsed documents and 2,689 generated scenarios. Compared with `origin/main`, Top 1 improved from 31.5% to 86.5%, Top 3 from 43.0% to 92.2%, Top 5 from 48.0% to 93.5%, and MRR from 0.387 to 0.896. The weakest remaining bucket is generic section-heading retrieval, where many generated queries are intentionally ambiguous.

Follow-up: #18141 tracks adding a human-judged golden-set evaluation for future docs search ranking changes.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
