### PR TITLE
Update Cosmos DB preview emulator tag to vnext-latest

### DIFF
--- a/.agents/skills/update-container-images/SKILL.md
+++ b/.agents/skills/update-container-images/SKILL.md
@@ -145,7 +145,7 @@ If such a comment exists, stay within the noted version range (e.g., v2.5.x for 
 #### Rule 5: Skip Non-Updatable Tags
 
 - Tags set to `"latest"` — cannot be version-bumped
-- Tags set to `"vnext-preview"` — not a version scheme
+- Tags set to `"vnext-latest"` — not a version scheme
 - Derived/computed tags (e.g., `$"{Tag}-management"`) — updated automatically
 
 ### Step 4: Present Update Summary

--- a/.agents/skills/update-container-images/UpdateImageTags.cs
+++ b/.agents/skills/update-container-images/UpdateImageTags.cs
@@ -227,7 +227,7 @@ static List<ImageEntry> ParseImageTagsFile(string content, string relativePath)
         }
 
         var isDerived = derivedFields.Contains(tagField);
-        var isLatestOrUnversioned = !isDerived && (tag == "latest" || tag == "vnext-preview");
+        var isLatestOrUnversioned = !isDerived && (tag == "latest" || tag == "vnext-latest");
 
         var entry = new ImageEntry
         {

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -74,7 +74,7 @@ public static class AzureCosmosExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.TagVNextPreview"/> tag of the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.Registry"/>/<inheritdoc cref="CosmosDBEmulatorContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.TagVNextLatest"/> tag of the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.Registry"/>/<inheritdoc cref="CosmosDBEmulatorContainerImageTags.Image"/> container image.
     /// </remarks>
     [AspireExport(RunSyncOnBackgroundThread = true)]
     [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
@@ -101,7 +101,7 @@ public static class AzureCosmosExtensions
                {
                    Registry = CosmosDBEmulatorContainerImageTags.Registry,
                    Image = CosmosDBEmulatorContainerImageTags.Image,
-                   Tag = useVNextPreview ? CosmosDBEmulatorContainerImageTags.TagVNextPreview : CosmosDBEmulatorContainerImageTags.Tag
+                   Tag = useVNextPreview ? CosmosDBEmulatorContainerImageTags.TagVNextLatest : CosmosDBEmulatorContainerImageTags.Tag
                });
 
         CosmosClient? cosmosClient = null;

--- a/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBEmulatorContainerImageTags.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBEmulatorContainerImageTags.cs
@@ -15,5 +15,5 @@ internal static class CosmosDBEmulatorContainerImageTags
     public const string Tag = "stable";
 
     /// <remarks>vnext-latest</remarks>
-    public const string TagVNextPreview = "vnext-latest";
+    public const string TagVNextLatest = "vnext-latest";
 }

--- a/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBEmulatorContainerImageTags.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBEmulatorContainerImageTags.cs
@@ -14,6 +14,6 @@ internal static class CosmosDBEmulatorContainerImageTags
     /// <remarks>stable</remarks>
     public const string Tag = "stable";
 
-    /// <remarks>vnext-preview</remarks>
-    public const string TagVNextPreview = "vnext-preview";
+    /// <remarks>vnext-latest</remarks>
+    public const string TagVNextPreview = "vnext-latest";
 }


### PR DESCRIPTION
## Description

The Azure Cosmos DB Linux-based (preview) emulator container image
(`mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator`) has moved its
moving preview tag from `vnext-preview` to `vnext-latest`. This updates the tag
that the preview emulator resolves so that `RunAsPreviewEmulator()` continues to
pull the current preview image instead of a stale/retired tag.

What changes for users of the preview emulator:

- `builder.AddAzureCosmosDB("cosmos").RunAsPreviewEmulator()` now pulls the
  `vnext-latest` tag instead of `vnext-preview`. The API and call site are
  unchanged; only the resolved container image tag differs.

Implementation details:

- `CosmosDBEmulatorContainerImageTags.TagVNextPreview` value changed from
  `vnext-preview` to `vnext-latest` (the constant name is intentionally left
  unchanged to keep this scoped to the tag value).
- The `update-container-images` skill hardcoded `vnext-preview` in its
  "skip non-updatable tags" detection (`UpdateImageTags.cs`) and docs
  (`SKILL.md`); both are updated to `vnext-latest` so the skill keeps treating
  this moving tag as non-version-bumpable.

### User-facing usage

```csharp
// Pulls mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-latest
var cosmos = builder.AddAzureCosmosDB("cosmos")
                    .RunAsPreviewEmulator();
```

Validation: built `Aspire.Hosting.Azure.CosmosDB` successfully (0 warnings,
0 errors). No tests assert the literal tag value.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
