### PR TITLE
test: throwaway PR to validate selective-CI comment (do not merge)

### DIFF
--- a/src/Components/Aspire.Azure.Data.Tables/AspireTablesExtensions.cs
+++ b/src/Components/Aspire.Azure.Data.Tables/AspireTablesExtensions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// Throwaway no-op edit to exercise the audit-mode selective-CI test selector (#18127). Do not merge.
+
 using Aspire.Azure.Common;
 using Aspire.Azure.Data.Tables;
 using Azure.Core;


### PR DESCRIPTION
Throwaway PR to exercise the audit-mode test selector (#18127) on a real `pull_request` event. Touches a single client component file; the selector should post a sticky comment selecting only `Aspire.Azure.Data.Tables.Tests`.

**Do not merge — will be closed once the selection comment is posted.**
