### PR TITLE
Use aligned grid for DisplayIncompatibleVersionError

### DIFF
--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -49,6 +49,7 @@ internal sealed class RenderCommand : BaseCommand
         ["markdown-plain"] = "Render markdown as plain text with DisplayRawText (non-interactive)",
         ["markdown-renderable"] = "Render markdown via ConvertToRenderable with ANSI disabled",
         ["links"] = "Render terminal links with SafeLink and SafeFileLink",
+        ["incompatible-version-error"] = "Display incompatible version error (borderless table)",
         ["debug-activities"] = "Debug pipeline activities (calls ProcessPublishingActivitiesDebugAsync)",
         ["pipeline-activities"] = "Pipeline activities with spinner (calls ProcessAndDisplayPublishingActivitiesAsync)",
         ["publish-summary-all"] = "Publish summary timeline (stress scenarios)",
@@ -183,6 +184,8 @@ internal sealed class RenderCommand : BaseCommand
                     return TestMarkdownRenderRenderable();
                 case "links":
                     return await TestLinksAsync(cancellationToken);
+                case "incompatible-version-error":
+                    return TestIncompatibleVersionError();
                 case "debug-activities":
                     return await RenderDebugActivitiesAsync(cancellationToken);
                 case "pipeline-activities":
@@ -448,6 +451,15 @@ internal sealed class RenderCommand : BaseCommand
         InteractionService.DisplayMarkupLine($"SafeFileLink: {MarkupHelpers.SafeFileLink(InteractionService, filePath)}");
 
         return CliExitCodes.Success;
+    }
+
+    private int TestIncompatibleVersionError()
+    {
+        var ex = new AppHostIncompatibleException(
+            "The AppHost is not compatible with this version of the Aspire CLI.",
+            requiredCapability: "baseline.v2",
+            aspireHostingVersion: "9.2.0");
+        return InteractionService.DisplayIncompatibleVersionError(ex, ex.AspireHostingVersion ?? ex.RequiredCapability);
     }
 
     private int RenderPublishSummaryScenarios(IEnumerable<string> scenarioKeys)

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -468,10 +468,20 @@ internal class ConsoleInteractionService : IInteractionService
 
         DisplayError(errorMessage);
         MessageConsole.WriteLine();
-        MessageConsole.MarkupLine(
-            $"\t[bold]{InteractionServiceStrings.AspireHostingSDKVersion}[/]: {appHostHostingVersion.EscapeMarkup()}");
-        MessageConsole.MarkupLine($"\t[bold]{InteractionServiceStrings.AspireCLIVersion}[/]: {cliInformationalVersion.EscapeMarkup()}");
-        MessageConsole.MarkupLine($"\t[bold]{InteractionServiceStrings.RequiredCapability}[/]: {ex.RequiredCapability.EscapeMarkup()}");
+
+        var grid = new Grid();
+        grid.AddColumn(new GridColumn { Padding = new Padding(2, 0, 1, 0), NoWrap = true });
+        grid.AddColumn(new GridColumn { Padding = new Padding(0) });
+        grid.AddRow(
+            new Markup($"[bold]{InteractionServiceStrings.AspireHostingSDKVersion.EscapeMarkup()}[/]"),
+            new Markup(appHostHostingVersion.EscapeMarkup()));
+        grid.AddRow(
+            new Markup($"[bold]{InteractionServiceStrings.AspireCLIVersion.EscapeMarkup()}[/]"),
+            new Markup(cliInformationalVersion.EscapeMarkup()));
+        grid.AddRow(
+            new Markup($"[bold]{InteractionServiceStrings.RequiredCapability.EscapeMarkup()}[/]"),
+            new Markup(ex.RequiredCapability.EscapeMarkup()));
+        MessageConsole.Write(grid);
 
         if (updateCommand is not null)
         {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -88,7 +88,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Aspire CLI Version.
+        ///   Looks up a localized string similar to Aspire CLI version.
         /// </summary>
         public static string AspireCLIVersion {
             get {
@@ -97,7 +97,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Aspire.Hosting Version.
+        ///   Looks up a localized string similar to Aspire.Hosting version.
         /// </summary>
         public static string AspireHostingSDKVersion {
             get {
@@ -376,7 +376,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Required Capability.
+        ///   Looks up a localized string similar to Required capability.
         /// </summary>
         public static string RequiredCapability {
             get {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -131,13 +131,13 @@
     <value>The Aspire CLI is older than the Aspire version used by the AppHost. Update the Aspire CLI to continue.</value>
   </data>
   <data name="AspireHostingSDKVersion" xml:space="preserve">
-    <value>Aspire.Hosting Version</value>
+    <value>Aspire.Hosting version</value>
   </data>
   <data name="AspireCLIVersion" xml:space="preserve">
-    <value>Aspire CLI Version</value>
+    <value>Aspire CLI version</value>
   </data>
   <data name="RequiredCapability" xml:space="preserve">
-    <value>Required Capability</value>
+    <value>Required capability</value>
   </data>
   <data name="Dashboard" xml:space="preserve">
     <value>Dashboard</value>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Verze Aspire CLI</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Verze Aspire CLI</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Verze Aspire.Hosting</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Verze Aspire.Hosting</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">Požadovaná funkce</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">Požadovaná funkce</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Aspire CLI-Version</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Aspire CLI-Version</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Apsire.Hosting-Version</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Apsire.Hosting-Version</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">Erforderliche Funktion</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">Erforderliche Funktion</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Versión de la CLI de Aspire</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Versión de la CLI de Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Versión de Aspire.Hosting</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Versión de Aspire.Hosting</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">Funcionalidad requerida</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">Funcionalidad requerida</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Version de l’interface CLI Aspire</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Version de l’interface CLI Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Version d’Aspire.Hosting</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Version d’Aspire.Hosting</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">Capacité requise</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">Capacité requise</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Versione dell'interfaccia della riga di comando Aspire</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Versione dell'interfaccia della riga di comando Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Versione di Aspire.Hosting</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Versione di Aspire.Hosting</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">Funzionalità richiesta</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">Funzionalità richiesta</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Aspire CLI バージョン</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Aspire CLI バージョン</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Aspire.Hosting バージョン</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Aspire.Hosting バージョン</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">必要な機能</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">必要な機能</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Aspire CLI 버전</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Aspire CLI 버전</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Aspire.Hosting 버전</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Aspire.Hosting 버전</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">필수 기능</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">필수 기능</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Wersja interfejsu wiersza polecenia platformy Aspire</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Wersja interfejsu wiersza polecenia platformy Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Wersja Aspire.Hosting</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Wersja Aspire.Hosting</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">Wymagana możliwość</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">Wymagana możliwość</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Versão da CLI do Aspire</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Versão da CLI do Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Versão do Aspire.Hosting</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Versão do Aspire.Hosting</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">Funcionalidade Necessária</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">Funcionalidade Necessária</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Версия CLI Aspire</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Версия CLI Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Версия Aspire.Hosting</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Версия Aspire.Hosting</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">Нужная возможность</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">Нужная возможность</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Aspire CLI Sürümü</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Aspire CLI Sürümü</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Aspire.Hosting Sürümü</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Aspire.Hosting Sürümü</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">Gerekli Yetenek</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">Gerekli Yetenek</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Aspire CLI 版本</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Aspire CLI 版本</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Aspire.Hosting 版本</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Aspire.Hosting 版本</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">所需功能</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">所需功能</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireCLIVersion">
-        <source>Aspire CLI Version</source>
-        <target state="translated">Aspire CLI 版本</target>
+        <source>Aspire CLI version</source>
+        <target state="needs-review-translation">Aspire CLI 版本</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">
-        <source>Aspire.Hosting Version</source>
-        <target state="translated">Aspire.Hosting 版本</target>
+        <source>Aspire.Hosting version</source>
+        <target state="needs-review-translation">Aspire.Hosting 版本</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildingAppHost">
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RequiredCapability">
-        <source>Required Capability</source>
-        <target state="translated">必要的功能</target>
+        <source>Required capability</source>
+        <target state="needs-review-translation">必要的功能</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingProjects">


### PR DESCRIPTION
## Summary

Replace tab-prefixed `MarkupLine` calls in `DisplayIncompatibleVersionError` with a Spectre.Console `Grid` so the version details align in a column with 2-char indentation.

**Before:**
```
	Aspire.Hosting Version: 9.2.0
	Aspire CLI Version: 9.1.0
	Required Capability: baseline.v2
```

<img width="1451" height="219" alt="image" src="https://github.com/user-attachments/assets/2524c2f0-351c-4396-92e6-a848ba371b38" />

**After:**
```
  Aspire.Hosting version 9.2.0
  Aspire CLI version     9.1.0
  Required capability    baseline.v2
```

<img width="1433" height="223" alt="image" src="https://github.com/user-attachments/assets/83b9fee4-e0e7-4d28-b0c0-283eab30828d" />

## Changes

- Use a `Grid` with `NoWrap` first column and padding for aligned key-value display
- Lowercase labels for consistency with CLI output conventions
- Add `incompatible-version-error` scenario to the debug `render` command for visual testing

Fixes #18090