### PR TITLE
ci: temporarily force-rerun all failed CI jobs

### DIFF
--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -1,4 +1,26 @@
 // Shared matcher, summary, and rerun helpers for the transient CI rerun workflow.
+//
+// TEMPORARY — FORCE_RERUN_ALL (revert when no longer needed):
+// When the YAML `FORCE_RERUN_ALL` env var is 'true', the workflow runs in force mode:
+// it is a plain short-circuit. If a CI run failed and has a currently-open associated
+// PR, it reruns the failed jobs — full stop. No job is fetched or classified, the
+// patterns config is not consulted, and there is no job-count cap.
+//
+// The two hard gates are already enforced by the YAML trigger `if`, so force mode does
+// not re-implement them:
+//   * "CI failed"      -> trigger only fires on `workflow_run.conclusion == 'failure'`,
+//                         which also means a run that was merely *cancelled* never
+//                         triggers a rerun (its conclusion is 'cancelled', not 'failure').
+//   * "max 3 reruns"   -> trigger gates on `run_attempt <= 3`; computeRerunEligibility
+//                         re-checks the same attempt cap for the manual-dispatch path.
+//
+// Force mode still KEEPS the open-PR requirement (no point spending CI on a run whose
+// PRs are all closed/merged). `forceRerunAll` defaults to false everywhere, so the
+// normal transient-failure classification/eligibility path — and its tests — are
+// unchanged when the flag is off.
+//
+// To disable: flip FORCE_RERUN_ALL to 'false' (or remove the env var) on both jobs in
+// the YAML. See docs/ci/auto-rerun-transient-ci-failures.md.
 const fs = require('node:fs');
 
 const failureConclusions = new Set(['failure', 'cancelled', 'timed_out', 'startup_failure']);
@@ -518,9 +540,23 @@ function computeRerunEligibility({
     retryableCount,
     maxRetryableJobs = defaultMaxRetryableJobs,
     runAttempt = 1,
-    maxRunAttempt = defaultMaxRunAttempt
+    maxRunAttempt = defaultMaxRunAttempt,
+    forceRerunAll = false
 }) {
-    if (retryableCount <= 0 || runAttempt > maxRunAttempt) {
+    // The attempt cap applies in every mode: never rerun past maxRunAttempt source
+    // attempts (up to 3 auto-reruns / 4 total attempts).
+    if (runAttempt > maxRunAttempt) {
+        return false;
+    }
+
+    // FORCE_RERUN_ALL short-circuit: the run failed (YAML trigger gate) and has an open
+    // PR (checked in the workflow), so it is eligible — only the attempt cap above
+    // matters. There is no job-count analysis. See the file-level comment to disable.
+    if (forceRerunAll) {
+        return true;
+    }
+
+    if (retryableCount <= 0) {
         return false;
     }
 
@@ -537,9 +573,10 @@ function computeRerunExecutionEligibility({
     retryableCount,
     maxRetryableJobs = defaultMaxRetryableJobs,
     runAttempt = 1,
-    maxRunAttempt = defaultMaxRunAttempt
+    maxRunAttempt = defaultMaxRunAttempt,
+    forceRerunAll = false
 }) {
-    return !dryRun && computeRerunEligibility({ retryableCount, maxRetryableJobs, runAttempt, maxRunAttempt });
+    return !dryRun && computeRerunEligibility({ retryableCount, maxRetryableJobs, runAttempt, maxRunAttempt, forceRerunAll });
 }
 
 function buildSummaryReference(url, text) {
@@ -663,6 +700,61 @@ async function writeAnalysisSummary({
     await summary.write();
 }
 
+// FORCE_RERUN_ALL summary. Force mode does not enumerate or classify jobs, so the
+// analyze-step summary is intentionally minimal: it records the eligibility decision
+// (the attempt cap is the only force-mode eligibility rule) and the analyzed run, with
+// no job/skip tables.
+async function writeForceRerunSummary({
+    summary,
+    rerunEligible,
+    dryRun,
+    sourceRunUrl,
+    sourceRunAttempt,
+    runAttempt,
+    maxRunAttempt = defaultMaxRunAttempt,
+    openPullRequestNumbers = [],
+}) {
+    const analyzedRunReference = buildSummaryReference(
+        buildWorkflowRunAttemptUrl(sourceRunUrl, sourceRunAttempt),
+        Number.isInteger(sourceRunAttempt) && sourceRunAttempt > 0
+            ? `workflow run attempt ${sourceRunAttempt}`
+            : 'workflow run'
+    );
+    const outcome = rerunEligible ? 'Rerun eligible' : 'Rerun skipped';
+    // In force mode the only way to be ineligible is the attempt cap: this summary runs
+    // after the open-PR gate (the zero-PR case returns earlier), and force-mode
+    // computeRerunEligibility returns false solely when runAttempt > maxRunAttempt. The
+    // skipped case is reachable only via a manual workflow_dispatch on a run past the cap
+    // (the workflow_run trigger gates run_attempt <= 3, so the auto path is always eligible).
+    const outcomeDetails = rerunEligible
+        ? dryRun
+            ? 'Force-rerun mode: the failed jobs would be rerun if dry run were disabled (transient-failure analysis bypassed).'
+            : 'Force-rerun mode: re-running the failed jobs (transient-failure analysis bypassed).'
+        : `Force-rerun mode: the attempt cap was reached (attempt ${runAttempt} > ${maxRunAttempt}); no rerun was requested.`;
+
+    const summaryRows = [
+        [{ data: 'Category', header: true }, { data: 'Value', header: true }],
+        ['Mode', 'Force rerun (transient-failure analysis bypassed)'],
+        ['Outcome', outcome],
+        ['Source run attempt', String(Number.isInteger(runAttempt) ? runAttempt : sourceRunAttempt ?? 'unknown')],
+        ['Max run attempt', String(maxRunAttempt)],
+        ['Associated pull requests', String(openPullRequestNumbers.length)],
+        ['Dry run', String(dryRun)],
+        ['Eligible to rerun', String(rerunEligible)],
+    ];
+
+    await summary
+        .addHeading(outcome)
+        .addTable(summaryRows);
+
+    addSummaryReference(summary, 'Analyzed run', analyzedRunReference)
+        .addRaw(outcomeDetails)
+        .addBreak()
+        .addBreak();
+
+    await summary.write();
+}
+
 async function getOpenPullRequestNumbers({ github, owner, repo, pullRequestNumbers }) {
     const openPullRequestNumbers = [];
 
@@ -738,7 +830,15 @@ function buildPullRequestCommentBody({
     rerunAttemptUrl,
     retryableJobs,
     testPatternMatchedTests = [],
+    forceRerunAll = false,
 }) {
+    // FORCE_RERUN_ALL: force mode is a plain short-circuit — no jobs are fetched or
+    // classified, so there is no job list to show. Keep the comment to a single short
+    // line: the failed jobs are being retried. See the file-level comment.
+    if (forceRerunAll) {
+        return `Retrying the failed CI jobs for this pull request from ${formatMarkdownLink('the CI run attempt', failedAttemptUrl)}. The rerun is being tracked in ${formatMarkdownLink('the rerun attempt', rerunAttemptUrl)}.`;
+    }
+
     const lines = [
         `Re-running the failed jobs in the CI workflow for this pull request because ${retryableJobs.length} job${retryableJobs.length === 1 ? ' was' : 's were'} identified as retry-safe transient failures in ${formatMarkdownLink('the CI run attempt', failedAttemptUrl)}.`,
         `GitHub was asked to rerun all failed jobs for that attempt, and the rerun is being tracked in ${formatMarkdownLink('the rerun attempt', rerunAttemptUrl)}.`,
@@ -803,8 +903,12 @@ async function rerunMatchedJobs({
     sourceRunUrl,
     sourceRunAttempt,
     testPatternMatchedTests = [],
+    forceRerunAll = false,
 }) {
-    if (retryableJobs.length === 0) {
+    // Normal mode lists retry-safe jobs first; an empty list means nothing to rerun.
+    // Force mode is a short-circuit that does not enumerate jobs (retryableJobs is
+    // empty by design), so it must proceed to the rerun regardless.
+    if (!forceRerunAll && retryableJobs.length === 0) {
         return;
     }
 
@@ -815,6 +919,9 @@ async function rerunMatchedJobs({
         pullRequestNumbers,
     });
 
+    // The open-PR gate applies in all modes (including force mode): a rerun is
+    // skipped when every associated PR is closed. There is no value in spending CI on
+    // a closed/merged PR, so force mode does NOT bypass this.
     if (pullRequestNumbers.length > 0 && openPullRequestNumbers.length === 0) {
         const failedAttemptReference = buildWorkflowRunReference(sourceRunUrl, sourceRunAttempt);
         await summary
@@ -870,6 +977,7 @@ async function rerunMatchedJobs({
                 rerunAttemptUrl: rerunAttemptReference.url,
                 retryableJobs,
                 testPatternMatchedTests,
+                forceRerunAll,
             }),
         });
     }
@@ -879,7 +987,20 @@ async function rerunMatchedJobs({
 
     addSummaryReference(summaryBuilder, 'Failed attempt', failedAttemptReference);
     addSummaryReference(summaryBuilder, 'Rerun attempt', rerunAttemptReference);
-    addSummaryCommentReferences(summaryBuilder, postedComments)
+    addSummaryCommentReferences(summaryBuilder, postedComments);
+
+    // Force mode does not enumerate jobs, so there is no retry-safe job table to show.
+    if (forceRerunAll) {
+        summaryBuilder
+            .addBreak()
+            .addRaw('Force-rerun mode: the CI run failed, so GitHub was asked to rerun all failed jobs for the failed attempt. Transient-failure analysis was bypassed.')
+            .addBreak();
+
+        await summaryBuilder.write();
+        return;
+    }
+
+    summaryBuilder
         .addBreak()
         .addRaw('The matched jobs below made the run eligible for rerun. GitHub was asked to rerun all failed jobs for the failed attempt.')
         .addBreak()
@@ -1355,4 +1476,5 @@ module.exports = {
     testExecutionFailureStepPatterns,
     validateRetryPatternsConfig,
     writeAnalysisSummary,
+    writeForceRerunSummary,
 };

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -65,6 +65,15 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           MANUAL_RUN_ID: ${{ inputs.run_id }}
           MANUAL_DRY_RUN: ${{ inputs.dry_run }}
+          # TEMPORARY — FORCE_RERUN_ALL (revert when no longer needed):
+          # Short-circuit the analysis: if a CI run failed and has a currently-open
+          # associated PR, rerun its failed jobs — no job is fetched or classified, and
+          # there is no job-count cap. The "CI failed" and "max 3 reruns" gates come from
+          # the job-level `if` above; the open-PR requirement and the manual-dispatch
+          # attempt cap are preserved. This is a for-now measure until CI auto-rerun
+          # patterns are improved; disable by setting this to 'false' (or removing it) on
+          # both jobs. See docs/ci/auto-rerun-transient-ci-failures.md.
+          FORCE_RERUN_ALL: 'true'
         with:
           script: |
             const rerunWorkflow = require('./.github/workflows/auto-rerun-transient-ci-failures.js');
@@ -77,6 +86,8 @@ jobs:
             const isWorkflowDispatch = context.eventName === 'workflow_dispatch';
             const maxRetryableJobs = rerunWorkflow.defaultMaxRetryableJobs;
             const maxJobLogInspectionBytes = 256 * 1024;
+            // FORCE_RERUN_ALL: see env comment above.
+            const forceRerunAll = String(process.env.FORCE_RERUN_ALL).toLowerCase() === 'true';
 
             async function paginate(route, parameters, selectItems) {
               const items = [];
@@ -224,8 +235,51 @@ jobs:
             });
             core.setOutput('pull_request_numbers', JSON.stringify(pullRequestNumbers));
 
+            // The open-PR requirement applies in all modes: skip runs with no
+            // associated PR. Force mode does not bypass this — there is no value in
+            // spending CI on a run that has no open PR behind it.
             if (pullRequestNumbers.length === 0) {
               console.log('No associated pull request could be resolved for this workflow run. Skipping.');
+              return;
+            }
+
+            // TEMPORARY — FORCE_RERUN_ALL short-circuit (revert when no longer needed):
+            // The run failed (job-level `if`) and has an associated PR (checked above),
+            // so request a rerun without fetching or classifying any jobs. Only the
+            // attempt cap is re-checked here (it matters for the manual-dispatch path,
+            // which bypasses the trigger's run_attempt gate). The retryable_jobs output
+            // stays '[]' on purpose: the rerun job uses GitHub's rerun-failed-jobs API,
+            // which reruns every failed job regardless of this list, and the final
+            // open-PR state is re-checked there. See the JS file-level comment.
+            if (forceRerunAll) {
+              const forceRunAttempt = workflowRun.run_attempt;
+              const forceRerunEligible = rerunWorkflow.computeRerunEligibility({
+                runAttempt: forceRunAttempt,
+                forceRerunAll: true,
+              });
+              const forceRerunExecutionEligible = rerunWorkflow.computeRerunExecutionEligibility({
+                dryRun,
+                runAttempt: forceRunAttempt,
+                forceRerunAll: true,
+              });
+
+              core.setOutput('rerun_eligible', String(forceRerunEligible));
+              core.setOutput('rerun_execution_eligible', String(forceRerunExecutionEligible));
+
+              await rerunWorkflow.writeForceRerunSummary({
+                summary: core.summary,
+                rerunEligible: forceRerunEligible,
+                dryRun,
+                sourceRunUrl,
+                sourceRunAttempt: forceRunAttempt,
+                runAttempt: forceRunAttempt,
+                openPullRequestNumbers: pullRequestNumbers,
+              });
+
+              if (!forceRerunEligible) {
+                console.log(`Force-rerun mode: attempt cap reached (attempt ${forceRunAttempt}). Skipping.`);
+              }
+
               return;
             }
 
@@ -248,7 +302,7 @@ jobs:
               retryPatternsConfig,
             });
 
-            // TRX-based analysis: check test output for transient patterns
+            // TRX-based analysis: check test output for transient patterns.
             let testPatternMatchedTests = [];
             const hasSkippedTestExecJobs = skippedJobs.some(job =>
               rerunWorkflow.hasTestExecutionFailureStep(job.failedSteps)
@@ -396,6 +450,12 @@ jobs:
           SOURCE_RUN_ATTEMPT: ${{ needs.analyze-transient-failures.outputs.source_run_attempt }}
           SOURCE_RUN_URL: ${{ needs.analyze-transient-failures.outputs.source_run_url }}
           TEST_PATTERN_MATCHED_TESTS: ${{ needs.analyze-transient-failures.outputs.test_pattern_matched_tests }}
+          # TEMPORARY — FORCE_RERUN_ALL (revert when no longer needed): in force mode the
+          # analyze step does not enumerate jobs, so RETRYABLE_JOBS is '[]'. This flag tells
+          # the rerun step to proceed anyway (GitHub's rerun-failed-jobs API reruns every
+          # failed job) and to use the short force-mode PR comment / summary wording. Keep
+          # in sync with the analyze step's FORCE_RERUN_ALL.
+          FORCE_RERUN_ALL: 'true'
         with:
           script: |
             const rerunWorkflow = require('./.github/workflows/auto-rerun-transient-ci-failures.js');
@@ -407,8 +467,13 @@ jobs:
             const sourceRunAttempt = Number(process.env.SOURCE_RUN_ATTEMPT);
             const sourceRunUrl = process.env.SOURCE_RUN_URL;
             const testPatternMatchedTests = JSON.parse(process.env.TEST_PATTERN_MATCHED_TESTS || '[]');
+            // FORCE_RERUN_ALL: see env comment above.
+            const forceRerunAll = String(process.env.FORCE_RERUN_ALL).toLowerCase() === 'true';
 
-            if (retryableJobs.length === 0) {
+            // Normal mode passes the retry-safe job list; an empty list means nothing to
+            // rerun. Force mode intentionally passes an empty list (no enumeration), so it
+            // must proceed to the rerun.
+            if (!forceRerunAll && retryableJobs.length === 0) {
               console.log('No retryable jobs were provided to the rerun job.');
               return;
             }
@@ -424,4 +489,5 @@ jobs:
               sourceRunAttempt,
               sourceRunUrl,
               testPatternMatchedTests,
+              forceRerunAll,
             });

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -6,6 +6,8 @@ This document explains how the automatic CI rerun system works and how to config
 
 When a `CI` pull request run fails on GitHub Actions, a companion workflow automatically analyzes the failure, determines whether it was caused by transient infrastructure or test issues, and — if safe — requests GitHub to rerun the failed jobs. It also posts a comment on the PR explaining what it did and why.
 
+> **Currently in force mode.** The workflow is temporarily configured to skip the analysis below and rerun the failed jobs on **any** failed run with an open PR. See [Force-rerun all failures](#force-rerun-all-failures-force_rerun_all). The rest of this section describes the normal (analysis) behavior that force mode bypasses.
+
 ```text
 CI run fails on PR
        │
@@ -21,7 +23,7 @@ CI run fails on PR
                ▼
 ┌──────────────────────────────────┐
 │  Safety rails                    │
-│  • ≤ 3 total attempts            │
+│  • attempts 1–3 → up to 3 reruns │
 │  • ≤ 5 retryable jobs (default)  │
 │  • PR must still be open         │
 └──────────────┬───────────────────┘
@@ -179,13 +181,36 @@ The workflow is intentionally conservative. All of these conditions must be met 
 
 | Rail | Detail |
 |------|--------|
-| **Attempt limit** | The source run must be on attempt ≤ 3 (allowing up to 2 automatic reruns, 3 total attempts). |
+| **Attempt limit** | The source run must be on attempt ≤ 3. Reruns are triggered from source attempts 1, 2, and 3, so a run gets up to 3 automatic reruns (4 total attempts) before the cap stops further reruns. |
 | **Retryable job cap** | At least 1 but no more than 5 retryable jobs (default). On attempts > 1, the cap is stricter: the count must be *strictly less than* 5. |
 | **Open PR** | At least one associated pull request must still be open. |
 | **Non-aggregator** | Aggregator jobs (`Final Results`, `Tests / Final Test Results`) are excluded from analysis. |
 | **Mixed-failure veto** | A job with both a test execution failure (`Run tests*`) and unrelated transient post-step noise is *not* retried on infrastructure grounds alone — the test execution failure must match a pattern (pass 3 or 4) to qualify. |
 
 When a rerun is requested, GitHub reruns **all** failed jobs for that attempt — not just the matched ones. This is a GitHub API constraint (there is no API for atomically rerunning a subset of failed jobs). The matched-job count and safety rails are the eligibility gate; once eligible, the rerun covers the full failed set.
+
+## Force-rerun all failures (`FORCE_RERUN_ALL`)
+
+> **For-now behavior:** the workflow reruns the failed CI jobs on any failed run with an open PR, without analyzing the failure. This stays in place until CI auto-rerun patterns are improved (e.g. agents curating the transient-failure rules). Disable it by flipping the flag (see below); the classification rules are kept intact behind it.
+
+The workflow currently runs in **force mode**, enabled by the `FORCE_RERUN_ALL: 'true'` environment variable set on both jobs in [`auto-rerun-transient-ci-failures.yml`](../../.github/workflows/auto-rerun-transient-ci-failures.yml). Force mode is a **short-circuit**: as soon as the run is eligible (failed run, attempt ≤ 3, open PR), it requests a rerun of the failed jobs and stops. It does not look at individual jobs at all.
+
+**Force mode bypasses:**
+
+1. **All job analysis** — the workflow does not enumerate jobs, fetch annotations, download logs, parse TRX files, or run any of the four classification passes. The annotation-allowlist, infrastructure/network-log-override, job-log-pattern, and TRX test-pattern analysis are all skipped. No per-job decision is made.
+2. **The retryable-job-count cap** — the `≤ 5 retryable jobs` rail is not applied (there is no job list to count).
+
+Because the rerun uses GitHub's `rerun-failed-jobs` API — which reruns **all** non-successful jobs for the attempt regardless of any job list — the short-circuit reruns exactly what the normal path would have, without doing the analysis to get there.
+
+**Force mode keeps:**
+
+- **The open-PR requirement** — a rerun only fires for a run that has a currently-open associated PR. Runs with no associated PR, or where every associated PR is closed/merged, are still skipped. There is no value in spending CI on an inactive PR, so force mode does not bypass this.
+- **The attempt cap** — reruns still only fire from source attempts 1–3 (up to 3 automatic reruns / 4 total attempts). This is unchanged.
+- **Failed-run-only triggering** — the workflow only fires on `workflow_run.conclusion == 'failure'`. A `cancelled` run (which is what you get when a run is cancelled, or when fail-fast cancels siblings) has conclusion `cancelled`, not `failure`, so it never triggers a rerun. Cancellation is excluded for free by the trigger; force mode adds nothing here.
+
+The classification rules and [`eng/test-retry-patterns.json`](../../eng/test-retry-patterns.json) config are left fully intact; force mode is gated behind an optional `forceRerunAll` flag (default `false`), so the normal behavior is preserved when it is off.
+
+**To disable:** set `FORCE_RERUN_ALL: 'true'` to `'false'` (or remove the env var) on both jobs in the YAML.
 
 ### PR association
 

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -726,6 +726,137 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.False(rerunExecutionEligible);
     }
 
+    // TEMPORARY — FORCE_RERUN_ALL (remove with the force-mode plumbing):
+    // Force mode is a short-circuit. It does NOT enumerate or classify jobs, so these
+    // tests cover the only force-mode logic that lives in the JS: the eligibility
+    // decision (attempt cap only) and the rerun execution (rerun fires with an empty
+    // job list, simple comment, open-PR gate preserved).
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ForceModeEligibilityDependsOnlyOnTheAttemptCap()
+    {
+        // Force mode bypasses the job-count cap entirely: eligibility does not depend on
+        // retryableCount (the short-circuit never supplies one). It stays true through the
+        // attempt cap and flips to false only once the attempt cap is exceeded.
+        bool eligibleAttempt1 = await InvokeHarnessAsync<bool>(
+            "computeRerunEligibility",
+            new { runAttempt = 1, forceRerunAll = true });
+        Assert.True(eligibleAttempt1);
+
+        bool eligibleAttempt3 = await InvokeHarnessAsync<bool>(
+            "computeRerunEligibility",
+            new { runAttempt = 3, forceRerunAll = true });
+        Assert.True(eligibleAttempt3);
+
+        bool eligibleAttempt4 = await InvokeHarnessAsync<bool>(
+            "computeRerunEligibility",
+            new { runAttempt = 4, forceRerunAll = true });
+        Assert.False(eligibleAttempt4);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ForceModeExecutionEligibilityRespectsDryRunAndTheAttemptCap()
+    {
+        bool executeAttempt1 = await InvokeHarnessAsync<bool>(
+            "computeRerunExecutionEligibility",
+            new { dryRun = false, runAttempt = 1, forceRerunAll = true });
+        Assert.True(executeAttempt1);
+
+        bool dryRunBlocks = await InvokeHarnessAsync<bool>(
+            "computeRerunExecutionEligibility",
+            new { dryRun = true, runAttempt = 1, forceRerunAll = true });
+        Assert.False(dryRunBlocks);
+
+        bool attemptCapBlocks = await InvokeHarnessAsync<bool>(
+            "computeRerunExecutionEligibility",
+            new { dryRun = false, runAttempt = 4, forceRerunAll = true });
+        Assert.False(attemptCapBlocks);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ForceModeRerunsFailedJobsWithAnEmptyJobListWhenPullRequestIsOpen()
+    {
+        // Force mode passes an empty retryableJobs list (no enumeration). rerunMatchedJobs
+        // must still POST the run-level rerun, post a short comment with no job list, and
+        // write a summary with no "Retryable jobs" table.
+        RerunMatchedJobsResult result = await InvokeHarnessAsync<RerunMatchedJobsResult>(
+            "rerunMatchedJobs",
+            new
+            {
+                owner = "dotnet",
+                repo = "aspire",
+                retryableJobs = Array.Empty<RetryableJobInput>(),
+                pullRequestNumbers = new[] { 15110 },
+                issueStatesByNumber = new Dictionary<string, string>
+                {
+                    ["15110"] = "open"
+                },
+                commentHtmlUrlByNumber = new Dictionary<string, string>
+                {
+                    ["15110"] = "https://github.com/microsoft/aspire/pull/15110#issuecomment-123"
+                },
+                latestRunAttempt = 2,
+                sourceRunId = 123,
+                sourceRunAttempt = 1,
+                sourceRunUrl = "https://github.com/microsoft/aspire/actions/runs/123",
+                forceRerunAll = true
+            });
+
+        Assert.Contains(
+            result.Requests,
+            r => r.Route == "POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs");
+
+        RequestRecord commentRequest = Assert.Single(
+            result.Requests,
+            r => r.Route == "POST /repos/{owner}/{repo}/issues/{issue_number}/comments");
+        string commentBody = commentRequest.Payload.GetProperty("body").GetString()!;
+        Assert.Equal(
+            "Retrying the failed CI jobs for this pull request from [the CI run attempt](https://github.com/microsoft/aspire/actions/runs/123/attempts/1). The rerun is being tracked in [the rerun attempt](https://github.com/microsoft/aspire/actions/runs/123/attempts/2).",
+            commentBody);
+
+        SummaryEvent headingEvent = Assert.Single(result.Events, e => e.Type == "heading" && e.Level == 1);
+        Assert.Equal("Rerun requested", headingEvent.Text);
+
+        // No retry-safe job table is written in force mode (no jobs were enumerated).
+        Assert.DoesNotContain(result.Events, e => e.Type == "heading" && e.Level == 2 && e.Text == "Retryable jobs");
+        Assert.DoesNotContain(result.Events, e => e.Type == "table");
+    }
+
+    [Fact]
+    public async Task WorkflowYamlEnablesForceRerunAllMode()
+    {
+        string workflowText = await ReadRepoFileAsync(".github/workflows/auto-rerun-transient-ci-failures.yml");
+
+        // Force mode is controlled by FORCE_RERUN_ALL on BOTH jobs (analyze + rerun).
+        // It must be set consistently: either enabled ('true') on both or disabled
+        // ('false') on both. A half-flip (toggling only one job) leaves the workflow in
+        // a confusing partially-bypassed state and must fail. The documented disable
+        // path (flip both to 'false') stays valid here; fully removing the temporary
+        // measure removes these tests along with the env vars.
+        int enabledCount = workflowText.Split("FORCE_RERUN_ALL: 'true'").Length - 1;
+        int disabledCount = workflowText.Split("FORCE_RERUN_ALL: 'false'").Length - 1;
+        bool consistentlyEnabled = enabledCount >= 2 && disabledCount == 0;
+        bool consistentlyDisabled = disabledCount >= 2 && enabledCount == 0;
+        Assert.True(
+            consistentlyEnabled || consistentlyDisabled,
+            $"FORCE_RERUN_ALL must be set consistently on both jobs. Found {enabledCount} 'true' and {disabledCount} 'false'.");
+
+        // The env var is parsed to a boolean on both jobs and gates the short-circuit.
+        Assert.Contains("const forceRerunAll = String(process.env.FORCE_RERUN_ALL).toLowerCase() === 'true';", workflowText);
+
+        // The analyze step short-circuits on force mode: it computes eligibility with
+        // forceRerunAll: true and writes the dedicated force-mode summary instead of
+        // enumerating jobs.
+        Assert.Contains("if (forceRerunAll) {", workflowText);
+        Assert.Contains("forceRerunAll: true,", workflowText);
+        Assert.Contains("writeForceRerunSummary", workflowText);
+
+        // The rerun step proceeds even with an empty job list when force mode is on.
+        Assert.Contains("if (!forceRerunAll && retryableJobs.length === 0) {", workflowText);
+    }
+
     [Fact]
     public async Task RepresentativeWorkflowFixturesStayAlignedWithCurrentWorkflowDefinitions()
     {
@@ -1014,6 +1145,42 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
         SummaryEvent skippedRaw = Assert.Single(result.Events, e => e.Type == "raw" && e.Text is not null && e.Text.Contains("All associated pull requests are closed."));
         Assert.Contains("All associated pull requests are closed. No jobs were rerun.", skippedRaw.Text);
+    }
+
+    // FORCE_RERUN_ALL: force mode must NOT bypass the open-PR gate. A closed associated
+    // PR is still skipped (no value in spending CI on a closed/merged PR). If the gate
+    // is ever re-bypassed in force mode, this test fails because the rerun POST fires.
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ForceRerunAllStillSkipsRerunWhenAllAssociatedPullRequestsAreClosed()
+    {
+        RerunMatchedJobsResult result = await InvokeHarnessAsync<RerunMatchedJobsResult>(
+            "rerunMatchedJobs",
+            new
+            {
+                owner = "dotnet",
+                repo = "aspire",
+                retryableJobs = Array.Empty<RetryableJobInput>(),
+                pullRequestNumbers = new[] { 15110 },
+                issueStatesByNumber = new Dictionary<string, string>
+                {
+                    ["15110"] = "closed"
+                },
+                sourceRunId = 123,
+                sourceRunAttempt = 1,
+                sourceRunUrl = "https://github.com/microsoft/aspire/actions/runs/123",
+                forceRerunAll = true
+            });
+
+        SummaryEvent skippedHeading = Assert.Single(result.Events, e => e.Type == "heading" && e.Text == "Rerun skipped");
+        Assert.Equal(1, skippedHeading.Level);
+
+        SummaryEvent skippedRaw = Assert.Single(result.Events, e => e.Type == "raw" && e.Text is not null && e.Text.Contains("All associated pull requests are closed."));
+        Assert.Contains("All associated pull requests are closed. No jobs were rerun.", skippedRaw.Text);
+
+        Assert.DoesNotContain(
+            result.Requests,
+            r => r.Route == "POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs");
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
@@ -71,6 +71,12 @@ async function dispatch(operation, payload) {
         case 'formatMatchedPatternForMarkdown':
             return rerunWorkflow.formatMatchedPatternForMarkdown(payload.matchedPattern);
 
+        case 'promoteTestExecutionFailureJobs':
+            return rerunWorkflow.promoteTestExecutionFailureJobs(
+                payload.retryableJobs ?? [],
+                payload.skippedJobs ?? [],
+                payload.allMatchedTests ?? []);
+
         case 'getCheckRunIdForJob':
             return rerunWorkflow.getCheckRunIdForJob({
                 job: payload.job,
@@ -124,12 +130,6 @@ async function dispatch(operation, payload) {
             return rerunWorkflow.analyzeTrxFiles(
                 payload.trxFileContents,
                 payload.testFailurePatterns);
-
-        case 'promoteTestExecutionFailureJobs':
-            return rerunWorkflow.promoteTestExecutionFailureJobs(
-                payload.retryableJobs ?? [],
-                payload.skippedJobs ?? [],
-                payload.allMatchedTests ?? []);
 
         case 'selectTestResultsArtifact':
             return rerunWorkflow.selectTestResultsArtifact(payload.artifacts);


### PR DESCRIPTION
**Temporary measure.** The `auto-rerun-transient-ci-failures` workflow reruns a failed CI run **only** when the failure matches a curated transient-failure pattern. This PR adds a **force mode** that short-circuits that analysis: if a CI run failed and has an open PR, it reruns the failed jobs — full stop.

It is gated behind a default-off `forceRerunAll` flag / `FORCE_RERUN_ALL` env var, which this branch sets to `'true'` on both jobs. The transient-classification rules and `eng/test-retry-patterns.json` are kept fully intact behind the flag, so flipping it back to `'false'` restores the normal behavior exactly.

## What force mode does

When `FORCE_RERUN_ALL` is on and a run is eligible, the analyze step requests a rerun of the failed jobs and stops. It does **not** fetch jobs, classify them, or consult the patterns config — there is no per-job decision and no job list.

The rerun uses GitHub's `rerun-failed-jobs` API, which reruns **all** non-successful jobs for the attempt regardless of any list — so the short-circuit reruns exactly what the normal path would have, without doing the analysis to get there. The analyze step emits an empty `retryable_jobs` (`'[]'`) and the rerun step proceeds anyway.

The auto-posted PR comment in force mode is a single line — the failed CI jobs are being retried, with links to the failed and rerun attempts; no job table.

## What force mode bypasses

1. **All job analysis** — no enumeration and no classification.
2. **The retryable-job-count cap** — the `≤ 5 retryable jobs` rail is not applied (there is no job list to count).

## What force mode keeps

- **Open-PR requirement** — a rerun only fires for a run with a currently-open associated PR. Runs with no associated PR (analyze step), or where every associated PR is closed/merged (re-checked in the rerun step), are still skipped. No CI is spent on inactive PRs.
- **Attempt cap** — reruns still fire only from source attempts 1–3, yielding **up to 3 automatic reruns / 4 total attempts**. `computeRerunEligibility` re-checks this for the manual-dispatch path, which bypasses the trigger gate.
- **Failure-only triggering** — the workflow only fires on `workflow_run.conclusion == 'failure'`. A `cancelled` run (run cancelled, or fail-fast cancelling siblings) has conclusion `cancelled`, not `failure`, so it never triggers a rerun.

The two hard gates — "CI failed" and "max 3 reruns" — are already enforced by the workflow trigger `if` (`conclusion == 'failure'` and `run_attempt <= 3`), so force mode does not re-implement them.

## Implementation

`forceRerunAll` defaults to `false` in `computeRerunEligibility`, `computeRerunExecutionEligibility`, `rerunMatchedJobs`, and `buildPullRequestCommentBody`, so the normal classification/eligibility path is unchanged when the flag is off. The attempt-cap check is moved ahead of the force short-circuit in `computeRerunEligibility` but stays logically identical in normal mode.

## Validation

```
dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- \
  --filter-class "*.AutoRerunTransientCiFailuresTests" \
  --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"

Test run summary: Passed!
  total: 98
  failed: 0
  succeeded: 98
  skipped: 0
```

New force-mode tests cover attempt-cap-only eligibility (true at attempts 1–3, false at 4), dry-run/attempt-cap execution eligibility, `rerunMatchedJobs` firing with an empty job list when the PR is open (simple comment, no job table), and the closed-PR skip. A YAML wiring test asserts the short-circuit is present and `FORCE_RERUN_ALL` is set consistently on both jobs.

## Docs

`docs/ci/auto-rerun-transient-ci-failures.md` documents the temporary `FORCE_RERUN_ALL` short-circuit and exactly what it bypasses/keeps, with a pointer at the top so the normal-path "how it works" section isn't mistaken for current behavior while force mode is on.

## How to turn off

Set `FORCE_RERUN_ALL: 'true'` → `'false'` (or remove the env var) on both jobs in `.github/workflows/auto-rerun-transient-ci-failures.yml`, or revert this PR.