### PR TITLE
Align Azure Cosmos DB emulator with GA vnext-latest image

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBEmulatorConnectionString.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBEmulatorConnectionString.cs
@@ -8,8 +8,8 @@ namespace Aspire.Hosting.Azure;
 
 internal static class AzureCosmosDBEmulatorConnectionString
 {
-    public static ReferenceExpression Create(EndpointReference endpoint, bool isPreviewEmulator) =>
-        isPreviewEmulator
+    public static ReferenceExpression Create(EndpointReference endpoint, bool isVNext) =>
+        isVNext
             ? ReferenceExpression.Create($"AccountKey={CosmosConstants.EmulatorAccountKey};AccountEndpoint={endpoint.Property(EndpointProperty.Url)}")
             : ReferenceExpression.Create($"AccountKey={CosmosConstants.EmulatorAccountKey};AccountEndpoint=https://{endpoint.Property(EndpointProperty.IPV4Host)}:{endpoint.Property(EndpointProperty.Port)};DisableServerCertificateValidation=True;");
 }

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -217,26 +217,30 @@ public static class AzureCosmosExtensions
         }
 
         return builder;
+    }
 
-        static CosmosClient CreateCosmosClient(string connectionString)
+    // Creates a CosmosClient from a connection string or an absolute account endpoint URI.
+    // Internal (rather than a local function) so it can be unit-tested directly: the emulator code path
+    // always passes an emulator connection string, so the absolute-URI and non-emulator branches would
+    // otherwise be unreachable from tests.
+    internal static CosmosClient CreateCosmosClient(string connectionString)
+    {
+        var clientOptions = new CosmosClientOptions();
+        clientOptions.CosmosClientTelemetryOptions.DisableDistributedTracing = true;
+
+        if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
         {
-            var clientOptions = new CosmosClientOptions();
-            clientOptions.CosmosClientTelemetryOptions.DisableDistributedTracing = true;
-
-            if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
+            return new CosmosClient(uri.OriginalString, AzureCredentialHelper.CreateDefaultAzureCredential(), clientOptions);
+        }
+        else
+        {
+            if (CosmosUtils.IsEmulatorConnectionString(connectionString))
             {
-                return new CosmosClient(uri.OriginalString, AzureCredentialHelper.CreateDefaultAzureCredential(), clientOptions);
+                clientOptions.ConnectionMode = ConnectionMode.Gateway;
+                clientOptions.LimitToEndpoint = true;
             }
-            else
-            {
-                if (CosmosUtils.IsEmulatorConnectionString(connectionString))
-                {
-                    clientOptions.ConnectionMode = ConnectionMode.Gateway;
-                    clientOptions.LimitToEndpoint = true;
-                }
 
-                return new CosmosClient(connectionString, clientOptions);
-            }
+            return new CosmosClient(connectionString, clientOptions);
         }
     }
 

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -154,9 +154,10 @@ public static class AzureCosmosExtensions
 
             // The vNext image enables the Data Explorer by default (ENABLE_EXPLORER=true). That runs an
             // otherwise-unused Node process and, because the emulator's readiness probe is
-            // "ready = postgres && gateway && (explorer || !ENABLE_EXPLORER)", it makes /ready wait on the
-            // explorer even when it is never exposed. Disable it by default; WithDataExplorer re-enables it
-            // later through configureContainer (environment callbacks are last-write-wins).
+            // "ready = postgres && gateway && (explorer || !ENABLE_EXPLORER)" (the vNext emulator uses
+            // PostgreSQL internally as its storage engine), it makes /ready wait on the explorer even when
+            // it is never exposed. Disable it by default; WithDataExplorer re-enables it later through
+            // configureContainer (environment callbacks are last-write-wins).
             emulatorSurrogateBuilder.WithEnvironment("ENABLE_EXPLORER", "false");
 
             // VNext cosmosdb sets a default CERT_SECRET environment variable for the default emulator certificate and we can't

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -62,13 +62,13 @@ public static class AzureCosmosExtensions
     /// </remarks>
     [AspireExport(RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureCosmosDBResource> RunAsEmulator(this IResourceBuilder<AzureCosmosDBResource> builder, Action<IResourceBuilder<AzureCosmosDBEmulatorResource>>? configureContainer = null)
-        => RunAsEmulator(builder, configureContainer, useVNextPreview: false);
+        => RunAsEmulator(builder, configureContainer, useVNext: false);
 
     /// <summary>
-    /// Configures an Azure Cosmos DB resource to be emulated using the Azure Cosmos DB Linux-based emulator (preview) with the NoSQL API. This resource requires an <see cref="AzureCosmosDBResource"/> to be added to the application model.
+    /// Configures an Azure Cosmos DB resource to be emulated using the Azure Cosmos DB Linux-based (vNext) emulator with the NoSQL API. This resource requires an <see cref="AzureCosmosDBResource"/> to be added to the application model.
     /// For more information on the Azure Cosmos DB emulator, see <a href="https://learn.microsoft.com/azure/cosmos-db/emulator-linux"></a>.
     /// </summary>
-    /// <ats-summary>Configures the Azure Cosmos DB resource to run using the preview emulator</ats-summary>
+    /// <ats-summary>Configures the Azure Cosmos DB resource to run using the Linux-based (vNext) emulator</ats-summary>
     /// <param name="builder">The Azure Cosmos DB resource builder.</param>
     /// <param name="configureContainer">Callback that exposes underlying container used for emulation to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
@@ -79,9 +79,9 @@ public static class AzureCosmosExtensions
     [AspireExport(RunSyncOnBackgroundThread = true)]
     [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<AzureCosmosDBResource> RunAsPreviewEmulator(this IResourceBuilder<AzureCosmosDBResource> builder, Action<IResourceBuilder<AzureCosmosDBEmulatorResource>>? configureContainer = null)
-        => RunAsEmulator(builder, configureContainer, useVNextPreview: true);
+        => RunAsEmulator(builder, configureContainer, useVNext: true);
 
-    private static IResourceBuilder<AzureCosmosDBResource> RunAsEmulator(this IResourceBuilder<AzureCosmosDBResource> builder, Action<IResourceBuilder<AzureCosmosDBEmulatorResource>>? configureContainer, bool useVNextPreview)
+    private static IResourceBuilder<AzureCosmosDBResource> RunAsEmulator(this IResourceBuilder<AzureCosmosDBResource> builder, Action<IResourceBuilder<AzureCosmosDBEmulatorResource>>? configureContainer, bool useVNext)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -90,18 +90,18 @@ public static class AzureCosmosExtensions
             return builder;
         }
 
-        builder.Resource.IsPreviewEmulator = useVNextPreview;
+        builder.Resource.IsVNextEmulator = useVNext;
 
         // Mark this resource as an emulator for consistent resource identification and tooling support
         builder.WithAnnotation(new EmulatorResourceAnnotation());
 
-        var scheme = useVNextPreview ? "http" : null;
+        var scheme = useVNext ? "http" : null;
         builder.WithEndpoint(name: "emulator", scheme: scheme, targetPort: 8081)
                .WithAnnotation(new ContainerImageAnnotation
                {
                    Registry = CosmosDBEmulatorContainerImageTags.Registry,
                    Image = CosmosDBEmulatorContainerImageTags.Image,
-                   Tag = useVNextPreview ? CosmosDBEmulatorContainerImageTags.TagVNextLatest : CosmosDBEmulatorContainerImageTags.Tag
+                   Tag = useVNext ? CosmosDBEmulatorContainerImageTags.TagVNextLatest : CosmosDBEmulatorContainerImageTags.Tag
                });
 
         CosmosClient? cosmosClient = null;
@@ -138,14 +138,14 @@ public static class AzureCosmosExtensions
             }
         });
 
-        if (useVNextPreview)
+        if (useVNext)
         {
             builder.WithHttpEndpoint(name: EmulatorHealthEndpointName, targetPort: 8080)
                 .WithEndpoint(EmulatorHealthEndpointName, e => e.ExcludeReferenceEndpoint = true)
                 .WithHttpHealthCheck(endpointName: EmulatorHealthEndpointName, path: "/ready")
                 .WithUrlForEndpoint(EmulatorHealthEndpointName, u => u.DisplayLocation = UrlDisplayLocation.DetailsOnly);
 
-            // Configure the preview emulator to use an Aspire-managed HTTPS certificate.
+            // Configure the vNext emulator to use an Aspire-managed HTTPS certificate.
             // Use a surrogate builder since AzureCosmosDBResource doesn't implement IResourceWithEnvironment/IResourceWithArgs
             // but AzureCosmosDBEmulatorResource (which extends ContainerResource) does. The surrogate's Annotations
             // delegate to the inner resource, so the annotation ends up on the correct resource.
@@ -244,7 +244,7 @@ public static class AzureCosmosExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        var dataPath = builder.Resource.InnerResource.IsPreviewEmulator ? "/data" : "/tmp/cosmos/appdata";
+        var dataPath = builder.Resource.InnerResource.IsVNextEmulator ? "/data" : "/tmp/cosmos/appdata";
 
         return builder.WithEnvironment("AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE", "true")
             .WithVolume(name ?? VolumeNameGenerator.Generate(builder, "data"), dataPath, isReadOnly: false);
@@ -281,9 +281,9 @@ public static class AzureCosmosExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        if (builder.Resource.InnerResource.IsPreviewEmulator)
+        if (builder.Resource.InnerResource.IsVNextEmulator)
         {
-            throw new NotSupportedException($"'{nameof(WithPartitionCount)}' does not work when using the preview version of the Azure Cosmos DB emulator.");
+            throw new NotSupportedException($"'{nameof(WithPartitionCount)}' does not work when using the Linux-based (vNext) Azure Cosmos DB emulator.");
         }
 
         if (count < 1 || count > 250)
@@ -431,7 +431,7 @@ public static class AzureCosmosExtensions
     }
 
     /// <summary>
-    /// Configures the Azure Cosmos DB preview emulator to expose the Data Explorer endpoint.
+    /// Configures the Azure Cosmos DB Linux-based (vNext) emulator to expose the Data Explorer endpoint.
     /// </summary>
     /// <param name="builder">Builder for the Cosmos emulator container</param>
     /// <param name="port">Optional host port to bind the Data Explorer to.</param>
@@ -445,9 +445,9 @@ public static class AzureCosmosExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        if (!builder.Resource.InnerResource.IsPreviewEmulator)
+        if (!builder.Resource.InnerResource.IsVNextEmulator)
         {
-            throw new NotSupportedException($"The Data Explorer endpoint is only available when using the preview version of the Azure Cosmos DB emulator. Call '{nameof(RunAsPreviewEmulator)}' instead.");
+            throw new NotSupportedException($"The Data Explorer endpoint is only available when using the Linux-based (vNext) Azure Cosmos DB emulator. Call '{nameof(RunAsPreviewEmulator)}' instead.");
         }
 
         var result = builder.WithEndpoint(endpointName: KnownUrls.DataExplorer.EndpointName, endpoint =>

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -244,10 +244,19 @@ public static class AzureCosmosExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        var dataPath = builder.Resource.InnerResource.IsVNextEmulator ? "/data" : "/tmp/cosmos/appdata";
+        var isVNext = builder.Resource.InnerResource.IsVNextEmulator;
 
-        return builder.WithEnvironment("AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE", "true")
-            .WithVolume(name ?? VolumeNameGenerator.Generate(builder, "data"), dataPath, isReadOnly: false);
+        // The vNext (Linux-based) emulator persists to /data and turns on persistence implicitly when a
+        // volume is mounted there; it does not read AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE (that
+        // variable is only honored by the classic emulator, which persists to /tmp/cosmos/appdata).
+        var dataPath = isVNext ? "/data" : "/tmp/cosmos/appdata";
+
+        if (!isVNext)
+        {
+            builder.WithEnvironment("AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE", "true");
+        }
+
+        return builder.WithVolume(name ?? VolumeNameGenerator.Generate(builder, "data"), dataPath, isReadOnly: false);
     }
 
     /// <summary>
@@ -449,6 +458,10 @@ public static class AzureCosmosExtensions
         {
             throw new NotSupportedException($"The Data Explorer endpoint is only available when using the Linux-based (vNext) Azure Cosmos DB emulator. Call '{nameof(RunAsPreviewEmulator)}' instead.");
         }
+
+        // The vNext image enables the Data Explorer by default, but set ENABLE_EXPLORER explicitly so that
+        // exposing this endpoint does not silently depend on the image's default remaining "true".
+        builder.WithEnvironment("ENABLE_EXPLORER", "true");
 
         var result = builder.WithEndpoint(endpointName: KnownUrls.DataExplorer.EndpointName, endpoint =>
             {

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -152,6 +152,13 @@ public static class AzureCosmosExtensions
             var emulatorSurrogate = new AzureCosmosDBEmulatorResource(builder.Resource);
             var emulatorSurrogateBuilder = builder.ApplicationBuilder.CreateResourceBuilder(emulatorSurrogate);
 
+            // The vNext image enables the Data Explorer by default (ENABLE_EXPLORER=true). That runs an
+            // otherwise-unused Node process and, because the emulator's readiness probe is
+            // "ready = postgres && gateway && (explorer || !ENABLE_EXPLORER)", it makes /ready wait on the
+            // explorer even when it is never exposed. Disable it by default; WithDataExplorer re-enables it
+            // later through configureContainer (environment callbacks are last-write-wins).
+            emulatorSurrogateBuilder.WithEnvironment("ENABLE_EXPLORER", "false");
+
             // VNext cosmosdb sets a default CERT_SECRET environment variable for the default emulator certificate and we can't
             // remove it, so we need to provide "some" secret value to avoid issues with our provided certificate. This simply sets the
             // dev cert used by cosmos to have a stable passphrase. Users can override by calling `WithHttpsDeveloperCertificate` again

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -88,9 +88,9 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     public bool IsEmulator => this.IsContainer();
 
     /// <summary>
-    /// Is this instance running a preview emulator version?
+    /// Is this instance running the Linux-based (vNext) emulator?
     /// </summary>
-    internal bool IsPreviewEmulator
+    internal bool IsVNextEmulator
     {
         get => IsEmulator && field;
         set => field = value;
@@ -125,7 +125,7 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         IsEmulator ?
-            AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint, IsPreviewEmulator) :
+            AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint, IsVNextEmulator) :
             UseAccessKeyAuthentication ?
                 ReferenceExpression.Create($"{ConnectionStringSecretOutput}") :
                 ReferenceExpression.Create($"{ConnectionStringOutput}");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -957,6 +957,7 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
                            .RunAsPreviewEmulator(e => e.WithDataExplorer(9999));
 
         var endpoint = Assert.Single(cosmos.Resource.Annotations.OfType<EndpointAnnotation>(), e => e.Name == "data-explorer");
+        // 1234 is the vNext emulator's fixed internal Data Explorer port; the host port (9999) is configurable.
         Assert.Equal(1234, endpoint.TargetPort);
         Assert.Equal(9999, endpoint.Port);
 
@@ -1065,6 +1066,7 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
                            .RunAsPreviewEmulator(e => e.WithDataExplorer());
 
         var endpoint = Assert.Single(cosmos.Resource.Annotations.OfType<EndpointAnnotation>(), e => e.Name == "data-explorer");
+        // 1234 is the vNext emulator's fixed internal Data Explorer port; no host port is bound by default.
         Assert.Equal(1234, endpoint.TargetPort);
         Assert.Null(endpoint.Port);
     }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -14,6 +14,7 @@ using Aspire.Hosting.Utils;
 using Azure.Provisioning.CosmosDB;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;
@@ -1129,6 +1130,102 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
 
         Assert.Equal("localhost", client.Endpoint.Host);
         Assert.Equal(8081, client.Endpoint.Port);
+    }
+
+    [Fact]
+    public void RunAsEmulatorInPublishModeIsNoOp()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsEmulator(e => e.WithDataVolume());
+
+        // In publish mode RunAsEmulator returns before configuring any local container.
+        Assert.False(cosmos.Resource.IsEmulator);
+        Assert.DoesNotContain(cosmos.Resource.Annotations, a => a is ContainerImageAnnotation);
+        Assert.DoesNotContain(cosmos.Resource.Annotations, a => a is EmulatorResourceAnnotation);
+        Assert.DoesNotContain(cosmos.Resource.Annotations, a => a is ContainerMountAnnotation);
+    }
+
+    [Fact]
+    public void RunAsPreviewEmulatorInPublishModeIsNoOp()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsPreviewEmulator(e => e.WithDataVolume());
+
+        Assert.False(cosmos.Resource.IsEmulator);
+        Assert.DoesNotContain(cosmos.Resource.Annotations, a => a is ContainerImageAnnotation);
+        Assert.DoesNotContain(cosmos.Resource.Annotations, a => a is EmulatorResourceAnnotation);
+        Assert.DoesNotContain(cosmos.Resource.Annotations, a => a is ContainerMountAnnotation);
+    }
+
+    [Fact]
+    public async Task RunAsEmulatorHealthCheckThrowsBeforeCosmosClientInitialized()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
+
+        using var app = builder.Build();
+
+        // The classic emulator registers a health check whose CosmosClient factory throws until the
+        // connection string is available. The factory runs when the check is resolved, so running it
+        // before that surfaces the guard.
+        var healthCheckService = app.Services.GetRequiredService<HealthCheckService>();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => healthCheckService.CheckHealthAsync(r => r.Name == "cosmos_check", CancellationToken.None));
+
+        Assert.Equal("CosmosClient is not initialized.", ex.Message);
+    }
+
+    [Fact]
+    public async Task RunAsPreviewEmulatorMarksHealthEndpointUrlAsDetailsOnly()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsPreviewEmulator();
+
+        var urls = new List<ResourceUrlAnnotation>
+        {
+            new() { Url = "http://localhost:8080", Endpoint = cosmos.GetEndpoint("emulatorhealth") }
+        };
+        var context = new ResourceUrlsCallbackContext(
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            cosmos.Resource,
+            urls);
+
+        foreach (var callback in cosmos.Resource.Annotations.OfType<ResourceUrlsCallbackAnnotation>())
+        {
+            await callback.Callback(context);
+        }
+
+        var healthUrl = Assert.Single(urls, u => u.Endpoint?.EndpointName == "emulatorhealth");
+        Assert.Equal(UrlDisplayLocation.DetailsOnly, healthUrl.DisplayLocation);
+    }
+
+    [Fact]
+    public async Task WithDataExplorerSetsDataExplorerDisplayText()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsPreviewEmulator(e => e.WithDataExplorer());
+
+        var urls = new List<ResourceUrlAnnotation>
+        {
+            new() { Url = "http://localhost:1234", Endpoint = cosmos.GetEndpoint("data-explorer") }
+        };
+        var context = new ResourceUrlsCallbackContext(
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            cosmos.Resource,
+            urls);
+
+        foreach (var callback in cosmos.Resource.Annotations.OfType<ResourceUrlsCallbackAnnotation>())
+        {
+            await callback.Callback(context);
+        }
+
+        var explorerUrl = Assert.Single(urls, u => u.Endpoint?.EndpointName == "data-explorer");
+        Assert.Equal("Data Explorer", explorerUrl.DisplayText);
     }
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -673,6 +673,38 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task RunAsPreviewEmulatorCertificateTrustCallbackSetsNodeExtraCaCerts()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var cosmos = builder.AddAzureCosmosDB("cosmos")
+                           .RunAsPreviewEmulator();
+
+        var trustConfigAnnotation = Assert.Single(
+            cosmos.Resource.Annotations.OfType<CertificateTrustConfigurationCallbackAnnotation>());
+
+        var env = new Dictionary<string, object>();
+        var bundlePath = ReferenceExpression.Create($"/certs/bundle.pem");
+
+        var context = new CertificateTrustConfigurationCallbackAnnotationContext
+        {
+            ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            Resource = cosmos.Resource,
+            Arguments = new List<object>(),
+            EnvironmentVariables = env,
+            CertificateBundlePath = bundlePath,
+            CertificateDirectoriesPath = ReferenceExpression.Create($"/certs"),
+            Scope = CertificateTrustScope.Append,
+            CancellationToken = CancellationToken.None
+        };
+
+        await trustConfigAnnotation.Callback(context);
+
+        // The vNext emulator's Node-based Data Explorer trusts the Aspire-managed certificate bundle via NODE_EXTRA_CA_CERTS.
+        Assert.True(env.TryGetValue("NODE_EXTRA_CA_CERTS", out var caCerts));
+        Assert.Same(bundlePath, caCerts);
+    }
+
+    [Fact]
     public async Task RunAsPreviewEmulatorHttpsCertificateCallbackSetsPasswordWhenProvided()
     {
         using var builder = TestDistributedApplicationBuilder.Create();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.CosmosDB;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.CosmosDB;
@@ -885,9 +886,11 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         var mount = Assert.Single(cosmos.Resource.Annotations.OfType<ContainerMountAnnotation>());
         Assert.Equal("/tmp/cosmos/appdata", mount.Target);
         Assert.Equal(ContainerMountType.Volume, mount.Type);
+        Assert.False(mount.IsReadOnly);
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(cosmos.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
-        Assert.Equal("true", config["AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE"]);
+        Assert.True(config.TryGetValue("AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE", out var persistence));
+        Assert.Equal("true", persistence);
     }
 
     [Fact]
@@ -925,7 +928,8 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         Assert.Equal(9999, endpoint.Port);
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(cosmos.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
-        Assert.Equal("true", config["ENABLE_EXPLORER"]);
+        Assert.True(config.TryGetValue("ENABLE_EXPLORER", out var enableExplorer));
+        Assert.Equal("true", enableExplorer);
     }
 
     [Fact]
@@ -939,9 +943,34 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         // the vNext emulator uses a URL-based AccountEndpoint whose scheme follows the emulator endpoint.
         var csExpr = cosmos.Resource.ConnectionStringExpression;
         Assert.Equal(
-            "AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;AccountEndpoint={cosmos.bindings.emulator.url}",
+            $"AccountKey={CosmosConstants.EmulatorAccountKey};AccountEndpoint={{cosmos.bindings.emulator.url}}",
             csExpr.ValueExpression);
         Assert.DoesNotContain("DisableServerCertificateValidation", csExpr.ValueExpression);
+    }
+
+    [Fact]
+    public async Task RunAsPreviewEmulatorDisablesDataExplorerByDefault()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsPreviewEmulator();
+
+        // The vNext image enables the Data Explorer by default; Aspire disables it unless WithDataExplorer is called.
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(cosmos.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+        Assert.True(config.TryGetValue("ENABLE_EXPLORER", out var enableExplorer));
+        Assert.Equal("false", enableExplorer);
+    }
+
+    [Fact]
+    public async Task RunAsEmulatorDoesNotSetEnableExplorer()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
+
+        // ENABLE_EXPLORER is a vNext-only concept; the classic emulator should not have it set.
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(cosmos.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+        Assert.DoesNotContain("ENABLE_EXPLORER", config.Keys);
     }
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -829,6 +829,121 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         Assert.Equal("http", dataExplorerEndpoint.UriScheme);
     }
 
+    [Fact]
+    public void RunAsEmulatorUsesStableImageTag()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
+
+        var image = Assert.Single(cosmos.Resource.Annotations.OfType<ContainerImageAnnotation>());
+        Assert.Equal("mcr.microsoft.com", image.Registry);
+        Assert.Equal("cosmosdb/linux/azure-cosmos-emulator", image.Image);
+        Assert.Equal("stable", image.Tag);
+    }
+
+    [Fact]
+    public void RunAsPreviewEmulatorUsesVNextLatestImageTag()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsPreviewEmulator();
+
+        var image = Assert.Single(cosmos.Resource.Annotations.OfType<ContainerImageAnnotation>());
+        Assert.Equal("mcr.microsoft.com", image.Registry);
+        Assert.Equal("cosmosdb/linux/azure-cosmos-emulator", image.Image);
+        Assert.Equal("vnext-latest", image.Tag);
+    }
+
+    [Fact]
+    public async Task WithDataVolumeOnVNextEmulatorUsesDataPathWithoutPersistenceEnvVar()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos")
+                           .RunAsPreviewEmulator(e => e.WithDataVolume());
+
+        var mount = Assert.Single(cosmos.Resource.Annotations.OfType<ContainerMountAnnotation>());
+        Assert.Equal("/data", mount.Target);
+        Assert.Equal(ContainerMountType.Volume, mount.Type);
+        Assert.False(mount.IsReadOnly);
+
+        // The vNext emulator does not read AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE; persistence is
+        // enabled implicitly by mounting the volume at /data.
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(cosmos.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+        Assert.DoesNotContain("AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE", config.Keys);
+    }
+
+    [Fact]
+    public async Task WithDataVolumeOnClassicEmulatorUsesAppDataPathWithPersistenceEnvVar()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos")
+                           .RunAsEmulator(e => e.WithDataVolume());
+
+        var mount = Assert.Single(cosmos.Resource.Annotations.OfType<ContainerMountAnnotation>());
+        Assert.Equal("/tmp/cosmos/appdata", mount.Target);
+        Assert.Equal(ContainerMountType.Volume, mount.Type);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(cosmos.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+        Assert.Equal("true", config["AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE"]);
+    }
+
+    [Fact]
+    public void WithPartitionCountThrowsOnVNextEmulator()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos");
+
+        Assert.Throws<NotSupportedException>(() => cosmos.RunAsPreviewEmulator(e => e.WithPartitionCount(10)));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(251)]
+    public void WithPartitionCountThrowsWhenOutOfRange(int count)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => cosmos.RunAsEmulator(e => e.WithPartitionCount(count)));
+    }
+
+    [Fact]
+    public async Task WithDataExplorerExposesCustomPortAndEnablesExplorer()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos")
+                           .RunAsPreviewEmulator(e => e.WithDataExplorer(9999));
+
+        var endpoint = Assert.Single(cosmos.Resource.Annotations.OfType<EndpointAnnotation>(), e => e.Name == "data-explorer");
+        Assert.Equal(1234, endpoint.TargetPort);
+        Assert.Equal(9999, endpoint.Port);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(cosmos.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+        Assert.Equal("true", config["ENABLE_EXPLORER"]);
+    }
+
+    [Fact]
+    public void RunAsPreviewEmulatorUsesUrlBasedConnectionString()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsPreviewEmulator();
+
+        // Unlike the classic emulator (which uses https://{host}:{port};DisableServerCertificateValidation=True),
+        // the vNext emulator uses a URL-based AccountEndpoint whose scheme follows the emulator endpoint.
+        var csExpr = cosmos.Resource.ConnectionStringExpression;
+        Assert.Equal(
+            "AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;AccountEndpoint={cosmos.bindings.emulator.url}",
+            csExpr.ValueExpression);
+        Assert.DoesNotContain("DisableServerCertificateValidation", csExpr.ValueExpression);
+    }
+
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]
     private static extern Task ExecuteBeforeStartHooksAsync(DistributedApplication app, CancellationToken cancellationToken);
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -12,6 +12,7 @@ using Aspire.Hosting.Azure.CosmosDB;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.CosmosDB;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
@@ -666,9 +667,9 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
 
         await certConfigAnnotation.Callback(context);
 
-        Assert.Contains("PROTOCOL", env.Keys);
-        Assert.Contains("EXPLORER_PROTOCOL", env.Keys);
-        Assert.Contains("CERT_PATH", env.Keys);
+        Assert.Equal("https", env["PROTOCOL"]);
+        Assert.Equal("https", env["EXPLORER_PROTOCOL"]);
+        Assert.Same(context.PfxPath, env["CERT_PATH"]);
         Assert.DoesNotContain("CERT_SECRET", env.Keys);
     }
 
@@ -733,10 +734,9 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
 
         await certConfigAnnotation.Callback(context);
 
-        Assert.Contains("PROTOCOL", env.Keys);
-        Assert.Contains("EXPLORER_PROTOCOL", env.Keys);
-        Assert.Contains("CERT_PATH", env.Keys);
-        Assert.Contains("CERT_SECRET", env.Keys);
+        Assert.Equal("https", env["PROTOCOL"]);
+        Assert.Equal("https", env["EXPLORER_PROTOCOL"]);
+        Assert.Same(context.PfxPath, env["CERT_PATH"]);
         Assert.Same(passwordParam, env["CERT_SECRET"]);
     }
 
@@ -1003,6 +1003,132 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         // ENABLE_EXPLORER is a vNext-only concept; the classic emulator should not have it set.
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(cosmos.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
         Assert.DoesNotContain("ENABLE_EXPLORER", config.Keys);
+    }
+
+    [Fact]
+    public void RunAsPreviewEmulatorConfiguresHealthEndpoint()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsPreviewEmulator();
+
+        var healthEndpoint = Assert.Single(cosmos.Resource.Annotations.OfType<EndpointAnnotation>(), e => e.Name == "emulatorhealth");
+        Assert.Equal(8080, healthEndpoint.TargetPort);
+        Assert.Equal("http", healthEndpoint.UriScheme);
+        Assert.True(healthEndpoint.ExcludeReferenceEndpoint);
+
+        Assert.Contains(cosmos.Resource.Annotations, a => a is HealthCheckAnnotation);
+    }
+
+    [Fact]
+    public void RunAsEmulatorRegistersHealthCheck()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
+
+        Assert.Contains(cosmos.Resource.Annotations, a => a is HealthCheckAnnotation hc && hc.Key == "cosmos_check");
+    }
+
+    [Fact]
+    public void WithDataVolumeUsesProvidedVolumeName()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos")
+                           .RunAsEmulator(e => e.WithDataVolume("my-custom-volume"));
+
+        var mount = Assert.Single(cosmos.Resource.Annotations.OfType<ContainerMountAnnotation>());
+        Assert.Equal("my-custom-volume", mount.Source);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(250)]
+    public async Task WithPartitionCountAcceptsBoundaryValues(int count)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsEmulator(e => e.WithPartitionCount(count));
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(cosmos.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+        Assert.Equal(count.ToString(CultureInfo.InvariantCulture), config["AZURE_COSMOS_EMULATOR_PARTITION_COUNT"]);
+    }
+
+    [Fact]
+    public void WithDataExplorerDefaultPortLeavesHostPortNull()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos")
+                           .RunAsPreviewEmulator(e => e.WithDataExplorer());
+
+        var endpoint = Assert.Single(cosmos.Resource.Annotations.OfType<EndpointAnnotation>(), e => e.Name == "data-explorer");
+        Assert.Equal(1234, endpoint.TargetPort);
+        Assert.Null(endpoint.Port);
+    }
+
+    [Fact]
+    public async Task RunAsPreviewEmulatorResourceReadyThrowsWhenCosmosClientNotInitialized()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsPreviewEmulator();
+
+        using var app = builder.Build();
+
+        // Publishing ResourceReadyEvent without ConnectionStringAvailableEvent leaves the CosmosClient uninitialized.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => builder.Eventing.PublishAsync(new ResourceReadyEvent(cosmos.Resource, app.Services)));
+        Assert.Equal("CosmosClient is not initialized.", ex.Message);
+    }
+
+    [Fact]
+    public async Task RunAsEmulatorConnectionStringAvailableInitializesCosmosClient()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsEmulator(e =>
+        {
+            e.WithEndpoint("emulator", endpoint => endpoint.AllocatedEndpoint = new(endpoint, "localhost", 10001));
+        });
+
+        using var app = builder.Build();
+
+        // Resolves the emulator connection string and constructs the CosmosClient without throwing.
+        await builder.Eventing.PublishAsync(new ConnectionStringAvailableEvent(cosmos.Resource, app.Services));
+    }
+
+    [Fact]
+    public void CreateCosmosClientForEmulatorConnectionStringUsesGatewayMode()
+    {
+        var connectionString = $"AccountKey={CosmosConstants.EmulatorAccountKey};AccountEndpoint=https://localhost:8081/";
+
+        using var client = AzureCosmosExtensions.CreateCosmosClient(connectionString);
+
+        Assert.Equal(ConnectionMode.Gateway, client.ClientOptions.ConnectionMode);
+        Assert.True(client.ClientOptions.LimitToEndpoint);
+    }
+
+    [Fact]
+    public void CreateCosmosClientForNonEmulatorConnectionStringUsesDefaults()
+    {
+        // A well-formed non-emulator connection string (valid base64 key) must not force Gateway/LimitToEndpoint.
+        var connectionString = "AccountEndpoint=https://example.documents.azure.com:443/;AccountKey=dGVzdGtleQ==";
+
+        using var client = AzureCosmosExtensions.CreateCosmosClient(connectionString);
+
+        Assert.NotEqual(ConnectionMode.Gateway, client.ClientOptions.ConnectionMode);
+        Assert.False(client.ClientOptions.LimitToEndpoint);
+    }
+
+    [Fact]
+    public void CreateCosmosClientForAbsoluteUriUsesEndpoint()
+    {
+        using var client = AzureCosmosExtensions.CreateCosmosClient("https://localhost:8081/");
+
+        Assert.Equal("localhost", client.Endpoint.Host);
+        Assert.Equal(8081, client.Endpoint.Port);
     }
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]


### PR DESCRIPTION
## Description

#18158 (merged) bumped the Azure Cosmos DB Linux-based (vNext) emulator image
tag to the GA `vnext-latest`. This PR completes the GA alignment of the Aspire
integration: it updates the integration's internal naming and docs from
"preview" to "vNext", fixes emulator environment-variable inconsistencies, and
adds comprehensive test coverage for the emulator surface.

What changes for users:

- `WithDataVolume()` on the vNext emulator no longer emits the
  `AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE` environment variable. That
  variable is only honored by the classic (Windows) emulator; the vNext emulator
  persists implicitly when a volume is mounted at `/data`, so setting it was a
  no-op. It is still emitted for the classic emulator.
- The in-container Data Explorer is now opt-in on the vNext emulator:
  `RunAsPreviewEmulator()` sets `ENABLE_EXPLORER=false` by default, and
  `WithDataExplorer()` re-enables it (`ENABLE_EXPLORER=true`). Previously the
  explorer ran unconditionally (the GA image defaults it on), which also made the
  emulator's `/ready` readiness probe wait on the explorer even when it was never
  exposed (the probe is `ready = postgres && gateway && (explorer || !ENABLE_EXPLORER)`).
- `RunAsPreviewEmulator()` continues to pull the GA `vnext-latest` image (from
  #18158). The public API and call site are unchanged.

Implementation details:

- Internal naming aligned with the GA image: `IsPreviewEmulator` ->
  `IsVNextEmulator`, `useVNextPreview` -> `useVNext`, parameter
  `isPreviewEmulator` -> `isVNext`, plus comments, XML doc descriptions, and
  `NotSupportedException` messages updated from "preview" to "Linux-based (vNext)".
- `CreateCosmosClient` was extracted from a static local into an `internal static`
  method so its branches can be unit-tested directly.
- The public `RunAsPreviewEmulator` method and the
  `[Experimental("ASPIRECOSMOSDB001")]` attribute are intentionally kept to avoid
  a breaking API-surface change.

This change was validated against the GA emulator source: the gateway advertises
endpoints from `GATEWAY_PUBLIC_ENDPOINT`, and Aspire neutralizes the dynamic
host-port mapping by setting `LimitToEndpoint = true` for emulator connection
strings in the hosting seeding client and both the Cosmos and EF Core Cosmos
client integrations. The configured ports (gateway 8081, health `/ready` on
8080, Data Explorer 1234), `PROTOCOL`/`EXPLORER_PROTOCOL`/`CERT_PATH`/`CERT_SECRET`/`NODE_EXTRA_CA_CERTS`
env vars, and the `/data` persistence path all match the GA image.

### User-facing usage

```csharp
// Pulls mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-latest
var cosmos = builder.AddAzureCosmosDB("cosmos")
                    .RunAsPreviewEmulator(emulator =>
                    {
                        emulator.WithDataVolume();    // persists to /data
                        emulator.WithDataExplorer();  // opt-in: ENABLE_EXPLORER=true, exposes port 1234
                    });
```

### Testing

Added comprehensive unit coverage for the emulator surface in
`AzureCosmosDBExtensionsTests` (141 Cosmos tests pass; build is clean, 0 warnings,
0 errors):

- Default image tags (`vnext-latest` / `stable`); publish-mode no-op for both `RunAsEmulator` and `RunAsPreviewEmulator`.
- `WithDataVolume` vNext (`/data`, no persistence env) vs classic (`/tmp/cosmos/appdata` + env), and a custom volume name.
- `WithPartitionCount` happy path, boundary values (1/250), out-of-range throw, and vNext `NotSupportedException`.
- `WithDataExplorer` opt-in (`ENABLE_EXPLORER=true`), default/custom host port, non-vNext throw, HTTPS endpoint flip, and the Data Explorer display-text URL callback.
- vNext health endpoint (`emulatorhealth`/8080, `ExcludeReferenceEndpoint`, `/ready`, DetailsOnly URL) and classic health-check registration + factory guard.
- Event-driven paths: `OnConnectionStringAvailable` initializes the client; `OnResourceReady` throws when the client is uninitialized.
- `CreateCosmosClient` all three branches (emulator connection string → Gateway/`LimitToEndpoint`, non-emulator, absolute URI).
- HTTPS certificate config callback (asserting `PROTOCOL`/`EXPLORER_PROTOCOL`/`CERT_PATH`/`CERT_SECRET` values, with/without password) and the certificate-trust callback (`NODE_EXTRA_CA_CERTS`).
- vNext URL-based connection string (no `DisableServerCertificateValidation`) and classic connection string.

> Coverage note: every emulator code path reachable without a live container is
> now unit-tested. The only uncovered code is the `OnResourceReady` happy-path
> body (`ReadAccountAsync` + database/container creation), which requires a live
> emulator and is exercised by the functional tests that are currently skipped
> (flaky #5820 / ActiveIssue #7178 / Docker-gated), plus defensive argument/null
> guards and copy-paste defensive branches shared across Aspire integrations.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
