### PR TITLE
ci-probe: requires_nugets bucket (ProjectTemplates)

### DIFF
--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -151,4 +151,5 @@
 
   </Target>
 
+  <!-- ci-probe: no-op to select Aspire.Templates.Tests (requires_nugets bucket) -->
 </Project>


### PR DESCRIPTION
**Throwaway CI probe — do not merge.**

Exercises the selective test selector on a PR targeting `ankj/ci-test-trigger-map`.
See the `setup_for_tests` job's "Select relevant tests" step + the generated test matrix.
