### PR TITLE
ci-probe: winget-only triggers CI + winget installer (B)

### DIFF
--- a/eng/winget/dogfood.ps1
+++ b/eng/winget/dogfood.ps1
@@ -731,3 +731,5 @@ Write-Host ""
 Write-Host "To uninstall: .\dogfood.ps1 -Uninstall"
 
 # ci-probe: winget-only change (no longer a CI skip pattern; should trigger winget installer job).
+
+# ci-probe: re-trigger after gate + comment fixes.

--- a/eng/winget/dogfood.ps1
+++ b/eng/winget/dogfood.ps1
@@ -729,3 +729,5 @@ Write-Host "Installed successfully!"
 
 Write-Host ""
 Write-Host "To uninstall: .\dogfood.ps1 -Uninstall"
+
+# ci-probe: winget-only change (no longer a CI skip pattern; should trigger winget installer job).


### PR DESCRIPTION
**Throwaway CI probe — do not merge.**

Exercises the selective test selector on a PR targeting `ankj/ci-test-trigger-map`.
See the `setup_for_tests` job's "Select relevant tests" step + the generated test matrix.
