### PR TITLE
ci-probe: ALL backstop (Directory.Build.props)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -59,4 +59,5 @@
     <AspireTerminalHostDir>$(MSBuildThisFileDirectory)/artifacts/bin/Aspire.TerminalHost/$(Configuration)/net8.0/</AspireTerminalHostDir>
   </PropertyGroup>
 
+  <!-- ci-probe: no-op change to exercise the build-infra ALL backstop -->
 </Project>


### PR DESCRIPTION
**Throwaway CI probe — do not merge.**

Exercises the selective test selector on a PR targeting `ankj/ci-test-trigger-map`.
See the `setup_for_tests` job's "Select relevant tests" step for the selection result.
