### PR TITLE
Add troubleshooting link to dashboard resource service connection error logs

### DIFF
--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -339,7 +339,7 @@ internal sealed class DashboardClient : IDashboardClient
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error loading data from the resource service. For troubleshooting, see https://aka.ms/aspire/dashboard-connection-failed");
+            _logger.LogError(ex, "Error loading data from the resource service. For troubleshooting, see https://aka.ms/aspire/dashboard-apphost-connection-failed");
             throw;
         }
     }
@@ -411,7 +411,7 @@ internal sealed class DashboardClient : IDashboardClient
             catch (Exception ex)
             {
                 errorCount++;
-                _logger.LogError(ex, "Error #{ErrorCount} connecting to the resource service. For troubleshooting, see https://aka.ms/aspire/dashboard-connection-failed", errorCount);
+                _logger.LogError(ex, "Error #{ErrorCount} connecting to the resource service. For troubleshooting, see https://aka.ms/aspire/dashboard-apphost-connection-failed", errorCount);
             }
         }
     }
@@ -500,7 +500,7 @@ internal sealed class DashboardClient : IDashboardClient
             {
                 retryContext.ErrorCount++;
 
-                _logger.LogError(ex, "Error #{ErrorCount} watching {WatchName}. For troubleshooting, see https://aka.ms/aspire/dashboard-connection-failed", retryContext.ErrorCount, actionName);
+                _logger.LogError(ex, "Error #{ErrorCount} watching {WatchName}. For troubleshooting, see https://aka.ms/aspire/dashboard-apphost-connection-failed", retryContext.ErrorCount, actionName);
             }
         }
 

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -340,7 +340,7 @@ internal sealed class DashboardClient : IDashboardClient
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error loading data from the resource service. For troubleshooting, see https://aka.ms/aspire/dashboard-apphost-connection-failed");
+            _logger.LogError(ex, "Error loading data from the resource service. For troubleshooting, see {TroubleshootingUrl}", TroubleshootingUrl);
             throw;
         }
     }
@@ -412,7 +412,7 @@ internal sealed class DashboardClient : IDashboardClient
             catch (Exception ex)
             {
                 errorCount++;
-                _logger.LogError(ex, "Error #{ErrorCount} connecting to the resource service. For troubleshooting, see https://aka.ms/aspire/dashboard-apphost-connection-failed", errorCount);
+                _logger.LogError(ex, "Error #{ErrorCount} connecting to the resource service. For troubleshooting, see {TroubleshootingUrl}", errorCount, TroubleshootingUrl);
             }
         }
     }
@@ -501,7 +501,7 @@ internal sealed class DashboardClient : IDashboardClient
             {
                 retryContext.ErrorCount++;
 
-                _logger.LogError(ex, "Error #{ErrorCount} watching {WatchName}. For troubleshooting, see https://aka.ms/aspire/dashboard-apphost-connection-failed", retryContext.ErrorCount, actionName);
+                _logger.LogError(ex, "Error #{ErrorCount} watching {WatchName}. For troubleshooting, see {TroubleshootingUrl}", retryContext.ErrorCount, actionName, TroubleshootingUrl);
             }
         }
 

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -339,7 +339,7 @@ internal sealed class DashboardClient : IDashboardClient
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error loading data from the resource service.");
+            _logger.LogError(ex, "Error loading data from the resource service. For troubleshooting, see https://aka.ms/aspire/dashboard-connection-failed");
             throw;
         }
     }
@@ -411,7 +411,7 @@ internal sealed class DashboardClient : IDashboardClient
             catch (Exception ex)
             {
                 errorCount++;
-                _logger.LogError(ex, "Error #{ErrorCount} connecting to the resource service.", errorCount);
+                _logger.LogError(ex, "Error #{ErrorCount} connecting to the resource service. For troubleshooting, see https://aka.ms/aspire/dashboard-connection-failed", errorCount);
             }
         }
     }
@@ -500,7 +500,7 @@ internal sealed class DashboardClient : IDashboardClient
             {
                 retryContext.ErrorCount++;
 
-                _logger.LogError(ex, "Error #{ErrorCount} watching {WatchName}.", retryContext.ErrorCount, actionName);
+                _logger.LogError(ex, "Error #{ErrorCount} watching {WatchName}. For troubleshooting, see https://aka.ms/aspire/dashboard-connection-failed", retryContext.ErrorCount, actionName);
             }
         }
 

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -41,6 +41,7 @@ namespace Aspire.Dashboard.ServiceClient;
 internal sealed class DashboardClient : IDashboardClient
 {
     private const string ApiKeyHeaderName = "x-resource-service-api-key";
+    private const string TroubleshootingUrl = "https://aka.ms/aspire/dashboard-apphost-connection-failed";
 
     private readonly Dictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
     private readonly InteractionCollection _pendingInteractionCollection = new();

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -394,7 +394,7 @@ public sealed class DashboardClientTests
 
         var errorLog = testSink.Writes.FirstOrDefault(w => w.LogLevel == LogLevel.Error);
         Assert.NotNull(errorLog);
-        Assert.Contains("https://aka.ms/aspire/dashboard-connection-failed", errorLog.Message);
+        Assert.Contains("https://aka.ms/aspire/dashboard-apphost-connection-failed", errorLog.Message);
     }
 
     private sealed class MockDashboardServiceClient : Aspire.DashboardService.Proto.V1.DashboardService.DashboardServiceClient

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -8,7 +8,9 @@ using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -359,15 +361,46 @@ public sealed class DashboardClientTests
         // Without the Connecting transition between retries, only 1 Disconnected event would fire.
         for (var i = 0; i < 3; i++)
         {
-            await disconnectedSemaphore.WaitAsync(TimeSpan.FromSeconds(30)).DefaultTimeout();
+            await disconnectedSemaphore.WaitAsync().DefaultTimeout();
         }
 
         Assert.True(disconnectedCount >= 3, $"Expected at least 3 Disconnected events but got {disconnectedCount}.");
     }
 
+    [Fact]
+    public async Task ConnectWithRetry_LogsErrorWithTroubleshootingLink()
+    {
+        var testSink = new TestSink();
+        var loggerFactory = LoggerFactory.Create(b => b.AddProvider(new TestLoggerProvider(testSink)));
+
+        await using var instance = new DashboardClient(loggerFactory, _configuration, _dashboardOptions, new MockKnownPropertyLookup());
+        instance.SetDashboardServiceClient(new MockDashboardServiceClient { FailOnGetApplicationInformation = true });
+
+        IDashboardClient client = instance;
+        var disconnectedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.ConnectionStateChanged += state =>
+        {
+            if (state == DashboardConnectionState.Disconnected)
+            {
+                disconnectedTcs.TrySetResult();
+            }
+        };
+
+        // Trigger the connection attempt which will fail on GetApplicationInformationAsync.
+        _ = client.WhenConnected;
+
+        // Wait for the first Disconnected event which means the error has been logged.
+        await disconnectedTcs.Task.DefaultTimeout();
+
+        var errorLog = testSink.Writes.FirstOrDefault(w => w.LogLevel == LogLevel.Error);
+        Assert.NotNull(errorLog);
+        Assert.Contains("https://aka.ms/aspire/dashboard-connection-failed", errorLog.Message);
+    }
+
     private sealed class MockDashboardServiceClient : Aspire.DashboardService.Proto.V1.DashboardService.DashboardServiceClient
     {
         public bool FailOnWatchResources { get; init; }
+        public bool FailOnGetApplicationInformation { get; init; }
 
         public override AsyncDuplexStreamingCall<WatchInteractionsRequestUpdate, WatchInteractionsResponseUpdate> WatchInteractions(CallOptions options)
         {
@@ -382,6 +415,16 @@ public sealed class DashboardClientTests
 
         public override AsyncUnaryCall<ApplicationInformationResponse> GetApplicationInformationAsync(ApplicationInformationRequest request, CallOptions options)
         {
+            if (FailOnGetApplicationInformation)
+            {
+                return new AsyncUnaryCall<ApplicationInformationResponse>(
+                    Task.FromException<ApplicationInformationResponse>(new RpcException(new Status(StatusCode.Unavailable, "Service unavailable"))),
+                    Task.FromResult(new Metadata()),
+                    () => new Status(StatusCode.Unavailable, "Service unavailable"),
+                    () => new Metadata(),
+                    () => { });
+            }
+
             return new AsyncUnaryCall<ApplicationInformationResponse>(
                 Task.FromResult(new ApplicationInformationResponse
                 {


### PR DESCRIPTION
## Description

When the dashboard fails to connect to the resource service, users see error log messages but have no guidance on how to troubleshoot the problem. This change appends a troubleshooting link (`https://aka.ms/aspire/dashboard-apphost-connection-failed`) to the error log messages emitted during connection failures, so users can quickly find relevant documentation.

The URL is defined as a `private const string` to avoid repetition across the three error paths:
- Initial connection retry failures (`ConnectWithRetryAsync`)
- Overall connection task failure (`ConnectAndWatchAsync`)
- Watch stream disconnections (`WatchWithRecoveryAsync`)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No