### PR TITLE
ci-probe: Layer 2 job routing (extension)

### DIFF
--- a/extension/src/capabilities.ts
+++ b/extension/src/capabilities.ts
@@ -111,3 +111,5 @@ export function getRunSessionInfo(): RunSessionInfo {
 // ci-probe: re-trigger after empty-matrix fix; still extension-only (0 .NET tests expected).
 
 // ci-probe: verify enumerate-skip fix; extension-only (0 .NET tests, jobs still run).
+
+// ci-probe: re-trigger after gate + comment fixes.

--- a/extension/src/capabilities.ts
+++ b/extension/src/capabilities.ts
@@ -107,3 +107,5 @@ export function getRunSessionInfo(): RunSessionInfo {
 }
 
 // ci-probe: no-op change to exercise Layer 2 extension job routing.
+
+// ci-probe: re-trigger after empty-matrix fix; still extension-only (0 .NET tests expected).

--- a/extension/src/capabilities.ts
+++ b/extension/src/capabilities.ts
@@ -105,3 +105,5 @@ export function getRunSessionInfo(): RunSessionInfo {
         supported_launch_configurations: getSupportedCapabilities()
     };
 }
+
+// ci-probe: no-op change to exercise Layer 2 extension job routing.

--- a/extension/src/capabilities.ts
+++ b/extension/src/capabilities.ts
@@ -109,3 +109,5 @@ export function getRunSessionInfo(): RunSessionInfo {
 // ci-probe: no-op change to exercise Layer 2 extension job routing.
 
 // ci-probe: re-trigger after empty-matrix fix; still extension-only (0 .NET tests expected).
+
+// ci-probe: verify enumerate-skip fix; extension-only (0 .NET tests, jobs still run).


### PR DESCRIPTION
**Throwaway CI probe — do not merge.**

Exercises the selective test selector on a PR targeting `ankj/ci-test-trigger-map`.
See the `setup_for_tests` job's "Select relevant tests" step for the selection result.
