### PR TITLE
Fix race condition in RepeatedFailureEvents_OnlyDiagnoseOnce test

### DIFF
--- a/tests/Aspire.Hosting.Tests/Lifecycle/TerminalHostFailureDiagnosticServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Lifecycle/TerminalHostFailureDiagnosticServiceTests.cs
@@ -177,7 +177,21 @@ public class TerminalHostFailureDiagnosticServiceTests
         {
             await service.StartAsync(stopCts.Token).DefaultTimeout();
 
-            for (var i = 0; i < 3; i++)
+            // Publish the first failure event that triggers the diagnostic.
+            await notifications.PublishUpdateAsync(host, s => s with
+            {
+                State = new ResourceStateSnapshot(KnownResourceStates.FailedToStart, null),
+                IsHidden = true,
+            }).DefaultTimeout();
+
+            // Wait for the service to process the first event and unhide the host.
+            // This ensures the service has added the host to its diagnosed set before
+            // we publish repeated events that should be de-duped.
+            await WaitForUnhideAsync(notifications, host).DefaultTimeout();
+            await ReadLogsAsync(loggers, host, expected: 2).DefaultTimeout();
+
+            // Now publish repeated failures — these must be de-duped.
+            for (var i = 0; i < 2; i++)
             {
                 await notifications.PublishUpdateAsync(host, s => s with
                 {
@@ -185,9 +199,6 @@ public class TerminalHostFailureDiagnosticServiceTests
                     IsHidden = true,
                 }).DefaultTimeout();
             }
-
-            await WaitForUnhideAsync(notifications, host).DefaultTimeout();
-            await ReadLogsAsync(loggers, host, expected: 2).DefaultTimeout();
 
             // Give the service a tick to spuriously write more lines if the dedupe
             // logic is broken.


### PR DESCRIPTION
## Fix

Fixes #18137

The `RepeatedFailureEvents_OnlyDiagnoseOnce` test had a race condition causing intermittent 30s timeouts on CI.

### Root cause

The test published 3 `FailedToStart` events (all with `IsHidden = true`) in a tight loop, then called `WaitForUnhideAsync`. If the service processed event 1 and published its unhide (`IsHidden = false`) between test events 1 and 2, event 2's transform (`s with { IsHidden = true }`) would re-hide the resource. Since the service de-duplicates by host ID, it would never unhide again, causing `WaitForUnhideAsync` to hang until the 30s timeout.

### Fix

Publish the first failure event, wait for the service to fully process it (unhide + write logs — confirming the host is in the `diagnosedHosts` set), then publish repeated events to verify dedup behavior. This eliminates the race between test event publication and service processing.