### PR TITLE
Avoid redundant rebuild in persistent container E2E restart

### DIFF
--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -1078,7 +1078,10 @@ internal sealed class DotNetCliRunner(
         using var activity = telemetry.StartDiagnosticActivity();
 
         var noRestoreSwitch = noRestore ? "--no-restore" : string.Empty;
-        string[] cliArgs = ["build", noRestoreSwitch, projectFilePath.FullName];
+        // AppHost builds can run repeatedly from long-lived CLI sessions. Avoid reusing stale
+        // MSBuild/Roslyn build servers across stop/start cycles because a stuck server can consume
+        // the entire AppHost startup timeout before any build output is produced.
+        string[] cliArgs = ["build", noRestoreSwitch, "--disable-build-servers", projectFilePath.FullName];
         cliArgs = [.. cliArgs.Where(arg => !string.IsNullOrWhiteSpace(arg))];
 
         return await ExecuteAsync(

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -173,7 +173,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task BuildAsyncDoesNotInjectDotnetCliUseMsBuildServerEnvironmentVariable()
+    public async Task BuildAsyncDisablesBuildServersWithCommandLineArgument()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
@@ -190,6 +190,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             executionContext,
             (args, env, _, _) =>
             {
+                Assert.Contains("--disable-build-servers", args);
                 Assert.NotNull(env);
                 Assert.False(env.ContainsKey("DOTNET_CLI_USE_MSBUILD_SERVER"));
             },
@@ -255,6 +256,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             executionContext,
             (args, env, _, _) =>
             {
+                Assert.Contains("--disable-build-servers", args);
                 Assert.NotNull(env);
                 Assert.False(env.ContainsKey("DOTNET_CLI_USE_MSBUILD_SERVER"));
             },


### PR DESCRIPTION
## Description

Related to #17995

This PR is still draft while the fix is validated.

The original proposed change disabled build servers for every `DotNetCliRunner.BuildAsync` call. That was too broad and has been reverted on this branch. The evidence from the quarantined failure artifacts confirms the symptom, not a global build-server root cause:

- The first `aspire start`, `/write`, and `aspire stop` completed.
- `aspire stop` reported success and the first AppHost process exited with code 0.
- The second `aspire start` spawned the detached child and reached `dotnet build`.
- That second `dotnet build` emitted no stdout/stderr for the full 300 second `ASPIRE_CLI_START_TIMEOUT`, then the CLI timed out.

The narrower change keeps production CLI build behavior unchanged and only changes this E2E path: after the first successful start, the generated AppHost project is unchanged, so the second `aspire start` uses `--no-build`. This keeps the test focused on verifying persistent container data across AppHost runs and avoids the redundant second build path that is the observed flaky failure point.

Validation so far:

- `dotnet build tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj -v:q /p:RunQuarantinedTests=true`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.DotNetCliRunnerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` — 59 passed

Pending:

- CI reproduce verification using a branch-built CLI archive/workflow configuration. The previous reproduce run used `InstallScript (--quality dev)`, so it reproduced the existing dev-channel failure and did not validate this branch.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No