### PR TITLE
Default AppHosts to use the CLI bundle

### DIFF
--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -11,6 +11,8 @@
 | `ASPIRE005` | Error | (Deprecated) This diagnostic is no longer used. | |
 | `ASPIRE007` | Error | '\[ProjectName\]' project requires a reference to &quot;Aspire.AppHost.Sdk&quot; with version &quot;9.0.0&quot; or greater to work correctly. Please add the following line after the Project declaration `<Sdk Name=Aspire.AppHost.Sdk" Version="9.0.0" />`. | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets](../src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets) |
 | `ASPIRE008` | Error | '\[ProjectName\]' project requires GenerateAssemblyInfo to be enabled. The Aspire AppHost relies on assembly metadata attributes to locate required dependencies. Please remove &lt;GenerateAssemblyInfo&gt;false&lt;/GenerateAssemblyInfo&gt; from your project file or set it to true. | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets](../src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets) |
+| `ASPIRE009` | Error | '\[ProjectName\]' is configured to use the Aspire CLI bundle, but the bundle could not be resolved. | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets](../src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets) |
+| `ASPIRE010` | Warning | '\[ProjectName\]' is configured with AspireUseCliBundle=false. Some Aspire features may not work when the Aspire CLI bundle is not being used. | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets](../src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets) |
 
 ## Analyzer Warnings
 

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -22,6 +22,7 @@
          This defaults to true for backward compatibility but can be set to false to disable the behavior.
          This is particularly useful in file-based apps where metadata cannot be set on individual ProjectReference items. -->
     <TreatProjectReferencesAsResources Condition="'$(TreatProjectReferencesAsResources)' == ''">true</TreatProjectReferencesAsResources>
+    <AspireUseCliBundle Condition="'$(AspireUseCliBundle)' == '' and '$(MSBuildProjectExtension)' == '.csproj'">true</AspireUseCliBundle>
   </PropertyGroup>
 
   <!--

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -22,7 +22,7 @@
          This defaults to true for backward compatibility but can be set to false to disable the behavior.
          This is particularly useful in file-based apps where metadata cannot be set on individual ProjectReference items. -->
     <TreatProjectReferencesAsResources Condition="'$(TreatProjectReferencesAsResources)' == ''">true</TreatProjectReferencesAsResources>
-    <AspireUseCliBundle Condition="'$(AspireUseCliBundle)' == '' and '$(MSBuildProjectExtension)' == '.csproj'">true</AspireUseCliBundle>
+    <AspireUseCliBundle Condition="'$(AspireUseCliBundle)' == ''">true</AspireUseCliBundle>
   </PropertyGroup>
 
   <!--

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -104,6 +104,7 @@ internal sealed class DotNetCliRunner(
         // Build the final environment variables by merging caller-provided env with dotnet-specific settings.
         var finalEnv = env?.ToDictionary() ?? new Dictionary<string, string>();
         ConfigureDotNetEnvironment(finalEnv);
+        AddAspireCliPathEnvironment(finalEnv, projectFile);
         processActivity.AddContextToEnvironment(finalEnv);
 
         var command = commandOverride is null ? null : CommandPathResolver.NormalizeRunCommand(commandOverride);
@@ -477,6 +478,16 @@ internal sealed class DotNetCliRunner(
             }
 
         } while (await timer.WaitForNextTickAsync(cancellationToken));
+    }
+
+    private static void AddAspireCliPathEnvironment(Dictionary<string, string> env, FileInfo? projectFile)
+    {
+        if (projectFile is null || env.ContainsKey("AspireCliPath") || string.IsNullOrWhiteSpace(Environment.ProcessPath))
+        {
+            return;
+        }
+
+        env["AspireCliPath"] = Environment.ProcessPath;
     }
 
     private TimeSpan GetBackchannelConnectionTimeout()

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -202,6 +202,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
         // The resolver owns the cache/MSBuild fallback so validation and later run/publish
         // decisions share a single source of truth for AppHost project metadata.
+        using var cliBundleLease = await AcquireCliBundleLayoutAsync(cancellationToken);
         var information = await _appHostInfoResolver.GetAppHostInfoAsync(appHostFile, cancellationToken);
 
         if (information.ExitCode == 0 && information.IsAspireHost)
@@ -223,6 +224,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         // Use the same MSBuild-based inspection as validation so version resolution
         // follows the project model that run/publish already rely on, including
         // SDK-style projects, package references, and Central Package Management.
+        using var cliBundleLease = await AcquireCliBundleLayoutAsync(cancellationToken);
         var information = await _appHostInfoResolver.GetAppHostInfoAsync(appHostFile, cancellationToken);
         return information.ExitCode == 0 && information.IsAspireHost
             ? information.AspireHostingVersion
@@ -290,6 +292,10 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
         await EnsureDevCertificatesTrustedAsync(context, env, cancellationToken);
 
+        var cliBundleLease = await AcquireCliBundleLayoutAsync(cancellationToken);
+        using var cliBundleLeaseScope = cliBundleLease;
+        ConfigureCliBundleEnvironment(env, cliBundleLease, injectDcpAndDashboard: false);
+
         var watch = !isSingleFileAppHost && _features.IsFeatureEnabled(KnownFeatures.DefaultWatchEnabled, defaultValue: false);
         var preparationExitCode = await PrepareAppHostAsync(
             context,
@@ -314,8 +320,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         var canQueryCliBundleProperty = !isSingleFileAppHost || !context.NoBuild;
         var injectDcpAndDashboard = canQueryCliBundleProperty
             && await IsUsingCliBundleAsync(effectiveAppHostFile, cancellationToken);
-        var cliBundleLease = await ConfigureCliBundleEnvironmentAsync(env, injectDcpAndDashboard, cancellationToken);
-        using var cliBundleLeaseScope = cliBundleLease;
+        ConfigureCliBundleEnvironment(env, cliBundleLease, injectDcpAndDashboard);
 
         // RunCommand may display captured AppHost output as soon as BuildCompletionSource is signaled.
         // Store the collector first so failures that occur immediately after preparation are not lost
@@ -1060,6 +1065,9 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         var effectiveAppHostFile = context.AppHostFile;
         var isSingleFileAppHost = !IsProjectFile(effectiveAppHostFile) && IsValidSingleFileAppHost(effectiveAppHostFile);
         var env = new Dictionary<string, string>(context.EnvironmentVariables);
+        var cliBundleLease = await AcquireCliBundleLayoutAsync(cancellationToken);
+        using var cliBundleLeaseScope = cliBundleLease;
+        ConfigureCliBundleEnvironment(env, cliBundleLease, injectDcpAndDashboard: false);
 
         // Check compatibility for project-based apphosts
         if (!isSingleFileAppHost)
@@ -1088,7 +1096,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         // the AppHost did not opt into AspireUseCliBundle, but DCP/Dashboard env vars are
         // not (they would clobber per-RID NuGet metadata).
         var injectDcpAndDashboardForPublish = await IsUsingCliBundleAsync(effectiveAppHostFile, cancellationToken);
-        using var cliBundleLease = await ConfigureCliBundleEnvironmentAsync(env, injectDcpAndDashboardForPublish, cancellationToken);
+        ConfigureCliBundleEnvironment(env, cliBundleLease, injectDcpAndDashboardForPublish);
 
         // Build the apphost (unless --no-build is specified)
         if (!isSingleFileAppHost && !context.NoBuild)
@@ -1257,17 +1265,17 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         return info.IsUsingCliBundle;
     }
 
-    private async Task<BundleLayoutLease?> ConfigureCliBundleEnvironmentAsync(
+    private Task<BundleLayoutLease?> AcquireCliBundleLayoutAsync(CancellationToken cancellationToken)
+        => _bundleService.EnsureExtractedAndAcquireLayoutAsync("cli", "dotnet-apphost", cancellationToken);
+
+    private void ConfigureCliBundleEnvironment(
         Dictionary<string, string> env,
-        bool injectDcpAndDashboard,
-        CancellationToken cancellationToken)
+        BundleLayoutLease? layoutLease,
+        bool injectDcpAndDashboard)
     {
-        var layoutLease = await _bundleService.EnsureExtractedAndAcquireLayoutAsync("cli", "dotnet-apphost", cancellationToken);
         var layout = layoutLease?.Layout;
         if (layout is null)
         {
-            layoutLease?.Dispose();
-            layoutLease = null;
             // Only log when the AppHost actually opted into the bundle; for non-CliBundle
             // AppHosts a missing layout is expected (e.g. the CLI may not have a bundle on
             // disk) and would otherwise spam the debug log on every run.
@@ -1278,6 +1286,11 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             // Don't return yet — repo-mode runs (DEBUG, `dotnet run --project src/Aspire.Cli`)
             // can still inject the terminal host path from the just-built artifact even when
             // no bundle layout exists at all (e.g. clean dev machine with no `aspire` install).
+        }
+
+        if (!env.ContainsKey("AspireCliBundlePath") && !string.IsNullOrEmpty(layout?.LayoutPath))
+        {
+            env["AspireCliBundlePath"] = layout.LayoutPath;
         }
 
         if (injectDcpAndDashboard && layout is not null)
@@ -1327,7 +1340,6 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         }
 
         layoutLease?.AddEnvironment(env);
-        return layoutLease;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -149,6 +149,12 @@ namespace Projects%3B
     <Warning Code="ASPIRE001" Text="The '$(Language)' language isn't fully supported by Aspire - some code generation targets will not run, so will require manual authoring." HelpLink="https://aka.ms/aspire/diagnostics/aspire001" />
   </Target>
 
+  <Target Name="_WarnOnAspireCliBundleDisabled" BeforeTargets="PrepareForBuild" Condition="'$(IsAspireHost)' == 'true' and '$(AspireUseCliBundle)' == 'false'">
+    <Warning Code="ASPIRE010"
+             Text="$(MSBuildProjectName) is configured with AspireUseCliBundle=false. Some Aspire features may not work when the Aspire CLI bundle is not being used."
+             HelpLink="https://aka.ms/aspire/diagnostics/aspire010" />
+  </Target>
+
   <!--
   Validates that all the ProjectReferences of an Aspire AppHost project are executables and
   informs the developer to set 'IsAspireProjectResource=false' if they really intended on ProjectReferencing a library.
@@ -208,7 +214,7 @@ namespace Projects%3B
     </PropertyGroup>
 
     <PropertyGroup>
-      <_AspireCliBundleNotFoundError>$(MSBuildProjectName) is configured with AspireUseCliBundle=true, but the Aspire CLI bundle could not be resolved. Install the Aspire CLI from https://get.aspire.dev and ensure the aspire command is available on PATH, or set AspireCliBundlePath/AspireCliPath to a valid Aspire CLI installation or bundle layout.</_AspireCliBundleNotFoundError>
+      <_AspireCliBundleNotFoundError>$(MSBuildProjectName) is configured to use the Aspire CLI bundle, but the bundle could not be resolved. Some new Aspire features require the Aspire CLI to be installed. Install the Aspire CLI from https://get.aspire.dev and ensure the aspire command is available on PATH, or set AspireCliBundlePath/AspireCliPath to a valid Aspire CLI installation or bundle layout.</_AspireCliBundleNotFoundError>
     </PropertyGroup>
 
     <Error Code="ASPIRE009"

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -214,7 +214,10 @@ namespace Projects%3B
     </PropertyGroup>
 
     <PropertyGroup>
-      <_AspireCliBundleNotFoundError>$(MSBuildProjectName) is configured to use the Aspire CLI bundle, but the bundle could not be resolved. Some new Aspire features require the Aspire CLI to be installed. Install the Aspire CLI from https://get.aspire.dev and ensure the aspire command is available on PATH, or set AspireCliBundlePath/AspireCliPath to a valid Aspire CLI installation or bundle layout.</_AspireCliBundleNotFoundError>
+      <_AspireCliBundleNotFoundError>
+        $(MSBuildProjectName) is configured to use the Aspire CLI bundle, but the bundle could not be resolved. New features require the Aspire CLI to be installed. The Aspire dashboard &amp; DCP packages will be deprecated in a future release.
+        Install the Aspire CLI from https://get.aspire.dev and ensure the aspire command is available on PATH, or set AspireCliBundlePath/AspireCliPath to a valid Aspire CLI installation or bundle layout.
+      </_AspireCliBundleNotFoundError>
     </PropertyGroup>
 
     <Error Code="ASPIRE009"

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.props
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.props
@@ -4,6 +4,7 @@
     <!-- Aspire hosting projects aren't publishable right now until https://github.com/microsoft/aspire/issues/147 is good -->
     <IsPublishable Condition="'$(IsPublishable)' == ''">false</IsPublishable>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
+    <AspireUseCliBundle Condition="'$(AspireUseCliBundle)' == '' and '$(MSBuildProjectExtension)' == '.csproj'">true</AspireUseCliBundle>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.props
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.props
@@ -4,7 +4,7 @@
     <!-- Aspire hosting projects aren't publishable right now until https://github.com/microsoft/aspire/issues/147 is good -->
     <IsPublishable Condition="'$(IsPublishable)' == ''">false</IsPublishable>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
-    <AspireUseCliBundle Condition="'$(AspireUseCliBundle)' == '' and '$(MSBuildProjectExtension)' == '.csproj'">true</AspireUseCliBundle>
+    <AspireUseCliBundle Condition="'$(AspireUseCliBundle)' == ''">true</AspireUseCliBundle>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">

--- a/src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs
+++ b/src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs
@@ -16,6 +16,7 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
     private const string InstallSidecarFileName = ".aspire-install.json";
     private const string AspireHomeEnvironmentVariable = "ASPIRE_HOME";
     private const int MaxInstallSidecarBytes = 64 * 1024;
+    private static readonly Version s_unversionedDirectoryVersion = new(0, 0);
 
     /// <summary>
     /// Optional path to an Aspire CLI bundle or layout directory.
@@ -332,7 +333,9 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
         var versionsRoot = Path.Combine(layoutPath, VersionsDirectoryName);
         if (Directory.Exists(versionsRoot))
         {
-            foreach (var versionDirectory in EnumerateDirectories(versionsRoot))
+            foreach (var versionDirectory in EnumerateDirectories(versionsRoot)
+                         .OrderByDescending(GetVersionDirectoryVersion)
+                         .ThenByDescending(Path.GetFileName, StringComparer.OrdinalIgnoreCase))
             {
                 if (TryResolveBundleRoot(versionDirectory, out resolution))
                 {
@@ -343,6 +346,44 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
 
         resolution = default!;
         return false;
+    }
+
+    private static Version GetVersionDirectoryVersion(string path)
+    {
+        var directoryName = Path.GetFileName(path);
+        return Version.TryParse(StripVersionIdHash(directoryName), out var version)
+            ? version
+            : s_unversionedDirectoryVersion;
+    }
+
+    private static string StripVersionIdHash(string directoryName)
+    {
+        // BundleService version directories are named "<sanitized-version>-<16-hex-xxhash>",
+        // for example "9.10.0-bbbbbbbbbbbbbbbb". Strip the hash so System.Version
+        // compares the semantic version instead of the full directory name.
+        var separatorIndex = directoryName.LastIndexOf('-');
+        if (separatorIndex < 0 ||
+            directoryName.Length - separatorIndex - 1 != 16 ||
+            !ContainsOnlyHexDigits(directoryName, separatorIndex + 1))
+        {
+            return directoryName;
+        }
+
+        return directoryName.Substring(0, separatorIndex);
+    }
+
+    private static bool ContainsOnlyHexDigits(string value, int startIndex)
+    {
+        for (var i = startIndex; i < value.Length; i++)
+        {
+            var ch = value[i];
+            if (ch is not ((>= '0' and <= '9') or (>= 'A' and <= 'F') or (>= 'a' and <= 'f')))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static IEnumerable<string> EnumerateDirectories(string path)

--- a/src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs
+++ b/src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs
@@ -77,6 +77,7 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
                 return true;
             }
 
+            Log.LogWarning("The AspireCliBundlePath value '{0}' does not point to a valid Aspire CLI bundle layout.", AspireCliBundlePath);
             return true;
         }
 
@@ -88,12 +89,19 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
                 return true;
             }
 
+            Log.LogWarning("The AspireCliPath value '{0}' does not point to an existing Aspire CLI executable with a valid bundle layout.", AspireCliPath);
             return true;
         }
 
         if (TryResolveFromPath(out var pathBundle))
         {
             SetOutputs(pathBundle);
+            return true;
+        }
+
+        if (TryResolveFromLayoutPath(GetDefaultAspireHomeDirectory(), out var aspireHomeBundle))
+        {
+            SetOutputs(aspireHomeBundle);
             return true;
         }
 
@@ -334,6 +342,7 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
         if (Directory.Exists(versionsRoot))
         {
             foreach (var versionDirectory in EnumerateDirectories(versionsRoot)
+                         .Where(IsVersionDirectoryCandidate)
                          .OrderByDescending(GetVersionDirectoryVersion)
                          .ThenByDescending(Path.GetFileName, StringComparer.OrdinalIgnoreCase))
             {
@@ -351,9 +360,26 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
     private static Version GetVersionDirectoryVersion(string path)
     {
         var directoryName = Path.GetFileName(path);
-        return Version.TryParse(StripVersionIdHash(directoryName), out var version)
+        return Version.TryParse(GetLeadingVersion(StripVersionIdHash(directoryName)), out var version)
             ? version
             : s_unversionedDirectoryVersion;
+    }
+
+    private static string GetLeadingVersion(string directoryName)
+    {
+        // BundleService.ComputeVersionId keeps the informational-version prefix and appends a hash:
+        //   13.10.0-preview.1.25301.1_gdae6efcb-bbbbbbbbbbbbbbbb
+        // System.Version cannot parse the prerelease/hash suffix, but it can compare the leading
+        // numeric version that determines which extracted bundle is newer.
+        var versionEnd = 0;
+        while (versionEnd < directoryName.Length && directoryName[versionEnd] is (>= '0' and <= '9') or '.')
+        {
+            versionEnd++;
+        }
+
+        return versionEnd == 0
+            ? string.Empty
+            : directoryName.Substring(0, versionEnd).TrimEnd('.');
     }
 
     private static string StripVersionIdHash(string directoryName)
@@ -384,6 +410,14 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
         }
 
         return true;
+    }
+
+    private static bool IsVersionDirectoryCandidate(string path)
+    {
+        var directoryName = Path.GetFileName(path);
+        return !directoryName.Contains(".tmp.", StringComparison.Ordinal)
+            && !directoryName.Contains(".bad.", StringComparison.Ordinal)
+            && !directoryName.Contains(".old.", StringComparison.Ordinal);
     }
 
     private static IEnumerable<string> EnumerateDirectories(string path)

--- a/src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs
+++ b/src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 
 namespace Aspire.Hosting.Tasks;
@@ -10,6 +11,12 @@ namespace Aspire.Hosting.Tasks;
 /// </summary>
 public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
 {
+    private const string BundleDirectoryName = "bundle";
+    private const string VersionsDirectoryName = "versions";
+    private const string InstallSidecarFileName = ".aspire-install.json";
+    private const string AspireHomeEnvironmentVariable = "ASPIRE_HOME";
+    private const int MaxInstallSidecarBytes = 64 * 1024;
+
     /// <summary>
     /// Optional path to an Aspire CLI bundle or layout directory.
     /// </summary>
@@ -154,23 +161,42 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
             : ["aspire"];
     }
 
-    private static bool TryResolveFromCliPath(string cliPath, out BundleResolution resolution)
+    private static bool TryResolveFromCliPath(string cliPath, out BundleResolution resolution, bool includeDefaultAspireHomeFallback = true)
     {
         resolution = default!;
 
-        var cliDirectory = Path.GetDirectoryName(Path.GetFullPath(cliPath));
-        if (string.IsNullOrEmpty(cliDirectory))
+        var candidateCliPaths = EnumerateCandidateCliPaths(Path.GetFullPath(cliPath));
+        foreach (var candidateCliPath in candidateCliPaths)
         {
-            return false;
+            var cliDirectory = Path.GetDirectoryName(candidateCliPath);
+            if (string.IsNullOrEmpty(cliDirectory))
+            {
+                continue;
+            }
+
+            foreach (var layoutPath in EnumerateLayoutPathsForCliDirectory(cliDirectory))
+            {
+                if (TryResolveFromLayoutPath(layoutPath, out resolution))
+                {
+                    return true;
+                }
+            }
+
+            foreach (var dotnetToolCliPath in EnumerateDotNetToolStoreCliPaths(cliDirectory))
+            {
+                if (TryResolveFromCliPath(dotnetToolCliPath, out resolution, includeDefaultAspireHomeFallback: false))
+                {
+                    return true;
+                }
+            }
         }
 
-        if (TryResolveFromLayoutPath(cliDirectory, out resolution))
+        if (includeDefaultAspireHomeFallback && TryResolveFromLayoutPath(GetDefaultAspireHomeDirectory(), out resolution))
         {
             return true;
         }
 
-        var parentDirectory = Path.GetDirectoryName(cliDirectory);
-        return !string.IsNullOrEmpty(parentDirectory) && TryResolveFromLayoutPath(parentDirectory, out resolution);
+        return false;
     }
 
     private static bool TryResolveFromLayoutPath(string layoutPath, out BundleResolution resolution)
@@ -181,7 +207,12 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
             return true;
         }
 
-        return TryResolveBundleRoot(Path.Combine(fullPath, "bundle"), out resolution);
+        if (TryResolveBundleRoot(Path.Combine(fullPath, BundleDirectoryName), out resolution))
+        {
+            return true;
+        }
+
+        return TryResolveVersionedBundleRoot(fullPath, out resolution);
     }
 
     private static bool TryResolveBundleRoot(string bundleRoot, out BundleResolution resolution)
@@ -211,6 +242,184 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
     }
 
     private static bool IsWindows() => Path.DirectorySeparatorChar == '\\';
+
+    private static IEnumerable<string> EnumerateCandidateCliPaths(string cliPath)
+    {
+        var seenPaths = new HashSet<string>(GetPathComparer());
+
+        if (seenPaths.Add(cliPath))
+        {
+            yield return cliPath;
+        }
+
+        var resolvedCliPath = ResolveSymlinkOrOriginalPath(cliPath);
+        if (seenPaths.Add(resolvedCliPath))
+        {
+            yield return resolvedCliPath;
+        }
+    }
+
+    private static IEnumerable<string> EnumerateLayoutPathsForCliDirectory(string cliDirectory)
+    {
+        var seenPaths = new HashSet<string>(GetPathComparer());
+
+        foreach (var layoutPath in EnumerateLayoutPathsForCliDirectoryCore(cliDirectory))
+        {
+            if (!string.IsNullOrEmpty(layoutPath) && seenPaths.Add(layoutPath))
+            {
+                yield return layoutPath;
+            }
+        }
+    }
+
+    private static IEnumerable<string?> EnumerateLayoutPathsForCliDirectoryCore(string cliDirectory)
+    {
+        yield return cliDirectory;
+
+        // Install-route sidecars are written as:
+        //   { "source": "winget" }
+        // Known package-manager routes extract beside the binary and script/localhive
+        // routes extract under the parent prefix. Sidecar-less/unknown routes fall
+        // back to ASPIRE_HOME after any dotnet-tool store payload has been probed.
+        yield return TryReadInstallSource(cliDirectory) switch
+        {
+            "winget" or "brew" or "dotnet-tool" => cliDirectory,
+            "script" or "pr" or "localhive" => Path.GetDirectoryName(cliDirectory) ?? cliDirectory,
+            _ => null,
+        };
+
+        yield return Path.GetDirectoryName(cliDirectory);
+    }
+
+    private static IEnumerable<string> EnumerateDotNetToolStoreCliPaths(string cliDirectory)
+    {
+        var storeRoot = Path.Combine(cliDirectory, ".store", "aspire.cli");
+        if (!Directory.Exists(storeRoot))
+        {
+            yield break;
+        }
+
+        foreach (var executableName in GetNativeAspireExecutableNames())
+        {
+            foreach (var candidate in EnumerateFiles(storeRoot, executableName))
+            {
+                yield return candidate;
+            }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateFiles(string path, string searchPattern)
+    {
+        try
+        {
+            return Directory.GetFiles(path, searchPattern, SearchOption.AllDirectories);
+        }
+        catch (Exception ex) when (IsPathDiscoveryException(ex))
+        {
+            return [];
+        }
+    }
+
+    private static string[] GetNativeAspireExecutableNames()
+    {
+        return IsWindows()
+            ? ["aspire.exe"]
+            : ["aspire"];
+    }
+
+    private static bool TryResolveVersionedBundleRoot(string layoutPath, out BundleResolution resolution)
+    {
+        var versionsRoot = Path.Combine(layoutPath, VersionsDirectoryName);
+        if (Directory.Exists(versionsRoot))
+        {
+            foreach (var versionDirectory in EnumerateDirectories(versionsRoot))
+            {
+                if (TryResolveBundleRoot(versionDirectory, out resolution))
+                {
+                    return true;
+                }
+            }
+        }
+
+        resolution = default!;
+        return false;
+    }
+
+    private static IEnumerable<string> EnumerateDirectories(string path)
+    {
+        try
+        {
+            return Directory.GetDirectories(path);
+        }
+        catch (Exception ex) when (IsPathDiscoveryException(ex))
+        {
+            return [];
+        }
+    }
+
+    private static string? TryReadInstallSource(string cliDirectory)
+    {
+        var sidecarPath = Path.Combine(cliDirectory, InstallSidecarFileName);
+        if (!File.Exists(sidecarPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            if (new FileInfo(sidecarPath).Length > MaxInstallSidecarBytes)
+            {
+                return null;
+            }
+
+            var sidecar = File.ReadAllText(sidecarPath);
+            var sourceMatch = Regex.Match(sidecar, @"""source""\s*:\s*""(?<source>[^""]*)""");
+            return sourceMatch.Success ? sourceMatch.Groups["source"].Value : null;
+        }
+        catch (Exception ex) when (IsPathDiscoveryException(ex))
+        {
+            return null;
+        }
+    }
+
+    private static string GetDefaultAspireHomeDirectory()
+    {
+        var aspireHome = Environment.GetEnvironmentVariable(AspireHomeEnvironmentVariable);
+        return string.IsNullOrWhiteSpace(aspireHome)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire")
+            : aspireHome;
+    }
+
+    private static StringComparer GetPathComparer()
+    {
+        return IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+    }
+
+    private static string ResolveSymlinkOrOriginalPath(string path)
+    {
+#if NET8_0_OR_GREATER
+        try
+        {
+            return File.ResolveLinkTarget(path, returnFinalTarget: true)?.FullName ?? path;
+        }
+        catch (Exception ex) when (IsPathDiscoveryException(ex))
+        {
+            return path;
+        }
+#else
+        return path;
+#endif
+    }
+
+    private static bool IsPathDiscoveryException(Exception ex)
+    {
+        return ex is IOException
+            or UnauthorizedAccessException
+            or ArgumentException
+            or NotSupportedException
+            or PathTooLongException
+            or System.Security.SecurityException;
+    }
 
     private sealed class BundleResolution(string dcpDir, string managedDir, string managedPath)
     {

--- a/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
@@ -74,14 +74,7 @@ public sealed class BundleSmokeTests(ITestOutputHelper output)
 
         var appHostProject = File.ReadAllText(appHostProjectPath);
         Assert.Contains("<Nullable>enable</Nullable>", appHostProject);
-        File.WriteAllText(
-            appHostProjectPath,
-            appHostProject.Replace(
-                "<Nullable>enable</Nullable>",
-                """
-                    <Nullable>enable</Nullable>
-                    <AspireUseCliBundle>true</AspireUseCliBundle>
-                """));
+        Assert.DoesNotContain("AspireUseCliBundle", appHostProject);
 
         File.WriteAllText(
             appHostSourcePath,
@@ -142,10 +135,7 @@ public sealed class BundleSmokeTests(ITestOutputHelper output)
         var appHostSource = File.ReadAllText(appHostSourcePath);
         Assert.Contains("#:sdk Aspire.AppHost.Sdk", appHostSource);
         Assert.Contains("var builder = DistributedApplication.CreateBuilder(args);", appHostSource);
-
-        var firstLineEnd = appHostSource.IndexOf('\n', StringComparison.Ordinal);
-        Assert.True(firstLineEnd >= 0, $"Expected file-based AppHost source to contain a newline: {appHostSourcePath}");
-        appHostSource = appHostSource.Insert(firstLineEnd + 1, "#:property AspireUseCliBundle=true\n");
+        Assert.DoesNotContain("AspireUseCliBundle", appHostSource);
 
         File.WriteAllText(
             appHostSourcePath,

--- a/tests/Aspire.Cli.EndToEnd.Tests/SingleFileAppHostInitDotnetRunTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SingleFileAppHostInitDotnetRunTests.cs
@@ -91,9 +91,8 @@ public sealed class SingleFileAppHostInitDotnetRunTests(ITestOutputHelper output
         Assert.False(string.IsNullOrWhiteSpace(httpsEnv["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]?.GetValue<string>()));
         Assert.False(string.IsNullOrWhiteSpace(httpsEnv["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]?.GetValue<string>()));
 
-        // `dotnet run apphost.cs` is routed through the Aspire CLI run hook when the CLI
-        // bundle is enabled, so the AppHost-ready signal is the CLI's run summary rather
-        // than the raw DistributedApplication lifecycle log.
+        // `dotnet run apphost.cs` is intercepted by the Aspire CLI run hook when the CLI
+        // bundle is active; the CLI run summary is the AppHost-ready signal.
         await auto.TypeAsync("dotnet run apphost.cs");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync(

--- a/tests/Aspire.Cli.EndToEnd.Tests/SingleFileAppHostInitDotnetRunTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SingleFileAppHostInitDotnetRunTests.cs
@@ -91,15 +91,13 @@ public sealed class SingleFileAppHostInitDotnetRunTests(ITestOutputHelper output
         Assert.False(string.IsNullOrWhiteSpace(httpsEnv["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]?.GetValue<string>()));
         Assert.False(string.IsNullOrWhiteSpace(httpsEnv["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]?.GetValue<string>()));
 
-        // `dotnet run apphost.cs` should print "Distributed application started." once the
-        // AppHost is fully up. 1 minute is plenty — even a cold dotnet build of the bare
-        // single-file AppHost completes well inside that budget; if it hasn't started by
-        // then something is wrong (build failure, missing env var, hang) and we should
-        // fail fast rather than wait several minutes.
+        // `dotnet run apphost.cs` is routed through the Aspire CLI run hook when the CLI
+        // bundle is enabled, so the AppHost-ready signal is the CLI's run summary rather
+        // than the raw DistributedApplication lifecycle log.
         await auto.TypeAsync("dotnet run apphost.cs");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync(
-            "Distributed application started.",
+            "Press CTRL+C to stop the AppHost and exit.",
             timeout: TimeSpan.FromMinutes(1));
 
         // Stop the running AppHost with Ctrl+C and wait for the shell prompt.
@@ -107,4 +105,3 @@ public sealed class SingleFileAppHostInitDotnetRunTests(ITestOutputHelper output
         await auto.WaitForAnyPromptAsync(counter, TimeSpan.FromMinutes(1));
     }
 }
-

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -201,6 +201,32 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task BuildAsyncPassesCurrentAspireCliPathToMSBuild()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (_, env, _, _) =>
+            {
+                Assert.NotNull(env);
+                Assert.Equal(Environment.ProcessPath, env["AspireCliPath"]);
+            },
+            0);
+
+        var exitCode = await runner.BuildAsync(projectFile, noRestore: false, new ProcessInvocationOptions(), CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
     public async Task RestoreAsyncRunsDotnetRestoreCommand()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
@@ -273,6 +273,7 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             Assert.False(watch);
             Assert.True(noBuild);
             Assert.False(noRestore);
+            Assert.Equal(bundleRoot.FullName, env!["AspireCliBundlePath"]);
             Assert.Equal(Path.Combine(bundleRoot.FullName, BundleDiscovery.DcpDirectoryName), env![BundleDiscovery.DcpPathEnvVar]);
             Assert.Equal(
                 Path.Combine(bundleRoot.FullName, BundleDiscovery.ManagedDirectoryName, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -25,9 +25,24 @@ public class AppHostSdkTargetsTests
     ];
 
     [Fact]
-    public async Task AddReferenceToDashboardAndDcpUsesSdkRidSelectionTask()
+    public async Task AddReferenceToDashboardAndDcpIsSkippedWhenCliBundleIsDefaulted()
     {
         var packageReferences = await RunAddReferenceToDashboardAndDcpAsync(extraProjectXml: null);
+
+        Assert.DoesNotContain(packageReferences, static packageReference => packageReference.StartsWith("Aspire.Dashboard.Sdk.", StringComparison.Ordinal));
+        Assert.DoesNotContain(packageReferences, static packageReference => packageReference.StartsWith("Aspire.Hosting.Orchestration.", StringComparison.Ordinal));
+        Assert.Contains("Aspire.Hosting.AppHost=13.4.0", packageReferences);
+    }
+
+    [Fact]
+    public async Task AddReferenceToDashboardAndDcpUsesSdkRidSelectionTask()
+    {
+        var packageReferences = await RunAddReferenceToDashboardAndDcpAsync(
+            """
+              <PropertyGroup>
+                <AspireUseCliBundle>false</AspireUseCliBundle>
+              </PropertyGroup>
+            """);
 
         Assert.Contains("UseSdkPickBestRid=true", packageReferences);
         Assert.Contains("RunRidToolFallback=false", packageReferences);
@@ -44,6 +59,7 @@ public class AppHostSdkTargetsTests
 
         var extraProjectXml = $"""
               <PropertyGroup>
+                <AspireUseCliBundle>false</AspireUseCliBundle>
                 <_AspireUseSdkPickBestRid>false</_AspireUseSdkPickBestRid>
                 <AspireRidToolExecutable>{SecurityElement.Escape(ridToolPath)}</AspireRidToolExecutable>
               </PropertyGroup>

--- a/tests/Aspire.Hosting.Tests/Directory.Build.props
+++ b/tests/Aspire.Hosting.Tests/Directory.Build.props
@@ -1,6 +1,8 @@
 <Project>
   <PropertyGroup>
     <IsAspireHost>true</IsAspireHost>
+    <AspireUseCliBundle>false</AspireUseCliBundle>
+    <NoWarn>$(NoWarn);ASPIRE010</NoWarn>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO.Compression;
 using System.Text;
 using System.Xml.Linq;
+using Aspire.Hosting.Tests.Utils;
 
 namespace Aspire.Hosting.Tests;
 
@@ -347,8 +348,32 @@ public class MSBuildTests
         using var tempDirectory = new TestTempDirectory();
 
         var layoutRoot = Path.Combine(tempDirectory.Path, "layout");
-        _ = CreateFakeCliBundleAtVersionedLayoutRoot(layoutRoot, "9.9.0-aaaaaaaaaaaaaaaa");
-        var newestBundle = CreateFakeCliBundleAtVersionedLayoutRoot(layoutRoot, "9.10.0-bbbbbbbbbbbbbbbb");
+        _ = CreateFakeCliBundleAtVersionedLayoutRoot(layoutRoot, "13.9.0-preview.1.25301.1_older-aaaaaaaaaaaaaaaa");
+        var newestBundle = CreateFakeCliBundleAtVersionedLayoutRoot(layoutRoot, "13.10.0-preview.1.25301.1_newer-bbbbbbbbbbbbbbbb");
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
+            $"""
+              <AspireCliBundlePath>{layoutRoot}</AspireCliBundlePath>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        BuildProject(appHostDirectory);
+
+        var resolvedPaths = await File.ReadAllLinesAsync(Path.Combine(appHostDirectory, "obj", "resolved-aspire-paths.txt"));
+        Assert.Equal(newestBundle.DcpDir, resolvedPaths[0]);
+        Assert.Equal(newestBundle.ManagedDir, resolvedPaths[1]);
+        Assert.Equal(newestBundle.ManagedPath, resolvedPaths[2]);
+    }
+
+    [Fact]
+    public async Task CliBundleDefaultIgnoresTemporaryVersionedBundleDirectories()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var tempDirectory = new TestTempDirectory();
+
+        var layoutRoot = Path.Combine(tempDirectory.Path, "layout");
+        _ = CreateFakeCliBundleAtVersionedLayoutRoot(layoutRoot, "99.0.0-preview.1.tmp.aaaaaaaaaaaaaaaa");
+        var newestBundle = CreateFakeCliBundleAtVersionedLayoutRoot(layoutRoot, "13.10.0-preview.1.25301.1_newer-bbbbbbbbbbbbbbbb");
         var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
             $"""
               <AspireCliBundlePath>{layoutRoot}</AspireCliBundlePath>
@@ -400,6 +425,29 @@ public class MSBuildTests
         CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
 
         BuildProject(appHostDirectory, new Dictionary<string, string> { ["ASPIRE_HOME"] = bundle.LayoutRoot });
+
+        var resolvedPaths = await File.ReadAllLinesAsync(Path.Combine(appHostDirectory, "obj", "resolved-aspire-paths.txt"));
+        Assert.Equal(bundle.DcpDir, resolvedPaths[0]);
+        Assert.Equal(bundle.ManagedDir, resolvedPaths[1]);
+        Assert.Equal(bundle.ManagedPath, resolvedPaths[2]);
+    }
+
+    [Fact]
+    public async Task CliBundleDefaultResolvesAspireHomeBundleWithoutCliOnPath()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var tempDirectory = new TestTempDirectory();
+
+        var bundle = CreateFakeCliBundle(Path.Combine(tempDirectory.Path, "aspire-home"));
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot, additionalProperties: "");
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        BuildProject(appHostDirectory, new Dictionary<string, string>
+        {
+            ["ASPIRE_HOME"] = bundle.LayoutRoot,
+            ["PATH"] = GetDotNetOnlyPath()
+        });
 
         var resolvedPaths = await File.ReadAllLinesAsync(Path.Combine(appHostDirectory, "obj", "resolved-aspire-paths.txt"));
         Assert.Equal(bundle.DcpDir, resolvedPaths[0]);
@@ -478,20 +526,79 @@ public class MSBuildTests
         var repoRoot = MSBuildUtils.GetRepoRoot();
         using var tempDirectory = new TestTempDirectory();
 
+        var missingBundlePath = Path.Combine(tempDirectory.Path, "missing-bundle");
         var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
             $"""
-              <AspireCliBundlePath>{Path.Combine(tempDirectory.Path, "missing-bundle")}</AspireCliBundlePath>
+              <AspireCliBundlePath>{missingBundlePath}</AspireCliBundlePath>
             """);
 
         CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
 
         var output = BuildProjectWithFailure(appHostDirectory);
 
+        Assert.Contains("warning", output);
+        Assert.Contains("AspireCliBundlePath", output);
+        Assert.Contains(missingBundlePath, output);
         Assert.Contains("ASPIRE009", output);
         Assert.Contains("the bundle could not be resolved", output);
         Assert.Contains("New features require the Aspire CLI to be installed.", output);
         Assert.Contains("https://get.aspire.dev", output);
         Assert.DoesNotContain("DCP path could not be resolved", output);
+    }
+
+    [Fact]
+    public void CliBundleOptInFailsWhenExplicitCliPathIsInvalid()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var tempDirectory = new TestTempDirectory();
+
+        var missingCliPath = Path.Combine(tempDirectory.Path, "missing-aspire");
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
+            $"""
+              <AspireCliPath>{missingCliPath}</AspireCliPath>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        var output = BuildProjectWithFailure(appHostDirectory);
+
+        Assert.Contains("warning", output);
+        Assert.Contains("AspireCliPath", output);
+        Assert.Contains(missingCliPath, output);
+        Assert.Contains("ASPIRE009", output);
+    }
+
+    [Fact]
+    public async Task CliBundleDefaultAppliesToNonCSharpAppHostProject()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var tempDirectory = new TestTempDirectory();
+
+        var appHostDirectory = Path.Combine(tempDirectory.Path, "AppHost");
+        Directory.CreateDirectory(appHostDirectory);
+        File.WriteAllText(Path.Combine(appHostDirectory, "AppHost.fsproj"),
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <IsAspireHost>true</IsAspireHost>
+              </PropertyGroup>
+
+              <Target Name="WriteAspireUseCliBundleProperty">
+                <WriteLinesToFile File="$(BaseIntermediateOutputPath)aspire-use-cli-bundle.txt"
+                                  Lines="Value=$(AspireUseCliBundle)"
+                                  Overwrite="true" />
+              </Target>
+            </Project>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        var result = RunDotNet(appHostDirectory, "msbuild AppHost.fsproj /t:WriteAspireUseCliBundleProperty /v:minimal", timeoutMilliseconds: 180_000);
+
+        Assert.Equal(0, result.ExitCode);
+        var property = await File.ReadAllTextAsync(Path.Combine(appHostDirectory, "obj", "aspire-use-cli-bundle.txt"));
+        Assert.Equal("Value=true", property.Trim());
     }
 
     [Fact]
@@ -634,6 +741,16 @@ public class MSBuildTests
     private static string EnsureTrailingSeparator(string path)
     {
         return path.EndsWith(Path.DirectorySeparatorChar) ? path : path + Path.DirectorySeparatorChar;
+    }
+
+    private static string GetDotNetOnlyPath()
+    {
+        var dotnetPath = DotnetFileAppProcess.ResolvedExecutablePath;
+        var dotnetDirectory = Path.GetDirectoryName(dotnetPath);
+
+        Assert.False(string.IsNullOrEmpty(dotnetDirectory), $"Could not determine the directory for dotnet path '{dotnetPath}'.");
+
+        return dotnetDirectory;
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -341,6 +341,30 @@ public class MSBuildTests
     }
 
     [Fact]
+    public async Task CliBundleDefaultResolvesNewestVersionedBundlePath()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var tempDirectory = new TestTempDirectory();
+
+        var layoutRoot = Path.Combine(tempDirectory.Path, "layout");
+        _ = CreateFakeCliBundleAtVersionedLayoutRoot(layoutRoot, "9.9.0-aaaaaaaaaaaaaaaa");
+        var newestBundle = CreateFakeCliBundleAtVersionedLayoutRoot(layoutRoot, "9.10.0-bbbbbbbbbbbbbbbb");
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
+            $"""
+              <AspireCliBundlePath>{layoutRoot}</AspireCliBundlePath>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        BuildProject(appHostDirectory);
+
+        var resolvedPaths = await File.ReadAllLinesAsync(Path.Combine(appHostDirectory, "obj", "resolved-aspire-paths.txt"));
+        Assert.Equal(newestBundle.DcpDir, resolvedPaths[0]);
+        Assert.Equal(newestBundle.ManagedDir, resolvedPaths[1]);
+        Assert.Equal(newestBundle.ManagedPath, resolvedPaths[2]);
+    }
+
+    [Fact]
     public void CliBundleOptOutEmitsWarning()
     {
         var repoRoot = MSBuildUtils.GetRepoRoot();
@@ -578,7 +602,16 @@ public class MSBuildTests
 
     private static (string LayoutRoot, string DcpDir, string ManagedDir, string ManagedPath) CreateFakeCliBundleAtLayoutRoot(string layoutRoot)
     {
-        var bundleRoot = Path.Combine(layoutRoot, "bundle");
+        return CreateFakeCliBundleRoot(layoutRoot, Path.Combine(layoutRoot, "bundle"));
+    }
+
+    private static (string LayoutRoot, string DcpDir, string ManagedDir, string ManagedPath) CreateFakeCliBundleAtVersionedLayoutRoot(string layoutRoot, string versionId)
+    {
+        return CreateFakeCliBundleRoot(layoutRoot, Path.Combine(layoutRoot, "versions", versionId));
+    }
+
+    private static (string LayoutRoot, string DcpDir, string ManagedDir, string ManagedPath) CreateFakeCliBundleRoot(string layoutRoot, string bundleRoot)
+    {
         var dcpDir = EnsureTrailingSeparator(Path.Combine(bundleRoot, "dcp"));
         var managedDir = EnsureTrailingSeparator(Path.Combine(bundleRoot, "managed"));
         Directory.CreateDirectory(dcpDir);

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -154,6 +154,8 @@ public class MSBuildTests
         <Project>
           <PropertyGroup>
             <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
+            <AspireUseCliBundle>false</AspireUseCliBundle>
+            <NoWarn>$(NoWarn);ASPIRE010</NoWarn>
           </PropertyGroup>
 
           <Import Project="{repoRoot}\src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.props" />
@@ -221,27 +223,27 @@ public class MSBuildTests
             """);
     }
 
-    private static string BuildProject(string workingDirectory)
+    private static string BuildProject(string workingDirectory, IDictionary<string, string>? environment = null)
     {
-        var result = BuildProjectCore(workingDirectory);
+        var result = BuildProjectCore(workingDirectory, environment);
 
         Assert.True(result.ExitCode == 0, $"Build failed: {Environment.NewLine}{result.Output}");
 
         return result.Output;
     }
 
-    private static string BuildProjectWithFailure(string workingDirectory)
+    private static string BuildProjectWithFailure(string workingDirectory, IDictionary<string, string>? environment = null)
     {
-        var result = BuildProjectCore(workingDirectory);
+        var result = BuildProjectCore(workingDirectory, environment);
 
         Assert.NotEqual(0, result.ExitCode);
 
         return result.Output;
     }
 
-    private static (int ExitCode, string Output) BuildProjectCore(string workingDirectory)
+    private static (int ExitCode, string Output) BuildProjectCore(string workingDirectory, IDictionary<string, string>? environment = null)
     {
-        return RunDotNet(workingDirectory, "build --disable-build-servers", timeoutMilliseconds: 180_000);
+        return RunDotNet(workingDirectory, "build --disable-build-servers", timeoutMilliseconds: 180_000, environment);
     }
 
     private static string PackProject(string projectFile, string outputDirectory, string packageId)
@@ -276,7 +278,7 @@ public class MSBuildTests
         return version!;
     }
 
-    private static (int ExitCode, string Output) RunDotNet(string workingDirectory, string arguments, int timeoutMilliseconds)
+    private static (int ExitCode, string Output) RunDotNet(string workingDirectory, string arguments, int timeoutMilliseconds, IDictionary<string, string>? environment = null)
     {
         var output = new StringBuilder();
         var outputDone = new ManualResetEvent(false);
@@ -289,6 +291,13 @@ public class MSBuildTests
             CreateNoWindow = true,
             WorkingDirectory = workingDirectory
         };
+        if (environment is not null)
+        {
+            foreach (var (key, value) in environment)
+            {
+                process.StartInfo.Environment[key] = value;
+            }
+        }
         process.OutputDataReceived += (sender, e) =>
         {
             if (e.Data == null)
@@ -310,15 +319,94 @@ public class MSBuildTests
     }
 
     [Fact]
-    public async Task CliBundleOptInResolvesExplicitBundlePath()
+    public async Task CliBundleDefaultResolvesExplicitBundlePath()
     {
         var repoRoot = MSBuildUtils.GetRepoRoot();
         using var tempDirectory = new TestTempDirectory();
 
         var bundle = CreateFakeCliBundle(tempDirectory.Path);
-        var appHostDirectory = CreateSdkBundleOptInAppHostProject(tempDirectory.Path, repoRoot,
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
             $"""
               <AspireCliBundlePath>{bundle.LayoutRoot}</AspireCliBundlePath>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        BuildProject(appHostDirectory);
+
+        var resolvedPaths = await File.ReadAllLinesAsync(Path.Combine(appHostDirectory, "obj", "resolved-aspire-paths.txt"));
+        Assert.Equal(bundle.DcpDir, resolvedPaths[0]);
+        Assert.Equal(bundle.ManagedDir, resolvedPaths[1]);
+        Assert.Equal(bundle.ManagedPath, resolvedPaths[2]);
+    }
+
+    [Fact]
+    public void CliBundleOptOutEmitsWarning()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var tempDirectory = new TestTempDirectory();
+
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
+            """
+              <AspireUseCliBundle>false</AspireUseCliBundle>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        var output = BuildProject(appHostDirectory);
+
+        Assert.Contains("warning ASPIRE010", output);
+        Assert.Contains("Some Aspire features may not work when the Aspire CLI bundle is not being used", output);
+    }
+
+    [Fact]
+    public async Task CliBundleDefaultResolvesAspireHomeBundleForSidecarlessCli()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var tempDirectory = new TestTempDirectory();
+
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.Path, "bin"));
+        var fakeCliPath = CreateFakeAspireCli(fakeCliDirectory.FullName);
+        var bundle = CreateFakeCliBundle(Path.Combine(tempDirectory.Path, "aspire-home"));
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
+            $"""
+              <AspireCliPath>{fakeCliPath}</AspireCliPath>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        BuildProject(appHostDirectory, new Dictionary<string, string> { ["ASPIRE_HOME"] = bundle.LayoutRoot });
+
+        var resolvedPaths = await File.ReadAllLinesAsync(Path.Combine(appHostDirectory, "obj", "resolved-aspire-paths.txt"));
+        Assert.Equal(bundle.DcpDir, resolvedPaths[0]);
+        Assert.Equal(bundle.ManagedDir, resolvedPaths[1]);
+        Assert.Equal(bundle.ManagedPath, resolvedPaths[2]);
+    }
+
+    [Fact]
+    public async Task CliBundleDefaultResolvesDotNetToolStoreBundleFromShimPath()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var tempDirectory = new TestTempDirectory();
+
+        var toolsDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.Path, ".dotnet", "tools"));
+        var shimPath = CreateFakeAspireCli(toolsDirectory.FullName);
+        var nativeCliDirectory = Directory.CreateDirectory(Path.Combine(
+            toolsDirectory.FullName,
+            ".store",
+            "aspire.cli",
+            "13.4.0",
+            OperatingSystem.IsWindows() ? "aspire.cli.win-x64" : "aspire.cli.linux-x64",
+            "13.4.0",
+            "tools",
+            "net10.0",
+            OperatingSystem.IsWindows() ? "win-x64" : "linux-x64"));
+        _ = CreateFakeAspireCli(nativeCliDirectory.FullName);
+        File.WriteAllText(Path.Combine(nativeCliDirectory.FullName, ".aspire-install.json"), """{"source":"dotnet-tool"}""");
+        var bundle = CreateFakeCliBundleAtLayoutRoot(nativeCliDirectory.FullName);
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
+            $"""
+              <AspireCliPath>{shimPath}</AspireCliPath>
             """);
 
         CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
@@ -343,7 +431,7 @@ public class MSBuildTests
         Directory.CreateDirectory(repoDcpDir);
         Directory.CreateDirectory(repoDashboardDir);
 
-        var appHostDirectory = CreateSdkBundleOptInAppHostProject(tempDirectory.Path, repoRoot,
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
             $"""
               <DcpDir>{repoDcpDir}</DcpDir>
               <AspireDashboardDir>{repoDashboardDir}</AspireDashboardDir>
@@ -366,7 +454,7 @@ public class MSBuildTests
         var repoRoot = MSBuildUtils.GetRepoRoot();
         using var tempDirectory = new TestTempDirectory();
 
-        var appHostDirectory = CreateSdkBundleOptInAppHostProject(tempDirectory.Path, repoRoot,
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
             $"""
               <AspireCliBundlePath>{Path.Combine(tempDirectory.Path, "missing-bundle")}</AspireCliBundlePath>
             """);
@@ -376,7 +464,8 @@ public class MSBuildTests
         var output = BuildProjectWithFailure(appHostDirectory);
 
         Assert.Contains("ASPIRE009", output);
-        Assert.Contains("Aspire CLI bundle could not be resolved", output);
+        Assert.Contains("the bundle could not be resolved", output);
+        Assert.Contains("Some new Aspire features require the Aspire CLI to be installed", output);
         Assert.Contains("https://get.aspire.dev", output);
         Assert.DoesNotContain("DCP path could not be resolved", output);
     }
@@ -389,7 +478,7 @@ public class MSBuildTests
 
         CreateAppProject(tempDirectory.Path, "App");
         var bundle = CreateFakeCliBundle(tempDirectory.Path);
-        var appHostDirectory = CreateSdkBundleOptInAppHostProject(tempDirectory.Path, repoRoot,
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
             $"""
               <AspireCliBundlePath>{bundle.LayoutRoot}</AspireCliBundlePath>
             """,
@@ -407,7 +496,7 @@ public class MSBuildTests
         Assert.Contains("class App : global::Aspire.Hosting.IProjectMetadata", appMetadata);
     }
 
-    private static string CreateSdkBundleOptInAppHostProject(string basePath, string repoRoot, string additionalProperties, string additionalProjectReferences = "")
+    private static string CreateSdkBundleAppHostProject(string basePath, string repoRoot, string additionalProperties, string additionalProjectReferences = "")
     {
         var appHostDirectory = Path.Combine(basePath, "AppHost");
         Directory.CreateDirectory(appHostDirectory);
@@ -423,7 +512,6 @@ public class MSBuildTests
                 <Nullable>enable</Nullable>
                 <IsAspireHost>true</IsAspireHost>
                 <AspireHostingSDKVersion>9.0.0</AspireHostingSDKVersion>
-                <AspireUseCliBundle>true</AspireUseCliBundle>
                 <SkipAddAspireDefaultReferences>true</SkipAddAspireDefaultReferences>
                 <_AspireUseTaskHostFactory>true</_AspireUseTaskHostFactory>
             {additionalProperties}
@@ -485,7 +573,11 @@ public class MSBuildTests
 
     private static (string LayoutRoot, string DcpDir, string ManagedDir, string ManagedPath) CreateFakeCliBundle(string basePath)
     {
-        var layoutRoot = Path.Combine(basePath, "layout");
+        return CreateFakeCliBundleAtLayoutRoot(Path.Combine(basePath, "layout"));
+    }
+
+    private static (string LayoutRoot, string DcpDir, string ManagedDir, string ManagedPath) CreateFakeCliBundleAtLayoutRoot(string layoutRoot)
+    {
         var bundleRoot = Path.Combine(layoutRoot, "bundle");
         var dcpDir = EnsureTrailingSeparator(Path.Combine(bundleRoot, "dcp"));
         var managedDir = EnsureTrailingSeparator(Path.Combine(bundleRoot, "managed"));
@@ -497,6 +589,13 @@ public class MSBuildTests
         File.WriteAllText(managedPath, "");
 
         return (layoutRoot, dcpDir, managedDir, managedPath);
+    }
+
+    private static string CreateFakeAspireCli(string directory)
+    {
+        var cliPath = Path.Combine(directory, OperatingSystem.IsWindows() ? "aspire.exe" : "aspire");
+        File.WriteAllText(cliPath, "");
+        return cliPath;
     }
 
     private static string EnsureTrailingSeparator(string path)

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -465,7 +465,7 @@ public class MSBuildTests
 
         Assert.Contains("ASPIRE009", output);
         Assert.Contains("the bundle could not be resolved", output);
-        Assert.Contains("Some new Aspire features require the Aspire CLI to be installed", output);
+        Assert.Contains("New features require the Aspire CLI to be installed.", output);
         Assert.Contains("https://get.aspire.dev", output);
         Assert.DoesNotContain("DCP path could not be resolved", output);
     }

--- a/tests/Shared/TemplatesTesting/BuildEnvironment.cs
+++ b/tests/Shared/TemplatesTesting/BuildEnvironment.cs
@@ -179,6 +179,10 @@ public class BuildEnvironment
         // in the tests
         EnvVars["_MSBUILDTLENABLED"] = "0";
         EnvVars["SkipAspireWorkloadManifest"] = "true";
+        // Template tests build generated apps from repo-built packages, not from an installed
+        // Aspire CLI bundle layout, so keep bundle resolution disabled for these test builds.
+        EnvVars["AspireUseCliBundle"] = "false";
+        EnvVars["NoWarn"] = "ASPIRE010";
 
         if (OperatingSystem.IsMacOS())
         {


### PR DESCRIPTION
## Description

C# AppHosts now use the Aspire CLI bundle by default by setting `AspireUseCliBundle` to `true` when the property is otherwise unspecified. This moves new/default AppHost builds to the bundled DCP/dashboard layout and avoids requiring users to explicitly opt in to the CLI bundle path.

Fixes #18270

### User-facing usage

AppHost projects no longer need to set `AspireUseCliBundle=true` to use the CLI bundle. If the bundle cannot be resolved, build reports `ASPIRE009` with install guidance and a link to https://get.aspire.dev.

Users can still opt out explicitly:

```xml
<PropertyGroup>
  <AspireUseCliBundle>false</AspireUseCliBundle>
</PropertyGroup>
```

Opting out emits `ASPIRE010` because some Aspire features may not work without the CLI bundle. Users who intentionally opt out can suppress that warning by ID, for example with `NoWarn`.

### Breaking changes

This changes the default AppHost build behavior from per-RID DCP/dashboard NuGet package resolution to CLI bundle resolution. Users without an installed Aspire CLI may now see `ASPIRE009`; install the Aspire CLI from https://get.aspire.dev or set `AspireUseCliBundle=false` to keep using the previous package-based path.

### Implementation details

- Defaults `AspireUseCliBundle` to `true` for C# AppHost projects in both AppHost package props and SDK targets.
- Adds `ASPIRE010` for explicit opt-out and updates `ASPIRE009` wording.
- Updates CLI bundle MSBuild discovery for current install layouts, including `bundle/`, versioned extraction roots, install-route sidecars, `ASPIRE_HOME`, and dotnet-tool shim/store layouts.
- Updates diagnostics docs and source-layout tests that intentionally do not use the bundle.

### Validation

- `dotnet test --project tests\Aspire.Hosting.Sdk.Tests\Aspire.Hosting.Sdk.Tests.csproj --no-launch-profile -- --filter-class "*.AppHostSdkTargetsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.MSBuildTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build src\Aspire.Hosting.Tasks\Aspire.Hosting.Tasks.csproj /p:SkipNativeBuild=true`
- Manual local-hive E2E: built/installed a local hive, created a new `aspire-starter` under `D:\scratch`, verified `AspireUseCliBundle` defaults to `true`, verified normal build/run uses the local hive bundle/dashboard, verified opt-out emits `ASPIRE010`, and verified a missing CLI bundle fails with `ASPIRE009` and install guidance.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
