### PR TITLE
[release/13.4] Validate playwrightCliVersion shape with strict SemVer

### DIFF
--- a/src/Aspire.Cli/Agents/Playwright/PlaywrightCliInstaller.cs
+++ b/src/Aspire.Cli/Agents/Playwright/PlaywrightCliInstaller.cs
@@ -124,11 +124,27 @@ internal sealed class PlaywrightCliInstaller(
 
         // Step 1: Resolve the target version and integrity hash from the npm registry.
         var versionOverride = configuration[VersionOverrideKey];
-        var effectiveRange = !string.IsNullOrEmpty(versionOverride) ? versionOverride : VersionRange;
+        string effectiveRange;
 
         if (!string.IsNullOrEmpty(versionOverride))
         {
+            // The override is forwarded directly to npm as an exact version specifier, so reject
+            // anything that is not a strict SemVer 2.0 version (e.g. ranges like ">=1.0.0", npm
+            // dist-tags like "latest", or arbitrary strings). This prevents a malformed config
+            // value from being interpreted by npm in unexpected ways and gives the user a clear
+            // error rather than a generic resolve failure.
+            // See https://semver.org/spec/v2.0.0.html for the accepted shape.
+            if (!SemVersion.TryParse(versionOverride, SemVersionStyles.Strict, out _))
+            {
+                return (PlaywrightInstallStatus.Failed, string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.PlaywrightCliInstaller_InvalidVersionOverride, VersionOverrideKey, versionOverride));
+            }
+
+            effectiveRange = versionOverride;
             logger.LogDebug("Using version override from '{ConfigKey}': {Version}", VersionOverrideKey, versionOverride);
+        }
+        else
+        {
+            effectiveRange = VersionRange;
         }
 
         logger.LogDebug("Resolving {Package}@{Range} from npm registry.", PackageName, effectiveRange);

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
@@ -412,6 +412,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The value of configuration setting &apos;{0}&apos; (&apos;{1}&apos;) is not a valid SemVer 2.0 version..
+        /// </summary>
+        internal static string PlaywrightCliInstaller_InvalidVersionOverride {
+            get {
+                return ResourceManager.GetString("PlaywrightCliInstaller_InvalidVersionOverride", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Provenance verification failed for {0}: {1}.
         /// </summary>
         internal static string PlaywrightCliInstaller_ProvenanceVerificationFailed {

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.resx
@@ -177,6 +177,9 @@
   <data name="PlaywrightCliInstaller_FailedToResolvePackage" xml:space="preserve">
     <value>Failed to resolve {0} from the npm registry.</value>
   </data>
+  <data name="PlaywrightCliInstaller_InvalidVersionOverride" xml:space="preserve">
+    <value>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</value>
+  </data>
   <data name="PlaywrightCliInstaller_ProvenanceVerificationFailed" xml:space="preserve">
     <value>Provenance verification failed for {0}: {1}</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
@@ -137,6 +137,11 @@
         <target state="new">Integrity verification failed for {0}. The downloaded package may have been tampered with.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlaywrightCliInstaller_InvalidVersionOverride">
+        <source>The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</source>
+        <target state="new">The value of configuration setting '{0}' ('{1}') is not a valid SemVer 2.0 version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlaywrightCliInstaller_ProvenanceVerificationFailed">
         <source>Provenance verification failed for {0}: {1}</source>
         <target state="new">Provenance verification failed for {0}: {1}</target>

--- a/tests/Aspire.Cli.Tests/Agents/PlaywrightCliInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/PlaywrightCliInstallerTests.cs
@@ -586,6 +586,47 @@ public class PlaywrightCliInstallerTests
         }
     }
 
+    [Theory]
+    [InlineData(">=0.2.0")]
+    [InlineData("latest")]
+    [InlineData("0.2")]
+    [InlineData("not-a-version")]
+    [InlineData("v0.2.0")]
+    public async Task InstallAsync_WhenVersionOverrideIsNotStrictSemVer_ReturnsFailed(string invalidVersion)
+    {
+        var tempDir = CreateTestRepoRoot();
+
+        try
+        {
+            var npmRunner = new TestNpmRunner
+            {
+                ResolveResult = new NpmPackageInfo { Version = SemVersion.Parse("0.2.0", SemVersionStyles.Strict), Integrity = "sha512-abc123" }
+            };
+            var playwrightRunner = new TestPlaywrightCliRunner();
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [PlaywrightCliInstaller.VersionOverrideKey] = invalidVersion
+                })
+                .Build();
+            var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestInteractionService(), configuration, NullLogger<PlaywrightCliInstaller>.Instance);
+
+            var (status, message) = await installer.InstallAsync(tempDir, s_emptySkillDirs, CancellationToken.None);
+
+            Assert.Equal(PlaywrightInstallStatus.Failed, status);
+            Assert.NotNull(message);
+            Assert.Contains(invalidVersion, message);
+            Assert.Null(npmRunner.ResolvedVersionRange);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
     [Fact]
     public async Task InstallAsync_WhenNoVersionOverride_UsesDefaultRange()
     {


### PR DESCRIPTION
Backport of the internal fix for strict SemVer validation of playwrightCliVersion.