### PR TITLE
ci: cross-compile osx-x64 CLI archive on Apple Silicon runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,16 @@ jobs:
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
-      targets: '[{"os": "macos-15-intel", "runner": "macos-15-intel", "rids": "osx-x64"}]'
+      # Cross-compile osx-x64 on the Apple Silicon (arm64) macos-latest runner
+      # instead of the Intel macos-15-intel runner. The Intel runner is ~2.5x
+      # slower per core and made this the long pole of the CLI build (~18m vs
+      # ~8m on Apple Silicon). Native AOT officially supports arm64 -> osx-x64
+      # cross-compilation, and this archive is only packaged and structurally
+      # verified (verify-cli-tool-nupkg.ps1 / verify-cli-npm-package.ps1) — the
+      # x64 binary is never executed here, so running it on arm64 hardware is
+      # never attempted. This mirrors the AzDO release pipeline, which already
+      # builds osx-x64 on an arm64 mac agent (eng/pipelines/templates/build_sign_native.yml).
+      targets: '[{"os": "macos-latest", "runner": "macos-latest", "rids": "osx-x64"}]'
 
   prepare_winget_installer_artifacts:
     name: Prepare WinGet installer artifacts


### PR DESCRIPTION
## Description

The **Build native CLI archive (macOS x64)** job is the long pole of the CLI build matrix on PRs — ~18m vs ~8m for the equivalent osx-arm64 job.

**Root cause:** it ran on the `macos-15-intel` runner. The dominant cost is Native AOT codegen; the `BuildCli.binlog` from run 27448293173 shows `IlcCompile` ~327s, `CoreCompile` ~193s, `LinkNative` ~84s. The Intel runner is ~2.5x slower per core than Apple Silicon, so every step pays that tax.

**The fix:** build osx-x64 on the arm64 `macos-latest` runner, cross-compiling the x64 archive. Native AOT officially supports arm64 → osx-x64 cross-compilation (.NET 8+); no project changes are needed — the SDK resolves the osx-x64 NativeAOT runtime package and clang targets `x86_64-apple-macos` automatically.

**Why this is safe:** the reusable build workflow (`build-cli-native-archives.yml`) only packages and *structurally* verifies the archive (`verify-cli-tool-nupkg.ps1` / `verify-cli-npm-package.ps1` check the binary's presence in the nupkg/npm package, never run it). The x64 binary is never executed, so running x64 on arm64 hardware is never attempted. This mirrors the AzDO release pipeline, which already builds osx-x64 on an arm64 mac agent (`eng/pipelines/templates/build_sign_native.yml`), gating only its execute-verify step by agent arch.

**Validation:** cross-compile was reproduced locally on Apple Silicon — `dotnet publish -r osx-x64 -p:PublishAot=true` produced a real `Mach-O 64-bit executable x86_64` (confirmed with `file` / `lipo -archs`). This PR's own `macos-latest` run is the end-to-end proof on GitHub-hosted hardware.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
