### PR TITLE
Don't create nuget.config for stable channel in aspire new/update

### DIFF
--- a/src/Aspire.Cli/Packaging/PackageChannel.cs
+++ b/src/Aspire.Cli/Packaging/PackageChannel.cs
@@ -14,7 +14,7 @@ using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Packaging;
 
-internal class PackageChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, IFeatures features, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, ILogger? logger = null)
+internal class PackageChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, IFeatures features, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, bool requiresProjectNuGetConfig = true, ILogger? logger = null)
 {
     // Threaded so the local-folder integration listing can honor the same
     // ShowDeprecatedPackages flag that NuGetPackageCache honors on the feed-based path.
@@ -31,6 +31,13 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
     public bool ConfigureGlobalPackagesFolder { get; } = configureGlobalPackagesFolder;
     public string? CliDownloadBaseUrl { get; } = cliDownloadBaseUrl;
     public string? PinnedVersion { get; } = pinnedVersion;
+
+    /// <summary>
+    /// Whether projects created with this channel should have a project-level nuget.config
+    /// written. Channels whose mappings only point to default sources (e.g. nuget.org) set
+    /// this to <see langword="false"/> because the config would be redundant.
+    /// </summary>
+    public bool RequiresProjectNuGetConfig { get; } = requiresProjectNuGetConfig;
 
     public string SourceDetails { get; } = ComputeSourceDetails(mappings);
 
@@ -398,7 +405,7 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
             .SelectMany(mapping => CreateScopedMappings(mapping, requestedPackageIds, logger))
             .ToArray();
 
-        return new PackageChannel(Name, Quality, scopedMappings, nuGetPackageCache, _features, ConfigureGlobalPackagesFolder, CliDownloadBaseUrl, PinnedVersion, logger);
+        return new PackageChannel(Name, Quality, scopedMappings, nuGetPackageCache, _features, ConfigureGlobalPackagesFolder, CliDownloadBaseUrl, PinnedVersion, RequiresProjectNuGetConfig, logger);
     }
 
     private static IEnumerable<PackageMapping> CreateScopedMappings(PackageMapping mapping, IReadOnlyCollection<string> packageIds, ILogger? logger)
@@ -562,9 +569,9 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
         return isHostingOrCommunityToolkitNamespaced && !isExcluded;
     }
 
-    public static PackageChannel CreateExplicitChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, IFeatures features, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, ILogger? logger = null)
+    public static PackageChannel CreateExplicitChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, IFeatures features, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, bool requiresProjectNuGetConfig = true, ILogger? logger = null)
     {
-        return new PackageChannel(name, quality, mappings, nuGetPackageCache, features, configureGlobalPackagesFolder, cliDownloadBaseUrl, pinnedVersion, logger);
+        return new PackageChannel(name, quality, mappings, nuGetPackageCache, features, configureGlobalPackagesFolder, cliDownloadBaseUrl, pinnedVersion, requiresProjectNuGetConfig, logger);
     }
 
     public static PackageChannel CreateImplicitChannel(INuGetPackageCache nuGetPackageCache, IFeatures features, ILogger? logger = null)

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -135,7 +135,7 @@ internal class PackagingService : IPackagingService
         var stableChannel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Stable, new[]
         {
             new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)
-        }, _nuGetPackageCache, _features, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/ga/daily", logger: _logger);
+        }, _nuGetPackageCache, _features, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/ga/daily", requiresProjectNuGetConfig: false, logger: _logger);
 
         var dailyChannel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Daily, PackageChannelQuality.Prerelease, new[]
         {

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -116,23 +116,39 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
                 _ => throw new InvalidOperationException(UpdateCommandStrings.UnexpectedCodePath)
             };
 
-            interactionService.DisplayEmptyLine();
+            // For channels that don't require a project-level nuget.config (e.g. stable,
+            // whose mappings only point to nuget.org), only update an existing config to
+            // clean up old channel feeds — don't create a new one.
+            // See: https://github.com/microsoft/aspire/issues/18124
+            if (!channel.RequiresProjectNuGetConfig)
+            {
+                var candidateDirectory = new DirectoryInfo(recommendedNuGetConfigFileDirectory!);
+                if (NuGetConfigMerger.TryFindNuGetConfigInDirectory(candidateDirectory, out _))
+                {
+                    interactionService.DisplayEmptyLine();
+                    await NuGetConfigMerger.CreateOrUpdateAsync(candidateDirectory, channel, (_, orig, proposed, ct) => AnalyzeAndConfirmNuGetConfigChanges(context, orig, proposed, ct), cancellationToken: cancellationToken);
+                }
+            }
+            else
+            {
+                interactionService.DisplayEmptyLine();
 
-            // Carry the recommended directory as the default on the binding.
-            // The original binding (from UpdateCommand) may not have a default because
-            // the recommended directory is computed here, after NuGet config discovery.
-            var nugetConfigDirBinding = context.NuGetConfigDirBinding.WithDefault(recommendedNuGetConfigFileDirectory);
+                // Carry the recommended directory as the default on the binding.
+                // The original binding (from UpdateCommand) may not have a default because
+                // the recommended directory is computed here, after NuGet config discovery.
+                var nugetConfigDirBinding = context.NuGetConfigDirBinding.WithDefault(recommendedNuGetConfigFileDirectory);
 
-            var selectedPathForNewNuGetConfigFile = await interactionService.PromptForFilePathAsync(
-                promptText: UpdateCommandStrings.WhichDirectoryNuGetConfigPrompt,
-                binding: nugetConfigDirBinding,
-                validator: null,
-                directory: true,
-                required: true,
-                cancellationToken: cancellationToken);
+                var selectedPathForNewNuGetConfigFile = await interactionService.PromptForFilePathAsync(
+                    promptText: UpdateCommandStrings.WhichDirectoryNuGetConfigPrompt,
+                    binding: nugetConfigDirBinding,
+                    validator: null,
+                    directory: true,
+                    required: true,
+                    cancellationToken: cancellationToken);
 
-            var nugetConfigDirectory = new DirectoryInfo(selectedPathForNewNuGetConfigFile);
-            await NuGetConfigMerger.CreateOrUpdateAsync(nugetConfigDirectory, channel, (_, orig, proposed, ct) => AnalyzeAndConfirmNuGetConfigChanges(context, orig, proposed, ct), cancellationToken: cancellationToken);
+                var nugetConfigDirectory = new DirectoryInfo(selectedPathForNewNuGetConfigFile);
+                await NuGetConfigMerger.CreateOrUpdateAsync(nugetConfigDirectory, channel, (_, orig, proposed, ct) => AnalyzeAndConfirmNuGetConfigChanges(context, orig, proposed, ct), cancellationToken: cancellationToken);
+            }
         }
 
         interactionService.DisplayEmptyLine();

--- a/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
+++ b/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
@@ -40,6 +40,20 @@ internal sealed class TemplateNuGetConfigService(
             return;
         }
 
+        // Skip channels that don't require a project-level nuget.config (e.g. stable,
+        // whose mappings only point to nuget.org — the default source) unless a config
+        // already exists in the target directory. An existing config should still be
+        // updated to clean up stale feeds from a previous channel.
+        // See: https://github.com/microsoft/aspire/issues/18124
+        if (!channel.RequiresProjectNuGetConfig)
+        {
+            var targetDir = new DirectoryInfo(outputPath);
+            if (!NuGetConfigMerger.TryFindNuGetConfigInDirectory(targetDir, out _))
+            {
+                return;
+            }
+        }
+
         var mappings = channel.Mappings;
         if (mappings is null || mappings.Length == 0)
         {
@@ -136,6 +150,18 @@ internal sealed class TemplateNuGetConfigService(
         if (mappings is null || mappings.Length == 0)
         {
             return false;
+        }
+
+        // Skip channels that don't require a project-level nuget.config (e.g. stable,
+        // whose mappings only point to nuget.org) unless a config already exists.
+        // See: https://github.com/microsoft/aspire/issues/18124
+        if (!matchingChannel.RequiresProjectNuGetConfig)
+        {
+            var targetDir = new DirectoryInfo(outputPath);
+            if (!NuGetConfigMerger.TryFindNuGetConfigInDirectory(targetDir, out _))
+            {
+                return false;
+            }
         }
 
         // Call the merger directly — bypass NuGetConfigPrompter so we don't emit a

--- a/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
@@ -86,12 +86,8 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("Perform updates?", timeout: TimeSpan.FromSeconds(60));
         await auto.EnterAsync(); // confirm "Perform updates?" (default: Yes)
-        // The updater may prompt for a NuGet.config location and ask to apply changes
-        // when the project doesn't have an existing NuGet.config. Accept defaults for both.
-        await auto.WaitUntilTextAsync("Which directory for NuGet.config file?", timeout: TimeSpan.FromSeconds(30));
-        await auto.EnterAsync(); // accept default directory
-        await auto.WaitUntilTextAsync("Apply these changes to NuGet.config?", timeout: TimeSpan.FromSeconds(30));
-        await auto.EnterAsync(); // confirm "Apply these changes to NuGet.config?" (default: Yes)
+        // Stable channel does not prompt for NuGet.config creation because
+        // RequiresProjectNuGetConfig is false and there is no existing config.
         await auto.WaitUntilTextAsync("Update successful!", timeout: TimeSpan.FromSeconds(60));
         await auto.WaitForSuccessPromptAsync(counter);
 
@@ -194,13 +190,11 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
             """);
 
         // First update: migrate to the new SDK format on the latest stable version.
+        // Stable channel does not prompt for NuGet.config creation because
+        // RequiresProjectNuGetConfig is false and there is no existing config.
         await auto.TypeAsync($"aspire update --project \"{containerAppHostCsprojPath}\" --channel stable");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("Perform updates?", timeout: TimeSpan.FromSeconds(60));
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("Which directory for NuGet.config file?", timeout: TimeSpan.FromSeconds(30));
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("Apply these changes to NuGet.config?", timeout: TimeSpan.FromSeconds(30));
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("Update successful!", timeout: TimeSpan.FromSeconds(60));
         await auto.WaitForSuccessPromptAsync(counter);
@@ -236,17 +230,12 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
         // Second update: SDK is already current, so AnalyzeAppHostSdkAsync will
         // skip the SDK update step. The updater must still detect and remove the
         // orphan PackageVersion - that cleanup is itself an update step, so the
-        // run prompts for confirmation just like the first update did, and
-        // re-prompts for the NuGet.config because any update step (not just SDK
-        // migration) can introduce package mappings the existing config may not
-        // cover.
+        // run prompts for confirmation just like the first update did.
+        // Stable channel does not prompt for NuGet.config because
+        // RequiresProjectNuGetConfig is false and there is no existing config.
         await auto.TypeAsync($"aspire update --project \"{containerAppHostCsprojPath}\" --channel stable");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("Perform updates?", timeout: TimeSpan.FromSeconds(60));
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("Which directory for NuGet.config file?", timeout: TimeSpan.FromSeconds(30));
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("Apply these changes to NuGet.config?", timeout: TimeSpan.FromSeconds(30));
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("Update successful!", timeout: TimeSpan.FromSeconds(60));
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(120));

--- a/tests/Aspire.Cli.EndToEnd.Tests/NewChannelNuGetConfigTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/NewChannelNuGetConfigTests.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// Verifies that <c>aspire new</c> does or does not create a project-level <c>nuget.config</c>
+/// depending on the selected channel.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The stable channel maps only to nuget.org (the default source), so a project-level
+/// <c>nuget.config</c> would be redundant and is suppressed. Other explicit channels
+/// (daily, local, PR hives) require a <c>nuget.config</c> to pin Aspire packages to
+/// their non-default feed.
+/// </para>
+/// <para>
+/// See: https://github.com/microsoft/aspire/issues/18124
+/// </para>
+/// </remarks>
+public sealed class NewChannelNuGetConfigTests(ITestOutputHelper output)
+{
+    [CaptureWorkspaceOnFailure]
+    [Theory]
+    [InlineData("stable", false)]
+    [InlineData(null, true)]
+    public async Task AspireNew_CreatesNuGetConfig_BasedOnChannel(string? channel, bool expectNuGetConfig)
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+
+        // This test needs an explicit (non-stable) channel for the "creates nuget.config" case.
+        // When no channel is passed, the CLI uses its baked-in channel. For LocalHive that's
+        // the "local" channel; for PR/dev/staging install strategies it's their respective
+        // explicit channel. Only a bare InstallScript (latest GA) would default to stable and
+        // make the null-channel case indistinguishable from the stable case — skip in that scenario.
+        if (channel is null && strategy.Mode == CliInstallMode.InstallScript && strategy.Quality is null && strategy.Version is null)
+        {
+            Assert.Skip(
+                "This test needs a non-stable baked channel for the null-channel case. " +
+                "Run with ASPIRE_E2E_ARCHIVE (LocalHive), in CI (dev/staging quality), or " +
+                "against a specific non-stable build.");
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(
+            repoRoot, strategy, output, mountDockerSocket: false, workspace: workspace);
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        const string projectName = "NuGetConfigTest";
+        await auto.AspireNewCSharpEmptyAppHostAsync(projectName, counter, channel: channel);
+
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, projectName, "nuget.config");
+
+        if (expectNuGetConfig)
+        {
+            Assert.True(File.Exists(nugetConfigPath),
+                $"Expected nuget.config to be created for channel '{channel ?? "(default)"}' at: {nugetConfigPath}");
+        }
+        else
+        {
+            Assert.False(File.Exists(nugetConfigPath),
+                $"Expected no nuget.config for channel '{channel}' but found one at: {nugetConfigPath}");
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -1541,6 +1541,162 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         Assert.DoesNotContain("<PackageVersion", updatedProps, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task UpdateProjectAsync_StableChannel_DoesNotCreateNuGetConfigWhenNoneExists()
+    {
+        // When updating to the stable channel (RequiresProjectNuGetConfig = false) and no
+        // project-local nuget.config exists, the updater should NOT create one.
+        // See: https://github.com/microsoft/aspire/issues/18124
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var (appHostProjectFile, _) = await SetupNuGetConfigTestProject(workspace);
+
+        var services = CreateNuGetConfigTestServices(workspace, "9.5.0", "nuget.org");
+        using var provider = services.BuildServiceProvider();
+
+        var channels = await provider.GetRequiredService<IPackagingService>().GetChannelsAsync().DefaultTimeout();
+        var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
+        await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, channels.Single(c => c.Name == "stable"))).DefaultTimeout();
+
+        Assert.False(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config")));
+        Assert.False(File.Exists(Path.Combine(appHostProjectFile.DirectoryName!, "nuget.config")));
+    }
+
+    [Fact]
+    public async Task UpdateProjectAsync_StableChannel_UpdatesExistingNuGetConfig()
+    {
+        // When updating to the stable channel and a project-local nuget.config already
+        // exists (e.g. from a previous daily channel), the updater should update it to
+        // clean up old feeds.
+        // See: https://github.com/microsoft/aspire/issues/18124
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var (appHostProjectFile, _) = await SetupNuGetConfigTestProject(workspace);
+
+        // Pre-existing nuget.config from a previous daily channel
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+        await File.WriteAllTextAsync(nugetConfigPath,
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <add key="aspire-daily" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+                <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="aspire-daily">
+                  <package pattern="Aspire*" />
+                </packageSource>
+                <packageSource key="nuget.org">
+                  <package pattern="*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        var services = CreateNuGetConfigTestServices(workspace, "9.5.0", "nuget.org", getNuGetConfigPathsCallback: (_, _, _) =>
+        {
+            return (0, new[]
+            {
+                nugetConfigPath,
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "NuGet", "NuGet.Config")
+            });
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var channels = await provider.GetRequiredService<IPackagingService>().GetChannelsAsync().DefaultTimeout();
+        var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
+        await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, channels.Single(c => c.Name == "stable"))).DefaultTimeout();
+
+        Assert.True(File.Exists(nugetConfigPath));
+        var updatedConfig = await File.ReadAllTextAsync(nugetConfigPath);
+        Assert.Contains("https://api.nuget.org/v3/index.json", updatedConfig);
+    }
+
+    [Fact]
+    public async Task UpdateProjectAsync_DailyChannel_CreatesNuGetConfigWhenNoneExists()
+    {
+        // Contrast: when updating to the daily channel (RequiresProjectNuGetConfig = true),
+        // the updater should create a nuget.config if none exists.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var (appHostProjectFile, _) = await SetupNuGetConfigTestProject(workspace);
+
+        var services = CreateNuGetConfigTestServices(workspace, "9.5.0-preview.1", "daily");
+        using var provider = services.BuildServiceProvider();
+
+        var channels = await provider.GetRequiredService<IPackagingService>().GetChannelsAsync().DefaultTimeout();
+        var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
+        await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, channels.Single(c => c.Name == "daily"))).DefaultTimeout();
+
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config")));
+    }
+
+    private static async Task<(FileInfo AppHostProjectFile, DirectoryInfo AppHostFolder)> SetupNuGetConfigTestProject(TemporaryWorkspace workspace)
+    {
+        var appHostFolder = workspace.CreateDirectory("UpdateTester.AppHost");
+        var appHostProjectFile = new FileInfo(Path.Combine(appHostFolder.FullName, "UpdateTester.AppHost.csproj"));
+
+        await File.WriteAllTextAsync(
+            appHostProjectFile.FullName,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <Sdk Name="Aspire.AppHost.Sdk" Version="9.4.1" />
+            </Project>
+            """);
+
+        return (appHostProjectFile, appHostFolder);
+    }
+
+    private IServiceCollection CreateNuGetConfigTestServices(
+        TemporaryWorkspace workspace,
+        string targetVersion,
+        string source,
+        Func<DirectoryInfo, ProcessInvocationOptions, CancellationToken, (int, string[])>? getNuGetConfigPathsCallback = null)
+    {
+        return CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
+        {
+            config.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner()
+                {
+                    SearchPackagesAsyncCallback = (_, query, _, _, _, _, _, _, _, _) =>
+                    {
+                        var packages = new List<NuGetPackageCli>
+                        {
+                            query switch
+                            {
+                                "Aspire.AppHost.Sdk" => new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = targetVersion, Source = source },
+                                "Aspire.Hosting.AppHost" => new NuGetPackageCli { Id = "Aspire.Hosting.AppHost", Version = targetVersion, Source = source },
+                                _ => throw new InvalidOperationException("Unexpected package query."),
+                            }
+                        };
+                        return (0, packages.ToArray());
+                    },
+
+                    GetProjectItemsAndPropertiesAsyncCallback = (projectFile, _, _, _, _) =>
+                    {
+                        var itemsAndProperties = new JsonObject();
+                        itemsAndProperties.WithSdkVersion("9.4.1");
+                        itemsAndProperties.WithPackageReference("Aspire.Hosting.AppHost", "9.4.1");
+
+                        var json = itemsAndProperties.ToJsonString();
+                        var document = JsonDocument.Parse(json);
+                        return (0, document);
+                    },
+
+                    AddPackageAsyncCallback = (_, _, _, _, _, _, _) => 0
+                };
+
+                if (getNuGetConfigPathsCallback is not null)
+                {
+                    runner.GetNuGetConfigPathsAsyncCallback = getNuGetConfigPathsCallback;
+                }
+
+                return runner;
+            };
+
+            config.InteractionServiceFactory = (s) => new TestInteractionService();
+        });
+    }
+
     private static UpdatePackagesContext CreateUpdateContext(FileInfo appHostFile, PackageChannel channel) =>
         new()
         {

--- a/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
@@ -444,6 +444,195 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
             .ToArray();
     }
 
+    [Fact]
+    public async Task PromptToCreateOrUpdateNuGetConfigAsync_ExplicitChannelRequiringConfig_CreatesConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputDir = workspace.WorkspaceRoot.CreateSubdirectory("output");
+
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ =>
+            {
+                // Simulate the daily channel: explicit and RequiresProjectNuGetConfig = true (default)
+                var dailyCh = PackageChannel.CreateExplicitChannel(
+                    "daily",
+                    PackageChannelQuality.Prerelease,
+                    [
+                        new PackageMapping("Aspire*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json"),
+                        new PackageMapping("*", "https://api.nuget.org/v3/index.json")
+                    ],
+                    new FakeNuGetPackageCache(),
+                    features: new TestFeatures());
+                return Task.FromResult<IEnumerable<PackageChannel>>([dailyCh]);
+            }
+        };
+
+        var service = CreateService(packagingService: packagingService);
+
+        await service.PromptToCreateOrUpdateNuGetConfigAsync(channelName: "daily", outputDir.FullName, CancellationToken.None);
+
+        // nuget.config should be created because RequiresProjectNuGetConfig is true
+        var configPath = Path.Combine(outputDir.FullName, "nuget.config");
+        Assert.True(File.Exists(configPath));
+        var doc = XDocument.Load(configPath);
+        var sources = doc.Root!.Element("packageSources")!.Elements("add")
+            .Select(e => (string)e.Attribute("value")!)
+            .ToArray();
+        Assert.Equal(
+            ["https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json", "https://api.nuget.org/v3/index.json"],
+            sources);
+    }
+
+    [Fact]
+    public async Task PromptToCreateOrUpdateNuGetConfigAsync_ChannelWithRequiresProjectNuGetConfigFalse_DoesNotCreateConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputDir = workspace.WorkspaceRoot.CreateSubdirectory("output");
+
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ =>
+            {
+                // Simulate the stable channel: explicit but RequiresProjectNuGetConfig = false
+                var stableCh = PackageChannel.CreateExplicitChannel(
+                    "stable",
+                    PackageChannelQuality.Stable,
+                    [new PackageMapping("*", "https://api.nuget.org/v3/index.json")],
+                    new FakeNuGetPackageCache(),
+                    features: new TestFeatures(),
+                    requiresProjectNuGetConfig: false);
+                return Task.FromResult<IEnumerable<PackageChannel>>([stableCh]);
+            }
+        };
+
+        var service = CreateService(packagingService: packagingService);
+
+        await service.PromptToCreateOrUpdateNuGetConfigAsync(channelName: "stable", outputDir.FullName, CancellationToken.None);
+
+        // No nuget.config should be created because RequiresProjectNuGetConfig is false
+        Assert.False(File.Exists(Path.Combine(outputDir.FullName, "nuget.config")));
+    }
+
+    [Fact]
+    public async Task PromptToCreateOrUpdateNuGetConfigAsync_ChannelWithRequiresProjectNuGetConfigFalse_UpdatesExistingConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputDir = workspace.WorkspaceRoot.CreateSubdirectory("output");
+
+        // Pre-existing nuget.config from a previous daily channel
+        await File.WriteAllTextAsync(
+            Path.Combine(outputDir.FullName, "nuget.config"),
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <add key="aspire-daily" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="aspire-daily">
+                  <package pattern="Aspire*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ =>
+            {
+                var stableCh = PackageChannel.CreateExplicitChannel(
+                    "stable",
+                    PackageChannelQuality.Stable,
+                    [new PackageMapping("*", "https://api.nuget.org/v3/index.json")],
+                    new FakeNuGetPackageCache(),
+                    features: new TestFeatures(),
+                    requiresProjectNuGetConfig: false);
+                return Task.FromResult<IEnumerable<PackageChannel>>([stableCh]);
+            }
+        };
+
+        var service = CreateService(packagingService: packagingService);
+
+        await service.PromptToCreateOrUpdateNuGetConfigAsync(channelName: "stable", outputDir.FullName, CancellationToken.None);
+
+        // Existing nuget.config should still exist (it was updated)
+        var configPath = Path.Combine(outputDir.FullName, "nuget.config");
+        Assert.True(File.Exists(configPath));
+
+        // The stable channel's mapping (* → nuget.org) should now be present
+        var doc = XDocument.Load(configPath);
+        var sources = doc.Root!.Element("packageSources")!.Elements("add")
+            .Select(e => (string)e.Attribute("value")!)
+            .ToArray();
+        Assert.Equal(["https://api.nuget.org/v3/index.json"], sources);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CreateOrUpdateNuGetConfigWithoutPromptAsync_ChannelWithRequiresProjectNuGetConfigFalse_RespectsExistingConfig(bool hasExistingConfig)
+    {
+        // The "without prompt" path is used by aspire init. When the channel does not
+        // require a project-level nuget.config (e.g. stable → nuget.org only):
+        //   - No existing config → skip creation entirely (return false)
+        //   - Existing config → update it to clean up stale feeds (return true)
+        // See: https://github.com/microsoft/aspire/issues/18124
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputDir = workspace.WorkspaceRoot.CreateSubdirectory("output");
+
+        if (hasExistingConfig)
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(outputDir.FullName, "nuget.config"),
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <add key="aspire-daily" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+                  </packageSources>
+                </configuration>
+                """);
+        }
+
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ =>
+            {
+                var stableCh = PackageChannel.CreateExplicitChannel(
+                    "stable",
+                    PackageChannelQuality.Stable,
+                    [new PackageMapping("*", "https://api.nuget.org/v3/index.json")],
+                    new FakeNuGetPackageCache(),
+                    features: new TestFeatures(),
+                    requiresProjectNuGetConfig: false);
+                return Task.FromResult<IEnumerable<PackageChannel>>([stableCh]);
+            }
+        };
+
+        var service = CreateService(packagingService: packagingService);
+
+        var result = await service.CreateOrUpdateNuGetConfigWithoutPromptAsync(channelName: "stable", outputDir.FullName, CancellationToken.None);
+
+        var configPath = Path.Combine(outputDir.FullName, "nuget.config");
+
+        if (hasExistingConfig)
+        {
+            Assert.True(result);
+            Assert.True(File.Exists(configPath));
+            var doc = XDocument.Load(configPath);
+            var sources = doc.Root!.Element("packageSources")!.Elements("add")
+                .Select(e => (string)e.Attribute("value")!)
+                .ToArray();
+            Assert.Equal(["https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json", "https://api.nuget.org/v3/index.json"], sources);
+        }
+        else
+        {
+            Assert.False(result);
+            Assert.False(File.Exists(configPath));
+        }
+    }
+
     private static TemplateNuGetConfigService CreateService(
         TestPackagingService? packagingService = null,
         CliExecutionContext? executionContext = null)


### PR DESCRIPTION
## Summary

When using the stable channel, `aspire new` and `aspire update` no longer create a project-level `nuget.config` since it only maps to nuget.org (the default source). If a `nuget.config` already exists, it is still updated to clean up stale feeds.

## Changes

- Added `RequiresProjectNuGetConfig` property to `PackageChannel` (defaults to `true`)
- Set `requiresProjectNuGetConfig: false` for the stable channel in `PackagingService`
- Updated `TemplateNuGetConfigService` (`aspire new` path) to skip config creation when `RequiresProjectNuGetConfig` is false but still update existing configs
- Updated `ProjectUpdater` (`aspire update` path) with the same semantics
- Added unit tests for both paths (creation skipped, existing configs updated, non-stable still creates)
- Added E2E test verifying nuget.config presence/absence by channel

Fxies #17899
Fixes #18124