### PR TITLE
Fix flaky GetRpcClientAsync server-exit timing test

### DIFF
--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
@@ -16,6 +16,7 @@ using Aspire.Hosting;
 using Aspire.Shared;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Projects;
@@ -117,11 +118,17 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
     {
         var project = new RecordingAppHostServerProject();
 
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddXunit(outputHelper));
+
         await using var session = AppHostServerSession.Start(
             project,
             environmentVariables: null,
             debug: false,
-            NullLogger<AppHostServerSession>.Instance);
+            loggerFactory.CreateLogger<AppHostServerSession>());
+
+        // Wait for the process to exit so the stopwatch measures only the early-exit detection
+        // latency, not the variable execution time of "dotnet --version" on loaded CI machines.
+        await project.StartedProcess!.WaitForExitAsync(TestContext.Current.CancellationToken).DefaultTimeout();
 
         var stopwatch = Stopwatch.StartNew();
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -236,6 +243,8 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
 
         public Dictionary<string, string>? ReceivedEnvironmentVariables { get; private set; }
 
+        public Process? StartedProcess { get; private set; }
+
         public string GetInstanceIdentifier() => AppDirectoryPath;
 
         public Task<AppHostServerPrepareResult> PrepareAsync(
@@ -263,6 +272,7 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
                 UseShellExecute = false
             })!;
 
+            StartedProcess = process;
             return ("test.sock", process, new OutputCollector());
         }
     }


### PR DESCRIPTION
## Fix

The \GetRpcClientAsync_WhenServerExitsBeforeSocketIsAvailable_FailsWithoutWaitingForConnectionTimeout\ test was flaky because it measured total elapsed time including \dotnet --version\ execution. On loaded CI machines this exceeded the 5-second threshold (observed: 6.6s).

**Changes:**
- Wait for the spawned process to exit before starting the stopwatch, so we only measure the early-exit detection latency (cancellation propagation)
- Route session logs to xunit test output for better diagnostics on failure

## Validation

Test passes locally and the timing assertion is now resilient to slow CI process startup.