### PR TITLE
ci: force-rerun all failed CI jobs (FORCE_RERUN_ALL)

### DIFF
--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -6,11 +6,12 @@
 // makes the workflow rerun EVERY failed CI job for a run when enabled (via the YAML
 // `FORCE_RERUN_ALL` env var), bypassing:
 //   1. the 4-pass transient-failure classification (every non-ignored failed job
-//      becomes retryable),
-//   2. the retryable-job-count cap in computeRerunEligibility, and
-//   3. the open-PR gate in the YAML orchestration / rerunMatchedJobs.
-// It deliberately KEEPS the attempt cap (up to 3 auto-reruns / 4 total attempts),
-// the aggregator-job exclusion (ignoredJobs), and the failureConclusions filter.
+//      becomes retryable), and
+//   2. the retryable-job-count cap in computeRerunEligibility.
+// It deliberately KEEPS the open-PR requirement (reruns only fire for runs that have
+// a currently-open associated PR — there is no point spending CI on closed/merged
+// PRs), the attempt cap (up to 3 auto-reruns / 4 total attempts), the aggregator-job
+// exclusion (ignoredJobs), and the failureConclusions filter.
 // The transient-classification rules and the patterns config are left intact behind
 // this flag. `forceRerunAll` defaults to false everywhere so the existing unit tests
 // keep exercising the normal classification/eligibility behavior.
@@ -882,11 +883,10 @@ async function rerunMatchedJobs({
         pullRequestNumbers,
     });
 
-    // FORCE_RERUN_ALL: bypass the open-PR gate. Normally a rerun is
-    // skipped when every associated PR is closed; in force mode we rerun anyway. PR
-    // comments are still only posted to PRs that are currently open (closed PRs are
-    // not commented on). See the file-level comment for how to disable.
-    if (!forceRerunAll && pullRequestNumbers.length > 0 && openPullRequestNumbers.length === 0) {
+    // The open-PR gate applies in all modes (including force mode): a rerun is
+    // skipped when every associated PR is closed. There is no value in spending CI on
+    // a closed/merged PR, so force mode does NOT bypass this.
+    if (pullRequestNumbers.length > 0 && openPullRequestNumbers.length === 0) {
         const failedAttemptReference = buildWorkflowRunReference(sourceRunUrl, sourceRunAttempt);
         await summary
             .addHeading('Rerun skipped');

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -1,4 +1,23 @@
 // Shared matcher, summary, and rerun helpers for the transient CI rerun workflow.
+//
+// TEMPORARY — FORCE_RERUN_ALL:
+// The `forceRerunAll` parameter threaded through analyzeFailedJobs,
+// computeRerunEligibility, computeRerunExecutionEligibility, and rerunMatchedJobs
+// is a temporary, easily-revertible measure. When enabled (via the YAML
+// `FORCE_RERUN_ALL` env var) it makes the workflow rerun EVERY failed CI job for a
+// run, bypassing:
+//   1. the 4-pass transient-failure classification (every non-ignored failed job
+//      becomes retryable),
+//   2. the retryable-job-count cap in computeRerunEligibility, and
+//   3. the open-PR gate in the YAML orchestration / rerunMatchedJobs.
+// It deliberately KEEPS the attempt cap (up to 3 auto-reruns / 4 total attempts),
+// the aggregator-job exclusion (ignoredJobs), and the failureConclusions filter.
+// The transient-classification rules and the patterns config are left intact behind
+// this flag. `forceRerunAll` defaults to false everywhere so the existing unit tests
+// keep exercising the normal classification/eligibility behavior.
+// REVERT THIS before it is no longer needed: flip FORCE_RERUN_ALL to 'false' (or
+// remove the env var) in the YAML, and ideally remove this force-mode plumbing.
+// Do not merge force mode to main long-term.
 const fs = require('node:fs');
 
 const failureConclusions = new Set(['failure', 'cancelled', 'timed_out', 'startup_failure']);
@@ -435,6 +454,7 @@ async function analyzeFailedJobs({
     getJobLogTextForJob,
     maxRetryableJobs = defaultMaxRetryableJobs,
     retryPatternsConfig = null,
+    forceRerunAll = false,
 }) {
     const normalizedMaxRetryableJobs =
         Number.isInteger(maxRetryableJobs) && maxRetryableJobs >= 0
@@ -444,6 +464,24 @@ async function analyzeFailedJobs({
     const retryableJobs = [];
     const skippedJobs = [];
     const jobFailurePatterns = retryPatternsConfig?.jobFailurePatterns;
+
+    // TEMPORARY (FORCE_RERUN_ALL): skip every classification pass and mark all
+    // failed (non-ignored) jobs as retryable. The failureConclusions / ignoredJobs
+    // filtering above still defines what counts as a failed CI job. See the
+    // file-level comment for the revert procedure.
+    if (forceRerunAll) {
+        for (const job of failedJobs) {
+            retryableJobs.push({
+                id: job.id,
+                name: job.name,
+                htmlUrl: job.html_url || null,
+                failedSteps: getFailedSteps(job),
+                reason: 'Force-rerun mode (temporary): bypassing transient-failure analysis.',
+            });
+        }
+
+        return { failedJobs, retryableJobs, skippedJobs };
+    }
 
     for (const job of failedJobs) {
         const failedSteps = getFailedSteps(job);
@@ -518,10 +556,17 @@ function computeRerunEligibility({
     retryableCount,
     maxRetryableJobs = defaultMaxRetryableJobs,
     runAttempt = 1,
-    maxRunAttempt = defaultMaxRunAttempt
+    maxRunAttempt = defaultMaxRunAttempt,
+    forceRerunAll = false
 }) {
     if (retryableCount <= 0 || runAttempt > maxRunAttempt) {
         return false;
+    }
+
+    // TEMPORARY (FORCE_RERUN_ALL): skip the job-count cap but keep the attempt cap
+    // (already enforced above). See the file-level comment for the revert procedure.
+    if (forceRerunAll) {
+        return true;
     }
 
     // For attempts after the first (runAttempt > 1) apply a stricter cap:
@@ -537,9 +582,10 @@ function computeRerunExecutionEligibility({
     retryableCount,
     maxRetryableJobs = defaultMaxRetryableJobs,
     runAttempt = 1,
-    maxRunAttempt = defaultMaxRunAttempt
+    maxRunAttempt = defaultMaxRunAttempt,
+    forceRerunAll = false
 }) {
-    return !dryRun && computeRerunEligibility({ retryableCount, maxRetryableJobs, runAttempt, maxRunAttempt });
+    return !dryRun && computeRerunEligibility({ retryableCount, maxRetryableJobs, runAttempt, maxRunAttempt, forceRerunAll });
 }
 
 function buildSummaryReference(url, text) {
@@ -803,6 +849,7 @@ async function rerunMatchedJobs({
     sourceRunUrl,
     sourceRunAttempt,
     testPatternMatchedTests = [],
+    forceRerunAll = false,
 }) {
     if (retryableJobs.length === 0) {
         return;
@@ -815,7 +862,11 @@ async function rerunMatchedJobs({
         pullRequestNumbers,
     });
 
-    if (pullRequestNumbers.length > 0 && openPullRequestNumbers.length === 0) {
+    // TEMPORARY (FORCE_RERUN_ALL): bypass the open-PR gate. Normally a rerun is
+    // skipped when every associated PR is closed; in force mode we rerun anyway and
+    // still post a comment on any PR numbers we know about. See the file-level
+    // comment for the revert procedure.
+    if (!forceRerunAll && pullRequestNumbers.length > 0 && openPullRequestNumbers.length === 0) {
         const failedAttemptReference = buildWorkflowRunReference(sourceRunUrl, sourceRunAttempt);
         await summary
             .addHeading('Rerun skipped');

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -640,6 +640,7 @@ async function writeAnalysisSummary({
     sourceRunUrl,
     sourceRunAttempt,
     testPatternMatchedTests = [],
+    forceRerunAll = false,
 }) {
     const analyzedRunReference = buildSummaryReference(
         buildWorkflowRunAttemptUrl(sourceRunUrl, sourceRunAttempt),
@@ -648,13 +649,22 @@ async function writeAnalysisSummary({
             : 'workflow run'
     );
     const outcome = rerunEligible ? 'Rerun eligible' : 'Rerun skipped';
+    // TEMPORARY (FORCE_RERUN_ALL): in force mode the jobs were not classified as
+    // retry-safe (analysis was bypassed) and the job-count cap does not apply, so use
+    // wording that does not claim a transient-failure match. See the file-level comment.
     const outcomeDetails = rerunEligible
-        ? dryRun
-            ? `Matched ${retryableJobs.length} retry-safe job${retryableJobs.length === 1 ? '' : 's'} that would be rerun if dry run were disabled.`
-            : `Matched ${retryableJobs.length} retry-safe job${retryableJobs.length === 1 ? '' : 's'} for rerun.`
+        ? forceRerunAll
+            ? dryRun
+                ? `Force-rerun mode (temporary): ${retryableJobs.length} failed job${retryableJobs.length === 1 ? '' : 's'} would be rerun if dry run were disabled (transient-failure analysis bypassed).`
+                : `Force-rerun mode (temporary): re-running ${retryableJobs.length} failed job${retryableJobs.length === 1 ? '' : 's'} (transient-failure analysis bypassed).`
+            : dryRun
+                ? `Matched ${retryableJobs.length} retry-safe job${retryableJobs.length === 1 ? '' : 's'} that would be rerun if dry run were disabled.`
+                : `Matched ${retryableJobs.length} retry-safe job${retryableJobs.length === 1 ? '' : 's'} for rerun.`
         : retryableJobs.length === 0
-            ? 'No retry-safe jobs were found in the analyzed run.'
-            : retryableJobs.length > maxRetryableJobs
+            ? forceRerunAll
+                ? 'No failed jobs were found in the analyzed run.'
+                : 'No retry-safe jobs were found in the analyzed run.'
+            : (!forceRerunAll && retryableJobs.length > maxRetryableJobs)
                 ? `Matched ${retryableJobs.length} jobs, which exceeds the cap of ${maxRetryableJobs}.`
                 : 'The analyzed run did not satisfy the workflow safety rails for reruns.';
     const summaryRows = [
@@ -784,11 +794,21 @@ function buildPullRequestCommentBody({
     rerunAttemptUrl,
     retryableJobs,
     testPatternMatchedTests = [],
+    forceRerunAll = false,
 }) {
+    // TEMPORARY (FORCE_RERUN_ALL): in force mode the jobs were rerun without
+    // transient-failure analysis, so the comment must not claim they "matched the
+    // retry-safe transient failure rules." See the file-level comment.
+    const introLine = forceRerunAll
+        ? `Re-running the failed jobs in the CI workflow for this pull request. Force-rerun mode (temporary) is enabled, so all ${retryableJobs.length} failed job${retryableJobs.length === 1 ? '' : 's'} from ${formatMarkdownLink('the CI run attempt', failedAttemptUrl)} ${retryableJobs.length === 1 ? 'is' : 'are'} being rerun without transient-failure analysis.`
+        : `Re-running the failed jobs in the CI workflow for this pull request because ${retryableJobs.length} job${retryableJobs.length === 1 ? ' was' : 's were'} identified as retry-safe transient failures in ${formatMarkdownLink('the CI run attempt', failedAttemptUrl)}.`;
+    const jobListLine = forceRerunAll
+        ? 'The job links below point to the failed attempt jobs that will be rerun.'
+        : 'The job links below point to the failed attempt jobs that matched the retry-safe transient failure rules.';
     const lines = [
-        `Re-running the failed jobs in the CI workflow for this pull request because ${retryableJobs.length} job${retryableJobs.length === 1 ? ' was' : 's were'} identified as retry-safe transient failures in ${formatMarkdownLink('the CI run attempt', failedAttemptUrl)}.`,
+        introLine,
         `GitHub was asked to rerun all failed jobs for that attempt, and the rerun is being tracked in ${formatMarkdownLink('the rerun attempt', rerunAttemptUrl)}.`,
-        'The job links below point to the failed attempt jobs that matched the retry-safe transient failure rules.',
+        jobListLine,
         '',
         ...retryableJobs.map(job => {
             const jobReference = job.htmlUrl
@@ -863,9 +883,9 @@ async function rerunMatchedJobs({
     });
 
     // TEMPORARY (FORCE_RERUN_ALL): bypass the open-PR gate. Normally a rerun is
-    // skipped when every associated PR is closed; in force mode we rerun anyway and
-    // still post a comment on any PR numbers we know about. See the file-level
-    // comment for the revert procedure.
+    // skipped when every associated PR is closed; in force mode we rerun anyway. PR
+    // comments are still only posted to PRs that are currently open (closed PRs are
+    // not commented on). See the file-level comment for the revert procedure.
     if (!forceRerunAll && pullRequestNumbers.length > 0 && openPullRequestNumbers.length === 0) {
         const failedAttemptReference = buildWorkflowRunReference(sourceRunUrl, sourceRunAttempt);
         await summary
@@ -921,6 +941,7 @@ async function rerunMatchedJobs({
                 rerunAttemptUrl: rerunAttemptReference.url,
                 retryableJobs,
                 testPatternMatchedTests,
+                forceRerunAll,
             }),
         });
     }

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -1,11 +1,10 @@
 // Shared matcher, summary, and rerun helpers for the transient CI rerun workflow.
 //
-// TEMPORARY — FORCE_RERUN_ALL:
+// FORCE_RERUN_ALL:
 // The `forceRerunAll` parameter threaded through analyzeFailedJobs,
 // computeRerunEligibility, computeRerunExecutionEligibility, and rerunMatchedJobs
-// is a temporary, easily-revertible measure. When enabled (via the YAML
-// `FORCE_RERUN_ALL` env var) it makes the workflow rerun EVERY failed CI job for a
-// run, bypassing:
+// makes the workflow rerun EVERY failed CI job for a run when enabled (via the YAML
+// `FORCE_RERUN_ALL` env var), bypassing:
 //   1. the 4-pass transient-failure classification (every non-ignored failed job
 //      becomes retryable),
 //   2. the retryable-job-count cap in computeRerunEligibility, and
@@ -15,9 +14,10 @@
 // The transient-classification rules and the patterns config are left intact behind
 // this flag. `forceRerunAll` defaults to false everywhere so the existing unit tests
 // keep exercising the normal classification/eligibility behavior.
-// REVERT THIS before it is no longer needed: flip FORCE_RERUN_ALL to 'false' (or
-// remove the env var) in the YAML, and ideally remove this force-mode plumbing.
-// Do not merge force mode to main long-term.
+//
+// This is a for-now measure until CI auto-rerun patterns are improved (e.g. agents
+// curating the transient-failure rules). To disable: flip FORCE_RERUN_ALL to 'false'
+// (or remove the env var) on both jobs in the YAML.
 const fs = require('node:fs');
 
 const failureConclusions = new Set(['failure', 'cancelled', 'timed_out', 'startup_failure']);
@@ -465,10 +465,10 @@ async function analyzeFailedJobs({
     const skippedJobs = [];
     const jobFailurePatterns = retryPatternsConfig?.jobFailurePatterns;
 
-    // TEMPORARY (FORCE_RERUN_ALL): skip every classification pass and mark all
+    // FORCE_RERUN_ALL: skip every classification pass and mark all
     // failed (non-ignored) jobs as retryable. The failureConclusions / ignoredJobs
     // filtering above still defines what counts as a failed CI job. See the
-    // file-level comment for the revert procedure.
+    // file-level comment for how to disable.
     if (forceRerunAll) {
         for (const job of failedJobs) {
             retryableJobs.push({
@@ -476,7 +476,7 @@ async function analyzeFailedJobs({
                 name: job.name,
                 htmlUrl: job.html_url || null,
                 failedSteps: getFailedSteps(job),
-                reason: 'Force-rerun mode (temporary): bypassing transient-failure analysis.',
+                reason: 'Force-rerun mode: bypassing transient-failure analysis.',
             });
         }
 
@@ -563,8 +563,8 @@ function computeRerunEligibility({
         return false;
     }
 
-    // TEMPORARY (FORCE_RERUN_ALL): skip the job-count cap but keep the attempt cap
-    // (already enforced above). See the file-level comment for the revert procedure.
+    // FORCE_RERUN_ALL: skip the job-count cap but keep the attempt cap
+    // (already enforced above). See the file-level comment for how to disable.
     if (forceRerunAll) {
         return true;
     }
@@ -649,14 +649,14 @@ async function writeAnalysisSummary({
             : 'workflow run'
     );
     const outcome = rerunEligible ? 'Rerun eligible' : 'Rerun skipped';
-    // TEMPORARY (FORCE_RERUN_ALL): in force mode the jobs were not classified as
+    // FORCE_RERUN_ALL: in force mode the jobs were not classified as
     // retry-safe (analysis was bypassed) and the job-count cap does not apply, so use
     // wording that does not claim a transient-failure match. See the file-level comment.
     const outcomeDetails = rerunEligible
         ? forceRerunAll
             ? dryRun
-                ? `Force-rerun mode (temporary): ${retryableJobs.length} failed job${retryableJobs.length === 1 ? '' : 's'} would be rerun if dry run were disabled (transient-failure analysis bypassed).`
-                : `Force-rerun mode (temporary): re-running ${retryableJobs.length} failed job${retryableJobs.length === 1 ? '' : 's'} (transient-failure analysis bypassed).`
+                ? `Force-rerun mode: ${retryableJobs.length} failed job${retryableJobs.length === 1 ? '' : 's'} would be rerun if dry run were disabled (transient-failure analysis bypassed).`
+                : `Force-rerun mode: re-running ${retryableJobs.length} failed job${retryableJobs.length === 1 ? '' : 's'} (transient-failure analysis bypassed).`
             : dryRun
                 ? `Matched ${retryableJobs.length} retry-safe job${retryableJobs.length === 1 ? '' : 's'} that would be rerun if dry run were disabled.`
                 : `Matched ${retryableJobs.length} retry-safe job${retryableJobs.length === 1 ? '' : 's'} for rerun.`
@@ -796,11 +796,11 @@ function buildPullRequestCommentBody({
     testPatternMatchedTests = [],
     forceRerunAll = false,
 }) {
-    // TEMPORARY (FORCE_RERUN_ALL): in force mode the jobs were rerun without
+    // FORCE_RERUN_ALL: in force mode the jobs were rerun without
     // transient-failure analysis, so the comment must not claim they "matched the
     // retry-safe transient failure rules." See the file-level comment.
     const introLine = forceRerunAll
-        ? `Re-running the failed jobs in the CI workflow for this pull request. Force-rerun mode (temporary) is enabled, so all ${retryableJobs.length} failed job${retryableJobs.length === 1 ? '' : 's'} from ${formatMarkdownLink('the CI run attempt', failedAttemptUrl)} ${retryableJobs.length === 1 ? 'is' : 'are'} being rerun without transient-failure analysis.`
+        ? `Re-running the failed jobs in the CI workflow for this pull request. Force-rerun mode is enabled, so all ${retryableJobs.length} failed job${retryableJobs.length === 1 ? '' : 's'} from ${formatMarkdownLink('the CI run attempt', failedAttemptUrl)} ${retryableJobs.length === 1 ? 'is' : 'are'} being rerun without transient-failure analysis.`
         : `Re-running the failed jobs in the CI workflow for this pull request because ${retryableJobs.length} job${retryableJobs.length === 1 ? ' was' : 's were'} identified as retry-safe transient failures in ${formatMarkdownLink('the CI run attempt', failedAttemptUrl)}.`;
     const jobListLine = forceRerunAll
         ? 'The job links below point to the failed attempt jobs that will be rerun.'
@@ -882,10 +882,10 @@ async function rerunMatchedJobs({
         pullRequestNumbers,
     });
 
-    // TEMPORARY (FORCE_RERUN_ALL): bypass the open-PR gate. Normally a rerun is
+    // FORCE_RERUN_ALL: bypass the open-PR gate. Normally a rerun is
     // skipped when every associated PR is closed; in force mode we rerun anyway. PR
     // comments are still only posted to PRs that are currently open (closed PRs are
-    // not commented on). See the file-level comment for the revert procedure.
+    // not commented on). See the file-level comment for how to disable.
     if (!forceRerunAll && pullRequestNumbers.length > 0 && openPullRequestNumbers.length === 0) {
         const failedAttemptReference = buildWorkflowRunReference(sourceRunUrl, sourceRunAttempt);
         await summary

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -65,6 +65,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           MANUAL_RUN_ID: ${{ inputs.run_id }}
           MANUAL_DRY_RUN: ${{ inputs.dry_run }}
+          # TEMPORARY (FORCE_RERUN_ALL): force-rerun EVERY failed CI job, bypassing the
+          # transient-failure classification, the retryable-job-count cap, and the open-PR
+          # gate. The attempt cap (up to 3 auto-reruns / 4 total attempts) is preserved.
+          # Revert by setting this to 'false' (or removing it). Do not keep this enabled
+          # on main long-term. See docs/ci/auto-rerun-transient-ci-failures.md.
+          FORCE_RERUN_ALL: 'true'
         with:
           script: |
             const rerunWorkflow = require('./.github/workflows/auto-rerun-transient-ci-failures.js');
@@ -77,6 +83,8 @@ jobs:
             const isWorkflowDispatch = context.eventName === 'workflow_dispatch';
             const maxRetryableJobs = rerunWorkflow.defaultMaxRetryableJobs;
             const maxJobLogInspectionBytes = 256 * 1024;
+            // TEMPORARY (FORCE_RERUN_ALL): see env comment above.
+            const forceRerunAll = String(process.env.FORCE_RERUN_ALL).toLowerCase() === 'true';
 
             async function paginate(route, parameters, selectItems) {
               const items = [];
@@ -224,7 +232,10 @@ jobs:
             });
             core.setOutput('pull_request_numbers', JSON.stringify(pullRequestNumbers));
 
-            if (pullRequestNumbers.length === 0) {
+            // TEMPORARY (FORCE_RERUN_ALL): in force mode, do not bail out when no PR is
+            // associated — still rerun the failed jobs. Outside force mode, keep the
+            // original behavior of skipping runs with no associated PR.
+            if (pullRequestNumbers.length === 0 && !forceRerunAll) {
               console.log('No associated pull request could be resolved for this workflow run. Skipping.');
               return;
             }
@@ -246,6 +257,7 @@ jobs:
               getJobLogTextForJob: async job => getJobLogText(job.id),
               maxRetryableJobs,
               retryPatternsConfig,
+              forceRerunAll,
             });
 
             // TRX-based analysis: check test output for transient patterns
@@ -341,12 +353,14 @@ jobs:
               retryableCount: retryableJobs.length,
               maxRetryableJobs,
               runAttempt,
+              forceRerunAll,
             });
             const rerunExecutionEligible = rerunWorkflow.computeRerunExecutionEligibility({
               dryRun,
               retryableCount: retryableJobs.length,
               maxRetryableJobs,
               runAttempt,
+              forceRerunAll,
             });
             core.setOutput('rerun_eligible', String(rerunEligible));
             core.setOutput('rerun_execution_eligible', String(rerunExecutionEligible));
@@ -396,6 +410,9 @@ jobs:
           SOURCE_RUN_ATTEMPT: ${{ needs.analyze-transient-failures.outputs.source_run_attempt }}
           SOURCE_RUN_URL: ${{ needs.analyze-transient-failures.outputs.source_run_url }}
           TEST_PATTERN_MATCHED_TESTS: ${{ needs.analyze-transient-failures.outputs.test_pattern_matched_tests }}
+          # TEMPORARY (FORCE_RERUN_ALL): bypass the open-PR gate so closed/absent PRs do
+          # not block the rerun. Keep this in sync with the analyze step's FORCE_RERUN_ALL.
+          FORCE_RERUN_ALL: 'true'
         with:
           script: |
             const rerunWorkflow = require('./.github/workflows/auto-rerun-transient-ci-failures.js');
@@ -407,6 +424,8 @@ jobs:
             const sourceRunAttempt = Number(process.env.SOURCE_RUN_ATTEMPT);
             const sourceRunUrl = process.env.SOURCE_RUN_URL;
             const testPatternMatchedTests = JSON.parse(process.env.TEST_PATTERN_MATCHED_TESTS || '[]');
+            // TEMPORARY (FORCE_RERUN_ALL): see env comment above.
+            const forceRerunAll = String(process.env.FORCE_RERUN_ALL).toLowerCase() === 'true';
 
             if (retryableJobs.length === 0) {
               console.log('No retryable jobs were provided to the rerun job.');
@@ -424,4 +443,5 @@ jobs:
               sourceRunAttempt,
               sourceRunUrl,
               testPatternMatchedTests,
+              forceRerunAll,
             });

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -66,11 +66,11 @@ jobs:
           MANUAL_RUN_ID: ${{ inputs.run_id }}
           MANUAL_DRY_RUN: ${{ inputs.dry_run }}
           # FORCE_RERUN_ALL: force-rerun EVERY failed CI job, bypassing the
-          # transient-failure classification, the retryable-job-count cap, and the open-PR
-          # gate. The attempt cap (up to 3 auto-reruns / 4 total attempts) is preserved.
-          # This is a for-now measure until CI auto-rerun patterns are improved; disable
-          # by setting this to 'false' (or removing it) on both jobs.
-          # See docs/ci/auto-rerun-transient-ci-failures.md.
+          # transient-failure classification and the retryable-job-count cap. The
+          # open-PR requirement and the attempt cap (up to 3 auto-reruns / 4 total
+          # attempts) are preserved. This is a for-now measure until CI auto-rerun
+          # patterns are improved; disable by setting this to 'false' (or removing it)
+          # on both jobs. See docs/ci/auto-rerun-transient-ci-failures.md.
           FORCE_RERUN_ALL: 'true'
         with:
           script: |
@@ -233,10 +233,10 @@ jobs:
             });
             core.setOutput('pull_request_numbers', JSON.stringify(pullRequestNumbers));
 
-            // FORCE_RERUN_ALL: in force mode, do not bail out when no PR is
-            // associated — still rerun the failed jobs. Outside force mode, keep the
-            // original behavior of skipping runs with no associated PR.
-            if (pullRequestNumbers.length === 0 && !forceRerunAll) {
+            // The open-PR requirement applies in all modes: skip runs with no
+            // associated PR. Force mode does not bypass this — there is no value in
+            // spending CI on a run that has no open PR behind it.
+            if (pullRequestNumbers.length === 0) {
               console.log('No associated pull request could be resolved for this workflow run. Skipping.');
               return;
             }
@@ -412,8 +412,9 @@ jobs:
           SOURCE_RUN_ATTEMPT: ${{ needs.analyze-transient-failures.outputs.source_run_attempt }}
           SOURCE_RUN_URL: ${{ needs.analyze-transient-failures.outputs.source_run_url }}
           TEST_PATTERN_MATCHED_TESTS: ${{ needs.analyze-transient-failures.outputs.test_pattern_matched_tests }}
-          # FORCE_RERUN_ALL: bypass the open-PR gate so closed/absent PRs do
-          # not block the rerun. Keep this in sync with the analyze step's FORCE_RERUN_ALL.
+          # FORCE_RERUN_ALL: drives the force-mode wording in the rerun summary and the
+          # PR comment (the jobs were rerun without transient-failure analysis). Keep
+          # this in sync with the analyze step's FORCE_RERUN_ALL.
           FORCE_RERUN_ALL: 'true'
         with:
           script: |

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -380,6 +380,7 @@ jobs:
               sourceRunUrl,
               sourceRunAttempt: runAttempt,
               testPatternMatchedTests,
+              forceRerunAll,
             });
 
             if (retryableJobs.length === 0) {

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -65,11 +65,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           MANUAL_RUN_ID: ${{ inputs.run_id }}
           MANUAL_DRY_RUN: ${{ inputs.dry_run }}
-          # TEMPORARY (FORCE_RERUN_ALL): force-rerun EVERY failed CI job, bypassing the
+          # FORCE_RERUN_ALL: force-rerun EVERY failed CI job, bypassing the
           # transient-failure classification, the retryable-job-count cap, and the open-PR
           # gate. The attempt cap (up to 3 auto-reruns / 4 total attempts) is preserved.
-          # Revert by setting this to 'false' (or removing it). Do not keep this enabled
-          # on main long-term. See docs/ci/auto-rerun-transient-ci-failures.md.
+          # This is a for-now measure until CI auto-rerun patterns are improved; disable
+          # by setting this to 'false' (or removing it) on both jobs.
+          # See docs/ci/auto-rerun-transient-ci-failures.md.
           FORCE_RERUN_ALL: 'true'
         with:
           script: |
@@ -83,7 +84,7 @@ jobs:
             const isWorkflowDispatch = context.eventName === 'workflow_dispatch';
             const maxRetryableJobs = rerunWorkflow.defaultMaxRetryableJobs;
             const maxJobLogInspectionBytes = 256 * 1024;
-            // TEMPORARY (FORCE_RERUN_ALL): see env comment above.
+            // FORCE_RERUN_ALL: see env comment above.
             const forceRerunAll = String(process.env.FORCE_RERUN_ALL).toLowerCase() === 'true';
 
             async function paginate(route, parameters, selectItems) {
@@ -232,7 +233,7 @@ jobs:
             });
             core.setOutput('pull_request_numbers', JSON.stringify(pullRequestNumbers));
 
-            // TEMPORARY (FORCE_RERUN_ALL): in force mode, do not bail out when no PR is
+            // FORCE_RERUN_ALL: in force mode, do not bail out when no PR is
             // associated — still rerun the failed jobs. Outside force mode, keep the
             // original behavior of skipping runs with no associated PR.
             if (pullRequestNumbers.length === 0 && !forceRerunAll) {
@@ -411,7 +412,7 @@ jobs:
           SOURCE_RUN_ATTEMPT: ${{ needs.analyze-transient-failures.outputs.source_run_attempt }}
           SOURCE_RUN_URL: ${{ needs.analyze-transient-failures.outputs.source_run_url }}
           TEST_PATTERN_MATCHED_TESTS: ${{ needs.analyze-transient-failures.outputs.test_pattern_matched_tests }}
-          # TEMPORARY (FORCE_RERUN_ALL): bypass the open-PR gate so closed/absent PRs do
+          # FORCE_RERUN_ALL: bypass the open-PR gate so closed/absent PRs do
           # not block the rerun. Keep this in sync with the analyze step's FORCE_RERUN_ALL.
           FORCE_RERUN_ALL: 'true'
         with:
@@ -425,7 +426,7 @@ jobs:
             const sourceRunAttempt = Number(process.env.SOURCE_RUN_ATTEMPT);
             const sourceRunUrl = process.env.SOURCE_RUN_URL;
             const testPatternMatchedTests = JSON.parse(process.env.TEST_PATTERN_MATCHED_TESTS || '[]');
-            // TEMPORARY (FORCE_RERUN_ALL): see env comment above.
+            // FORCE_RERUN_ALL: see env comment above.
             const forceRerunAll = String(process.env.FORCE_RERUN_ALL).toLowerCase() === 'true';
 
             if (retryableJobs.length === 0) {

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -21,7 +21,7 @@ CI run fails on PR
                ▼
 ┌──────────────────────────────────┐
 │  Safety rails                    │
-│  • ≤ 3 total attempts            │
+│  • attempts 1–3 → up to 3 reruns │
 │  • ≤ 5 retryable jobs (default)  │
 │  • PR must still be open         │
 └──────────────┬───────────────────┘
@@ -179,13 +179,34 @@ The workflow is intentionally conservative. All of these conditions must be met 
 
 | Rail | Detail |
 |------|--------|
-| **Attempt limit** | The source run must be on attempt ≤ 3 (allowing up to 2 automatic reruns, 3 total attempts). |
+| **Attempt limit** | The source run must be on attempt ≤ 3. Reruns are triggered from source attempts 1, 2, and 3, so a run gets up to 3 automatic reruns (4 total attempts) before the cap stops further reruns. |
 | **Retryable job cap** | At least 1 but no more than 5 retryable jobs (default). On attempts > 1, the cap is stricter: the count must be *strictly less than* 5. |
 | **Open PR** | At least one associated pull request must still be open. |
 | **Non-aggregator** | Aggregator jobs (`Final Results`, `Tests / Final Test Results`) are excluded from analysis. |
 | **Mixed-failure veto** | A job with both a test execution failure (`Run tests*`) and unrelated transient post-step noise is *not* retried on infrastructure grounds alone — the test execution failure must match a pattern (pass 3 or 4) to qualify. |
 
 When a rerun is requested, GitHub reruns **all** failed jobs for that attempt — not just the matched ones. This is a GitHub API constraint (there is no API for atomically rerunning a subset of failed jobs). The matched-job count and safety rails are the eligibility gate; once eligible, the rerun covers the full failed set.
+
+## ⚠️ Temporary: force-rerun all failures (`FORCE_RERUN_ALL`)
+
+> **This is a temporary, easily-revertible measure and must not stay on `main` long-term.**
+
+The workflow currently runs in **force mode**, enabled by the `FORCE_RERUN_ALL: 'true'` environment variable set on both jobs in [`auto-rerun-transient-ci-failures.yml`](../../.github/workflows/auto-rerun-transient-ci-failures.yml). In force mode the workflow requests a rerun on **any** failed CI run for a PR, regardless of whether the failure looks transient.
+
+**Force mode bypasses:**
+
+1. **Transient-failure classification** — every failed (non-ignored) job is treated as retryable; the 4-pass analysis is skipped entirely.
+2. **The retryable-job-count cap** — the `≤ 5 retryable jobs` rail is not applied.
+3. **The open-PR gate** — the run is rerun even if no associated PR is currently open (a PR comment is still posted when PR numbers are known).
+
+**Force mode keeps:**
+
+- **The attempt cap** — reruns still only fire from source attempts 1–3 (up to 3 automatic reruns / 4 total attempts). This is unchanged.
+- **The aggregator-job exclusion** (`Final Results`, `Tests / Final Test Results`) and the `failureConclusions` filter — these define what counts as a failed CI job, not an eligibility rule.
+
+**How it is implemented:** the classification rules and [`eng/test-retry-patterns.json`](../../eng/test-retry-patterns.json) config are left fully intact. Force mode is gated behind an optional `forceRerunAll` parameter (default `false`) threaded through `analyzeFailedJobs`, `computeRerunEligibility`, `computeRerunExecutionEligibility`, and `rerunMatchedJobs` in the JS module, plus the `FORCE_RERUN_ALL` env var read in the YAML. With the default off, all normal behavior (and its tests) is preserved.
+
+**To revert:** set `FORCE_RERUN_ALL: 'true'` to `'false'` (or remove the env var) on both jobs in the YAML. Ideally also remove the `forceRerunAll` plumbing and the force-mode tests.
 
 ### PR association
 

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -191,16 +191,16 @@ When a rerun is requested, GitHub reruns **all** failed jobs for that attempt �
 
 > **For-now behavior:** the workflow reruns every failed CI job, not just transient-looking ones. This stays in place until CI auto-rerun patterns are improved (e.g. agents curating the transient-failure rules). Disable it by flipping the flag (see below); the classification rules are kept intact behind it.
 
-The workflow currently runs in **force mode**, enabled by the `FORCE_RERUN_ALL: 'true'` environment variable set on both jobs in [`auto-rerun-transient-ci-failures.yml`](../../.github/workflows/auto-rerun-transient-ci-failures.yml). In force mode the workflow requests a rerun on **any** failed CI run for a PR, regardless of whether the failure looks transient.
+The workflow currently runs in **force mode**, enabled by the `FORCE_RERUN_ALL: 'true'` environment variable set on both jobs in [`auto-rerun-transient-ci-failures.yml`](../../.github/workflows/auto-rerun-transient-ci-failures.yml). In force mode the workflow requests a rerun on **any** failed CI run that has a currently-open associated PR, regardless of whether the failure looks transient.
 
 **Force mode bypasses:**
 
 1. **Transient-failure classification** — every failed (non-ignored) job is treated as retryable; the 4-pass analysis is skipped entirely.
 2. **The retryable-job-count cap** — the `≤ 5 retryable jobs` rail is not applied.
-3. **The open-PR gate** — the run is rerun even if no associated PR is currently open. PR comments are still posted only to associated PRs that are currently open; when every associated PR is closed, the rerun fires with no comment.
 
 **Force mode keeps:**
 
+- **The open-PR requirement** — a rerun only fires for a run that has a currently-open associated PR. Runs with no associated PR, or where every associated PR is closed/merged, are still skipped. There is no value in spending CI on an inactive PR, so force mode does not bypass this.
 - **The attempt cap** — reruns still only fire from source attempts 1–3 (up to 3 automatic reruns / 4 total attempts). This is unchanged.
 - **The aggregator-job exclusion** (`Final Results`, `Tests / Final Test Results`) and the `failureConclusions` filter — these define what counts as a failed CI job, not an eligibility rule.
 

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -197,7 +197,7 @@ The workflow currently runs in **force mode**, enabled by the `FORCE_RERUN_ALL: 
 
 1. **Transient-failure classification** — every failed (non-ignored) job is treated as retryable; the 4-pass analysis is skipped entirely.
 2. **The retryable-job-count cap** — the `≤ 5 retryable jobs` rail is not applied.
-3. **The open-PR gate** — the run is rerun even if no associated PR is currently open (a PR comment is still posted when PR numbers are known).
+3. **The open-PR gate** — the run is rerun even if no associated PR is currently open. PR comments are still posted only to associated PRs that are currently open; when every associated PR is closed, the rerun fires with no comment.
 
 **Force mode keeps:**
 

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -187,9 +187,9 @@ The workflow is intentionally conservative. All of these conditions must be met 
 
 When a rerun is requested, GitHub reruns **all** failed jobs for that attempt — not just the matched ones. This is a GitHub API constraint (there is no API for atomically rerunning a subset of failed jobs). The matched-job count and safety rails are the eligibility gate; once eligible, the rerun covers the full failed set.
 
-## ⚠️ Temporary: force-rerun all failures (`FORCE_RERUN_ALL`)
+## Force-rerun all failures (`FORCE_RERUN_ALL`)
 
-> **This is a temporary, easily-revertible measure and must not stay on `main` long-term.**
+> **For-now behavior:** the workflow reruns every failed CI job, not just transient-looking ones. This stays in place until CI auto-rerun patterns are improved (e.g. agents curating the transient-failure rules). Disable it by flipping the flag (see below); the classification rules are kept intact behind it.
 
 The workflow currently runs in **force mode**, enabled by the `FORCE_RERUN_ALL: 'true'` environment variable set on both jobs in [`auto-rerun-transient-ci-failures.yml`](../../.github/workflows/auto-rerun-transient-ci-failures.yml). In force mode the workflow requests a rerun on **any** failed CI run for a PR, regardless of whether the failure looks transient.
 
@@ -204,9 +204,9 @@ The workflow currently runs in **force mode**, enabled by the `FORCE_RERUN_ALL: 
 - **The attempt cap** — reruns still only fire from source attempts 1–3 (up to 3 automatic reruns / 4 total attempts). This is unchanged.
 - **The aggregator-job exclusion** (`Final Results`, `Tests / Final Test Results`) and the `failureConclusions` filter — these define what counts as a failed CI job, not an eligibility rule.
 
-**How it is implemented:** the classification rules and [`eng/test-retry-patterns.json`](../../eng/test-retry-patterns.json) config are left fully intact. Force mode is gated behind an optional `forceRerunAll` parameter (default `false`) threaded through `analyzeFailedJobs`, `computeRerunEligibility`, `computeRerunExecutionEligibility`, and `rerunMatchedJobs` in the JS module, plus the `FORCE_RERUN_ALL` env var read in the YAML. With the default off, all normal behavior (and its tests) is preserved.
+The classification rules and [`eng/test-retry-patterns.json`](../../eng/test-retry-patterns.json) config are left fully intact; force mode is gated behind an optional `forceRerunAll` flag (default `false`), so the normal behavior is preserved when it is off.
 
-**To revert:** set `FORCE_RERUN_ALL: 'true'` to `'false'` (or remove the env var) on both jobs in the YAML. Ideally also remove the `forceRerunAll` plumbing and the force-mode tests.
+**To disable:** set `FORCE_RERUN_ALL: 'true'` to `'false'` (or remove the env var) on both jobs in the YAML.
 
 ### PR association
 

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -726,8 +726,8 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.False(rerunExecutionEligible);
     }
 
-    // TEMPORARY (FORCE_RERUN_ALL): these tests cover the temporary force-rerun mode.
-    // Remove them when the FORCE_RERUN_ALL plumbing is reverted.
+    // FORCE_RERUN_ALL: these tests cover the force-rerun mode.
+    // Remove them when the FORCE_RERUN_ALL plumbing is removed.
     [Fact]
     [RequiresTools(["node"])]
     public async Task ForceRerunAllMarksJobsThatWouldNormallyBeSkippedAsRetryable()
@@ -778,12 +778,12 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
     }
 
     [Fact]
-    public async Task WorkflowYamlEnablesTemporaryForceRerunAllMode()
+    public async Task WorkflowYamlEnablesForceRerunAllMode()
     {
         string workflowText = await ReadRepoFileAsync(".github/workflows/auto-rerun-transient-ci-failures.yml");
 
         // Force mode must be enabled on BOTH jobs (analyze + rerun). A single occurrence
-        // would let a partial revert (flipping only one job) pass while leaving the
+        // would let a partial flip (toggling only one job) pass while leaving the
         // workflow in a confusing half-bypassed state.
         int enabledCount = workflowText.Split("FORCE_RERUN_ALL: 'true'").Length - 1;
         Assert.True(enabledCount >= 2, $"Expected FORCE_RERUN_ALL: 'true' on both jobs, found {enabledCount}.");
@@ -1089,8 +1089,8 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.Contains("All associated pull requests are closed. No jobs were rerun.", skippedRaw.Text);
     }
 
-    // TEMPORARY (FORCE_RERUN_ALL): falsifiable coverage for the open-PR-gate bypass.
-    // If the `!forceRerunAll &&` guard in rerunMatchedJobs is reverted, this test fails
+    // FORCE_RERUN_ALL: falsifiable coverage for the open-PR-gate bypass.
+    // If the `!forceRerunAll &&` guard in rerunMatchedJobs is removed, this test fails
     // because the rerun would be skipped. Remove with the rest of the force-mode plumbing.
     [Fact]
     [RequiresTools(["node"])]
@@ -1109,7 +1109,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
                         Id = 11,
                         Name = "Tests / One",
                         HtmlUrl = "https://github.com/microsoft/aspire/actions/runs/123/job/11",
-                        Reason = "Force-rerun mode (temporary): bypassing transient-failure analysis."
+                        Reason = "Force-rerun mode: bypassing transient-failure analysis."
                     }
                 },
                 pullRequestNumbers = new[] { 15110 },

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -782,8 +782,21 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
     {
         string workflowText = await ReadRepoFileAsync(".github/workflows/auto-rerun-transient-ci-failures.yml");
 
-        Assert.Contains("FORCE_RERUN_ALL: 'true'", workflowText);
-        Assert.Contains("forceRerunAll", workflowText);
+        // Force mode must be enabled on BOTH jobs (analyze + rerun). A single occurrence
+        // would let a partial revert (flipping only one job) pass while leaving the
+        // workflow in a confusing half-bypassed state.
+        int enabledCount = workflowText.Split("FORCE_RERUN_ALL: 'true'").Length - 1;
+        Assert.True(enabledCount >= 2, $"Expected FORCE_RERUN_ALL: 'true' on both jobs, found {enabledCount}.");
+        Assert.DoesNotContain("FORCE_RERUN_ALL: 'false'", workflowText);
+
+        // The env var is parsed to a boolean and the open-PR no-association gate is
+        // bypassed in force mode.
+        Assert.Contains("const forceRerunAll = String(process.env.FORCE_RERUN_ALL).toLowerCase() === 'true';", workflowText);
+        Assert.Contains("pullRequestNumbers.length === 0 && !forceRerunAll", workflowText);
+
+        // forceRerunAll is threaded into the analyze + eligibility + rerun calls.
+        int threadedCount = workflowText.Split("forceRerunAll,").Length - 1;
+        Assert.True(threadedCount >= 4, $"Expected forceRerunAll threaded into the JS calls, found {threadedCount}.");
     }
 
     [Fact]
@@ -1074,6 +1087,53 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
         SummaryEvent skippedRaw = Assert.Single(result.Events, e => e.Type == "raw" && e.Text is not null && e.Text.Contains("All associated pull requests are closed."));
         Assert.Contains("All associated pull requests are closed. No jobs were rerun.", skippedRaw.Text);
+    }
+
+    // TEMPORARY (FORCE_RERUN_ALL): falsifiable coverage for the open-PR-gate bypass.
+    // If the `!forceRerunAll &&` guard in rerunMatchedJobs is reverted, this test fails
+    // because the rerun would be skipped. Remove with the rest of the force-mode plumbing.
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ForceRerunAllRerunsEvenWhenAllAssociatedPullRequestsAreClosed()
+    {
+        RerunMatchedJobsResult result = await InvokeHarnessAsync<RerunMatchedJobsResult>(
+            "rerunMatchedJobs",
+            new
+            {
+                owner = "dotnet",
+                repo = "aspire",
+                retryableJobs = new[]
+                {
+                    new RetryableJobInput
+                    {
+                        Id = 11,
+                        Name = "Tests / One",
+                        HtmlUrl = "https://github.com/microsoft/aspire/actions/runs/123/job/11",
+                        Reason = "Force-rerun mode (temporary): bypassing transient-failure analysis."
+                    }
+                },
+                pullRequestNumbers = new[] { 15110 },
+                issueStatesByNumber = new Dictionary<string, string>
+                {
+                    ["15110"] = "closed"
+                },
+                sourceRunId = 123,
+                sourceRunAttempt = 1,
+                sourceRunUrl = "https://github.com/microsoft/aspire/actions/runs/123",
+                forceRerunAll = true
+            });
+
+        Assert.Contains(
+            result.Requests,
+            r => r.Route == "POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs"
+                && r.Payload.GetProperty("run_id").GetInt32() == 123);
+
+        Assert.DoesNotContain(result.Events, e => e.Type == "heading" && e.Text == "Rerun skipped");
+
+        // The associated PR is closed, so force mode reruns but posts no comment.
+        Assert.DoesNotContain(
+            result.Requests,
+            r => r.Route == "POST /repos/{owner}/{repo}/issues/{issue_number}/comments");
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -726,6 +726,66 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.False(rerunExecutionEligible);
     }
 
+    // TEMPORARY (FORCE_RERUN_ALL): these tests cover the temporary force-rerun mode.
+    // Remove them when the FORCE_RERUN_ALL plumbing is reverted.
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ForceRerunAllMarksJobsThatWouldNormallyBeSkippedAsRetryable()
+    {
+        WorkflowJob job = CreateJob(failedSteps: ["Run tests"]);
+
+        // A plain test execution failure with a generic annotation is normally skipped.
+        AnalyzeFailedJobsResult normal = await AnalyzeSingleJobAsync(job, "Process completed with exit code 1.");
+        Assert.Empty(normal.RetryableJobs);
+        Assert.Single(normal.SkippedJobs);
+
+        AnalyzeFailedJobsResult forced = await AnalyzeJobsAsync(
+            [job],
+            new Dictionary<string, string> { [job.Id.ToString()] = "Process completed with exit code 1." },
+            forceRerunAll: true);
+
+        AnalyzedJob retryable = Assert.Single(forced.RetryableJobs);
+        Assert.Equal(job.Id, retryable.Id);
+        Assert.Empty(forced.SkippedJobs);
+        Assert.Contains("Force-rerun mode", retryable.Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ForceRerunAllBypassesTheJobCountCapButKeepsTheAttemptCap()
+    {
+        bool eligibleAboveCap = await InvokeHarnessAsync<bool>(
+            "computeRerunEligibility",
+            new
+            {
+                retryableCount = 10,
+                runAttempt = 1,
+                forceRerunAll = true
+            });
+
+        Assert.True(eligibleAboveCap);
+
+        bool eligiblePastAttemptCap = await InvokeHarnessAsync<bool>(
+            "computeRerunEligibility",
+            new
+            {
+                retryableCount = 10,
+                runAttempt = 4,
+                forceRerunAll = true
+            });
+
+        Assert.False(eligiblePastAttemptCap);
+    }
+
+    [Fact]
+    public async Task WorkflowYamlEnablesTemporaryForceRerunAllMode()
+    {
+        string workflowText = await ReadRepoFileAsync(".github/workflows/auto-rerun-transient-ci-failures.yml");
+
+        Assert.Contains("FORCE_RERUN_ALL: 'true'", workflowText);
+        Assert.Contains("forceRerunAll", workflowText);
+    }
+
     [Fact]
     public async Task RepresentativeWorkflowFixturesStayAlignedWithCurrentWorkflowDefinitions()
     {
@@ -2019,7 +2079,8 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Dictionary<string, string> annotationTextByJobId,
         Dictionary<string, string>? jobLogTextByJobId = null,
         int? maxRetryableJobs = null,
-        object? retryPatternsConfig = null)
+        object? retryPatternsConfig = null,
+        bool forceRerunAll = false)
         => InvokeHarnessAsync<AnalyzeFailedJobsResult>(
             "analyzeFailedJobs",
             new AnalyzeFailedJobsRequest
@@ -2028,7 +2089,8 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
                 AnnotationTextByJobId = annotationTextByJobId,
                 JobLogTextByJobId = jobLogTextByJobId,
                 MaxRetryableJobs = maxRetryableJobs,
-                RetryPatternsConfig = retryPatternsConfig
+                RetryPatternsConfig = retryPatternsConfig,
+                ForceRerunAll = forceRerunAll
             });
 
     private async Task<T> InvokeHarnessAsync<T>(string operation, object payload)
@@ -2088,6 +2150,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         public Dictionary<string, string>? JobLogTextByJobId { get; init; }
         public int? MaxRetryableJobs { get; init; }
         public object? RetryPatternsConfig { get; init; }
+        public bool ForceRerunAll { get; init; }
     }
 
     private sealed class AnalyzeFailedJobsResult

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -789,10 +789,8 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.True(enabledCount >= 2, $"Expected FORCE_RERUN_ALL: 'true' on both jobs, found {enabledCount}.");
         Assert.DoesNotContain("FORCE_RERUN_ALL: 'false'", workflowText);
 
-        // The env var is parsed to a boolean and the open-PR no-association gate is
-        // bypassed in force mode.
+        // The env var is parsed to a boolean and threaded into the force-mode calls.
         Assert.Contains("const forceRerunAll = String(process.env.FORCE_RERUN_ALL).toLowerCase() === 'true';", workflowText);
-        Assert.Contains("pullRequestNumbers.length === 0 && !forceRerunAll", workflowText);
 
         // forceRerunAll is threaded into the analyze + eligibility + rerun calls.
         int threadedCount = workflowText.Split("forceRerunAll,").Length - 1;
@@ -1089,12 +1087,12 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.Contains("All associated pull requests are closed. No jobs were rerun.", skippedRaw.Text);
     }
 
-    // FORCE_RERUN_ALL: falsifiable coverage for the open-PR-gate bypass.
-    // If the `!forceRerunAll &&` guard in rerunMatchedJobs is removed, this test fails
-    // because the rerun would be skipped. Remove with the rest of the force-mode plumbing.
+    // FORCE_RERUN_ALL: force mode must NOT bypass the open-PR gate. A closed associated
+    // PR is still skipped (no value in spending CI on a closed/merged PR). If the gate
+    // is ever re-bypassed in force mode, this test fails because the rerun POST fires.
     [Fact]
     [RequiresTools(["node"])]
-    public async Task ForceRerunAllRerunsEvenWhenAllAssociatedPullRequestsAreClosed()
+    public async Task ForceRerunAllStillSkipsRerunWhenAllAssociatedPullRequestsAreClosed()
     {
         RerunMatchedJobsResult result = await InvokeHarnessAsync<RerunMatchedJobsResult>(
             "rerunMatchedJobs",
@@ -1123,17 +1121,15 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
                 forceRerunAll = true
             });
 
-        Assert.Contains(
-            result.Requests,
-            r => r.Route == "POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs"
-                && r.Payload.GetProperty("run_id").GetInt32() == 123);
+        SummaryEvent skippedHeading = Assert.Single(result.Events, e => e.Type == "heading" && e.Text == "Rerun skipped");
+        Assert.Equal(1, skippedHeading.Level);
 
-        Assert.DoesNotContain(result.Events, e => e.Type == "heading" && e.Text == "Rerun skipped");
+        SummaryEvent skippedRaw = Assert.Single(result.Events, e => e.Type == "raw" && e.Text is not null && e.Text.Contains("All associated pull requests are closed."));
+        Assert.Contains("All associated pull requests are closed. No jobs were rerun.", skippedRaw.Text);
 
-        // The associated PR is closed, so force mode reruns but posts no comment.
         Assert.DoesNotContain(
             result.Requests,
-            r => r.Route == "POST /repos/{owner}/{repo}/issues/{issue_number}/comments");
+            r => r.Route == "POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs");
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
@@ -63,6 +63,7 @@ async function dispatch(operation, payload) {
                     },
                     maxRetryableJobs: payload.maxRetryableJobs,
                     retryPatternsConfig: payload.retryPatternsConfig ?? null,
+                    forceRerunAll: payload.forceRerunAll ?? false,
                 });
 
                 return { ...result, logRequestJobIds };


### PR DESCRIPTION
The `auto-rerun-transient-ci-failures` workflow normally reruns a failed CI run **only** when the failure matches a transient-failure pattern. This PR adds a **force mode** that reruns **every** failed CI job for an open PR, regardless of whether the failure looks transient.

This is a for-now measure: it stays on until CI auto-rerun patterns are improved (e.g. agents curating the transient-failure rules). It is gated behind a default-off `forceRerunAll` flag / `FORCE_RERUN_ALL` env var, which this branch sets to `'true'`. The transient-classification rules and `eng/test-retry-patterns.json` are kept intact behind the flag.

## What force mode bypasses

1. **Transient-failure classification** — every failed, non-ignored job becomes retryable; the 4-pass analysis is skipped.
2. **Retryable-job-count cap** — the `≤ 5 retryable jobs` rail is not applied.

## What force mode keeps

- **Open-PR requirement** — a rerun only fires for a run that has a currently-open associated PR. Runs with no associated PR, or where every associated PR is closed/merged, are still skipped. No CI is spent on inactive PRs.
- **Attempt cap** — reruns still fire only from source attempts 1–3, yielding **up to 3 automatic reruns / 4 total attempts**, unchanged.
- **Aggregator-job exclusion** (`Final Results`, `Tests / Final Test Results`) and the `failureConclusions` filter — these define what counts as a failed CI job, not an eligibility rule.

In force mode the analysis summary and PR comment use wording that does not claim a transient-failure match; normal-mode wording is unchanged.

## Docs fix

Corrected the inaccurate "≤ 3 total attempts / 2 reruns" wording. Reruns fire from source attempts 1–3, so the real limit is **up to 3 auto-reruns / 4 total attempts**. Documented the `FORCE_RERUN_ALL` mode and exactly what it bypasses/keeps.

## Validation

```
dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- \
  --filter-class "*.AutoRerunTransientCiFailuresTests" \
  --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"

Test run summary: Passed!
  total: 97
  failed: 0
  succeeded: 97
  skipped: 0
```

## How to turn off

Set `FORCE_RERUN_ALL: 'true'` → `'false'` (or remove the env var) on both jobs in `.github/workflows/auto-rerun-transient-ci-failures.yml`.
