### PR TITLE
Surface actionable diagnostic when TypeScript codegen generator is dropped by load failure

### DIFF
--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationDiagnostic.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationDiagnostic.cs
@@ -159,6 +159,13 @@ internal static class CodeGenerationDiagnosticBuilder
             case FileLoadException fle:
                 typeName = fle.FileName;
                 break;
+            case FileNotFoundException fnfe:
+                // The CLR reports a missing dependency assembly (e.g. a diverged Aspire.TypeSystem)
+                // as "Could not load file or assembly '...'. The system cannot find the file
+                // specified.", which surfaces as a FileNotFoundException in the LoaderExceptions of
+                // a ReflectionTypeLoadException. Capture the offending assembly name for diagnostics.
+                typeName = fnfe.FileName;
+                break;
             case BadImageFormatException bife:
                 typeName = bife.FileName;
                 break;
@@ -214,6 +221,7 @@ internal static class CodeGenerationDiagnosticBuilder
         or MissingMethodException
         or MissingFieldException
         or FileLoadException
+        or FileNotFoundException
         or BadImageFormatException
         or ReflectionTypeLoadException;
 

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationDiagnostic.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationDiagnostic.cs
@@ -197,7 +197,12 @@ internal static class CodeGenerationDiagnosticBuilder
             {
                 foreach (var loaderException in rtle.LoaderExceptions)
                 {
-                    if (loaderException is not null && IsReflectionLoadException(loaderException))
+                    // A FileNotFoundException surfaced as an RTLE loader exception is always an
+                    // assembly-bind failure (the CLR could not load a referenced assembly while
+                    // enumerating types), so accept it here without the assembly-name shape check
+                    // applied to standalone exceptions below.
+                    if (loaderException is not null &&
+                        (IsReflectionLoadException(loaderException) || loaderException is FileNotFoundException))
                     {
                         return loaderException;
                     }
@@ -207,7 +212,8 @@ internal static class CodeGenerationDiagnosticBuilder
                 // failure — fall through and return it from the IsReflectionLoadException check below.
             }
 
-            if (IsReflectionLoadException(current))
+            if (IsReflectionLoadException(current) ||
+                (current is FileNotFoundException fnfe && IsAssemblyBindFailure(fnfe)))
             {
                 return current;
             }
@@ -221,9 +227,42 @@ internal static class CodeGenerationDiagnosticBuilder
         or MissingMethodException
         or MissingFieldException
         or FileLoadException
-        or FileNotFoundException
         or BadImageFormatException
         or ReflectionTypeLoadException;
+
+    /// <summary>
+    /// Determines whether a standalone <see cref="FileNotFoundException"/> represents an
+    /// assembly-bind failure (a missing dependency assembly) rather than ordinary missing-file IO.
+    /// </summary>
+    /// <remarks>
+    /// The CLR raises a <see cref="FileNotFoundException"/> whose <see cref="FileNotFoundException.FileName"/>
+    /// is an assembly display name (for example
+    /// <c>"Aspire.TypeSystem, Version=42.42.42.42, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"</c>)
+    /// when it cannot bind a referenced assembly. A code generator that simply fails to open a data
+    /// file produces a path-like <c>FileName</c> instead. We only want to classify the former as an
+    /// incompatible-SDK failure, otherwise a genuine missing-file error would be misreported as a
+    /// version mismatch with a "run aspire update" hint that cannot help.
+    /// </remarks>
+    private static bool IsAssemblyBindFailure(FileNotFoundException exception)
+    {
+        if (exception.FileName is not { Length: > 0 } fileName)
+        {
+            return false;
+        }
+
+        try
+        {
+            // Require an identity component beyond the simple name (Version or PublicKeyToken) so a
+            // plain filename such as "data.json" - which AssemblyName happily parses as a simple
+            // name - is not mistaken for an assembly reference.
+            var name = new AssemblyName(fileName);
+            return name.Version is not null || name.GetPublicKeyToken() is { Length: > 0 };
+        }
+        catch (Exception ex) when (ex is FileLoadException or ArgumentException)
+        {
+            return false;
+        }
+    }
 
     private static (string? Version, string? Path, List<CodeGenerationLoadedAssemblyInfo> Assemblies) CaptureLoadedAssemblies(
         AssemblyLoader? assemblyLoader,

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationService.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationService.cs
@@ -247,7 +247,7 @@ internal sealed class CodeGenerationService
                 // exception. This lets CodeGenerationDiagnosticBuilder classify the failure as an
                 // incompatible SDK and return the actionable "run aspire update" diagnostic instead
                 // of the opaque "no code generator found" message reaching the user verbatim.
-                var loadFailures = _resolver.GetDiscoveryLoadFailures();
+                var loadFailures = _resolver.Discovery.LoadFailures;
                 var loadFailure = loadFailures.Count > 0 ? loadFailures[0] : null;
                 throw new ArgumentException(BuildNoCodeGeneratorMessage(language), loadFailure);
             }

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationService.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationService.cs
@@ -240,7 +240,16 @@ internal sealed class CodeGenerationService
             var generator = _resolver.GetCodeGenerator(language);
             if (generator == null)
             {
-                throw new ArgumentException(BuildNoCodeGeneratorMessage(language));
+                // A missing generator is frequently the visible symptom of an integration assembly
+                // that failed to load (typically an Aspire.TypeSystem binary mismatch between the
+                // bundled apphost server and the restored SDK packages). The resolver swallows that
+                // ReflectionTypeLoadException during discovery, so surface it here as the inner
+                // exception. This lets CodeGenerationDiagnosticBuilder classify the failure as an
+                // incompatible SDK and return the actionable "run aspire update" diagnostic instead
+                // of the opaque "no code generator found" message reaching the user verbatim.
+                var loadFailures = _resolver.GetDiscoveryLoadFailures();
+                var loadFailure = loadFailures.Count > 0 ? loadFailures[0] : null;
+                throw new ArgumentException(BuildNoCodeGeneratorMessage(language), loadFailure);
             }
 
             var context = _atsContextFactory.GetContext();

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGeneratorResolver.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGeneratorResolver.cs
@@ -57,14 +57,7 @@ internal sealed class CodeGeneratorResolver
     }
 
     /// <summary>
-    /// Gets the result of generator discovery: the resolved generators and any
-    /// <see cref="ReflectionTypeLoadException"/>s swallowed while probing assemblies. A non-empty
-    /// <see cref="DiscoveryResult.LoadFailures"/> almost always means a code generator was silently
-    /// dropped because of a binary mismatch (typically a diverged <c>Aspire.TypeSystem</c> version
-    /// between the bundled apphost server and the restored SDK assemblies); callers use it to turn an
-    /// otherwise-opaque "no generator found" failure into an actionable incompatible-SDK diagnostic.
-    /// Exposing the whole result (rather than a dedicated accessor) also lets unit tests observe the
-    /// swallowed failures, which discovery otherwise hides; see <c>ResolverDiagnosticsTests</c>.
+    /// Gets the result of generator discovery, including any load failures swallowed during probing.
     /// </summary>
     internal DiscoveryResult Discovery => _discovery.Value;
 

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGeneratorResolver.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGeneratorResolver.cs
@@ -63,6 +63,10 @@ internal sealed class CodeGeneratorResolver
     /// the bundled apphost server and the restored SDK assemblies). Callers use this to turn an
     /// otherwise-opaque "no generator found" failure into an actionable incompatible-SDK diagnostic.
     /// </summary>
+    /// <remarks>
+    /// This is also the only way unit tests can observe the swallowed load failures, since discovery
+    /// otherwise hides them; see <c>ResolverDiagnosticsTests</c>.
+    /// </remarks>
     public IReadOnlyList<ReflectionTypeLoadException> GetDiscoveryLoadFailures()
     {
         return _discovery.Value.LoadFailures;

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGeneratorResolver.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGeneratorResolver.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.RemoteHost.CodeGeneration;
 /// </summary>
 internal sealed class CodeGeneratorResolver
 {
-    private readonly Lazy<Dictionary<string, ICodeGenerator>> _generators;
+    private readonly Lazy<DiscoveryResult> _discovery;
     private readonly ILogger<CodeGeneratorResolver> _logger;
 
     public CodeGeneratorResolver(
@@ -32,7 +32,7 @@ internal sealed class CodeGeneratorResolver
         ILogger<CodeGeneratorResolver> logger)
     {
         _logger = logger;
-        _generators = new Lazy<Dictionary<string, ICodeGenerator>>(
+        _discovery = new Lazy<DiscoveryResult>(
             () => DiscoverGenerators(serviceProvider, assembliesProvider()));
     }
 
@@ -43,7 +43,7 @@ internal sealed class CodeGeneratorResolver
     /// <returns>The code generator, or null if not found.</returns>
     public ICodeGenerator? GetCodeGenerator(string language)
     {
-        _generators.Value.TryGetValue(language, out var generator);
+        _discovery.Value.Generators.TryGetValue(language, out var generator);
         return generator;
     }
 
@@ -53,14 +53,27 @@ internal sealed class CodeGeneratorResolver
     /// <returns>The set of supported language identifiers.</returns>
     public IReadOnlyCollection<string> GetSupportedLanguages()
     {
-        return _generators.Value.Keys.ToArray();
+        return _discovery.Value.Generators.Keys.ToArray();
     }
 
-    private Dictionary<string, ICodeGenerator> DiscoverGenerators(
+    /// <summary>
+    /// Gets the <see cref="ReflectionTypeLoadException"/>s that were swallowed while discovering
+    /// generators. A non-empty result almost always means a code generator was silently dropped
+    /// because of a binary mismatch (typically a diverged <c>Aspire.TypeSystem</c> version between
+    /// the bundled apphost server and the restored SDK assemblies). Callers use this to turn an
+    /// otherwise-opaque "no generator found" failure into an actionable incompatible-SDK diagnostic.
+    /// </summary>
+    public IReadOnlyList<ReflectionTypeLoadException> GetDiscoveryLoadFailures()
+    {
+        return _discovery.Value.LoadFailures;
+    }
+
+    private DiscoveryResult DiscoverGenerators(
         IServiceProvider serviceProvider,
         IReadOnlyList<Assembly> assemblies)
     {
         var generators = new Dictionary<string, ICodeGenerator>(StringComparer.OrdinalIgnoreCase);
+        var loadFailures = new List<ReflectionTypeLoadException>();
 
         foreach (var assembly in assemblies)
         {
@@ -74,6 +87,10 @@ internal sealed class CodeGeneratorResolver
             catch (ReflectionTypeLoadException ex)
             {
                 hadTypeLoadFailure = true;
+                // Remember the load failure so a downstream "no generator found" error can be
+                // re-cast as an actionable incompatible-SDK diagnostic instead of a cryptic
+                // ArgumentException (see GetDiscoveryLoadFailures).
+                loadFailures.Add(ex);
                 // Surface loader binding failures at Warning level. These typically indicate
                 // a binary mismatch between the bundled runtime assemblies and the integration
                 // assemblies loaded from disk (for example, when Aspire.TypeSystem versions
@@ -130,10 +147,14 @@ internal sealed class CodeGeneratorResolver
             }
         }
 
-        return generators;
+        return new DiscoveryResult(generators, loadFailures);
     }
 
     private static bool LooksLikeCodeGeneratorAssembly(string? assemblyName)
         => assemblyName is not null
            && assemblyName.StartsWith("Aspire.Hosting.CodeGeneration.", StringComparison.OrdinalIgnoreCase);
+
+    private sealed record DiscoveryResult(
+        Dictionary<string, ICodeGenerator> Generators,
+        IReadOnlyList<ReflectionTypeLoadException> LoadFailures);
 }

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGeneratorResolver.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGeneratorResolver.cs
@@ -57,20 +57,16 @@ internal sealed class CodeGeneratorResolver
     }
 
     /// <summary>
-    /// Gets the <see cref="ReflectionTypeLoadException"/>s that were swallowed while discovering
-    /// generators. A non-empty result almost always means a code generator was silently dropped
-    /// because of a binary mismatch (typically a diverged <c>Aspire.TypeSystem</c> version between
-    /// the bundled apphost server and the restored SDK assemblies). Callers use this to turn an
+    /// Gets the result of generator discovery: the resolved generators and any
+    /// <see cref="ReflectionTypeLoadException"/>s swallowed while probing assemblies. A non-empty
+    /// <see cref="DiscoveryResult.LoadFailures"/> almost always means a code generator was silently
+    /// dropped because of a binary mismatch (typically a diverged <c>Aspire.TypeSystem</c> version
+    /// between the bundled apphost server and the restored SDK assemblies); callers use it to turn an
     /// otherwise-opaque "no generator found" failure into an actionable incompatible-SDK diagnostic.
+    /// Exposing the whole result (rather than a dedicated accessor) also lets unit tests observe the
+    /// swallowed failures, which discovery otherwise hides; see <c>ResolverDiagnosticsTests</c>.
     /// </summary>
-    /// <remarks>
-    /// This is also the only way unit tests can observe the swallowed load failures, since discovery
-    /// otherwise hides them; see <c>ResolverDiagnosticsTests</c>.
-    /// </remarks>
-    public IReadOnlyList<ReflectionTypeLoadException> GetDiscoveryLoadFailures()
-    {
-        return _discovery.Value.LoadFailures;
-    }
+    internal DiscoveryResult Discovery => _discovery.Value;
 
     private DiscoveryResult DiscoverGenerators(
         IServiceProvider serviceProvider,
@@ -93,7 +89,7 @@ internal sealed class CodeGeneratorResolver
                 hadTypeLoadFailure = true;
                 // Remember the load failure so a downstream "no generator found" error can be
                 // re-cast as an actionable incompatible-SDK diagnostic instead of a cryptic
-                // ArgumentException (see GetDiscoveryLoadFailures).
+                // ArgumentException (see Discovery).
                 loadFailures.Add(ex);
                 // Surface loader binding failures at Warning level. These typically indicate
                 // a binary mismatch between the bundled runtime assemblies and the integration
@@ -158,7 +154,7 @@ internal sealed class CodeGeneratorResolver
         => assemblyName is not null
            && assemblyName.StartsWith("Aspire.Hosting.CodeGeneration.", StringComparison.OrdinalIgnoreCase);
 
-    private sealed record DiscoveryResult(
+    internal sealed record DiscoveryResult(
         Dictionary<string, ICodeGenerator> Generators,
         IReadOnlyList<ReflectionTypeLoadException> LoadFailures);
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CodeGenerationDiagnosticBuilderTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CodeGenerationDiagnosticBuilderTests.cs
@@ -96,6 +96,44 @@ public class CodeGenerationDiagnosticBuilderTests
     }
 
     [Fact]
+    public void TryCreateRpcException_FileNotFoundLoaderException_CapturesMissingAssemblyName()
+    {
+        // Mirrors the real failure: a code-generation assembly references an Aspire.TypeSystem
+        // version that is absent on disk, so the CLR raises a FileNotFoundException inside the
+        // ReflectionTypeLoadException's LoaderExceptions.
+        var loader = new FileNotFoundException(
+            "Could not load file or assembly 'Aspire.TypeSystem, Version=42.42.42.42'. The system cannot find the file specified.",
+            "Aspire.TypeSystem, Version=42.42.42.42, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51");
+        var rtle = new ReflectionTypeLoadException([null], [loader]);
+
+        var result = CodeGenerationDiagnosticBuilder.TryCreateRpcException(rtle, assemblyLoader: null);
+
+        var localRpc = Assert.IsType<LocalRpcException>(result);
+        Assert.Equal(CodeGenerationErrorCodes.IncompatibleAspireSdk, localRpc.ErrorCode);
+        var diagnostic = Assert.IsType<CodeGenerationDiagnostic>(localRpc.ErrorData);
+        Assert.Equal(typeof(FileNotFoundException).FullName, diagnostic.OriginalExceptionType);
+        Assert.Contains("Aspire.TypeSystem", diagnostic.TypeName);
+    }
+
+    [Fact]
+    public void TryCreateRpcException_ArgumentExceptionWrappingReflectionLoad_FindsInnerCause()
+    {
+        // Repro of the TypeScript "no code generator found" path: GenerateCode throws an
+        // ArgumentException whose inner exception is the swallowed ReflectionTypeLoadException.
+        var loader = new FileNotFoundException("missing", "Aspire.TypeSystem, Version=42.42.42.42");
+        var rtle = new ReflectionTypeLoadException([null], [loader]);
+        var argument = new ArgumentException("No code generator found for language: TypeScript.", rtle);
+
+        var result = CodeGenerationDiagnosticBuilder.TryCreateRpcException(argument, assemblyLoader: null);
+
+        var localRpc = Assert.IsType<LocalRpcException>(result);
+        Assert.Equal(CodeGenerationErrorCodes.IncompatibleAspireSdk, localRpc.ErrorCode);
+        Assert.False(string.IsNullOrWhiteSpace(localRpc.Message));
+        // The actionable message must not leak the raw "no code generator found" text.
+        Assert.DoesNotContain("no code generator found", localRpc.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildDiagnostic_CapturesRuntimeAspireHostingVersion()
     {
         // BuildDiagnostic looks for the loaded Aspire.Hosting assembly via AppDomain. Calling

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CodeGenerationDiagnosticBuilderTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CodeGenerationDiagnosticBuilderTests.cs
@@ -134,6 +134,39 @@ public class CodeGenerationDiagnosticBuilderTests
     }
 
     [Fact]
+    public void TryCreateRpcException_StandaloneFileNotFound_PlainFilePath_IsNotClassified()
+    {
+        // A code generator (or ATS context build) that fails to open a genuine data file raises a
+        // FileNotFoundException with a path-like FileName. This must NOT be reported as an
+        // incompatible SDK, otherwise the user gets a misleading "run aspire update" hint for an
+        // unrelated missing-file error.
+        var ioFailure = new FileNotFoundException(
+            "Could not find file '/tmp/codegen/template.json'.",
+            "/tmp/codegen/template.json");
+
+        var result = CodeGenerationDiagnosticBuilder.TryCreateRpcException(ioFailure, assemblyLoader: null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryCreateRpcException_StandaloneFileNotFound_AssemblyDisplayName_IsClassified()
+    {
+        // A direct assembly-bind failure (for example a JIT-time bind during generation) surfaces a
+        // FileNotFoundException whose FileName is a full assembly display name. That IS an
+        // incompatible-SDK signal and should be classified even though it is not wrapped in a
+        // ReflectionTypeLoadException.
+        var bindFailure = new FileNotFoundException(
+            "Could not load file or assembly 'Aspire.TypeSystem, Version=42.42.42.42'. The system cannot find the file specified.",
+            "Aspire.TypeSystem, Version=42.42.42.42, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51");
+
+        var result = CodeGenerationDiagnosticBuilder.TryCreateRpcException(bindFailure, assemblyLoader: null);
+
+        var localRpc = Assert.IsType<LocalRpcException>(result);
+        Assert.Equal(CodeGenerationErrorCodes.IncompatibleAspireSdk, localRpc.ErrorCode);
+    }
+
+    [Fact]
     public void BuildDiagnostic_CapturesRuntimeAspireHostingVersion()
     {
         // BuildDiagnostic looks for the loaded Aspire.Hosting assembly via AppDomain. Calling

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CodeGenerationDiagnosticBuilderTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CodeGenerationDiagnosticBuilderTests.cs
@@ -128,9 +128,10 @@ public class CodeGenerationDiagnosticBuilderTests
 
         var localRpc = Assert.IsType<LocalRpcException>(result);
         Assert.Equal(CodeGenerationErrorCodes.IncompatibleAspireSdk, localRpc.ErrorCode);
-        Assert.False(string.IsNullOrWhiteSpace(localRpc.Message));
-        // The actionable message must not leak the raw "no code generator found" text.
-        Assert.DoesNotContain("no code generator found", localRpc.Message, StringComparison.OrdinalIgnoreCase);
+        // The cryptic ArgumentException is replaced with the actionable incompatible-SDK guidance.
+        Assert.Equal(
+            "Aspire SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured SDK version. Run 'aspire update' to align the CLI and SDK and try again.",
+            localRpc.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.RemoteHost.Tests/FakeAssembly.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/FakeAssembly.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+
+namespace Aspire.Hosting.RemoteHost.Tests;
+
+/// <summary>
+/// A configurable <see cref="Assembly"/> test double whose name and <see cref="GetTypes"/>
+/// behavior are supplied by the caller. Use the factory methods to either return a fixed set of
+/// types or to simulate a loader failure (the discovery resolvers probe assemblies via
+/// <see cref="Assembly.GetTypes"/>, so throwing from it reproduces a real type-load failure).
+/// </summary>
+internal sealed class FakeAssembly : Assembly
+{
+    private readonly AssemblyName _name;
+    private readonly Func<Type[]> _getTypes;
+
+    private FakeAssembly(string name, Func<Type[]> getTypes)
+    {
+        _name = new AssemblyName(name);
+        _getTypes = getTypes;
+    }
+
+    public override AssemblyName GetName() => _name;
+
+    public override Type[] GetTypes() => _getTypes();
+
+    /// <summary>
+    /// Creates a fake assembly whose <see cref="GetTypes"/> returns the supplied types.
+    /// </summary>
+    public static FakeAssembly WithTypes(string name, params Type[] types)
+        => new(name, () => types);
+
+    /// <summary>
+    /// Creates a fake assembly whose <see cref="GetTypes"/> throws the supplied exception,
+    /// simulating an assembly that loads but cannot have its types enumerated.
+    /// </summary>
+    public static FakeAssembly ThrowingOnGetTypes(string name, Exception exception)
+        => new(name, () => throw exception);
+}

--- a/tests/Aspire.Hosting.RemoteHost.Tests/ResolverDiagnosticsTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/ResolverDiagnosticsTests.cs
@@ -97,7 +97,7 @@ public class ResolverDiagnosticsTests
         // callers can turn it into an actionable incompatible-SDK diagnostic.
         Assert.Null(resolver.GetCodeGenerator("TypeScript"));
 
-        var failure = Assert.Single(resolver.GetDiscoveryLoadFailures());
+        var failure = Assert.Single(resolver.Discovery.LoadFailures);
         Assert.Contains("synthetic loader exception", failure.LoaderExceptions[0]!.Message);
     }
 
@@ -110,7 +110,7 @@ public class ResolverDiagnosticsTests
         var resolver = new CodeGeneratorResolver(services, Array.Empty<Assembly>, logger);
 
         Assert.Null(resolver.GetCodeGenerator("TypeScript"));
-        Assert.Empty(resolver.GetDiscoveryLoadFailures());
+        Assert.Empty(resolver.Discovery.LoadFailures);
     }
 
     private sealed class TypeLoadFailingAssembly : Assembly

--- a/tests/Aspire.Hosting.RemoteHost.Tests/ResolverDiagnosticsTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/ResolverDiagnosticsTests.cs
@@ -84,6 +84,35 @@ public class ResolverDiagnosticsTests
         Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("did not contribute"));
     }
 
+    [Fact]
+    public void CodeGeneratorResolver_ExposesSwallowedLoadFailures()
+    {
+        var logger = new RecordingLogger<CodeGeneratorResolver>();
+        var stub = new TypeLoadFailingAssembly("Aspire.Hosting.CodeGeneration.TypeScript");
+
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var resolver = new CodeGeneratorResolver(services, () => (IReadOnlyList<Assembly>)[stub], logger);
+
+        // The generator is silently dropped, but the underlying load failure must be retained so
+        // callers can turn it into an actionable incompatible-SDK diagnostic.
+        Assert.Null(resolver.GetCodeGenerator("TypeScript"));
+
+        var failure = Assert.Single(resolver.GetDiscoveryLoadFailures());
+        Assert.Contains("synthetic loader exception", failure.LoaderExceptions[0]!.Message);
+    }
+
+    [Fact]
+    public void CodeGeneratorResolver_NoLoadFailures_ReturnsEmpty()
+    {
+        var logger = new RecordingLogger<CodeGeneratorResolver>();
+
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var resolver = new CodeGeneratorResolver(services, Array.Empty<Assembly>, logger);
+
+        Assert.Null(resolver.GetCodeGenerator("TypeScript"));
+        Assert.Empty(resolver.GetDiscoveryLoadFailures());
+    }
+
     private sealed class TypeLoadFailingAssembly : Assembly
     {
         private readonly AssemblyName _name;

--- a/tests/Aspire.Hosting.RemoteHost.Tests/ResolverDiagnosticsTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/ResolverDiagnosticsTests.cs
@@ -23,7 +23,7 @@ public class ResolverDiagnosticsTests
     public void CodeGeneratorResolver_LogsWarning_WhenAssemblyTypeLoadFails()
     {
         var logger = new RecordingLogger<CodeGeneratorResolver>();
-        var stub = new TypeLoadFailingAssembly("Aspire.Hosting.CodeGeneration.Synthetic");
+        var stub = CreateTypeLoadFailingAssembly("Aspire.Hosting.CodeGeneration.Synthetic");
 
         using var services = new ServiceCollection().BuildServiceProvider();
         var resolver = new CodeGeneratorResolver(services, () => (IReadOnlyList<Assembly>)[stub], logger);
@@ -41,7 +41,7 @@ public class ResolverDiagnosticsTests
     public void LanguageSupportResolver_LogsWarning_WhenAssemblyTypeLoadFails()
     {
         var logger = new RecordingLogger<LanguageSupportResolver>();
-        var stub = new TypeLoadFailingAssembly("Aspire.Hosting.CodeGeneration.Synthetic");
+        var stub = CreateTypeLoadFailingAssembly("Aspire.Hosting.CodeGeneration.Synthetic");
 
         using var services = new ServiceCollection().BuildServiceProvider();
         var resolver = new LanguageSupportResolver(services, () => (IReadOnlyList<Assembly>)[stub], logger);
@@ -60,7 +60,7 @@ public class ResolverDiagnosticsTests
     {
         var logger = new RecordingLogger<CodeGeneratorResolver>();
         // The marker name is what triggers the "did not contribute any" diagnostic.
-        var empty = new EmptyNamedAssembly("Aspire.Hosting.CodeGeneration.Synthetic");
+        var empty = FakeAssembly.WithTypes("Aspire.Hosting.CodeGeneration.Synthetic", typeof(string));
 
         using var services = new ServiceCollection().BuildServiceProvider();
         var resolver = new CodeGeneratorResolver(services, () => (IReadOnlyList<Assembly>)[empty], logger);
@@ -76,7 +76,7 @@ public class ResolverDiagnosticsTests
     public void CodeGeneratorResolver_DoesNotLogContributionWarning_ForArbitraryAssembly()
     {
         var logger = new RecordingLogger<CodeGeneratorResolver>();
-        var arbitrary = new EmptyNamedAssembly("My.Custom.Integration");
+        var arbitrary = FakeAssembly.WithTypes("My.Custom.Integration", typeof(string));
 
         using var services = new ServiceCollection().BuildServiceProvider();
         _ = new CodeGeneratorResolver(services, () => (IReadOnlyList<Assembly>)[arbitrary], logger).GetCodeGenerator("anything");
@@ -88,7 +88,7 @@ public class ResolverDiagnosticsTests
     public void CodeGeneratorResolver_ExposesSwallowedLoadFailures()
     {
         var logger = new RecordingLogger<CodeGeneratorResolver>();
-        var stub = new TypeLoadFailingAssembly("Aspire.Hosting.CodeGeneration.TypeScript");
+        var stub = CreateTypeLoadFailingAssembly("Aspire.Hosting.CodeGeneration.TypeScript");
 
         using var services = new ServiceCollection().BuildServiceProvider();
         var resolver = new CodeGeneratorResolver(services, () => (IReadOnlyList<Assembly>)[stub], logger);
@@ -113,28 +113,12 @@ public class ResolverDiagnosticsTests
         Assert.Empty(resolver.Discovery.LoadFailures);
     }
 
-    private sealed class TypeLoadFailingAssembly : Assembly
-    {
-        private readonly AssemblyName _name;
-
-        public TypeLoadFailingAssembly(string name) => _name = new AssemblyName(name);
-
-        public override AssemblyName GetName() => _name;
-
-        public override Type[] GetTypes()
-            => throw new ReflectionTypeLoadException(
+    // Simulates a code-generation assembly that loads but whose type enumeration fails with a
+    // ReflectionTypeLoadException, mirroring a real Aspire.TypeSystem binary mismatch.
+    private static FakeAssembly CreateTypeLoadFailingAssembly(string name)
+        => FakeAssembly.ThrowingOnGetTypes(
+            name,
+            new ReflectionTypeLoadException(
                 [null, typeof(string)],
-                [new FileLoadException("synthetic loader exception: simulated Aspire.TypeSystem mismatch")]);
-    }
-
-    private sealed class EmptyNamedAssembly : Assembly
-    {
-        private readonly AssemblyName _name;
-
-        public EmptyNamedAssembly(string name) => _name = new AssemblyName(name);
-
-        public override AssemblyName GetName() => _name;
-
-        public override Type[] GetTypes() => [typeof(string)];
-    }
+                [new FileLoadException("synthetic loader exception: simulated Aspire.TypeSystem mismatch")]));
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/ServiceErrorMessageTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/ServiceErrorMessageTests.cs
@@ -8,6 +8,7 @@ using Aspire.Hosting.RemoteHost.Language;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using StreamJsonRpc;
 using Xunit;
 
 namespace Aspire.Hosting.RemoteHost.Tests;
@@ -65,6 +66,21 @@ public class ServiceErrorMessageTests
         Assert.Contains("No code generator found for language: TypeScript", ex.Message);
         Assert.Contains("LoaderExceptions", ex.Message);
         Assert.Contains("binary mismatch", ex.Message);
+    }
+
+    [Fact]
+    public void GenerateCode_GeneratorDroppedByLoadFailure_ThrowsIncompatibleSdkDiagnostic()
+    {
+        // Reproduces the TypeScript AppHost failure: the TypeScript generator is silently dropped
+        // because Aspire.TypeSystem failed to load. Instead of a cryptic ArgumentException, the
+        // service must emit the actionable incompatible-SDK RPC error the CLI knows how to render.
+        var codeService = CreateCodeGenerationServiceWithLoadFailingAssembly();
+
+        var ex = Assert.Throws<LocalRpcException>(() => codeService.GenerateCode("TypeScript"));
+
+        Assert.Equal(CodeGenerationErrorCodes.IncompatibleAspireSdk, ex.ErrorCode);
+        var diagnostic = Assert.IsType<CodeGenerationDiagnostic>(ex.ErrorData);
+        Assert.False(string.IsNullOrWhiteSpace(diagnostic.RemediationHint));
     }
 
     private static (LanguageService Lang, CodeGenerationService Code) CreateServices()
@@ -133,10 +149,47 @@ public class ServiceErrorMessageTests
         return new CodeGenerationService(auth, atsContextFactory, codeResolver, loader, NullLogger<CodeGenerationService>.Instance, telemetry);
     }
 
+    private static CodeGenerationService CreateCodeGenerationServiceWithLoadFailingAssembly()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var telemetry = CreateTelemetry();
+        var loader = new AssemblyLoader(configuration, NullLogger<AssemblyLoader>.Instance, telemetry);
+        var services = new ServiceCollection().BuildServiceProvider();
+        var codeResolver = new CodeGeneratorResolver(
+            services,
+            () => (IReadOnlyList<Assembly>)[new LoadFailingAssembly("Aspire.Hosting.CodeGeneration.TypeScript")],
+            NullLogger<CodeGeneratorResolver>.Instance);
+
+        var auth = CreateAuthenticatedState();
+        var atsContextFactory = new AtsContextFactory(loader, NullLogger<AtsContextFactory>.Instance, telemetry);
+        return new CodeGenerationService(auth, atsContextFactory, codeResolver, loader, NullLogger<CodeGenerationService>.Instance, telemetry);
+    }
+
     // The default state is "authenticated" when no JsonRpcAuthToken is present in configuration.
     private static JsonRpcAuthenticationState CreateAuthenticatedState()
         => new(new ConfigurationBuilder().Build());
 
     private static RemoteHostProfilingTelemetry CreateTelemetry()
         => new(new ConfigurationBuilder().Build());
+
+    // Simulates a code-generation assembly whose type discovery fails because a dependency
+    // (Aspire.TypeSystem) cannot be loaded — the exact shape of the reported TypeScript failure.
+    private sealed class LoadFailingAssembly : Assembly
+    {
+        private readonly AssemblyName _name;
+
+        public LoadFailingAssembly(string name) => _name = new AssemblyName(name);
+
+        public override AssemblyName GetName() => _name;
+
+        public override Type[] GetTypes()
+            => throw new ReflectionTypeLoadException(
+                [null, typeof(string)],
+                [new FileNotFoundException(
+                    "Could not load file or assembly 'Aspire.TypeSystem, Version=42.42.42.42'. The system cannot find the file specified.",
+                    "Aspire.TypeSystem, Version=42.42.42.42, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51")]);
+    }
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/ServiceErrorMessageTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/ServiceErrorMessageTests.cs
@@ -160,7 +160,7 @@ public class ServiceErrorMessageTests
         var services = new ServiceCollection().BuildServiceProvider();
         var codeResolver = new CodeGeneratorResolver(
             services,
-            () => (IReadOnlyList<Assembly>)[new LoadFailingAssembly("Aspire.Hosting.CodeGeneration.TypeScript")],
+            () => (IReadOnlyList<Assembly>)[CreateLoadFailingAssembly("Aspire.Hosting.CodeGeneration.TypeScript")],
             NullLogger<CodeGeneratorResolver>.Instance);
 
         var auth = CreateAuthenticatedState();
@@ -177,19 +177,12 @@ public class ServiceErrorMessageTests
 
     // Simulates a code-generation assembly whose type discovery fails because a dependency
     // (Aspire.TypeSystem) cannot be loaded — the exact shape of the reported TypeScript failure.
-    private sealed class LoadFailingAssembly : Assembly
-    {
-        private readonly AssemblyName _name;
-
-        public LoadFailingAssembly(string name) => _name = new AssemblyName(name);
-
-        public override AssemblyName GetName() => _name;
-
-        public override Type[] GetTypes()
-            => throw new ReflectionTypeLoadException(
+    private static FakeAssembly CreateLoadFailingAssembly(string name)
+        => FakeAssembly.ThrowingOnGetTypes(
+            name,
+            new ReflectionTypeLoadException(
                 [null, typeof(string)],
                 [new FileNotFoundException(
                     "Could not load file or assembly 'Aspire.TypeSystem, Version=42.42.42.42'. The system cannot find the file specified.",
-                    "Aspire.TypeSystem, Version=42.42.42.42, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51")]);
-    }
+                    "Aspire.TypeSystem, Version=42.42.42.42, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51")]));
 }


### PR DESCRIPTION
## Description

When the configured Aspire SDK is out of sync with the installed CLI, running or restoring a TypeScript (Node.js) AppHost could fail with a cryptic, unactionable error:

> Failed to run TypeScript (Node.js) AppHost: No code generator found for language: TypeScript. No code generators were discovered in any loaded assembly.

The root cause is a binary mismatch between the bundled apphost server and the integration assemblies on disk. The TypeScript code generator assembly (from the SDK packages) references an `Aspire.TypeSystem` assembly that the running apphost server cannot provide (for example, an older bundled server that predates that assembly version). During assembly discovery, `CodeGeneratorResolver.DiscoverGenerators` calls `GetTypes()`, hits a `ReflectionTypeLoadException` (whose loader exception is a `FileNotFoundException` for `Aspire.TypeSystem`), and silently drops the TypeScript generator. The downstream `CodeGenerationService.GenerateCode` then threw a plain `ArgumentException`, which the diagnostic builder did not classify, so the existing actionable `IncompatibleAspireSdk` diagnostic (with a "run aspire update" remediation hint) was never emitted. The bare exception then propagated across StreamJsonRpc to the CLI and surfaced as a raw stack trace / "unexpected error".

This change routes the swallowed load failure into that existing actionable diagnostic so the user instead sees:

> Failed to run TypeScript (Node.js) AppHost: Aspire SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured SDK version. Run 'aspire update' to align the CLI and SDK and try again.

### Approach

The fix is contained entirely within `Aspire.Hosting.RemoteHost` (the apphost server, which is bundled into the CLI). It has three parts:

- `CodeGeneratorResolver` now retains the `ReflectionTypeLoadException`s it swallows during discovery (via a new `DiscoveryResult` and `GetDiscoveryLoadFailures()`), instead of discarding them.
- `CodeGenerationService.GenerateCode` chains the first retained load failure as the inner exception of the `ArgumentException` it throws when no generator is found.
- `CodeGenerationDiagnostic` recognizes `FileNotFoundException` in the exception chain (in addition to the existing reflection-load cases) and builds the structured `IncompatibleAspireSdk` RPC error that the CLI already renders with the actionable "run aspire update" message.

Because both the affected server code and the CLI client catch path (`AppHostRpcClient.InvokeCodeGenerationAsync`) are shared, this applies to every command that triggers code generation (`aspire run`, `aspire restore`, etc.). No public API or codegen exports coverage changed; the CLI-side rendering path was already in place.

### Verification

In addition to the unit tests, I ran a functional A/B test against a real TypeScript AppHost configured with a daily SDK, injecting the same `Aspire.TypeSystem` load failure. With the fix, the message flips from the cryptic "No code generator found..." to the actionable "...incompatible with the configured SDK version. Run 'aspire update'...". This was verified end-to-end via `aspire run`; `aspire restore` exercises the same shared RPC and client paths.

Fixes #18110
Fixes #17910

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No