### PR TITLE
Fix trace detail span pane on navigation and improve stress/playground apps

### DIFF
--- a/playground/Stress/Stress.ApiService/TraceCreator.cs
+++ b/playground/Stress/Stress.ApiService/TraceCreator.cs
@@ -68,11 +68,32 @@ public class TraceCreator
     {
         if (Random.Shared.NextDouble() > 0.05)
         {
-            var name = parentName + "-0";
-
             var links = CreateLinks();
+            var distinctLinks = links.DistinctBy(l => l.Context.SpanId).ToArray();
 
-            using var activity = s_activitySource.StartActivity(ActivityKind.Client, name: name, links: links.DistinctBy(l => l.Context.SpanId));
+            var sameTraceCount = 0;
+            var crossTraceCount = 0;
+            var currentTraceId = Activity.Current?.TraceId.ToString();
+            foreach (var link in distinctLinks)
+            {
+                if (link.Context.TraceId.ToString() == currentTraceId)
+                {
+                    sameTraceCount++;
+                }
+                else
+                {
+                    crossTraceCount++;
+                }
+            }
+
+            var name = $"{parentName}-0";
+            var resolvedName = name;
+            if (distinctLinks.Length > 0)
+            {
+                resolvedName = $"{name} (links: {distinctLinks.Length}, same-trace: {sameTraceCount}, cross-trace: {crossTraceCount})";
+            }
+
+            using var activity = s_activitySource.StartActivity(ActivityKind.Client, name: resolvedName, links: distinctLinks);
             if (activity == null)
             {
                 return;
@@ -120,8 +141,6 @@ public class TraceCreator
                 activityTags.Add($"key-{j}", "Value!");
             }
 
-            // Create the activity link. There is a 50% chance the activity link goes to an activity
-            // that doesn't exist. This logic is here to ensure incomplete links are handled correctly.
             ActivityContext activityContext;
             if (!IncludeBrokenLinks || Random.Shared.Next() % 2 == 0)
             {
@@ -134,10 +153,35 @@ public class TraceCreator
                     ActivityTraceId.CreateRandom(),
                     ActivitySpanId.CreateRandom(),
                     ActivityTraceFlags.None);
+
+                if (Random.Shared.Next() % 2 == 0)
+                {
+                    // 50% of cross-trace links create a real new trace+span so the link is navigable.
+                    CreateLinkedTrace(activityContext);
+                }
             }
             links[i] = new ActivityLink(activityContext, activityTags);
         }
 
         return links;
+    }
+
+    private static void CreateLinkedTrace(ActivityContext activityContext)
+    {
+        // Temporarily clear Activity.Current so the new activity doesn't inherit the current trace.
+        var previous = Activity.Current;
+        Activity.Current = null;
+
+        var activity = s_activitySource.StartActivity("linked-trace-span", ActivityKind.Internal);
+        if (activity is not null)
+        {
+            // Force the activity to use the exact trace and span ID from activityContext
+            // so the span link points to this recorded span.
+            typeof(Activity).GetField("_spanId", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(activity, activityContext.SpanId.ToString());
+            typeof(Activity).GetField("_traceId", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(activity, activityContext.TraceId.ToString());
+            activity.Stop();
+        }
+
+        Activity.Current = previous;
     }
 }

--- a/playground/TestShop/BasketService/BasketService.cs
+++ b/playground/TestShop/BasketService/BasketService.cs
@@ -6,12 +6,12 @@ using GrpcBasket;
 using RabbitMQ.Client;
 namespace BasketService;
 
-public class BasketService(IBasketRepository repository, IConfiguration configuration, IServiceProvider serviceProvider, ILogger<BasketService> logger) : Basket.BasketBase
+public class BasketService(IBasketRepository repository, IConfiguration configuration, IConnection? messageConnection, ILogger<BasketService> logger) : Basket.BasketBase
 {
     private readonly IBasketRepository _repository = repository;
     private readonly IConfiguration _configuration = configuration;
     private readonly ILogger<BasketService> _logger = logger;
-    private IConnection? _messageConnection;
+    private readonly IConnection? _messageConnection = messageConnection;
 
     public override async Task<CustomerBasketResponse> GetBasketById(BasketRequest request, ServerCallContext context)
     {
@@ -60,7 +60,6 @@ public class BasketService(IBasketRepository repository, IConfiguration configur
 
         _logger.LogInformation("Checking out {Count} item(s) for BuyerId: {BuyerId}.", order.Items.Count, buyerId);
 
-        _messageConnection ??= serviceProvider.GetService<IConnection>();
         if (_messageConnection is null)
         {
             _logger.LogWarning("RabbitMQ is unavailable. Ensure you have configured it in AppHosts's config / user secrets under 'ConnectionStrings:messaging'.");

--- a/playground/TestShop/BasketService/Program.cs
+++ b/playground/TestShop/BasketService/Program.cs
@@ -8,7 +8,7 @@ builder.Services.AddGrpc();
 builder.AddRedisClient("basketcache");
 builder.Services.AddTransient<IBasketRepository, RedisBasketRepository>();
 
-builder.AddRabbitMQClient("messaging");
+builder.AddRabbitMQClient("messaging", configureSettings: settings => settings.DisableAutoActivation = false);
 
 var app = builder.Build();
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -443,6 +443,10 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     {
         if (TraceId != _trace?.TraceId)
         {
+            // Close the span detail pane when navigating between traces (e.g. browser back/forward).
+            // If the new trace has a SpanId query parameter, it will be re-opened below.
+            SelectedData = null;
+
             UpdateDetailViewData();
             UpdateSubscription();
 


### PR DESCRIPTION
## Description

Fixes #10162

Three related improvements to dashboard trace navigation and playground apps:

1. **Dashboard: Close span detail pane on trace navigation** — When navigating between traces (e.g., clicking a span link to another trace, then pressing browser Back), the span detail pane from the previous trace was left open showing a span that doesn't belong to the current trace. Now `SelectedData` is cleared whenever the trace changes, and if the new URL includes a `?spanId=` parameter the correct span is re-opened.

2. **TestShop: Fix checkout timeout** — The BasketService resolved `IConnection` lazily on first checkout, hitting RabbitMQ connection retries (21s) that triggered the frontend's 10-second resilience timeout. Fixed by enabling auto-activation and using constructor injection.

3. **Stress app: Create real cross-trace span links** — When the stress app creates span links to other traces, 50% now create an actual recorded trace+span so the link is navigable in the dashboard. The span name also includes link metadata (count, same-trace, cross-trace).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
