### PR TITLE
docs: capture how to test the AzDO release pipeline (previewRun + DryRun read-only)

### DIFF
--- a/.agents/skills/azdo-internal/SKILL.md
+++ b/.agents/skills/azdo-internal/SKILL.md
@@ -30,9 +30,10 @@ The Aspire repo (`microsoft/aspire` on GitHub) has an internal mirror at `dnceng
 | Pipeline | Definition ID | YAML | Purpose |
 |----------|--------------|------|---------|
 | **microsoft-aspire** (main) | 1602 | `eng/pipelines/azure-pipelines.yml` | Official internal build (PR + CI) |
-| **microsoft-aspire unofficial** | *(discover — see note)* | `eng/pipelines/azure-pipelines-unofficial.yml` | Unofficial/dev builds |
+| **microsoft-aspire-unofficial** | 1601 | `eng/pipelines/azure-pipelines-unofficial.yml` | Unofficial/dev builds |
+| **microsoft-aspire-Release-To-NuGet** | 1600 | `eng/pipelines/release-publish-nuget.yml` | Release: NuGet/npm publish, channel promotion, installer (WinGet/Homebrew), GitHub release tasks. Consumes a def-1602 build via `resources.pipelines: aspire-build`. **Side-effecting — run only with `DryRun=true`** (see *Validating publish/release-only changes safely*). |
 
-> The definition ID for the unofficial pipeline isn't hardcoded here because it can change. Discover it with:
+> Definition IDs are stable — a pipeline keeps its ID for life. The only way one changes is if the pipeline is deleted and recreated (which assigns a new ID). If a build won't start or targets the wrong pipeline, re-verify with:
 >
 > ```bash
 > az pipelines list --organization https://dev.azure.com/dnceng --project internal \
@@ -102,6 +103,54 @@ az pipelines run \
 
 The command returns JSON with the build details including `id` (build ID) and `url`.
 
+### Compile-check without queuing a build (`previewRun`)
+
+For a **YAML/template change**, validate that the pipeline still *compiles* before spending a real build — this is instant and queues nothing. AzDO compiles a pipeline on every run, but it never compiles on a GitHub PR, so a template error can pass all GitHub checks and only surface at run time (e.g. a literal `${{ … }}` inside an inlined PowerShell script block — even in a comment — is evaluated by the template engine and can fail with `Unable to convert from Object to String`).
+
+`previewRun` requires the branch to be on the **mirror** (it resolves repo/template refs from there), so push first. Then:
+
+```bash
+cat > /tmp/preview.json <<'EOF'
+{ "previewRun": true,
+  "resources": { "repositories": { "self": { "refName": "refs/heads/<your-alias>/<branch>" } } } }
+EOF
+
+az devops invoke --area pipelines --resource runs \
+  --route-parameters project=internal pipelineId=<DEF_ID> \
+  --api-version 7.1 --http-method POST --in-file /tmp/preview.json \
+  --organization https://dev.azure.com/dnceng -o json
+```
+
+Exit 0 + a `finalYaml` field ⇒ compiles. A non-zero exit prints the exact `file (Line: N, Col: C)` of the error. Compare base vs. PR branch to confirm the PR (not a pre-existing issue) introduced any failure, and bisect by neutralizing suspect lines on a throwaway branch.
+
+> **api-version quirk:** use `--api-version 7.1`. Passing `7.1-preview.1` trips an `az` parsing bug (`could not convert string to float: '7.1.1'`).
+
+### Run a pipeline that consumes another pipeline's artifacts (pin the source build)
+
+The release pipeline consumes a def-1602 build via `resources.pipelines: aspire-build`. To run it against a **specific** upstream build you must pin that resource — `az pipelines run` **cannot** pin a pipeline-resource version, so use the REST `runs` API. Pick a source build whose artifacts your change touches (verify with `az pipelines runs artifact list --run-id <SRC_BUILD_ID>`), and pass its **run name** (e.g. `20260610.6`), not its numeric id:
+
+```bash
+cat > /tmp/release-run.json <<'EOF'
+{
+  "resources": {
+    "repositories": { "self": { "refName": "refs/heads/<your-alias>/<branch>" } },
+    "pipelines": { "aspire-build": { "version": "<SOURCE_BUILD_RUN_NAME>" } }
+  },
+  "templateParameters": {
+    "DryRun": "true",
+    "SkipGitHubTasks": "true"
+  }
+}
+EOF
+
+az devops invoke --area pipelines --resource runs \
+  --route-parameters project=internal pipelineId=1600 \
+  --api-version 7.1 --http-method POST --in-file /tmp/release-run.json \
+  --organization https://dev.azure.com/dnceng -o json
+```
+
+Set the other `Skip*` parameters to scope the run to the stages your change touches. **Always pass `DryRun=true`** for the release pipeline (see below).
+
 ## Pipeline structure
 
 Don't rely on a snapshot here — the stages, job conditions, and variables change. Read the current definition from the repo:
@@ -168,7 +217,7 @@ There is **no** `az pipelines watch` command. For a long build, don't poll in a 
 
 Some stages only run on `main`/`release/*` and will be skipped or fail on a `<your-alias>/...` branch, so they can't be exercised this way:
 
-- **Publish / release stages** (NuGet push, WinGet/Homebrew PR submission) run in the release pipeline, not on feature-branch CI.
+- **Real-publish steps** (NuGet push, npm ESRP publish, WinGet/Homebrew PR submission) only run when `DryRun=false`, which you must never set on a personal branch. But the **release pipeline itself *can* be run on a personal branch** under `DryRun=true` — the publish steps are compile-excluded or runtime-skipped, and the surrounding validation/dry-run path (artifact download, version checks, dry-run package listing) runs for real. Pin a source build and validate that path (next section).
 - Steps that read the `publish-build-assets` variable group fail on non-`main`/non-`release/*` branches — by Arcade convention that group is only pulled for non-PR official branches. A feature-branch build legitimately can't access it.
 
 When validating pipeline changes, confirm up front whether the path you're testing is even reachable from a personal branch; if not, validate the *mechanism* safely (next section) rather than running it for real on a release branch.
@@ -177,22 +226,20 @@ When validating pipeline changes, confirm up front whether the path you're testi
 
 When a change only runs on `main`/`release/*` (publish, NuGet push, WinGet/Homebrew PR submission, release notifications), validate the mechanism **without real side effects**. Never let a publishing or PR-submitting step run live during validation. In order of preference:
 
-**1. Run the release pipeline with `DryRun=true`.** The release/publish pipeline (`eng/pipelines/release-publish-nuget.yml`) exposes a `DryRun` runtime parameter that **defaults to `false` (live)** — so you must pass it explicitly:
+**0. Compile-check first with `previewRun`** (see *Triggering the Pipeline*). For any YAML/template change this is the cheapest gate and catches the whole class of compile errors that GitHub PR CI never sees. Do this before spending a real build.
 
-```bash
-az pipelines run --id <RELEASE_PIPELINE_ID> \
-  --organization https://dev.azure.com/dnceng --project internal \
-  --branch <your-alias>/<branch> \
-  --parameters DryRun=true
-```
+**1. Run the release pipeline with `DryRun=true`, pinned to a source build.** The release/publish pipeline (`eng/pipelines/release-publish-nuget.yml`) exposes a `DryRun` runtime parameter that **defaults to `false` (live)** — so you must pass it explicitly, and you must pin the `aspire-build` source build via the REST `runs` API (`az pipelines run` can't pin a resource version — see *Run a pipeline that consumes another pipeline's artifacts* above for the recipe).
 
-ESRP sign/publish, the `gh release` upload (`publish-release-cli-assets.ps1`), and the WinGet/npm publish steps are all gated on this flag, so the path runs end-to-end without pushing anything.
+ESRP sign/publish, npm publish (compile-excluded under `DryRun=true`), the `gh release` upload (`publish-release-cli-assets.ps1`, runtime `-DryRun`), darc channel promotion, and WinGet submit are all gated on this flag, so the path runs end-to-end without pushing anything.
+
+⚠️ **`DryRun` is not fully end-to-end read-only today.** The `GitHubTasks` stage is gated by `SkipGitHubTasks`, **not** by `DryRun` — so with `SkipGitHubTasks=false` (default), even a dry run mints a bot token and dispatches a real `release-github-tasks.yml` Actions run (which honors `dry_run` internally, creating nothing durable, but is still an external reach). **Set `SkipGitHubTasks=true` for a focused, fully read-only validation.** Tracked by [microsoft/aspire#18129](https://github.com/microsoft/aspire/issues/18129).
 
 **Always verify dry-run actually engaged** — don't assume it. The scripts print it; grep the job log for:
 
 ```
 DryRun: True        # publish-release-cli-assets.ps1
 Dry Run: true       # release-publish-nuget.yml
+=== DRY RUN - No npm packages were actually published ===   # npm dry-run listing
 ```
 
 If you don't see it, treat the step as having run live. (A malformed `-DryRun` argument has silently bound positionally before and run live against the wrong target — confirm from the log, don't trust the intent.)

--- a/.agents/skills/pr-testing/ci-infra-testing.md
+++ b/.agents/skills/pr-testing/ci-infra-testing.md
@@ -702,8 +702,34 @@ and the must-not-skip validation bar.
 |----------|----------------------|--------------------------------|
 | **Internal build** `eng/pipelines/azure-pipelines.yml` | def **1602**, `dnceng/internal` mirror | Most `eng/pipelines/**`, `eng/common/**`, signing/packaging/version/asset-manifest changes. **This is the default target** — run it via the `azdo-internal` skill. |
 | **Unofficial** `azure-pipelines-unofficial.yml` | dev/unofficial build | Changes scoped to that pipeline. |
-| **Release** `release-publish-nuget.yml` | separate definition; consumes def-1602 artifacts | Publish / NuGet / installer-promotion logic. Side-effecting — read the skill's dry-run caveats. |
+| **Release** `release-publish-nuget.yml` | separate definition (`microsoft-aspire-Release-To-NuGet`, *not* def 1602); consumes def-1602 artifacts | Publish / NuGet / npm / installer-promotion logic. Side-effecting — see **Testing a release-pipeline change** below. |
 | **Public / Helix** `azure-pipelines-public.yml` | weekly + `/azp run aspire-tests` | Helix test routing / test execution. Different pipeline, different breakage patterns — see `docs/ci/azdo-public-pipeline.md`; out of scope for the internal skill. |
+
+## Testing a release-pipeline change (`release-publish-nuget.yml`)
+
+The release pipeline is a **separate definition** (`microsoft-aspire-Release-To-NuGet`, *not* def 1602) that consumes a def-1602 build via a `resources.pipelines: aspire-build` input. Two traps make it unlike a normal infra change:
+
+- **It never compiles on a GitHub PR.** A YAML/template error fails the pipeline *before any stage runs* — yet it passes every GitHub check **and** the offline `Infrastructure.Tests`, because AzDO doesn't compile it on a PR. Real example: a literal `${{ … }}` token inside an *inlined PowerShell script block* — even in a comment or a string — is evaluated by the AzDO template engine, not treated as script text. `${{ parameters.* }}` resolves to the parameters object and fails compilation with `Unable to convert from Object to String`. **Always compile-check first** (see `azdo-internal` → `previewRun`): it's instant and queues no build.
+- **It is side-effecting.** Validate only under `DryRun=true`, and audit that the flag actually makes the run read-only end-to-end (below).
+
+**Loop for a release-pipeline change:**
+
+1. **Compile-check with `previewRun`** — on the PR branch *pushed to the mirror* (`previewRun` resolves repo/template refs from the mirror, so the branch must be there). Confirm the base compiles and the PR does too; a compile failure here is a blocking finding. → `azdo-internal`.
+2. **Pick a source build to consume** — a recent def-1602 run *on the release branch* that produced the artifacts your change touches. Verify they're present (`az pipelines runs artifact list`). A release run is only meaningful against real upstream artifacts.
+3. **Run with `DryRun=true`, pinned to that source build.** Pinning a pipeline-resource version needs the REST `runs` API (`az pipelines run` can't do it) — recipe in `azdo-internal`. Set the `Skip*` flags to scope the run to the stages your change touches.
+4. **Validate the change took effect** from the timeline + logs (green ≠ validated — see below) and confirm the DryRun audit held.
+
+**DryRun read-only audit** — before trusting a dry run, confirm every side-effecting step is gated so `DryRun=true` is a no-op:
+
+| Side-effect | Expected gate under `DryRun=true` |
+|---|---|
+| NuGet push (`1ES.PublishNuget@1`), npm ESRP publish (`MicroBuild.Publish.yml`) | compile-time `${{ if and(eq(parameters.DryRun, false), …) }}` — step not emitted |
+| darc channel promotion, `gh release upload`, WinGet submit | runtime `if ($dryRun) { skip / exit 0 }` |
+| GitHub tag / release / merge-PR / baseline-PR | gated inside `release-github-tasks.yml` on `dry_run` |
+
+⚠️ **Known gap ([microsoft/aspire#18129](https://github.com/microsoft/aspire/issues/18129)):** the **`GitHubTasks` stage is gated by `Skip*`, not `DryRun`.** With `SkipGitHubTasks=false` (default), a dry run *still* mints a bot token and dispatches a real `release-github-tasks.yml` Actions run (which then honors `dry_run` internally and creates nothing durable, but is a visible external reach). For a focused, fully-read-only validation set **`SkipGitHubTasks=true`**. Until #18129 is fixed, treat "DryRun ⇒ read-only" as true *only* with `SkipGitHubTasks=true`.
+
+**Review rule:** every side-effecting step in the release pipeline must be a no-op under `DryRun=true`, including the GitHub Tasks dispatch — see `.github/instructions/release-pipeline.instructions.md`.
 
 ## The loop (handed off to `azdo-internal`)
 
@@ -746,9 +772,10 @@ change must produce the **same artifact set** as the baseline. What is
   def-1602's build via a `resources.pipelines:` (`aspire-build`) input. If your
   change alters what a stage produces (artifact name, contents, layout) or
   reorders/removes a stage, confirm every downstream `dependsOn`/`download` still
-  resolves — and that the **release** pipeline, which you can't run from a feature
-  branch, still finds the artifacts it expects (validate its `download` inputs and
-  the produced names statically, and flag for a maintainer run).
+  resolves — and that the **release** pipeline still finds the artifacts it
+  expects. Validate its `download` inputs and the produced names statically, then
+  confirm with a `DryRun=true` release run pinned to that source build (see
+  *Testing a release-pipeline change* above).
 - **Distinguish a real break from an expected contributor-branch skip.** Publish /
   BAR / release stages are gated on `main`/`release` and **will** skip on an
   `<alias>/` branch — that's by design, not a regression. Branch-gated variable

--- a/.github/instructions/release-pipeline.instructions.md
+++ b/.github/instructions/release-pipeline.instructions.md
@@ -1,0 +1,28 @@
+---
+applyTo: "eng/pipelines/release-publish-nuget.yml,eng/pipelines/templates/publish-*.yml,eng/pipelines/scripts/**,.github/workflows/release-github-tasks.yml"
+---
+
+# Release Pipeline Review Patterns
+
+The release pipeline (`eng/pipelines/release-publish-nuget.yml`, definition `microsoft-aspire-Release-To-NuGet`) and the GitHub release tasks it dispatches (`.github/workflows/release-github-tasks.yml`) are **side-effecting and never run on a GitHub PR**. Review them with that in mind.
+
+## DryRun must be fully read-only
+
+Every step that has an external side effect MUST be a no-op when `DryRun=true` — including the GitHub Tasks dispatch. "Side effect" means any of: publishing a package (NuGet, npm), pushing a git ref or tag, creating/editing a GitHub release, opening or editing a PR or issue, minting a credential/token for a live call, promoting a build to a channel (darc), submitting a manifest (WinGet/Homebrew), or **dispatching/triggering an external workflow**.
+
+When reviewing a new or changed step:
+
+- Confirm it is gated on `DryRun` — either compile-time (`${{ if and(eq(parameters.DryRun, false), …) }}`, so the step is not emitted) or runtime (`if ($dryRun) { … exit 0 }`).
+- A dry run must reach `DryRun`/`Dry Run`/`No … were actually published` markers in the log instead of performing the action.
+- Gating a side effect *only* on a `Skip*` flag is **not** sufficient — `Skip*` is for idempotent re-runs, not for read-only validation. A reviewer should flag any side-effecting step reachable under `DryRun=true`. (Known gap: the `GitHubTasks` stage dispatch is gated only by `SkipGitHubTasks`, tracked by microsoft/aspire#18129.)
+
+## Template-expression traps in inlined scripts
+
+AzDO evaluates `${{ … }}` template expressions **anywhere** inside an inlined `powershell:`/`pwsh:`/`bash:` block scalar — including inside PowerShell/shell **comments and string literals**. It does not treat them as script text.
+
+- Never write a literal `${{ … }}` inside an inlined script block unless you intend the template engine to expand it. A comment like `# interpolating ${{ parameters.* }} into this script` compiles `parameters.*` to the parameters **object** and fails with `Unable to convert from Object to String`.
+- This class of error fails template compilation **before any stage runs**, and passes every GitHub PR check plus the offline `Infrastructure.Tests` (AzDO never compiles the pipeline on a PR). Validate compilation with AzDO `previewRun` (see the `azdo-internal` skill) for any change to these files.
+
+## Testing
+
+Changes here are validated via the `pr-testing` skill's `ci-infra-testing.md` (Track B) and the `azdo-internal` skill: compile-check with `previewRun` first, then a `DryRun=true` run pinned to a real def-1602 source build, with `SkipGitHubTasks=true` for a fully read-only run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -543,3 +543,4 @@ Additional instructions are automatically applied when editing files matching sp
 | `tools/QuarantineTools/*` | `.github/instructions/quarantine.instructions.md` - QuarantineTools usage |
 | `tests/**/*.cs` | `.github/instructions/test-review-guidelines.instructions.md` - Flaky test patterns and test review guidelines |
 | `eng/scripts/get-aspire-cli*.sh`, `eng/scripts/get-aspire-cli*.ps1` | `.github/instructions/acquisition-tests.instructions.md` - CLI acquisition script tests |
+| `eng/pipelines/release-publish-nuget.yml`, `eng/pipelines/templates/publish-*.yml`, `eng/pipelines/scripts/**`, `.github/workflows/release-github-tasks.yml` | `.github/instructions/release-pipeline.instructions.md` - Release pipeline review patterns (DryRun read-only, template-expression traps) |


### PR DESCRIPTION
## What was missing

The AzDO release pipeline (`eng/pipelines/release-publish-nuget.yml`, def `microsoft-aspire-Release-To-NuGet`) is **never compiled on a GitHub PR** — AzDO only compiles it at run time, and no AzDO pipeline runs on a GitHub PR. So two whole classes of defect pass every PR check (and the offline `Infrastructure.Tests`) and only surface at release time:

1. **Template/compile errors** that fail the pipeline before any stage runs.
2. **Dry-run runs that aren't actually read-only.**

Both were hit while testing a recent release-pipeline change. A literal template expression inside an *inlined PowerShell script block comment* compiled the parameters object to a string and broke the pipeline:

```
/eng/pipelines/release-publish-nuget.yml (Line: 710, Col: 29): Unable to convert from Object to String. Value: Object
```

And a `DryRun=true` run still dispatched a real `release-github-tasks.yml` Actions run, because that stage is gated on `SkipGitHubTasks`, not `DryRun` (tracked separately by #18129).

None of our skills or review instructions captured how to catch either before merge.

## The change (docs / agent-tooling only)

- **New `.github/instructions/release-pipeline.instructions.md`** (auto-applied to the release pipeline YAML, `publish-*.yml`, `eng/pipelines/scripts/**`, and `release-github-tasks.yml`): a review rule that every side-effecting step must be a no-op under `DryRun=true` — including the GitHub Tasks dispatch — plus the literal-template-expression-in-inlined-script trap.

- **`pr-testing` skill `ci-infra-testing.md` (Track B):** new "Testing a release-pipeline change" section — `previewRun` compile-check first, then a `DryRun=true` run pinned to a real def-1602 source build; a DryRun read-only audit table; the `GitHubTasks`-not-gated-by-`DryRun` caveat; and a fix for a stale claim that the release pipeline "can't be run from a feature branch" (it can, under DryRun).

- **`azdo-internal` skill `SKILL.md`:** release + unofficial pipelines added to Related Pipelines with their (stable) definition IDs; a `previewRun` compile-without-queuing recipe; the REST `runs` API recipe for pinning a consumed source build (`az pipelines run` can't pin a resource version); and the `--api-version 7.1` quirk.

- **`AGENTS.md`:** register the new instructions file.

## Surprises / call-outs

- No product or pipeline code changes — docs and agent skills/instructions only.
- Definition IDs are now hard-coded (1600 release / 1601 unofficial / 1602 main) and the note that "IDs can change" is corrected — AzDO definition IDs are stable for a pipeline's lifetime.
- The skills live under `.agents/skills/` on `main` (they were relocated from `.github/skills/`); these edits target the `main` layout.

Refs #18129
