### PR TITLE
Increase BrowserLogs CDP command timeout for tracked browser startup

### DIFF
--- a/src/Aspire.Hosting.Browsers/BrowserLogsCdpConnection.cs
+++ b/src/Aspire.Hosting.Browsers/BrowserLogsCdpConnection.cs
@@ -40,8 +40,8 @@ internal sealed class BrowserLogsCdpConnection : IBrowserLogsCdpConnection
     private static readonly TimeSpan s_closeTimeout = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan s_commandTimeout = TimeSpan.FromSeconds(30);
     // Screenshot capture asks the browser to rasterize and encode the current surface. Real browsers can take longer
-    // than lightweight lifecycle/enable commands, especially under CI or agent load, so give this command a larger
-    // protocol budget without slowing down ordinary command failures.
+    // than lightweight lifecycle/enable commands, especially under CI or agent load, so keep a dedicated timeout even
+    // though it currently matches the general command budget.
     private static readonly TimeSpan s_screenshotCommandTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan s_keepAliveInterval = TimeSpan.FromSeconds(15);
 

--- a/src/Aspire.Hosting.Browsers/BrowserLogsCdpConnection.cs
+++ b/src/Aspire.Hosting.Browsers/BrowserLogsCdpConnection.cs
@@ -38,7 +38,7 @@ internal sealed class BrowserLogsCdpConnection : IBrowserLogsCdpConnection
     // budget because it runs during disposal, while the websocket keep-alive stays comfortably below common proxy idle
     // timers without sending frequent pings during normal local development.
     private static readonly TimeSpan s_closeTimeout = TimeSpan.FromSeconds(3);
-    private static readonly TimeSpan s_commandTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan s_commandTimeout = TimeSpan.FromSeconds(30);
     // Screenshot capture asks the browser to rasterize and encode the current surface. Real browsers can take longer
     // than lightweight lifecycle/enable commands, especially under CI or agent load, so give this command a larger
     // protocol budget without slowing down ordinary command failures.


### PR DESCRIPTION
## Description

This fixes a tracked-browser startup reliability issue where `WithBrowserLogs()` could fail early with `Browser debug pipe closed`-class errors even when the browser eventually became responsive.

`BrowserLogsCdpConnection` used a 10-second per-command timeout for CDP startup commands. During investigation for #16861, the BrowserTelemetry playground repeatedly failed in both Shared and Isolated modes with timeouts such as:

- `Timed out waiting for a tracked browser protocol response to 'Target.setDiscoverTargets'.`
- `Timed out waiting for a tracked browser protocol response to 'Page.navigate'.`

Increasing the default command timeout from 10 seconds to 30 seconds allowed the same repro flow to complete successfully, and `web-browser-logs` transitioned to `Running` with healthy sessions.

### User-facing usage

No API or command changes are required. Existing `.WithBrowserLogs()` usage becomes more resilient during slower browser startup:

```csharp
builder.AddProject<Projects.BrowserTelemetry_Web>("web")
    .WithExternalHttpEndpoints()
    .WithBrowserLogs();
```

Validation:

- `dotnet test --project tests/Aspire.Hosting.Browsers.Tests/Aspire.Hosting.Browsers.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (90 passed)
- Manual repro with `playground/BrowserTelemetry`:
  - before change: `open-tracked-browser` failed with CDP timeout and resource `FailedToStart`
  - after change: command succeeded and resource became `Running` in both Shared and Isolated modes

Fixes #16861

@davidfowl

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
