### PR TITLE
Fail cleanly when AppHost selection would require a prompt in non-interactive mode

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -43,6 +43,7 @@ internal sealed class AppHostConnectionResolver(
     IInteractionService interactionService,
     IProjectLocator projectLocator,
     CliExecutionContext executionContext,
+    ICliHostEnvironment hostEnvironment,
     ILogger logger,
     ProfilingTelemetry? profilingTelemetry = null)
 {
@@ -199,6 +200,17 @@ internal sealed class AppHostConnectionResolver(
         }
         else if (inScopeConnections.Count > 1)
         {
+            if (!hostEnvironment.SupportsInteractiveInput)
+            {
+                // Can't prompt the user to pick an AppHost in non-interactive mode;
+                // fail with an actionable message instead of letting the prompt throw.
+                return new AppHostConnectionResult
+                {
+                    ErrorMessage = SharedCommandStrings.MultipleAppHostsNonInteractive,
+                    ExitCode = CliExitCodes.FailedToFindProject,
+                };
+            }
+
             selectedConnection = await PromptForAppHostSelectionAsync(
                 inScopeConnections,
                 SharedCommandStrings.MultipleInScopeAppHosts,
@@ -208,6 +220,18 @@ internal sealed class AppHostConnectionResolver(
         }
         else if (outOfScopeConnections.Count > 0)
         {
+            if (!hostEnvironment.SupportsInteractiveInput)
+            {
+                // No in-scope AppHosts, and selecting from out-of-scope AppHosts requires
+                // a prompt. In non-interactive mode treat this as "not found" so scripts
+                // get a clean error and exit code instead of an unexpected prompt failure.
+                return new AppHostConnectionResult
+                {
+                    ErrorMessage = notFoundMessage,
+                    ExitCode = CliExitCodes.FailedToFindProject,
+                };
+            }
+
             selectedConnection = await PromptForAppHostSelectionAsync(
                 outOfScopeConnections,
                 SharedCommandStrings.NoInScopeAppHostsShowingAll,

--- a/src/Aspire.Cli/Commands/CommonCommandServices.cs
+++ b/src/Aspire.Cli/Commands/CommonCommandServices.cs
@@ -16,7 +16,8 @@ internal sealed class CommonCommandServices(
     IInteractionService interactionService,
     AspireCliTelemetry telemetry,
     ConsoleCancellationManager cancellationManager,
-    ILoggerFactory loggerFactory)
+    ILoggerFactory loggerFactory,
+    ICliHostEnvironment hostEnvironment)
 {
     public IFeatures Features { get; } = features;
     public ICliUpdateNotifier UpdateNotifier { get; } = updateNotifier;
@@ -25,4 +26,5 @@ internal sealed class CommonCommandServices(
     public AspireCliTelemetry Telemetry { get; } = telemetry;
     public ConsoleCancellationManager CancellationManager { get; } = cancellationManager;
     public ILoggerFactory LoggerFactory { get; } = loggerFactory;
+    public ICliHostEnvironment HostEnvironment { get; } = hostEnvironment;
 }

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -111,7 +111,7 @@ internal sealed class DescribeCommand : BaseCommand
     {
         Aliases.Add("resources");
         _resourceColorMap = resourceColorMap;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/ExportCommand.cs
+++ b/src/Aspire.Cli/Commands/ExportCommand.cs
@@ -61,7 +61,7 @@ internal sealed class ExportCommand : BaseCommand
         _httpClientFactory = httpClientFactory;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -128,7 +128,7 @@ internal sealed class LogsCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _hostEnvironment = hostEnvironment;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger, profilingTelemetry);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger, profilingTelemetry);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/McpCallCommand.cs
+++ b/src/Aspire.Cli/Commands/McpCallCommand.cs
@@ -45,7 +45,7 @@ internal sealed class McpCallCommand : BaseCommand
         CommonCommandServices services)
         : base("call", McpCommandStrings.CallCommand_Description, services)
     {
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Arguments.Add(s_toolArgument);

--- a/src/Aspire.Cli/Commands/McpToolsCommand.cs
+++ b/src/Aspire.Cli/Commands/McpToolsCommand.cs
@@ -35,7 +35,7 @@ internal sealed class McpToolsCommand : BaseCommand
         CommonCommandServices services)
         : base("tools", McpCommandStrings.ToolsCommand_Description, services)
     {
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Options.Add(s_appHostOption);
         Options.Add(s_formatOption);

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -82,7 +82,7 @@ internal sealed class ResourceCommand : BaseCommand
     {
         _backchannelMonitor = backchannelMonitor;
         _projectLocator = projectLocator;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
         _logger = logger;
 
         Arguments.Add(s_resourceArgument);

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -44,7 +44,7 @@ internal sealed class StopCommand : BaseCommand
         CommonCommandServices services)
         : base("stop", StopCommandStrings.Description, services)
     {
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, services.ExecutionContext, logger, profilingTelemetry);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger, profilingTelemetry);
         _hostEnvironment = hostEnvironment;
         _processShutdownService = processShutdownService;
         _logger = logger;

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -64,7 +64,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -54,7 +54,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -54,7 +54,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/WaitCommand.cs
+++ b/src/Aspire.Cli/Commands/WaitCommand.cs
@@ -47,7 +47,7 @@ internal sealed class WaitCommand : BaseCommand
         TimeProvider? timeProvider = null)
         : base("wait", WaitCommandStrings.Description, services)
     {
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, ExecutionContext, services.HostEnvironment, logger);
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
 

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
@@ -171,6 +171,15 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        /// <summary>
+        ///   Looks up a localized string similar to Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use..
+        /// </summary>
+        internal static string MultipleAppHostsNonInteractive {
+            get {
+                return ResourceManager.GetString("MultipleAppHostsNonInteractive", resourceCulture);
+            }
+        }
+
         internal static string PromptRunAgentInit {
             get {
                 return ResourceManager.GetString("PromptRunAgentInit", resourceCulture);

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.resx
@@ -182,6 +182,9 @@
   <data name="MultipleInScopeAppHosts" xml:space="preserve">
     <value>Multiple running AppHosts found in the current directory. Select from running AppHosts.</value>
   </data>
+  <data name="MultipleAppHostsNonInteractive" xml:space="preserve">
+    <value>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</value>
+  </data>
   <data name="PromptRunAgentInit" xml:space="preserve">
     <value>Would you like to configure AI agent environments for this project?</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -35,6 +35,7 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             interactionService,
             projectLocator,
             executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
             NullLogger.Instance);
 
         var result = await resolver.ResolveConnectionAsync(
@@ -64,6 +65,7 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             new TestInteractionService(),
             new TestProjectLocator(),
             executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
             NullLogger.Instance);
 
         var result = await resolver.ResolveConnectionAsync(
@@ -109,6 +111,7 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             interactionService,
             projectLocator,
             executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
             NullLogger.Instance);
 
         var result = await resolver.ResolveConnectionAsync(
@@ -141,6 +144,7 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             interactionService,
             projectLocator,
             executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
             NullLogger.Instance);
 
         var result = await resolver.ResolveConnectionAsync(
@@ -154,6 +158,65 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
         Assert.True(result.IsProjectResolutionError);
         Assert.Equal(CliExitCodes.FailedToFindProject, result.ExitCode);
         Assert.Equal(InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsNoAppHosts, result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ResolveConnectionAsync_NonInteractiveWithOnlyOutOfScopeAppHosts_ReturnsNotFoundError()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash1", "socket-other", new TestAppHostAuxiliaryBackchannel { IsInScope = false });
+
+        var resolver = new AppHostConnectionResolver(
+            monitor,
+            new TestInteractionService(),
+            new TestProjectLocator(),
+            executionContext,
+            TestHelpers.CreateNonInteractiveHostEnvironment(),
+            NullLogger.Instance);
+
+        var result = await resolver.ResolveConnectionAsync(
+            projectFile: null,
+            "Scanning",
+            "Select",
+            SharedCommandStrings.AppHostNotRunning,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.True(result.IsProjectResolutionError);
+        Assert.Equal(SharedCommandStrings.AppHostNotRunning, result.ErrorMessage);
+        Assert.Equal(CliExitCodes.FailedToFindProject, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task ResolveConnectionAsync_NonInteractiveWithMultipleInScopeAppHosts_ReturnsActionableError()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash1", "socket-one", new TestAppHostAuxiliaryBackchannel { IsInScope = true });
+        monitor.AddConnection("hash2", "socket-two", new TestAppHostAuxiliaryBackchannel { IsInScope = true });
+
+        var resolver = new AppHostConnectionResolver(
+            monitor,
+            new TestInteractionService(),
+            new TestProjectLocator(),
+            executionContext,
+            TestHelpers.CreateNonInteractiveHostEnvironment(),
+            NullLogger.Instance);
+
+        var result = await resolver.ResolveConnectionAsync(
+            projectFile: null,
+            "Scanning",
+            "Select",
+            SharedCommandStrings.AppHostNotRunning,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.True(result.IsProjectResolutionError);
+        Assert.Equal(SharedCommandStrings.MultipleAppHostsNonInteractive, result.ErrorMessage);
+        Assert.Equal(CliExitCodes.FailedToFindProject, result.ExitCode);
     }
 
     private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -227,7 +227,7 @@ internal static class TestNuGetPrefetcher
 // Test command implementations
 internal sealed class TestCommand : BaseCommand
 {
-    public TestCommand(string name = "test") : base(name, "Test command", new CommonCommandServices(null!, null!, null!, null!, null!, null!, null!))
+    public TestCommand(string name = "test") : base(name, "Test command", new CommonCommandServices(null!, null!, null!, null!, null!, null!, null!, null!))
     {
     }
 
@@ -239,7 +239,7 @@ internal sealed class TestCommand : BaseCommand
 
 internal sealed class TestCommandWithInterface : BaseCommand, IPackageMetaPrefetchingCommand
 {
-    public TestCommandWithInterface() : base("test-interface", "Test command with interface", new CommonCommandServices(null!, null!, null!, null!, null!, null!, null!))
+    public TestCommandWithInterface() : base("test-interface", "Test command with interface", new CommonCommandServices(null!, null!, null!, null!, null!, null!, null!, null!))
     {
     }
 


### PR DESCRIPTION
## Description

Fixes #17619

When no AppHost is found in the current directory but other AppHosts are running on the system, `aspire describe --non-interactive` (and the other commands that resolve a running AppHost: logs, stop, wait, export, telemetry, mcp) fell through to the interactive "Select from all running AppHosts" prompt. The prompt guard then threw, surfacing as:

> ❌ An unexpected error occurred: This prompt requires interactive input but the CLI is running in non-interactive mode...

with the generic unexpected-error exit code, which is not diagnosable from CI scripts.

`AppHostConnectionResolver` now checks `ICliHostEnvironment.SupportsInteractiveInput` before either selection prompt:

- **Only out-of-scope AppHosts running** → returns the command's standard not-found error (e.g. `The AppHost is not running.`) with `CliExitCodes.FailedToFindProject`.
- **Multiple in-scope AppHosts** → returns a new actionable error: *"Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use."*, also with `FailedToFindProject`.

Interactive behavior is unchanged. To give the resolver access to the host environment, `ICliHostEnvironment` was added to `CommonCommandServices` (DI-provided) and passed through at each construction site.

## Testing

- Added `ResolveConnectionAsync_NonInteractiveWithOnlyOutOfScopeAppHosts_ReturnsNotFoundError` and `ResolveConnectionAsync_NonInteractiveWithMultipleInScopeAppHosts_ReturnsActionableError`
- `dotnet test --project tests/Aspire.Cli.Tests -- --filter-class "*AppHostConnectionResolverTests" --filter-class "*DescribeCommandTests" --filter-class "*StopCommandTests" --filter-class "*WaitCommandTests" --filter-class "*ExportCommandTests"`: 79/79 passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)