### PR TITLE
Replace custom RemoveSpectreFormatting with Spectre.Console's Markup.Remove

### DIFF
--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -415,7 +415,7 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
 
         var choicesList = choices.ToList();
         // this will throw if formatting results in non-distinct values. that should happen because we cannot send the formatter over the wire.
-        var choicesByFormattedValue = choicesList.ToDictionary(choice => choiceFormatter(choice).RemoveSpectreFormatting(), choice => choice);
+        var choicesByFormattedValue = choicesList.ToDictionary(choice => Markup.Remove(choiceFormatter(choice)), choice => choice);
 
         using var activity = _activitySource.StartActivity();
 
@@ -445,7 +445,7 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
 
         var choicesList = choices.ToList();
         // this will throw if formatting results in non-distinct values. that should happen because we cannot send the formatter over the wire.
-        var choicesByFormattedValue = choicesList.ToDictionary(choice => choiceFormatter(choice).RemoveSpectreFormatting(), choice => choice);
+        var choicesByFormattedValue = choicesList.ToDictionary(choice => Markup.Remove(choiceFormatter(choice)), choice => choice);
 
         using var activity = _activitySource.StartActivity();
 

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -415,7 +415,7 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
 
         var choicesList = choices.ToList();
         // this will throw if formatting results in non-distinct values. that should happen because we cannot send the formatter over the wire.
-        var choicesByFormattedValue = choicesList.ToDictionary(choice => Markup.Remove(choiceFormatter(choice)), choice => choice);
+        var choicesByFormattedValue = choicesList.ToDictionary(choice => StringUtils.RemoveMarkup(choiceFormatter(choice)), choice => choice);
 
         using var activity = _activitySource.StartActivity();
 
@@ -445,7 +445,7 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
 
         var choicesList = choices.ToList();
         // this will throw if formatting results in non-distinct values. that should happen because we cannot send the formatter over the wire.
-        var choicesByFormattedValue = choicesList.ToDictionary(choice => Markup.Remove(choiceFormatter(choice)), choice => choice);
+        var choicesByFormattedValue = choicesList.ToDictionary(choice => StringUtils.RemoveMarkup(choiceFormatter(choice)), choice => choice);
 
         using var activity = _activitySource.StartActivity();
 

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -511,7 +511,7 @@ internal class ConsoleInteractionService : IInteractionService
         {
             // Only attempt to parse/remove markup when the message is expected to contain it.
             // Plain text messages may contain characters like '[' that would be rejected by the markup parser.
-            var logMessage = allowMarkup ? message.RemoveMarkup() : message;
+            var logMessage = allowMarkup ? StringUtils.RemoveMarkup(message) : message;
             logger.LogInformation("{Message}", ConsoleHelpers.FormatEmojiPrefix(emoji, target, replaceEmoji: true) + logMessage);
         }
 
@@ -845,7 +845,7 @@ internal class ConsoleInteractionService : IInteractionService
         // text. Some choice formatters intentionally include [bold]/[dim]/etc. tokens for the
         // interactive multi-select renderer; those tokens would otherwise leak verbatim through
         // DisplaySubtleMessage and confuse anyone diagnosing a typoed --option value.
-        var availableChoices = string.Join(", ", choices.Select(c => Markup.Remove(choiceFormatter(c))));
+        var availableChoices = string.Join(", ", choices.Select(c => StringUtils.RemoveMarkup(choiceFormatter(c))));
         DisplaySubtleMessage(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NonInteractiveAvailableValues, availableChoices));
         throw new NonInteractiveException(symbolDisplayName);
     }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -845,7 +845,7 @@ internal class ConsoleInteractionService : IInteractionService
         // text. Some choice formatters intentionally include [bold]/[dim]/etc. tokens for the
         // interactive multi-select renderer; those tokens would otherwise leak verbatim through
         // DisplaySubtleMessage and confuse anyone diagnosing a typoed --option value.
-        var availableChoices = string.Join(", ", choices.Select(c => choiceFormatter(c).RemoveSpectreFormatting()));
+        var availableChoices = string.Join(", ", choices.Select(c => Markup.Remove(choiceFormatter(c))));
         DisplaySubtleMessage(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NonInteractiveAvailableValues, availableChoices));
         throw new NonInteractiveException(symbolDisplayName);
     }

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -62,7 +62,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 {
                     try
                     {
-                        await Backchannel.DisplayErrorAsync(Markup.Remove(ex.Message), _cancellationToken);
+                        await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(ex.Message), _cancellationToken);
                     }
                     catch (Exception displayErrorException)
                     {
@@ -94,7 +94,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(Markup.Remove(statusText), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cancellationToken));
         Debug.Assert(result);
 
         try
@@ -111,7 +111,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public async Task<T> ShowDynamicStatusAsync<T>(string initialStatusText, Func<Action<string>, Task<T>> action, KnownEmoji? emoji = null)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(Markup.Remove(initialStatusText), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(initialStatusText), _cancellationToken));
         Debug.Assert(result);
 
         try
@@ -120,7 +120,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 initialStatusText,
                 updateStatus => action(statusText =>
                 {
-                    var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(Markup.Remove(statusText), _cancellationToken));
+                    var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cancellationToken));
                     Debug.Assert(result);
                     updateStatus(statusText);
                 }),
@@ -135,7 +135,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(Markup.Remove(statusText), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cancellationToken));
         Debug.Assert(result);
 
         try
@@ -178,17 +178,17 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                         if (hasSecretPromptsCapability)
                         {
                             // Use the new dedicated secret prompt method (no default value for secrets)
-                            result = await Backchannel.PromptForSecretStringAsync(Markup.Remove(promptText), validator, required, _cancellationToken).ConfigureAwait(false);
+                            result = await Backchannel.PromptForSecretStringAsync(StringUtils.RemoveMarkup(promptText), validator, required, _cancellationToken).ConfigureAwait(false);
                         }
                         else
                         {
                             // Fallback to regular prompt for older extension versions
-                            result = await Backchannel.PromptForStringAsync(Markup.Remove(promptText), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
+                            result = await Backchannel.PromptForStringAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
                         }
                     }
                     else
                     {
-                        result = await Backchannel.PromptForStringAsync(Markup.Remove(promptText), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
+                        result = await Backchannel.PromptForStringAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
                     }
 
                     tcs.SetResult(result);
@@ -228,7 +228,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 {
                     try
                     {
-                        var result = await Backchannel.PromptForFilePathAsync(Markup.Remove(promptText), binding?.DefaultValue, directory, _cancellationToken).ConfigureAwait(false);
+                        var result = await Backchannel.PromptForFilePathAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, directory, _cancellationToken).ConfigureAwait(false);
                         tcs.SetResult(result);
                     }
                     catch (Exception ex)
@@ -282,7 +282,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
             {
                 try
                 {
-                    var result = await Backchannel.ConfirmAsync(Markup.Remove(promptText), binding?.DefaultValue ?? false, _cancellationToken).ConfigureAwait(false);
+                    var result = await Backchannel.ConfirmAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue ?? false, _cancellationToken).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -320,7 +320,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
             {
                 try
                 {
-                    var result = await Backchannel.PromptForSelectionAsync(Markup.Remove(promptText), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
+                    var result = await Backchannel.PromptForSelectionAsync(StringUtils.RemoveMarkup(promptText), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -361,7 +361,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 {
                     // Note: The extension backchannel protocol does not yet support preSelected items.
                     // Pre-selected items are applied only when falling back to the console interaction service.
-                    var result = await Backchannel.PromptForSelectionsAsync(Markup.Remove(promptText), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
+                    var result = await Backchannel.PromptForSelectionsAsync(StringUtils.RemoveMarkup(promptText), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -399,7 +399,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         // out-of-order output like an error message preceding the lines that explain it.
         var result = _extensionTaskChannel.Writer.TryWrite(async () =>
         {
-            await Backchannel.DisplayErrorAsync(Markup.Remove(errorMessage), _cancellationToken);
+            await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(errorMessage), _cancellationToken);
             _consoleInteractionService.DisplayError(errorMessage, allowMarkup);
         });
         Debug.Assert(result);
@@ -409,7 +409,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
     {
         var result = _extensionTaskChannel.Writer.TryWrite(async () =>
         {
-            await Backchannel.DisplayMessageAsync(emoji.Name, Markup.Remove(message), _cancellationToken);
+            await Backchannel.DisplayMessageAsync(emoji.Name, StringUtils.RemoveMarkup(message), _cancellationToken);
             _consoleInteractionService.DisplayMessage(emoji, message, allowMarkup, consoleOverride);
         });
         Debug.Assert(result);
@@ -417,14 +417,14 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySuccessAsync(Markup.Remove(message), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySuccessAsync(StringUtils.RemoveMarkup(message), _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplaySuccess(message, allowMarkup);
     }
 
     public void DisplaySubtleMessage(string message, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySubtleMessageAsync(Markup.Remove(message), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySubtleMessageAsync(StringUtils.RemoveMarkup(message), _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplaySubtleMessage(message, allowMarkup);
     }
@@ -447,7 +447,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(materialized.Select(line => new DisplayLineState(
             line.Stream == OutputLineStream.StdOut ? "stdout" : "stderr",
-            Markup.Remove(line.Line))), _cancellationToken));
+            StringUtils.RemoveMarkup(line.Line))), _cancellationToken));
         Debug.Assert(result);
 
         // Intentionally do NOT also write to the local console here. Unlike most Display* methods
@@ -514,7 +514,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
     public void DisplayMarkupLine(string markup)
     {
         // Strip markup for backchannel, display as-is to console
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, Markup.Remove(markup), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, StringUtils.RemoveMarkup(markup), _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplayMarkupLine(markup);
     }
@@ -536,7 +536,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void LogMessage(LogLevel logLevel, string message)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(logLevel, Markup.Remove(message), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(logLevel, StringUtils.RemoveMarkup(message), _cancellationToken));
         Debug.Assert(result);
     }
 
@@ -568,7 +568,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void WriteDebugSessionMessage(string message, bool stdout, string? textStyle)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(Markup.Remove(message), stdout, textStyle, _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(StringUtils.RemoveMarkup(message), stdout, textStyle, _cancellationToken));
         Debug.Assert(result);
     }
 }

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -62,7 +62,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 {
                     try
                     {
-                        await Backchannel.DisplayErrorAsync(ex.Message.RemoveSpectreFormatting(), _cancellationToken);
+                        await Backchannel.DisplayErrorAsync(Markup.Remove(ex.Message), _cancellationToken);
                     }
                     catch (Exception displayErrorException)
                     {
@@ -94,7 +94,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(statusText.RemoveSpectreFormatting(), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(Markup.Remove(statusText), _cancellationToken));
         Debug.Assert(result);
 
         try
@@ -111,7 +111,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public async Task<T> ShowDynamicStatusAsync<T>(string initialStatusText, Func<Action<string>, Task<T>> action, KnownEmoji? emoji = null)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(initialStatusText.RemoveSpectreFormatting(), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(Markup.Remove(initialStatusText), _cancellationToken));
         Debug.Assert(result);
 
         try
@@ -120,7 +120,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 initialStatusText,
                 updateStatus => action(statusText =>
                 {
-                    var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(statusText.RemoveSpectreFormatting(), _cancellationToken));
+                    var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(Markup.Remove(statusText), _cancellationToken));
                     Debug.Assert(result);
                     updateStatus(statusText);
                 }),
@@ -135,7 +135,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(statusText.RemoveSpectreFormatting(), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(Markup.Remove(statusText), _cancellationToken));
         Debug.Assert(result);
 
         try
@@ -178,17 +178,17 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                         if (hasSecretPromptsCapability)
                         {
                             // Use the new dedicated secret prompt method (no default value for secrets)
-                            result = await Backchannel.PromptForSecretStringAsync(promptText.RemoveSpectreFormatting(), validator, required, _cancellationToken).ConfigureAwait(false);
+                            result = await Backchannel.PromptForSecretStringAsync(Markup.Remove(promptText), validator, required, _cancellationToken).ConfigureAwait(false);
                         }
                         else
                         {
                             // Fallback to regular prompt for older extension versions
-                            result = await Backchannel.PromptForStringAsync(promptText.RemoveSpectreFormatting(), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
+                            result = await Backchannel.PromptForStringAsync(Markup.Remove(promptText), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
                         }
                     }
                     else
                     {
-                        result = await Backchannel.PromptForStringAsync(promptText.RemoveSpectreFormatting(), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
+                        result = await Backchannel.PromptForStringAsync(Markup.Remove(promptText), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
                     }
 
                     tcs.SetResult(result);
@@ -228,7 +228,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 {
                     try
                     {
-                        var result = await Backchannel.PromptForFilePathAsync(promptText.RemoveSpectreFormatting(), binding?.DefaultValue, directory, _cancellationToken).ConfigureAwait(false);
+                        var result = await Backchannel.PromptForFilePathAsync(Markup.Remove(promptText), binding?.DefaultValue, directory, _cancellationToken).ConfigureAwait(false);
                         tcs.SetResult(result);
                     }
                     catch (Exception ex)
@@ -282,7 +282,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
             {
                 try
                 {
-                    var result = await Backchannel.ConfirmAsync(promptText.RemoveSpectreFormatting(), binding?.DefaultValue ?? false, _cancellationToken).ConfigureAwait(false);
+                    var result = await Backchannel.ConfirmAsync(Markup.Remove(promptText), binding?.DefaultValue ?? false, _cancellationToken).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -320,7 +320,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
             {
                 try
                 {
-                    var result = await Backchannel.PromptForSelectionAsync(promptText.RemoveSpectreFormatting(), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
+                    var result = await Backchannel.PromptForSelectionAsync(Markup.Remove(promptText), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -361,7 +361,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 {
                     // Note: The extension backchannel protocol does not yet support preSelected items.
                     // Pre-selected items are applied only when falling back to the console interaction service.
-                    var result = await Backchannel.PromptForSelectionsAsync(promptText.RemoveSpectreFormatting(), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
+                    var result = await Backchannel.PromptForSelectionsAsync(Markup.Remove(promptText), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -399,7 +399,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         // out-of-order output like an error message preceding the lines that explain it.
         var result = _extensionTaskChannel.Writer.TryWrite(async () =>
         {
-            await Backchannel.DisplayErrorAsync(errorMessage.RemoveSpectreFormatting(), _cancellationToken);
+            await Backchannel.DisplayErrorAsync(Markup.Remove(errorMessage), _cancellationToken);
             _consoleInteractionService.DisplayError(errorMessage, allowMarkup);
         });
         Debug.Assert(result);
@@ -409,7 +409,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
     {
         var result = _extensionTaskChannel.Writer.TryWrite(async () =>
         {
-            await Backchannel.DisplayMessageAsync(emoji.Name, message.RemoveSpectreFormatting(), _cancellationToken);
+            await Backchannel.DisplayMessageAsync(emoji.Name, Markup.Remove(message), _cancellationToken);
             _consoleInteractionService.DisplayMessage(emoji, message, allowMarkup, consoleOverride);
         });
         Debug.Assert(result);
@@ -417,14 +417,14 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySuccessAsync(message.RemoveSpectreFormatting(), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySuccessAsync(Markup.Remove(message), _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplaySuccess(message, allowMarkup);
     }
 
     public void DisplaySubtleMessage(string message, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySubtleMessageAsync(message.RemoveSpectreFormatting(), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySubtleMessageAsync(Markup.Remove(message), _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplaySubtleMessage(message, allowMarkup);
     }
@@ -447,7 +447,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(materialized.Select(line => new DisplayLineState(
             line.Stream == OutputLineStream.StdOut ? "stdout" : "stderr",
-            line.Line.RemoveSpectreFormatting())), _cancellationToken));
+            Markup.Remove(line.Line))), _cancellationToken));
         Debug.Assert(result);
 
         // Intentionally do NOT also write to the local console here. Unlike most Display* methods
@@ -514,7 +514,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
     public void DisplayMarkupLine(string markup)
     {
         // Strip markup for backchannel, display as-is to console
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, markup.RemoveSpectreFormatting(), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, Markup.Remove(markup), _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplayMarkupLine(markup);
     }
@@ -536,7 +536,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void LogMessage(LogLevel logLevel, string message)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(logLevel, message.RemoveSpectreFormatting(), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(logLevel, Markup.Remove(message), _cancellationToken));
         Debug.Assert(result);
     }
 
@@ -568,7 +568,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void WriteDebugSessionMessage(string message, bool stdout, string? textStyle)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(message.RemoveSpectreFormatting(), stdout, textStyle, _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(Markup.Remove(message), stdout, textStyle, _cancellationToken));
         Debug.Assert(result);
     }
 }

--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -463,7 +463,7 @@ internal sealed class ConsoleActivityLogger
         var timelineLabel = SharedCommandStrings.PipelineStepTimelineLabel;
         var totalTimeline = orderedRecords.Max(r => r.EndOffset > TimeSpan.Zero ? r.EndOffset : r.Duration);
         var durationWidth = Math.Max(10, orderedRecords.Max(r => FormatSummaryDuration(r.Duration, totalTimeline).Length));
-        var nameWidth = Math.Max(timelineLabel.Length, orderedRecords.Max(r => GetIndentedDisplayName(r).RemoveMarkup().Length));
+        var nameWidth = Math.Max(timelineLabel.Length, orderedRecords.Max(r => StringUtils.RemoveMarkup(GetIndentedDisplayName(r)).Length));
         var renderTimeline = ShouldRenderTimeline(durationWidth, nameWidth, totalTimeline);
         var timelinePrefix = $"  {new string(' ', durationWidth)}    {new string(' ', nameWidth)}  ";
         var timelineLabelPrefix = $"  {new string(' ', durationWidth)}    {timelineLabel.PadRight(nameWidth)}  ";
@@ -490,7 +490,7 @@ internal sealed class ConsoleActivityLogger
             };
             var symbol = _enableColor ? $"[{GetStateColor(rec.State)}]{stateSymbol}[/]" : stateSymbol;
             var displayName = GetIndentedDisplayName(rec);
-            var plainDisplayName = displayName.RemoveMarkup();
+            var plainDisplayName = StringUtils.RemoveMarkup(displayName);
             // Pad based on visible (plain-text) width, then re-append the markup name so tags render correctly.
             var padding = renderTimeline ? Math.Max(0, nameWidth - plainDisplayName.Length) : 0;
             var name = displayName + new string(' ', padding);

--- a/src/Aspire.Cli/Utils/Markdown/MarkdownToSpectreConverter.Markup.cs
+++ b/src/Aspire.Cli/Utils/Markdown/MarkdownToSpectreConverter.Markup.cs
@@ -186,7 +186,7 @@ internal partial class MarkdownToSpectreConverter
                 .Select(cell => RenderTableCellToMarkup(cell, markdown)).ToList())
             .ToList();
         var plainValues = markupValues
-            .Select(static row => row.Select(static cell => cell.RemoveMarkup()).ToList())
+            .Select(static row => row.Select(static cell => StringUtils.RemoveMarkup(cell)).ToList())
             .ToList();
 
         var columnCount = markupValues.Max(static row => row.Count);

--- a/src/Aspire.Cli/Utils/StringUtils.cs
+++ b/src/Aspire.Cli/Utils/StringUtils.cs
@@ -1,10 +1,32 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Spectre.Console;
+
 namespace Aspire.Cli.Utils;
 
 internal static class StringUtils
 {
+    public static string RemoveMarkup(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return input;
+        }
+
+        try
+        {
+            return Markup.Remove(input).Trim();
+        }
+        catch (Exception)
+        {
+            // Backchannel payloads can contain plain text with literal '[' or ']' from
+            // user/project output (for example, compiler diagnostics). Treat malformed
+            // markup as plain text so error reporting never throws while logging another error.
+            return input.Trim();
+        }
+    }
+
     /// <summary>
     /// Calculates a fuzzy match score between a search term and a target string.
     /// </summary>

--- a/src/Aspire.Cli/Utils/StringUtils.cs
+++ b/src/Aspire.Cli/Utils/StringUtils.cs
@@ -16,14 +16,14 @@ internal static class StringUtils
 
         try
         {
-            return Markup.Remove(input).Trim();
+            return Markup.Remove(input);
         }
         catch (InvalidOperationException)
         {
             // Backchannel payloads can contain plain text with literal '[' or ']' from
             // user/project output (for example, compiler diagnostics). Treat malformed
             // markup as plain text so error reporting never throws while logging another error.
-            return input.Trim();
+            return input;
         }
     }
 

--- a/src/Aspire.Cli/Utils/StringUtils.cs
+++ b/src/Aspire.Cli/Utils/StringUtils.cs
@@ -18,7 +18,7 @@ internal static class StringUtils
         {
             return Markup.Remove(input).Trim();
         }
-        catch (Exception)
+        catch (InvalidOperationException)
         {
             // Backchannel payloads can contain plain text with literal '[' or ']' from
             // user/project output (for example, compiler diagnostics). Treat malformed

--- a/src/Aspire.Cli/Utils/StringUtils.cs
+++ b/src/Aspire.Cli/Utils/StringUtils.cs
@@ -1,20 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.RegularExpressions;
-
 namespace Aspire.Cli.Utils;
 
-internal static partial class StringUtils
+internal static class StringUtils
 {
-    public static string RemoveSpectreFormatting(this string input)
-    {
-        return RemoveSpectreFormattingRegex().Replace(input, string.Empty).Trim();
-    }
-
-    [GeneratedRegex(@"\[[^\]]+\]")]
-    private static partial Regex RemoveSpectreFormattingRegex();
-
     /// <summary>
     /// Calculates a fuzzy match score between a search term and a target string.
     /// </summary>

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -1602,21 +1602,21 @@ public class ConsoleInteractionServiceTests
     }
 
     [Fact]
-    public async Task PromptForSelectionsAsync_NonInteractive_CliProvidedInvalidValue_WithUnescapedClosingBracketInChoiceLabel_ThrowsInvalidOperationException()
+    public async Task PromptForSelectionsAsync_NonInteractive_CliProvidedInvalidValue_WithUnescapedClosingBracketInChoiceLabel_DoesNotThrowInvalidOperationException()
     {
-        // Markup.Remove throws when it encounters an unescaped ']' token.
-        // This reproduces the failure mode where choice labels contain literal brackets.
+        // Non-interactive error reporting should tolerate literal brackets in labels.
+        // These labels can come from user data and are not guaranteed to be valid Spectre markup.
         var output = new StringBuilder();
         var console = CreateInteractiveConsoleWithInput(output, "");
         var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
         var choices = new[] { "alpha", "beta" };
 
-        var option = new System.CommandLine.Option<string?>("--items");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--items");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("--items invalid");
         var binding = PromptBinding.Create(parseResult, option);
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        await Assert.ThrowsAsync<NonInteractiveException>(() =>
             interactionService.PromptForSelectionsAsync(
                 "Select:",
                 choices,
@@ -1624,7 +1624,9 @@ public class ConsoleInteractionServiceTests
                 binding: binding,
                 cancellationToken: CancellationToken.None));
 
-        Assert.Contains("unescaped ']'", ex.Message, StringComparison.OrdinalIgnoreCase);
+        var outputString = output.ToString();
+        Assert.Contains("alpha]", outputString);
+        Assert.Contains("beta]", outputString);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -1602,6 +1602,32 @@ public class ConsoleInteractionServiceTests
     }
 
     [Fact]
+    public async Task PromptForSelectionsAsync_NonInteractive_CliProvidedInvalidValue_WithUnescapedClosingBracketInChoiceLabel_ThrowsInvalidOperationException()
+    {
+        // Markup.Remove throws when it encounters an unescaped ']' token.
+        // This reproduces the failure mode where choice labels contain literal brackets.
+        var output = new StringBuilder();
+        var console = CreateInteractiveConsoleWithInput(output, "");
+        var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
+        var choices = new[] { "alpha", "beta" };
+
+        var option = new System.CommandLine.Option<string?>("--items");
+        var command = new System.CommandLine.RootCommand { option };
+        var parseResult = command.Parse("--items invalid");
+        var binding = PromptBinding.Create(parseResult, option);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            interactionService.PromptForSelectionsAsync(
+                "Select:",
+                choices,
+                x => $"{x}]",
+                binding: binding,
+                cancellationToken: CancellationToken.None));
+
+        Assert.Contains("unescaped ']'", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task PromptForSelectionAsync_NonInteractive_WithDefaultValue_ReturnsMatch()
     {
         var output = new StringBuilder();

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
+using System.CommandLine;
 using System.Text;
 
 namespace Aspire.Cli.Tests.Interaction;
@@ -1254,8 +1255,8 @@ public class ConsoleInteractionServiceTests
         var console = CreateInteractiveConsoleWithInput(output, "");
         var interactionService = CreateInteractionService(console);
 
-        var option = new System.CommandLine.Option<string?>("--value");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--value");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("--value bad-value");
         var binding = PromptBinding.Create(parseResult, option);
         Func<string, ValidationResult> validator = v =>
@@ -1317,8 +1318,8 @@ public class ConsoleInteractionServiceTests
         var console = CreateInteractiveConsoleWithInput(output, "");
         var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
 
-        var option = new System.CommandLine.Option<bool>("--confirm");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<bool>("--confirm");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("");
         var binding = PromptBinding.Create(parseResult, option);
 
@@ -1347,8 +1348,8 @@ public class ConsoleInteractionServiceTests
         var console = CreateInteractiveConsoleWithInput(output, "");
         var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
 
-        var option = new System.CommandLine.Option<bool?>("--confirm");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<bool?>("--confirm");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("");
         var binding = PromptBinding.CreateBoolConfirm(parseResult, option, interactiveDefault: true, nonInteractiveDefault: false);
 
@@ -1364,8 +1365,8 @@ public class ConsoleInteractionServiceTests
         var console = CreateInteractiveConsoleWithInput(output, "\n");
         var interactionService = CreateInteractionService(console);
 
-        var option = new System.CommandLine.Option<bool?>("--confirm");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<bool?>("--confirm");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("");
         var binding = PromptBinding.CreateBoolConfirm(parseResult, option, interactiveDefault: true, nonInteractiveDefault: false);
 
@@ -1446,8 +1447,8 @@ public class ConsoleInteractionServiceTests
     [Fact]
     public void PromptBinding_CreateWithoutDefault_HasNoExplicitDefault()
     {
-        var option = new System.CommandLine.Option<bool>("--flag");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<bool>("--flag");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("");
 
         var binding = PromptBinding.Create(parseResult, option);
@@ -1458,8 +1459,8 @@ public class ConsoleInteractionServiceTests
     [Fact]
     public void PromptBinding_CreateWithDefault_HasExplicitDefault()
     {
-        var option = new System.CommandLine.Option<bool>("--flag");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<bool>("--flag");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("");
 
         var binding = PromptBinding.Create(parseResult, option, true);
@@ -1474,8 +1475,8 @@ public class ConsoleInteractionServiceTests
     [InlineData("--nuget-config-dir", "'--nuget-config-dir'")]
     public void PromptBinding_SymbolDisplayName_DoesNotDoubleDash(string optionName, string expectedDisplay)
     {
-        var option = new System.CommandLine.Option<string?>(optionName);
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>(optionName);
+        var command = new RootCommand { option };
         var parseResult = command.Parse("");
 
         var binding = PromptBinding.Create(parseResult, option);
@@ -1504,8 +1505,8 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
         var choices = new[] { "option1", "option2", "option3" };
 
-        var option = new System.CommandLine.Option<string?>("--choice");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--choice");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("--choice invalid");
         var binding = PromptBinding.Create(parseResult, option);
 
@@ -1526,8 +1527,8 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
         var choices = new[] { "alpha", "beta", "gamma" };
 
-        var option = new System.CommandLine.Option<string?>("--items");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--items");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("--items invalid");
         var binding = PromptBinding.Create(parseResult, option);
 
@@ -1553,8 +1554,8 @@ public class ConsoleInteractionServiceTests
         var visibleChoices = new[] { "alpha", "beta", "ux-only-entry" };
         var bindingChoices = new[] { "alpha", "beta" };
 
-        var option = new System.CommandLine.Option<string?>("--items");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--items");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("--items invalid");
         var binding = PromptBinding.Create(parseResult, option);
 
@@ -1579,8 +1580,8 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
         var choices = new[] { "alpha", "beta" };
 
-        var option = new System.CommandLine.Option<string?>("--items");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--items");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("--items invalid");
         var binding = PromptBinding.Create(parseResult, option);
 
@@ -1637,8 +1638,8 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
         var choices = new[] { "option1", "option2" };
 
-        var option = new System.CommandLine.Option<string?>("--choice");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--choice");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("");
         var binding = PromptBinding.Create(parseResult, option, "option2");
 
@@ -1655,8 +1656,8 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console);
         var choices = new[] { "option1", "option2" };
 
-        var option = new System.CommandLine.Option<string?>("--choice");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--choice");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("--choice option1");
         var binding = PromptBinding.Create(parseResult, option);
 
@@ -1673,8 +1674,8 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console);
         var choices = new[] { "alpha", "beta", "gamma" };
 
-        var option = new System.CommandLine.Option<string?>("--items");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--items");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("--items alpha,gamma");
         var binding = PromptBinding.Create(parseResult, option);
 
@@ -1688,8 +1689,8 @@ public class ConsoleInteractionServiceTests
     [Fact]
     public void PromptBinding_InvertedBoolConfirm_SymbolDisplayName_IsCorrect()
     {
-        var option = new System.CommandLine.Option<bool?>("--yes");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<bool?>("--yes");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("--yes");
 
         var binding = PromptBinding.CreateInvertedBoolConfirm(parseResult, option, defaultValue: true);
@@ -1700,8 +1701,8 @@ public class ConsoleInteractionServiceTests
     [Fact]
     public void PromptBinding_BoolConfirm_SymbolDisplayName_IsCorrect()
     {
-        var option = new System.CommandLine.Option<bool?>("--include");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<bool?>("--include");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("--include");
 
         var binding = PromptBinding.CreateBoolConfirm(parseResult, option, defaultValue: false);
@@ -1762,8 +1763,8 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(AnsiConsole.Console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
         var choices = new[] { "option1", "option2" };
 
-        var option = new System.CommandLine.Option<string?>("--choice");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--choice");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("");
         var binding = PromptBinding.Create(parseResult, option);
 
@@ -1779,8 +1780,8 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console);
         var choices = new[] { "option1", "option2" };
 
-        var option = new System.CommandLine.Option<string?>("--choice");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--choice");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("--choice option1");
         var binding = PromptBinding.Create(parseResult, option);
 
@@ -1798,8 +1799,8 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console);
         var choices = new[] { "alpha", "beta", "gamma" };
 
-        var option = new System.CommandLine.Option<string?>("--items");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--items");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("--items alpha,gamma");
         var binding = PromptBinding.Create(parseResult, option);
 
@@ -1817,8 +1818,8 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
         var choices = new[] { "option1", "option2" };
 
-        var option = new System.CommandLine.Option<string?>("--choice");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--choice");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("");
         var binding = PromptBinding.Create(parseResult, option, "option2");
 
@@ -1836,8 +1837,8 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
         var choices = new[] { "alpha", "beta", "gamma" };
 
-        var option = new System.CommandLine.Option<string?>("--items");
-        var command = new System.CommandLine.RootCommand { option };
+        var option = new Option<string?>("--items");
+        var command = new RootCommand { option };
         var parseResult = command.Parse("");
         var binding = PromptBinding.Create(parseResult, option, "alpha,beta");
 


### PR DESCRIPTION
Replace the custom `RemoveSpectreFormatting()` extension method with Spectre.Console's built-in `Markup.Remove()` static method via a new `StringUtils.RemoveMarkup` helper.

## Description

Replaced all usages of the custom regex-based `RemoveSpectreFormatting()` extension with `StringUtils.RemoveMarkup`, which delegates to `Spectre.Console.Markup.Remove()`. The helper catches `InvalidOperationException` for inputs containing unescaped bracket characters (e.g. plain-text compiler diagnostics passed through the backchannel) and returns the original string unchanged rather than throwing.

`StringUtils.RemoveMarkup` does **not** trim the result, matching the behaviour of Spectre.Console's own `Markup.Remove()` extension. This preserves intentional leading whitespace — for example the indentation spaces prepended by `ConsoleActivityLogger.GetIndentedDisplayName` for hierarchical display and column-width calculations.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No