### PR TITLE
ci-probe: Layer 1 narrowing (Redis component)

### DIFF
--- a/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
@@ -279,3 +279,5 @@ public static class AspireRedisExtensions
         public override bool AbortOnConnectFail => false;
     }
 }
+
+// ci-probe: no-op change to exercise the selective test selector (Layer 1 narrowing).


### PR DESCRIPTION
**Throwaway CI probe — do not merge.**

Exercises the selective test selector on a PR targeting `ankj/ci-test-trigger-map`.
See the `setup_for_tests` job's "Select relevant tests" step for the selection result.
