### PR TITLE
Fix ProcessSignaler.AreClose flaky tolerance on second boundaries

### DIFF
--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -110,9 +110,9 @@ internal static partial class ProcessSignaler
             return true;
         }
 
-        // Truncate processStartTime to whole seconds before comparing. The expected start time
-        // is already at second granularity (passed as unix seconds via ToUnixTimeSeconds()),
-        // so sub-second precision on the OS-reported start time would cause false mismatches.
+        // Truncate both sides to whole seconds before comparing. The expected start time
+        // may already be at second granularity (e.g. from the orphan detector via ToUnixTimeSeconds()),
+        // and the OS-reported start time has sub-second precision that would cause false mismatches.
         var processStartTruncated = new DateTimeOffset(processStartTime).ToUnixTimeSeconds();
         var expectedSeconds = ((DateTimeOffset)expectedStartTime).ToUnixTimeSeconds();
 

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -103,15 +103,21 @@ internal static partial class ProcessSignaler
         }
     }
 
-    private static bool AreClose(DateTimeOffset? expectedStartTime, DateTime processStartTime, TimeSpan? tolerance = default)
+    internal static bool AreClose(DateTimeOffset? expectedStartTime, DateTime processStartTime, TimeSpan? tolerance = default)
     {
         if (expectedStartTime is null)
         {
             return true;
         }
 
+        // Truncate processStartTime to whole seconds before comparing. The expected start time
+        // is already at second granularity (passed as unix seconds via ToUnixTimeSeconds()),
+        // so sub-second precision on the OS-reported start time would cause false mismatches.
+        var processStartTruncated = new DateTimeOffset(processStartTime).ToUnixTimeSeconds();
+        var expectedSeconds = ((DateTimeOffset)expectedStartTime).ToUnixTimeSeconds();
+
         tolerance ??= TimeSpan.FromSeconds(1);
-        return ((DateTimeOffset)expectedStartTime - new DateTimeOffset(processStartTime)).Duration() <= tolerance;
+        return Math.Abs(expectedSeconds - processStartTruncated) <= (long)tolerance.Value.TotalSeconds;
     }
 
     private const int SigTerm = 15;

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Tests;
+
+[Trait("Partition", "4")]
+public class ProcessSignalerTests(ITestOutputHelper testOutputHelper)
+{
+    [Theory]
+    [InlineData(0, true)]       // Exact match
+    [InlineData(0.8, true)]     // Sub-second difference (the flaky test scenario: truncation crosses second boundary)
+    [InlineData(1, true)]       // Exactly 1 second apart (within tolerance)
+    [InlineData(3, false)]      // 3 seconds apart (PID reuse)
+    [InlineData(-0.5, true)]    // Negative sub-second difference
+    public void AreClose_ComparesAtSecondGranularity(double offsetSeconds, bool expected)
+    {
+        var baseTime = new DateTime(2025, 6, 12, 10, 30, 45, 0, DateTimeKind.Local);
+        var expectedStartTime = new DateTimeOffset(baseTime);
+        var processStartTime = baseTime.AddSeconds(offsetSeconds);
+
+        var result = ProcessSignaler.AreClose(expectedStartTime, processStartTime);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void TryGetRunningProcess_CurrentProcess_WithTruncatedStartTime_ReturnsProcess()
+    {
+        var loggerFactory = LoggerFactory.Create(b => b.AddXunit(testOutputHelper));
+        var logger = loggerFactory.CreateLogger<ProcessSignalerTests>();
+        var currentProcess = Process.GetCurrentProcess();
+
+        // Simulate what the CLI does: truncate to unix seconds
+        var truncatedStartTime = DateTimeOffset.FromUnixTimeSeconds(
+            ((DateTimeOffset)currentProcess.StartTime).ToUnixTimeSeconds());
+
+        using var result = ProcessSignaler.TryGetRunningProcess(
+            currentProcess.Id, truncatedStartTime, logger);
+
+        Assert.NotNull(result);
+        Assert.Equal(currentProcess.Id, result.Id);
+    }
+}
+

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
@@ -12,7 +12,7 @@ public class ProcessSignalerTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(0, true)]       // Exact match
     [InlineData(0.8, true)]     // Sub-second difference within same second after truncation
-    [InlineData(1.2, true)]     // Sub-second precision causes truncation to cross a second boundary (the flaky test scenario)
+    [InlineData(1.2, true)]
     [InlineData(1, true)]       // Exactly 1 second apart (within tolerance)
     [InlineData(3, false)]      // 3 seconds apart (PID reuse)
     [InlineData(-0.5, true)]    // Negative sub-second difference

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
@@ -11,7 +11,8 @@ public class ProcessSignalerTests(ITestOutputHelper testOutputHelper)
 {
     [Theory]
     [InlineData(0, true)]       // Exact match
-    [InlineData(0.8, true)]     // Sub-second difference (the flaky test scenario: truncation crosses second boundary)
+    [InlineData(0.8, true)]     // Sub-second difference within same second after truncation
+    [InlineData(1.2, true)]     // Sub-second precision causes truncation to cross a second boundary (the flaky test scenario)
     [InlineData(1, true)]       // Exactly 1 second apart (within tolerance)
     [InlineData(3, false)]      // 3 seconds apart (PID reuse)
     [InlineData(-0.5, true)]    // Negative sub-second difference


### PR DESCRIPTION
## Summary

Fixes a flaky CI test failure in `CliOrphanDetector` where `ProcessSignaler.AreClose` would incorrectly reject the current process as a PID-reuse candidate due to sub-second precision mismatch.

## Root Cause

The CLI truncates process start time to unix seconds via `ToUnixTimeSeconds()`, but the OS-reported `Process.StartTime` has sub-second precision. When a process starts near a second boundary (e.g., 34.999s → truncated to 34s, but OS reports 35.003s), the old comparison could fail because the effective difference exceeded the 1-second tolerance.

CI evidence:
```
Process 510 start time 06/12/2026 00:03:35 does not match expected start time 06/12/2026 00:03:34 +00:00
```

## Fix

Truncate **both** sides to unix seconds before comparing, eliminating sub-second precision mismatches entirely. The 1-second tolerance is kept for genuine platform jitter at whole-second granularity.

## Changes

- `src/Shared/ProcessSignaler.cs`: Changed `AreClose` to compare at second granularity by converting both values via `ToUnixTimeSeconds()`. Made the method `internal static` for testability.
- `tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs`: New test file with theory-based tests covering exact match, sub-second boundary crossing, within tolerance, exceeds tolerance, and integration with `TryGetRunningProcess`.