### PR TITLE
Log custom creation script execution in resource logger for `WithCreationScript(...)`

### DIFF
--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -283,6 +283,7 @@ public static class AzureKustoBuilderExtensions
         crp.SetParameter(ClientRequestProperties.OptionQueryConsistency, ClientRequestProperties.OptionQueryConsistency_Strong);
 
         var script = databaseResource.GetDatabaseCreationScript();
+        var hasCustomScript = databaseResource.Annotations.OfType<AzureKustoCreateDatabaseScriptAnnotation>().Any();
 
         var logger = serviceProvider.GetRequiredService<ResourceLoggerService>().GetLogger(databaseResource);
         var rns = serviceProvider.GetRequiredService<ResourceNotificationService>();
@@ -291,7 +292,18 @@ public static class AzureKustoBuilderExtensions
 
         try
         {
+            if (hasCustomScript)
+            {
+                logger.LogInformation("Executing custom creation script for database '{DatabaseName}':{NewLine}{Script}", databaseResource.DatabaseName, Environment.NewLine, script);
+            }
+
             await AzureKustoEmulatorResiliencePipelines.Default.ExecuteAsync(async ct => await adminProvider.ExecuteControlCommandAsync(databaseResource.DatabaseName, script, crp).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);
+
+            if (hasCustomScript)
+            {
+                logger.LogInformation("Completed custom creation script for database '{DatabaseName}'", databaseResource.DatabaseName);
+            }
+
             logger.LogDebug("Database '{DatabaseName}' created successfully", databaseResource.DatabaseName);
         }
         catch (Exception e)

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -294,7 +294,7 @@ public static class AzureKustoBuilderExtensions
         {
             if (hasCustomScript)
             {
-                logger.LogInformation("Executing custom creation script for database '{DatabaseName}':{NewLine}{Script}", databaseResource.DatabaseName, Environment.NewLine, script);
+                logger.LogInformation("Executing custom creation script for database '{DatabaseName}'", databaseResource.DatabaseName);
             }
 
             await AzureKustoEmulatorResiliencePipelines.Default.ExecuteAsync(async ct => await adminProvider.ExecuteControlCommandAsync(databaseResource.DatabaseName, script, crp).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -168,7 +168,16 @@ public static class MySqlBuilderExtensions
                 using var command = sqlConnection.CreateCommand();
                 command.CommandText = scriptAnnotation.Script;
                 var rowsAffected = await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
-                logger.LogInformation("Completed custom creation script for database '{DatabaseName}' with {RowsAffected} rows affected", sqlDatabase.DatabaseName, rowsAffected);
+                // ADO.NET returns -1 for DDL statements (CREATE DATABASE, etc.) because they don't affect data rows.
+                // Only include the rows-affected count when it carries meaningful information.
+                if (rowsAffected >= 0)
+                {
+                    logger.LogInformation("Completed custom creation script for database '{DatabaseName}' ({RowsAffected} rows affected)", sqlDatabase.DatabaseName, rowsAffected);
+                }
+                else
+                {
+                    logger.LogInformation("Completed custom creation script for database '{DatabaseName}'", sqlDatabase.DatabaseName);
+                }
             }
 
             logger.LogDebug("Database '{DatabaseName}' created successfully", sqlDatabase.DatabaseName);

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -164,9 +164,11 @@ public static class MySqlBuilderExtensions
             }
             else
             {
+                logger.LogInformation("Executing custom creation script for database '{DatabaseName}':{NewLine}{Script}", sqlDatabase.DatabaseName, Environment.NewLine, scriptAnnotation.Script);
                 using var command = sqlConnection.CreateCommand();
                 command.CommandText = scriptAnnotation.Script;
-                await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                var rowsAffected = await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                logger.LogInformation("Completed custom creation script for database '{DatabaseName}' with {RowsAffected} rows affected", sqlDatabase.DatabaseName, rowsAffected);
             }
 
             logger.LogDebug("Database '{DatabaseName}' created successfully", sqlDatabase.DatabaseName);

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -164,7 +164,7 @@ public static class MySqlBuilderExtensions
             }
             else
             {
-                logger.LogInformation("Executing custom creation script for database '{DatabaseName}':{NewLine}{Script}", sqlDatabase.DatabaseName, Environment.NewLine, scriptAnnotation.Script);
+                logger.LogInformation("Executing custom creation script for database '{DatabaseName}'", sqlDatabase.DatabaseName);
                 using var command = sqlConnection.CreateCommand();
                 command.CommandText = scriptAnnotation.Script;
                 var rowsAffected = await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -746,7 +746,16 @@ public static class PostgresBuilderExtensions
 
             if (scriptAnnotation?.Script is not null)
             {
-                logger.LogInformation("Completed custom creation script for database '{DatabaseName}' with {RowsAffected} rows affected", npgsqlDatabase.DatabaseName, rowsAffected);
+                // ADO.NET returns -1 for DDL statements (CREATE DATABASE, etc.) because they don't affect data rows.
+                // Only include the rows-affected count when it carries meaningful information.
+                if (rowsAffected >= 0)
+                {
+                    logger.LogInformation("Completed custom creation script for database '{DatabaseName}' ({RowsAffected} rows affected)", npgsqlDatabase.DatabaseName, rowsAffected);
+                }
+                else
+                {
+                    logger.LogInformation("Completed custom creation script for database '{DatabaseName}'", npgsqlDatabase.DatabaseName);
+                }
             }
 
             logger.LogDebug("Database '{DatabaseName}' created successfully", npgsqlDatabase.DatabaseName);

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -739,7 +739,7 @@ public static class PostgresBuilderExtensions
 
             if (scriptAnnotation?.Script is { } script)
             {
-                logger.LogInformation("Executing custom creation script for database '{DatabaseName}':{NewLine}{Script}", npgsqlDatabase.DatabaseName, Environment.NewLine, script);
+                logger.LogInformation("Executing custom creation script for database '{DatabaseName}'", npgsqlDatabase.DatabaseName);
             }
 
             var rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -737,7 +737,7 @@ public static class PostgresBuilderExtensions
             var commandText = scriptAnnotation?.Script ?? $"CREATE DATABASE {quotedDatabaseIdentifier}";
             command.CommandText = commandText;
 
-            if (scriptAnnotation?.Script is { } script)
+            if (scriptAnnotation?.Script is not null)
             {
                 logger.LogInformation("Executing custom creation script for database '{DatabaseName}'", npgsqlDatabase.DatabaseName);
             }

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -734,8 +734,21 @@ public static class PostgresBuilderExtensions
         {
             var quotedDatabaseIdentifier = new NpgsqlCommandBuilder().QuoteIdentifier(npgsqlDatabase.DatabaseName);
             using var command = npgsqlConnection.CreateCommand();
-            command.CommandText = scriptAnnotation?.Script ?? $"CREATE DATABASE {quotedDatabaseIdentifier}";
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            var commandText = scriptAnnotation?.Script ?? $"CREATE DATABASE {quotedDatabaseIdentifier}";
+            command.CommandText = commandText;
+
+            if (scriptAnnotation?.Script is { } script)
+            {
+                logger.LogInformation("Executing custom creation script for database '{DatabaseName}':{NewLine}{Script}", npgsqlDatabase.DatabaseName, Environment.NewLine, script);
+            }
+
+            var rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+            if (scriptAnnotation?.Script is not null)
+            {
+                logger.LogInformation("Completed custom creation script for database '{DatabaseName}' with {RowsAffected} rows affected", npgsqlDatabase.DatabaseName, rowsAffected);
+            }
+
             logger.LogDebug("Database '{DatabaseName}' created successfully", npgsqlDatabase.DatabaseName);
         }
         catch (PostgresException p) when (p.SqlState == "42P04")

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -320,7 +320,10 @@ public static partial class SqlServerBuilderExtensions
                     }
                 }
 
-                logger.LogInformation("Completed custom creation script for database '{DatabaseName}'", sqlDatabase.DatabaseName);
+                if (batchNumber > 0)
+                {
+                    logger.LogInformation("Completed custom creation script for database '{DatabaseName}'", sqlDatabase.DatabaseName);
+                }
             }
 
             logger.LogDebug("Database '{DatabaseName}' created successfully", sqlDatabase.DatabaseName);
@@ -332,7 +335,7 @@ public static partial class SqlServerBuilderExtensions
 
         async Task ExecuteBatchAsync(string batch, int batchNumber, int executionCount, CancellationToken cancellationToken)
         {
-            logger.LogInformation("Executing custom creation script batch {BatchNumber} for database '{DatabaseName}':{NewLine}{Batch}", batchNumber, sqlDatabase.DatabaseName, Environment.NewLine, batch);
+            logger.LogInformation("Executing custom creation script batch {BatchNumber} for database '{DatabaseName}'", batchNumber, sqlDatabase.DatabaseName);
 
             for (var i = 0; i < executionCount; i++)
             {

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -277,8 +277,10 @@ public static partial class SqlServerBuilderExtensions
             }
             else
             {
+                logger.LogInformation("Executing custom creation script for database '{DatabaseName}'", sqlDatabase.DatabaseName);
                 using var reader = new StringReader(scriptAnnotation.Script);
                 var batchBuilder = new StringBuilder();
+                var batchNumber = 0;
 
                 while (reader.ReadLine() is { } line)
                 {
@@ -286,15 +288,13 @@ public static partial class SqlServerBuilderExtensions
 
                     if (matchGo.Success)
                     {
-                        // Execute the current batch
                         var count = matchGo.Groups["repeat"].Success ? int.Parse(matchGo.Groups["repeat"].Value, CultureInfo.InvariantCulture) : 1;
                         var batch = batchBuilder.ToString();
 
-                        for (var i = 0; i < count; i++)
+                        if (!string.IsNullOrWhiteSpace(batch))
                         {
-                            using var command = sqlConnection.CreateCommand();
-                            command.CommandText = batch;
-                            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                            batchNumber++;
+                            await ExecuteBatchAsync(batch, batchNumber, count, ct).ConfigureAwait(false);
                         }
 
                         batchBuilder.Clear();
@@ -312,10 +312,15 @@ public static partial class SqlServerBuilderExtensions
                 // Process the remaining batch lines
                 if (batchBuilder.Length > 0)
                 {
-                    using var command = sqlConnection.CreateCommand();
-                    command.CommandText = batchBuilder.ToString();
-                    await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                    var batch = batchBuilder.ToString();
+                    if (!string.IsNullOrWhiteSpace(batch))
+                    {
+                        batchNumber++;
+                        await ExecuteBatchAsync(batch, batchNumber, 1, ct).ConfigureAwait(false);
+                    }
                 }
+
+                logger.LogInformation("Completed custom creation script for database '{DatabaseName}'", sqlDatabase.DatabaseName);
             }
 
             logger.LogDebug("Database '{DatabaseName}' created successfully", sqlDatabase.DatabaseName);
@@ -323,6 +328,20 @@ public static partial class SqlServerBuilderExtensions
         catch (Exception e)
         {
             logger.LogError(e, "Failed to create database '{DatabaseName}'", sqlDatabase.DatabaseName);
+        }
+
+        async Task ExecuteBatchAsync(string batch, int batchNumber, int executionCount, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Executing custom creation script batch {BatchNumber} for database '{DatabaseName}':{NewLine}{Batch}", batchNumber, sqlDatabase.DatabaseName, Environment.NewLine, batch);
+
+            for (var i = 0; i < executionCount; i++)
+            {
+                using var command = sqlConnection.CreateCommand();
+                command.CommandText = batch;
+                var rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+                logger.LogInformation("Completed custom creation script batch {BatchNumber} execution {ExecutionNumber}/{ExecutionCount} for database '{DatabaseName}' with {RowsAffected} rows affected", batchNumber, i + 1, executionCount, sqlDatabase.DatabaseName, rowsAffected);
+            }
         }
     }
 }

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -340,7 +340,16 @@ public static partial class SqlServerBuilderExtensions
                 command.CommandText = batch;
                 var rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
-                logger.LogInformation("Completed custom creation script batch {BatchNumber} execution {ExecutionNumber}/{ExecutionCount} for database '{DatabaseName}' with {RowsAffected} rows affected", batchNumber, i + 1, executionCount, sqlDatabase.DatabaseName, rowsAffected);
+                // ADO.NET returns -1 for DDL statements (CREATE DATABASE, USE, etc.) because they don't affect data rows.
+                // Only include the rows-affected count when it carries meaningful information.
+                if (rowsAffected >= 0)
+                {
+                    logger.LogInformation("Completed custom creation script batch {BatchNumber} execution {ExecutionNumber}/{ExecutionCount} for database '{DatabaseName}' ({RowsAffected} rows affected)", batchNumber, i + 1, executionCount, sqlDatabase.DatabaseName, rowsAffected);
+                }
+                else
+                {
+                    logger.LogInformation("Completed custom creation script batch {BatchNumber} execution {ExecutionNumber}/{ExecutionCount} for database '{DatabaseName}'", batchNumber, i + 1, executionCount, sqlDatabase.DatabaseName);
+                }
             }
         }
     }

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -671,6 +671,13 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
 
         await app.ResourceNotifications.WaitForResourceHealthyAsync(newDb.Resource.Name, cts.Token);
 
+        // Verify that the resource logger emitted feedback about the custom creation script.
+        // Logs are attributed to the parent server resource, not the database resource.
+        await app.WaitForAllTextAsync(
+            ["Executing custom creation script for database", "Completed custom creation script for database"],
+            resourceName: mysql.Resource.Name,
+            cts.Token);
+
         // Test SqlConnection
         await pipeline.ExecuteAsync(async token =>
         {

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -629,6 +629,13 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
 
         await app.ResourceNotifications.WaitForResourceHealthyAsync(newDb.Resource.Name, cts.Token);
 
+        // Verify that the resource logger emitted feedback about the custom creation script.
+        // Logs are attributed to the parent server resource, not the database resource.
+        await app.WaitForAllTextAsync(
+            ["Executing custom creation script for database", "Completed custom creation script for database"],
+            resourceName: postgres.Resource.Name,
+            cts.Token);
+
         var conn = host.Services.GetRequiredService<NpgsqlConnection>();
 
         if (conn.State != ConnectionState.Open)

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -6,6 +6,7 @@
 using System.Data;
 using Aspire.TestUtilities;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
@@ -379,6 +380,13 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
         await host.StartAsync();
 
         await app.ResourceNotifications.WaitForResourceHealthyAsync(newDb.Resource.Name, cts.Token);
+
+        // Verify that the resource logger emitted feedback about the custom creation script.
+        // Logs are attributed to the parent server resource, not the database resource.
+        await app.WaitForAllTextAsync(
+            ["Executing custom creation script for database", "Completed custom creation script for database"],
+            resourceName: sqlserver.Resource.Name,
+            cts.Token);
 
         // Test SqlConnection
         await pipeline.ExecuteAsync(async token =>


### PR DESCRIPTION
Fixes #9228

## Summary

When a custom database creation script is provided via `WithCreationScript(...)`, the resource logger now emits informational messages showing what is being executed and what the outcome was. Previously only generic "Creating database" / "created successfully" / "Failed to create database" messages were logged, with no visibility into the custom script itself.

## Changes

### SQL Server (`Aspire.Hosting.SqlServer`)
- Logs that custom script execution is starting
- For each `GO`-delimited batch: logs the batch content and rows affected per execution
- Logs overall script completion

### PostgreSQL (`Aspire.Hosting.PostgreSQL`)
- Logs custom script content before execution
- Logs rows affected on completion
- Default (no `WithCreationScript`) path is unchanged

### MySQL (`Aspire.Hosting.MySql`)
- Logs custom script content before execution
- Logs rows affected on completion
- Default (no `WithCreationScript`) path is unchanged

### Azure Kusto (`Aspire.Hosting.Azure.Kusto`)
- Detects custom annotation vs. default generated command
- When a custom script is present: logs script content before execution and logs completion

## Testing

All non-Docker unit tests pass:
- SQL Server: 65/65 ✅
- PostgreSQL: 106/106 ✅
- MySQL: 65/65 ✅
- Kusto (unit tests): 52/52 ✅