### PR TITLE
Add --skills flag to aspire init

### DIFF
--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -72,7 +72,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             ConsoleInteractionService.NoneChoice)
     };
 
-    private static readonly Option<string?> s_skillsOption = new("--skills")
+    internal static readonly Option<string?> s_skillsOption = new("--skills")
     {
         Description = string.Format(CultureInfo.InvariantCulture, AgentCommandStrings.InitCommand_SkillsOptionDescription,
             string.Join(",", SkillDefinition.CliDefined.Select(s => s.Name)),
@@ -96,6 +96,8 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
     /// pre-selected, which is what <c>aspire init</c> wants because aspireify is the natural follow-up.
     /// Other callers (e.g. <c>aspire new</c>) can pass a predicate to additionally filter out skills that
     /// don't fit their context (such as one-time setup skills after a template has already produced the AppHost).
+    /// Callers that expose <c>--skills</c> can pass <paramref name="skillsBinding"/> so the chained
+    /// execution reuses the same non-interactive selection semantics as standalone <c>aspire agent init</c>.
     /// </summary>
     internal async Task<AgentInitExecutionResult> PromptAndChainAsync(
         IInteractionService interactionService,
@@ -103,7 +105,8 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         DirectoryInfo workspaceRoot,
         PromptBinding<bool> agentInitBinding,
         CancellationToken cancellationToken,
-        Func<SkillDefinition, bool>? selectByDefault = null)
+        Func<SkillDefinition, bool>? selectByDefault = null,
+        PromptBinding<string?>? skillsBinding = null)
     {
         if (previousResultExitCode != CliExitCodes.Success)
         {
@@ -120,7 +123,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
 
         if (runAgentInit)
         {
-            return await ExecuteAgentInitAsync(workspaceRoot, parseResult: null, selectByDefault, cancellationToken);
+            return await ExecuteAgentInitAsync(workspaceRoot, parseResult: null, selectByDefault, cancellationToken, skillsBinding);
         }
 
         return new(CliExitCodes.Success, [], []);
@@ -192,7 +195,12 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         return new DirectoryInfo(workspaceRootPath);
     }
 
-    private async Task<AgentInitExecutionResult> ExecuteAgentInitAsync(DirectoryInfo workspaceRoot, ParseResult? parseResult, Func<SkillDefinition, bool>? selectByDefault, CancellationToken cancellationToken)
+    private async Task<AgentInitExecutionResult> ExecuteAgentInitAsync(
+        DirectoryInfo workspaceRoot,
+        ParseResult? parseResult,
+        Func<SkillDefinition, bool>? selectByDefault,
+        CancellationToken cancellationToken,
+        PromptBinding<string?>? skillsBindingOverride = null)
     {
         var context = new AgentEnvironmentScanContext
         {
@@ -252,7 +260,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         if (selectedLocations.Count > 0)
         {
             IReadOnlyList<SkillDefinition> availableSkills;
-            if (ShouldSkipBundleCatalogResolution(parseResult))
+            if (ShouldSkipBundleCatalogResolution(parseResult, skillsBindingOverride))
             {
                 availableSkills = SkillDefinition.CliDefined
                     .Where(s => s.IsApplicableToLanguage(detectedLanguage))
@@ -296,7 +304,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             var defaultSkillNames = string.Join(",", defaultSkills.Select(s => s.Name));
             var skillsBinding = parseResult is not null
                 ? PromptBinding.Create(parseResult, s_skillsOption, defaultSkillNames)
-                : PromptBinding.CreateDefault<string?>(defaultSkillNames);
+                : skillsBindingOverride?.WithDefault(defaultSkillNames) ?? PromptBinding.CreateDefault<string?>(defaultSkillNames);
 
             // When the bundle failed to install and the caller passed an explicit --skills value
             // that names a bundle-only skill, the upcoming MatchChoicesOrThrow will reject the
@@ -529,11 +537,17 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         return false;
     }
 
-    private static bool ShouldSkipBundleCatalogResolution(ParseResult? parseResult)
+    private static bool ShouldSkipBundleCatalogResolution(ParseResult? parseResult, PromptBinding<string?>? skillsBinding)
     {
         if (parseResult is null)
         {
-            return false;
+            var (wasProvided, optionValue, _) = PromptBinding.Resolve(skillsBinding);
+            if (!wasProvided)
+            {
+                return false;
+            }
+
+            return ShouldSkipBundleCatalogResolution(optionValue);
         }
 
         var optionResult = parseResult.GetResult(s_skillsOption);
@@ -542,7 +556,11 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             return false;
         }
 
-        var value = parseResult.GetValue(s_skillsOption);
+        return ShouldSkipBundleCatalogResolution(parseResult.GetValue(s_skillsOption));
+    }
+
+    private static bool ShouldSkipBundleCatalogResolution(string? value)
+    {
         if (string.Equals(value, ConsoleInteractionService.NoneChoice, StringComparison.OrdinalIgnoreCase))
         {
             return true;

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -104,6 +104,7 @@ internal sealed class InitCommand : BaseCommand
         Options.Add(_channelOption);
         Options.Add(_languageOption);
         Options.Add(NewCommand.s_suppressAgentInitOption);
+        Options.Add(AgentInitCommand.s_skillsOption);
     }
 
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -163,6 +164,7 @@ internal sealed class InitCommand : BaseCommand
         // This prompt lets users choose which skills to install — including aspireify.
         var workspaceRoot = solutionFile?.Directory ?? workingDirectory;
         var agentInitBinding = PromptBinding.CreateInvertedBoolConfirm(parseResult, NewCommand.s_suppressAgentInitOption, defaultValue: true);
+        var skillsBinding = PromptBinding.Create(parseResult, AgentInitCommand.s_skillsOption);
         // aspire init creates an AppHost in an existing repo, so pre-select every bundle skill
         // (which includes aspireify as the natural follow-up wiring skill).
         var agentInitResult = await _agentInitCommand.PromptAndChainAsync(
@@ -170,7 +172,8 @@ internal sealed class InitCommand : BaseCommand
             CliExitCodes.Success,
             workspaceRoot,
             agentInitBinding,
-            cancellationToken);
+            cancellationToken,
+            skillsBinding: skillsBinding);
 
         // Step 5: Print follow-up commands only when the user selected the one-time init skill.
         if (agentInitResult.ExitCode == CliExitCodes.Success &&

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -570,6 +570,28 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task InitCommand_NonInteractive_WithNoneSkills_DoesNotInstallAgentSkills()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var serviceProvider = services.BuildServiceProvider();
+        var command = serviceProvider.GetRequiredService<RootCommand>();
+
+        var parseResult = command.Parse("init --non-interactive --skills none");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs")));
+
+        var aspireSkillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", CommonAgentApplicators.AspireSkillName);
+        Assert.False(Directory.Exists(aspireSkillPath), $"Expected no aspire skill directory but found {aspireSkillPath}");
+
+        var aspireifySkillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", CommonAgentApplicators.AspireifySkillName);
+        Assert.False(Directory.Exists(aspireifySkillPath), $"Expected no aspireify skill directory but found {aspireifySkillPath}");
+    }
+
+    [Fact]
     public async Task InitCommand_WhenNoSolutionExists_SingleFileSkeletonPinsSdkVersion()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Summary

Fixes #18095.

This adds the existing `--skills` option from `aspire agent init` to `aspire init`, so non-interactive init flows can control which agent skills are installed while keeping the same selection semantics as the standalone command.

The implementation reuses `AgentInitCommand`'s option rather than defining a second parser surface, then forwards the resulting prompt binding into the chained agent-init step that runs after `aspire init` creates the AppHost. The chained path now preserves explicit values such as `--skills none`, while still applying the existing default skill selection when the option is omitted.

I also added a focused regression test covering `aspire init --non-interactive --skills none`, asserting that the AppHost is still created and neither the `aspire` nor `aspireify` skill directories are installed.

## Verification

- `./dotnet.sh test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-method '*InitCommand_NonInteractive_WithNoneSkills_DoesNotInstallAgentSkills'`
- `./dotnet.sh build tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-restore --configuration Debug`
