### PR TITLE
ci-probe: requires_cli_archive bucket (Cli.EndToEnd.Tests)

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
@@ -434,3 +434,5 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
         await auto.RunCommandAsync($"export aspireSkillsVersion={AspireCliShellCommandHelpers.QuoteBashArg(aspireSkillsVersion)}", counter, TimeSpan.FromSeconds(30));
     }
 }
+
+// ci-probe: no-op to select Aspire.Cli.EndToEnd.Tests (requires_cli_archive bucket).


### PR DESCRIPTION
**Throwaway CI probe — do not merge.**

Exercises the selective test selector on a PR targeting `ankj/ci-test-trigger-map`.
See the `setup_for_tests` job's "Select relevant tests" step + the generated test matrix.
