### PR TITLE
Reference Microsoft.Data.SqlClient.Extensions.Azure in SqlServer client integrations for Entra ID auth

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -111,6 +111,7 @@
     <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.1" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" /> <!-- No stable release available -->

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/Aspire.Microsoft.Data.SqlClient.csproj
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/Aspire.Microsoft.Data.SqlClient.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/README.md
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/README.md
@@ -59,6 +59,12 @@ And then the connection string will be retrieved from the `ConnectionStrings` co
 
 See the [ConnectionString documentation](https://learn.microsoft.com/dotnet/api/system.data.sqlclient.sqlconnection.connectionstring#remarks) for more information on how to format this connection string.
 
+### Microsoft Entra ID (Azure AD) authentication
+
+To connect to Azure SQL using Microsoft Entra ID (for example, with managed identity), the connection string specifies an `Authentication` mode such as `Authentication="Active Directory Default"`. This is the connection string the `Aspire.Hosting.Azure.Sql` integration emits by default.
+
+Since [Microsoft.Data.SqlClient 7.0](https://techcommunity.microsoft.com/blog/sqlserver/microsoft-data-sqlclient-7-0-is-here-a-leaner-more-modular-driver-for-sql-server/4503173), the Entra ID authentication providers are no longer bundled in the core driver; they ship in the separate [Microsoft.Data.SqlClient.Extensions.Azure](https://www.nuget.org/packages/Microsoft.Data.SqlClient.Extensions.Azure) package. This integration references that package so those connection strings work out of the box, with no extra package or registration code required. As a result, this integration also brings in `Azure.Identity`.
+
 ### Use configuration providers
 
 The Aspire SqlClient component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `MicrosoftDataSqlClientSettings` from configuration by using the `Aspire:Microsoft:Data:SqlClient` key. Example `appsettings.json` that configures some of the options:

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/README.md
@@ -69,6 +69,12 @@ The `EnrichSqlServerDbContext` won't make use of the `ConnectionStrings` configu
 
 See the [ConnectionString documentation](https://learn.microsoft.com/dotnet/api/system.data.sqlclient.sqlconnection.connectionstring#remarks) for more information on how to format this connection string.
 
+### Microsoft Entra ID (Azure AD) authentication
+
+To connect to Azure SQL using Microsoft Entra ID (for example, with managed identity), the connection string specifies an `Authentication` mode such as `Authentication="Active Directory Default"`. This is the connection string the `Aspire.Hosting.Azure.Sql` integration emits by default.
+
+Since [Microsoft.Data.SqlClient 7.0](https://techcommunity.microsoft.com/blog/sqlserver/microsoft-data-sqlclient-7-0-is-here-a-leaner-more-modular-driver-for-sql-server/4503173) (pulled in transitively by `Microsoft.EntityFrameworkCore.SqlServer`), the Entra ID authentication providers are no longer bundled in the core driver; they ship in the separate [Microsoft.Data.SqlClient.Extensions.Azure](https://www.nuget.org/packages/Microsoft.Data.SqlClient.Extensions.Azure) package. This integration references that package so those connection strings work out of the box, with no extra package or registration code required. As a result, this integration also brings in `Azure.Identity`.
+
 ### Use configuration providers
 
 The Aspire SQL Server EntityFrameworkCore SqlClient component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `MicrosoftEntityFrameworkCoreSqlServerSettings` from configuration by using the `Aspire:Microsoft:EntityFrameworkCore:SqlServer` key. Example `appsettings.json` that configures some of the options:

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/AspireSqlServerSqlClientExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/AspireSqlServerSqlClientExtensionsTests.cs
@@ -130,4 +130,17 @@ public class AspireSqlServerSqlClientExtensionsTests
         Assert.Contains("fake2", connection2.ConnectionString);
         Assert.Contains("fake3", connection3.ConnectionString);
     }
+
+    // Regression guard: SqlClient 7.0 moved the Entra ID (Active Directory) auth providers into
+    // Microsoft.Data.SqlClient.Extensions.Azure. This integration references that package, so they must resolve here;
+    // otherwise the Authentication="Active Directory Default" connection strings Aspire emits fail at runtime.
+    [Theory]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryDefault)]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity)]
+    public void EntraIdAuthenticationProviderIsRegistered(SqlAuthenticationMethod method)
+    {
+        var provider = SqlAuthenticationProvider.GetProvider(method);
+
+        Assert.NotNull(provider);
+    }
 }

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/AspireSqlServerEFCoreSqlClientExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/AspireSqlServerEFCoreSqlClientExtensionsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.TestUtilities;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
@@ -359,6 +360,19 @@ public class AspireSqlServerEFCoreSqlClientExtensionsTests
 #else
         Assert.Equal(expectedConnectionString, actualConnectionString);
 #endif
+    }
+
+    // Regression guard: EF Core's SqlServer provider pulls in SqlClient 7.0, which moved the Entra ID (Active
+    // Directory) auth providers into Microsoft.Data.SqlClient.Extensions.Azure. This integration references that
+    // package, so they must resolve here; otherwise the Authentication="Active Directory Default" strings Aspire emits fail.
+    [Theory]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryDefault)]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity)]
+    public void EntraIdAuthenticationProviderIsRegistered(SqlAuthenticationMethod method)
+    {
+        var provider = SqlAuthenticationProvider.GetProvider(method);
+
+        Assert.NotNull(provider);
     }
 
     public class TestDbContext2 : DbContext


### PR DESCRIPTION
## Description

Fixes #18148.

`Microsoft.Data.SqlClient` 7.0 moved the Microsoft Entra ID (Active Directory) authentication providers out of the core driver into the separate [`Microsoft.Data.SqlClient.Extensions.Azure`](https://www.nuget.org/packages/Microsoft.Data.SqlClient.Extensions.Azure) package. Aspire's `Aspire.Hosting.Azure.Sql` integration emits a connection string using `Authentication="Active Directory Default"` by default, but the client integrations that consume it don't reference the provider package, so deployed apps using managed identity against Azure SQL throw `Cannot find an authentication provider for 'ActiveDirectoryDefault'` at runtime. It passes local dev (the container path uses SQL auth) and only fails in production.

This adds `Microsoft.Data.SqlClient.Extensions.Azure` to both SqlServer client integrations so Entra connection strings work out of the box:

- `Directory.Packages.props`: central `PackageVersion` `1.0.0` (companion release to the pinned SqlClient 7.0.1).
- `Aspire.Microsoft.Data.SqlClient` and `Aspire.Microsoft.EntityFrameworkCore.SqlServer`: package reference (explicit in both; EF gets SqlClient only transitively and would not otherwise get the provider).
- README note in both integrations documenting the behavior and the resulting transitive `Azure.Identity`.
- A regression test in each test project asserting `SqlAuthenticationProvider.GetProvider(...)` resolves for `ActiveDirectoryDefault` / `ActiveDirectoryManagedIdentity`. Both fail before the change and pass after; full suites pass with no regressions.

Trade-off: these integrations now pull `Azure.Identity` transitively onto all consumers (including non-Entra users). This is the unavoidable cost of out-of-the-box managed-identity support and restores pre-7.0 behavior; no AOT/trim regression (both already `IsAotCompatible=false`), and it's consistent with sibling Aspire Azure integrations that already bundle `Azure.Identity`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
