### PR TITLE
Dashboard: gracefully handle resource service connection errors

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ApplicationName.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ApplicationName.razor.cs
@@ -27,15 +27,54 @@ public sealed partial class ApplicationName : ComponentBase, IDisposable
 
     protected override async Task OnInitializedAsync()
     {
-        // We won't have an application name until the client has connected to the server.
+        DashboardClient.ConnectionStateChanged += OnConnectionStateChanged;
+
+        // Wait for the client to connect, but proceed after 2 seconds regardless so the
+        // page title is set even when the app host is unreachable.
         if (DashboardClient.IsEnabled && !DashboardClient.WhenConnected.IsCompletedSuccessfully)
         {
             _disposalCts = new CancellationTokenSource();
-            await DashboardClient.WhenConnected.WaitAsync(_disposalCts.Token);
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_disposalCts.Token);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(2));
+
+            try
+            {
+                await DashboardClient.WhenConnected.WaitAsync(timeoutCts.Token);
+            }
+            catch (OperationCanceledException) when (!_disposalCts.IsCancellationRequested)
+            {
+                // Timed out waiting for connection — proceed with whatever ApplicationName is available.
+            }
+        }
+    }
+
+    private async void OnConnectionStateChanged(DashboardConnectionState state)
+    {
+        if (state is not DashboardConnectionState.Connected)
+        {
+            return;
+        }
+
+        try
+        {
+            await InvokeAsync(() =>
+            {
+                UpdatePageTitle();
+                StateHasChanged();
+            });
+        }
+        catch (ObjectDisposedException)
+        {
+            // Component disposed, ignore.
         }
     }
 
     protected override void OnParametersSet()
+    {
+        UpdatePageTitle();
+    }
+
+    private void UpdatePageTitle()
     {
         string applicationName;
 
@@ -55,6 +94,7 @@ public sealed partial class ApplicationName : ComponentBase, IDisposable
 
     public void Dispose()
     {
+        DashboardClient.ConnectionStateChanged -= OnConnectionStateChanged;
         _disposalCts?.Cancel();
         _disposalCts?.Dispose();
     }

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -116,6 +116,7 @@
     <FluentTooltipProvider />
     <FluentMenuProvider />
     <InteractionsProvider />
+    <ResourceServiceConnectionProvider />
     <div id="blazor-error-ui">
         @Loc[nameof(Layout.MainLayoutUnhandledErrorMessage)]
         <a href="" class="reload">@Loc[nameof(Layout.MainLayoutUnhandledErrorReload)]</a>

--- a/src/Aspire.Dashboard/Components/Layout/ReconnectModal.razor
+++ b/src/Aspire.Dashboard/Components/Layout/ReconnectModal.razor
@@ -7,6 +7,7 @@
             <div></div>
             <div></div>
         </div>
+        @* Blazor circuit reconnection messages *@
         <p class="components-reconnect-first-attempt-visible">
             @((MarkupString)Loc[nameof(Layout.ReconnectFirstAttemptText)].Value)
         </p>
@@ -19,6 +20,15 @@
         <div class="components-reconnect-failed-visible">
             <FluentButton Id="components-reconnect-button" Appearance="Appearance.Accent">
                 @Loc[nameof(Layout.ReconnectRetryButtonText)]
+            </FluentButton>
+        </div>
+        @* Resource service connection messages *@
+        <p class="components-reconnect-resource-service-disconnected-visible">
+            @Loc[nameof(Layout.ResourceServiceReconnectDisconnectedText)]
+        </p>
+        <div class="components-reconnect-resource-service-retry-visible">
+            <FluentButton Id="components-reconnect-resource-service-button" Appearance="Appearance.Accent">
+                @Loc[nameof(Layout.ResourceServiceReconnectRetryButtonText)]
             </FluentButton>
         </div>
     </div>

--- a/src/Aspire.Dashboard/Components/Layout/ReconnectModal.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/ReconnectModal.razor.css
@@ -1,6 +1,8 @@
 .components-reconnect-first-attempt-visible,
 .components-reconnect-repeated-attempt-visible,
 .components-reconnect-failed-visible,
+.components-reconnect-resource-service-disconnected-visible,
+.components-reconnect-resource-service-retry-visible,
 .components-rejoining-animation {
     display: none;
 }
@@ -11,7 +13,10 @@
 #components-reconnect-modal.components-reconnect-retrying .components-reconnect-repeated-attempt-visible,
 #components-reconnect-modal.components-reconnect-retrying .components-rejoining-animation,
 #components-reconnect-modal.components-reconnect-failed,
-#components-reconnect-modal.components-reconnect-failed .components-reconnect-failed-visible {
+#components-reconnect-modal.components-reconnect-failed .components-reconnect-failed-visible,
+#components-reconnect-modal.components-reconnect-resource-service-disconnected .components-reconnect-resource-service-disconnected-visible,
+#components-reconnect-modal.components-reconnect-resource-service-disconnected .components-rejoining-animation,
+#components-reconnect-modal.components-reconnect-resource-service-show-retry .components-reconnect-resource-service-retry-visible {
     display: block;
 }
 

--- a/src/Aspire.Dashboard/Components/Layout/ResourceServiceConnectionProvider.cs
+++ b/src/Aspire.Dashboard/Components/Layout/ResourceServiceConnectionProvider.cs
@@ -1,12 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.ServiceClient;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Layout;
 
-public sealed partial class ResourceServiceConnectionProvider : ComponentBase, IAsyncDisposable
+public sealed class ResourceServiceConnectionProvider : ComponentBase, IAsyncDisposable
 {
     private const int MaxAttemptsBeforeShowingRetry = 5;
 

--- a/src/Aspire.Dashboard/Components/Layout/ResourceServiceConnectionProvider.cs
+++ b/src/Aspire.Dashboard/Components/Layout/ResourceServiceConnectionProvider.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.ServiceClient;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 

--- a/src/Aspire.Dashboard/Components/Layout/ResourceServiceConnectionProvider.razor
+++ b/src/Aspire.Dashboard/Components/Layout/ResourceServiceConnectionProvider.razor
@@ -1,2 +1,0 @@
-@using Aspire.Dashboard.ServiceClient
-@implements IAsyncDisposable

--- a/src/Aspire.Dashboard/Components/Layout/ResourceServiceConnectionProvider.razor
+++ b/src/Aspire.Dashboard/Components/Layout/ResourceServiceConnectionProvider.razor
@@ -1,0 +1,2 @@
+@using Aspire.Dashboard.ServiceClient
+@implements IAsyncDisposable

--- a/src/Aspire.Dashboard/Components/Layout/ResourceServiceConnectionProvider.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/ResourceServiceConnectionProvider.razor.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace Aspire.Dashboard.Components.Layout;
+
+public sealed partial class ResourceServiceConnectionProvider : ComponentBase, IAsyncDisposable
+{
+    private const int MaxAttemptsBeforeShowingRetry = 5;
+
+    private DotNetObjectReference<ResourceServiceConnectionProvider>? _dotNetRef;
+    private int _disconnectedCount;
+
+    [Inject]
+    public required IDashboardClient DashboardClient { get; init; }
+
+    [Inject]
+    public required IJSRuntime JS { get; init; }
+
+    protected override void OnInitialized()
+    {
+        if (!DashboardClient.IsEnabled)
+        {
+            return;
+        }
+
+        DashboardClient.ConnectionStateChanged += OnConnectionStateChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && DashboardClient.IsEnabled)
+        {
+            // Register the .NET object reference so JS can call back for retry.
+            _dotNetRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("registerResourceServiceConnectionProvider", _dotNetRef);
+
+            // Report the current state immediately in case we're already disconnected.
+            // Don't report Connecting — that's normal startup. Only report Disconnected.
+            if (DashboardClient.ConnectionState is DashboardConnectionState.Disconnected)
+            {
+                await UpdateModalStateAsync(DashboardConnectionState.Disconnected);
+            }
+        }
+    }
+
+    private async void OnConnectionStateChanged(DashboardConnectionState state)
+    {
+        try
+        {
+            await InvokeAsync(() => UpdateModalStateAsync(state));
+        }
+        catch (ObjectDisposedException)
+        {
+            // Component disposed, ignore.
+        }
+        catch (JSDisconnectedException)
+        {
+            // Circuit disconnected, JS interop is no longer available.
+        }
+    }
+
+    private async Task UpdateModalStateAsync(DashboardConnectionState state)
+    {
+        if (state is DashboardConnectionState.Connected)
+        {
+            _disconnectedCount = 0;
+            await JS.InvokeVoidAsync("updateResourceServiceConnectionState", "connected", false);
+        }
+        else if (state is DashboardConnectionState.Disconnected)
+        {
+            _disconnectedCount++;
+            var showRetry = _disconnectedCount >= MaxAttemptsBeforeShowingRetry;
+            await JS.InvokeVoidAsync("updateResourceServiceConnectionState", "disconnected", showRetry);
+        }
+
+        // Connecting state — don't update modal.
+    }
+
+    [JSInvokable]
+    public async Task ReconnectFromJs()
+    {
+        await DashboardClient.ReconnectAsync();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        DashboardClient.ConnectionStateChanged -= OnConnectionStateChanged;
+        _dotNetRef?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Aspire.Dashboard/Resources/Layout.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Layout.Designer.cs
@@ -277,6 +277,24 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Lost connection to the AppHost. Attempting to reconnect....
+        /// </summary>
+        public static string ResourceServiceReconnectDisconnectedText {
+            get {
+                return ResourceManager.GetString("ResourceServiceReconnectDisconnectedText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Retry.
+        /// </summary>
+        public static string ResourceServiceReconnectRetryButtonText {
+            get {
+                return ResourceManager.GetString("ResourceServiceReconnectRetryButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to AI agents.
         /// </summary>
         public static string MainLayoutLaunchAIAgents {

--- a/src/Aspire.Dashboard/Resources/Layout.resx
+++ b/src/Aspire.Dashboard/Resources/Layout.resx
@@ -183,6 +183,12 @@
   <data name="ReconnectRetryButtonText" xml:space="preserve">
     <value>Retry</value>
   </data>
+  <data name="ResourceServiceReconnectDisconnectedText" xml:space="preserve">
+    <value>Lost connection to the AppHost. Attempting to reconnect...</value>
+  </data>
+  <data name="ResourceServiceReconnectRetryButtonText" xml:space="preserve">
+    <value>Retry</value>
+  </data>
   <data name="MessageUnsecuredEndpointTitle" xml:space="preserve">
     <value>Endpoint is unsecured</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
@@ -127,6 +127,16 @@
         <target state="translated">Zkusit znovu</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
@@ -127,6 +127,16 @@
         <target state="translated">Erneut versuchen</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
@@ -127,6 +127,16 @@
         <target state="translated">Reintentar</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
@@ -127,6 +127,16 @@
         <target state="translated">Réessayer</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
@@ -127,6 +127,16 @@
         <target state="translated">Riprova</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
@@ -127,6 +127,16 @@
         <target state="translated">再試行</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
@@ -127,6 +127,16 @@
         <target state="translated">다시 시도</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
@@ -127,6 +127,16 @@
         <target state="translated">Ponów próbę</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
@@ -127,6 +127,16 @@
         <target state="translated">Repetir</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
@@ -127,6 +127,16 @@
         <target state="translated">Повторить попытку</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
@@ -127,6 +127,16 @@
         <target state="translated">Yeniden dene</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
@@ -127,6 +127,16 @@
         <target state="translated">重试</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
@@ -127,6 +127,16 @@
         <target state="translated">重試</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceServiceReconnectDisconnectedText">
+        <source>Lost connection to the AppHost. Attempting to reconnect...</source>
+        <target state="new">Lost connection to the AppHost. Attempting to reconnect...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceServiceReconnectRetryButtonText">
+        <source>Retry</source>
+        <target state="new">Retry</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -246,7 +246,11 @@ internal sealed class DashboardClient : IDashboardClient
         // Cancel any existing reconnect delay to attempt immediately.
         lock (_reconnectDelayLock)
         {
-            _reconnectDelayCts?.Cancel();
+            if (_reconnectDelayCts is { } cts)
+            {
+                cts.Cancel();
+                _reconnectDelayCts = null;
+            }
         }
 
         return Task.CompletedTask;
@@ -266,9 +270,15 @@ internal sealed class DashboardClient : IDashboardClient
             _connectionState = state;
             _logger.LogDebug("Dashboard connection state changed to {State}.", state);
 
-            // Reset the WhenConnected TCS when disconnecting so that callers can re-await it.
-            if (state is DashboardConnectionState.Disconnected or DashboardConnectionState.Connecting)
+            if (state is DashboardConnectionState.Connected)
             {
+                // Complete the WhenConnected TCS so that callers waiting on it can proceed.
+                // This handles both initial connection and reconnection after a disconnect.
+                _whenConnectedTcs.TrySetResult();
+            }
+            else if (state is DashboardConnectionState.Disconnected or DashboardConnectionState.Connecting)
+            {
+                // Reset the WhenConnected TCS when disconnecting so that callers can re-await it.
                 if (_whenConnectedTcs.Task.IsCompleted)
                 {
                     _whenConnectedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -358,8 +368,7 @@ internal sealed class DashboardClient : IDashboardClient
                 CancellationTokenSource delayCts;
                 lock (_reconnectDelayLock)
                 {
-                    delayCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                    _reconnectDelayCts = delayCts;
+                    delayCts = _reconnectDelayCts ??= CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 }
                 try
                 {
@@ -374,8 +383,12 @@ internal sealed class DashboardClient : IDashboardClient
                 {
                     lock (_reconnectDelayLock)
                     {
-                        _reconnectDelayCts = null;
+                        if (ReferenceEquals(_reconnectDelayCts, delayCts))
+                        {
+                            _reconnectDelayCts = null;
+                        }
                     }
+
                     delayCts.Dispose();
                 }
 
@@ -389,7 +402,6 @@ internal sealed class DashboardClient : IDashboardClient
                 _applicationName = response.ApplicationName;
 
                 SetConnectionState(DashboardConnectionState.Connected);
-                _whenConnectedTcs.TrySetResult();
                 return;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -433,11 +445,11 @@ internal sealed class DashboardClient : IDashboardClient
                 var delay = ExponentialBackOff(retryContext.ErrorCount, maxSeconds: 15);
 
                 // Allow the delay to be cancelled by ReconnectAsync() for immediate retry.
+                // Multiple watchers share the same CTS so ReconnectAsync cancels all pending delays.
                 CancellationTokenSource delayCts;
                 lock (_reconnectDelayLock)
                 {
-                    delayCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                    _reconnectDelayCts = delayCts;
+                    delayCts = _reconnectDelayCts ??= CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 }
                 try
                 {
@@ -451,8 +463,16 @@ internal sealed class DashboardClient : IDashboardClient
                 {
                     lock (_reconnectDelayLock)
                     {
-                        _reconnectDelayCts = null;
+                        // Clear the shared field if we're still the owner, so the next retry
+                        // iteration creates a fresh CTS.
+                        if (ReferenceEquals(_reconnectDelayCts, delayCts))
+                        {
+                            _reconnectDelayCts = null;
+                        }
                     }
+
+                    // Always dispose locally. CTS.Dispose is idempotent so multiple watchers
+                    // or ReconnectAsync disposing the same instance is safe.
                     delayCts.Dispose();
                 }
             }
@@ -501,6 +521,7 @@ internal sealed class DashboardClient : IDashboardClient
         await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
         {
             List<ResourceViewModelChange>? changes = null;
+            var shouldUpdateConnectionState = false;
 
             lock (_lock)
             {
@@ -508,7 +529,7 @@ internal sealed class DashboardClient : IDashboardClient
                 if (retryContext.ErrorCount > 0)
                 {
                     retryContext.ErrorCount = 0;
-                    SetConnectionState(DashboardConnectionState.Connected);
+                    shouldUpdateConnectionState = true;
                 }
 
                 if (response.KindCase == WatchResourcesUpdate.KindOneofCase.InitialData)
@@ -576,6 +597,13 @@ internal sealed class DashboardClient : IDashboardClient
                         .Select(r => ResourceViewModel.GetResourceName(r, _resourceByName));
                     ColorGenerator.Instance.ResolveAll(resolvedNames);
                 }
+            }
+
+            // Update connection state outside the lock to avoid potential deadlocks
+            // if a subscriber tries to access DashboardClient state.
+            if (shouldUpdateConnectionState)
+            {
+                SetConnectionState(DashboardConnectionState.Connected);
             }
 
             if (changes is not null)

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -46,8 +46,8 @@ internal sealed class DashboardClient : IDashboardClient
     private readonly InteractionCollection _pendingInteractionCollection = new();
     private readonly CancellationTokenSource _cts = new();
     private readonly CancellationToken _clientCancellationToken;
-    private readonly TaskCompletionSource _whenConnectedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private readonly TaskCompletionSource _initialDataReceivedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private TaskCompletionSource _whenConnectedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private TaskCompletionSource _initialDataReceivedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly Channel<WatchInteractionsRequestUpdate> _incomingInteractionChannel = Channel.CreateUnbounded<WatchInteractionsRequestUpdate>();
     private readonly object _lock = new();
     private readonly TaskCompletionSource _resourceWatchCompleteTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -61,6 +61,10 @@ internal sealed class DashboardClient : IDashboardClient
     private ImmutableHashSet<Channel<IReadOnlyList<ResourceViewModelChange>>> _outgoingResourceChannels = [];
     private ImmutableHashSet<Channel<WatchInteractionsResponseUpdate>> _outgoingInteractionChannels = [];
     private string? _applicationName;
+
+    private DashboardConnectionState _connectionState;
+    private readonly object _reconnectDelayLock = new();
+    private CancellationTokenSource? _reconnectDelayCts;
 
     private const int StateDisabled = -1;
     private const int StateNone = 0;
@@ -227,6 +231,53 @@ internal sealed class DashboardClient : IDashboardClient
 
     public bool IsEnabled => _state is not StateDisabled;
 
+    public DashboardConnectionState ConnectionState => _connectionState;
+
+    public event Action<DashboardConnectionState>? ConnectionStateChanged;
+
+    public Task ReconnectAsync()
+    {
+        if (_state is StateDisabled or StateDisposed)
+        {
+            return Task.CompletedTask;
+        }
+
+        // Cancel any existing reconnect delay to attempt immediately.
+        lock (_reconnectDelayLock)
+        {
+            _reconnectDelayCts?.Cancel();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void SetConnectionState(DashboardConnectionState state)
+    {
+        if (_connectionState == state)
+        {
+            return;
+        }
+
+        _connectionState = state;
+        _logger.LogDebug("Dashboard connection state changed to {State}.", state);
+
+        // Reset the WhenConnected TCS when disconnecting so that callers can re-await it.
+        if (state is DashboardConnectionState.Disconnected or DashboardConnectionState.Connecting)
+        {
+            if (_whenConnectedTcs.Task.IsCompleted)
+            {
+                _whenConnectedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+
+            if (_initialDataReceivedTcs.Task.IsCompleted)
+            {
+                _initialDataReceivedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+        }
+
+        ConnectionStateChanged?.Invoke(state);
+    }
+
     private void EnsureInitialized()
     {
         var priorState = Interlocked.CompareExchange(ref _state, value: StateInitialized, comparand: StateNone);
@@ -242,6 +293,7 @@ internal sealed class DashboardClient : IDashboardClient
             return;
         }
 
+        SetConnectionState(DashboardConnectionState.Connecting);
         _connection = Task.Run(() => ConnectAndWatchAsync(_clientCancellationToken), _clientCancellationToken);
     }
 
@@ -249,7 +301,7 @@ internal sealed class DashboardClient : IDashboardClient
     {
         try
         {
-            await ConnectAsync().ConfigureAwait(false);
+            await ConnectWithRetryAsync(cancellationToken).ConfigureAwait(false);
 
             await Task.WhenAll(
                 Task.Run(async () =>
@@ -272,20 +324,74 @@ internal sealed class DashboardClient : IDashboardClient
             _logger.LogError(ex, "Error loading data from the resource service.");
             throw;
         }
+    }
 
-        async Task ConnectAsync()
+    /// <summary>
+    /// Attempts to connect to the resource service with exponential backoff retry.
+    /// On failure, transitions to Disconnected and waits before retrying. The delay can be
+    /// cancelled by <see cref="ReconnectAsync"/> for immediate retry.
+    /// </summary>
+    private async Task ConnectWithRetryAsync(CancellationToken cancellationToken)
+    {
+        var errorCount = 0;
+
+        while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (errorCount > 0)
+            {
+                SetConnectionState(DashboardConnectionState.Disconnected);
+
+                var delay = TimeSpan.FromSeconds(Math.Min(Math.Pow(2, errorCount - 1), 15));
+                _logger.LogDebug("Waiting {Delay} before next connection attempt.", delay);
+
+                // Allow the delay to be cancelled by ReconnectAsync() for immediate retry.
+                CancellationTokenSource delayCts;
+                lock (_reconnectDelayLock)
+                {
+                    delayCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    _reconnectDelayCts = delayCts;
+                }
+                try
+                {
+                    await Task.Delay(delay, delayCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    // ReconnectAsync() cancelled the delay — retry immediately.
+                    _logger.LogDebug("Reconnect delay cancelled, retrying immediately.");
+                }
+                finally
+                {
+                    lock (_reconnectDelayLock)
+                    {
+                        _reconnectDelayCts = null;
+                    }
+                    delayCts.Dispose();
+                }
+
+                SetConnectionState(DashboardConnectionState.Connecting);
+            }
+
             try
             {
                 var response = await _client!.GetApplicationInformationAsync(new(), headers: _headers, cancellationToken: cancellationToken);
 
                 _applicationName = response.ApplicationName;
 
+                SetConnectionState(DashboardConnectionState.Connected);
                 _whenConnectedTcs.TrySetResult();
+                return;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
-                _whenConnectedTcs.TrySetException(ex);
+                errorCount++;
+                _logger.LogError(ex, "Error #{ErrorCount} connecting to the resource service.", errorCount);
             }
         }
     }
@@ -309,12 +415,38 @@ internal sealed class DashboardClient : IDashboardClient
 
             if (retryContext.ErrorCount > 0)
             {
+                // Transition to disconnected when watch streams fail.
+                // Only the first watcher to fail will trigger the state change.
+                SetConnectionState(DashboardConnectionState.Disconnected);
+
                 // The most recent attempt failed. There may be more than one failure.
                 // We wait for a period of time determined by the number of errors,
                 // where the time grows exponentially, until a threshold.
                 var delay = ExponentialBackOff(retryContext.ErrorCount, maxSeconds: 15);
 
-                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                // Allow the delay to be cancelled by ReconnectAsync() for immediate retry.
+                CancellationTokenSource delayCts;
+                lock (_reconnectDelayLock)
+                {
+                    delayCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    _reconnectDelayCts = delayCts;
+                }
+                try
+                {
+                    await Task.Delay(delay, delayCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    // ReconnectAsync() cancelled the delay — retry immediately.
+                }
+                finally
+                {
+                    lock (_reconnectDelayLock)
+                    {
+                        _reconnectDelayCts = null;
+                    }
+                    delayCts.Dispose();
+                }
             }
 
             try
@@ -365,7 +497,11 @@ internal sealed class DashboardClient : IDashboardClient
             lock (_lock)
             {
                 // We received a message, which means we are connected. Clear the error count.
-                retryContext.ErrorCount = 0;
+                if (retryContext.ErrorCount > 0)
+                {
+                    retryContext.ErrorCount = 0;
+                    SetConnectionState(DashboardConnectionState.Connected);
+                }
 
                 if (response.KindCase == WatchResourcesUpdate.KindOneofCase.InitialData)
                 {
@@ -490,7 +626,11 @@ internal sealed class DashboardClient : IDashboardClient
             await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken: cts.Token).ConfigureAwait(false))
             {
                 // We received a message, which means we are connected. Clear the error count.
-                retryContext.ErrorCount = 0;
+                if (retryContext.ErrorCount > 0)
+                {
+                    retryContext.ErrorCount = 0;
+                    SetConnectionState(DashboardConnectionState.Connected);
+                }
 
                 lock (_lock)
                 {

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -63,6 +63,7 @@ internal sealed class DashboardClient : IDashboardClient
     private string? _applicationName;
 
     private DashboardConnectionState _connectionState;
+    private readonly object _connectionStateLock = new();
     private readonly object _reconnectDelayLock = new();
     private CancellationTokenSource? _reconnectDelayCts;
 
@@ -253,28 +254,35 @@ internal sealed class DashboardClient : IDashboardClient
 
     private void SetConnectionState(DashboardConnectionState state)
     {
-        if (_connectionState == state)
+        // Lock ensures that concurrent calls from both watch tasks don't duplicate
+        // state transitions or fire the ConnectionStateChanged event multiple times.
+        lock (_connectionStateLock)
         {
-            return;
-        }
-
-        _connectionState = state;
-        _logger.LogDebug("Dashboard connection state changed to {State}.", state);
-
-        // Reset the WhenConnected TCS when disconnecting so that callers can re-await it.
-        if (state is DashboardConnectionState.Disconnected or DashboardConnectionState.Connecting)
-        {
-            if (_whenConnectedTcs.Task.IsCompleted)
+            if (_connectionState == state)
             {
-                _whenConnectedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                return;
             }
 
-            if (_initialDataReceivedTcs.Task.IsCompleted)
+            _connectionState = state;
+            _logger.LogDebug("Dashboard connection state changed to {State}.", state);
+
+            // Reset the WhenConnected TCS when disconnecting so that callers can re-await it.
+            if (state is DashboardConnectionState.Disconnected or DashboardConnectionState.Connecting)
             {
-                _initialDataReceivedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                if (_whenConnectedTcs.Task.IsCompleted)
+                {
+                    _whenConnectedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                }
+
+                if (_initialDataReceivedTcs.Task.IsCompleted)
+                {
+                    _initialDataReceivedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                }
             }
         }
 
+        // Invoke the event outside the lock to avoid potential deadlocks
+        // if a subscriber tries to access DashboardClient state.
         ConnectionStateChanged?.Invoke(state);
     }
 
@@ -951,6 +959,9 @@ internal sealed class DashboardClient : IDashboardClient
             await TaskHelpers.WaitIgnoreCancelAsync(_connection, _logger, "Unexpected error from connection task.").ConfigureAwait(false);
         }
     }
+
+    // Internal for testing.
+    internal void SetConnectionStateForTesting(DashboardConnectionState state) => SetConnectionState(state);
 
     // Internal for testing.
     // TODO: Improve this in the future by making the client injected with DI and have it return data.

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -475,6 +475,12 @@ internal sealed class DashboardClient : IDashboardClient
                     // or ReconnectAsync disposing the same instance is safe.
                     delayCts.Dispose();
                 }
+
+                // Transition to Connecting so that SetConnectionState fires a new Disconnected
+                // event on the next failure. Without this, duplicate Disconnected transitions
+                // are suppressed and the retry button in ResourceServiceConnectionProvider
+                // never appears (it requires multiple disconnect events).
+                SetConnectionState(DashboardConnectionState.Connecting);
             }
 
             try

--- a/src/Aspire.Dashboard/ServiceClient/DashboardConnectionState.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardConnectionState.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.ServiceClient;
+
+/// <summary>
+/// Represents the connection state between the dashboard and the app host resource service.
+/// </summary>
+public enum DashboardConnectionState
+{
+    /// <summary>
+    /// The dashboard is attempting to connect to the resource service.
+    /// </summary>
+    Connecting,
+
+    /// <summary>
+    /// The dashboard is connected to the resource service and receiving data.
+    /// </summary>
+    Connected,
+
+    /// <summary>
+    /// The dashboard has lost its connection to the resource service and is attempting to reconnect.
+    /// </summary>
+    Disconnected
+}

--- a/src/Aspire.Dashboard/ServiceClient/IDashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/IDashboardClient.cs
@@ -25,6 +25,21 @@ public interface IDashboardClient : IAsyncDisposable
     bool IsEnabled { get; }
 
     /// <summary>
+    /// Gets the current connection state of the client to the resource service.
+    /// </summary>
+    DashboardConnectionState ConnectionState { get; }
+
+    /// <summary>
+    /// An event raised when the connection state changes. Subscribers receive the new state.
+    /// </summary>
+    event Action<DashboardConnectionState>? ConnectionStateChanged;
+
+    /// <summary>
+    /// Explicitly triggers a reconnection attempt to the resource service.
+    /// </summary>
+    Task ReconnectAsync();
+
+    /// <summary>
     /// Gets the application name advertised by the server.
     /// </summary>
     /// <remarks>

--- a/src/Aspire.Dashboard/wwwroot/js/app-reconnect.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-reconnect.js
@@ -1,24 +1,82 @@
+// Tracks which mode the reconnect modal is currently in:
+// "none" - modal is hidden
+// "resource-service" - showing resource service connection failure (triggered by C# JS interop)
+// "circuit" - showing Blazor circuit reconnection failure (triggered by framework event)
+//
+// Circuit mode always takes precedence over resource-service mode. When the circuit reconnects,
+// the C# code will re-evaluate and re-trigger resource-service mode if still needed.
+let currentMode = "none";
+
 // Set up event handlers
 const reconnectModal = document.getElementById("components-reconnect-modal");
 reconnectModal.addEventListener("components-reconnect-state-changed", handleReconnectStateChanged);
 
 const retryButton = document.getElementById("components-reconnect-button");
-retryButton.addEventListener("click", retry);
+retryButton.addEventListener("click", retryCircuit);
+
+const resourceServiceRetryButton = document.getElementById("components-reconnect-resource-service-button");
+resourceServiceRetryButton.addEventListener("click", retryResourceService);
 
 function handleReconnectStateChanged(event) {
     if (event.detail.state === "show") {
-        reconnectModal.showModal();
+        // Blazor circuit disconnection always takes precedence.
+        currentMode = "circuit";
+        setModalClass("components-reconnect-show");
+        if (!reconnectModal.open) {
+            reconnectModal.showModal();
+        }
     } else if (event.detail.state === "hide") {
+        // Circuit reconnected. If resource service was also disconnected,
+        // C# will re-trigger the resource-service modal via JS interop.
+        currentMode = "none";
+        setModalClass("");
         reconnectModal.close();
     } else if (event.detail.state === "failed") {
-        document.addEventListener("visibilitychange", retryWhenDocumentBecomesVisible);
+        currentMode = "circuit";
+        setModalClass("components-reconnect-failed");
+        document.addEventListener("visibilitychange", retryCircuitWhenDocumentBecomesVisible);
     } else if (event.detail.state === "rejected") {
         location.reload();
     }
 }
 
-async function retry() {
-    document.removeEventListener("visibilitychange", retryWhenDocumentBecomesVisible);
+// Called from C# JS interop when the resource service connection state changes.
+// "disconnected" and "connected" are the two states. The initial "connecting" state
+// does not show a modal — it's normal startup behavior, just like Blazor's circuit
+// doesn't show a reconnect dialog on initial page load.
+// The optional "show-retry" flag adds the retry button after repeated failures.
+window.updateResourceServiceConnectionState = function (state, showRetry) {
+    if (state === "disconnected") {
+        // Only show resource service modal if we're not already in circuit mode.
+        if (currentMode === "circuit") {
+            return;
+        }
+        currentMode = "resource-service";
+        var className = "components-reconnect-resource-service-disconnected";
+        if (showRetry) {
+            className += " components-reconnect-resource-service-show-retry";
+        }
+        setModalClass(className);
+        if (!reconnectModal.open) {
+            reconnectModal.showModal();
+        }
+    } else if (state === "connected") {
+        // Only close if we're in resource-service mode, not circuit mode.
+        if (currentMode === "resource-service") {
+            currentMode = "none";
+            setModalClass("");
+            reconnectModal.close();
+        }
+    }
+};
+
+function setModalClass(className) {
+    // Remove all state classes before applying the new one.
+    reconnectModal.className = className;
+}
+
+async function retryCircuit() {
+    document.removeEventListener("visibilitychange", retryCircuitWhenDocumentBecomesVisible);
 
     try {
         // Reconnect will asynchronously return:
@@ -33,12 +91,24 @@ async function retry() {
         }
     } catch (err) {
         // We got an exception, server is currently unavailable
-        document.addEventListener("visibilitychange", retryWhenDocumentBecomesVisible);
+        document.addEventListener("visibilitychange", retryCircuitWhenDocumentBecomesVisible);
     }
 }
 
-async function retryWhenDocumentBecomesVisible() {
+// Called from C# to register the .NET object reference for callbacks.
+window.registerResourceServiceConnectionProvider = function (dotNetRef) {
+    window.resourceServiceConnectionProviderRef = dotNetRef;
+};
+
+function retryResourceService() {
+    // Call the .NET method via JS interop reference set by ResourceServiceConnectionProvider.
+    if (window.resourceServiceConnectionProviderRef) {
+        window.resourceServiceConnectionProviderRef.invokeMethodAsync("ReconnectFromJs");
+    }
+}
+
+async function retryCircuitWhenDocumentBecomesVisible() {
     if (document.visibilityState === "visible") {
-        await retry();
+        await retryCircuit();
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
@@ -39,6 +39,11 @@ public sealed class MockDashboardClient : IDashboardClient
     public bool IsEnabled => true;
     public Task WhenConnected => Task.CompletedTask;
     public string ApplicationName => "IntegrationTestApplication";
+    public DashboardConnectionState ConnectionState => DashboardConnectionState.Connected;
+#pragma warning disable CS0067 // Event is never used - required by interface
+    public event Action<DashboardConnectionState>? ConnectionStateChanged;
+#pragma warning restore CS0067
+    public Task ReconnectAsync() => Task.CompletedTask;
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, ExecuteResourceCommandOptions options, CancellationToken cancellationToken) => throw new NotImplementedException();
     public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -334,8 +334,41 @@ public sealed class DashboardClientTests
         Assert.Equal(1, eventCount);
     }
 
+    [Fact]
+    public async Task WatchWithRecovery_RepeatedFailures_FiresMultipleDisconnectedEvents()
+    {
+        await using var instance = CreateResourceServiceClient();
+        instance.SetDashboardServiceClient(new MockDashboardServiceClient { FailOnWatchResources = true });
+
+        IDashboardClient client = instance;
+        var disconnectedCount = 0;
+        var disconnectedSemaphore = new SemaphoreSlim(0);
+        client.ConnectionStateChanged += state =>
+        {
+            if (state == DashboardConnectionState.Disconnected)
+            {
+                Interlocked.Increment(ref disconnectedCount);
+                disconnectedSemaphore.Release();
+            }
+        };
+
+        // Trigger the connection. ConnectWithRetryAsync succeeds, then WatchResources starts failing.
+        await instance.WhenConnected.DefaultTimeout();
+
+        // Wait for at least 3 Disconnected events to prove each retry fires a new event.
+        // Without the Connecting transition between retries, only 1 Disconnected event would fire.
+        for (var i = 0; i < 3; i++)
+        {
+            await disconnectedSemaphore.WaitAsync(TimeSpan.FromSeconds(30)).DefaultTimeout();
+        }
+
+        Assert.True(disconnectedCount >= 3, $"Expected at least 3 Disconnected events but got {disconnectedCount}.");
+    }
+
     private sealed class MockDashboardServiceClient : Aspire.DashboardService.Proto.V1.DashboardService.DashboardServiceClient
     {
+        public bool FailOnWatchResources { get; init; }
+
         public override AsyncDuplexStreamingCall<WatchInteractionsRequestUpdate, WatchInteractionsResponseUpdate> WatchInteractions(CallOptions options)
         {
             return new AsyncDuplexStreamingCall<WatchInteractionsRequestUpdate, WatchInteractionsResponseUpdate>(
@@ -362,12 +395,26 @@ public sealed class DashboardClientTests
 
         public override AsyncServerStreamingCall<WatchResourcesUpdate> WatchResources(WatchResourcesRequest request, CallOptions options)
         {
+            var reader = FailOnWatchResources
+                ? (IAsyncStreamReader<WatchResourcesUpdate>)new FailingAsyncStreamReader<WatchResourcesUpdate>()
+                : new AsyncStreamReader<WatchResourcesUpdate>();
+
             return new AsyncServerStreamingCall<WatchResourcesUpdate>(
-                new AsyncStreamReader<WatchResourcesUpdate>(),
+                reader,
                 Task.FromResult(new Metadata()),
                 () => Status.DefaultSuccess,
                 () => new Metadata(),
                 () => { });
+        }
+    }
+
+    private sealed class FailingAsyncStreamReader<T> : IAsyncStreamReader<T>
+    {
+        public T Current { get; } = default!;
+
+        public Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            throw new RpcException(new Status(StatusCode.Unavailable, "Service unavailable"));
         }
     }
 

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -243,6 +243,97 @@ public sealed class DashboardClientTests
         await instance.InteractionWatchCompleteTask.DefaultTimeout();
     }
 
+    [Fact]
+    public async Task ConnectionState_InitialState_IsConnecting()
+    {
+        await using var instance = CreateResourceServiceClient();
+
+        IDashboardClient client = instance;
+
+        Assert.Equal(DashboardConnectionState.Connecting, client.ConnectionState);
+    }
+
+    [Fact]
+    public async Task ConnectionState_SetConnected_FiresEvent()
+    {
+        await using var instance = CreateResourceServiceClient();
+
+        IDashboardClient client = instance;
+        var stateChanges = new List<DashboardConnectionState>();
+        client.ConnectionStateChanged += stateChanges.Add;
+
+        instance.SetConnectionStateForTesting(DashboardConnectionState.Connected);
+
+        Assert.Equal(DashboardConnectionState.Connected, client.ConnectionState);
+        Assert.Single(stateChanges);
+        Assert.Equal(DashboardConnectionState.Connected, stateChanges[0]);
+    }
+
+    [Fact]
+    public async Task ConnectionState_DuplicateState_DoesNotFireEvent()
+    {
+        await using var instance = CreateResourceServiceClient();
+
+        IDashboardClient client = instance;
+        var stateChanges = new List<DashboardConnectionState>();
+        client.ConnectionStateChanged += stateChanges.Add;
+
+        instance.SetConnectionStateForTesting(DashboardConnectionState.Connected);
+        instance.SetConnectionStateForTesting(DashboardConnectionState.Connected);
+
+        Assert.Single(stateChanges);
+    }
+
+    [Fact]
+    public async Task ConnectionState_DisconnectedResetsWhenConnected()
+    {
+        await using var instance = CreateResourceServiceClient();
+
+        IDashboardClient client = instance;
+        var stateChanges = new List<DashboardConnectionState>();
+        client.ConnectionStateChanged += stateChanges.Add;
+
+        // Transition through Connected then to Disconnected.
+        instance.SetConnectionStateForTesting(DashboardConnectionState.Connected);
+        instance.SetConnectionStateForTesting(DashboardConnectionState.Disconnected);
+
+        Assert.Equal(DashboardConnectionState.Disconnected, client.ConnectionState);
+        Assert.Collection(stateChanges,
+            s => Assert.Equal(DashboardConnectionState.Connected, s),
+            s => Assert.Equal(DashboardConnectionState.Disconnected, s));
+    }
+
+    [Fact]
+    public async Task ReconnectAsync_CancelsDelay()
+    {
+        await using var instance = CreateResourceServiceClient();
+
+        IDashboardClient client = instance;
+
+        // ReconnectAsync should not throw even when there's no active delay.
+        await client.ReconnectAsync().DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task ConnectionState_ConcurrentSetSameState_FiresEventOnce()
+    {
+        await using var instance = CreateResourceServiceClient();
+
+        IDashboardClient client = instance;
+        var eventCount = 0;
+        client.ConnectionStateChanged += _ => Interlocked.Increment(ref eventCount);
+
+        // Simulate concurrent calls from both watch tasks transitioning to Disconnected.
+        var tasks = Enumerable.Range(0, 10).Select(_ => Task.Run(() =>
+        {
+            instance.SetConnectionStateForTesting(DashboardConnectionState.Disconnected);
+        }));
+        await Task.WhenAll(tasks).DefaultTimeout();
+
+        // The event should fire exactly once because the lock prevents duplicate transitions.
+        Assert.Equal(1, eventCount);
+    }
+
     private sealed class MockDashboardServiceClient : Aspire.DashboardService.Proto.V1.DashboardService.DashboardServiceClient
     {
         public override AsyncDuplexStreamingCall<WatchInteractionsRequestUpdate, WatchInteractionsResponseUpdate> WatchInteractions(CallOptions options)

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -414,6 +414,11 @@ public class ResourceOutgoingPeerResolverTests
         public bool IsEnabled => true;
         public Task WhenConnected => Task.CompletedTask;
         public string ApplicationName => "ApplicationName";
+        public DashboardConnectionState ConnectionState => DashboardConnectionState.Connected;
+#pragma warning disable CS0067 // Event is never used - required by interface
+        public event Action<DashboardConnectionState>? ConnectionStateChanged;
+#pragma warning restore CS0067
+        public Task ReconnectAsync() => Task.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
         public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, ExecuteResourceCommandOptions options, CancellationToken cancellationToken) => throw new NotImplementedException();
         public ResourceViewModel? GetResource(string resourceName) => null;

--- a/tests/Aspire.Dashboard.Tests/Terminal/DefaultTerminalConnectionResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Terminal/DefaultTerminalConnectionResolverTests.cs
@@ -140,6 +140,11 @@ public class DefaultTerminalConnectionResolverTests
         public bool IsEnabled => false;
         public Task WhenConnected => Task.CompletedTask;
         public string ApplicationName => "Disabled";
+        public DashboardConnectionState ConnectionState => DashboardConnectionState.Connected;
+#pragma warning disable CS0067 // Event is never used - required by interface
+        public event Action<DashboardConnectionState>? ConnectionStateChanged;
+#pragma warning restore CS0067
+        public Task ReconnectAsync() => Task.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
         public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, ExecuteResourceCommandOptions options, CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/tests/Shared/TestDashboardClient.cs
+++ b/tests/Shared/TestDashboardClient.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.ServiceClient;
 using Aspire.DashboardService.Proto.V1;
 using Google.Protobuf.WellKnownTypes;
 
@@ -23,6 +24,11 @@ public class TestDashboardClient : IDashboardClient
     public bool IsEnabled { get; }
     public Task WhenConnected { get; }
     public string ApplicationName { get; } = "TestApp";
+    public DashboardConnectionState ConnectionState => DashboardConnectionState.Connected;
+#pragma warning disable CS0067 // Event is never used - required by interface
+    public event Action<DashboardConnectionState>? ConnectionStateChanged;
+#pragma warning restore CS0067
+    public Task ReconnectAsync() => Task.CompletedTask;
 
     public TestDashboardClient(
         bool? isEnabled = false,


### PR DESCRIPTION
## Description

Gracefully handle connection errors between the dashboard and app host resource service. When the gRPC connection to the resource service is lost, the dashboard now shows a reconnect modal with a status message and animation. After 5 failed retry attempts, a "Reconnect now" button appears so the user can trigger an immediate reconnect.

### User-facing usage

When the app host resource service becomes unavailable, users see a modal dialog:
- **During retries (first 5 attempts):** "Lost connection to the app host resource service. Attempting to reconnect..." with an animation
- **After 5 failed attempts:** The same message with an additional "Retry" button for manual retry

The modal automatically dismisses when the connection is restored.

### Screenshots / Recordings

> **This PR includes UI changes.** Please add screenshots or screen recordings so reviewers can evaluate the visual changes without running locally.

<img width="1654" height="967" alt="image" src="https://github.com/user-attachments/assets/c902fdee-63a1-4a8e-9828-bee6692e502a" />

### Implementation details

- Added `DashboardConnectionState` enum (`Connecting`, `Connected`, `Disconnected`) and connection state tracking to `IDashboardClient`
- `DashboardClient` now retries with exponential backoff (max 15s) on connection failure, with cancellable delays for immediate retry
- Added `ResourceServiceConnectionProvider` Blazor component that observes connection state and controls the modal via JS interop
- Extended the existing `<dialog id="components-reconnect-modal">` element with resource service reconnect states, using CSS classes to toggle visibility
- Blazor circuit reconnect always takes precedence over resource service reconnect (when circuit is dead, JS interop is impossible anyway)

Fixes #10879

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
