### PR TITLE
Make release pipeline DryRun read-only — skip GitHub workflow dispatch in dry run

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -82,7 +82,7 @@ Before starting a release:
    |-----------|-------------|---------|
    | `ReleaseVersion` | Override for the version label (used as `v<version>` tag). Leave as `auto` to derive from the source build's `release-version - *` tag, which is the normal case. Only set this when re-shipping under a corrected tag. | `auto` |
    | `IsPrerelease` | `true` for preview releases. Non-dry-run npm publishing is blocked for prereleases until the MicroBuild npm publish path supports non-`latest` dist-tags. | `false` |
-   | `DryRun` | Set `true` to test without publishing, promoting, tagging, or creating PRs. | `false` |
+   | `DryRun` | Set `true` to test without publishing, promoting, tagging, or creating PRs. The `GitHubTasks` stage becomes read-only: the `release-github-tasks.yml` dispatch and Homebrew live-release validation are skipped (no bot token mint, no dispatched Actions run), and CLI-asset upload verifies SHA512s only without uploading. | `false` |
    | `GaChannelName` | Target GA channel. | `Aspire 9.x GA` |
 
    **Advanced (leave defaults unless you know what you're doing):**
@@ -108,7 +108,7 @@ Before starting a release:
 4. Select the **Resources** button in the bottom right, then select the source build from the `aspire-build` dropdown.
    - The picker shows all recent builds from the `microsoft-aspire` pipeline regardless of branch. Pick the build that corresponds to the release branch and version you intend to ship.
    - Each build's tags are shown alongside its number. Verify the `release-version - X.Y.Z` tag matches the version you intend to ship before clicking **Run**. If the tag is missing, either re-run the source build after the tag-emitting change in `azure-pipelines.yml` is on that release branch or pass an explicit `ReleaseVersion` override.
-5. Click **Run** and monitor the pipeline. The final stage (`GitHubTasks`) dispatches `release-github-tasks.yml`, waits for it to complete, uploads the `aspire-cli-*` archives from the source build's `BlobArtifacts` onto the newly-created GitHub release, and validates the Homebrew cask against that live release. The AzDO pipeline only succeeds if the enabled GitHub tasks, asset upload, and Homebrew validation succeed.
+5. Click **Run** and monitor the pipeline. In a real (non-dry-run) release, the final stage (`GitHubTasks`) dispatches `release-github-tasks.yml`, waits for it to complete, uploads the `aspire-cli-*` archives from the source build's `BlobArtifacts` onto the newly-created GitHub release, and validates the Homebrew cask against that live release. The AzDO pipeline only succeeds if the enabled GitHub tasks, asset upload, and Homebrew validation succeed. Under `DryRun=true` the dispatch and Homebrew validation are skipped and the asset job only verifies SHA512s (see the `DryRun` row above).
 6. Verify packages appear on NuGet.org and npm, and verify that the `aspire-cli-*` archives are attached to the GitHub release.
 
 To publish only the VS Code extension after merging an extension release PR, run the same `release-publish-nuget` pipeline, select the signed source build from that merge, and set:
@@ -137,7 +137,7 @@ The npm release path validates Windows, Linux, and macOS install summaries, publ
 
 `commit_sha` and `release_branch` for the GitHub workflow are derived automatically from the source build resource, so there is no need to copy them by hand.
 
-> **Tip**: Use `DryRun: true` to test end-to-end without publishing, promoting, tagging, creating PRs, or uploading release assets. The dry-run state is propagated to the GitHub workflow as `dry_run: true`.
+> **Tip**: Use `DryRun: true` to test end-to-end without publishing, promoting, tagging, creating PRs, or uploading release assets. A dry run is read-only with respect to GitHub: the `release-github-tasks.yml` workflow is **not** dispatched (no bot installation token is minted and no Actions run is produced), and Homebrew live-release validation is skipped. The CLI-asset job still verifies the `aspire-cli-*` SHA512s locally but uploads nothing.
 
 ### Step 2: Prepare a VS Code extension release PR
 
@@ -340,9 +340,9 @@ Azure DevOps release-publish-nuget.yml
      -> promote BAR build to GA channel
   -> WinGetJob
   -> GitHubTasks
-     -> dispatch release-github-tasks.yml as aspire-repo-bot
-     -> upload aspire-cli-* assets to the GitHub release
-     -> validate Homebrew cask against the live release
+     -> dispatch release-github-tasks.yml as aspire-repo-bot   (skipped when DryRun=true)
+     -> upload aspire-cli-* assets to the GitHub release        (verify SHA512s only when DryRun=true)
+     -> validate Homebrew cask against the live release         (skipped when DryRun=true)
 
 GitHub release-github-tasks.yml
   -> create tag

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -2013,7 +2013,7 @@ extends:
                   if ("${{ parameters.SkipGitHubTasks }}" -eq "true") {
                     Write-Host " (SKIPPED)"
                   } elseif ("${{ parameters.DryRun }}" -eq "true") {
-                    Write-Host " (dispatched after Release stage; dry_run=true forwarded)"
+                    Write-Host " (SKIPPED in dry-run; no dispatch, no token mint, no Actions run)"
                   } else {
                     Write-Host " (dispatched after Release stage)"
                   }
@@ -2021,13 +2021,15 @@ extends:
                   if ("${{ parameters.SkipReleaseAssets }}" -eq "true") {
                     Write-Host " (SKIPPED)"
                   } elseif ("${{ parameters.DryRun }}" -eq "true") {
-                    Write-Host " (verify only; no upload in dry-run)"
+                    Write-Host " (verify SHA512s only; no token mint or upload in dry-run)"
                   } else {
                     Write-Host " (uploaded after GitHub Tasks job)"
                   }
                   Write-Host "║ Homebrew Val:   ${{ parameters.SkipHomebrewValidation }}" -NoNewline
                   if ("${{ parameters.SkipHomebrewValidation }}" -eq "true") {
                     Write-Host " (SKIPPED)"
+                  } elseif ("${{ parameters.DryRun }}" -eq "true") {
+                    Write-Host " (SKIPPED in dry-run; needs a live GitHub release)"
                   } else {
                     Write-Host " (validates cask against live GH release after asset upload)"
                   }
@@ -2271,17 +2273,21 @@ extends:
       # SkipHomebrewValidation) so partial-failure re-runs can recover any
       # piece independently. Skipping all three skips the stage entirely.
       #
-      # DryRun behavior: this stage still runs when DryRun=true. DryRun is
-      # propagated to the GH workflow as dry_run=true (keeps it from
-      # creating tags/releases/PRs) and to the asset script (downloads and
-      # verifies SHA512s but skips the gh release upload). HomebrewValidateJob
-      # also runs under DryRun — it does not publish anything, it only audits
-      # and `brew install`/`brew uninstall` against a public URL. If the
-      # release for the version being validated does not yet exist (DryRun,
-      # or a re-run after assets were already uploaded), the job is expected
-      # to surface that as a real failure rather than be silently skipped.
-      # This lets a release manager validate the full AzDO → GitHub path
-      # end-to-end without performing a real release.
+      # DryRun behavior (issue #18129): DryRun=true is read-only for everything
+      # that reaches out to GitHub as the aspire-repo-bot App. The only piece
+      # that still runs is the local SHA512 verification:
+      #   - DispatchGitHubTasksJob is skipped — no installation token is minted,
+      #     no release-github-tasks.yml run is dispatched, and there is no
+      #     bot-authored Actions run to wait on.
+      #   - PublishReleaseAssetsJob still runs but takes the credential-less
+      #     path: it downloads the aspire-cli-* archives and verifies their
+      #     SHA512s without minting a token or uploading anything (no AppId /
+      #     PrivateKeyPem are passed to the script in DryRun).
+      #   - HomebrewValidateJob is skipped — it validates against the *live*
+      #     GitHub release URL for the version being shipped, which does not
+      #     exist in a dry run, so there is nothing meaningful to validate.
+      # A dry run therefore exercises the AzDO-side artifact plumbing and the
+      # local integrity check without leaving the pipeline.
       - stage: GitHubTasks
         displayName: 'Dispatch GitHub Release Tasks'
         # PrepareArtifacts is listed explicitly (in addition to Release) so the
@@ -2306,7 +2312,15 @@ extends:
         jobs:
           - job: DispatchGitHubTasksJob
             displayName: 'Dispatch and Wait for release-github-tasks workflow'
-            condition: eq('${{ parameters.SkipGitHubTasks }}', 'false')
+            # Gated on DryRun=false (issue #18129): a dry run must not mint a bot
+            # installation token, dispatch release-github-tasks.yml, or produce a
+            # visible bot-authored Actions run. There is nothing read-only this
+            # job can do, so it is skipped entirely in dry run.
+            condition: |
+              and(
+                eq('${{ parameters.SkipGitHubTasks }}', 'false'),
+                eq('${{ parameters.DryRun }}', 'false')
+              )
             timeoutInMinutes: 90
             pool:
               name: NetCore1ESPool-Internal
@@ -2355,6 +2369,10 @@ extends:
                     commit_sha          = "$(CommitShaDerived)"
                     release_branch      = "$(ReleaseBranchDerived)"
                     is_prerelease       = ([System.Convert]::ToBoolean("${{ parameters.IsPrerelease }}")).ToString().ToLowerInvariant()
+                    # Always "false": this job is gated on DryRun=false (issue
+                    # #18129), so a dry run skips it entirely rather than
+                    # dispatching the workflow in dry-run mode. Forward DryRun
+                    # anyway so the input stays correct if that gate ever changes.
                     dry_run             = ([System.Convert]::ToBoolean("${{ parameters.DryRun }}")).ToString().ToLowerInvariant()
                     # The AzDO pipeline owns idempotency for the *AzDO* side via its
                     # own Skip* parameters. The GH workflow skip_* flags stay at
@@ -2515,10 +2533,19 @@ extends:
                   $scriptArgs = @{
                     AssetsDir     = $assetsDir
                     Tag           = $tag
-                    AppId         = $env:ASPIRE_BOT_APP_ID
-                    PrivateKeyPem = $env:ASPIRE_BOT_PRIVATE_KEY
                   }
-                  if ($dryRun) { $scriptArgs.DryRun = $true }
+                  if ($dryRun) {
+                    # Read-only dry run (issue #18129): take the script's
+                    # credential-less path. Without AppId/PrivateKeyPem it
+                    # verifies SHA512s but mints no installation token and
+                    # performs no `gh release upload`. Passing the credentials
+                    # here would still mint a token even though the upload is
+                    # skipped, which is exactly what a dry run must avoid.
+                    $scriptArgs.DryRun = $true
+                  } else {
+                    $scriptArgs.AppId         = $env:ASPIRE_BOT_APP_ID
+                    $scriptArgs.PrivateKeyPem = $env:ASPIRE_BOT_PRIVATE_KEY
+                  }
 
                   & "$(Build.SourcesDirectory)/eng/pipelines/scripts/publish-release-cli-assets.ps1" @scriptArgs
                 displayName: 'Verify SHA512s and upload to GitHub Release'
@@ -2553,6 +2580,7 @@ extends:
             condition: |
               and(
                 eq('${{ parameters.SkipHomebrewValidation }}', 'false'),
+                eq('${{ parameters.DryRun }}', 'false'),
                 in(dependencies.PublishReleaseAssetsJob.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
               )
             timeoutInMinutes: 30


### PR DESCRIPTION
## What was wrong

Running the release pipeline (`eng/pipelines/release-publish-nuget.yml`) with `DryRun=true` was meant to be safe validation, but it was not read-only. With default flags (`SkipGitHubTasks=false`), the `GitHubTasks` stage still reached out to GitHub as the `aspire-repo-bot` App on every dry run:

- **`DispatchGitHubTasksJob`** minted an installation token, dispatched a real `release-github-tasks.yml` `workflow_dispatch` run (a visible bot-authored Actions run), and waited up to 90 minutes for it.
- **`PublishReleaseAssetsJob`** minted a token (the pipeline always passed credentials) even though the upload itself was skipped under dry run.
- **`HomebrewValidateJob`** ran `brew audit`/`install` against the **live** release URL for the version being shipped — which doesn't exist in a dry run.

The dispatched workflow honored `dry_run` internally (no tags/releases/PRs), so there was no durable GitHub mutation — but a dry run still minted tokens and produced a bot-authored Actions run every time.

## Root cause

The `GitHubTasks` stage jobs were gated only by the `Skip*` flags. `DryRun` appeared nowhere in their conditions — the only `DryRun` reference in the stage was the `dry_run` input forwarded to the dispatched workflow.

## The fix

Gate the GitHub-reaching work on `DryRun=false`:

- `DispatchGitHubTasksJob` and `HomebrewValidateJob` now require `DryRun=false` and are skipped entirely in a dry run.
- `PublishReleaseAssetsJob` still runs but passes the bot credentials (`AppId`/`PrivateKeyPem`) to `publish-release-cli-assets.ps1` only when `DryRun=false`. In a dry run it takes the script's existing credential-less path — verifying `aspire-cli-*` SHA512s locally without minting a token or uploading.

A dry run now exercises the AzDO-side artifact plumbing and the local integrity check without leaving the pipeline.

## Call-outs

- **This reverses a previously intentional design.** The old stage comments said the stage runs under `DryRun` on purpose, to validate the full AzDO→GitHub path end-to-end (forwarding `dry_run=true`). That is the behavior this PR removes.
- **No automated test.** This is AzDO pipeline-conditional behavior that does not run in PR CI, and per maintainer direction this PR does not add tests that assert on the pipeline YAML's text content. The behavior is validated by queuing the release pipeline with `DryRun=true` and confirming the `GitHubTasks` stage skips the dispatch + Homebrew jobs and the asset job runs verify-only.
- `docs/release-process.md` updated: the `DryRun` parameter row, the step-5 narration, the dry-run Tip (previously said the state is "propagated to the GitHub workflow as `dry_run: true`", now no longer true), and the ASCII flow.

Fixes #18129
