### PR TITLE
Preserve raw VS Code extension output

### DIFF
--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -445,9 +445,10 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         // Materialize so we can iterate twice without re-enumerating a possibly lazy/one-shot source.
         var materialized = lines as IReadOnlyCollection<(OutputLineStream Stream, string Line)> ?? lines.ToList();
 
+        // DisplayLines carries raw process output, not Spectre markup.
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(materialized.Select(line => new DisplayLineState(
             line.Stream == OutputLineStream.StdOut ? "stdout" : "stderr",
-            Markup.Remove(line.Line))), _cancellationToken));
+            line.Line)), _cancellationToken));
         Debug.Assert(result);
 
         // Intentionally do NOT also write to the local console here. Unlike most Display* methods
@@ -568,7 +569,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void WriteDebugSessionMessage(string message, bool stdout, string? textStyle)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(Markup.Remove(message), stdout, textStyle, _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(message, stdout, textStyle, _cancellationToken));
         Debug.Assert(result);
     }
 }

--- a/tests/Aspire.Cli.Tests/Interaction/ExtensionInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ExtensionInteractionServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Text;
+using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
@@ -15,6 +16,49 @@ namespace Aspire.Cli.Tests.Interaction;
 
 public class ExtensionInteractionServiceTests(ITestOutputHelper outputHelper)
 {
+    [Fact]
+    public async Task DisplayLines_PreservesRawCompilerOutputWithBracketedProjectPath()
+    {
+        var backchannel = new TestExtensionBackchannel();
+        DisplayLineState[]? capturedLines = null;
+        backchannel.DisplayLinesAsyncCallback = lines =>
+        {
+            capturedLines = lines.ToArray();
+            return Task.CompletedTask;
+        };
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var extensionInteractionService = CreateExtensionInteractionService(backchannel, workspace);
+        var compilerOutput = "Program.cs(10,5): error CS0103: The name '__AspireE2EFlushRegressionMissingSymbol__' does not exist in the current context [/tmp/AspireE2E.AppHost.csproj]";
+
+        extensionInteractionService.DisplayLines([(OutputLineStream.StdErr, compilerOutput)]);
+        await extensionInteractionService.FlushAsync();
+
+        Assert.NotNull(capturedLines);
+        var line = Assert.Single(capturedLines);
+        Assert.Equal("stderr", line.Stream);
+        Assert.Equal(compilerOutput, line.Line);
+    }
+
+    [Fact]
+    public async Task WriteDebugSessionMessage_PreservesRawOutputWithSquareBrackets()
+    {
+        var backchannel = new TestExtensionBackchannel();
+        string? capturedMessage = null;
+        backchannel.WriteDebugSessionMessageAsyncCallback = (message, _, _) =>
+        {
+            capturedMessage = message;
+            return Task.CompletedTask;
+        };
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var extensionInteractionService = CreateExtensionInteractionService(backchannel, workspace);
+        var debugOutput = "Path: $.values[0].Type | file [/tmp/AspireE2E.AppHost.csproj]";
+
+        extensionInteractionService.WriteDebugSessionMessage(debugOutput, stdout: false, textStyle: null);
+        await extensionInteractionService.FlushAsync();
+
+        Assert.Equal(debugOutput, capturedMessage);
+    }
+
     [Fact]
     public async Task DisplayMessage_DoesNotRenderTerminalHyperlinksToDebugConsoleCapturedOutput()
     {
@@ -55,5 +99,26 @@ public class ExtensionInteractionServiceTests(ITestOutputHelper outputHelper)
         Assert.Contains(logFilePath, outputString);
         Assert.DoesNotContain("\u001b]8;", outputString);
         Assert.DoesNotContain("file://", outputString);
+    }
+
+    private static ExtensionInteractionService CreateExtensionInteractionService(TestExtensionBackchannel backchannel, TemporaryWorkspace workspace)
+    {
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter())
+        });
+        var consoleInteractionService = new ConsoleInteractionService(
+            new ConsoleEnvironment(console, console),
+            workspace.CreateExecutionContext(),
+            TestHelpers.CreateInteractiveHostEnvironment(),
+            NullLoggerFactory.Instance,
+            new ConsoleLogBufferContext());
+
+        return new ExtensionInteractionService(
+            consoleInteractionService,
+            backchannel,
+            extensionPromptEnabled: false);
     }
 }


### PR DESCRIPTION
## Description

This is a small follow-up for #18209. `Markup.Remove()` is correct for strings that the CLI intentionally renders as Spectre markup, but `DisplayLines` and `WriteDebugSessionMessage` carry raw build/debug output into the VS Code extension.

Raw compiler output can include bracketed project paths, and debug output can include JSON paths like `$.values[0].Type`. Those should reach the extension unchanged rather than being parsed as Spectre markup.

Fixes # (issue)

Validation:

```bash
./dotnet.sh build tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj /p:SkipNativeBuild=true
./.dotnet/dotnet exec artifacts/bin/Aspire.Cli.Tests/Debug/net10.0/Aspire.Cli.Tests.dll --filter-class Aspire.Cli.Tests.Interaction.ExtensionInteractionServiceTests --filter-not-trait quarantined=true --filter-not-trait outerloop=true
./.dotnet/dotnet exec artifacts/bin/Aspire.Cli.Tests/Debug/net10.0/Aspire.Cli.Tests.dll --filter-namespace Aspire.Cli.Tests.Interaction --filter-not-trait quarantined=true --filter-not-trait outerloop=true
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
