### PR TITLE
Support wildcard ignore patterns for pre-release version checks

### DIFF
--- a/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
+++ b/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
@@ -134,6 +134,11 @@ internal sealed class VersionCheckService : BackgroundService
                 return;
             }
         }
+        else if (IsVersionIgnoredByWildcard(latestVersion))
+        {
+            _logger.LogDebug("Ignoring version {Version} as it matches the ignored version wildcard pattern.", latestVersion);
+            return;
+        }
 
         if (IsVersionGreater(latestVersion, storedKnownLatestVersion) || storedKnownLatestVersion == null)
         {
@@ -156,7 +161,18 @@ internal sealed class VersionCheckService : BackgroundService
         if (result.Data)
         {
             _logger.LogDebug("User chose to ignore version {Version}.", latestVersion);
-            _userSecretsManager.TrySetSecret(IgnoreVersionKey, latestVersion.ToString());
+
+            if (latestVersion.IsPrerelease)
+            {
+                // Store a wildcard pattern that ignores all pre-release versions with the same major.minor.patch.
+                // For example, 13.5.0-preview1 becomes 13.5.0-* which will ignore all 13.5.0 pre-releases
+                // but still notify when the stable 13.5.0 is released.
+                _userSecretsManager.TrySetSecret(IgnoreVersionKey, $"{latestVersion.Major}.{latestVersion.Minor}.{latestVersion.Patch}-*");
+            }
+            else
+            {
+                _userSecretsManager.TrySetSecret(IgnoreVersionKey, latestVersion.ToString());
+            }
         }
     }
 
@@ -176,6 +192,35 @@ internal sealed class VersionCheckService : BackgroundService
             return false;
         }
         return SemVersion.ComparePrecedence(version1, version2) > 0;
+    }
+
+    /// <summary>
+    /// Checks whether the given version matches a wildcard ignore pattern (e.g., "13.5.0-*").
+    /// A wildcard pattern ignores all pre-release versions with the same major.minor.patch,
+    /// but does not ignore the stable release.
+    /// </summary>
+    internal bool IsVersionIgnoredByWildcard(SemVersion latestVersion)
+    {
+        if (_configuration[IgnoreVersionKey] is string ignorePattern &&
+            ignorePattern.EndsWith("-*", StringComparison.Ordinal))
+        {
+            // Only pre-release versions can be matched by the wildcard pattern.
+            // The stable release (e.g., 13.5.0) should still trigger a notification.
+            if (!latestVersion.IsPrerelease)
+            {
+                return false;
+            }
+
+            var versionPrefix = ignorePattern[..^2];
+            if (SemVersion.TryParse(versionPrefix, out var baseVersion))
+            {
+                return latestVersion.Major == baseVersion.Major &&
+                       latestVersion.Minor == baseVersion.Minor &&
+                       latestVersion.Patch == baseVersion.Patch;
+            }
+        }
+
+        return false;
     }
 
     private bool TryGetConfigVersion(string key, [NotNullWhen(true)] out SemVersion? knownLatestVersion)

--- a/tests/Aspire.Hosting.Tests/Utils/TestPackageFetcher.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestPackageFetcher.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.VersionChecking;
+using Aspire.Shared;
+
+namespace Aspire.Hosting.Tests.Utils;
+
+internal sealed class TestPackageFetcher : IPackageFetcher
+{
+    private readonly Task<List<NuGetPackage>> _versionTask;
+
+    public bool FetchCalled { get; private set; }
+
+    public TestPackageFetcher(Task<List<NuGetPackage>>? versionTask = null)
+    {
+        _versionTask = versionTask ?? Task.FromResult<List<NuGetPackage>>([]);
+    }
+
+    public Task<List<NuGetPackage>> TryFetchPackagesAsync(string appHostDirectory, CancellationToken cancellationToken)
+    {
+        FetchCalled = true;
+        return _versionTask;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Utils/TestPackageVersionProvider.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestPackageVersionProvider.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.VersionChecking;
+using Semver;
+
+namespace Aspire.Hosting.Tests.Utils;
+
+internal sealed class TestPackageVersionProvider : IPackageVersionProvider
+{
+    private readonly SemVersion _version;
+
+    public TestPackageVersionProvider(SemVersion? version = null)
+    {
+        _version = version ?? new SemVersion(1, 0, 0);
+    }
+
+    public SemVersion? GetPackageVersion()
+    {
+        return _version;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
@@ -4,6 +4,7 @@
 #pragma warning disable ASPIREUSERSECRETS001
 
 using System.Globalization;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.UserSecrets;
 using Aspire.Hosting.VersionChecking;
 using Aspire.Shared;
@@ -245,6 +246,112 @@ public class VersionCheckServiceTests
         Assert.False(interactionService.Interactions.Reader.TryRead(out var _));
     }
 
+    [Theory]
+    [InlineData("100.0.0-preview2", true)]
+    [InlineData("100.0.0-preview3", true)]
+    [InlineData("100.0.0-rc1", true)]
+    [InlineData("100.0.0", false)]
+    [InlineData("100.0.1-preview1", false)]
+    [InlineData("100.1.0-preview1", false)]
+    public async Task ExecuteAsync_IgnoredWildcardVersion_IgnoresPrereleasesOnly(string latestVersion, bool shouldBeIgnored)
+    {
+        // Arrange
+        var interactionService = new TestInteractionService();
+        var configurationManager = new ConfigurationManager();
+        configurationManager.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            // Simulates user having ignored 100.0.0-preview1, which stores "100.0.0-*"
+            [VersionCheckService.IgnoreVersionKey] = "100.0.0-*"
+        });
+        var packagesTcs = new TaskCompletionSource<List<NuGetPackage>>();
+        var packageFetcher = new TestPackageFetcher(packagesTcs.Task);
+        var service = CreateVersionCheckService(
+            interactionService: interactionService,
+            packageFetcher: packageFetcher,
+            configuration: configurationManager,
+            packageVersionProvider: new TestPackageVersionProvider(SemVersion.Parse("1.0.0-preview1")));
+
+        // Act
+        _ = service.StartAsync(CancellationToken.None);
+
+        packagesTcs.SetResult([new NuGetPackage { Id = PackageFetcher.PackageId, Version = latestVersion }]);
+
+        if (shouldBeIgnored)
+        {
+            await service.ExecuteTask!.DefaultTimeout();
+            interactionService.Interactions.Writer.Complete();
+            Assert.False(interactionService.Interactions.Reader.TryRead(out var _));
+        }
+        else
+        {
+            var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+            interaction.CompletionTcs.TrySetResult(InteractionResult.Ok(true));
+            await service.ExecuteTask!.DefaultTimeout();
+        }
+
+        // Assert
+        Assert.True(packageFetcher.FetchCalled);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_IgnorePrerelease_StoresWildcardPattern()
+    {
+        // Arrange
+        var interactionService = new TestInteractionService();
+        var configurationManager = new ConfigurationManager();
+        var packagesTcs = new TaskCompletionSource<List<NuGetPackage>>();
+        var packageFetcher = new TestPackageFetcher(packagesTcs.Task);
+        var mockSecretsManager = new MockUserSecretsManager();
+        var service = CreateVersionCheckService(
+            interactionService: interactionService,
+            packageFetcher: packageFetcher,
+            configuration: configurationManager,
+            packageVersionProvider: new TestPackageVersionProvider(SemVersion.Parse("1.0.0-preview1")),
+            userSecretsManager: mockSecretsManager);
+
+        // Act
+        _ = service.StartAsync(CancellationToken.None);
+
+        packagesTcs.TrySetResult([new NuGetPackage { Id = PackageFetcher.PackageId, Version = "100.0.0-preview1" }]);
+
+        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        interaction.CompletionTcs.TrySetResult(InteractionResult.Ok(true));
+
+        await service.ExecuteTask!.DefaultTimeout();
+
+        // Assert - should store wildcard pattern instead of exact version
+        Assert.Equal("100.0.0-*", mockSecretsManager.Secrets[VersionCheckService.IgnoreVersionKey]);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_IgnoreStableVersion_StoresExactVersion()
+    {
+        // Arrange
+        var interactionService = new TestInteractionService();
+        var configurationManager = new ConfigurationManager();
+        var packagesTcs = new TaskCompletionSource<List<NuGetPackage>>();
+        var packageFetcher = new TestPackageFetcher(packagesTcs.Task);
+        var mockSecretsManager = new MockUserSecretsManager();
+        var service = CreateVersionCheckService(
+            interactionService: interactionService,
+            packageFetcher: packageFetcher,
+            configuration: configurationManager,
+            userSecretsManager: mockSecretsManager);
+
+        // Act
+        _ = service.StartAsync(CancellationToken.None);
+
+        packagesTcs.TrySetResult([new NuGetPackage { Id = PackageFetcher.PackageId, Version = "100.0.0" }]);
+
+        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        interaction.CompletionTcs.TrySetResult(InteractionResult.Ok(true));
+
+        await service.ExecuteTask!.DefaultTimeout();
+
+        // Assert - should store exact version for stable releases
+        Assert.Equal("100.0.0", mockSecretsManager.Secrets[VersionCheckService.IgnoreVersionKey]);
+    }
+
     private static VersionCheckService CreateVersionCheckService(
         IInteractionService? interactionService = null,
         IPackageFetcher? packageFetcher = null,
@@ -278,37 +385,5 @@ public class VersionCheckServiceTests
         }
     }
 
-    private sealed class TestPackageVersionProvider : IPackageVersionProvider
-    {
-        private readonly SemVersion _version;
-
-        public TestPackageVersionProvider(SemVersion? version = null)
-        {
-            _version = version ?? new SemVersion(1, 0, 0);
-        }
-
-        public SemVersion? GetPackageVersion()
-        {
-            return _version;
-        }
-    }
-
-    private sealed class TestPackageFetcher : IPackageFetcher
-    {
-        private readonly Task<List<NuGetPackage>> _versionTask;
-
-        public bool FetchCalled { get; private set; }
-
-        public TestPackageFetcher(Task<List<NuGetPackage>>? versionTask = null)
-        {
-            _versionTask = versionTask ?? Task.FromResult<List<NuGetPackage>>([]);
-        }
-
-        public Task<List<NuGetPackage>> TryFetchPackagesAsync(string appHostDirectory, CancellationToken cancellationToken)
-        {
-            FetchCalled = true;
-            return _versionTask;
-        }
-    }
 }
 


### PR DESCRIPTION
## Summary

When a user clicks "Ignore" on a version update notification for a pre-release version (e.g. `13.5.0-preview1`), the stored ignore value is now `13.5.0-*` instead of the exact version. This wildcard pattern suppresses notifications for all subsequent pre-releases of the same patch version (preview2, preview3, rc1, etc.) but still triggers the notification when the stable release (`13.5.0`) becomes available.

## Changes

- **VersionCheckService.cs**: 
  - When ignoring a pre-release, store `{major}.{minor}.{patch}-*` wildcard pattern
  - Added `IsVersionIgnoredByWildcard` method that matches the wildcard pattern against pre-release versions only
  - Stable versions never match the wildcard (so users are notified of the final release)
- **Tests**: Added tests for wildcard ignore behavior (storage and matching)
- Moved `TestPackageFetcher` and `TestPackageVersionProvider` to shared `Utils/` directory