### PR TITLE
Move resource property metadata to producers

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -175,10 +175,9 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
                         value: property.Value,
                         isValueSensitive: false,
                         knownProperty: property.KnownProperty,
-                        priority: property.Priority,
+                        sortOrder: property.SortOrder,
                         displayName: property.DisplayName,
-                        isHighlighted: property.IsHighlighted,
-                        sortOrder: property.SortOrder);
+                        isHighlighted: property.IsHighlighted);
                 }
 
                 _displayedResourcePropertyViewModels.Add(new DisplayedResourcePropertyViewModel(displayedProperty, Loc, TimeProvider));
@@ -400,7 +399,9 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
                 value: Value.ForString(stateDescription),
                 isValueSensitive: false,
                 knownProperty: new KnownProperty(StateDescriptionPropertyKey, _ => ControlStringsLoc[nameof(ControlsStrings.ResourceDetailsStateDescriptionHeader)]),
-                priority: 1),
+                sortOrder: KnownResourcePropertySortOrder.State,
+                displayName: null,
+                isHighlighted: false),
             Loc,
             TimeProvider));
     }

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -238,6 +238,9 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
                     }
                 };
 
+                // Parameter value is producer metadata for new resource servers, but legacy
+                // fallback metadata exposes the same property as an unknown property key.
+                // Register both keys so the unset-value renderer works in both cases.
                 _valueComponents[KnownProperties.Parameter.Value] = metadata;
                 _valueComponents[DisplayedResourcePropertyViewModel.GetUnknownKey(KnownProperties.Parameter.Value)] = metadata;
             }
@@ -399,6 +402,8 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
                 value: Value.ForString(stateDescription),
                 isValueSensitive: false,
                 knownProperty: new KnownProperty(StateDescriptionPropertyKey, _ => ControlStringsLoc[nameof(ControlsStrings.ResourceDetailsStateDescriptionHeader)]),
+                // The description explains the current state, so keep it in the same generic
+                // sort group as State rather than treating it as producer-defined metadata.
                 sortOrder: KnownResourcePropertySortOrder.State,
                 displayName: null,
                 isHighlighted: false),

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -167,7 +167,7 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
                 // in the details grid instead of routing it through masking behavior. Preserve the
                 // display/highlight metadata so the placeholder keeps the original property behavior.
                 if (_resource.HasMissingParameterValueState() &&
-                    property.KnownProperty?.Key == KnownProperties.Parameter.Value &&
+                    string.Equals(property.Name, KnownProperties.Parameter.Value, StringComparisons.ResourcePropertyName) &&
                     property.IsValueSensitive)
                 {
                     displayedProperty = new ResourcePropertyViewModel(
@@ -177,7 +177,8 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
                         knownProperty: property.KnownProperty,
                         priority: property.Priority,
                         displayName: property.DisplayName,
-                        isHighlighted: property.IsHighlighted);
+                        isHighlighted: property.IsHighlighted,
+                        sortOrder: property.SortOrder);
                 }
 
                 _displayedResourcePropertyViewModels.Add(new DisplayedResourcePropertyViewModel(displayedProperty, Loc, TimeProvider));
@@ -227,7 +228,7 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
             // as the parameters grid so the details panel stays consistent with the grid.
             if (_resource.HasMissingParameterValueState())
             {
-                _valueComponents[KnownProperties.Parameter.Value] = new ComponentMetadata
+                var metadata = new ComponentMetadata
                 {
                     Type = typeof(ParameterValueDisplayCell),
                     Parameters =
@@ -237,6 +238,9 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
                         ["IsCommandExecuting"] = IsCommandExecuting,
                     }
                 };
+
+                _valueComponents[KnownProperties.Parameter.Value] = metadata;
+                _valueComponents[DisplayedResourcePropertyViewModel.GetUnknownKey(KnownProperties.Parameter.Value)] = metadata;
             }
 
             UpdateResourceActionsMenu();
@@ -410,7 +414,7 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
                 || string.Equals(vm.KnownProperty?.Key, KnownProperties.Resource.State, StringComparisons.ResourcePropertyName));
 
         return ordered
-            ? vms.OrderBy(vm => vm.Priority).ThenBy(vm => vm.DisplayName)
+            ? vms.OrderBy(vm => vm.SortOrder).ThenBy(vm => vm.DisplayName)
             : vms;
     }
 

--- a/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
+++ b/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
@@ -7,35 +7,34 @@ namespace Aspire.Dashboard.Model;
 
 public interface IKnownPropertyLookup
 {
-    (int priority, KnownProperty? knownProperty) FindProperty(string resourceType, string uid);
+    (int SortOrder, KnownProperty? KnownProperty) FindProperty(string uid);
 }
 
 public sealed class KnownPropertyLookup : IKnownPropertyLookup
 {
-    private readonly List<KnownProperty> _resourceProperties;
+    private readonly List<(KnownProperty Property, int SortOrder)> _resourceProperties;
 
     public KnownPropertyLookup()
     {
         _resourceProperties =
         [
-            new(KnownProperties.Resource.DisplayName, loc => loc[nameof(ResourcesDetailsDisplayNameProperty)]),
-            new(KnownProperties.Resource.State, loc => loc[nameof(ResourcesDetailsStateProperty)]),
-            new(KnownProperties.Resource.HealthState, loc => loc[nameof(ResourcesDetailsHealthStateProperty)]),
-            new(KnownProperties.Resource.StartTime, loc => loc[nameof(ResourcesDetailsStartTimeProperty)]),
-            new(KnownProperties.Resource.StopTime, loc => loc[nameof(ResourcesDetailsStopTimeProperty)]),
-            new(KnownProperties.Resource.ExitCode, loc => loc[nameof(ResourcesDetailsExitCodeProperty)]),
-            new(KnownProperties.Resource.ConnectionString, loc => loc[nameof(ResourcesDetailsConnectionStringProperty)])
+            new(new(KnownProperties.Resource.DisplayName, loc => loc[nameof(ResourcesDetailsDisplayNameProperty)]), KnownResourcePropertySortOrder.DisplayName),
+            new(new(KnownProperties.Resource.State, loc => loc[nameof(ResourcesDetailsStateProperty)]), KnownResourcePropertySortOrder.State),
+            new(new(KnownProperties.Resource.HealthState, loc => loc[nameof(ResourcesDetailsHealthStateProperty)]), KnownResourcePropertySortOrder.HealthState),
+            new(new(KnownProperties.Resource.StartTime, loc => loc[nameof(ResourcesDetailsStartTimeProperty)]), KnownResourcePropertySortOrder.StartTime),
+            new(new(KnownProperties.Resource.StopTime, loc => loc[nameof(ResourcesDetailsStopTimeProperty)]), KnownResourcePropertySortOrder.StopTime),
+            new(new(KnownProperties.Resource.ExitCode, loc => loc[nameof(ResourcesDetailsExitCodeProperty)]), KnownResourcePropertySortOrder.ExitCode),
+            new(new(KnownProperties.Resource.ConnectionString, loc => loc[nameof(ResourcesDetailsConnectionStringProperty)]), KnownResourcePropertySortOrder.ConnectionString)
         ];
     }
 
-    public (int priority, KnownProperty? knownProperty) FindProperty(string resourceType, string uid)
+    public (int SortOrder, KnownProperty? KnownProperty) FindProperty(string uid)
     {
-        for (var i = 0; i < _resourceProperties.Count; i++)
+        foreach (var property in _resourceProperties)
         {
-            var kp = _resourceProperties[i];
-            if (kp.Key == uid)
+            if (property.Property.Key == uid)
             {
-                return (i, kp);
+                return (property.SortOrder, property.Property);
             }
         }
 

--- a/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
+++ b/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
@@ -13,10 +13,6 @@ public interface IKnownPropertyLookup
 public sealed class KnownPropertyLookup : IKnownPropertyLookup
 {
     private readonly List<KnownProperty> _resourceProperties;
-    private readonly List<KnownProperty> _projectProperties;
-    private readonly List<KnownProperty> _executableProperties;
-    private readonly List<KnownProperty> _containerProperties;
-    private readonly List<KnownProperty> _parameterProperties;
 
     public KnownPropertyLookup()
     {
@@ -30,55 +26,13 @@ public sealed class KnownPropertyLookup : IKnownPropertyLookup
             new(KnownProperties.Resource.ExitCode, loc => loc[nameof(ResourcesDetailsExitCodeProperty)]),
             new(KnownProperties.Resource.ConnectionString, loc => loc[nameof(ResourcesDetailsConnectionStringProperty)])
         ];
-
-        _projectProperties =
-        [
-            .. _resourceProperties,
-            new(KnownProperties.Project.Path, loc => loc[nameof(ResourcesDetailsProjectPathProperty)]),
-            new(KnownProperties.Project.LaunchProfile, loc => loc[nameof(ResourcesDetailsProjectLaunchProfileProperty)]),
-            new(KnownProperties.Executable.Pid, loc => loc[nameof(ResourcesDetailsExecutableProcessIdProperty)]),
-        ];
-
-        _executableProperties =
-        [
-            .. _resourceProperties,
-            new(KnownProperties.Executable.Path, loc => loc[nameof(ResourcesDetailsExecutablePathProperty)]),
-            new(KnownProperties.Executable.WorkDir, loc => loc[nameof(ResourcesDetailsExecutableWorkingDirectoryProperty)]),
-            new(KnownProperties.Executable.Args, loc => loc[nameof(ResourcesDetailsExecutableArgumentsProperty)]),
-            new(KnownProperties.Executable.Pid, loc => loc[nameof(ResourcesDetailsExecutableProcessIdProperty)]),
-        ];
-
-        _containerProperties =
-        [
-            .. _resourceProperties,
-            new(KnownProperties.Container.Image, loc => loc[nameof(ResourcesDetailsContainerImageProperty)]),
-            new(KnownProperties.Container.Id, loc => loc[nameof(ResourcesDetailsContainerIdProperty)]),
-            new(KnownProperties.Container.Command, loc => loc[nameof(ResourcesDetailsContainerCommandProperty)]),
-            new(KnownProperties.Container.Args, loc => loc[nameof(ResourcesDetailsContainerArgumentsProperty)]),
-            new(KnownProperties.Container.Ports, loc => loc[nameof(ResourcesDetailsContainerPortsProperty)]),
-            new(KnownProperties.Container.Lifetime, loc => loc[nameof(ResourcesDetailsContainerLifetimeProperty)]),
-        ];
-
-        _parameterProperties =
-        [
-            new(KnownProperties.Parameter.Value, loc => loc[nameof(ResourcesDetailsParameterValueProperty)])
-        ];
     }
 
     public (int priority, KnownProperty? knownProperty) FindProperty(string resourceType, string uid)
     {
-        var knownProperties = resourceType switch
+        for (var i = 0; i < _resourceProperties.Count; i++)
         {
-            KnownResourceTypes.Project => _projectProperties,
-            KnownResourceTypes.Executable => _executableProperties,
-            KnownResourceTypes.Container => _containerProperties,
-            KnownResourceTypes.Parameter => _parameterProperties,
-            _ => _resourceProperties
-        };
-
-        for (var i = 0; i < knownProperties.Count; i++)
-        {
-            var kp = knownProperties[i];
+            var kp = _resourceProperties[i];
             if (kp.Key == uid)
             {
                 return (i, kp);

--- a/src/Aspire.Dashboard/Model/LegacyResourcePropertyMetadata.cs
+++ b/src/Aspire.Dashboard/Model/LegacyResourcePropertyMetadata.cs
@@ -17,20 +17,20 @@ internal static class LegacyResourcePropertyMetadata
     {
         var metadata = (resourceType, propertyName) switch
         {
-            (KnownResourceTypes.Container, KnownProperties.Container.Image) => Create(KnownProperties.Container.Image, nameof(ResourcesDetailsContainerImageProperty), KnownResourcePropertySortOrder.ProducerDefinedStart),
-            (KnownResourceTypes.Container, KnownProperties.Container.Id) => Create(KnownProperties.Container.Id, nameof(ResourcesDetailsContainerIdProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 1),
-            (KnownResourceTypes.Container, KnownProperties.Container.Command) => Create(KnownProperties.Container.Command, nameof(ResourcesDetailsContainerCommandProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 2),
-            (KnownResourceTypes.Container, KnownProperties.Container.Args) => Create(KnownProperties.Container.Args, nameof(ResourcesDetailsContainerArgumentsProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 3),
-            (KnownResourceTypes.Container, KnownProperties.Container.Ports) => Create(KnownProperties.Container.Ports, nameof(ResourcesDetailsContainerPortsProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 4),
-            (KnownResourceTypes.Container, KnownProperties.Container.Lifetime) => Create(KnownProperties.Container.Lifetime, nameof(ResourcesDetailsContainerLifetimeProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 5),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.Path) => Create(KnownProperties.Executable.Path, nameof(ResourcesDetailsExecutablePathProperty), KnownResourcePropertySortOrder.ProducerDefinedStart),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir) => Create(KnownProperties.Executable.WorkDir, nameof(ResourcesDetailsExecutableWorkingDirectoryProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 1),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.Args) => Create(KnownProperties.Executable.Args, nameof(ResourcesDetailsExecutableArgumentsProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 2),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.Pid) => Create(KnownProperties.Executable.Pid, nameof(ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 3),
-            (KnownResourceTypes.Project, KnownProperties.Project.Path) => Create(KnownProperties.Project.Path, nameof(ResourcesDetailsProjectPathProperty), KnownResourcePropertySortOrder.ProducerDefinedStart),
-            (KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile) => Create(KnownProperties.Project.LaunchProfile, nameof(ResourcesDetailsProjectLaunchProfileProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 1),
-            (KnownResourceTypes.Project, KnownProperties.Executable.Pid) => Create(KnownProperties.Executable.Pid, nameof(ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 2),
-            (KnownResourceTypes.Parameter, KnownProperties.Parameter.Value) => Create(KnownProperties.Parameter.Value, nameof(ResourcesDetailsParameterValueProperty), KnownResourcePropertySortOrder.ProducerDefinedStart),
+            (KnownResourceTypes.Container, KnownProperties.Container.Image) => Create(KnownProperties.Container.Image, nameof(ResourcesDetailsContainerImageProperty), 0),
+            (KnownResourceTypes.Container, KnownProperties.Container.Id) => Create(KnownProperties.Container.Id, nameof(ResourcesDetailsContainerIdProperty), 1),
+            (KnownResourceTypes.Container, KnownProperties.Container.Command) => Create(KnownProperties.Container.Command, nameof(ResourcesDetailsContainerCommandProperty), 2),
+            (KnownResourceTypes.Container, KnownProperties.Container.Args) => Create(KnownProperties.Container.Args, nameof(ResourcesDetailsContainerArgumentsProperty), 3),
+            (KnownResourceTypes.Container, KnownProperties.Container.Ports) => Create(KnownProperties.Container.Ports, nameof(ResourcesDetailsContainerPortsProperty), 4),
+            (KnownResourceTypes.Container, KnownProperties.Container.Lifetime) => Create(KnownProperties.Container.Lifetime, nameof(ResourcesDetailsContainerLifetimeProperty), 5),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Path) => Create(KnownProperties.Executable.Path, nameof(ResourcesDetailsExecutablePathProperty), 0),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir) => Create(KnownProperties.Executable.WorkDir, nameof(ResourcesDetailsExecutableWorkingDirectoryProperty), 1),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Args) => Create(KnownProperties.Executable.Args, nameof(ResourcesDetailsExecutableArgumentsProperty), 2),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Pid) => Create(KnownProperties.Executable.Pid, nameof(ResourcesDetailsExecutableProcessIdProperty), 3),
+            (KnownResourceTypes.Project, KnownProperties.Project.Path) => Create(KnownProperties.Project.Path, nameof(ResourcesDetailsProjectPathProperty), 0),
+            (KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile) => Create(KnownProperties.Project.LaunchProfile, nameof(ResourcesDetailsProjectLaunchProfileProperty), 1),
+            (KnownResourceTypes.Project, KnownProperties.Executable.Pid) => Create(KnownProperties.Executable.Pid, nameof(ResourcesDetailsExecutableProcessIdProperty), 2),
+            (KnownResourceTypes.Parameter, KnownProperties.Parameter.Value) => Create(KnownProperties.Parameter.Value, nameof(ResourcesDetailsParameterValueProperty), 0),
             _ => ((int SortOrder, KnownProperty KnownProperty)?)null
         };
 

--- a/src/Aspire.Dashboard/Model/LegacyResourcePropertyMetadata.cs
+++ b/src/Aspire.Dashboard/Model/LegacyResourcePropertyMetadata.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using static Aspire.Dashboard.Resources.Resources;
+
+namespace Aspire.Dashboard.Model;
+
+/// <summary>
+/// Provides temporary display metadata for resource-specific properties emitted by older resource servers.
+/// </summary>
+internal static class LegacyResourcePropertyMetadata
+{
+    /// <summary>
+    /// Gets legacy metadata for resource-specific properties that predate producer-supplied display metadata.
+    /// </summary>
+    internal static (int SortOrder, KnownProperty KnownProperty)? Get(string resourceType, string propertyName)
+    {
+        var metadata = (resourceType, propertyName) switch
+        {
+            (KnownResourceTypes.Container, KnownProperties.Container.Image) => Create(KnownProperties.Container.Image, nameof(ResourcesDetailsContainerImageProperty), KnownResourcePropertySortOrder.FirstResourceSpecific),
+            (KnownResourceTypes.Container, KnownProperties.Container.Id) => Create(KnownProperties.Container.Id, nameof(ResourcesDetailsContainerIdProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 1),
+            (KnownResourceTypes.Container, KnownProperties.Container.Command) => Create(KnownProperties.Container.Command, nameof(ResourcesDetailsContainerCommandProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 2),
+            (KnownResourceTypes.Container, KnownProperties.Container.Args) => Create(KnownProperties.Container.Args, nameof(ResourcesDetailsContainerArgumentsProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 3),
+            (KnownResourceTypes.Container, KnownProperties.Container.Ports) => Create(KnownProperties.Container.Ports, nameof(ResourcesDetailsContainerPortsProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 4),
+            (KnownResourceTypes.Container, KnownProperties.Container.Lifetime) => Create(KnownProperties.Container.Lifetime, nameof(ResourcesDetailsContainerLifetimeProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 5),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Path) => Create(KnownProperties.Executable.Path, nameof(ResourcesDetailsExecutablePathProperty), KnownResourcePropertySortOrder.FirstResourceSpecific),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir) => Create(KnownProperties.Executable.WorkDir, nameof(ResourcesDetailsExecutableWorkingDirectoryProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 1),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Args) => Create(KnownProperties.Executable.Args, nameof(ResourcesDetailsExecutableArgumentsProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 2),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Pid) => Create(KnownProperties.Executable.Pid, nameof(ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 3),
+            (KnownResourceTypes.Project, KnownProperties.Project.Path) => Create(KnownProperties.Project.Path, nameof(ResourcesDetailsProjectPathProperty), KnownResourcePropertySortOrder.FirstResourceSpecific),
+            (KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile) => Create(KnownProperties.Project.LaunchProfile, nameof(ResourcesDetailsProjectLaunchProfileProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 1),
+            (KnownResourceTypes.Project, KnownProperties.Executable.Pid) => Create(KnownProperties.Executable.Pid, nameof(ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 2),
+            (KnownResourceTypes.Parameter, KnownProperties.Parameter.Value) => Create(KnownProperties.Parameter.Value, nameof(ResourcesDetailsParameterValueProperty), KnownResourcePropertySortOrder.FirstResourceSpecific),
+            _ => ((int SortOrder, KnownProperty KnownProperty)?)null
+        };
+
+        return metadata;
+    }
+
+    private static (int SortOrder, KnownProperty KnownProperty) Create(string propertyName, string displayNameResourceName, int sortOrder)
+    {
+        // This fallback exists only for dashboards connected to pre-metadata resource servers.
+        // New resource-specific properties should be emitted with producer metadata instead.
+        return (sortOrder, new(propertyName, loc => loc[displayNameResourceName]));
+    }
+}

--- a/src/Aspire.Dashboard/Model/LegacyResourcePropertyMetadata.cs
+++ b/src/Aspire.Dashboard/Model/LegacyResourcePropertyMetadata.cs
@@ -17,20 +17,20 @@ internal static class LegacyResourcePropertyMetadata
     {
         var metadata = (resourceType, propertyName) switch
         {
-            (KnownResourceTypes.Container, KnownProperties.Container.Image) => Create(KnownProperties.Container.Image, nameof(ResourcesDetailsContainerImageProperty), KnownResourcePropertySortOrder.FirstResourceSpecific),
-            (KnownResourceTypes.Container, KnownProperties.Container.Id) => Create(KnownProperties.Container.Id, nameof(ResourcesDetailsContainerIdProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 1),
-            (KnownResourceTypes.Container, KnownProperties.Container.Command) => Create(KnownProperties.Container.Command, nameof(ResourcesDetailsContainerCommandProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 2),
-            (KnownResourceTypes.Container, KnownProperties.Container.Args) => Create(KnownProperties.Container.Args, nameof(ResourcesDetailsContainerArgumentsProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 3),
-            (KnownResourceTypes.Container, KnownProperties.Container.Ports) => Create(KnownProperties.Container.Ports, nameof(ResourcesDetailsContainerPortsProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 4),
-            (KnownResourceTypes.Container, KnownProperties.Container.Lifetime) => Create(KnownProperties.Container.Lifetime, nameof(ResourcesDetailsContainerLifetimeProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 5),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.Path) => Create(KnownProperties.Executable.Path, nameof(ResourcesDetailsExecutablePathProperty), KnownResourcePropertySortOrder.FirstResourceSpecific),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir) => Create(KnownProperties.Executable.WorkDir, nameof(ResourcesDetailsExecutableWorkingDirectoryProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 1),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.Args) => Create(KnownProperties.Executable.Args, nameof(ResourcesDetailsExecutableArgumentsProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 2),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.Pid) => Create(KnownProperties.Executable.Pid, nameof(ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 3),
-            (KnownResourceTypes.Project, KnownProperties.Project.Path) => Create(KnownProperties.Project.Path, nameof(ResourcesDetailsProjectPathProperty), KnownResourcePropertySortOrder.FirstResourceSpecific),
-            (KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile) => Create(KnownProperties.Project.LaunchProfile, nameof(ResourcesDetailsProjectLaunchProfileProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 1),
-            (KnownResourceTypes.Project, KnownProperties.Executable.Pid) => Create(KnownProperties.Executable.Pid, nameof(ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 2),
-            (KnownResourceTypes.Parameter, KnownProperties.Parameter.Value) => Create(KnownProperties.Parameter.Value, nameof(ResourcesDetailsParameterValueProperty), KnownResourcePropertySortOrder.FirstResourceSpecific),
+            (KnownResourceTypes.Container, KnownProperties.Container.Image) => Create(KnownProperties.Container.Image, nameof(ResourcesDetailsContainerImageProperty), KnownResourcePropertySortOrder.ProducerDefinedStart),
+            (KnownResourceTypes.Container, KnownProperties.Container.Id) => Create(KnownProperties.Container.Id, nameof(ResourcesDetailsContainerIdProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 1),
+            (KnownResourceTypes.Container, KnownProperties.Container.Command) => Create(KnownProperties.Container.Command, nameof(ResourcesDetailsContainerCommandProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 2),
+            (KnownResourceTypes.Container, KnownProperties.Container.Args) => Create(KnownProperties.Container.Args, nameof(ResourcesDetailsContainerArgumentsProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 3),
+            (KnownResourceTypes.Container, KnownProperties.Container.Ports) => Create(KnownProperties.Container.Ports, nameof(ResourcesDetailsContainerPortsProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 4),
+            (KnownResourceTypes.Container, KnownProperties.Container.Lifetime) => Create(KnownProperties.Container.Lifetime, nameof(ResourcesDetailsContainerLifetimeProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 5),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Path) => Create(KnownProperties.Executable.Path, nameof(ResourcesDetailsExecutablePathProperty), KnownResourcePropertySortOrder.ProducerDefinedStart),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir) => Create(KnownProperties.Executable.WorkDir, nameof(ResourcesDetailsExecutableWorkingDirectoryProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 1),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Args) => Create(KnownProperties.Executable.Args, nameof(ResourcesDetailsExecutableArgumentsProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 2),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Pid) => Create(KnownProperties.Executable.Pid, nameof(ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 3),
+            (KnownResourceTypes.Project, KnownProperties.Project.Path) => Create(KnownProperties.Project.Path, nameof(ResourcesDetailsProjectPathProperty), KnownResourcePropertySortOrder.ProducerDefinedStart),
+            (KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile) => Create(KnownProperties.Project.LaunchProfile, nameof(ResourcesDetailsProjectLaunchProfileProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 1),
+            (KnownResourceTypes.Project, KnownProperties.Executable.Pid) => Create(KnownProperties.Executable.Pid, nameof(ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 2),
+            (KnownResourceTypes.Parameter, KnownProperties.Parameter.Value) => Create(KnownProperties.Parameter.Value, nameof(ResourcesDetailsParameterValueProperty), KnownResourcePropertySortOrder.ProducerDefinedStart),
             _ => ((int SortOrder, KnownProperty KnownProperty)?)null
         };
 

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -379,7 +379,7 @@ public sealed class DisplayedResourcePropertyViewModel : IPropertyGridItem
         ToolTip.Contains(filter, StringComparison.CurrentCultureIgnoreCase);
 }
 
-[DebuggerDisplay("Name = {Name}, Value = {Value}, IsValueSensitive = {IsValueSensitive}, IsValueMasked = {IsValueMasked}")]
+[DebuggerDisplay("Name = {Name}, Value = {Value}, IsValueSensitive = {IsValueSensitive}, IsValueMasked = {IsValueMasked}, IsHighlighted = {IsHighlighted}, SortOrder = {SortOrder}")]
 public sealed class ResourcePropertyViewModel
 {
     public string Name { get; }

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -322,6 +322,7 @@ public sealed class DisplayedResourcePropertyViewModel : IPropertyGridItem
     public int Priority => _propertyViewModel.Priority;
     public Value Value => _propertyViewModel.Value;
     public bool IsHighlighted => _propertyViewModel.IsHighlighted;
+    public int SortOrder => _propertyViewModel.SortOrder ?? _propertyViewModel.Priority;
     public string DisplayName => _propertyViewModel.DisplayName ?? _propertyViewModel.KnownProperty?.GetDisplayName(_loc) ?? _propertyViewModel.Name;
 
     string IPropertyGridItem.Name => DisplayName;
@@ -338,7 +339,7 @@ public sealed class DisplayedResourcePropertyViewModel : IPropertyGridItem
         _browserTimeProvider = browserTimeProvider;
 
         // Known and unknown properties are displayed together. Avoid any duplicate keys.
-        _key = propertyViewModel.KnownProperty != null ? propertyViewModel.KnownProperty.Key : $"unknown-{propertyViewModel.Name}";
+        _key = propertyViewModel.KnownProperty != null ? propertyViewModel.KnownProperty.Key : GetUnknownKey(propertyViewModel.Name);
 
         _tooltip = new(() => propertyViewModel.Value.HasStringValue ? propertyViewModel.Value.StringValue : propertyViewModel.Value.ToString());
 
@@ -371,6 +372,8 @@ public sealed class DisplayedResourcePropertyViewModel : IPropertyGridItem
         });
     }
 
+    internal static string GetUnknownKey(string propertyName) => $"unknown-{propertyName}";
+
     public bool MatchesFilter(string filter) =>
         _propertyViewModel.Name.Contains(filter, StringComparison.CurrentCultureIgnoreCase) ||
         DisplayName.Contains(filter, StringComparison.CurrentCultureIgnoreCase) ||
@@ -387,9 +390,10 @@ public sealed class ResourcePropertyViewModel
     public bool IsValueSensitive { get; }
     public bool IsValueMasked { get; set; }
     public bool IsHighlighted { get; }
+    public int? SortOrder { get; }
     public int Priority { get; }
 
-    public ResourcePropertyViewModel(string name, Value value, bool isValueSensitive, KnownProperty? knownProperty, int priority, string? displayName = null, bool isHighlighted = false)
+    public ResourcePropertyViewModel(string name, Value value, bool isValueSensitive, KnownProperty? knownProperty, int priority, string? displayName = null, bool isHighlighted = false, int? sortOrder = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
@@ -400,6 +404,7 @@ public sealed class ResourcePropertyViewModel
         KnownProperty = knownProperty;
         Priority = priority;
         IsHighlighted = isHighlighted;
+        SortOrder = sortOrder;
         IsValueMasked = isValueSensitive;
     }
 }

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -319,10 +319,9 @@ public sealed class DisplayedResourcePropertyViewModel : IPropertyGridItem
 
     public string ToolTip => _tooltip.Value;
     public KnownProperty? KnownProperty => _propertyViewModel.KnownProperty;
-    public int Priority => _propertyViewModel.Priority;
     public Value Value => _propertyViewModel.Value;
     public bool IsHighlighted => _propertyViewModel.IsHighlighted;
-    public int SortOrder => _propertyViewModel.SortOrder ?? _propertyViewModel.Priority;
+    public int SortOrder => _propertyViewModel.SortOrder;
     public string DisplayName => _propertyViewModel.DisplayName ?? _propertyViewModel.KnownProperty?.GetDisplayName(_loc) ?? _propertyViewModel.Name;
 
     string IPropertyGridItem.Name => DisplayName;
@@ -390,10 +389,9 @@ public sealed class ResourcePropertyViewModel
     public bool IsValueSensitive { get; }
     public bool IsValueMasked { get; set; }
     public bool IsHighlighted { get; }
-    public int? SortOrder { get; }
-    public int Priority { get; }
+    public int SortOrder { get; }
 
-    public ResourcePropertyViewModel(string name, Value value, bool isValueSensitive, KnownProperty? knownProperty, int priority, string? displayName = null, bool isHighlighted = false, int? sortOrder = null)
+    public ResourcePropertyViewModel(string name, Value value, bool isValueSensitive, KnownProperty? knownProperty, int sortOrder, string? displayName, bool isHighlighted)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
@@ -402,7 +400,6 @@ public sealed class ResourcePropertyViewModel
         DisplayName = displayName;
         IsValueSensitive = isValueSensitive;
         KnownProperty = knownProperty;
-        Priority = priority;
         IsHighlighted = isHighlighted;
         SortOrder = sortOrder;
         IsValueMasked = isValueSensitive;

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Aspire.Dashboard.Resources {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace Aspire.Dashboard.Resources {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Resources() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace Aspire.Dashboard.Resources {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace Aspire.Dashboard.Resources {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Commands.
         /// </summary>
@@ -68,7 +68,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceActionCommandsText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Console logs.
         /// </summary>
@@ -77,7 +77,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceActionConsoleLogsText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Metrics.
         /// </summary>
@@ -86,7 +86,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceActionMetricsText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Structured logs.
         /// </summary>
@@ -95,7 +95,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceActionStructuredLogsText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Traces.
         /// </summary>
@@ -104,7 +104,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceActionTracesText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to URLs.
         /// </summary>
@@ -113,7 +113,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceActionUrlsText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Collapse child resources.
         /// </summary>
@@ -122,7 +122,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceCollapseAllChildren", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to &quot;{0}&quot; canceled.
         /// </summary>
@@ -131,7 +131,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceCommandCanceled", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to &quot;{0}&quot; failed.
         /// </summary>
@@ -140,7 +140,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceCommandFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to &quot;{0}&quot; starting.
         /// </summary>
@@ -149,7 +149,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceCommandStarting", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to &quot;{0}&quot; succeeded.
         /// </summary>
@@ -158,7 +158,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceCommandSuccess", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to View console logs.
         /// </summary>
@@ -167,7 +167,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceCommandToastViewLogs", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to View response.
         /// </summary>
@@ -176,7 +176,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceCommandViewResponse", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to View console logs.
         /// </summary>
@@ -185,7 +185,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceDetailsViewConsoleLogs", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Expand child resources.
         /// </summary>
@@ -194,7 +194,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceExpandAllChildren", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to (Unset).
         /// </summary>
@@ -203,7 +203,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceFilterOptionEmpty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} ({1} ago).
         /// </summary>
@@ -212,7 +212,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("HealthCheckStatusWithTimeFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} (just now).
         /// </summary>
@@ -221,7 +221,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("HealthCheckStatusJustNowFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} (last run at {1}).
         /// </summary>
@@ -230,7 +230,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("HealthCheckStatusWithTimeTooltipFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Actions.
         /// </summary>
@@ -239,7 +239,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesActionsColumnHeader", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to View options.
         /// </summary>
@@ -248,7 +248,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesChangeViewOptions", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Connection string.
         /// </summary>
@@ -257,7 +257,61 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesDetailsConnectionStringProperty", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Container arguments.
+        /// </summary>
+        public static string ResourcesDetailsContainerArgumentsProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsContainerArgumentsProperty", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Container command.
+        /// </summary>
+        public static string ResourcesDetailsContainerCommandProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsContainerCommandProperty", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Container ID.
+        /// </summary>
+        public static string ResourcesDetailsContainerIdProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsContainerIdProperty", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Container image.
+        /// </summary>
+        public static string ResourcesDetailsContainerImageProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsContainerImageProperty", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Container lifetime.
+        /// </summary>
+        public static string ResourcesDetailsContainerLifetimeProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsContainerLifetimeProperty", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Container ports.
+        /// </summary>
+        public static string ResourcesDetailsContainerPortsProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsContainerPortsProperty", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Display name.
         /// </summary>
@@ -266,7 +320,43 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesDetailsDisplayNameProperty", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Executable arguments.
+        /// </summary>
+        public static string ResourcesDetailsExecutableArgumentsProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsExecutableArgumentsProperty", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Executable path.
+        /// </summary>
+        public static string ResourcesDetailsExecutablePathProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsExecutablePathProperty", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Process ID.
+        /// </summary>
+        public static string ResourcesDetailsExecutableProcessIdProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsExecutableProcessIdProperty", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Working directory.
+        /// </summary>
+        public static string ResourcesDetailsExecutableWorkingDirectoryProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsExecutableWorkingDirectoryProperty", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Exit code.
         /// </summary>
@@ -275,7 +365,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesDetailsExitCodeProperty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Health state.
         /// </summary>
@@ -284,7 +374,34 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesDetailsHealthStateProperty", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Value.
+        /// </summary>
+        public static string ResourcesDetailsParameterValueProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsParameterValueProperty", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Project path.
+        /// </summary>
+        public static string ResourcesDetailsProjectPathProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsProjectPathProperty", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Launch profile.
+        /// </summary>
+        public static string ResourcesDetailsProjectLaunchProfileProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsProjectLaunchProfileProperty", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Start time.
         /// </summary>
@@ -293,7 +410,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesDetailsStartTimeProperty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to State.
         /// </summary>
@@ -302,7 +419,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesDetailsStateProperty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Stop time.
         /// </summary>
@@ -311,7 +428,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesDetailsStopTimeProperty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Has filters.
         /// </summary>
@@ -320,7 +437,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesFiltered", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Reset.
         /// </summary>
@@ -329,7 +446,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesGraphResetButton", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Zoom in.
         /// </summary>
@@ -338,7 +455,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesGraphZoomInButton", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Zoom out.
         /// </summary>
@@ -347,7 +464,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesGraphZoomOutButton", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Resources.
         /// </summary>
@@ -356,7 +473,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesHeader", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Hide resource types.
         /// </summary>
@@ -365,7 +482,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesHideTypes", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No resources found.
         /// </summary>
@@ -392,7 +509,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesNotFiltered", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} resources.
         /// </summary>
@@ -401,7 +518,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesPageTitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to State.
         /// </summary>
@@ -410,7 +527,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesResourceStatesHeader", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Resource types.
         /// </summary>
@@ -419,7 +536,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesResourceTypesHeader", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Show resource types.
         /// </summary>
@@ -428,7 +545,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesShowTypes", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Source.
         /// </summary>
@@ -437,7 +554,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesSourceColumnHeader", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Start time.
         /// </summary>
@@ -446,7 +563,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesStartTimeColumnHeader", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to State.
         /// </summary>
@@ -455,7 +572,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesStateColumnHeader", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Type.
         /// </summary>
@@ -464,7 +581,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesTypeColumnHeader", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to URLs.
         /// </summary>
@@ -473,7 +590,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesUrlsColumnHeader", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Showing &lt;strong&gt;{0} resources&lt;/strong&gt;.
         /// </summary>
@@ -482,7 +599,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("TotalItemsFooterPluralText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Showing &lt;strong&gt;{0} resource&lt;/strong&gt;.
         /// </summary>
@@ -491,7 +608,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("TotalItemsFooterSingularText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Showing &lt;strong&gt;{0} parameters&lt;/strong&gt;.
         /// </summary>
@@ -500,7 +617,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("TotalItemsFooterParametersPluralText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Showing &lt;strong&gt;{0} parameter&lt;/strong&gt;.
         /// </summary>
@@ -509,7 +626,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("TotalItemsFooterParametersSingularText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Waiting for health data....
         /// </summary>
@@ -518,7 +635,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("WaitingForHealthDataMessage", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Waiting....
         /// </summary>

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -259,101 +259,11 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Container arguments.
-        /// </summary>
-        public static string ResourcesDetailsContainerArgumentsProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsContainerArgumentsProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Container command.
-        /// </summary>
-        public static string ResourcesDetailsContainerCommandProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsContainerCommandProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Container ID.
-        /// </summary>
-        public static string ResourcesDetailsContainerIdProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsContainerIdProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Container image.
-        /// </summary>
-        public static string ResourcesDetailsContainerImageProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsContainerImageProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Container lifetime.
-        /// </summary>
-        public static string ResourcesDetailsContainerLifetimeProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsContainerLifetimeProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Container ports.
-        /// </summary>
-        public static string ResourcesDetailsContainerPortsProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsContainerPortsProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Display name.
         /// </summary>
         public static string ResourcesDetailsDisplayNameProperty {
             get {
                 return ResourceManager.GetString("ResourcesDetailsDisplayNameProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Executable arguments.
-        /// </summary>
-        public static string ResourcesDetailsExecutableArgumentsProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsExecutableArgumentsProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Executable path.
-        /// </summary>
-        public static string ResourcesDetailsExecutablePathProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsExecutablePathProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Process ID.
-        /// </summary>
-        public static string ResourcesDetailsExecutableProcessIdProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsExecutableProcessIdProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Working directory.
-        /// </summary>
-        public static string ResourcesDetailsExecutableWorkingDirectoryProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsExecutableWorkingDirectoryProperty", resourceCulture);
             }
         }
         
@@ -372,33 +282,6 @@ namespace Aspire.Dashboard.Resources {
         public static string ResourcesDetailsHealthStateProperty {
             get {
                 return ResourceManager.GetString("ResourcesDetailsHealthStateProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Value.
-        /// </summary>
-        public static string ResourcesDetailsParameterValueProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsParameterValueProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Project path.
-        /// </summary>
-        public static string ResourcesDetailsProjectPathProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsProjectPathProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Launch profile.
-        /// </summary>
-        public static string ResourcesDetailsProjectLaunchProfileProperty {
-            get {
-                return ResourceManager.GetString("ResourcesDetailsProjectLaunchProfileProperty", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -163,44 +163,8 @@
   <data name="ResourcesNoParameters" xml:space="preserve">
     <value>No parameters found</value>
   </data>
-  <data name="ResourcesDetailsContainerArgumentsProperty" xml:space="preserve">
-    <value>Container arguments</value>
-  </data>
-  <data name="ResourcesDetailsContainerCommandProperty" xml:space="preserve">
-    <value>Container command</value>
-  </data>
-  <data name="ResourcesDetailsContainerIdProperty" xml:space="preserve">
-    <value>Container ID</value>
-  </data>
-  <data name="ResourcesDetailsContainerImageProperty" xml:space="preserve">
-    <value>Container image</value>
-  </data>
-  <data name="ResourcesDetailsContainerPortsProperty" xml:space="preserve">
-    <value>Container ports</value>
-  </data>
-  <data name="ResourcesDetailsContainerLifetimeProperty" xml:space="preserve">
-    <value>Container lifetime</value>
-  </data>
   <data name="ResourcesDetailsDisplayNameProperty" xml:space="preserve">
     <value>Display name</value>
-  </data>
-  <data name="ResourcesDetailsExecutableArgumentsProperty" xml:space="preserve">
-    <value>Executable arguments</value>
-  </data>
-  <data name="ResourcesDetailsExecutablePathProperty" xml:space="preserve">
-    <value>Executable path</value>
-  </data>
-  <data name="ResourcesDetailsExecutableProcessIdProperty" xml:space="preserve">
-    <value>Process ID</value>
-  </data>
-  <data name="ResourcesDetailsExecutableWorkingDirectoryProperty" xml:space="preserve">
-    <value>Working directory</value>
-  </data>
-  <data name="ResourcesDetailsProjectPathProperty" xml:space="preserve">
-    <value>Project path</value>
-  </data>
-  <data name="ResourcesDetailsProjectLaunchProfileProperty" xml:space="preserve">
-    <value>Launch profile</value>
   </data>
   <data name="ResourcesDetailsStartTimeProperty" xml:space="preserve">
     <value>Start time</value>
@@ -301,9 +265,6 @@
   </data>
   <data name="ResourcesShowTypes" xml:space="preserve">
     <value>Show resource types</value>
-  </data>
-  <data name="ResourcesDetailsParameterValueProperty" xml:space="preserve">
-    <value>Value</value>
   </data>
   <data name="TotalItemsFooterSingularText" xml:space="preserve">
     <value>Showing &lt;strong&gt;{0} resource&lt;/strong&gt;</value>

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -163,8 +163,44 @@
   <data name="ResourcesNoParameters" xml:space="preserve">
     <value>No parameters found</value>
   </data>
+  <data name="ResourcesDetailsContainerArgumentsProperty" xml:space="preserve">
+    <value>Container arguments</value>
+  </data>
+  <data name="ResourcesDetailsContainerCommandProperty" xml:space="preserve">
+    <value>Container command</value>
+  </data>
+  <data name="ResourcesDetailsContainerIdProperty" xml:space="preserve">
+    <value>Container ID</value>
+  </data>
+  <data name="ResourcesDetailsContainerImageProperty" xml:space="preserve">
+    <value>Container image</value>
+  </data>
+  <data name="ResourcesDetailsContainerPortsProperty" xml:space="preserve">
+    <value>Container ports</value>
+  </data>
+  <data name="ResourcesDetailsContainerLifetimeProperty" xml:space="preserve">
+    <value>Container lifetime</value>
+  </data>
   <data name="ResourcesDetailsDisplayNameProperty" xml:space="preserve">
     <value>Display name</value>
+  </data>
+  <data name="ResourcesDetailsExecutableArgumentsProperty" xml:space="preserve">
+    <value>Executable arguments</value>
+  </data>
+  <data name="ResourcesDetailsExecutablePathProperty" xml:space="preserve">
+    <value>Executable path</value>
+  </data>
+  <data name="ResourcesDetailsExecutableProcessIdProperty" xml:space="preserve">
+    <value>Process ID</value>
+  </data>
+  <data name="ResourcesDetailsExecutableWorkingDirectoryProperty" xml:space="preserve">
+    <value>Working directory</value>
+  </data>
+  <data name="ResourcesDetailsProjectPathProperty" xml:space="preserve">
+    <value>Project path</value>
+  </data>
+  <data name="ResourcesDetailsProjectLaunchProfileProperty" xml:space="preserve">
+    <value>Launch profile</value>
   </data>
   <data name="ResourcesDetailsStartTimeProperty" xml:space="preserve">
     <value>Start time</value>
@@ -265,6 +301,9 @@
   </data>
   <data name="ResourcesShowTypes" xml:space="preserve">
     <value>Show resource types</value>
+  </data>
+  <data name="ResourcesDetailsParameterValueProperty" xml:space="preserve">
+    <value>Value</value>
   </data>
   <data name="TotalItemsFooterSingularText" xml:space="preserve">
     <value>Showing &lt;strong&gt;{0} resource&lt;/strong&gt;</value>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -112,9 +112,59 @@
         <target state="translated">Připojovací řetězec</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Zobrazovaný název</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Stav</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -112,59 +112,9 @@
         <target state="translated">Připojovací řetězec</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">Argumenty kontejneru</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">Příkaz kontejneru</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">ID kontejneru</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">Image kontejneru</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">Životnost kontejneru</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">Porty kontejneru</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Zobrazovaný název</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">Argumenty spustitelného souboru</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">Cesta ke spustitelnému souboru</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">ID procesu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">Pracovní adresář</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Stav</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">Hodnota</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">Cesta k projektu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">Profil spuštění</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -112,9 +112,59 @@
         <target state="translated">Verbindungszeichenfolge</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Anzeigename</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Integritätsstatus</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -112,59 +112,9 @@
         <target state="translated">Verbindungszeichenfolge</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">Containerargumente</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">Containerbefehl</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">Container-ID</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">Containerimage</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">Containerlebensdauer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">Containerports</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Anzeigename</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">Ausführbare Argumente</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">Pfad der ausführbaren Datei</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">Prozess-ID</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">Arbeitsverzeichnis</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Integritätsstatus</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">Wert</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">Projektpfad</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">Profil starten</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -112,59 +112,9 @@
         <target state="translated">Cadena de conexión</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">Argumentos de contenedor</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">Comando de contenedor</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">Id. de contenedor</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">Imagen de contenedor</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">Duración del contenedor</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">Puertos de contenedor</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Nombre para mostrar</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">Argumentos ejecutables</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">Ruta de acceso ejecutable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">Id. del proceso</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">Directorio de trabajo</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Estado de mantenimiento</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">Valor</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">Ruta de acceso del proyecto</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">Iniciar perfil</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -112,9 +112,59 @@
         <target state="translated">Cadena de conexión</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Nombre para mostrar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Estado de mantenimiento</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -112,59 +112,9 @@
         <target state="translated">Chaîne de connexion</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">Arguments de conteneur</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">Commande de conteneur</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">ID de conteneur</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">Image conteneur</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">Durée de vie du conteneur</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">Ports de conteneur</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Nom d’affichage</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">Arguments exécutables</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">Chemin d’accès de l’exécutable</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">ID de processus</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">Répertoire de travail</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">État d’intégrité</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">Valeur</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">Chemin de projet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">Profil de lancement</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -112,9 +112,59 @@
         <target state="translated">Chaîne de connexion</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Nom d’affichage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">État d’intégrité</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -112,59 +112,9 @@
         <target state="translated">Stringa di connessione</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">Argomenti contenitore</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">Comando contenitore</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">ID contenitore</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">Immagine contenitore</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">Durata contenitore</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">Porte contenitore</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Nome visualizzato</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">Argomenti eseguibili</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">Percorso eseguibile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">ID processo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">Directory di lavoro</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Stato di integrità</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">Valore</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">Percorso del progetto</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">Avvia profilo</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -112,9 +112,59 @@
         <target state="translated">Stringa di connessione</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Nome visualizzato</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Stato di integrità</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -112,59 +112,9 @@
         <target state="translated">接続文字列</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">コンテナー引数</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">コンテナー コマンド</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">コンテナー ID</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">コンテナー イメージ</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">コンテナーの有効期間</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">コンテナー ポート</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">表示名</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">実行可能な引数</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">実行可能ファイルのパス</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">プロセス ID</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">作業ディレクトリ</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">正常性状態</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">値</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">プロジェクト パス</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">起動プロファイル</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -112,9 +112,59 @@
         <target state="translated">接続文字列</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">表示名</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">正常性状態</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -112,9 +112,59 @@
         <target state="translated">연결 문자열</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">표시 이름</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">성능 상태</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -112,59 +112,9 @@
         <target state="translated">연결 문자열</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">컨테이너 인수</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">컨테이너 명령</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">컨테이너 ID</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">컨테이너 이미지</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">컨테이너 수명</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">컨테이너 포트</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">표시 이름</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">실행 파일 인수</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">실행 파일 경로</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">프로세스 ID</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">작업 디렉터리</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">성능 상태</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">값</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">프로젝트 경로</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">프로필 시작</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -112,9 +112,59 @@
         <target state="translated">Parametry połączenia</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Nazwa wyświetlana</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Stan kondycji</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -112,59 +112,9 @@
         <target state="translated">Parametry połączenia</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">Argumenty kontenera</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">Polecenie kontenera</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">Identyfikator kontenera</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">Obraz kontenera</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">Okres istnienia kontenera</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">Porty kontenerów</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Nazwa wyświetlana</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">Argumenty pliku wykonywalnego</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">Ścieżka pliku wykonywalnego</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">Identyfikator procesu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">Katalog roboczy</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Stan kondycji</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">Wartość</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">Ścieżka projektu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">Uruchom profil</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -112,59 +112,9 @@
         <target state="translated">Cadeia de conexão</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">Argumentos de contêiner</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">Comando de contêiner</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">ID do Contêiner</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">Imagem de contêiner</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">Tempo de vida do contêiner</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">Portas de contêiner</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Nome de exibição</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">Argumentos executáveis</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">Caminho executável</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">ID do Processo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">Diretório de trabalho</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Estado de integridade</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">Valor</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">Caminho do projeto</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">Iniciar perfil</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -112,9 +112,59 @@
         <target state="translated">Cadeia de conexão</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Nome de exibição</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Estado de integridade</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -112,59 +112,9 @@
         <target state="translated">Строка подключения</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">Аргументы контейнера</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">Команда контейнера</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">ИД контейнера</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">Образ контейнера</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">Время существования контейнера</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">Порты контейнера</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Видимое имя</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">Аргументы исполняемого файла</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">Путь исполняемого файла</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">Идентификатор процесса</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">Рабочий каталог</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Состояние работоспособности</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">Значение</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">Путь к проекту</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">Профиль запуска</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -112,9 +112,59 @@
         <target state="translated">Строка подключения</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Видимое имя</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">Состояние работоспособности</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -112,59 +112,9 @@
         <target state="translated">Bağlantı dizesi</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">Kapsayıcı bağımsız değişkenleri</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">Kapsayıcı komutu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">Kapsayıcı Kimliği</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">Kapsayıcı görüntüsü</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">Kapsayıcı ömrü</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">Kapsayıcı bağlantı noktaları</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Görünen ad</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">Yürütülebilir bağımsız değişkenler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">Yürütülebilir yol</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">İşlem Kimliği</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">Çalışma dizini</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">İşlevsel durum</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">Değer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">Proje yolu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">Profili başlat</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -112,9 +112,59 @@
         <target state="translated">Bağlantı dizesi</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">Görünen ad</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">İşlevsel durum</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -112,59 +112,9 @@
         <target state="translated">连接字符串</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">容器参数</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">容器命令</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">容器 ID</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">容器映像</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">容器生存期</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">容器端口</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">显示名称</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">可执行参数</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">可执行路径</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">进程 ID</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">工作目录</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">运行状况状态</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">值</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">项目路径</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">启动配置文件</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -112,9 +112,59 @@
         <target state="translated">连接字符串</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">显示名称</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">运行状况状态</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -112,9 +112,59 @@
         <target state="translated">連接字串</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerCommandProperty">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerIdProperty">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerImageProperty">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerPortsProperty">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">顯示名稱</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutablePathProperty">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -125,6 +175,21 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">健全狀態</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsParameterValueProperty">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesDetailsProjectPathProperty">
+        <source>Project path</source>
+        <target state="new">Project path</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -112,59 +112,9 @@
         <target state="translated">連接字串</target>
         <note />
       </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
-        <source>Container arguments</source>
-        <target state="translated">容器引數</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerCommandProperty">
-        <source>Container command</source>
-        <target state="translated">容器命令</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerIdProperty">
-        <source>Container ID</source>
-        <target state="translated">容器識別碼</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerImageProperty">
-        <source>Container image</source>
-        <target state="translated">容器映像</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
-        <source>Container lifetime</source>
-        <target state="translated">容器存留期</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsContainerPortsProperty">
-        <source>Container ports</source>
-        <target state="translated">容器連接埠</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesDetailsDisplayNameProperty">
         <source>Display name</source>
         <target state="translated">顯示名稱</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableArgumentsProperty">
-        <source>Executable arguments</source>
-        <target state="translated">可執行檔變數</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutablePathProperty">
-        <source>Executable path</source>
-        <target state="translated">可執行檔路徑</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableProcessIdProperty">
-        <source>Process ID</source>
-        <target state="translated">處理序識別碼</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsExecutableWorkingDirectoryProperty">
-        <source>Working directory</source>
-        <target state="translated">工作目錄</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsExitCodeProperty">
@@ -175,21 +125,6 @@
       <trans-unit id="ResourcesDetailsHealthStateProperty">
         <source>Health state</source>
         <target state="translated">健全狀態</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsParameterValueProperty">
-        <source>Value</source>
-        <target state="translated">值</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectPathProperty">
-        <source>Project path</source>
-        <target state="translated">專案路徑</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ResourcesDetailsProjectLaunchProfileProperty">
-        <source>Launch profile</source>
-        <target state="translated">啟動設定檔</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsStartTimeProperty">

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -192,14 +192,19 @@ partial class Resource
     {
         if (legacySortOrder is { } legacyOrder)
         {
+            // Legacy fallback metadata represents built-in producer-specific properties from
+            // older resource servers, so treat its order as producer-local.
             return ToProducerDefinedDisplaySortOrder(legacyOrder);
         }
 
         if (knownProperty is not null)
         {
+            // Generic dashboard-known properties keep their fixed dashboard sort order.
             return knownSortOrder;
         }
 
+        // Unknown properties with producer metadata use producer-local ordering. Unknown
+        // properties without metadata keep the default "sort last" order from the caller.
         return property.HasSortOrder ? ToProducerDefinedDisplaySortOrder(property.SortOrder) : knownSortOrder;
     }
 

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -170,7 +170,7 @@ partial class Resource
                 value: ValidateNotNull(property.Value),
                 isValueSensitive: property.IsSensitive,
                 knownProperty: knownProperty ?? legacyMetadata?.KnownProperty,
-                sortOrder: property.HasSortOrder ? property.SortOrder : legacyMetadata?.SortOrder ?? sortOrder,
+                sortOrder: GetDisplaySortOrder(property, knownProperty, legacyMetadata?.SortOrder, sortOrder),
                 displayName: property.HasDisplayName ? property.DisplayName : null,
                 isHighlighted: property.IsHighlighted)
             {
@@ -186,6 +186,35 @@ partial class Resource
         }
 
         return builder.ToImmutable();
+    }
+
+    private static int GetDisplaySortOrder(ResourceProperty property, KnownProperty? knownProperty, int? legacySortOrder, int knownSortOrder)
+    {
+        if (legacySortOrder is { } legacyOrder)
+        {
+            return ToProducerDefinedDisplaySortOrder(legacyOrder);
+        }
+
+        if (knownProperty is not null)
+        {
+            return knownSortOrder;
+        }
+
+        return property.HasSortOrder ? ToProducerDefinedDisplaySortOrder(property.SortOrder) : knownSortOrder;
+    }
+
+    private static int ToProducerDefinedDisplaySortOrder(int producerSortOrder)
+    {
+        // Producers use local sort orders for their own resource-specific properties. The
+        // dashboard normalizes those values after the generic dashboard-owned properties.
+        var producerDefinedStart = KnownResourcePropertySortOrder.ConnectionString + 1;
+        if (producerSortOrder <= 0)
+        {
+            return producerDefinedStart;
+        }
+
+        var sortOrder = producerDefinedStart + (long)producerSortOrder;
+        return sortOrder > int.MaxValue ? int.MaxValue : (int)sortOrder;
     }
 
     private static bool ShouldUseLegacyResourcePropertyMetadata(string resourceType, RepeatedField<ResourceProperty> properties)

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -167,7 +167,8 @@ partial class Resource
                 knownProperty: knownProperty,
                 priority: priority,
                 displayName: property.HasDisplayName ? property.DisplayName : null,
-                isHighlighted: property.IsHighlighted)
+                isHighlighted: property.IsHighlighted,
+                sortOrder: property.HasSortOrder ? property.SortOrder : null)
             {
                 IsValueMasked = property.IsSensitive
             };

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -212,7 +212,7 @@ partial class Resource
     {
         // Producers use local sort orders for their own resource-specific properties. The
         // dashboard normalizes those values after the generic dashboard-owned properties.
-        var producerDefinedStart = KnownResourcePropertySortOrder.ConnectionString + 1;
+        var producerDefinedStart = KnownResourcePropertySortOrder.GetProducerDefinedStart();
         if (producerSortOrder <= 0)
         {
             return producerDefinedStart;

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -159,16 +159,15 @@ partial class Resource
 
         foreach (var property in properties)
         {
-            var (priority, knownProperty) = knownPropertyLookup.FindProperty(ResourceType, property.Name);
+            var (sortOrder, knownProperty) = knownPropertyLookup.FindProperty(property.Name);
             var propertyViewModel = new ResourcePropertyViewModel(
                 name: ValidateNotNull(property.Name),
                 value: ValidateNotNull(property.Value),
                 isValueSensitive: property.IsSensitive,
                 knownProperty: knownProperty,
-                priority: priority,
+                sortOrder: property.HasSortOrder ? property.SortOrder : sortOrder,
                 displayName: property.HasDisplayName ? property.DisplayName : null,
-                isHighlighted: property.IsHighlighted,
-                sortOrder: property.HasSortOrder ? property.SortOrder : null)
+                isHighlighted: property.IsHighlighted)
             {
                 IsValueMasked = property.IsSensitive
             };

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -20,17 +20,19 @@ partial class Resource
     {
         try
         {
+            var resourceType = ValidateNotNull(ResourceType);
+
             return new()
             {
                 Name = ValidateNotNull(Name),
-                ResourceType = ValidateNotNull(ResourceType),
+                ResourceType = resourceType,
                 DisplayName = ValidateNotNull(DisplayName),
                 Uid = ValidateNotNull(Uid),
                 ReplicaIndex = replicaIndex,
                 CreationTimeStamp = ValidateNotNull(CreatedAt).ToDateTime(),
                 StartTimeStamp = StartedAt?.ToDateTime(),
                 StopTimeStamp = StoppedAt?.ToDateTime(),
-                Properties = CreatePropertyViewModels(Properties, knownPropertyLookup, logger),
+                Properties = CreatePropertyViewModels(resourceType, Properties, knownPropertyLookup, logger),
                 Environment = GetEnvironment(),
                 Urls = GetUrls(),
                 Volumes = GetVolumes(),
@@ -153,19 +155,22 @@ partial class Resource
         }
     }
 
-    private ImmutableDictionary<string, ResourcePropertyViewModel> CreatePropertyViewModels(RepeatedField<ResourceProperty> properties, IKnownPropertyLookup knownPropertyLookup, ILogger logger)
+    private ImmutableDictionary<string, ResourcePropertyViewModel> CreatePropertyViewModels(string resourceType, RepeatedField<ResourceProperty> properties, IKnownPropertyLookup knownPropertyLookup, ILogger logger)
     {
         var builder = ImmutableDictionary.CreateBuilder<string, ResourcePropertyViewModel>(StringComparers.ResourcePropertyName);
+        var useLegacyMetadata = ShouldUseLegacyResourcePropertyMetadata(resourceType, properties);
 
         foreach (var property in properties)
         {
             var (sortOrder, knownProperty) = knownPropertyLookup.FindProperty(property.Name);
+            var legacyMetadata = useLegacyMetadata ? LegacyResourcePropertyMetadata.Get(resourceType, property.Name) : null;
+
             var propertyViewModel = new ResourcePropertyViewModel(
                 name: ValidateNotNull(property.Name),
                 value: ValidateNotNull(property.Value),
                 isValueSensitive: property.IsSensitive,
-                knownProperty: knownProperty,
-                sortOrder: property.HasSortOrder ? property.SortOrder : sortOrder,
+                knownProperty: knownProperty ?? legacyMetadata?.KnownProperty,
+                sortOrder: property.HasSortOrder ? property.SortOrder : legacyMetadata?.SortOrder ?? sortOrder,
                 displayName: property.HasDisplayName ? property.DisplayName : null,
                 isHighlighted: property.IsHighlighted)
             {
@@ -181,6 +186,32 @@ partial class Resource
         }
 
         return builder.ToImmutable();
+    }
+
+    private static bool ShouldUseLegacyResourcePropertyMetadata(string resourceType, RepeatedField<ResourceProperty> properties)
+    {
+        // Compatibility shim for dashboards connected to resource servers that predate
+        // ResourceProperty.DisplayName/IsHighlighted/SortOrder. If any resource-specific
+        // property already carries producer metadata, trust the producer and do not apply
+        // dashboard fallback metadata to the rest of the resource.
+        var hasLegacyResourceSpecificProperty = false;
+
+        foreach (var property in properties)
+        {
+            if (LegacyResourcePropertyMetadata.Get(resourceType, property.Name) is null)
+            {
+                continue;
+            }
+
+            hasLegacyResourceSpecificProperty = true;
+
+            if (property.HasDisplayName || property.IsHighlighted || property.HasSortOrder)
+            {
+                return false;
+            }
+        }
+
+        return hasLegacyResourceSpecificProperty;
     }
 
     private T ValidateNotNull<T>(T value, [CallerArgumentExpression(nameof(value))] string? expression = null) where T : class

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -279,6 +279,14 @@ public sealed record ResourcePropertySnapshot(string Name, object? Value)
     /// </remarks>
     public bool IsHighlighted { get; init; }
 
+    /// <summary>
+    /// Gets the optional sort order used when displaying the property in UI.
+    /// </summary>
+    /// <remarks>
+    /// Properties with lower values are displayed before properties with higher values.
+    /// </remarks>
+    public int? SortOrder { get; init; }
+
     internal void Deconstruct(out string name, out object? value, out bool isSensitive)
     {
         name = Name;

--- a/src/Aspire.Hosting/ApplicationModel/DotnetToolResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DotnetToolResource.cs
@@ -19,9 +19,7 @@ namespace Aspire.Hosting.ApplicationModel;
 [DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Tool = {ToolConfiguration?.PackageId}")]
 public class DotnetToolResource : ExecutableResource
 {
-    // Generic resource properties are still ordered by the dashboard as 0-6. Tool-specific
-    // properties start after those values so they appear after state/health/timing details.
-    private const int FirstToolSpecificSortOrder = 7;
+    private const int FirstToolSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DotnetToolResource"/> class.

--- a/src/Aspire.Hosting/ApplicationModel/DotnetToolResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DotnetToolResource.cs
@@ -19,8 +19,6 @@ namespace Aspire.Hosting.ApplicationModel;
 [DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Tool = {ToolConfiguration?.PackageId}")]
 public class DotnetToolResource : ExecutableResource
 {
-    private const int ToolMetadataSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="DotnetToolResource"/> class.
     /// </summary>
@@ -50,8 +48,8 @@ public class DotnetToolResource : ExecutableResource
             yield break;
         }
 
-        yield return CreateHighlightedProperty(KnownProperties.Tool.Package, toolConfig.PackageId, ResourcePropertyToolPackageDisplayName, ToolMetadataSortOrderStart);
-        yield return CreateHighlightedProperty(KnownProperties.Tool.Version, toolConfig.Version, ResourcePropertyToolVersionDisplayName, ToolMetadataSortOrderStart + 1);
+        yield return CreateHighlightedProperty(KnownProperties.Tool.Package, toolConfig.PackageId, ResourcePropertyToolPackageDisplayName, sortOrder: 0);
+        yield return CreateHighlightedProperty(KnownProperties.Tool.Version, toolConfig.Version, ResourcePropertyToolVersionDisplayName, sortOrder: 1);
         yield return new(KnownProperties.Resource.Source, toolConfig.PackageId);
     }
 

--- a/src/Aspire.Hosting/ApplicationModel/DotnetToolResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DotnetToolResource.cs
@@ -3,6 +3,8 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using Aspire.Dashboard.Model;
+using static Aspire.Hosting.Resources.MessageStrings;
 
 namespace Aspire.Hosting.ApplicationModel;
 
@@ -17,6 +19,10 @@ namespace Aspire.Hosting.ApplicationModel;
 [DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Tool = {ToolConfiguration?.PackageId}")]
 public class DotnetToolResource : ExecutableResource
 {
+    // Generic resource properties are still ordered by the dashboard as 0-6. Tool-specific
+    // properties start after those values so they appear after state/health/timing details.
+    private const int FirstToolSpecificSortOrder = 7;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DotnetToolResource"/> class.
     /// </summary>
@@ -36,5 +42,28 @@ public class DotnetToolResource : ExecutableResource
             this.TryGetLastAnnotation<DotnetToolAnnotation>(out var toolConfig);
             return toolConfig;
         }
+    }
+
+    internal IEnumerable<ResourcePropertySnapshot> CreateSnapshotProperties()
+    {
+        var toolConfig = ToolConfiguration;
+        if (toolConfig is null)
+        {
+            yield break;
+        }
+
+        yield return CreateHighlightedProperty(KnownProperties.Tool.Package, toolConfig.PackageId, ResourcePropertyToolPackageDisplayName, FirstToolSpecificSortOrder);
+        yield return CreateHighlightedProperty(KnownProperties.Tool.Version, toolConfig.Version, ResourcePropertyToolVersionDisplayName, FirstToolSpecificSortOrder + 1);
+        yield return new(KnownProperties.Resource.Source, toolConfig.PackageId);
+    }
+
+    private static ResourcePropertySnapshot CreateHighlightedProperty(string name, object? value, string displayName, int sortOrder)
+    {
+        return new(name, value)
+        {
+            DisplayName = displayName,
+            IsHighlighted = true,
+            SortOrder = sortOrder
+        };
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/DotnetToolResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DotnetToolResource.cs
@@ -19,7 +19,7 @@ namespace Aspire.Hosting.ApplicationModel;
 [DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Tool = {ToolConfiguration?.PackageId}")]
 public class DotnetToolResource : ExecutableResource
 {
-    private const int FirstToolSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
+    private const int ToolMetadataSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DotnetToolResource"/> class.
@@ -50,8 +50,8 @@ public class DotnetToolResource : ExecutableResource
             yield break;
         }
 
-        yield return CreateHighlightedProperty(KnownProperties.Tool.Package, toolConfig.PackageId, ResourcePropertyToolPackageDisplayName, FirstToolSpecificSortOrder);
-        yield return CreateHighlightedProperty(KnownProperties.Tool.Version, toolConfig.Version, ResourcePropertyToolVersionDisplayName, FirstToolSpecificSortOrder + 1);
+        yield return CreateHighlightedProperty(KnownProperties.Tool.Package, toolConfig.PackageId, ResourcePropertyToolPackageDisplayName, ToolMetadataSortOrderStart);
+        yield return CreateHighlightedProperty(KnownProperties.Tool.Version, toolConfig.Version, ResourcePropertyToolVersionDisplayName, ToolMetadataSortOrderStart + 1);
         yield return new(KnownProperties.Resource.Source, toolConfig.PackageId);
     }
 

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -98,7 +98,7 @@ public class ParameterResource : Resource, IExpressionValue
             IsSensitive = Secret,
             DisplayName = ResourcePropertyParameterValueDisplayName,
             IsHighlighted = true,
-            SortOrder = 0
+            SortOrder = KnownResourcePropertySortOrder.ProducerDefinedStart
         };
     }
 

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Dashboard.Model;
 using Aspire.Hosting.Resources;
+using static Aspire.Hosting.Resources.MessageStrings;
 
 namespace Aspire.Hosting.ApplicationModel;
 
@@ -88,6 +90,17 @@ public class ParameterResource : Resource, IExpressionValue
     /// A task completion source that can be used to wait for the value of the parameter to be set.
     /// </summary>
     internal TaskCompletionSource<string>? WaitForValueTcs { get; set; }
+
+    internal ResourcePropertySnapshot CreateValueSnapshotProperty(string value)
+    {
+        return new(KnownProperties.Parameter.Value, value)
+        {
+            IsSensitive = Secret,
+            DisplayName = ResourcePropertyParameterValueDisplayName,
+            IsHighlighted = true,
+            SortOrder = 0
+        };
+    }
 
     /// <summary>
     /// Gets the value of the parameter asynchronously, waiting if necessary for the value to be set.

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -98,7 +98,7 @@ public class ParameterResource : Resource, IExpressionValue
             IsSensitive = Secret,
             DisplayName = ResourcePropertyParameterValueDisplayName,
             IsHighlighted = true,
-            SortOrder = KnownResourcePropertySortOrder.ProducerDefinedStart
+            SortOrder = 0
         };
     }
 

--- a/src/Aspire.Hosting/Dashboard/GenericResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/GenericResourceSnapshot.cs
@@ -10,13 +10,13 @@ internal sealed class GenericResourceSnapshot(CustomResourceSnapshot state) : Re
 {
     public override string ResourceType => state.ResourceType;
 
-    protected override IEnumerable<(string Key, Value Value, bool IsSensitive, string? DisplayName, bool IsHighlighted)> GetProperties()
+    protected override IEnumerable<(string Key, Value Value, bool IsSensitive, string? DisplayName, bool IsHighlighted, int? SortOrder)> GetProperties()
     {
         foreach (var property in state.Properties)
         {
             var result = ConvertToValue(property.Value);
 
-            yield return (property.Name, result, property.IsSensitive, property.DisplayName, property.IsHighlighted);
+            yield return (property.Name, result, property.IsSensitive, property.DisplayName, property.IsHighlighted, property.SortOrder);
         }
     }
 }

--- a/src/Aspire.Hosting/Dashboard/ResourcePropertySnapshotMetadata.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourcePropertySnapshotMetadata.cs
@@ -17,9 +17,9 @@ namespace Aspire.Hosting.Dashboard;
 /// </remarks>
 internal static class ResourcePropertySnapshotMetadata
 {
-    // Generic resource properties are still ordered first by the dashboard. Resource-specific
+    // Generic resource properties are still ordered first by the dashboard. Producer-defined
     // properties start after those values to preserve the previous details grid order.
-    private const int FirstResourceSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
+    private const int ProducerDefinedSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
 
     internal static ResourcePropertySnapshot Create(string resourceType, string name, object? value, bool isSensitive = false)
     {
@@ -41,19 +41,19 @@ internal static class ResourcePropertySnapshotMetadata
     {
         return (resourceType, name) switch
         {
-            (KnownResourceTypes.Container, KnownProperties.Container.Image) => (ResourcePropertyContainerImageDisplayName, true, FirstResourceSpecificSortOrder),
-            (KnownResourceTypes.Container, KnownProperties.Container.Id) => (ResourcePropertyContainerIdDisplayName, true, FirstResourceSpecificSortOrder + 1),
-            (KnownResourceTypes.Container, KnownProperties.Container.Command) => (ResourcePropertyContainerCommandDisplayName, true, FirstResourceSpecificSortOrder + 2),
-            (KnownResourceTypes.Container, KnownProperties.Container.Args) => (ResourcePropertyContainerArgumentsDisplayName, true, FirstResourceSpecificSortOrder + 3),
-            (KnownResourceTypes.Container, KnownProperties.Container.Ports) => (ResourcePropertyContainerPortsDisplayName, true, FirstResourceSpecificSortOrder + 4),
-            (KnownResourceTypes.Container, KnownProperties.Container.Lifetime) => (ResourcePropertyContainerLifetimeDisplayName, true, FirstResourceSpecificSortOrder + 5),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.Path) => (ResourcePropertyExecutablePathDisplayName, true, FirstResourceSpecificSortOrder),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir) => (ResourcePropertyExecutableWorkingDirectoryDisplayName, true, FirstResourceSpecificSortOrder + 1),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.Args) => (ResourcePropertyExecutableArgumentsDisplayName, true, FirstResourceSpecificSortOrder + 2),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.Pid) => (ResourcePropertyExecutableProcessIdDisplayName, true, FirstResourceSpecificSortOrder + 3),
-            (KnownResourceTypes.Project, KnownProperties.Project.Path) => (ResourcePropertyProjectPathDisplayName, true, FirstResourceSpecificSortOrder),
-            (KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile) => (ResourcePropertyProjectLaunchProfileDisplayName, true, FirstResourceSpecificSortOrder + 1),
-            (KnownResourceTypes.Project, KnownProperties.Executable.Pid) => (ResourcePropertyExecutableProcessIdDisplayName, true, FirstResourceSpecificSortOrder + 2),
+            (KnownResourceTypes.Container, KnownProperties.Container.Image) => (ResourcePropertyContainerImageDisplayName, true, ProducerDefinedSortOrderStart),
+            (KnownResourceTypes.Container, KnownProperties.Container.Id) => (ResourcePropertyContainerIdDisplayName, true, ProducerDefinedSortOrderStart + 1),
+            (KnownResourceTypes.Container, KnownProperties.Container.Command) => (ResourcePropertyContainerCommandDisplayName, true, ProducerDefinedSortOrderStart + 2),
+            (KnownResourceTypes.Container, KnownProperties.Container.Args) => (ResourcePropertyContainerArgumentsDisplayName, true, ProducerDefinedSortOrderStart + 3),
+            (KnownResourceTypes.Container, KnownProperties.Container.Ports) => (ResourcePropertyContainerPortsDisplayName, true, ProducerDefinedSortOrderStart + 4),
+            (KnownResourceTypes.Container, KnownProperties.Container.Lifetime) => (ResourcePropertyContainerLifetimeDisplayName, true, ProducerDefinedSortOrderStart + 5),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Path) => (ResourcePropertyExecutablePathDisplayName, true, ProducerDefinedSortOrderStart),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir) => (ResourcePropertyExecutableWorkingDirectoryDisplayName, true, ProducerDefinedSortOrderStart + 1),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Args) => (ResourcePropertyExecutableArgumentsDisplayName, true, ProducerDefinedSortOrderStart + 2),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Pid) => (ResourcePropertyExecutableProcessIdDisplayName, true, ProducerDefinedSortOrderStart + 3),
+            (KnownResourceTypes.Project, KnownProperties.Project.Path) => (ResourcePropertyProjectPathDisplayName, true, ProducerDefinedSortOrderStart),
+            (KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile) => (ResourcePropertyProjectLaunchProfileDisplayName, true, ProducerDefinedSortOrderStart + 1),
+            (KnownResourceTypes.Project, KnownProperties.Executable.Pid) => (ResourcePropertyExecutableProcessIdDisplayName, true, ProducerDefinedSortOrderStart + 2),
             _ => (null, false, null)
         };
     }

--- a/src/Aspire.Hosting/Dashboard/ResourcePropertySnapshotMetadata.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourcePropertySnapshotMetadata.cs
@@ -17,9 +17,9 @@ namespace Aspire.Hosting.Dashboard;
 /// </remarks>
 internal static class ResourcePropertySnapshotMetadata
 {
-    // Generic resource properties are still ordered by the dashboard as 0-6. Resource-specific
+    // Generic resource properties are still ordered first by the dashboard. Resource-specific
     // properties start after those values to preserve the previous details grid order.
-    private const int FirstResourceSpecificSortOrder = 7;
+    private const int FirstResourceSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
 
     internal static ResourcePropertySnapshot Create(string resourceType, string name, object? value, bool isSensitive = false)
     {

--- a/src/Aspire.Hosting/Dashboard/ResourcePropertySnapshotMetadata.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourcePropertySnapshotMetadata.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Hosting.ApplicationModel;
+using static Aspire.Hosting.Resources.MessageStrings;
+
+namespace Aspire.Hosting.Dashboard;
+
+/// <summary>
+/// Provides dashboard display metadata for resource-specific properties emitted by Aspire.Hosting.
+/// </summary>
+/// <remarks>
+/// This keeps resource-specific labels, default visibility, and relative ordering with the resource
+/// producer instead of requiring the dashboard to hard-code those property names. Generic
+/// dashboard-owned properties, such as state and health, are still handled by the dashboard.
+/// </remarks>
+internal static class ResourcePropertySnapshotMetadata
+{
+    // Generic resource properties are still ordered by the dashboard as 0-6. Resource-specific
+    // properties start after those values to preserve the previous details grid order.
+    private const int FirstResourceSpecificSortOrder = 7;
+
+    internal static ResourcePropertySnapshot Create(string resourceType, string name, object? value, bool isSensitive = false)
+    {
+        var (displayName, isHighlighted, sortOrder) = Get(resourceType, name);
+
+        return new(name, value)
+        {
+            IsSensitive = isSensitive,
+            DisplayName = displayName,
+            IsHighlighted = isHighlighted,
+            SortOrder = sortOrder
+        };
+    }
+
+    // Some producers update one property on an existing snapshot rather than replacing a full
+    // property set. Keep the metadata lookup separate from Create so those update paths can
+    // preserve the same label, visibility, and ordering without constructing a throwaway snapshot.
+    internal static (string? DisplayName, bool IsHighlighted, int? SortOrder) Get(string resourceType, string name)
+    {
+        return (resourceType, name) switch
+        {
+            (KnownResourceTypes.Container, KnownProperties.Container.Image) => (ResourcePropertyContainerImageDisplayName, true, FirstResourceSpecificSortOrder),
+            (KnownResourceTypes.Container, KnownProperties.Container.Id) => (ResourcePropertyContainerIdDisplayName, true, FirstResourceSpecificSortOrder + 1),
+            (KnownResourceTypes.Container, KnownProperties.Container.Command) => (ResourcePropertyContainerCommandDisplayName, true, FirstResourceSpecificSortOrder + 2),
+            (KnownResourceTypes.Container, KnownProperties.Container.Args) => (ResourcePropertyContainerArgumentsDisplayName, true, FirstResourceSpecificSortOrder + 3),
+            (KnownResourceTypes.Container, KnownProperties.Container.Ports) => (ResourcePropertyContainerPortsDisplayName, true, FirstResourceSpecificSortOrder + 4),
+            (KnownResourceTypes.Container, KnownProperties.Container.Lifetime) => (ResourcePropertyContainerLifetimeDisplayName, true, FirstResourceSpecificSortOrder + 5),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Path) => (ResourcePropertyExecutablePathDisplayName, true, FirstResourceSpecificSortOrder),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir) => (ResourcePropertyExecutableWorkingDirectoryDisplayName, true, FirstResourceSpecificSortOrder + 1),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Args) => (ResourcePropertyExecutableArgumentsDisplayName, true, FirstResourceSpecificSortOrder + 2),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Pid) => (ResourcePropertyExecutableProcessIdDisplayName, true, FirstResourceSpecificSortOrder + 3),
+            (KnownResourceTypes.Project, KnownProperties.Project.Path) => (ResourcePropertyProjectPathDisplayName, true, FirstResourceSpecificSortOrder),
+            (KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile) => (ResourcePropertyProjectLaunchProfileDisplayName, true, FirstResourceSpecificSortOrder + 1),
+            (KnownResourceTypes.Project, KnownProperties.Executable.Pid) => (ResourcePropertyExecutableProcessIdDisplayName, true, FirstResourceSpecificSortOrder + 2),
+            _ => (null, false, null)
+        };
+    }
+}

--- a/src/Aspire.Hosting/Dashboard/ResourcePropertySnapshotMetadata.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourcePropertySnapshotMetadata.cs
@@ -17,10 +17,6 @@ namespace Aspire.Hosting.Dashboard;
 /// </remarks>
 internal static class ResourcePropertySnapshotMetadata
 {
-    // Generic resource properties are still ordered first by the dashboard. Producer-defined
-    // properties start after those values to preserve the previous details grid order.
-    private const int ProducerDefinedSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
-
     internal static ResourcePropertySnapshot Create(string resourceType, string name, object? value, bool isSensitive = false)
     {
         var (displayName, isHighlighted, sortOrder) = Get(resourceType, name);
@@ -41,19 +37,19 @@ internal static class ResourcePropertySnapshotMetadata
     {
         return (resourceType, name) switch
         {
-            (KnownResourceTypes.Container, KnownProperties.Container.Image) => (ResourcePropertyContainerImageDisplayName, true, ProducerDefinedSortOrderStart),
-            (KnownResourceTypes.Container, KnownProperties.Container.Id) => (ResourcePropertyContainerIdDisplayName, true, ProducerDefinedSortOrderStart + 1),
-            (KnownResourceTypes.Container, KnownProperties.Container.Command) => (ResourcePropertyContainerCommandDisplayName, true, ProducerDefinedSortOrderStart + 2),
-            (KnownResourceTypes.Container, KnownProperties.Container.Args) => (ResourcePropertyContainerArgumentsDisplayName, true, ProducerDefinedSortOrderStart + 3),
-            (KnownResourceTypes.Container, KnownProperties.Container.Ports) => (ResourcePropertyContainerPortsDisplayName, true, ProducerDefinedSortOrderStart + 4),
-            (KnownResourceTypes.Container, KnownProperties.Container.Lifetime) => (ResourcePropertyContainerLifetimeDisplayName, true, ProducerDefinedSortOrderStart + 5),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.Path) => (ResourcePropertyExecutablePathDisplayName, true, ProducerDefinedSortOrderStart),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir) => (ResourcePropertyExecutableWorkingDirectoryDisplayName, true, ProducerDefinedSortOrderStart + 1),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.Args) => (ResourcePropertyExecutableArgumentsDisplayName, true, ProducerDefinedSortOrderStart + 2),
-            (KnownResourceTypes.Executable, KnownProperties.Executable.Pid) => (ResourcePropertyExecutableProcessIdDisplayName, true, ProducerDefinedSortOrderStart + 3),
-            (KnownResourceTypes.Project, KnownProperties.Project.Path) => (ResourcePropertyProjectPathDisplayName, true, ProducerDefinedSortOrderStart),
-            (KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile) => (ResourcePropertyProjectLaunchProfileDisplayName, true, ProducerDefinedSortOrderStart + 1),
-            (KnownResourceTypes.Project, KnownProperties.Executable.Pid) => (ResourcePropertyExecutableProcessIdDisplayName, true, ProducerDefinedSortOrderStart + 2),
+            (KnownResourceTypes.Container, KnownProperties.Container.Image) => (ResourcePropertyContainerImageDisplayName, true, 0),
+            (KnownResourceTypes.Container, KnownProperties.Container.Id) => (ResourcePropertyContainerIdDisplayName, true, 1),
+            (KnownResourceTypes.Container, KnownProperties.Container.Command) => (ResourcePropertyContainerCommandDisplayName, true, 2),
+            (KnownResourceTypes.Container, KnownProperties.Container.Args) => (ResourcePropertyContainerArgumentsDisplayName, true, 3),
+            (KnownResourceTypes.Container, KnownProperties.Container.Ports) => (ResourcePropertyContainerPortsDisplayName, true, 4),
+            (KnownResourceTypes.Container, KnownProperties.Container.Lifetime) => (ResourcePropertyContainerLifetimeDisplayName, true, 5),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Path) => (ResourcePropertyExecutablePathDisplayName, true, 0),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir) => (ResourcePropertyExecutableWorkingDirectoryDisplayName, true, 1),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Args) => (ResourcePropertyExecutableArgumentsDisplayName, true, 2),
+            (KnownResourceTypes.Executable, KnownProperties.Executable.Pid) => (ResourcePropertyExecutableProcessIdDisplayName, true, 3),
+            (KnownResourceTypes.Project, KnownProperties.Project.Path) => (ResourcePropertyProjectPathDisplayName, true, 0),
+            (KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile) => (ResourcePropertyProjectLaunchProfileDisplayName, true, 1),
+            (KnownResourceTypes.Project, KnownProperties.Executable.Pid) => (ResourcePropertyExecutableProcessIdDisplayName, true, 2),
             _ => (null, false, null)
         };
     }

--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -33,22 +33,22 @@ internal abstract class ResourceSnapshot
     public required string? IconName { get; init; }
     public required IconVariant? IconVariant { get; init; }
 
-    protected abstract IEnumerable<(string Key, Value Value, bool IsSensitive, string? DisplayName, bool IsHighlighted)> GetProperties();
+    protected abstract IEnumerable<(string Key, Value Value, bool IsSensitive, string? DisplayName, bool IsHighlighted, int? SortOrder)> GetProperties();
 
-    public IEnumerable<(string Name, Value Value, bool IsSensitive, string? DisplayName, bool IsHighlighted)> Properties
+    public IEnumerable<(string Name, Value Value, bool IsSensitive, string? DisplayName, bool IsHighlighted, int? SortOrder)> Properties
     {
         get
         {
-            yield return (KnownProperties.Resource.Uid, Value.ForString(Uid), IsSensitive: false, DisplayName: null, IsHighlighted: false);
-            yield return (KnownProperties.Resource.Name, Value.ForString(Name), IsSensitive: false, DisplayName: null, IsHighlighted: false);
-            yield return (KnownProperties.Resource.Type, Value.ForString(ResourceType), IsSensitive: false, DisplayName: null, IsHighlighted: false);
-            yield return (KnownProperties.Resource.DisplayName, Value.ForString(DisplayName), IsSensitive: false, DisplayName: null, IsHighlighted: false);
-            yield return (KnownProperties.Resource.State, State is null ? Value.ForNull() : Value.ForString(State), IsSensitive: false, DisplayName: null, IsHighlighted: false);
-            yield return (KnownProperties.Resource.ExitCode, ExitCode is null ? Value.ForNull() : Value.ForString(ExitCode.Value.ToString("D", CultureInfo.InvariantCulture)), IsSensitive: false, DisplayName: null, IsHighlighted: false);
-            yield return (KnownProperties.Resource.CreateTime, CreationTimeStamp is null ? Value.ForNull() : Value.ForString(CreationTimeStamp.Value.ToString("O")), IsSensitive: false, DisplayName: null, IsHighlighted: false);
-            yield return (KnownProperties.Resource.StartTime, StartTimeStamp is null ? Value.ForNull() : Value.ForString(StartTimeStamp.Value.ToString("O")), IsSensitive: false, DisplayName: null, IsHighlighted: false);
-            yield return (KnownProperties.Resource.StopTime, StopTimeStamp is null ? Value.ForNull() : Value.ForString(StopTimeStamp.Value.ToString("O")), IsSensitive: false, DisplayName: null, IsHighlighted: false);
-            yield return (KnownProperties.Resource.HealthState, CustomResourceSnapshot.ComputeHealthStatus(HealthReports, State) is not { } healthStatus ? Value.ForNull() : Value.ForString(healthStatus.ToString()), IsSensitive: false, DisplayName: null, IsHighlighted: false);
+            yield return (KnownProperties.Resource.Uid, Value.ForString(Uid), IsSensitive: false, DisplayName: null, IsHighlighted: false, SortOrder: null);
+            yield return (KnownProperties.Resource.Name, Value.ForString(Name), IsSensitive: false, DisplayName: null, IsHighlighted: false, SortOrder: null);
+            yield return (KnownProperties.Resource.Type, Value.ForString(ResourceType), IsSensitive: false, DisplayName: null, IsHighlighted: false, SortOrder: null);
+            yield return (KnownProperties.Resource.DisplayName, Value.ForString(DisplayName), IsSensitive: false, DisplayName: null, IsHighlighted: false, SortOrder: null);
+            yield return (KnownProperties.Resource.State, State is null ? Value.ForNull() : Value.ForString(State), IsSensitive: false, DisplayName: null, IsHighlighted: false, SortOrder: null);
+            yield return (KnownProperties.Resource.ExitCode, ExitCode is null ? Value.ForNull() : Value.ForString(ExitCode.Value.ToString("D", CultureInfo.InvariantCulture)), IsSensitive: false, DisplayName: null, IsHighlighted: false, SortOrder: null);
+            yield return (KnownProperties.Resource.CreateTime, CreationTimeStamp is null ? Value.ForNull() : Value.ForString(CreationTimeStamp.Value.ToString("O")), IsSensitive: false, DisplayName: null, IsHighlighted: false, SortOrder: null);
+            yield return (KnownProperties.Resource.StartTime, StartTimeStamp is null ? Value.ForNull() : Value.ForString(StartTimeStamp.Value.ToString("O")), IsSensitive: false, DisplayName: null, IsHighlighted: false, SortOrder: null);
+            yield return (KnownProperties.Resource.StopTime, StopTimeStamp is null ? Value.ForNull() : Value.ForString(StopTimeStamp.Value.ToString("O")), IsSensitive: false, DisplayName: null, IsHighlighted: false, SortOrder: null);
+            yield return (KnownProperties.Resource.HealthState, CustomResourceSnapshot.ComputeHealthStatus(HealthReports, State) is not { } healthStatus ? Value.ForNull() : Value.ForString(healthStatus.ToString()), IsSensitive: false, DisplayName: null, IsHighlighted: false, SortOrder: null);
 
             foreach (var property in GetProperties())
             {

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -94,6 +94,11 @@ partial class Resource
                 resourceProperty.DisplayName = property.DisplayName;
             }
 
+            if (property.SortOrder is { } sortOrder)
+            {
+                resourceProperty.SortOrder = sortOrder;
+            }
+
             resource.Properties.Add(resourceProperty);
         }
 

--- a/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
@@ -223,6 +223,8 @@ message ResourceProperty {
     // A flag that indicates whether the property is highlighted in the UI.
     // Highlighted properties are shown by default even when they are not known to the dashboard.
     bool is_highlighted = 5;
+    // Optional sort order used when displaying the property in the UI.
+    optional int32 sort_order = 6;
 }
 
 // Models the full state of an resource (container, executable, project, etc) at a particular point in time.

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp.Model;
 
 namespace Aspire.Hosting.Dcp;
@@ -50,12 +51,12 @@ internal class ResourceSnapshotBuilder
             // Map a container exit code of -1 (unknown) to null
             ExitCode = container.Status?.ExitCode is null or Conventions.UnknownExitCode ? null : container.Status.ExitCode,
             Properties = previous.Properties.SetResourcePropertyRange([
-                new(KnownProperties.Container.Image, container.Spec.Image),
-                new(KnownProperties.Container.Id, containerId),
-                new(KnownProperties.Container.Command, container.Spec.Command),
-                new(KnownProperties.Container.Args, effectiveArgs ?? []) { IsSensitive = true },
-                new(KnownProperties.Container.Ports, GetPorts()),
-                new(KnownProperties.Container.Lifetime, GetContainerLifetime()),
+                ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Container, KnownProperties.Container.Image, container.Spec.Image),
+                ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Container, KnownProperties.Container.Id, containerId),
+                ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Container, KnownProperties.Container.Command, container.Spec.Command),
+                ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Container, KnownProperties.Container.Args, effectiveArgs ?? [], isSensitive: true),
+                ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Container, KnownProperties.Container.Ports, GetPorts()),
+                ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Container, KnownProperties.Container.Lifetime, GetContainerLifetime()),
                 new(KnownProperties.Resource.AppArgs, launchArguments?.Args) { IsSensitive = launchArguments?.IsSensitive ?? false },
                 new(KnownProperties.Resource.AppArgsSensitivity, launchArguments?.ArgsAreSensitive) { IsSensitive = launchArguments?.IsSensitive ?? false },
             ]),
@@ -114,8 +115,8 @@ internal class ResourceSnapshotBuilder
             State = state,
             ExitCode = executable.Status?.ExitCode,
             Properties = previous.Properties.SetResourcePropertyRange([
-                new(KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
-                new(KnownProperties.Executable.Args, effectiveArgs ?? []) { IsSensitive = true },
+                ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
+                ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Executable, KnownProperties.Executable.Args, effectiveArgs ?? [], isSensitive: true),
                 new(KnownProperties.Resource.AppArgs, launchArguments?.Args) { IsSensitive = launchArguments?.IsSensitive ?? false },
                 new(KnownProperties.Resource.AppArgsSensitivity, launchArguments?.ArgsAreSensitive) { IsSensitive = launchArguments?.IsSensitive ?? false },
             ]),
@@ -170,12 +171,12 @@ internal class ResourceSnapshotBuilder
                 State = state,
                 ExitCode = executable.Status?.ExitCode,
                 Properties = previous.Properties.SetResourcePropertyRange([
-                    new(KnownProperties.Executable.Path, executable.Spec.ExecutablePath),
-                    new(KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
-                    new(KnownProperties.Executable.Args, effectiveArgs ?? []) { IsSensitive = true },
-                    new(KnownProperties.Executable.Pid, executable.Status?.ProcessId),
-                    new(KnownProperties.Project.Path, projectPath),
-                    new(KnownProperties.Project.LaunchProfile, launchProfileName),
+                    ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Project, KnownProperties.Executable.Path, executable.Spec.ExecutablePath),
+                    ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Project, KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
+                    ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Project, KnownProperties.Executable.Args, effectiveArgs ?? [], isSensitive: true),
+                    ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Project, KnownProperties.Executable.Pid, executable.Status?.ProcessId),
+                    ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Project, KnownProperties.Project.Path, projectPath),
+                    ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile, launchProfileName),
                     new(KnownProperties.Resource.AppArgs, launchArguments?.Args) { IsSensitive = launchArguments?.IsSensitive ?? false },
                     new(KnownProperties.Resource.AppArgsSensitivity, launchArguments?.ArgsAreSensitive) { IsSensitive = launchArguments?.IsSensitive ?? false },
                 ]),
@@ -194,10 +195,10 @@ internal class ResourceSnapshotBuilder
             State = state,
             ExitCode = executable.Status?.ExitCode,
             Properties = previous.Properties.SetResourcePropertyRange([
-                new(KnownProperties.Executable.Path, executable.Spec.ExecutablePath),
-                new(KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
-                new(KnownProperties.Executable.Args, effectiveArgs ?? []) { IsSensitive = true },
-                new(KnownProperties.Executable.Pid, executable.Status?.ProcessId),
+                ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Executable, KnownProperties.Executable.Path, executable.Spec.ExecutablePath),
+                ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
+                ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Executable, KnownProperties.Executable.Args, effectiveArgs ?? [], isSensitive: true),
+                ResourcePropertySnapshotMetadata.Create(KnownResourceTypes.Executable, KnownProperties.Executable.Pid, executable.Status?.ProcessId),
                 new(KnownProperties.Resource.AppArgs, launchArguments?.Args) { IsSensitive = launchArguments?.IsSensitive ?? false },
                 new(KnownProperties.Resource.AppArgsSensitivity, launchArguments?.ArgsAreSensitive) { IsSensitive = launchArguments?.IsSensitive ?? false },
             ]),

--- a/src/Aspire.Hosting/DotnetToolResourceExtensions.cs
+++ b/src/Aspire.Hosting/DotnetToolResourceExtensions.cs
@@ -98,19 +98,15 @@ public static class DotnetToolResourceExtensions
         async Task BeforeResourceStarted(T resource, BeforeResourceStartedEvent evt, CancellationToken ct)
         {
             var rns = evt.Services.GetRequiredService<ResourceNotificationService>();
-            var toolConfig = resource.ToolConfiguration;
-            if (toolConfig == null)
+            var properties = resource.CreateSnapshotProperties().ToArray();
+            if (properties.Length == 0)
             {
                 return;
             }
 
             await rns.PublishUpdateAsync(resource, x => x with
             {
-                Properties = x.Properties.SetResourcePropertyRange([
-                    new (KnownProperties.Tool.Package, toolConfig.PackageId),
-                    new (KnownProperties.Tool.Version, toolConfig.Version),
-                    new (KnownProperties.Resource.Source, resource.ToolConfiguration?.PackageId)
-                    ])
+                Properties = x.Properties.SetResourcePropertyRange(properties)
             }).ConfigureAwait(false);
         }
 

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -181,10 +181,19 @@ internal sealed class ApplicationOrchestrator
 
                 break;
             case KnownResourceTypes.Container:
+            {
+                var (displayName, isHighlighted, sortOrder) = ResourcePropertySnapshotMetadata.Get(KnownResourceTypes.Container, KnownProperties.Container.Image);
+                var imageName = context.Resource.TryGetContainerImageName(out var resolvedImageName) ? resolvedImageName : "";
+
                 await PublishUpdateAsync(_notificationService, context.Resource, context.DcpResourceName, s => s with
                 {
                     State = KnownResourceStates.Starting,
-                    Properties = s.Properties.SetResourceProperty(KnownProperties.Container.Image, context.Resource.TryGetContainerImageName(out var imageName) ? imageName : ""),
+                    Properties = s.Properties.SetResourceProperty(
+                        KnownProperties.Container.Image,
+                        imageName,
+                        displayName: displayName,
+                        isHighlighted: isHighlighted,
+                        sortOrder: sortOrder),
                     HealthReports = GetInitialHealthReports(context.Resource)
                 })
                 .ConfigureAwait(false);
@@ -192,6 +201,7 @@ internal sealed class ApplicationOrchestrator
                 Debug.Assert(context.DcpResourceName is not null, "Container that is starting should always include the DCP name.");
                 await SetChildResourceAsync(context.Resource, state: KnownResourceStates.Starting, startTimeStamp: null, stopTimeStamp: null).ConfigureAwait(false);
                 break;
+            }
             default:
                 break;
         }

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -5,7 +5,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Resources;
@@ -666,7 +665,7 @@ public sealed class ParameterProcessor(
         {
             return s with
             {
-                Properties = s.Properties.SetResourceProperty(KnownProperties.Parameter.Value, value, parameterResource.Secret),
+                Properties = s.Properties.SetResourcePropertyRange([parameterResource.CreateValueSnapshotProperty(value)]),
                 State = state
             };
         }).ConfigureAwait(false);

--- a/src/Aspire.Hosting/Resources/MessageStrings.Designer.cs
+++ b/src/Aspire.Hosting/Resources/MessageStrings.Designer.cs
@@ -124,6 +124,141 @@ namespace Aspire.Hosting.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Container arguments.
+        /// </summary>
+        internal static string ResourcePropertyContainerArgumentsDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyContainerArgumentsDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Container command.
+        /// </summary>
+        internal static string ResourcePropertyContainerCommandDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyContainerCommandDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Container ID.
+        /// </summary>
+        internal static string ResourcePropertyContainerIdDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyContainerIdDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Container image.
+        /// </summary>
+        internal static string ResourcePropertyContainerImageDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyContainerImageDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Container lifetime.
+        /// </summary>
+        internal static string ResourcePropertyContainerLifetimeDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyContainerLifetimeDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Container ports.
+        /// </summary>
+        internal static string ResourcePropertyContainerPortsDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyContainerPortsDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Executable arguments.
+        /// </summary>
+        internal static string ResourcePropertyExecutableArgumentsDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyExecutableArgumentsDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Executable path.
+        /// </summary>
+        internal static string ResourcePropertyExecutablePathDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyExecutablePathDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Process ID.
+        /// </summary>
+        internal static string ResourcePropertyExecutableProcessIdDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyExecutableProcessIdDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Working directory.
+        /// </summary>
+        internal static string ResourcePropertyExecutableWorkingDirectoryDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyExecutableWorkingDirectoryDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Value.
+        /// </summary>
+        internal static string ResourcePropertyParameterValueDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyParameterValueDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Launch profile.
+        /// </summary>
+        internal static string ResourcePropertyProjectLaunchProfileDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyProjectLaunchProfileDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Project path.
+        /// </summary>
+        internal static string ResourcePropertyProjectPathDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyProjectPathDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tool package.
+        /// </summary>
+        internal static string ResourcePropertyToolPackageDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyToolPackageDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tool version.
+        /// </summary>
+        internal static string ResourcePropertyToolVersionDisplayName {
+            get {
+                return ResourceManager.GetString("ResourcePropertyToolVersionDisplayName", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Required command &apos;{0}&apos; was not found on PATH or at the specified location..
         /// </summary>
         internal static string RequiredCommandNotFound {

--- a/src/Aspire.Hosting/Resources/MessageStrings.resx
+++ b/src/Aspire.Hosting/Resources/MessageStrings.resx
@@ -138,6 +138,51 @@
   <data name="MissingCommandNotificationTitle" xml:space="preserve">
     <value>Missing command</value>
   </data>
+  <data name="ResourcePropertyContainerArgumentsDisplayName" xml:space="preserve">
+    <value>Container arguments</value>
+  </data>
+  <data name="ResourcePropertyContainerCommandDisplayName" xml:space="preserve">
+    <value>Container command</value>
+  </data>
+  <data name="ResourcePropertyContainerIdDisplayName" xml:space="preserve">
+    <value>Container ID</value>
+  </data>
+  <data name="ResourcePropertyContainerImageDisplayName" xml:space="preserve">
+    <value>Container image</value>
+  </data>
+  <data name="ResourcePropertyContainerLifetimeDisplayName" xml:space="preserve">
+    <value>Container lifetime</value>
+  </data>
+  <data name="ResourcePropertyContainerPortsDisplayName" xml:space="preserve">
+    <value>Container ports</value>
+  </data>
+  <data name="ResourcePropertyExecutableArgumentsDisplayName" xml:space="preserve">
+    <value>Executable arguments</value>
+  </data>
+  <data name="ResourcePropertyExecutablePathDisplayName" xml:space="preserve">
+    <value>Executable path</value>
+  </data>
+  <data name="ResourcePropertyExecutableProcessIdDisplayName" xml:space="preserve">
+    <value>Process ID</value>
+  </data>
+  <data name="ResourcePropertyExecutableWorkingDirectoryDisplayName" xml:space="preserve">
+    <value>Working directory</value>
+  </data>
+  <data name="ResourcePropertyParameterValueDisplayName" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="ResourcePropertyProjectLaunchProfileDisplayName" xml:space="preserve">
+    <value>Launch profile</value>
+  </data>
+  <data name="ResourcePropertyProjectPathDisplayName" xml:space="preserve">
+    <value>Project path</value>
+  </data>
+  <data name="ResourcePropertyToolPackageDisplayName" xml:space="preserve">
+    <value>Tool package</value>
+  </data>
+  <data name="ResourcePropertyToolVersionDisplayName" xml:space="preserve">
+    <value>Tool version</value>
+  </data>
   <data name="RequiredCommandNotFound" xml:space="preserve">
     <value>Required command '{0}' was not found on PATH or at the specified location.</value>
   </data>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.cs.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.cs.xlf
@@ -67,6 +67,81 @@
         <target state="translated">Spuštění prostředku {0} se nemusí podařit: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.de.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.de.xlf
@@ -67,6 +67,81 @@
         <target state="translated">Die Ressource „{0}“ kann möglicherweise nicht gestartet werden: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.es.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.es.xlf
@@ -67,6 +67,81 @@
         <target state="translated">El recurso "{0}" puede no iniciarse: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.fr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.fr.xlf
@@ -67,6 +67,81 @@
         <target state="translated">Le démarrage de la ressource « {0} » peut échouer : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.it.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.it.xlf
@@ -67,6 +67,81 @@
         <target state="translated">L'avvio della risorsa '{0}' potrebbe non riuscire: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.ja.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.ja.xlf
@@ -67,6 +67,81 @@
         <target state="translated">リソース '{0}' の開始に失敗する可能性があります: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.ko.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.ko.xlf
@@ -67,6 +67,81 @@
         <target state="translated">리소스 '{0}'을(를) 시작하지 못할 수 있음: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.pl.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.pl.xlf
@@ -67,6 +67,81 @@
         <target state="translated">Uruchomienie zasobu „{0}” może się nie powieść: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.pt-BR.xlf
@@ -67,6 +67,81 @@
         <target state="translated">O recurso ''{0}'' pode falhar ao iniciar: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.ru.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.ru.xlf
@@ -67,6 +67,81 @@
         <target state="translated">Ресурс "{0}" может не запуститься: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.tr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.tr.xlf
@@ -67,6 +67,81 @@
         <target state="translated">'{0}' kaynağı başlatılamayabilir: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.zh-Hans.xlf
@@ -67,6 +67,81 @@
         <target state="translated">资源 "{0}" 可能无法启动: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.zh-Hant.xlf
@@ -67,6 +67,81 @@
         <target state="translated">資源 '{0}' 可能無法啟動: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcePropertyContainerArgumentsDisplayName">
+        <source>Container arguments</source>
+        <target state="new">Container arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerCommandDisplayName">
+        <source>Container command</source>
+        <target state="new">Container command</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerIdDisplayName">
+        <source>Container ID</source>
+        <target state="new">Container ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerImageDisplayName">
+        <source>Container image</source>
+        <target state="new">Container image</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerLifetimeDisplayName">
+        <source>Container lifetime</source>
+        <target state="new">Container lifetime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyContainerPortsDisplayName">
+        <source>Container ports</source>
+        <target state="new">Container ports</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableArgumentsDisplayName">
+        <source>Executable arguments</source>
+        <target state="new">Executable arguments</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutablePathDisplayName">
+        <source>Executable path</source>
+        <target state="new">Executable path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableProcessIdDisplayName">
+        <source>Process ID</source>
+        <target state="new">Process ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyExecutableWorkingDirectoryDisplayName">
+        <source>Working directory</source>
+        <target state="new">Working directory</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyParameterValueDisplayName">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectLaunchProfileDisplayName">
+        <source>Launch profile</source>
+        <target state="new">Launch profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyProjectPathDisplayName">
+        <source>Project path</source>
+        <target state="new">Project path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolPackageDisplayName">
+        <source>Tool package</source>
+        <target state="new">Tool package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcePropertyToolVersionDisplayName">
+        <source>Tool version</source>
+        <target state="new">Tool version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/CustomResourceSnapshotExtensions.cs
+++ b/src/Shared/CustomResourceSnapshotExtensions.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting;
 
 internal static class CustomResourceSnapshotExtensions
 {
-    internal static ImmutableArray<ResourcePropertySnapshot> SetResourceProperty(this ImmutableArray<ResourcePropertySnapshot> properties, string name, object value, bool isSensitive = false, string? displayName = null, bool isHighlighted = false)
+    internal static ImmutableArray<ResourcePropertySnapshot> SetResourceProperty(this ImmutableArray<ResourcePropertySnapshot> properties, string name, object value, bool isSensitive = false, string? displayName = null, bool isHighlighted = false, int? sortOrder = null)
     {
         for (var i = 0; i < properties.Length; i++)
         {
@@ -19,19 +19,20 @@ internal static class CustomResourceSnapshotExtensions
                 if (Equals(property.Value, value) &&
                     property.IsSensitive == isSensitive &&
                     string.Equals(property.DisplayName, displayName, StringComparison.Ordinal) &&
-                    property.IsHighlighted == isHighlighted)
+                    property.IsHighlighted == isHighlighted &&
+                    property.SortOrder == sortOrder)
                 {
                     // Unchanged.
                     return properties;
                 }
 
                 // Set value.
-                return properties.SetItem(i, property with { Value = value, IsSensitive = isSensitive, DisplayName = displayName, IsHighlighted = isHighlighted });
+                return properties.SetItem(i, property with { Value = value, IsSensitive = isSensitive, DisplayName = displayName, IsHighlighted = isHighlighted, SortOrder = sortOrder });
             }
         }
 
         // Add property.
-        return [.. properties, new ResourcePropertySnapshot(name, value) { IsSensitive = isSensitive, DisplayName = displayName, IsHighlighted = isHighlighted }];
+        return [.. properties, new ResourcePropertySnapshot(name, value) { IsSensitive = isSensitive, DisplayName = displayName, IsHighlighted = isHighlighted, SortOrder = sortOrder }];
     }
 
     internal static ImmutableArray<ResourcePropertySnapshot> SetResourcePropertyRange(this ImmutableArray<ResourcePropertySnapshot> properties, IEnumerable<ResourcePropertySnapshot> newValues)

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -90,6 +90,4 @@ internal static class KnownResourcePropertySortOrder
     public const int StopTime = 4;
     public const int ExitCode = 5;
     public const int ConnectionString = 6;
-
-    public const int ProducerDefinedStart = ConnectionString + 1;
 }

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -90,4 +90,9 @@ internal static class KnownResourcePropertySortOrder
     public const int StopTime = 4;
     public const int ExitCode = 5;
     public const int ConnectionString = 6;
+
+    // Producers use local sort orders for their own resource-specific properties. The
+    // dashboard normalizes those values after the generic dashboard-owned properties.
+    // This value should always be greater than the largest known resource property.
+    public static int GetProducerDefinedStart() => ConnectionString + 1;
 }

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -77,3 +77,19 @@ internal static class KnownProperties
         public const string ExecArgs = "tool.execArgs";
     }
 }
+
+/// <summary>
+/// Defines dashboard sort order values for known resource properties.
+/// </summary>
+internal static class KnownResourcePropertySortOrder
+{
+    public const int DisplayName = 0;
+    public const int State = 1;
+    public const int HealthState = 2;
+    public const int StartTime = 3;
+    public const int StopTime = 4;
+    public const int ExitCode = 5;
+    public const int ConnectionString = 6;
+
+    public const int FirstResourceSpecific = ConnectionString + 1;
+}

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -91,5 +91,5 @@ internal static class KnownResourcePropertySortOrder
     public const int ExitCode = 5;
     public const int ConnectionString = 6;
 
-    public const int FirstResourceSpecific = ConnectionString + 1;
+    public const int ProducerDefinedStart = ConnectionString + 1;
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
@@ -430,7 +430,9 @@ public class ResourceDetailsTests : DashboardTestContext
                     Value.ForList(Value.ForString("nginx-abcxyz"), Value.ForString("redis")),
                     isValueSensitive: false,
                     knownProperty: null,
-                    priority: 0)
+                    sortOrder: 0,
+                    displayName: null,
+                    isHighlighted: false)
             });
 
         var cut = RenderComponent<ResourceDetails>(builder =>
@@ -463,7 +465,9 @@ public class ResourceDetailsTests : DashboardTestContext
                 Value.ForNull(),
                 isValueSensitive: false,
                 knownProperty: new KnownProperty(KnownProperties.Resource.State, _ => Aspire.Dashboard.Resources.Resources.ResourcesDetailsStateProperty),
-                priority: 0)
+                sortOrder: 0,
+                displayName: null,
+                isHighlighted: false)
         };
 
         var resource = ModelTestHelpers.CreateResource(
@@ -493,7 +497,7 @@ public class ResourceDetailsTests : DashboardTestContext
                 Value.ForString("The provider reported a recoverable deployment error."),
                 isValueSensitive: false,
                 knownProperty: null,
-                priority: int.MaxValue,
+                sortOrder: int.MaxValue,
                 displayName: "Provider diagnostic",
                 isHighlighted: true),
             ["provider.diagnostic.secret"] = new(
@@ -501,7 +505,7 @@ public class ResourceDetailsTests : DashboardTestContext
                 Value.ForString("Sensitive provider diagnostic detail."),
                 isValueSensitive: true,
                 knownProperty: null,
-                priority: int.MaxValue,
+                sortOrder: int.MaxValue,
                 displayName: "Provider secret",
                 isHighlighted: true),
             ["provider.diagnostic.hidden"] = new(
@@ -509,7 +513,9 @@ public class ResourceDetailsTests : DashboardTestContext
                 Value.ForString("This should require show all."),
                 isValueSensitive: false,
                 knownProperty: null,
-                priority: int.MaxValue)
+                sortOrder: int.MaxValue,
+                displayName: null,
+                isHighlighted: false)
         };
 
         var resource = ModelTestHelpers.CreateResource(
@@ -544,6 +550,7 @@ public class ResourceDetailsTests : DashboardTestContext
     public void Render_ProducerSuppliedSortOrder_OrdersUnknownHighlightedProperties()
     {
         ResourceSetupHelpers.SetupResourceDetails(this);
+        var firstResourceSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
 
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {
@@ -552,34 +559,31 @@ public class ResourceDetailsTests : DashboardTestContext
                 Value.ForString("redis-server"),
                 isValueSensitive: false,
                 knownProperty: null,
-                priority: int.MaxValue,
                 displayName: "Container command",
                 isHighlighted: true,
-                sortOrder: 9),
+                sortOrder: firstResourceSpecificSortOrder + 2),
             [KnownProperties.Container.Image] = new(
                 KnownProperties.Container.Image,
                 Value.ForString("redis:latest"),
                 isValueSensitive: false,
                 knownProperty: null,
-                priority: int.MaxValue,
                 displayName: "Container image",
                 isHighlighted: true,
-                sortOrder: 7),
+                sortOrder: firstResourceSpecificSortOrder),
             [KnownProperties.Container.Id] = new(
                 KnownProperties.Container.Id,
                 Value.ForString("1234567890abcdef"),
                 isValueSensitive: false,
                 knownProperty: null,
-                priority: int.MaxValue,
                 displayName: "Container ID",
                 isHighlighted: true,
-                sortOrder: 8),
+                sortOrder: firstResourceSpecificSortOrder + 1),
             ["provider.diagnostic"] = new(
                 "provider.diagnostic",
                 Value.ForString("diagnostic"),
                 isValueSensitive: false,
                 knownProperty: null,
-                priority: int.MaxValue,
+                sortOrder: int.MaxValue,
                 displayName: "AAA provider diagnostic",
                 isHighlighted: true)
         };
@@ -932,7 +936,6 @@ public class ResourceDetailsTests : DashboardTestContext
             Value.ForString(value),
             isValueSensitive,
             knownProperty: null,
-            priority: int.MaxValue,
             displayName: "Value",
             isHighlighted: true,
             sortOrder: 0);

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
@@ -541,6 +541,67 @@ public class ResourceDetailsTests : DashboardTestContext
     }
 
     [Fact]
+    public void Render_ProducerSuppliedSortOrder_OrdersUnknownHighlightedProperties()
+    {
+        ResourceSetupHelpers.SetupResourceDetails(this);
+
+        var properties = new Dictionary<string, ResourcePropertyViewModel>
+        {
+            [KnownProperties.Container.Command] = new(
+                KnownProperties.Container.Command,
+                Value.ForString("redis-server"),
+                isValueSensitive: false,
+                knownProperty: null,
+                priority: int.MaxValue,
+                displayName: "Container command",
+                isHighlighted: true,
+                sortOrder: 9),
+            [KnownProperties.Container.Image] = new(
+                KnownProperties.Container.Image,
+                Value.ForString("redis:latest"),
+                isValueSensitive: false,
+                knownProperty: null,
+                priority: int.MaxValue,
+                displayName: "Container image",
+                isHighlighted: true,
+                sortOrder: 7),
+            [KnownProperties.Container.Id] = new(
+                KnownProperties.Container.Id,
+                Value.ForString("1234567890abcdef"),
+                isValueSensitive: false,
+                knownProperty: null,
+                priority: int.MaxValue,
+                displayName: "Container ID",
+                isHighlighted: true,
+                sortOrder: 8),
+            ["provider.diagnostic"] = new(
+                "provider.diagnostic",
+                Value.ForString("diagnostic"),
+                isValueSensitive: false,
+                knownProperty: null,
+                priority: int.MaxValue,
+                displayName: "AAA provider diagnostic",
+                isHighlighted: true)
+        };
+
+        var resource = ModelTestHelpers.CreateResource(
+            resourceName: "redis",
+            properties: properties);
+
+        var cut = RenderComponent<ResourceDetails>(builder =>
+        {
+            builder.Add(p => p.Resource, resource);
+            builder.Add(p => p.ResourceByName, new ConcurrentDictionary<string, ResourceViewModel>([new KeyValuePair<string, ResourceViewModel>(resource.Name, resource)]));
+        });
+
+        Assert.Collection(cut.Instance.FilteredResourceProperties.Select(p => p.DisplayName),
+            name => Assert.Equal("Container image", name),
+            name => Assert.Equal("Container ID", name),
+            name => Assert.Equal("Container command", name),
+            name => Assert.Equal("AAA provider diagnostic", name));
+    }
+
+    [Fact]
     public void FilteredEnvironmentVariables_SortedByName()
     {
         // Arrange
@@ -666,12 +727,7 @@ public class ResourceDetailsTests : DashboardTestContext
 
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {
-            [KnownProperties.Parameter.Value] = new ResourcePropertyViewModel(
-                KnownProperties.Parameter.Value,
-                Value.ForString("Parameter 'p' not found in configuration."),
-                isValueSensitive: false,
-                knownProperty: new KnownProperty(KnownProperties.Parameter.Value, _ => "Value"),
-                priority: 0)
+            [KnownProperties.Parameter.Value] = CreateParameterValueProperty("Parameter 'p' not found in configuration.")
         };
 
         var resource = CreateParameterResource(
@@ -717,12 +773,7 @@ public class ResourceDetailsTests : DashboardTestContext
 
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {
-            [KnownProperties.Parameter.Value] = new ResourcePropertyViewModel(
-                KnownProperties.Parameter.Value,
-                Value.ForString("Parameter 'p' not found in configuration."),
-                isValueSensitive: false,
-                knownProperty: new KnownProperty(KnownProperties.Parameter.Value, _ => "Value"),
-                priority: 0)
+            [KnownProperties.Parameter.Value] = CreateParameterValueProperty("Parameter 'p' not found in configuration.")
         };
 
         var resource = CreateParameterResource(
@@ -768,12 +819,7 @@ public class ResourceDetailsTests : DashboardTestContext
 
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {
-            [KnownProperties.Parameter.Value] = new ResourcePropertyViewModel(
-                KnownProperties.Parameter.Value,
-                Value.ForString("Parameter 'p' not found in configuration."),
-                isValueSensitive: true,
-                knownProperty: new KnownProperty(KnownProperties.Parameter.Value, _ => "Value"),
-                priority: 0)
+            [KnownProperties.Parameter.Value] = CreateParameterValueProperty("Parameter 'p' not found in configuration.", isValueSensitive: true)
         };
 
         var resource = CreateParameterResource(
@@ -803,12 +849,7 @@ public class ResourceDetailsTests : DashboardTestContext
         const string errorMessage = "Failed to initialize parameter from external provider.";
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {
-            [KnownProperties.Parameter.Value] = new ResourcePropertyViewModel(
-                KnownProperties.Parameter.Value,
-                Value.ForString(errorMessage),
-                isValueSensitive: false,
-                knownProperty: new KnownProperty(KnownProperties.Parameter.Value, _ => "Value"),
-                priority: 0)
+            [KnownProperties.Parameter.Value] = CreateParameterValueProperty(errorMessage)
         };
 
         var resource = ModelTestHelpers.CreateResource(
@@ -835,12 +876,7 @@ public class ResourceDetailsTests : DashboardTestContext
 
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {
-            [KnownProperties.Parameter.Value] = new ResourcePropertyViewModel(
-                KnownProperties.Parameter.Value,
-                Value.ForString("resolved-value"),
-                isValueSensitive: false,
-                knownProperty: new KnownProperty(KnownProperties.Parameter.Value, _ => "Value"),
-                priority: 0)
+            [KnownProperties.Parameter.Value] = CreateParameterValueProperty("resolved-value")
         };
 
         var resource = ModelTestHelpers.CreateResource(
@@ -887,6 +923,19 @@ public class ResourceDetailsTests : DashboardTestContext
             Commands = commands ?? [],
             HealthReports = [],
         };
+    }
+
+    private static ResourcePropertyViewModel CreateParameterValueProperty(string value, bool isValueSensitive = false)
+    {
+        return new(
+            KnownProperties.Parameter.Value,
+            Value.ForString(value),
+            isValueSensitive,
+            knownProperty: null,
+            priority: int.MaxValue,
+            displayName: "Value",
+            isHighlighted: true,
+            sortOrder: 0);
     }
 
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
@@ -942,7 +942,7 @@ public class ResourceDetailsTests : DashboardTestContext
             knownProperty: null,
             displayName: "Value",
             isHighlighted: true,
-            sortOrder: 0);
+            sortOrder: ProducerDefinedDisplaySortOrder(0));
     }
 
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
@@ -550,7 +550,7 @@ public class ResourceDetailsTests : DashboardTestContext
     public void Render_ProducerSuppliedSortOrder_OrdersUnknownHighlightedProperties()
     {
         ResourceSetupHelpers.SetupResourceDetails(this);
-        var firstResourceSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
+        var producerDefinedSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
 
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {
@@ -561,7 +561,7 @@ public class ResourceDetailsTests : DashboardTestContext
                 knownProperty: null,
                 displayName: "Container command",
                 isHighlighted: true,
-                sortOrder: firstResourceSpecificSortOrder + 2),
+                sortOrder: producerDefinedSortOrderStart + 2),
             [KnownProperties.Container.Image] = new(
                 KnownProperties.Container.Image,
                 Value.ForString("redis:latest"),
@@ -569,7 +569,7 @@ public class ResourceDetailsTests : DashboardTestContext
                 knownProperty: null,
                 displayName: "Container image",
                 isHighlighted: true,
-                sortOrder: firstResourceSpecificSortOrder),
+                sortOrder: producerDefinedSortOrderStart),
             [KnownProperties.Container.Id] = new(
                 KnownProperties.Container.Id,
                 Value.ForString("1234567890abcdef"),
@@ -577,7 +577,7 @@ public class ResourceDetailsTests : DashboardTestContext
                 knownProperty: null,
                 displayName: "Container ID",
                 isHighlighted: true,
-                sortOrder: firstResourceSpecificSortOrder + 1),
+                sortOrder: producerDefinedSortOrderStart + 1),
             ["provider.diagnostic"] = new(
                 "provider.diagnostic",
                 Value.ForString("diagnostic"),

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
@@ -550,7 +550,6 @@ public class ResourceDetailsTests : DashboardTestContext
     public void Render_ProducerSuppliedSortOrder_OrdersUnknownHighlightedProperties()
     {
         ResourceSetupHelpers.SetupResourceDetails(this);
-        var producerDefinedSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
 
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {
@@ -561,7 +560,7 @@ public class ResourceDetailsTests : DashboardTestContext
                 knownProperty: null,
                 displayName: "Container command",
                 isHighlighted: true,
-                sortOrder: producerDefinedSortOrderStart + 2),
+                sortOrder: ProducerDefinedDisplaySortOrder(2)),
             [KnownProperties.Container.Image] = new(
                 KnownProperties.Container.Image,
                 Value.ForString("redis:latest"),
@@ -569,7 +568,7 @@ public class ResourceDetailsTests : DashboardTestContext
                 knownProperty: null,
                 displayName: "Container image",
                 isHighlighted: true,
-                sortOrder: producerDefinedSortOrderStart),
+                sortOrder: ProducerDefinedDisplaySortOrder(0)),
             [KnownProperties.Container.Id] = new(
                 KnownProperties.Container.Id,
                 Value.ForString("1234567890abcdef"),
@@ -577,7 +576,7 @@ public class ResourceDetailsTests : DashboardTestContext
                 knownProperty: null,
                 displayName: "Container ID",
                 isHighlighted: true,
-                sortOrder: producerDefinedSortOrderStart + 1),
+                sortOrder: ProducerDefinedDisplaySortOrder(1)),
             ["provider.diagnostic"] = new(
                 "provider.diagnostic",
                 Value.ForString("diagnostic"),
@@ -603,6 +602,11 @@ public class ResourceDetailsTests : DashboardTestContext
             name => Assert.Equal("Container ID", name),
             name => Assert.Equal("Container command", name),
             name => Assert.Equal("AAA provider diagnostic", name));
+    }
+
+    private static int ProducerDefinedDisplaySortOrder(int producerSortOrder)
+    {
+        return KnownResourcePropertySortOrder.ConnectionString + 1 + producerSortOrder;
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
@@ -186,6 +186,8 @@ public partial class ConsoleLogsTests
             new Value { StringValue = value },
             isValueSensitive: false,
             knownProperty: null,
-            priority: 0);
+            sortOrder: 0,
+            displayName: null,
+            isHighlighted: false);
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -557,7 +557,9 @@ public partial class ResourcesTests : DashboardTestContext
                 ProtobufValue.ForString("my-secret-value"),
                 isValueSensitive: true,
                 knownProperty: null,
-                priority: 0));
+                sortOrder: 0,
+                displayName: null,
+                isHighlighted: false));
 
         var initialResources = new List<ResourceViewModel>
         {
@@ -601,7 +603,9 @@ public partial class ResourcesTests : DashboardTestContext
                 ProtobufValue.ForString("Parameter 'myparameter' not found in configuration."),
                 isValueSensitive: false,
                 knownProperty: null,
-                priority: 0));
+                sortOrder: 0,
+                displayName: null,
+                isHighlighted: false));
 
         var initialResources = new List<ResourceViewModel>
         {
@@ -643,7 +647,9 @@ public partial class ResourcesTests : DashboardTestContext
                 ProtobufValue.ForString("Error initializing parameter"),
                 isValueSensitive: false,
                 knownProperty: null,
-                priority: 0));
+                sortOrder: 0,
+                displayName: null,
+                isHighlighted: false));
 
         var initialResources = new List<ResourceViewModel>
         {

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
@@ -25,7 +25,9 @@ public sealed class MockDashboardClient : IDashboardClient
                     },
                     isValueSensitive: false,
                     knownProperty: new(KnownProperties.Project.Path, loc => "Path"),
-                    priority: 0))
+                    sortOrder: 0,
+                    displayName: null,
+                    isHighlighted: false))
         }.ToDictionary(),
         state: KnownResourceState.Running);
 

--- a/tests/Aspire.Dashboard.Tests/Model/KnownPropertyLookupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/KnownPropertyLookupTests.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public class KnownPropertyLookupTests
+{
+    [Fact]
+    public void FindProperty_GenericResourceProperty_ReturnsKnownProperty()
+    {
+        var lookup = new KnownPropertyLookup();
+
+        var (priority, knownProperty) = lookup.FindProperty(KnownResourceTypes.Container, KnownProperties.Resource.State);
+
+        Assert.NotEqual(int.MaxValue, priority);
+        Assert.NotNull(knownProperty);
+        Assert.Equal(KnownProperties.Resource.State, knownProperty.Key);
+    }
+
+    [Theory]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Image)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Path)]
+    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.Path)]
+    [InlineData(KnownResourceTypes.Parameter, KnownProperties.Parameter.Value)]
+    public void FindProperty_ProducerSuppliedPropertyMetadata_ReturnsUnknownProperty(string resourceType, string propertyName)
+    {
+        var lookup = new KnownPropertyLookup();
+
+        var (priority, knownProperty) = lookup.FindProperty(resourceType, propertyName);
+
+        Assert.Equal(int.MaxValue, priority);
+        Assert.Null(knownProperty);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/KnownPropertyLookupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/KnownPropertyLookupTests.cs
@@ -13,25 +13,34 @@ public class KnownPropertyLookupTests
     {
         var lookup = new KnownPropertyLookup();
 
-        var (priority, knownProperty) = lookup.FindProperty(KnownResourceTypes.Container, KnownProperties.Resource.State);
+        var (sortOrder, knownProperty) = lookup.FindProperty(KnownProperties.Resource.State);
 
-        Assert.NotEqual(int.MaxValue, priority);
+        Assert.NotEqual(int.MaxValue, sortOrder);
         Assert.NotNull(knownProperty);
         Assert.Equal(KnownProperties.Resource.State, knownProperty.Key);
     }
 
     [Theory]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Image)]
-    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Path)]
-    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.Path)]
-    [InlineData(KnownResourceTypes.Parameter, KnownProperties.Parameter.Value)]
-    public void FindProperty_ProducerSuppliedPropertyMetadata_ReturnsUnknownProperty(string resourceType, string propertyName)
+    [InlineData(KnownProperties.Project.Path)]
+    [InlineData(KnownProperties.Project.LaunchProfile)]
+    [InlineData(KnownProperties.Executable.Path)]
+    [InlineData(KnownProperties.Executable.WorkDir)]
+    [InlineData(KnownProperties.Executable.Args)]
+    [InlineData(KnownProperties.Executable.Pid)]
+    [InlineData(KnownProperties.Container.Image)]
+    [InlineData(KnownProperties.Container.Id)]
+    [InlineData(KnownProperties.Container.Command)]
+    [InlineData(KnownProperties.Container.Args)]
+    [InlineData(KnownProperties.Container.Ports)]
+    [InlineData(KnownProperties.Container.Lifetime)]
+    [InlineData(KnownProperties.Parameter.Value)]
+    public void FindProperty_ProducerSuppliedPropertyMetadata_ReturnsUnknownProperty(string propertyName)
     {
         var lookup = new KnownPropertyLookup();
 
-        var (priority, knownProperty) = lookup.FindProperty(resourceType, propertyName);
+        var (sortOrder, knownProperty) = lookup.FindProperty(propertyName);
 
-        Assert.Equal(int.MaxValue, priority);
+        Assert.Equal(int.MaxValue, sortOrder);
         Assert.Null(knownProperty);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/MockKnownPropertyLookup.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/MockKnownPropertyLookup.cs
@@ -7,23 +7,23 @@ namespace Aspire.Dashboard;
 
 internal sealed class MockKnownPropertyLookup() : IKnownPropertyLookup
 {
-    private int _priority = int.MaxValue;
+    private int _sortOrder = int.MaxValue;
     private KnownProperty? _knownProperty;
 
-    public MockKnownPropertyLookup(int priority, KnownProperty? knownProperty) : this()
+    public MockKnownPropertyLookup(int sortOrder, KnownProperty? knownProperty) : this()
     {
-        _priority = priority;
+        _sortOrder = sortOrder;
         _knownProperty = knownProperty;
     }
 
-    public void Set(int priority, KnownProperty? knownProperty)
+    public void Set(int sortOrder, KnownProperty? knownProperty)
     {
-        _priority = priority;
+        _sortOrder = sortOrder;
         _knownProperty = knownProperty;
     }
 
-    public (int priority, KnownProperty? knownProperty) FindProperty(string resourceType, string uid)
+    public (int SortOrder, KnownProperty? KnownProperty) FindProperty(string uid)
     {
-        return (_priority, _knownProperty);
+        return (_sortOrder, _knownProperty);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceIconHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceIconHelpersTests.cs
@@ -117,7 +117,7 @@ public sealed class ResourceIconHelpersTests
         var projectPath = $"/path/to/project{extension}";
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {
-            [KnownProperties.Project.Path] = new ResourcePropertyViewModel(KnownProperties.Project.Path, Value.ForString(projectPath), isValueSensitive: false, knownProperty: null, priority: 0)
+            [KnownProperties.Project.Path] = new ResourcePropertyViewModel(KnownProperties.Project.Path, Value.ForString(projectPath), isValueSensitive: false, knownProperty: null, sortOrder: 0, displayName: null, isHighlighted: false)
         };
         var resource = ModelTestHelpers.CreateResource(
             resourceType: KnownResourceTypes.Project,

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -23,17 +23,17 @@ public sealed class ResourceSourceViewModelTests
 
         if (testData.ExecutableArguments is not null)
         {
-            properties.TryAdd(KnownProperties.Executable.Args, new ResourcePropertyViewModel(KnownProperties.Executable.Args, Value.ForList(testData.ExecutableArguments.Select(Value.ForString).ToArray()), false, null, 0));
+            properties.TryAdd(KnownProperties.Executable.Args, new ResourcePropertyViewModel(KnownProperties.Executable.Args, Value.ForList(testData.ExecutableArguments.Select(Value.ForString).ToArray()), false, null, 0, displayName: null, isHighlighted: false));
         }
 
         if (testData.AppArgs is not null)
         {
-            properties.TryAdd(KnownProperties.Resource.AppArgs, new ResourcePropertyViewModel(KnownProperties.Resource.AppArgs, Value.ForList(testData.AppArgs.Select(Value.ForString).ToArray()), false, null, 0));
+            properties.TryAdd(KnownProperties.Resource.AppArgs, new ResourcePropertyViewModel(KnownProperties.Resource.AppArgs, Value.ForList(testData.AppArgs.Select(Value.ForString).ToArray()), false, null, 0, displayName: null, isHighlighted: false));
         }
 
         if (testData.AppArgsSensitivity is not null)
         {
-            properties.TryAdd(KnownProperties.Resource.AppArgsSensitivity, new ResourcePropertyViewModel(KnownProperties.Resource.AppArgsSensitivity, Value.ForList(testData.AppArgsSensitivity.Select(b => Value.ForNumber(Convert.ToInt32(b))).ToArray()), false, null, 0));
+            properties.TryAdd(KnownProperties.Resource.AppArgsSensitivity, new ResourcePropertyViewModel(KnownProperties.Resource.AppArgsSensitivity, Value.ForList(testData.AppArgsSensitivity.Select(b => Value.ForNumber(Convert.ToInt32(b))).ToArray()), false, null, 0, displayName: null, isHighlighted: false));
         }
 
         var resource = ModelTestHelpers.CreateResource(
@@ -70,7 +70,7 @@ public sealed class ResourceSourceViewModelTests
 
         void AddStringProperty(string propertyName, string? propertyValue)
         {
-            properties.TryAdd(propertyName, new ResourcePropertyViewModel(propertyName, propertyValue is null ? Value.ForNull() : Value.ForString(propertyValue), false, null, 0));
+            properties.TryAdd(propertyName, new ResourcePropertyViewModel(propertyName, propertyValue is null ? Value.ForNull() : Value.ForString(propertyValue), false, null, 0, displayName: null, isHighlighted: false));
         }
     }
 

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceStateViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceStateViewModelTests.cs
@@ -79,7 +79,7 @@ public class ResourceStateViewModelTests
         var propertiesDictionary = new Dictionary<string, ResourcePropertyViewModel>();
         if (exitCode is not null)
         {
-            propertiesDictionary.TryAdd(KnownProperties.Resource.ExitCode, new ResourcePropertyViewModel(KnownProperties.Resource.ExitCode, Value.ForNumber((double)exitCode), false, null, 0));
+            propertiesDictionary.TryAdd(KnownProperties.Resource.ExitCode, new ResourcePropertyViewModel(KnownProperties.Resource.ExitCode, Value.ForNumber((double)exitCode), false, null, 0, displayName: null, isHighlighted: false));
         }
 
         var resource = ModelTestHelpers.CreateResource(
@@ -92,7 +92,7 @@ public class ResourceStateViewModelTests
 
         if (exitCode is not null)
         {
-            resource.Properties.TryAdd(KnownProperties.Resource.ExitCode, new ResourcePropertyViewModel(KnownProperties.Resource.ExitCode, Value.ForNumber((double)exitCode), false, null, 0));
+            resource.Properties.TryAdd(KnownProperties.Resource.ExitCode, new ResourcePropertyViewModel(KnownProperties.Resource.ExitCode, Value.ForNumber((double)exitCode), false, null, 0, displayName: null, isHighlighted: false));
         }
 
         var localizer = new TestStringLocalizer<Columns>();
@@ -121,7 +121,9 @@ public class ResourceStateViewModelTests
                     Value.ForList(Value.ForString("nginx"), Value.ForString("redis")),
                     isValueSensitive: false,
                     knownProperty: null,
-                    priority: 0)
+                    sortOrder: 0,
+                    displayName: null,
+                    isHighlighted: false)
             });
 
         var localizer = new TestStringLocalizer<Columns>();
@@ -147,7 +149,9 @@ public class ResourceStateViewModelTests
                     Value.ForList(Value.ForString("messaging-abcxyz")),
                     isValueSensitive: false,
                     knownProperty: null,
-                    priority: 0)
+                    sortOrder: 0,
+                    displayName: null,
+                    isHighlighted: false)
             });
 
         var localizer = new TestStringLocalizer<Columns>();
@@ -176,7 +180,9 @@ public class ResourceStateViewModelTests
                     Value.ForList(Value.ForString("messaging-abcxyz")),
                     isValueSensitive: false,
                     knownProperty: null,
-                    priority: 0)
+                    sortOrder: 0,
+                    displayName: null,
+                    isHighlighted: false)
             });
 
         var localizer = new TestStringLocalizer<Columns>();
@@ -202,7 +208,9 @@ public class ResourceStateViewModelTests
                     Value.ForList(Value.ForString("messaging-abcxyz")),
                     isValueSensitive: false,
                     knownProperty: null,
-                    priority: 0)
+                    sortOrder: 0,
+                    displayName: null,
+                    isHighlighted: false)
             });
 
         var resources = new CopyToThrowingResourceCollection(resource, dependency);

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelExtensionsTerminalTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelExtensionsTerminalTests.cs
@@ -100,6 +100,8 @@ public class ResourceViewModelExtensionsTerminalTests
             new Value { StringValue = value },
             isValueSensitive: false,
             knownProperty: null,
-            priority: 0);
+            sortOrder: 0,
+            displayName: null,
+            isHighlighted: false);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -175,7 +175,7 @@ public sealed class ResourceViewModelTests
                     Value = Value.ForString("redis:latest"),
                     DisplayName = "Container image",
                     IsHighlighted = true,
-                    SortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific
+                    SortOrder = KnownResourcePropertySortOrder.ProducerDefinedStart
                 }
             }
         };
@@ -187,25 +187,25 @@ public sealed class ResourceViewModelTests
         var property = vm.Properties[KnownProperties.Container.Image];
         Assert.Equal("Container image", property.DisplayName);
         Assert.True(property.IsHighlighted);
-        Assert.Equal(KnownResourcePropertySortOrder.FirstResourceSpecific, property.SortOrder);
+        Assert.Equal(KnownResourcePropertySortOrder.ProducerDefinedStart, property.SortOrder);
         Assert.Null(property.KnownProperty);
     }
 
     [Theory]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Image, nameof(DashboardResources.ResourcesDetailsContainerImageProperty), KnownResourcePropertySortOrder.FirstResourceSpecific)]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Id, nameof(DashboardResources.ResourcesDetailsContainerIdProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 1)]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Command, nameof(DashboardResources.ResourcesDetailsContainerCommandProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 2)]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Args, nameof(DashboardResources.ResourcesDetailsContainerArgumentsProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 3)]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Ports, nameof(DashboardResources.ResourcesDetailsContainerPortsProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 4)]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Lifetime, nameof(DashboardResources.ResourcesDetailsContainerLifetimeProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 5)]
-    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Path, nameof(DashboardResources.ResourcesDetailsExecutablePathProperty), KnownResourcePropertySortOrder.FirstResourceSpecific)]
-    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir, nameof(DashboardResources.ResourcesDetailsExecutableWorkingDirectoryProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 1)]
-    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Args, nameof(DashboardResources.ResourcesDetailsExecutableArgumentsProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 2)]
-    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Pid, nameof(DashboardResources.ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 3)]
-    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.Path, nameof(DashboardResources.ResourcesDetailsProjectPathProperty), KnownResourcePropertySortOrder.FirstResourceSpecific)]
-    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile, nameof(DashboardResources.ResourcesDetailsProjectLaunchProfileProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 1)]
-    [InlineData(KnownResourceTypes.Project, KnownProperties.Executable.Pid, nameof(DashboardResources.ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 2)]
-    [InlineData(KnownResourceTypes.Parameter, KnownProperties.Parameter.Value, nameof(DashboardResources.ResourcesDetailsParameterValueProperty), KnownResourcePropertySortOrder.FirstResourceSpecific)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Image, nameof(DashboardResources.ResourcesDetailsContainerImageProperty), KnownResourcePropertySortOrder.ProducerDefinedStart)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Id, nameof(DashboardResources.ResourcesDetailsContainerIdProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 1)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Command, nameof(DashboardResources.ResourcesDetailsContainerCommandProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 2)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Args, nameof(DashboardResources.ResourcesDetailsContainerArgumentsProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 3)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Ports, nameof(DashboardResources.ResourcesDetailsContainerPortsProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 4)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Lifetime, nameof(DashboardResources.ResourcesDetailsContainerLifetimeProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 5)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Path, nameof(DashboardResources.ResourcesDetailsExecutablePathProperty), KnownResourcePropertySortOrder.ProducerDefinedStart)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir, nameof(DashboardResources.ResourcesDetailsExecutableWorkingDirectoryProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 1)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Args, nameof(DashboardResources.ResourcesDetailsExecutableArgumentsProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 2)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Pid, nameof(DashboardResources.ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 3)]
+    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.Path, nameof(DashboardResources.ResourcesDetailsProjectPathProperty), KnownResourcePropertySortOrder.ProducerDefinedStart)]
+    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile, nameof(DashboardResources.ResourcesDetailsProjectLaunchProfileProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 1)]
+    [InlineData(KnownResourceTypes.Project, KnownProperties.Executable.Pid, nameof(DashboardResources.ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 2)]
+    [InlineData(KnownResourceTypes.Parameter, KnownProperties.Parameter.Value, nameof(DashboardResources.ResourcesDetailsParameterValueProperty), KnownResourcePropertySortOrder.ProducerDefinedStart)]
     public void ToViewModel_LegacyBuiltInResourceSpecificPropertyMetadata_AppliesFallback(string resourceType, string propertyName, string expectedDisplayNameResourceName, int expectedSortOrder)
     {
         var resource = new Resource
@@ -289,7 +289,7 @@ public sealed class ResourceViewModelTests
         }
         if (hasSortOrder)
         {
-            imageProperty.SortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
+            imageProperty.SortOrder = KnownResourcePropertySortOrder.ProducerDefinedStart;
         }
 
         var resource = new Resource
@@ -314,7 +314,7 @@ public sealed class ResourceViewModelTests
         var image = vm.Properties[KnownProperties.Container.Image];
         Assert.Equal(hasDisplayName ? "Producer container image" : null, image.DisplayName);
         Assert.Equal(isHighlighted, image.IsHighlighted);
-        Assert.Equal(hasSortOrder ? KnownResourcePropertySortOrder.FirstResourceSpecific : int.MaxValue, image.SortOrder);
+        Assert.Equal(hasSortOrder ? KnownResourcePropertySortOrder.ProducerDefinedStart : int.MaxValue, image.SortOrder);
         Assert.Null(image.KnownProperty);
 
         var id = vm.Properties[KnownProperties.Container.Id];

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -175,7 +175,7 @@ public sealed class ResourceViewModelTests
                     Value = Value.ForString("redis:latest"),
                     DisplayName = "Container image",
                     IsHighlighted = true,
-                    SortOrder = KnownResourcePropertySortOrder.ProducerDefinedStart
+                    SortOrder = 0
                 }
             }
         };
@@ -187,26 +187,26 @@ public sealed class ResourceViewModelTests
         var property = vm.Properties[KnownProperties.Container.Image];
         Assert.Equal("Container image", property.DisplayName);
         Assert.True(property.IsHighlighted);
-        Assert.Equal(KnownResourcePropertySortOrder.ProducerDefinedStart, property.SortOrder);
+        Assert.Equal(ProducerDefinedDisplaySortOrder(0), property.SortOrder);
         Assert.Null(property.KnownProperty);
     }
 
     [Theory]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Image, nameof(DashboardResources.ResourcesDetailsContainerImageProperty), KnownResourcePropertySortOrder.ProducerDefinedStart)]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Id, nameof(DashboardResources.ResourcesDetailsContainerIdProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 1)]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Command, nameof(DashboardResources.ResourcesDetailsContainerCommandProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 2)]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Args, nameof(DashboardResources.ResourcesDetailsContainerArgumentsProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 3)]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Ports, nameof(DashboardResources.ResourcesDetailsContainerPortsProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 4)]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Lifetime, nameof(DashboardResources.ResourcesDetailsContainerLifetimeProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 5)]
-    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Path, nameof(DashboardResources.ResourcesDetailsExecutablePathProperty), KnownResourcePropertySortOrder.ProducerDefinedStart)]
-    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir, nameof(DashboardResources.ResourcesDetailsExecutableWorkingDirectoryProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 1)]
-    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Args, nameof(DashboardResources.ResourcesDetailsExecutableArgumentsProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 2)]
-    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Pid, nameof(DashboardResources.ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 3)]
-    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.Path, nameof(DashboardResources.ResourcesDetailsProjectPathProperty), KnownResourcePropertySortOrder.ProducerDefinedStart)]
-    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile, nameof(DashboardResources.ResourcesDetailsProjectLaunchProfileProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 1)]
-    [InlineData(KnownResourceTypes.Project, KnownProperties.Executable.Pid, nameof(DashboardResources.ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.ProducerDefinedStart + 2)]
-    [InlineData(KnownResourceTypes.Parameter, KnownProperties.Parameter.Value, nameof(DashboardResources.ResourcesDetailsParameterValueProperty), KnownResourcePropertySortOrder.ProducerDefinedStart)]
-    public void ToViewModel_LegacyBuiltInResourceSpecificPropertyMetadata_AppliesFallback(string resourceType, string propertyName, string expectedDisplayNameResourceName, int expectedSortOrder)
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Image, nameof(DashboardResources.ResourcesDetailsContainerImageProperty), 0)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Id, nameof(DashboardResources.ResourcesDetailsContainerIdProperty), 1)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Command, nameof(DashboardResources.ResourcesDetailsContainerCommandProperty), 2)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Args, nameof(DashboardResources.ResourcesDetailsContainerArgumentsProperty), 3)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Ports, nameof(DashboardResources.ResourcesDetailsContainerPortsProperty), 4)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Lifetime, nameof(DashboardResources.ResourcesDetailsContainerLifetimeProperty), 5)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Path, nameof(DashboardResources.ResourcesDetailsExecutablePathProperty), 0)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir, nameof(DashboardResources.ResourcesDetailsExecutableWorkingDirectoryProperty), 1)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Args, nameof(DashboardResources.ResourcesDetailsExecutableArgumentsProperty), 2)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Pid, nameof(DashboardResources.ResourcesDetailsExecutableProcessIdProperty), 3)]
+    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.Path, nameof(DashboardResources.ResourcesDetailsProjectPathProperty), 0)]
+    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile, nameof(DashboardResources.ResourcesDetailsProjectLaunchProfileProperty), 1)]
+    [InlineData(KnownResourceTypes.Project, KnownProperties.Executable.Pid, nameof(DashboardResources.ResourcesDetailsExecutableProcessIdProperty), 2)]
+    [InlineData(KnownResourceTypes.Parameter, KnownProperties.Parameter.Value, nameof(DashboardResources.ResourcesDetailsParameterValueProperty), 0)]
+    public void ToViewModel_LegacyBuiltInResourceSpecificPropertyMetadata_AppliesFallback(string resourceType, string propertyName, string expectedDisplayNameResourceName, int expectedProducerSortOrder)
     {
         var resource = new Resource
         {
@@ -229,7 +229,7 @@ public sealed class ResourceViewModelTests
         var property = vm.Properties[propertyName];
         Assert.Null(property.DisplayName);
         Assert.False(property.IsHighlighted);
-        Assert.Equal(expectedSortOrder, property.SortOrder);
+        Assert.Equal(ProducerDefinedDisplaySortOrder(expectedProducerSortOrder), property.SortOrder);
         Assert.NotNull(property.KnownProperty);
         Assert.Equal(propertyName, property.KnownProperty.Key);
 
@@ -289,7 +289,7 @@ public sealed class ResourceViewModelTests
         }
         if (hasSortOrder)
         {
-            imageProperty.SortOrder = KnownResourcePropertySortOrder.ProducerDefinedStart;
+            imageProperty.SortOrder = 0;
         }
 
         var resource = new Resource
@@ -314,7 +314,7 @@ public sealed class ResourceViewModelTests
         var image = vm.Properties[KnownProperties.Container.Image];
         Assert.Equal(hasDisplayName ? "Producer container image" : null, image.DisplayName);
         Assert.Equal(isHighlighted, image.IsHighlighted);
-        Assert.Equal(hasSortOrder ? KnownResourcePropertySortOrder.ProducerDefinedStart : int.MaxValue, image.SortOrder);
+        Assert.Equal(hasSortOrder ? ProducerDefinedDisplaySortOrder(0) : int.MaxValue, image.SortOrder);
         Assert.Null(image.KnownProperty);
 
         var id = vm.Properties[KnownProperties.Container.Id];
@@ -322,6 +322,11 @@ public sealed class ResourceViewModelTests
         Assert.False(id.IsHighlighted);
         Assert.Equal(int.MaxValue, id.SortOrder);
         Assert.Null(id.KnownProperty);
+    }
+
+    private static int ProducerDefinedDisplaySortOrder(int producerSortOrder)
+    {
+        return KnownResourcePropertySortOrder.ConnectionString + 1 + producerSortOrder;
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -157,6 +157,41 @@ public sealed class ResourceViewModelTests
     }
 
     [Fact]
+    public void ToViewModel_ProducerSuppliedPropertyMetadata_DoesNotRequireKnownProperty()
+    {
+        // Arrange
+        var resource = new Resource
+        {
+            Name = "container-abc",
+            DisplayName = "container",
+            ResourceType = KnownResourceTypes.Container,
+            CreatedAt = Timestamp.FromDateTime(s_dateTime),
+            Properties =
+            {
+                new ResourceProperty
+                {
+                    Name = KnownProperties.Container.Image,
+                    Value = Value.ForString("redis:latest"),
+                    DisplayName = "Container image",
+                    IsHighlighted = true,
+                    SortOrder = 7
+                }
+            }
+        };
+
+        // Act
+        var vm = ToViewModel(resource, new KnownPropertyLookup());
+
+        // Assert
+        var property = vm.Properties[KnownProperties.Container.Image];
+        Assert.Equal("Container image", property.DisplayName);
+        Assert.True(property.IsHighlighted);
+        Assert.Equal(int.MaxValue, property.Priority);
+        Assert.Equal(7, property.SortOrder);
+        Assert.Null(property.KnownProperty);
+    }
+
+    [Fact]
     public void ToViewModel_WithCustomIcon_SetsIconProperties()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -190,6 +190,86 @@ public sealed class ResourceViewModelTests
         Assert.Null(property.KnownProperty);
     }
 
+    [Theory]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Image, KnownResourcePropertySortOrder.FirstResourceSpecific)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Path, KnownResourcePropertySortOrder.FirstResourceSpecific)]
+    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.Path, KnownResourcePropertySortOrder.FirstResourceSpecific)]
+    [InlineData(KnownResourceTypes.Parameter, KnownProperties.Parameter.Value, KnownResourcePropertySortOrder.FirstResourceSpecific)]
+    public void ToViewModel_LegacyResourceSpecificPropertyMetadata_AppliesFallback(string resourceType, string propertyName, int expectedSortOrder)
+    {
+        // Arrange
+        var resource = new Resource
+        {
+            Name = "resource-abc",
+            DisplayName = "resource",
+            ResourceType = resourceType,
+            CreatedAt = Timestamp.FromDateTime(s_dateTime),
+            Properties =
+            {
+                new ResourceProperty
+                {
+                    Name = propertyName,
+                    Value = Value.ForString("value")
+                }
+            }
+        };
+
+        // Act
+        var vm = ToViewModel(resource, new KnownPropertyLookup());
+
+        // Assert
+        var property = vm.Properties[propertyName];
+        Assert.Null(property.DisplayName);
+        Assert.False(property.IsHighlighted);
+        Assert.Equal(expectedSortOrder, property.SortOrder);
+        Assert.NotNull(property.KnownProperty);
+        Assert.Equal(propertyName, property.KnownProperty.Key);
+    }
+
+    [Fact]
+    public void ToViewModel_ProducerMetadataPresent_DisablesLegacyFallbackForResource()
+    {
+        // Arrange
+        var resource = new Resource
+        {
+            Name = "container-abc",
+            DisplayName = "container",
+            ResourceType = KnownResourceTypes.Container,
+            CreatedAt = Timestamp.FromDateTime(s_dateTime),
+            Properties =
+            {
+                new ResourceProperty
+                {
+                    Name = KnownProperties.Container.Image,
+                    Value = Value.ForString("redis:latest"),
+                    DisplayName = "Producer container image",
+                    IsHighlighted = true,
+                    SortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific
+                },
+                new ResourceProperty
+                {
+                    Name = KnownProperties.Container.Id,
+                    Value = Value.ForString("abc123")
+                }
+            }
+        };
+
+        // Act
+        var vm = ToViewModel(resource, new KnownPropertyLookup());
+
+        // Assert
+        var image = vm.Properties[KnownProperties.Container.Image];
+        Assert.Equal("Producer container image", image.DisplayName);
+        Assert.True(image.IsHighlighted);
+        Assert.Null(image.KnownProperty);
+
+        var id = vm.Properties[KnownProperties.Container.Id];
+        Assert.Null(id.DisplayName);
+        Assert.False(id.IsHighlighted);
+        Assert.Equal(int.MaxValue, id.SortOrder);
+        Assert.Null(id.KnownProperty);
+    }
+
     [Fact]
     public void ToViewModel_WithCustomIcon_SetsIconProperties()
     {

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -7,6 +7,7 @@ using Aspire.DashboardService.Proto.V1;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
+using DashboardResources = Aspire.Dashboard.Resources.Resources;
 using DiagnosticsHealthStatus = Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus;
 
 namespace Aspire.Dashboard.Tests.Model;
@@ -191,13 +192,22 @@ public sealed class ResourceViewModelTests
     }
 
     [Theory]
-    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Image, KnownResourcePropertySortOrder.FirstResourceSpecific)]
-    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Path, KnownResourcePropertySortOrder.FirstResourceSpecific)]
-    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.Path, KnownResourcePropertySortOrder.FirstResourceSpecific)]
-    [InlineData(KnownResourceTypes.Parameter, KnownProperties.Parameter.Value, KnownResourcePropertySortOrder.FirstResourceSpecific)]
-    public void ToViewModel_LegacyResourceSpecificPropertyMetadata_AppliesFallback(string resourceType, string propertyName, int expectedSortOrder)
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Image, nameof(DashboardResources.ResourcesDetailsContainerImageProperty), KnownResourcePropertySortOrder.FirstResourceSpecific)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Id, nameof(DashboardResources.ResourcesDetailsContainerIdProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 1)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Command, nameof(DashboardResources.ResourcesDetailsContainerCommandProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 2)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Args, nameof(DashboardResources.ResourcesDetailsContainerArgumentsProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 3)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Ports, nameof(DashboardResources.ResourcesDetailsContainerPortsProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 4)]
+    [InlineData(KnownResourceTypes.Container, KnownProperties.Container.Lifetime, nameof(DashboardResources.ResourcesDetailsContainerLifetimeProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 5)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Path, nameof(DashboardResources.ResourcesDetailsExecutablePathProperty), KnownResourcePropertySortOrder.FirstResourceSpecific)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.WorkDir, nameof(DashboardResources.ResourcesDetailsExecutableWorkingDirectoryProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 1)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Args, nameof(DashboardResources.ResourcesDetailsExecutableArgumentsProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 2)]
+    [InlineData(KnownResourceTypes.Executable, KnownProperties.Executable.Pid, nameof(DashboardResources.ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 3)]
+    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.Path, nameof(DashboardResources.ResourcesDetailsProjectPathProperty), KnownResourcePropertySortOrder.FirstResourceSpecific)]
+    [InlineData(KnownResourceTypes.Project, KnownProperties.Project.LaunchProfile, nameof(DashboardResources.ResourcesDetailsProjectLaunchProfileProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 1)]
+    [InlineData(KnownResourceTypes.Project, KnownProperties.Executable.Pid, nameof(DashboardResources.ResourcesDetailsExecutableProcessIdProperty), KnownResourcePropertySortOrder.FirstResourceSpecific + 2)]
+    [InlineData(KnownResourceTypes.Parameter, KnownProperties.Parameter.Value, nameof(DashboardResources.ResourcesDetailsParameterValueProperty), KnownResourcePropertySortOrder.FirstResourceSpecific)]
+    public void ToViewModel_LegacyBuiltInResourceSpecificPropertyMetadata_AppliesFallback(string resourceType, string propertyName, string expectedDisplayNameResourceName, int expectedSortOrder)
     {
-        // Arrange
         var resource = new Resource
         {
             Name = "resource-abc",
@@ -214,22 +224,74 @@ public sealed class ResourceViewModelTests
             }
         };
 
-        // Act
         var vm = ToViewModel(resource, new KnownPropertyLookup());
 
-        // Assert
         var property = vm.Properties[propertyName];
         Assert.Null(property.DisplayName);
         Assert.False(property.IsHighlighted);
         Assert.Equal(expectedSortOrder, property.SortOrder);
         Assert.NotNull(property.KnownProperty);
         Assert.Equal(propertyName, property.KnownProperty.Key);
+
+        var displayedProperty = new DisplayedResourcePropertyViewModel(
+            property,
+            new TestStringLocalizer<DashboardResources>(),
+            new BrowserTimeProvider(NullLoggerFactory.Instance));
+        Assert.Equal($"Localized:{expectedDisplayNameResourceName}", displayedProperty.DisplayName);
     }
 
     [Fact]
-    public void ToViewModel_ProducerMetadataPresent_DisablesLegacyFallbackForResource()
+    public void ToViewModel_LegacyBuiltInPropertyNameOnCustomResource_DoesNotApplyFallback()
     {
-        // Arrange
+        var resource = new Resource
+        {
+            Name = "resource-abc",
+            DisplayName = "resource",
+            ResourceType = "custom",
+            CreatedAt = Timestamp.FromDateTime(s_dateTime),
+            Properties =
+            {
+                new ResourceProperty
+                {
+                    Name = KnownProperties.Container.Image,
+                    Value = Value.ForString("redis:latest")
+                }
+            }
+        };
+
+        var vm = ToViewModel(resource, new KnownPropertyLookup());
+
+        var property = vm.Properties[KnownProperties.Container.Image];
+        Assert.Null(property.DisplayName);
+        Assert.False(property.IsHighlighted);
+        Assert.Equal(int.MaxValue, property.SortOrder);
+        Assert.Null(property.KnownProperty);
+    }
+
+    [Theory]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    public void ToViewModel_ProducerMetadataPresent_DisablesLegacyFallbackForResource(bool hasDisplayName, bool isHighlighted, bool hasSortOrder)
+    {
+        var imageProperty = new ResourceProperty
+        {
+            Name = KnownProperties.Container.Image,
+            Value = Value.ForString("redis:latest")
+        };
+        if (hasDisplayName)
+        {
+            imageProperty.DisplayName = "Producer container image";
+        }
+        if (isHighlighted)
+        {
+            imageProperty.IsHighlighted = true;
+        }
+        if (hasSortOrder)
+        {
+            imageProperty.SortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
+        }
+
         var resource = new Resource
         {
             Name = "container-abc",
@@ -238,14 +300,7 @@ public sealed class ResourceViewModelTests
             CreatedAt = Timestamp.FromDateTime(s_dateTime),
             Properties =
             {
-                new ResourceProperty
-                {
-                    Name = KnownProperties.Container.Image,
-                    Value = Value.ForString("redis:latest"),
-                    DisplayName = "Producer container image",
-                    IsHighlighted = true,
-                    SortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific
-                },
+                imageProperty,
                 new ResourceProperty
                 {
                     Name = KnownProperties.Container.Id,
@@ -254,13 +309,12 @@ public sealed class ResourceViewModelTests
             }
         };
 
-        // Act
         var vm = ToViewModel(resource, new KnownPropertyLookup());
 
-        // Assert
         var image = vm.Properties[KnownProperties.Container.Image];
-        Assert.Equal("Producer container image", image.DisplayName);
-        Assert.True(image.IsHighlighted);
+        Assert.Equal(hasDisplayName ? "Producer container image" : null, image.DisplayName);
+        Assert.Equal(isHighlighted, image.IsHighlighted);
+        Assert.Equal(hasSortOrder ? KnownResourcePropertySortOrder.FirstResourceSpecific : int.MaxValue, image.SortOrder);
         Assert.Null(image.KnownProperty);
 
         var id = vm.Properties[KnownProperties.Container.Id];

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -135,7 +135,7 @@ public sealed class ResourceViewModelTests
                 Assert.Equal("Property1", p.Key);
                 Assert.Equal("Property1", p.Value.Name);
                 Assert.Equal("Value1", p.Value.Value.StringValue);
-                Assert.Equal(123, p.Value.Priority);
+                Assert.Equal(123, p.Value.SortOrder);
                 Assert.Same(kp, p.Value.KnownProperty);
                 Assert.Equal("Property one", p.Value.DisplayName);
                 Assert.True(p.Value.IsHighlighted);
@@ -147,7 +147,7 @@ public sealed class ResourceViewModelTests
                 Assert.Equal("Property2", p.Key);
                 Assert.Equal("Property2", p.Value.Name);
                 Assert.Equal("Value2", p.Value.Value.StringValue);
-                Assert.Equal(123, p.Value.Priority);
+                Assert.Equal(123, p.Value.SortOrder);
                 Assert.Same(kp, p.Value.KnownProperty);
                 Assert.Null(p.Value.DisplayName);
                 Assert.False(p.Value.IsHighlighted);
@@ -174,7 +174,7 @@ public sealed class ResourceViewModelTests
                     Value = Value.ForString("redis:latest"),
                     DisplayName = "Container image",
                     IsHighlighted = true,
-                    SortOrder = 7
+                    SortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific
                 }
             }
         };
@@ -186,8 +186,7 @@ public sealed class ResourceViewModelTests
         var property = vm.Properties[KnownProperties.Container.Image];
         Assert.Equal("Container image", property.DisplayName);
         Assert.True(property.IsHighlighted);
-        Assert.Equal(int.MaxValue, property.Priority);
-        Assert.Equal(7, property.SortOrder);
+        Assert.Equal(KnownResourcePropertySortOrder.FirstResourceSpecific, property.SortOrder);
         Assert.Null(property.KnownProperty);
     }
 

--- a/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
@@ -1192,7 +1192,9 @@ public sealed class TelemetryExportServiceTests
                     Value.ForList(Value.ForString("dependency-resource")),
                     isValueSensitive: false,
                     knownProperty: null,
-                    priority: 0)
+                    sortOrder: 0,
+                    displayName: null,
+                    isHighlighted: false)
             },
             relationships: [new RelationshipViewModel("dependency", "Reference")]);
 
@@ -1312,19 +1314,25 @@ public sealed class TelemetryExportServiceTests
                     Value.ForList(Value.ForNumber(6379), Value.ForNumber(6380)),
                     isValueSensitive: false,
                     knownProperty: null,
-                    priority: 0),
+                    sortOrder: 0,
+                    displayName: null,
+                    isHighlighted: false),
                 ["resource.exitCode"] = new(
                     "resource.exitCode",
                     Value.ForNumber(0),
                     isValueSensitive: false,
                     knownProperty: null,
-                    priority: 0),
+                    sortOrder: 0,
+                    displayName: null,
+                    isHighlighted: false),
                 ["resource.enabled"] = new(
                     "resource.enabled",
                     Value.ForBool(true),
                     isValueSensitive: false,
                     knownProperty: null,
-                    priority: 0)
+                    sortOrder: 0,
+                    displayName: null,
+                    isHighlighted: false)
             });
 
         // Act

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -335,7 +335,9 @@ public class ResourceOutgoingPeerResolverTests
                 value: Value.ForString(connectionString),
                 isValueSensitive: false,
                 knownProperty: null,
-                priority: 0)
+                sortOrder: 0,
+                displayName: null,
+                isHighlighted: false)
         };
 
         return ModelTestHelpers.CreateResource(
@@ -353,7 +355,9 @@ public class ResourceOutgoingPeerResolverTests
                 value: Value.ForString(value),
                 isValueSensitive: false,
                 knownProperty: null,
-                priority: 0)
+                sortOrder: 0,
+                displayName: null,
+                isHighlighted: false)
         };
 
         return ModelTestHelpers.CreateResource(

--- a/tests/Aspire.Dashboard.Tests/Terminal/DefaultTerminalConnectionResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Terminal/DefaultTerminalConnectionResolverTests.cs
@@ -132,7 +132,9 @@ public class DefaultTerminalConnectionResolverTests
             new Value { StringValue = value },
             isValueSensitive: false,
             knownProperty: null,
-            priority: 0);
+            sortOrder: 0,
+            displayName: null,
+            isHighlighted: false);
     }
 
     private sealed class DisabledDashboardClient : IDashboardClient

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceDataTerminalTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceDataTerminalTests.cs
@@ -144,7 +144,7 @@ public class DashboardServiceDataTerminalTests
     private static bool HasTerminalProperty(ResourceSnapshot snapshot, string name)
         => snapshot.Properties.Any(p => string.Equals(p.Name, name, StringComparison.Ordinal));
 
-    private static (string Name, Google.Protobuf.WellKnownTypes.Value Value, bool IsSensitive, string? DisplayName, bool IsHighlighted) GetTerminalProperty(ResourceSnapshot snapshot, string name)
+    private static (string Name, Google.Protobuf.WellKnownTypes.Value Value, bool IsSensitive, string? DisplayName, bool IsHighlighted, int? SortOrder) GetTerminalProperty(ResourceSnapshot snapshot, string name)
         => snapshot.Properties.Single(p => string.Equals(p.Name, name, StringComparison.Ordinal));
 
     private static IReadOnlyList<TerminalHostResource> GetTerminalHosts(Resource resource)

--- a/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
@@ -16,6 +16,77 @@ public class ResourceSnapshotBuilderTests
     private const string ResolvedPortArgument = "52731";
 
     [Fact]
+    public void ContainerSnapshotAddsDisplayMetadataForDashboardProperties()
+    {
+        var container = Container.Create("container", "redis:latest");
+        container.Spec.Command = "redis-server";
+        container.Spec.Ports = [new() { ContainerPort = 6379 }];
+        container.Spec.Persistent = true;
+        container.Status = new ContainerStatus
+        {
+            ContainerId = "1234567890abcdef",
+            EffectiveArgs = ["--appendonly", "yes"]
+        };
+
+        var snapshot = CreateSnapshotBuilder().ToSnapshot(container, CreatePreviousSnapshot());
+
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Image, "Container image", isSensitive: false, sortOrder: 7);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Id, "Container ID", isSensitive: false, sortOrder: 8);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Command, "Container command", isSensitive: false, sortOrder: 9);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Args, "Container arguments", isSensitive: true, sortOrder: 10);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Ports, "Container ports", isSensitive: false, sortOrder: 11);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Lifetime, "Container lifetime", isSensitive: false, sortOrder: 12);
+    }
+
+    [Fact]
+    public void ExecutableSnapshotAddsDisplayMetadataForDashboardProperties()
+    {
+        var executable = Executable.Create("exe", "dotnet");
+        executable.Spec.WorkingDirectory = "/app";
+        executable.Status = new ExecutableStatus
+        {
+            EffectiveArgs = ["run"],
+            ProcessId = 1234
+        };
+
+        var snapshot = CreateSnapshotBuilder().ToSnapshot(executable, CreatePreviousSnapshot());
+
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Path, "Executable path", isSensitive: false, sortOrder: 7);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.WorkDir, "Working directory", isSensitive: false, sortOrder: 8);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Args, "Executable arguments", isSensitive: true, sortOrder: 9);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: 10);
+    }
+
+    [Fact]
+    public void ProjectSnapshotAddsDisplayMetadataForDashboardProperties()
+    {
+        var project = new ProjectResource("project");
+        project.Annotations.Add(new TestProjectMetadata());
+        project.Annotations.Add(new LaunchProfileAnnotation("https"));
+
+        var executable = Executable.Create("project", "dotnet");
+        executable.Annotate(DcpCustomResource.ResourceNameAnnotation, project.Name);
+        executable.Spec.WorkingDirectory = "/app";
+        executable.Status = new ExecutableStatus
+        {
+            EffectiveArgs = ["run"],
+            ProcessId = 1234
+        };
+
+        var snapshot = CreateSnapshotBuilder(new Dictionary<string, IResource>
+        {
+            [project.Name] = project
+        }).ToSnapshot(executable, CreatePreviousSnapshot());
+
+        AssertDefaultProperty(snapshot, KnownProperties.Executable.Path, isSensitive: false);
+        AssertDefaultProperty(snapshot, KnownProperties.Executable.WorkDir, isSensitive: false);
+        AssertDefaultProperty(snapshot, KnownProperties.Executable.Args, isSensitive: true);
+        AssertHighlightedProperty(snapshot, KnownProperties.Project.Path, "Project path", isSensitive: false, sortOrder: 7);
+        AssertHighlightedProperty(snapshot, KnownProperties.Project.LaunchProfile, "Launch profile", isSensitive: false, sortOrder: 8);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: 9);
+    }
+
+    [Fact]
     public void ExecutableSnapshotPreservesLaunchArgumentSensitivityWhenUsingEffectiveArgs()
     {
         var executable = CreateExecutable(
@@ -140,9 +211,43 @@ public class ResourceSnapshotBuilderTests
         return Assert.Single(snapshot.Properties, p => p.Name == name);
     }
 
+    private static void AssertHighlightedProperty(CustomResourceSnapshot snapshot, string name, string displayName, bool isSensitive, int sortOrder)
+    {
+        var property = GetProperty(snapshot, name);
+        Assert.Equal(displayName, property.DisplayName);
+        Assert.True(property.IsHighlighted);
+        Assert.Equal(isSensitive, property.IsSensitive);
+        Assert.Equal(sortOrder, property.SortOrder);
+    }
+
+    private static void AssertDefaultProperty(CustomResourceSnapshot snapshot, string name, bool isSensitive)
+    {
+        var property = GetProperty(snapshot, name);
+        Assert.Null(property.DisplayName);
+        Assert.False(property.IsHighlighted);
+        Assert.Equal(isSensitive, property.IsSensitive);
+        Assert.Null(property.SortOrder);
+    }
+
     private static IEnumerable<T> GetEnumerablePropertyValue<T>(CustomResourceSnapshot snapshot, string name)
     {
         var property = GetProperty(snapshot, name);
         return Assert.IsAssignableFrom<IEnumerable<T>>(property.Value);
+    }
+
+    private sealed class TestProjectMetadata : IProjectMetadata
+    {
+        public string ProjectPath => "/app/project.csproj";
+
+        public LaunchSettings LaunchSettings { get; } = new()
+        {
+            Profiles =
+            {
+                ["https"] = new LaunchProfile
+                {
+                    CommandName = "Project"
+                }
+            }
+        };
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
@@ -29,13 +29,14 @@ public class ResourceSnapshotBuilderTests
         };
 
         var snapshot = CreateSnapshotBuilder().ToSnapshot(container, CreatePreviousSnapshot());
+        var firstResourceSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
 
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Image, "Container image", isSensitive: false, sortOrder: 7);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Id, "Container ID", isSensitive: false, sortOrder: 8);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Command, "Container command", isSensitive: false, sortOrder: 9);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Args, "Container arguments", isSensitive: true, sortOrder: 10);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Ports, "Container ports", isSensitive: false, sortOrder: 11);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Lifetime, "Container lifetime", isSensitive: false, sortOrder: 12);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Image, "Container image", isSensitive: false, sortOrder: firstResourceSpecificSortOrder);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Id, "Container ID", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 1);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Command, "Container command", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 2);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Args, "Container arguments", isSensitive: true, sortOrder: firstResourceSpecificSortOrder + 3);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Ports, "Container ports", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 4);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Lifetime, "Container lifetime", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 5);
     }
 
     [Fact]
@@ -50,11 +51,12 @@ public class ResourceSnapshotBuilderTests
         };
 
         var snapshot = CreateSnapshotBuilder().ToSnapshot(executable, CreatePreviousSnapshot());
+        var firstResourceSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
 
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Path, "Executable path", isSensitive: false, sortOrder: 7);
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.WorkDir, "Working directory", isSensitive: false, sortOrder: 8);
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Args, "Executable arguments", isSensitive: true, sortOrder: 9);
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: 10);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Path, "Executable path", isSensitive: false, sortOrder: firstResourceSpecificSortOrder);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.WorkDir, "Working directory", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 1);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Args, "Executable arguments", isSensitive: true, sortOrder: firstResourceSpecificSortOrder + 2);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 3);
     }
 
     [Fact]
@@ -77,13 +79,14 @@ public class ResourceSnapshotBuilderTests
         {
             [project.Name] = project
         }).ToSnapshot(executable, CreatePreviousSnapshot());
+        var firstResourceSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
 
         AssertDefaultProperty(snapshot, KnownProperties.Executable.Path, isSensitive: false);
         AssertDefaultProperty(snapshot, KnownProperties.Executable.WorkDir, isSensitive: false);
         AssertDefaultProperty(snapshot, KnownProperties.Executable.Args, isSensitive: true);
-        AssertHighlightedProperty(snapshot, KnownProperties.Project.Path, "Project path", isSensitive: false, sortOrder: 7);
-        AssertHighlightedProperty(snapshot, KnownProperties.Project.LaunchProfile, "Launch profile", isSensitive: false, sortOrder: 8);
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: 9);
+        AssertHighlightedProperty(snapshot, KnownProperties.Project.Path, "Project path", isSensitive: false, sortOrder: firstResourceSpecificSortOrder);
+        AssertHighlightedProperty(snapshot, KnownProperties.Project.LaunchProfile, "Launch profile", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 1);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 2);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
@@ -29,14 +29,14 @@ public class ResourceSnapshotBuilderTests
         };
 
         var snapshot = CreateSnapshotBuilder().ToSnapshot(container, CreatePreviousSnapshot());
-        var firstResourceSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
+        var producerDefinedSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
 
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Image, "Container image", isSensitive: false, sortOrder: firstResourceSpecificSortOrder);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Id, "Container ID", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 1);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Command, "Container command", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 2);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Args, "Container arguments", isSensitive: true, sortOrder: firstResourceSpecificSortOrder + 3);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Ports, "Container ports", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 4);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Lifetime, "Container lifetime", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 5);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Image, "Container image", isSensitive: false, sortOrder: producerDefinedSortOrderStart);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Id, "Container ID", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 1);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Command, "Container command", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 2);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Args, "Container arguments", isSensitive: true, sortOrder: producerDefinedSortOrderStart + 3);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Ports, "Container ports", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 4);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Lifetime, "Container lifetime", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 5);
     }
 
     [Fact]
@@ -51,12 +51,12 @@ public class ResourceSnapshotBuilderTests
         };
 
         var snapshot = CreateSnapshotBuilder().ToSnapshot(executable, CreatePreviousSnapshot());
-        var firstResourceSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
+        var producerDefinedSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
 
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Path, "Executable path", isSensitive: false, sortOrder: firstResourceSpecificSortOrder);
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.WorkDir, "Working directory", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 1);
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Args, "Executable arguments", isSensitive: true, sortOrder: firstResourceSpecificSortOrder + 2);
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 3);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Path, "Executable path", isSensitive: false, sortOrder: producerDefinedSortOrderStart);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.WorkDir, "Working directory", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 1);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Args, "Executable arguments", isSensitive: true, sortOrder: producerDefinedSortOrderStart + 2);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 3);
     }
 
     [Fact]
@@ -79,14 +79,14 @@ public class ResourceSnapshotBuilderTests
         {
             [project.Name] = project
         }).ToSnapshot(executable, CreatePreviousSnapshot());
-        var firstResourceSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
+        var producerDefinedSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
 
         AssertDefaultProperty(snapshot, KnownProperties.Executable.Path, isSensitive: false);
         AssertDefaultProperty(snapshot, KnownProperties.Executable.WorkDir, isSensitive: false);
         AssertDefaultProperty(snapshot, KnownProperties.Executable.Args, isSensitive: true);
-        AssertHighlightedProperty(snapshot, KnownProperties.Project.Path, "Project path", isSensitive: false, sortOrder: firstResourceSpecificSortOrder);
-        AssertHighlightedProperty(snapshot, KnownProperties.Project.LaunchProfile, "Launch profile", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 1);
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: firstResourceSpecificSortOrder + 2);
+        AssertHighlightedProperty(snapshot, KnownProperties.Project.Path, "Project path", isSensitive: false, sortOrder: producerDefinedSortOrderStart);
+        AssertHighlightedProperty(snapshot, KnownProperties.Project.LaunchProfile, "Launch profile", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 1);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 2);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
@@ -27,16 +27,14 @@ public class ResourceSnapshotBuilderTests
             ContainerId = "1234567890abcdef",
             EffectiveArgs = ["--appendonly", "yes"]
         };
-
         var snapshot = CreateSnapshotBuilder().ToSnapshot(container, CreatePreviousSnapshot());
-        var producerDefinedSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
 
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Image, "Container image", isSensitive: false, sortOrder: producerDefinedSortOrderStart);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Id, "Container ID", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 1);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Command, "Container command", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 2);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Args, "Container arguments", isSensitive: true, sortOrder: producerDefinedSortOrderStart + 3);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Ports, "Container ports", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 4);
-        AssertHighlightedProperty(snapshot, KnownProperties.Container.Lifetime, "Container lifetime", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 5);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Image, "Container image", isSensitive: false, sortOrder: 0);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Id, "Container ID", isSensitive: false, sortOrder: 1);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Command, "Container command", isSensitive: false, sortOrder: 2);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Args, "Container arguments", isSensitive: true, sortOrder: 3);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Ports, "Container ports", isSensitive: false, sortOrder: 4);
+        AssertHighlightedProperty(snapshot, KnownProperties.Container.Lifetime, "Container lifetime", isSensitive: false, sortOrder: 5);
     }
 
     [Fact]
@@ -49,14 +47,12 @@ public class ResourceSnapshotBuilderTests
             EffectiveArgs = ["run"],
             ProcessId = 1234
         };
-
         var snapshot = CreateSnapshotBuilder().ToSnapshot(executable, CreatePreviousSnapshot());
-        var producerDefinedSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
 
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Path, "Executable path", isSensitive: false, sortOrder: producerDefinedSortOrderStart);
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.WorkDir, "Working directory", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 1);
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Args, "Executable arguments", isSensitive: true, sortOrder: producerDefinedSortOrderStart + 2);
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 3);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Path, "Executable path", isSensitive: false, sortOrder: 0);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.WorkDir, "Working directory", isSensitive: false, sortOrder: 1);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Args, "Executable arguments", isSensitive: true, sortOrder: 2);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: 3);
     }
 
     [Fact]
@@ -79,14 +75,13 @@ public class ResourceSnapshotBuilderTests
         {
             [project.Name] = project
         }).ToSnapshot(executable, CreatePreviousSnapshot());
-        var producerDefinedSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
 
         AssertDefaultProperty(snapshot, KnownProperties.Executable.Path, isSensitive: false);
         AssertDefaultProperty(snapshot, KnownProperties.Executable.WorkDir, isSensitive: false);
         AssertDefaultProperty(snapshot, KnownProperties.Executable.Args, isSensitive: true);
-        AssertHighlightedProperty(snapshot, KnownProperties.Project.Path, "Project path", isSensitive: false, sortOrder: producerDefinedSortOrderStart);
-        AssertHighlightedProperty(snapshot, KnownProperties.Project.LaunchProfile, "Launch profile", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 1);
-        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: producerDefinedSortOrderStart + 2);
+        AssertHighlightedProperty(snapshot, KnownProperties.Project.Path, "Project path", isSensitive: false, sortOrder: 0);
+        AssertHighlightedProperty(snapshot, KnownProperties.Project.LaunchProfile, "Launch profile", isSensitive: false, sortOrder: 1);
+        AssertHighlightedProperty(snapshot, KnownProperties.Executable.Pid, "Process ID", isSensitive: false, sortOrder: 2);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/DotnetToolResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/DotnetToolResourceTests.cs
@@ -17,9 +17,10 @@ public class DotnetToolResourceTests
         resource.ToolConfiguration!.Version = "1.2.3";
 
         var properties = resource.CreateSnapshotProperties().ToDictionary(p => p.Name);
+        var firstResourceSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
 
-        AssertToolProperty(properties[KnownProperties.Tool.Package], "dotnet-dump", MessageStrings.ResourcePropertyToolPackageDisplayName, 7);
-        AssertToolProperty(properties[KnownProperties.Tool.Version], "1.2.3", MessageStrings.ResourcePropertyToolVersionDisplayName, 8);
+        AssertToolProperty(properties[KnownProperties.Tool.Package], "dotnet-dump", MessageStrings.ResourcePropertyToolPackageDisplayName, firstResourceSpecificSortOrder);
+        AssertToolProperty(properties[KnownProperties.Tool.Version], "1.2.3", MessageStrings.ResourcePropertyToolVersionDisplayName, firstResourceSpecificSortOrder + 1);
 
         var sourceProperty = properties[KnownProperties.Resource.Source];
         Assert.Equal("dotnet-dump", sourceProperty.Value);

--- a/tests/Aspire.Hosting.Tests/DotnetToolResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/DotnetToolResourceTests.cs
@@ -17,10 +17,9 @@ public class DotnetToolResourceTests
         resource.ToolConfiguration!.Version = "1.2.3";
 
         var properties = resource.CreateSnapshotProperties().ToDictionary(p => p.Name);
-        var producerDefinedSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
 
-        AssertToolProperty(properties[KnownProperties.Tool.Package], "dotnet-dump", MessageStrings.ResourcePropertyToolPackageDisplayName, producerDefinedSortOrderStart);
-        AssertToolProperty(properties[KnownProperties.Tool.Version], "1.2.3", MessageStrings.ResourcePropertyToolVersionDisplayName, producerDefinedSortOrderStart + 1);
+        AssertToolProperty(properties[KnownProperties.Tool.Package], "dotnet-dump", MessageStrings.ResourcePropertyToolPackageDisplayName, expectedSortOrder: 0);
+        AssertToolProperty(properties[KnownProperties.Tool.Version], "1.2.3", MessageStrings.ResourcePropertyToolVersionDisplayName, expectedSortOrder: 1);
 
         var sourceProperty = properties[KnownProperties.Resource.Source];
         Assert.Equal("dotnet-dump", sourceProperty.Value);

--- a/tests/Aspire.Hosting.Tests/DotnetToolResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/DotnetToolResourceTests.cs
@@ -17,10 +17,10 @@ public class DotnetToolResourceTests
         resource.ToolConfiguration!.Version = "1.2.3";
 
         var properties = resource.CreateSnapshotProperties().ToDictionary(p => p.Name);
-        var firstResourceSpecificSortOrder = KnownResourcePropertySortOrder.FirstResourceSpecific;
+        var producerDefinedSortOrderStart = KnownResourcePropertySortOrder.ProducerDefinedStart;
 
-        AssertToolProperty(properties[KnownProperties.Tool.Package], "dotnet-dump", MessageStrings.ResourcePropertyToolPackageDisplayName, firstResourceSpecificSortOrder);
-        AssertToolProperty(properties[KnownProperties.Tool.Version], "1.2.3", MessageStrings.ResourcePropertyToolVersionDisplayName, firstResourceSpecificSortOrder + 1);
+        AssertToolProperty(properties[KnownProperties.Tool.Package], "dotnet-dump", MessageStrings.ResourcePropertyToolPackageDisplayName, producerDefinedSortOrderStart);
+        AssertToolProperty(properties[KnownProperties.Tool.Version], "1.2.3", MessageStrings.ResourcePropertyToolVersionDisplayName, producerDefinedSortOrderStart + 1);
 
         var sourceProperty = properties[KnownProperties.Resource.Source];
         Assert.Equal("dotnet-dump", sourceProperty.Value);

--- a/tests/Aspire.Hosting.Tests/DotnetToolResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/DotnetToolResourceTests.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREDOTNETTOOL // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
+using Aspire.Dashboard.Model;
+using Aspire.Hosting.Resources;
+
+namespace Aspire.Hosting.Tests;
+
+public class DotnetToolResourceTests
+{
+    [Fact]
+    public void CreateSnapshotPropertiesAddsDisplayMetadataForToolProperties()
+    {
+        var resource = new DotnetToolResource("tool", "dotnet-dump");
+        resource.ToolConfiguration!.Version = "1.2.3";
+
+        var properties = resource.CreateSnapshotProperties().ToDictionary(p => p.Name);
+
+        AssertToolProperty(properties[KnownProperties.Tool.Package], "dotnet-dump", MessageStrings.ResourcePropertyToolPackageDisplayName, 7);
+        AssertToolProperty(properties[KnownProperties.Tool.Version], "1.2.3", MessageStrings.ResourcePropertyToolVersionDisplayName, 8);
+
+        var sourceProperty = properties[KnownProperties.Resource.Source];
+        Assert.Equal("dotnet-dump", sourceProperty.Value);
+        Assert.Null(sourceProperty.DisplayName);
+        Assert.False(sourceProperty.IsHighlighted);
+        Assert.Null(sourceProperty.SortOrder);
+    }
+
+    private static void AssertToolProperty(ResourcePropertySnapshot property, string expectedValue, string expectedDisplayName, int expectedSortOrder)
+    {
+        Assert.Equal(expectedValue, property.Value);
+        Assert.Equal(expectedDisplayName, property.DisplayName);
+        Assert.True(property.IsHighlighted);
+        Assert.Equal(expectedSortOrder, property.SortOrder);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -259,16 +259,15 @@ public class ParameterProcessorTests
         // Marking them as Running with the provided values
         await updates.MoveNextAsync().DefaultTimeout();
         Assert.Equal(KnownResourceStates.Running, updates.Current.Snapshot.State?.Text);
-        Assert.Equal("value1", updates.Current.Snapshot.Properties.FirstOrDefault(p => p.Name == KnownProperties.Parameter.Value)?.Value);
+        AssertParameterValueProperty(updates.Current.Snapshot, "value1", isSensitive: false);
 
         await updates.MoveNextAsync().DefaultTimeout();
         Assert.Equal(KnownResourceStates.Running, updates.Current.Snapshot.State?.Text);
-        Assert.Equal("value2", updates.Current.Snapshot.Properties.FirstOrDefault(p => p.Name == KnownProperties.Parameter.Value)?.Value);
+        AssertParameterValueProperty(updates.Current.Snapshot, "value2", isSensitive: false);
 
         await updates.MoveNextAsync().DefaultTimeout();
         Assert.Equal(KnownResourceStates.Running, updates.Current.Snapshot.State?.Text);
-        Assert.Equal("secretValue", updates.Current.Snapshot.Properties.FirstOrDefault(p => p.Name == KnownProperties.Parameter.Value)?.Value);
-        Assert.True(updates.Current.Snapshot.Properties.FirstOrDefault(p => p.Name == KnownProperties.Parameter.Value)?.IsSensitive ?? false);
+        AssertParameterValueProperty(updates.Current.Snapshot, "secretValue", isSensitive: true);
     }
 
     [Fact]
@@ -1264,6 +1263,17 @@ public class ParameterProcessorTests
             .Build();
 
         return new ParameterResource(name, _ => configuration[$"Parameters:{name}"] ?? throw new MissingParameterValueException($"Parameter '{name}' is missing"), secret);
+    }
+
+    private static void AssertParameterValueProperty(CustomResourceSnapshot snapshot, string expectedValue, bool isSensitive)
+    {
+        var property = Assert.Single(snapshot.Properties, p => p.Name == KnownProperties.Parameter.Value);
+
+        Assert.Equal(expectedValue, property.Value);
+        Assert.Equal(isSensitive, property.IsSensitive);
+        Assert.Equal(MessageStrings.ResourcePropertyParameterValueDisplayName, property.DisplayName);
+        Assert.True(property.IsHighlighted);
+        Assert.Equal(KnownResourcePropertySortOrder.ProducerDefinedStart, property.SortOrder);
     }
 
     private static ParameterResource CreateParameterWithMissingValue(string name, bool secret = false)

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -1273,7 +1273,7 @@ public class ParameterProcessorTests
         Assert.Equal(isSensitive, property.IsSensitive);
         Assert.Equal(MessageStrings.ResourcePropertyParameterValueDisplayName, property.DisplayName);
         Assert.True(property.IsHighlighted);
-        Assert.Equal(KnownResourcePropertySortOrder.ProducerDefinedStart, property.SortOrder);
+        Assert.Equal(0, property.SortOrder);
     }
 
     private static ParameterResource CreateParameterWithMissingValue(string name, bool secret = false)


### PR DESCRIPTION
## Description

Follow-up to #1644 after PR #18132 added resource-supplied property display metadata.

This removes dashboard-owned, resource-specific property handling for built-in resource details where the resource/server side can now provide the metadata instead. The dashboard keeps ownership of generic resource properties such as display name, state, health, start/stop time, exit code, and connection string. Resource producers now provide labels, default highlighting, and ordering for resource-specific properties.

Producer metadata is emitted from:

- Hosting/DCP snapshot metadata for Project, Executable, and Container properties.
- `ParameterResource` for parameter values.
- `DotnetToolResource` for tool package/version details.

Sort order is producer-local: producers use simple values such as `0`, `1`, and `2` for their own properties. The dashboard normalizes producer-defined and legacy fallback sort orders after the generic dashboard-owned properties, preserving the previous details ordering without requiring producers to know a dashboard-specific starting constant.

### Compatibility

The protocol changes are additive metadata fields, so older dashboards ignore the new fields and newer dashboards handle missing metadata. To avoid a UX regression with old built-in resource servers, the dashboard includes a temporary legacy fallback for Project, Executable, Container, and Parameter snapshots that do not carry producer metadata. If producer metadata is present for a built-in resource, the dashboard trusts it and does not apply the fallback.

This is not expected to be a breaking change.

### User-facing behavior

The resource details panel continues to show the important Project, Executable, Container, Parameter, and DotnetTool properties with the same labels, default visibility, and ordering as before. Unknown properties that producers mark as highlighted are shown by default. Parameter resources still show the custom `Value not set` experience.

Manual Stress playground comparison was performed for `manual-project-args`, `manual-arg-source`, `manual-container-args`, `api-key`, and `manual-dotnet-tool-args`.

### Validation

```text
dotnet build /t:UpdateXlf src/Aspire.Hosting/Aspire.Hosting.csproj
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.ResourceSnapshotBuilderTests" --filter-class "*.DotnetToolResourceTests" --filter-class "*.ParameterProcessorTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-class "*.ResourceViewModelTests" --filter-class "*.KnownPropertyLookupTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet test --project tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj --no-launch-profile -- --filter-class "*.ResourceDetailsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
git diff --check
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No