### PR TITLE
ci-probe: prepare_for_ci skip (docs-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,5 @@ You should evaluate whichever containers you chose to compose and automate with 
 ## License
 
 The code in this repo is licensed under the [MIT](LICENSE.TXT) license.
+
+<!-- ci-probe: docs-only change to exercise prepare_for_ci skip gate -->


### PR DESCRIPTION
**Throwaway CI probe — do not merge.**

Exercises the selective test selector on a PR targeting `ankj/ci-test-trigger-map`.
See the `setup_for_tests` job's "Select relevant tests" step for the selection result.
