### PR TITLE
[release/13.4] Make npm package README TypeScript-only and document standalone dashboard

### DIFF
--- a/eng/scripts/pack-cli-npm-package.pointer.README.md
+++ b/eng/scripts/pack-cli-npm-package.pointer.README.md
@@ -13,53 +13,60 @@ Use an AppHost to describe how services, frontends, containers, databases, cache
 
 ## A simple app definition
 
-The same application definition can be written in different languages.
-
-__C#__ (`apphost.cs`)
-
-```csharp
-var builder = DistributedApplication.CreateBuilder(args);
-
-var cache = builder.AddRedis("cache");
-
-var api = builder.AddNodeApp("api", "./api", "src/index.ts")
-  .WithReference(cache)
-  .WaitFor(cache)
-  .WithHttpEndpoint(env: "PORT")
-  .WithExternalHttpEndpoints();
-
-builder.AddViteApp("frontend", "./frontend")
-  .WithReference(api)
-  .WaitFor(api);
-
-builder.Build().Run();
-```
-
-__TypeScript__ (`apphost.ts`)
+You describe your app in a TypeScript AppHost (`apphost.mts`). The example below runs an Express API and a Vite frontend, exposes the API over HTTP, and wires the frontend to it:
 
 ```typescript
-import { createBuilder } from './.aspire/modules/aspire.js';
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const cache = await builder.addRedis("cache");
-
-const api = await builder
-  .addNodeApp("api", "./api", "src/index.ts")
-  .withReference(cache)
-  .waitFor(cache)
+// Run the Express API and expose its HTTP endpoint externally.
+const app = await builder
+  .addNodeApp("app", "./api", "src/index.ts")
   .withHttpEndpoint({ env: "PORT" })
   .withExternalHttpEndpoints();
 
-await builder
+// Run the Vite frontend after the API and inject the API URL for local proxying.
+const frontend = await builder
   .addViteApp("frontend", "./frontend")
-  .withReference(api)
-  .waitFor(api);
+  .withReference(app)
+  .waitFor(app);
+
+// Bundle the frontend build output into the API container for publish/deploy.
+await app.publishWithContainerFiles(frontend, "./static");
 
 await builder.build().run();
 ```
 
-## Install
+Each builder call returns a promise, so `await` is used to get the resource before referencing it from another resource. `aspire run` builds and launches everything, then opens the dashboard.
+
+### Add backing services
+
+Resources like databases and caches are added the same way and connected with `withReference`. `waitFor` holds dependents until the resource is ready:
+
+```typescript
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const postgres = await builder.addPostgres("postgres");
+const db = await postgres.addDatabase("db");
+
+const cache = await builder.addRedis("cache");
+
+await builder
+  .addNodeApp("api", "./api", "src/index.ts")
+  .withHttpEndpoint({ env: "PORT" })
+  .withExternalHttpEndpoints()
+  .withReference(db)
+  .withReference(cache)
+  .waitFor(db)
+  .waitFor(cache);
+
+await builder.build().run();
+```
+
+`addPostgres` and `addRedis` become available once the matching integrations are installed with `aspire add postgresql` and `aspire add redis`.
 
 This package requires Node.js 20 or later.
 
@@ -82,6 +89,16 @@ aspire run
 ```
 
 The native platform packages are installed through npm optional dependencies. Do not install this package with optional dependencies disabled, or the `aspire` launcher will not be able to find the native CLI binary.
+
+## Standalone dashboard
+
+The Aspire dashboard shows logs, traces, and metrics for any app that exports OpenTelemetry, even without an AppHost. Start one in a single command:
+
+```bash
+aspire dashboard run
+```
+
+This launches the dashboard with an OTLP endpoint your apps can point at via `OTEL_EXPORTER_OTLP_ENDPOINT`. Use `aspire dashboard run --help` to see options such as `--frontend-url`, `--otlp-grpc-url`, and `--allow-anonymous`.
 
 ## Update
 

--- a/eng/scripts/pack-cli-npm-package.pointer.README.md
+++ b/eng/scripts/pack-cli-npm-package.pointer.README.md
@@ -68,6 +68,8 @@ await builder.build().run();
 
 `addPostgres` and `addRedis` become available once the matching integrations are installed with `aspire add postgresql` and `aspire add redis`.
 
+## Install
+
 This package requires Node.js 20 or later.
 
 ```bash

--- a/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
@@ -186,7 +186,15 @@ public sealed class NpmCliPackageTests : IDisposable
         Assert.Contains($"npm install -g {PackageName}", readme);
         Assert.Contains("The native platform packages are installed through npm optional dependencies.", readme);
         Assert.Contains("If you run `aspire update --self` from an npm install, the CLI points you back to this npm update command.", readme);
+        Assert.Contains("TypeScript AppHost (`apphost.mts`)", readme);
+        Assert.Contains("import { createBuilder } from './.aspire/modules/aspire.mjs';", readme);
+        Assert.Contains("aspire dashboard run", readme);
+        Assert.DoesNotContain("apphost.ts", readme);
+        Assert.DoesNotContain("./.aspire/modules/aspire.js", readme);
         Assert.DoesNotContain("__PACKAGE_NAME__", readme);
+        // The C# AppHost example was intentionally removed; the npm README is TypeScript-only.
+        Assert.DoesNotContain("apphost.cs", readme);
+        Assert.DoesNotContain("```csharp", readme);
     }
 
     [Theory]


### PR DESCRIPTION
## Description

Port of #18220 to `release/13.4`.

Updates the Aspire CLI npm package README (`eng/scripts/pack-cli-npm-package.pointer.README.md`) to be TypeScript-only and to document the standalone dashboard.

### Changes

- **Remove the C# AppHost example.** The npm package targets the TypeScript/JavaScript AppHost workflow, so the README now shows only TypeScript.
- **Refresh the TypeScript example.** The 13.4 README example was stale — it referenced `apphost.ts` and `./.aspire/modules/aspire.js`, but the actual 13.4 `ts-starter` template already uses `apphost.mts` importing `./.aspire/modules/aspire.mjs`. This change brings the README in line with the template (matching `main`).
- **Add a backing-services example** (Postgres + Redis) with a note that `addPostgres`/`addRedis` become available after `aspire add postgresql` and `aspire add redis`.
- **Document the standalone dashboard** with the one-line `aspire dashboard run` command and its OTLP endpoints/options.
- **Update `NpmCliPackageTests`** to assert the TypeScript-only README content.

### Verification

- The TypeScript examples were proven to compile against the real Aspire TypeScript codegen (`AtsCapabilityScanner` + `AtsTypeScriptCodeGenerator`) and `tsc --noEmit` (strict NodeNext) on the same release line; example 1 is byte-identical to the 13.4 `ts-starter` template.
- `aspire dashboard run` is provided by `DashboardRunCommand` on 13.4 with the documented options/defaults.
- `NpmCliPackageTests.PackScriptGeneratesPointerPackageMetadataMapAndReadme` passes locally.

Draft until CI is green.
