### PR TITLE
[tests] Stabilize TestEndpointsReturnOk startup waits

### DIFF
--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -46,7 +46,12 @@ public class AppHostTests
             // immediately during startup under CI contention.
             readyStateTexts = testEndpoints.WaitForTexts.ToArray();
             waitForTextTasks = readyStateTexts
-                .Select(wait => app.WaitForTextAsync(log => new Regex(wait.Pattern).IsMatch(log), wait.ResourceName))
+                .Select(wait =>
+                {
+                    // Compile once per wait entry; the callback runs for each emitted log line.
+                    var regex = new Regex(wait.Pattern);
+                    return app.WaitForTextAsync(log => regex.IsMatch(log), wait.ResourceName);
+                })
                 .ToArray();
         }
 

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -4,10 +4,9 @@
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
-using Aspire.TestUtilities;
 using Aspire.Hosting;
-using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Tests.Utils;
+using Aspire.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Polly.Timeout;
 using SamplesIntegrationTests;
@@ -36,27 +35,37 @@ public class AppHostTests
         var appHostType = testEndpoints.AppHostType!;
         var resourceEndpoints = testEndpoints.ResourceEndpoints!;
         var appHost = await DistributedApplicationTestFactory.CreateAsync(appHostType, _testOutput);
-        var projects = appHost.Resources.OfType<ProjectResource>();
         await using var app = await appHost.BuildAsync();
+
+        Task[]? waitForTextTasks = null;
+        TestEndpoints.ReadyStateText[]? readyStateTexts = null;
+
+        if (testEndpoints.WaitForTexts is { Count: > 0 })
+        {
+            // Subscribe before StartAsync so we don't miss readiness lines that can be emitted
+            // immediately during startup under CI contention.
+            readyStateTexts = testEndpoints.WaitForTexts.ToArray();
+            waitForTextTasks = readyStateTexts
+                .Select(wait => app.WaitForTextAsync(log => new Regex(wait.Pattern).IsMatch(log), wait.ResourceName))
+                .ToArray();
+        }
 
         await app.StartAsync();
 
-        if (testEndpoints.WaitForTexts != null)
+        if (waitForTextTasks is not null && readyStateTexts is not null)
         {
-            // If specific ready to start texts are available use it
-            var tasks = testEndpoints.WaitForTexts.Select(x => app.WaitForTextAsync(log => new Regex(x.Pattern).IsMatch(log), x.ResourceName)).ToArray();
             try
             {
-                await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromMinutes(5));
+                await Task.WhenAll(waitForTextTasks).WaitAsync(TimeSpan.FromMinutes(5));
             }
             catch (TimeoutException te)
             {
                 StringBuilder sb = new();
-                for (int i = 0; i < testEndpoints.WaitForTexts.Count; i++)
+                for (int i = 0; i < readyStateTexts.Length; i++)
                 {
-                    if (!tasks[i].IsCompleted)
+                    if (!waitForTextTasks[i].IsCompleted)
                     {
-                        sb.AppendLine($"Timed out waiting for this text from resource {testEndpoints.WaitForTexts[i].ResourceName}: {testEndpoints.WaitForTexts[i].Pattern}");
+                        sb.AppendLine($"Timed out waiting for this text from resource {readyStateTexts[i].ResourceName}: {readyStateTexts[i].Pattern}");
                     }
                 }
 
@@ -65,19 +74,19 @@ public class AppHostTests
         }
         else
         {
-            var applicationModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-
             await app.WaitForResources().WaitAsync(TimeSpan.FromMinutes(5));
 
             if (testEndpoints.WaitForResources?.Count > 0)
             {
                 // Wait until each resource transitions to the required state
-                var timeout = TimeSpan.FromMinutes(5);
-                foreach (var (ResourceName, TargetState) in testEndpoints.WaitForResources)
-                {
-                    _testOutput.WriteLine($"Waiting for resource '{ResourceName}' to reach state '{TargetState}' in app '{appHost.AppHostAssembly}'");
-                    await app.WaitForResource(ResourceName, TargetState).WaitAsync(TimeSpan.FromMinutes(5));
-                }
+                var waitForResourceTasks = testEndpoints.WaitForResources
+                    .Select(wait =>
+                    {
+                        _testOutput.WriteLine($"Waiting for resource '{wait.ResourceName}' to reach state '{wait.TargetState}' in app '{appHost.AppHostAssembly}'");
+                        return app.WaitForResource(wait.ResourceName, wait.TargetState).WaitAsync(TimeSpan.FromMinutes(5));
+                    });
+
+                await Task.WhenAll(waitForResourceTasks);
             }
         }
 

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -79,14 +79,32 @@ public class AppHostTests
             if (testEndpoints.WaitForResources?.Count > 0)
             {
                 // Wait until each resource transitions to the required state
-                var waitForResourceTasks = testEndpoints.WaitForResources
+                var waits = testEndpoints.WaitForResources.ToArray();
+                var waitForResourceTasks = waits
                     .Select(wait =>
                     {
                         _testOutput.WriteLine($"Waiting for resource '{wait.ResourceName}' to reach state '{wait.TargetState}' in app '{appHost.AppHostAssembly}'");
                         return app.WaitForResource(wait.ResourceName, wait.TargetState).WaitAsync(TimeSpan.FromMinutes(5));
-                    });
+                    })
+                    .ToArray();
 
-                await Task.WhenAll(waitForResourceTasks);
+                try
+                {
+                    await Task.WhenAll(waitForResourceTasks);
+                }
+                catch (TimeoutException te)
+                {
+                    StringBuilder sb = new();
+                    for (int i = 0; i < waits.Length; i++)
+                    {
+                        if (!waitForResourceTasks[i].IsCompletedSuccessfully)
+                        {
+                            sb.AppendLine($"Timed out waiting for resource '{waits[i].ResourceName}' to reach state '{waits[i].TargetState}' in app '{appHost.AppHostAssembly}'");
+                        }
+                    }
+
+                    throw new XunitException(sb.ToString(), te);
+                }
             }
         }
 

--- a/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationTestFactory.cs
+++ b/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationTestFactory.cs
@@ -3,8 +3,8 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
+using Aspire.Hosting.Lifecycle;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using SamplesIntegrationTests.Infrastructure;
 using Xunit;
@@ -23,7 +23,7 @@ internal static class DistributedApplicationTestFactory
         // Custom hook needed because we want to only override the registry when
         // the original is from `docker.io`, but the options.ContainerRegistryOverride will
         // always override.
-        builder.Services.AddHostedService<ContainerRegistryHook>();
+        builder.Services.AddEventingSubscriber<ContainerRegistryHook>();
 
         builder.WithRandomParameterValues();
         builder.WithRandomVolumeNames();
@@ -48,9 +48,10 @@ internal static class DistributedApplicationTestFactory
         return builder;
     }
 
-    internal sealed class ContainerRegistryHook(DistributedApplicationEventing eventing) : IHostedService
+    internal sealed class ContainerRegistryHook : IDistributedApplicationEventingSubscriber
     {
         public const string AspireTestContainerRegistry = "netaspireci.azurecr.io";
+
         public Task OnBeforeStartAsync(BeforeStartEvent @event, CancellationToken cancellationToken = default)
         {
             var resourcesWithContainerImages = @event.Model.Resources
@@ -69,14 +70,9 @@ internal static class DistributedApplicationTestFactory
             return Task.CompletedTask;
         }
 
-        public Task StartAsync(CancellationToken cancellationToken)
+        public Task SubscribeAsync(IDistributedApplicationEventing eventing, Aspire.Hosting.DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken)
         {
             eventing.Subscribe<BeforeStartEvent>(OnBeforeStartAsync);
-            return Task.CompletedTask;
-        }
-
-        public Task StopAsync(CancellationToken cancellationToken)
-        {
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Description

This updates `Aspire.Playground.Tests.AppHostTests.TestEndpointsReturnOk` to reduce startup timing races and unblock execution in current hosting/eventing wiring.

- Switched playground test setup from `AddHostedService<ContainerRegistryHook>()` to `AddEventingSubscriber<ContainerRegistryHook>()` with `IDistributedApplicationEventingSubscriber`, so `BeforeStartEvent` subscription works with current DI/eventing lifecycle.
- Registered `WaitForTextAsync` watchers before `StartAsync()` so readiness log lines emitted early during startup are not missed.
- Changed explicit `WaitForResources` waits from sequential to parallel (`Task.WhenAll`) to reduce timeout accumulation under CI contention.

Related to #6866

### User-facing usage

This is an internal test reliability change; no user-facing API or CLI behavior changes.

### Validation

- `TEST_PLAYGROUND_APPHOST_FILTER=Redis dotnet test --project tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj --no-launch-profile /p:RunQuarantinedTests=true -- --filter-method "*.TestEndpointsReturnOk"` (repeated 3 times, passed)
- `TEST_PLAYGROUND_APPHOST_FILTER=TestShop dotnet test --project tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj --no-launch-profile /p:RunQuarantinedTests=true -- --filter-method "*.TestEndpointsReturnOk"` (passed)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
