### PR TITLE
Upgrade Spectre.Console to 0.56.0 to fix #17307 OSC8 link wrapping bug

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -129,7 +129,7 @@
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageVersion Include="Qdrant.Client" Version="1.18.1" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />
-    <PackageVersion Include="Spectre.Console" Version="0.55.2" />
+    <PackageVersion Include="Spectre.Console" Version="0.56.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />


### PR DESCRIPTION
## Problem

Resolves #17307: The "Logs" and "Dashboard" links in `aspire ps` output are not clickable at default terminal window size (~80 characters).

**Symptom:** When running `aspire ps` in a terminal with default width, the OSC8 terminal links lose their clickability after being wrapped to the next line.

## Root Cause

This is a known issue in Spectre.Console #2124, where OSC8 terminal link markup loses its link attributes when wrapped in grid cells during line-wrapping. The issue manifests when:
- `PsCommand.DisplayTable()` renders Dashboard/Logs links using `MarkupHelpers.SafeLink()` (which wraps URLs in `[link=URL]text[/]` Spectre markup format)
- Links are placed in table cells
- Line wrapping occurs (triggered by narrow terminal width)
- In Spectre.Console 0.55.2, wrapping causes links to lose their OSC8 attributes, rendering them unclickable

## Solution

Upgrade Spectre.Console from **0.55.2** to **0.56.0**.

The upstream fix was merged in Spectre.Console PR #2135 ("Preserve links in segments") on 2026-06-05. This fix properly preserves OSC8 link attributes across segment manipulation during text wrapping.

- **Spectre.Console 0.55.2**: Released 2026-04-17 (predates fix)
- **Spectre.Console 0.56.0**: Released 2026-06-05 (includes fix from PR #2135)

## Changes

- `Directory.Packages.props` line 132: Bumped `Spectre.Console` version from `0.55.2` to `0.56.0`

## Validation

✅ **Unit Tests:** All 28 `PsCommandTests` passed without regression
✅ **E2E Tests:** Both `PsCommand` end-to-end tests passed (3m 43s)
✅ **Upstream Fix:** Verified in Spectre.Console 0.56.0 source

## Related Issues & References

- **This Issue:** #17307
- **Root Cause:** [spectreconsole/spectre.console#2124](https://github.com/spectreconsole/spectre.console/issues/2124) — Links lose clickability when wrapped in grid cells
- **Upstream Fix:** [spectreconsole/spectre.console#2135](https://github.com/spectreconsole/spectre.console/pull/2135) — "Preserve links in segments" (merged 2026-06-05)

## Code Impact

The fix is entirely upstream in Spectre.Console. No CLI code changes required. The following code paths benefit from this update:
- `src/Aspire.Cli/Commands/PsCommand.cs:394-443` — `DisplayTable()` method where Dashboard links are rendered
- `src/Aspire.Cli/Utils/MarkupHelpers.cs:18-30` — `SafeLink()` markup generation (now works correctly with 0.56.0)