### PR TITLE
ci-probe: force-all token (full matrix)

### DIFF
--- a/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
@@ -279,3 +279,5 @@ public static class AspireRedisExtensions
         public override bool AbortOnConnectFail => false;
     }
 }
+
+// ci-probe: no-op change; PR body carries the full-ci token to force the full matrix.


### PR DESCRIPTION
**Throwaway CI probe — do not merge.**

Carries the force-all token below to verify it overrides Layer 1 narrowing and forces the full matrix.

[full ci]
