### PR TITLE
Reconnect if necessary during DCP request execution

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
     <!-- This repo version -->
     <MajorVersion>13</MajorVersion>
     <MinorVersion>4</MinorVersion>
-    <PatchVersion>3</PatchVersion>
+    <PatchVersion>4</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>
     <DefaultTargetFramework>net8.0</DefaultTargetFramework>

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -428,6 +428,9 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
 
         await retryPipeline.ExecuteAsync(async cancellationContext =>
         {
+            // Re-establish the client before each attempt. A concurrent connectivity failure elsewhere can
+            // invalidate the cached client (set _kubernetes to null), so we must not dereference it directly.
+            await EnsureKubernetesAsync(cancellationContext).ConfigureAwait(false);
             return await _kubernetes!.GetExecutionDocumentAsync(cancellationToken).ConfigureAwait(false);
         }, cancellationToken).ConfigureAwait(false);
     }
@@ -471,10 +474,9 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         Func<Exception, bool> isRetryable,
         CancellationToken cancellationToken)
     {
-        var clientReady = await EnsureKubernetesAsync(cancellationToken).ConfigureAwait(false);
         using var activity = ProfilingTelemetry.StartDcpKubernetesApi(configuration, operationType, resourceType);
-        activity.AddKubernetesClientReady(clientReady.WaitMilliseconds, clientReady.Initialized);
         var retryCount = 0;
+        var clientReadyRecorded = false;
 
         var resiliencePipeline = CreateKubernetesCallResiliencePipeline(isRetryable, activity, () => retryCount++);
 
@@ -482,13 +484,62 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         {
             return await resiliencePipeline.ExecuteAsync<TResult>(async (cancellationToken) =>
             {
-                return await operation(_kubernetes!).ConfigureAwait(false);
+                // Establish (or re-establish) the connection to DCP inside the retry loop. Doing this here
+                // (rather than once up front) means a failure to read a partially-written kubeconfig, or a
+                // client built from a stale kubeconfig, is retried by this same pipeline instead of failing
+                // permanently. The cached client short-circuits EnsureKubernetesAsync once it is established.
+                var clientReady = await EnsureKubernetesAsync(cancellationToken).ConfigureAwait(false);
+                if (!clientReadyRecorded)
+                {
+                    // Record the readiness telemetry once, for the attempt that actually established the client.
+                    clientReadyRecorded = true;
+                    activity.AddKubernetesClientReady(clientReady.WaitMilliseconds, clientReady.Initialized);
+                }
+
+                var client = _kubernetes!;
+                try
+                {
+                    return await operation(client).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (RetryOnConnectivityErrors(ex))
+                {
+                    // A connectivity failure can mean the cached client was built from a stale or
+                    // partially-written kubeconfig (for example, DCP rewrote it with a new endpoint).
+                    // Invalidate the client so the next retry iteration re-reads the kubeconfig and
+                    // rebuilds it. We deliberately do NOT invalidate on other retryable errors such as
+                    // HTTP 409 Conflict, which are legitimate API results rather than a bad client.
+                    await InvalidateKubernetesClientAsync(client).ConfigureAwait(false);
+                    throw;
+                }
             }, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
             activity.SetDcpApiRetryCount(retryCount);
         }
+    }
+
+    private async Task InvalidateKubernetesClientAsync(DcpKubernetesClient failedClient)
+    {
+        await _kubeconfigReadSemaphore.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            // Only clear the field if it still points at the client that failed. A concurrent operation
+            // may already have rebuilt a fresh client, and we must not discard that one.
+            if (ReferenceEquals(_kubernetes, failedClient))
+            {
+                _kubernetes = null;
+            }
+        }
+        finally
+        {
+            _kubeconfigReadSemaphore.Release();
+        }
+
+        // Note: we intentionally do not dispose the failed client here. Other operations running
+        // concurrently may have captured the same instance and still be mid-request; disposing it would
+        // turn their connectivity failures into ObjectDisposedExceptions. The orphaned client is reclaimed
+        // by the GC, and KubernetesService.Dispose() disposes whatever client is current at shutdown.
     }
 
     private static bool RetryOnConnectivityErrors(Exception ex) => ex is HttpRequestException || ex is KubeConfigException;
@@ -593,43 +644,41 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
             readStopwatch.Start();
 
             var readPipeline = CreateReadKubeconfigResiliencePipeline();
-            var timeoutPipeline = new ResiliencePipelineBuilder<DcpKubernetesClient>()
-                .AddTimeout(new TimeoutStrategyOptions { Timeout = MaxRetryDuration })
-                .Build();
 
+            // The overall time budget for establishing the connection is enforced by the caller's
+            // resilience pipeline (CreateKubernetesCallResiliencePipeline applies MaxRetryDuration as a
+            // timeout) via the cancellation token, which the file-wait loop below observes. We therefore
+            // do not wrap the read in its own timeout pipeline here.
             try
             {
-                _kubernetes = await timeoutPipeline.ExecuteAsync(async (cancellationToken) =>
+                _kubernetes = await readPipeline.ExecuteAsync<DcpKubernetesClient>(async (cancellationToken) =>
                 {
-                    return await readPipeline.ExecuteAsync<DcpKubernetesClient>(async (cancellationToken) =>
+                    var fileWaitStopwatch = Stopwatch.StartNew();
+                    var fileInfo = new FileInfo(locations.DcpKubeconfigPath);
+                    while (!fileInfo.Exists)
                     {
-                        var fileWaitStopwatch = Stopwatch.StartNew();
-                        var fileInfo = new FileInfo(locations.DcpKubeconfigPath);
-                        while (!fileInfo.Exists)
-                        {
-                            await Task.Delay(TimeSpan.FromMilliseconds(dcpOptions.Value.KubernetesConfigReadRetryIntervalMilliseconds), cancellationToken).ConfigureAwait(false);
-                            fileInfo = new FileInfo(locations.DcpKubeconfigPath);
-                        }
-                        fileWaitStopwatch.Stop();
-                        activity.SetDcpKubeconfigFileWait(fileWaitStopwatch.ElapsedMilliseconds);
-                        activity.AddKubeconfigFileDetected();
+                        await Task.Delay(TimeSpan.FromMilliseconds(dcpOptions.Value.KubernetesConfigReadRetryIntervalMilliseconds), cancellationToken).ConfigureAwait(false);
+                        fileInfo = new FileInfo(locations.DcpKubeconfigPath);
+                    }
+                    fileWaitStopwatch.Stop();
+                    activity.SetDcpKubeconfigFileWait(fileWaitStopwatch.ElapsedMilliseconds);
+                    activity.AddKubeconfigFileDetected();
 
-                        var buildConfigStopwatch = Stopwatch.StartNew();
-                        var config = await KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(kubeconfig: fileInfo, useRelativePaths: false).ConfigureAwait(false);
-                        buildConfigStopwatch.Stop();
-                        readStopwatch.Stop();
+                    var buildConfigStopwatch = Stopwatch.StartNew();
+                    var config = await KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(kubeconfig: fileInfo, useRelativePaths: false).ConfigureAwait(false);
+                    buildConfigStopwatch.Stop();
+                    readStopwatch.Stop();
 
-                        logger.LogDebug(
-                            "Successfully read Kubernetes configuration from '{DcpKubeconfigPath}' after {DurationMs} milliseconds.",
-                            locations.DcpKubeconfigPath,
-                            readStopwatch.ElapsedMilliseconds
-                            );
-                        activity.SetDcpKubeconfigBuildDuration(buildConfigStopwatch.ElapsedMilliseconds);
-                        activity.SetDcpKubeconfigReadDuration(readStopwatch.ElapsedMilliseconds);
-                        activity.AddKubeconfigReadComplete();
+                    logger.LogDebug(
+                        "Successfully read Kubernetes configuration from '{DcpKubeconfigPath}' after {DurationMs} milliseconds.",
+                        locations.DcpKubeconfigPath,
+                        readStopwatch.ElapsedMilliseconds
+                        );
+                    activity.SetDcpKubeconfigBuildDuration(buildConfigStopwatch.ElapsedMilliseconds);
+                    activity.SetDcpKubeconfigReadDuration(readStopwatch.ElapsedMilliseconds);
+                    activity.AddKubeconfigReadComplete();
 
-                        return new DcpKubernetesClient(config);
-                    }, cancellationToken).ConfigureAwait(false);
+                    return new DcpKubernetesClient(config);
                 }, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -481,7 +481,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
             return await resiliencePipeline.ExecuteAsync(async (cancellationToken) =>
             {
                 // Establish (or re-establish) the connection to DCP inside the retry loop,
-                // to guard against a failure from partially-written kubeconfig.
+                // to guard against a failure from missing or partially-written kubeconfig.
                 var clientReady = await EnsureKubernetesAsync(cancellationToken).ConfigureAwait(false);
                 if (clientReady.Initialized)
                 {

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -428,9 +428,6 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
 
         await retryPipeline.ExecuteAsync(async cancellationContext =>
         {
-            // Re-establish the client before each attempt. A concurrent connectivity failure elsewhere can
-            // invalidate the cached client (set _kubernetes to null), so we must not dereference it directly.
-            await EnsureKubernetesAsync(cancellationContext).ConfigureAwait(false);
             return await _kubernetes!.GetExecutionDocumentAsync(cancellationToken).ConfigureAwait(false);
         }, cancellationToken).ConfigureAwait(false);
     }
@@ -476,70 +473,28 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
     {
         using var activity = ProfilingTelemetry.StartDcpKubernetesApi(configuration, operationType, resourceType);
         var retryCount = 0;
-        var clientReadyRecorded = false;
 
         var resiliencePipeline = CreateKubernetesCallResiliencePipeline(isRetryable, activity, () => retryCount++);
 
         try
         {
-            return await resiliencePipeline.ExecuteAsync<TResult>(async (cancellationToken) =>
+            return await resiliencePipeline.ExecuteAsync(async (cancellationToken) =>
             {
-                // Establish (or re-establish) the connection to DCP inside the retry loop. Doing this here
-                // (rather than once up front) means a failure to read a partially-written kubeconfig, or a
-                // client built from a stale kubeconfig, is retried by this same pipeline instead of failing
-                // permanently. The cached client short-circuits EnsureKubernetesAsync once it is established.
+                // Establish (or re-establish) the connection to DCP inside the retry loop,
+                // to guard against a failure from partially-written kubeconfig.
                 var clientReady = await EnsureKubernetesAsync(cancellationToken).ConfigureAwait(false);
-                if (!clientReadyRecorded)
+                if (clientReady.Initialized)
                 {
-                    // Record the readiness telemetry once, for the attempt that actually established the client.
-                    clientReadyRecorded = true;
                     activity.AddKubernetesClientReady(clientReady.WaitMilliseconds, clientReady.Initialized);
                 }
 
-                var client = _kubernetes!;
-                try
-                {
-                    return await operation(client).ConfigureAwait(false);
-                }
-                catch (Exception ex) when (RetryOnConnectivityErrors(ex))
-                {
-                    // A connectivity failure can mean the cached client was built from a stale or
-                    // partially-written kubeconfig (for example, DCP rewrote it with a new endpoint).
-                    // Invalidate the client so the next retry iteration re-reads the kubeconfig and
-                    // rebuilds it. We deliberately do NOT invalidate on other retryable errors such as
-                    // HTTP 409 Conflict, which are legitimate API results rather than a bad client.
-                    await InvalidateKubernetesClientAsync(client).ConfigureAwait(false);
-                    throw;
-                }
+                return await operation(_kubernetes!).ConfigureAwait(false);
             }, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
             activity.SetDcpApiRetryCount(retryCount);
         }
-    }
-
-    private async Task InvalidateKubernetesClientAsync(DcpKubernetesClient failedClient)
-    {
-        await _kubeconfigReadSemaphore.WaitAsync().ConfigureAwait(false);
-        try
-        {
-            // Only clear the field if it still points at the client that failed. A concurrent operation
-            // may already have rebuilt a fresh client, and we must not discard that one.
-            if (ReferenceEquals(_kubernetes, failedClient))
-            {
-                _kubernetes = null;
-            }
-        }
-        finally
-        {
-            _kubeconfigReadSemaphore.Release();
-        }
-
-        // Note: we intentionally do not dispose the failed client here. Other operations running
-        // concurrently may have captured the same instance and still be mid-request; disposing it would
-        // turn their connectivity failures into ObjectDisposedExceptions. The orphaned client is reclaimed
-        // by the GC, and KubernetesService.Dispose() disposes whatever client is current at shutdown.
     }
 
     private static bool RetryOnConnectivityErrors(Exception ex) => ex is HttpRequestException || ex is KubeConfigException;
@@ -645,13 +600,9 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
 
             var readPipeline = CreateReadKubeconfigResiliencePipeline();
 
-            // The overall time budget for establishing the connection is enforced by the caller's
-            // resilience pipeline (CreateKubernetesCallResiliencePipeline applies MaxRetryDuration as a
-            // timeout) via the cancellation token, which the file-wait loop below observes. We therefore
-            // do not wrap the read in its own timeout pipeline here.
             try
             {
-                _kubernetes = await readPipeline.ExecuteAsync<DcpKubernetesClient>(async (cancellationToken) =>
+                _kubernetes = await readPipeline.ExecuteAsync(async (cancellationToken) =>
                 {
                     var fileWaitStopwatch = Stopwatch.StartNew();
                     var fileInfo = new FileInfo(locations.DcpKubeconfigPath);

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -616,7 +616,14 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                     activity.AddKubeconfigFileDetected();
 
                     var buildConfigStopwatch = Stopwatch.StartNew();
-                    var config = await KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(kubeconfig: fileInfo, useRelativePaths: false).ConfigureAwait(false);
+                    // Open the file with FileShare.ReadWrite | FileShare.Delete so we do not interfere with DCP
+                    // if we happen to open the file while DCP is still writing to it.
+                    var kubeconfigStream = new FileStream(fileInfo.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                    KubernetesClientConfiguration config;
+                    await using (kubeconfigStream.ConfigureAwait(false))
+                    {
+                        config = await KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(kubeconfigStream).ConfigureAwait(false);
+                    }
                     buildConfigStopwatch.Stop();
                     readStopwatch.Stop();
 

--- a/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
@@ -4,12 +4,13 @@
 #pragma warning disable ASPIREFILESYSTEM001 // IFileSystemService is for evaluation purposes only.
 
 using System.Globalization;
-using System.Net;
-using System.Net.Sockets;
-using System.Text;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Dcp.Model;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -35,7 +36,43 @@ public class KubernetesServiceTests
 
         await Task.Delay(300, cts.Token);
 
-        using var server = new TestDcpApiServer();
+        await using var server = await TestDcpApiServer.StartAsync(cts.Token);
+        WriteKubeconfig(kubeconfigPath, server.Port);
+
+        var result = await listTask;
+        Assert.Empty(result);
+    }
+
+    // Verifies that establishing the connection survives a partially-written kubeconfig: when the file exists
+    // but DCP has only flushed part of it (so it does not yet parse as a valid kubeconfig), the read is retried
+    // and the operation succeeds once the complete, valid kubeconfig is written.
+    [Fact]
+    public async Task ExecuteWithRetry_EstablishesConnection_WhenKubeconfigInitiallyPartiallyWritten()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var (service, kubeconfigPath, fileSystem) = CreateService();
+        using var disposableFileSystem = fileSystem;
+        using var disposableService = service;
+
+        // Simulate DCP having flushed only the first part of the kubeconfig. The content is cut off mid-way
+        // through a double-quoted scalar, which is a faithful "half-written file" and deterministically fails
+        // YAML parsing. The production read pipeline handles that (KubeConfigException/YamlException/IOException)
+        // and retries instead of caching a broken client.
+        File.WriteAllText(kubeconfigPath, """
+            apiVersion: v1
+            kind: Config
+            clusters:
+            - name: dcp
+              cluster:
+                server: "http://127.0.0.1
+            """);
+
+        var listTask = service.ListAsync<Container>(cancellationToken: cts.Token);
+
+        await Task.Delay(300, cts.Token);
+
+        await using var server = await TestDcpApiServer.StartAsync(cts.Token);
         WriteKubeconfig(kubeconfigPath, server.Port);
 
         var result = await listTask;
@@ -95,102 +132,56 @@ public class KubernetesServiceTests
         File.Move(tempPath, path, overwrite: true);
     }
 
-    private static int GetFreePort()
-    {
-        // Bind to port 0 to let the OS pick a free port, then release it. There is a small race before the
-        // port is (intentionally, for the dead-port case) left unused, which is acceptable for a loopback test.
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        try
-        {
-            return ((IPEndPoint)listener.LocalEndpoint).Port;
-        }
-        finally
-        {
-            listener.Stop();
-        }
-    }
-
     // A minimal stand-in for the DCP API server. It answers every request with an empty Kubernetes list, which
     // is enough for ListAsync<Container>() to deserialize successfully.
-    private sealed class TestDcpApiServer : IDisposable
+    //
+    // It runs a real Kestrel server bound to port 0 so the OS assigns a free port that Kestrel actually binds and
+    // holds for the lifetime of the server. The bound port is read back after startup. This avoids the classic
+    // "probe a free port then release it and hope nobody grabs it before we rebind" race.
+    private sealed class TestDcpApiServer : IAsyncDisposable
     {
-        private readonly HttpListener _listener;
-        private readonly CancellationTokenSource _cts = new();
-        private readonly Task _loop;
+        private readonly WebApplication _app;
 
-        public TestDcpApiServer()
+        private TestDcpApiServer(WebApplication app, int port)
         {
-            Port = GetFreePort();
-            _listener = new HttpListener();
-            _listener.Prefixes.Add($"http://127.0.0.1:{Port}/");
-            _listener.Start();
-            _loop = Task.Run(ProcessRequestsAsync);
+            _app = app;
+            Port = port;
         }
 
         public int Port { get; }
 
-        private async Task ProcessRequestsAsync()
+        public static async Task<TestDcpApiServer> StartAsync(CancellationToken cancellationToken = default)
         {
-            while (!_cts.IsCancellationRequested)
-            {
-                HttpListenerContext context;
-                try
-                {
-                    context = await _listener.GetContextAsync();
-                }
-                catch (Exception) when (_cts.IsCancellationRequested)
-                {
-                    return;
-                }
-                catch (HttpListenerException)
-                {
-                    return;
-                }
-                catch (ObjectDisposedException)
-                {
-                    return;
-                }
+            var builder = WebApplication.CreateSlimBuilder();
+            // Keep the test output clean; the fake server's logs are noise.
+            builder.Logging.ClearProviders();
+            // Port 0 lets the OS pick a free port that Kestrel binds and holds. After StartAsync the addresses
+            // feature (exposed via app.Urls) is rewritten with the resolved address, so we can read the real port.
+            builder.WebHost.UseUrls("http://127.0.0.1:0");
 
-                try
-                {
-                    var body = Encoding.UTF8.GetBytes("""{"apiVersion":"usvc-dev.developer.microsoft.com/v1","kind":"ContainerList","items":[]}""");
-                    context.Response.StatusCode = (int)HttpStatusCode.OK;
-                    context.Response.ContentType = "application/json";
-                    context.Response.ContentLength64 = body.Length;
-                    await context.Response.OutputStream.WriteAsync(body);
-                    context.Response.OutputStream.Close();
-                }
-                catch
-                {
-                    // Ignore failures writing the response; the test's retry loop will simply try again.
-                }
-            }
+            var app = builder.Build();
+
+            // Answer every request with an empty container list.
+            app.Run(async context =>
+            {
+                context.Response.StatusCode = StatusCodes.Status200OK;
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsync("""{"apiVersion":"usvc-dev.developer.microsoft.com/v1","kind":"ContainerList","items":[]}""");
+            });
+
+            await app.StartAsync(cancellationToken).ConfigureAwait(false);
+
+            // e.g. "http://127.0.0.1:54321" -> 54321
+            var address = app.Urls.First();
+            var port = new Uri(address).Port;
+
+            return new TestDcpApiServer(app, port);
         }
 
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
-            _cts.Cancel();
-            try
-            {
-                _listener.Stop();
-                _listener.Close();
-            }
-            catch
-            {
-                // Best effort shutdown.
-            }
-
-            try
-            {
-                _loop.Wait(TimeSpan.FromSeconds(5));
-            }
-            catch
-            {
-                // Best effort shutdown.
-            }
-
-            _cts.Dispose();
+            await _app.StopAsync().ConfigureAwait(false);
+            await _app.DisposeAsync().ConfigureAwait(false);
         }
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
@@ -1,0 +1,230 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREFILESYSTEM001 // IFileSystemService is for evaluation purposes only.
+
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Aspire.Hosting.Dcp;
+using Aspire.Hosting.Dcp.Model;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Hosting.Tests.Dcp;
+
+public class KubernetesServiceTests
+{
+    // Regression test for the change that brought connecting to DCP (EnsureKubernetesAsync) back into the
+    // retry loop. When a client is first built from a stale kubeconfig (here, one pointing at a dead port),
+    // a connectivity failure must invalidate that cached client so the next retry re-reads the kubeconfig and
+    // rebuilds the client against the now-correct endpoint. Without the fix the stale client is cached forever
+    // and the operation fails permanently.
+    [Fact]
+    public async Task ExecuteWithRetry_RebuildsClient_WhenKubeconfigUpdatedAfterStaleConfig()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var (service, kubeconfigPath, fileSystem) = CreateService();
+        using var disposableFileSystem = fileSystem;
+        using var disposableService = service;
+
+        // Start with a kubeconfig that points at a port nobody is listening on. The first operation builds a
+        // client from this config and fails to connect (HttpRequestException -> connection refused).
+        var deadPort = GetFreePort();
+        WriteKubeconfig(kubeconfigPath, deadPort);
+
+        var listTask = service.ListAsync<Container>(cancellationToken: cts.Token);
+
+        // Give the operation a moment to build the stale client and start retrying, then stand up a real
+        // endpoint and repoint the kubeconfig at it.
+        await Task.Delay(300, cts.Token);
+
+        using var server = new FakeDcpApiServer();
+        WriteKubeconfig(kubeconfigPath, server.Port);
+
+        // With the fix the stale client is discarded and rebuilt against the live endpoint, so the call
+        // completes successfully (an empty list of containers).
+        var result = await listTask;
+        Assert.Empty(result);
+    }
+
+    // Verifies that establishing the connection happens inside the retry loop: when the kubeconfig does not
+    // exist yet (DCP has not finished writing it), the operation waits and succeeds once it appears.
+    [Fact]
+    public async Task ExecuteWithRetry_EstablishesConnection_WhenKubeconfigInitiallyMissing()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var (service, kubeconfigPath, fileSystem) = CreateService();
+        using var disposableFileSystem = fileSystem;
+        using var disposableService = service;
+
+        // No kubeconfig on disk initially.
+        Assert.False(File.Exists(kubeconfigPath));
+
+        var listTask = service.ListAsync<Container>(cancellationToken: cts.Token);
+
+        await Task.Delay(300, cts.Token);
+
+        using var server = new FakeDcpApiServer();
+        WriteKubeconfig(kubeconfigPath, server.Port);
+
+        var result = await listTask;
+        Assert.Empty(result);
+    }
+
+    private static (KubernetesService Service, string KubeconfigPath, IDisposable FileSystem) CreateService()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        var fileSystem = new FileSystemService(configuration);
+        var locations = new Locations(fileSystem);
+
+        var dcpOptions = Options.Create(new DcpOptions
+        {
+            // Poll quickly so the kubeconfig file-wait/read retries react promptly in tests.
+            KubernetesConfigReadRetryIntervalMilliseconds = 50,
+            KubernetesConfigReadRetryCount = 300,
+        });
+
+        var service = new KubernetesService(NullLogger<KubernetesService>.Instance, dcpOptions, locations, configuration)
+        {
+            // Generous enough that the test can flip the kubeconfig before the retry budget is exhausted.
+            MaxRetryDuration = TimeSpan.FromSeconds(30),
+        };
+
+        // Computing the path also creates the (real) temp session directory the kubeconfig lives in.
+        return (service, locations.DcpKubeconfigPath, fileSystem);
+    }
+
+    private static void WriteKubeconfig(string path, int port)
+    {
+        // Minimal kubeconfig pointing at a plain-HTTP loopback endpoint with no auth, which is all the
+        // DcpKubernetesClient needs to issue custom-object requests against the fake server.
+        var content = string.Format(CultureInfo.InvariantCulture, """
+            apiVersion: v1
+            kind: Config
+            clusters:
+            - name: dcp
+              cluster:
+                server: http://127.0.0.1:{0}
+            contexts:
+            - name: dcp
+              context:
+                cluster: dcp
+                user: dcp
+            current-context: dcp
+            users:
+            - name: dcp
+              user:
+                token: dcp-test-token
+            """, port);
+
+        // Write atomically (temp file + move on the same volume) so a concurrent read by the service never
+        // observes a half-written file.
+        var tempPath = path + ".tmp";
+        File.WriteAllText(tempPath, content);
+        File.Move(tempPath, path, overwrite: true);
+    }
+
+    private static int GetFreePort()
+    {
+        // Bind to port 0 to let the OS pick a free port, then release it. There is a small race before the
+        // port is (intentionally, for the dead-port case) left unused, which is acceptable for a loopback test.
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    // A minimal stand-in for the DCP API server. It answers every request with an empty Kubernetes list, which
+    // is enough for ListAsync<Container>() to deserialize successfully.
+    private sealed class FakeDcpApiServer : IDisposable
+    {
+        private readonly HttpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _loop;
+
+        public FakeDcpApiServer()
+        {
+            Port = GetFreePort();
+            _listener = new HttpListener();
+            _listener.Prefixes.Add($"http://127.0.0.1:{Port}/");
+            _listener.Start();
+            _loop = Task.Run(ProcessRequestsAsync);
+        }
+
+        public int Port { get; }
+
+        private async Task ProcessRequestsAsync()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                HttpListenerContext context;
+                try
+                {
+                    context = await _listener.GetContextAsync();
+                }
+                catch (Exception) when (_cts.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (HttpListenerException)
+                {
+                    return;
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+
+                try
+                {
+                    var body = Encoding.UTF8.GetBytes("""{"apiVersion":"usvc-dev.developer.microsoft.com/v1","kind":"ContainerList","items":[]}""");
+                    context.Response.StatusCode = (int)HttpStatusCode.OK;
+                    context.Response.ContentType = "application/json";
+                    context.Response.ContentLength64 = body.Length;
+                    await context.Response.OutputStream.WriteAsync(body);
+                    context.Response.OutputStream.Close();
+                }
+                catch
+                {
+                    // Ignore failures writing the response; the test's retry loop will simply try again.
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            try
+            {
+                _listener.Stop();
+                _listener.Close();
+            }
+            catch
+            {
+                // Best effort shutdown.
+            }
+
+            try
+            {
+                _loop.Wait(TimeSpan.FromSeconds(5));
+            }
+            catch
+            {
+                // Best effort shutdown.
+            }
+
+            _cts.Dispose();
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
@@ -55,25 +55,18 @@ public class KubernetesServiceTests
         using var disposableFileSystem = fileSystem;
         using var disposableService = service;
 
-        // Simulate DCP having flushed only the first part of the kubeconfig. The content is cut off mid-way
-        // through a double-quoted scalar, which is a faithful "half-written file" and deterministically fails
-        // YAML parsing. The production read pipeline handles that (KubeConfigException/YamlException/IOException)
-        // and retries instead of caching a broken client.
-        File.WriteAllText(kubeconfigPath, """
-            apiVersion: v1
-            kind: Config
-            clusters:
-            - name: dcp
-              cluster:
-                server: "http://127.0.0.1
-            """);
+        // Simulate DCP having flushed only the first part of the kubeconfig
+        WritePartialKubeconfig(kubeconfigPath);
 
         var listTask = service.ListAsync<Container>(cancellationToken: cts.Token);
 
+        // Give the read pipeline time to observe and retry the partial file before we finish writing it.
         await Task.Delay(300, cts.Token);
 
         await using var server = await TestDcpApiServer.StartAsync(cts.Token);
-        WriteKubeconfig(kubeconfigPath, server.Port);
+
+        // Finish the write by appending the remainder onto the same file. In-flight DCP calls will now succeed.
+        CompleteKubeconfig(kubeconfigPath, server.Port);
 
         var result = await listTask;
         Assert.Empty(result);
@@ -82,24 +75,34 @@ public class KubernetesServiceTests
     private static (KubernetesService Service, string KubeconfigPath, IDisposable FileSystem) CreateService()
     {
         var configuration = new ConfigurationBuilder().Build();
-        var fileSystem = new FileSystemService(configuration);
-        var locations = new Locations(fileSystem);
 
-        var dcpOptions = Options.Create(new DcpOptions
+        // Decouple the kubeconfig location from the production FileSystemService
+        var fileSystem = new TestFileSystemService();
+        try
         {
-            // Poll quickly so the kubeconfig file-wait/read retries react promptly in tests.
-            KubernetesConfigReadRetryIntervalMilliseconds = 50,
-            KubernetesConfigReadRetryCount = 300,
-        });
+            var locations = new Locations(fileSystem);
 
-        var service = new KubernetesService(NullLogger<KubernetesService>.Instance, dcpOptions, locations, configuration)
+            var dcpOptions = Options.Create(new DcpOptions
+            {
+                // Poll quickly so the kubeconfig file-wait/read retries react promptly in tests.
+                KubernetesConfigReadRetryIntervalMilliseconds = 50,
+                KubernetesConfigReadRetryCount = 300,
+            });
+
+            var service = new KubernetesService(NullLogger<KubernetesService>.Instance, dcpOptions, locations, configuration)
+            {
+                // Generous enough that the test can flip the kubeconfig before the retry budget is exhausted.
+                MaxRetryDuration = TimeSpan.FromSeconds(30),
+            };
+
+            return (service, locations.DcpKubeconfigPath, fileSystem);
+        }
+        catch
         {
-            // Generous enough that the test can flip the kubeconfig before the retry budget is exhausted.
-            MaxRetryDuration = TimeSpan.FromSeconds(30),
-        };
-
-        // Computing the path also creates the (real) temp session directory the kubeconfig lives in.
-        return (service, locations.DcpKubeconfigPath, fileSystem);
+            // Don't orphan the temp directory if wiring up the service fails before the test takes ownership.
+            fileSystem.Dispose();
+            throw;
+        }
     }
 
     private static void WriteKubeconfig(string path, int port)
@@ -130,6 +133,103 @@ public class KubernetesServiceTests
         var tempPath = path + ".tmp";
         File.WriteAllText(tempPath, content);
         File.Move(tempPath, path, overwrite: true);
+    }
+
+    private static void WritePartialKubeconfig(string path)
+    {
+        // A genuine prefix of the final kubeconfig that stops in the middle of the double-quoted server value.
+        // The unterminated quote makes this deterministically fail YAML parsing, which models DCP having only
+        // flushed part of the file. There is intentionally no trailing newline, so appending the remainder in
+        // CompleteKubeconfig closes the quote and yields exactly-valid YAML.
+        File.WriteAllText(path, """
+            apiVersion: v1
+            kind: Config
+            clusters:
+            - name: dcp
+              cluster:
+                server: "http://127.0.0.1:
+            """);
+    }
+
+    private static void CompleteKubeconfig(string path, int port)
+    {
+        // Append (do not rewrite) the remainder of the kubeconfig that WritePartialKubeconfig left unfinished.
+        // The remainder begins by closing the open server scalar ({port}") so the combined file parses as a
+        // valid kubeconfig pointing at the loopback fake server with no auth.
+        File.AppendAllText(path, string.Format(CultureInfo.InvariantCulture, """
+            {0}"
+            contexts:
+            - name: dcp
+              context:
+                cluster: dcp
+                user: dcp
+            current-context: dcp
+            users:
+            - name: dcp
+              user:
+                token: dcp-test-token
+            """, port));
+    }
+
+    // A self-contained IFileSystemService for these tests. It hands Locations a single, uniquely-suffixed temp
+    // directory that the test owns, decoupling the kubeconfig location from the production FileSystemService so
+    // concurrent runs on the same machine never share a path. Every file a test writes lives under this root, so
+    // disposing the fake (always, via `using`) removes the kubeconfig and any partial/temp files regardless of the
+    // test outcome.
+    private sealed class TestFileSystemService : IFileSystemService, IDisposable
+    {
+        private readonly TestTempFileSystemService _tempDirectory = new();
+
+        public ITempFileSystemService TempDirectory => _tempDirectory;
+
+        public void Dispose() => _tempDirectory.Dispose();
+
+        private sealed class TestTempFileSystemService : ITempFileSystemService, IDisposable
+        {
+            private string? _root;
+
+            public TempDirectory CreateTempSubdirectory(string? prefix = null)
+            {
+                // Created lazily (Locations calls this exactly once) so the directory can't be orphaned if the
+                // test fails to take ownership, and with a random suffix so each test instance is isolated.
+                _root ??= Directory.CreateTempSubdirectory("test-kubeconfig-").FullName;
+                return new TestTempDirectory(_root);
+            }
+
+            public TempFile CreateTempFile(string? fileName = null)
+                => throw new NotSupportedException("The kubeconfig tests only allocate a temp subdirectory.");
+
+            public void Dispose()
+            {
+                if (_root is null)
+                {
+                    return;
+                }
+
+                try
+                {
+                    if (Directory.Exists(_root))
+                    {
+                        Directory.Delete(_root, recursive: true);
+                    }
+                }
+                catch
+                {
+                    // Best-effort cleanup; a teardown failure must never mask the test result.
+                }
+            }
+        }
+
+        // The owning TestTempFileSystemService deletes the root recursively on Dispose, 
+        // so this handle has nothing of its own to release.
+        private sealed class TestTempDirectory(string path) : TempDirectory
+        {
+            public override string Path => path;
+
+            public override void Dispose()
+            {
+            }
+        }
     }
 
     // A minimal stand-in for the DCP API server. It answers every request with an empty Kubernetes list, which

--- a/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
@@ -17,40 +17,6 @@ namespace Aspire.Hosting.Tests.Dcp;
 
 public class KubernetesServiceTests
 {
-    // Regression test for the change that brought connecting to DCP (EnsureKubernetesAsync) back into the
-    // retry loop. When a client is first built from a stale kubeconfig (here, one pointing at a dead port),
-    // a connectivity failure must invalidate that cached client so the next retry re-reads the kubeconfig and
-    // rebuilds the client against the now-correct endpoint. Without the fix the stale client is cached forever
-    // and the operation fails permanently.
-    [Fact]
-    public async Task ExecuteWithRetry_RebuildsClient_WhenKubeconfigUpdatedAfterStaleConfig()
-    {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
-
-        var (service, kubeconfigPath, fileSystem) = CreateService();
-        using var disposableFileSystem = fileSystem;
-        using var disposableService = service;
-
-        // Start with a kubeconfig that points at a port nobody is listening on. The first operation builds a
-        // client from this config and fails to connect (HttpRequestException -> connection refused).
-        var deadPort = GetFreePort();
-        WriteKubeconfig(kubeconfigPath, deadPort);
-
-        var listTask = service.ListAsync<Container>(cancellationToken: cts.Token);
-
-        // Give the operation a moment to build the stale client and start retrying, then stand up a real
-        // endpoint and repoint the kubeconfig at it.
-        await Task.Delay(300, cts.Token);
-
-        using var server = new FakeDcpApiServer();
-        WriteKubeconfig(kubeconfigPath, server.Port);
-
-        // With the fix the stale client is discarded and rebuilt against the live endpoint, so the call
-        // completes successfully (an empty list of containers).
-        var result = await listTask;
-        Assert.Empty(result);
-    }
-
     // Verifies that establishing the connection happens inside the retry loop: when the kubeconfig does not
     // exist yet (DCP has not finished writing it), the operation waits and succeeds once it appears.
     [Fact]
@@ -69,7 +35,7 @@ public class KubernetesServiceTests
 
         await Task.Delay(300, cts.Token);
 
-        using var server = new FakeDcpApiServer();
+        using var server = new TestDcpApiServer();
         WriteKubeconfig(kubeconfigPath, server.Port);
 
         var result = await listTask;
@@ -147,13 +113,13 @@ public class KubernetesServiceTests
 
     // A minimal stand-in for the DCP API server. It answers every request with an empty Kubernetes list, which
     // is enough for ListAsync<Container>() to deserialize successfully.
-    private sealed class FakeDcpApiServer : IDisposable
+    private sealed class TestDcpApiServer : IDisposable
     {
         private readonly HttpListener _listener;
         private readonly CancellationTokenSource _cts = new();
         private readonly Task _loop;
 
-        public FakeDcpApiServer()
+        public TestDcpApiServer()
         {
             Port = GetFreePort();
             _listener = new HttpListener();


### PR DESCRIPTION
## Description

Brings back connecting to DCP API server into DCP request retry loop, thus guarding against timing issues associated with missing or partially-written DCP kubeconfig file.

Was not able to positively verify if this will fix the following for good, but it definitively helps
- https://github.com/microsoft/aspire/issues/18050
- https://github.com/microsoft/aspire/issues/18041

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
