### PR TITLE
Improve TypeScript AppHost startup

### DIFF
--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -135,7 +135,34 @@ internal sealed class AppHostServerSession : IAppHostServerSession
     {
         ObjectDisposedException.ThrowIf(_disposed, nameof(AppHostServerSession));
 
-        return _rpcClient ??= await AppHostRpcClient.ConnectAsync(_socketPath, _authenticationToken, _profilingTelemetry, cancellationToken);
+        if (_rpcClient is not null)
+        {
+            return _rpcClient;
+        }
+
+        // ConnectAsync already retries until the RPC socket is available. Race it against the
+        // server process lifetime instead of sleeping first, so fast startups connect immediately
+        // and failed server launches surface as soon as the process exits.
+        using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var connectTask = AppHostRpcClient.ConnectAsync(_socketPath, _authenticationToken, _profilingTelemetry, connectCts.Token);
+        var processExitTask = _serverProcess.WaitForExitAsync(connectCts.Token);
+        var completedTask = await Task.WhenAny(connectTask, processExitTask).ConfigureAwait(false);
+
+        if (completedTask == connectTask)
+        {
+            // Stop the process-exit watcher once the RPC connection wins the race.
+            connectCts.Cancel();
+            ObserveFaultedTask(processExitTask);
+            _rpcClient = await connectTask.ConfigureAwait(false);
+            return _rpcClient;
+        }
+
+        await processExitTask.ConfigureAwait(false);
+        // Stop the retrying connection attempt once the server has exited, then observe any
+        // cancellation/failure it reports so the losing task cannot raise an unobserved exception.
+        connectCts.Cancel();
+        ObserveFaultedTask(connectTask);
+        throw new InvalidOperationException($"AppHost server process exited before the RPC connection could be established. Exit code: {_serverProcess.ExitCode}.");
     }
 
     /// <inheritdoc />
@@ -175,6 +202,15 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         _serverProcess.Dispose();
         _projectLifetime?.Dispose();
         _activity.Dispose();
+    }
+
+    private static void ObserveFaultedTask(Task task)
+    {
+        _ = task.ContinueWith(
+            completedTask => _ = completedTask.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 }
 

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1917,7 +1917,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             return (CliExitCodes.FailedToDotnetRunAppHost, new OutputCollector());
         }
 
-        return await _guestRuntime.PublishAsync(appHostFile, directory, environmentVariables, publishArgs, _guestRuntime.CreateDefaultLauncher(), cancellationToken, noBuild: noBuild, afterAppHostLaunchedAsync: afterAppHostLaunchedAsync);
+        return await _guestRuntime.PublishAsync(appHostFile, directory, environmentVariables, publishArgs, _guestRuntime.CreateDefaultLauncher(), noBuild: noBuild, afterAppHostLaunchedAsync: afterAppHostLaunchedAsync, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -431,18 +431,8 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                     _profilingTelemetry);
                 try
                 {
-                    // Give the server a moment to start
-                    await Task.Delay(500, cancellationToken);
-
-                    if (serverSession.ServerProcess.HasExited)
-                    {
-                        _interactionService.DisplayLines(serverSession.Output.GetLines());
-                        _interactionService.DisplayError("App host exited unexpectedly.");
-                        await serverSession.DisposeAsync();
-                        return CliExitCodes.FailedToDotnetRunAppHost;
-                    }
-
-                    // Step 5: Connect to server for RPC calls
+                    // Step 5: Connect to server for RPC calls. The connection helper retries until
+                    // the RPC socket is available and fails early if the server process exits.
                     rpcClient = await serverSession.GetRpcClientAsync(cancellationToken);
 
                     // Step 6: Generate SDK code via RPC if needed
@@ -460,6 +450,15 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                     }
 
                     await EnsureRuntimeCreatedAsync(directory, rpcClient, cancellationToken);
+                }
+                catch (Exception) when (serverSession.ServerProcess.HasExited && !cancellationToken.IsCancellationRequested)
+                {
+                    // If the helper server exits while we are connecting or making setup RPC calls,
+                    // its captured output is the only place the real startup failure may be recorded.
+                    _interactionService.DisplayLines(serverSession.Output.GetLines());
+                    _interactionService.DisplayError("App host exited unexpectedly.");
+                    await serverSession.DisposeAsync();
+                    return CliExitCodes.FailedToDotnetRunAppHost;
                 }
                 catch
                 {
@@ -1010,27 +1009,10 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                     _logger,
                     _profilingTelemetry);
 
-                // Start connecting to the backchannel (fire-and-forget) so the caller is unblocked
-                // as soon as the server is reachable; the post-start work below races alongside it.
-                if (context.BackchannelCompletionSource is not null)
-                {
-                    _ = StartBackchannelConnectionAsync(serverSession.ServerProcess, backchannelSocketPath, context.BackchannelCompletionSource, enableHotReload: false, startProjectContext, cancellationToken);
-                }
-
                 try
                 {
-                    // Give the server a moment to start
-                    await Task.Delay(500, cancellationToken);
-
-                    if (serverSession.ServerProcess.HasExited)
-                    {
-                        _interactionService.DisplayLines(serverSession.Output.GetLines());
-                        _interactionService.DisplayError("App host exited unexpectedly.");
-                        await serverSession.DisposeAsync();
-                        return CliExitCodes.FailedToDotnetRunAppHost;
-                    }
-
-                    // Step 3: Connect to server for RPC calls
+                    // Step 3: Connect to server for RPC calls. The connection helper retries until
+                    // the RPC socket is available and fails early if the server process exits.
                     rpcClient = await serverSession.GetRpcClientAsync(cancellationToken);
 
                     // Step 4: Generate code via RPC if needed
@@ -1049,11 +1031,23 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
                     await EnsureRuntimeCreatedAsync(directory, rpcClient, cancellationToken);
                 }
+                catch (Exception) when (serverSession.ServerProcess.HasExited && !cancellationToken.IsCancellationRequested)
+                {
+                    // The publish pipeline waits on the AppHost backchannel independently from this
+                    // setup path. If the helper server exits before the guest AppHost can launch,
+                    // fault that waiter immediately instead of letting it burn the full connection timeout.
+                    context.BackchannelCompletionSource?.TrySetException(
+                        new InvalidOperationException("The app host server exited unexpectedly."));
+                    _interactionService.DisplayLines(serverSession.Output.GetLines());
+                    _interactionService.DisplayError("App host exited unexpectedly.");
+                    await serverSession.DisposeAsync();
+                    return CliExitCodes.FailedToDotnetRunAppHost;
+                }
                 catch (Exception ex)
                 {
-                    // The backchannel connection task was started before code generation
-                    // (see StartBackchannelConnectionAsync above); fault it eagerly so the
-                    // caller doesn't wait out the connection timeout when generateCode fails.
+                    // Code generation and runtime-spec lookup happen before the publish guest process
+                    // starts. Surface those setup failures through the same backchannel completion path
+                    // so callers do not keep waiting for a guest AppHost that will never be launched.
                     context.BackchannelCompletionSource?.TrySetException(ex);
 
                     // Once Start() succeeds we own the server process, so dispose it here when
@@ -1110,8 +1104,18 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
                 // Step 6: Execute the guest apphost for publishing
                 // Pass the publish arguments (e.g., --operation publish --step deploy)
+                Task StartBackchannelConnectionAfterGuestAppHostLaunchesAsync()
+                {
+                    if (context.BackchannelCompletionSource is not null)
+                    {
+                        _ = StartBackchannelConnectionAsync(appHostServerProcess, backchannelSocketPath, context.BackchannelCompletionSource, enableHotReload: false, startProjectContext, cancellationToken);
+                    }
+
+                    return Task.CompletedTask;
+                }
+
                 (guestExitCode, guestOutput) = await ExecuteGuestAppHostForPublishAsync(
-                    appHostFile, directory, environmentVariables, context.Arguments, context.NoBuild, rpcClient, cancellationToken);
+                    appHostFile, directory, environmentVariables, context.Arguments, context.NoBuild, rpcClient, StartBackchannelConnectionAfterGuestAppHostLaunchesAsync, cancellationToken);
             }
 
             if (guestExitCode != 0)
@@ -1902,6 +1906,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         string[]? publishArgs,
         bool noBuild,
         IAppHostRpcClient rpcClient,
+        Func<Task>? afterAppHostLaunchedAsync,
         CancellationToken cancellationToken)
     {
         await EnsureRuntimeCreatedAsync(directory, rpcClient, cancellationToken);
@@ -1912,7 +1917,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             return (CliExitCodes.FailedToDotnetRunAppHost, new OutputCollector());
         }
 
-        return await _guestRuntime.PublishAsync(appHostFile, directory, environmentVariables, publishArgs, _guestRuntime.CreateDefaultLauncher(), cancellationToken, noBuild: noBuild);
+        return await _guestRuntime.PublishAsync(appHostFile, directory, environmentVariables, publishArgs, _guestRuntime.CreateDefaultLauncher(), cancellationToken, noBuild: noBuild, afterAppHostLaunchedAsync: afterAppHostLaunchedAsync);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -186,9 +186,9 @@ internal sealed class GuestRuntime
     /// <param name="environmentVariables">Environment variables to set for the process.</param>
     /// <param name="publishArgs">Additional arguments for publishing.</param>
     /// <param name="launcher">Strategy for launching the process.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
     /// <param name="noBuild">Whether to skip pre-execution build/check commands.</param>
     /// <param name="afterAppHostLaunchedAsync">Callback invoked after the AppHost execute command has launched.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A tuple of the exit code and captured output.</returns>
     public async Task<(int ExitCode, OutputCollector? Output)> PublishAsync(
         FileInfo appHostFile,
@@ -196,9 +196,9 @@ internal sealed class GuestRuntime
         IDictionary<string, string> environmentVariables,
         string[]? publishArgs,
         IGuestProcessLauncher launcher,
-        CancellationToken cancellationToken,
         bool noBuild = false,
-        Func<Task>? afterAppHostLaunchedAsync = null)
+        Func<Task>? afterAppHostLaunchedAsync = null,
+        CancellationToken cancellationToken = default)
     {
         var commandSpec = _spec.PublishExecute ?? _spec.Execute;
 

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -188,6 +188,7 @@ internal sealed class GuestRuntime
     /// <param name="launcher">Strategy for launching the process.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <param name="noBuild">Whether to skip pre-execution build/check commands.</param>
+    /// <param name="afterAppHostLaunchedAsync">Callback invoked after the AppHost execute command has launched.</param>
     /// <returns>A tuple of the exit code and captured output.</returns>
     public async Task<(int ExitCode, OutputCollector? Output)> PublishAsync(
         FileInfo appHostFile,
@@ -196,7 +197,8 @@ internal sealed class GuestRuntime
         string[]? publishArgs,
         IGuestProcessLauncher launcher,
         CancellationToken cancellationToken,
-        bool noBuild = false)
+        bool noBuild = false,
+        Func<Task>? afterAppHostLaunchedAsync = null)
     {
         var commandSpec = _spec.PublishExecute ?? _spec.Execute;
 
@@ -213,7 +215,7 @@ internal sealed class GuestRuntime
         var phase = _spec.PublishExecute is not null
             ? ProfilingTelemetry.Values.GuestCommandPhasePublishExecute
             : ProfilingTelemetry.Values.GuestCommandPhaseExecute;
-        return await ExecuteCommandAsync(commandSpec, appHostFile, directory, environmentVariables, publishArgs, phase, launcher, cancellationToken);
+        return await ExecuteCommandAsync(commandSpec, appHostFile, directory, environmentVariables, publishArgs, phase, launcher, cancellationToken, afterLaunchAsync: afterAppHostLaunchedAsync);
     }
 
     private async Task<(int ExitCode, OutputCollector? Output)> RunPreExecuteCommandsAsync(

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
@@ -14,6 +14,7 @@ using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
 using Aspire.Shared;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -124,10 +125,10 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
 
         var stopwatch = Stopwatch.StartNew();
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => session.GetRpcClientAsync(TestContext.Current.CancellationToken));
+            () => session.GetRpcClientAsync(TestContext.Current.CancellationToken)).DefaultTimeout();
         stopwatch.Stop();
 
-        Assert.Contains("AppHost server process exited before the RPC connection could be established", exception.Message);
+        Assert.Equal("AppHost server process exited before the RPC connection could be established. Exit code: 0.", exception.Message);
         Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5),
             $"Expected RPC connection to fail promptly after the server process exited, but it took {stopwatch.Elapsed}.");
     }

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
@@ -112,6 +112,27 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task GetRpcClientAsync_WhenServerExitsBeforeSocketIsAvailable_FailsWithoutWaitingForConnectionTimeout()
+    {
+        var project = new RecordingAppHostServerProject();
+
+        await using var session = AppHostServerSession.Start(
+            project,
+            environmentVariables: null,
+            debug: false,
+            NullLogger<AppHostServerSession>.Instance);
+
+        var stopwatch = Stopwatch.StartNew();
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => session.GetRpcClientAsync(TestContext.Current.CancellationToken));
+        stopwatch.Stop();
+
+        Assert.Contains("AppHost server process exited before the RPC connection could be established", exception.Message);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+            $"Expected RPC connection to fail promptly after the server process exited, but it took {stopwatch.Elapsed}.");
+    }
+
+    [Fact]
     public async Task CreateAsync_DisposesProjectWhenPrepareFails()
     {
         var project = new FakeFailingAppHostServerProject(Directory.GetCurrentDirectory());

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -388,7 +388,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
 
-        await runtime.PublishAsync(appHostFile, directory, new Dictionary<string, string>(), ["--output", "/out"], launcher, CancellationToken.None);
+        await runtime.PublishAsync(appHostFile, directory, new Dictionary<string, string>(), ["--output", "/out"], launcher, cancellationToken: CancellationToken.None);
 
         Assert.Equal("publish-cmd", launcher.LastCommand);
         Assert.Contains(launcher.LastArgs, a => a.Contains("--output") && a.Contains("/out"));
@@ -409,7 +409,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
 
-        await runtime.PublishAsync(appHostFile, directory, new Dictionary<string, string>(), ["--output", "/out"], launcher, CancellationToken.None);
+        await runtime.PublishAsync(appHostFile, directory, new Dictionary<string, string>(), ["--output", "/out"], launcher, cancellationToken: CancellationToken.None);
 
         Assert.Equal(2, launcher.Calls.Count);
         Assert.Equal("typecheck-cmd", launcher.Calls[0].Command);
@@ -438,14 +438,14 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             new Dictionary<string, string>(),
             ["--output", "/out"],
             launcher,
-            CancellationToken.None,
             afterAppHostLaunchedAsync: () =>
             {
                 afterAppHostLaunchedCalls++;
                 Assert.Equal(2, launcher.Calls.Count);
                 Assert.Equal("publish-cmd", launcher.Calls[1].Command);
                 return Task.CompletedTask;
-            });
+            },
+            cancellationToken: CancellationToken.None);
 
         Assert.Equal(1, afterAppHostLaunchedCalls);
         Assert.Equal(2, launcher.Calls.Count);
@@ -467,8 +467,8 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             new Dictionary<string, string>(),
             ["--operation", "publish"],
             launcher,
-            CancellationToken.None,
-            noBuild: true);
+            noBuild: true,
+            cancellationToken: CancellationToken.None);
 
         Assert.Equal(0, exitCode);
         var call = Assert.Single(launcher.Calls);
@@ -485,7 +485,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
 
-        await runtime.PublishAsync(appHostFile, directory, new Dictionary<string, string>(), null, launcher, CancellationToken.None);
+        await runtime.PublishAsync(appHostFile, directory, new Dictionary<string, string>(), null, launcher, cancellationToken: CancellationToken.None);
 
         Assert.Equal("run-cmd", launcher.LastCommand);
     }
@@ -581,7 +581,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
 
-        await runtime.PublishAsync(appHostFile, directory, new Dictionary<string, string>(), ["--extra", "arg"], launcher, CancellationToken.None);
+        await runtime.PublishAsync(appHostFile, directory, new Dictionary<string, string>(), ["--extra", "arg"], launcher, cancellationToken: CancellationToken.None);
 
         Assert.Equal(appHostFile.FullName, launcher.LastArgs[0]);
         Assert.Equal("--extra", launcher.LastArgs[1]);

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -417,6 +417,42 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task PublishAsync_CallsAfterAppHostLaunchedAfterPreExecute()
+    {
+        var spec = CreateTestSpec(
+            execute: new CommandSpec { Command = "run-cmd", Args = ["{appHostFile}"] },
+            publishExecute: new CommandSpec { Command = "publish-cmd", Args = ["{appHostFile}", "{args}"] },
+            preExecute:
+            [
+                new CommandSpec { Command = "typecheck-cmd", Args = ["--project", "{appHostDir}"] }
+            ]);
+        var runtime = CreateRuntime(spec);
+        var launcher = new RecordingLauncher();
+        var appHostFile = new FileInfo("/tmp/apphost.ts");
+        var directory = new DirectoryInfo("/tmp");
+        var afterAppHostLaunchedCalls = 0;
+
+        await runtime.PublishAsync(
+            appHostFile,
+            directory,
+            new Dictionary<string, string>(),
+            ["--output", "/out"],
+            launcher,
+            CancellationToken.None,
+            afterAppHostLaunchedAsync: () =>
+            {
+                afterAppHostLaunchedCalls++;
+                Assert.Equal(2, launcher.Calls.Count);
+                Assert.Equal("publish-cmd", launcher.Calls[1].Command);
+                return Task.CompletedTask;
+            });
+
+        Assert.Equal(1, afterAppHostLaunchedCalls);
+        Assert.Equal(2, launcher.Calls.Count);
+        Assert.Equal("publish-cmd", launcher.Calls[1].Command);
+    }
+
+    [Fact]
     public async Task PublishAsync_NoBuildSkipsTypeScriptTscAndRunsAppHost()
     {
         var spec = CreateTypeScriptRuntimeSpec();


### PR DESCRIPTION
## Description

TypeScript AppHosts paid an artificial startup delay before the CLI attempted to connect to the AppHost server RPC endpoint. Measurements for #16704 showed that this delay was part of the shared `aspire start` cost even when the helper server was already ready.

This removes the fixed wait and lets the existing RPC connection retry loop connect as soon as the socket is available. The connection is now raced against the AppHost server process exiting so failed helper launches surface promptly with the captured server output. Publish mode also defers backchannel polling until the guest AppHost process has actually launched, avoiding an early connection attempt while code generation, runtime setup, dependency install, or pre-execute work is still running.

### User-facing usage

No new command syntax is required. Existing TypeScript AppHost commands benefit automatically:

```bash
aspire start
aspire start --no-build
```

### Profile results

Captured on a fresh `aspire-ts-empty` app on macOS arm64 with Node `v22.20.0` and npm `10.9.3`.

These numbers compare the same repo-local CLI path before and after this PR:

- **Before:** parent commit `24be3865e2`
- **After:** this branch commit `f7b5fb2161`
- **Profile command:** `aspire start --capture-profile --capture-profile-delay 0 --isolated --format Json --non-interactive --nologo`

Do not compare these wall-clock numbers to packaged CLI runs. Repo-local profiles include generated AppHost server build work and have different startup characteristics from the packaged `PrebuiltAppHostServer` path.

#### Wall time

| Command | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `aspire start` | `23.29s` | `19.08s` | `-4.21s` |
| `aspire start --no-build` | `13.33s` | `12.93s` | `-0.40s` |

#### Key startup spans

The removed 500ms wait is not emitted as its own span. `First AppHost RPC gap` is the nearest proxy for the region this PR changes, but it also includes AppHost process startup and other setup work.

| Scenario | Metric | Before | After | Delta |
| --- | --- | ---: | ---: | ---: |
| `aspire start` | AppHost server | `1.559s` | `1.156s` | `-0.403s` |
| `aspire start` | First AppHost RPC gap | `3.260s` | `3.029s` | `-0.231s` |
| `aspire start` | Guest AppHost | `6.382s` | `6.130s` | `-0.252s` |
| `aspire start` | Backchannel wait | `4.892s` | `4.249s` | `-0.643s` |
| `aspire start --no-build` | AppHost server | `1.533s` | `1.238s` | `-0.295s` |
| `aspire start --no-build` | First AppHost RPC gap | `1.759s` | `1.783s` | `+0.024s` |
| `aspire start --no-build` | Guest AppHost | `4.825s` | `4.899s` | `+0.074s` |
| `aspire start --no-build` | Backchannel wait | `3.345s` | `3.090s` | `-0.255s` |

Validation performed:

```bash
./restore.sh
dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.GuestRuntimeTests" --filter-class "*.AppHostServerSessionTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
./dotnet.sh build src/Aspire.Cli/Aspire.Cli.csproj /p:SkipNativeBuild=true
./dotnet.sh build src/Aspire.Managed/Aspire.Managed.csproj /p:SkipNativeBuild=true
```

Fixes: #16704

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
