### PR TITLE
Repair incomplete bundle cache layouts

### DIFF
--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -66,6 +66,18 @@ internal sealed class BundleService(
         BundleDiscovery.BundleDirectoryName,
     ];
 
+    internal static readonly string[] s_requiredManagedDashboardAssets = [
+        Path.Combine("wwwroot", "css", "app.css"),
+        Path.Combine("wwwroot", "css", "highlight.css"),
+        Path.Combine("wwwroot", "css", "markdown.css"),
+        Path.Combine("wwwroot", "js", "app.js"),
+        Path.Combine("wwwroot", "js", "app-reconnect.js"),
+        Path.Combine("wwwroot", "js", "app-theme.js"),
+    ];
+
+    internal const int DashboardBlazorMinSupportedMajor = 10;
+    internal const int DashboardBlazorMaxSupportedMajor = 11;
+
     /// <inheritdoc/>
     public async Task EnsureExtractedAsync(CancellationToken cancellationToken = default)
     {
@@ -161,11 +173,18 @@ internal sealed class BundleService(
                 var currentVersion = GetCurrentVersion(ProcessPathOverride);
                 if (existingVersion == currentVersion)
                 {
-                    logger.LogDebug("Bundle already extracted and up to date (version: {Version}).", existingVersion);
-                    return BundleExtractResult.AlreadyUpToDate;
-                }
+                    if (ResolveActiveVersionDirectory(destinationPath) is not null)
+                    {
+                        logger.LogDebug("Bundle already extracted and up to date (version: {Version}).", existingVersion);
+                        return BundleExtractResult.AlreadyUpToDate;
+                    }
 
-                logger.LogDebug("Version mismatch: existing={ExistingVersion}, current={CurrentVersion}. Re-extracting.", existingVersion, currentVersion);
+                    logger.LogDebug("Bundle version marker is up to date, but the active bundle layout is missing or incomplete. Re-extracting.");
+                }
+                else
+                {
+                    logger.LogDebug("Version mismatch: existing={ExistingVersion}, current={CurrentVersion}. Re-extracting.", existingVersion, currentVersion);
+                }
             }
 
             return await ExtractCoreAsync(destinationPath, cancellationToken);
@@ -525,7 +544,8 @@ internal sealed class BundleService(
 
     /// <summary>
     /// Returns <see langword="true"/> if <paramref name="versionDir"/> contains the
-    /// essential bundle components (<c>managed/aspire-managed</c> and a DCP directory).
+    /// essential bundle components (<c>managed/aspire-managed</c>, the dashboard assets,
+    /// and a DCP directory).
     /// </summary>
     internal static bool IsVersionedLayoutValid(string versionDir)
     {
@@ -561,7 +581,39 @@ internal sealed class BundleService(
             return false;
         }
 
-        return true;
+        return HasRequiredManagedDashboardAssets(managedDir);
+    }
+
+    private static bool HasRequiredManagedDashboardAssets(string managedDir)
+    {
+        // Layout discovery only needs aspire-managed and DCP to launch commands, but
+        // the same managed payload hosts the dashboard. The HTML entry point in
+        // Aspire.Dashboard/Components/App.razor references these root assets directly;
+        // accepting a partial wwwroot here leaves the dashboard serving HTML fallbacks
+        // for CSS/JS requests and surfaces as browser 404/MIME errors.
+        foreach (var relativeAssetPath in s_requiredManagedDashboardAssets)
+        {
+            if (!File.Exists(Path.Combine(managedDir, relativeAssetPath)))
+            {
+                return false;
+            }
+        }
+
+        var frameworkAssetPath = Path.Combine(managedDir, "wwwroot", "framework", GetRequiredDashboardBlazorFrameworkAssetFileName());
+
+        return File.Exists(frameworkAssetPath);
+    }
+
+    internal static string GetRequiredDashboardBlazorFrameworkAssetFileName()
+        => GetRequiredDashboardBlazorFrameworkAssetFileName(Environment.Version.Major);
+
+    internal static string GetRequiredDashboardBlazorFrameworkAssetFileName(int runtimeMajor)
+    {
+        // Keep these bounds in sync with Aspire.Dashboard/Components/BlazorScript.razor
+        // and the files produced by Aspire.Dashboard/BlazorAssets.targets.
+        var major = Math.Clamp(runtimeMajor, DashboardBlazorMinSupportedMajor, DashboardBlazorMaxSupportedMajor);
+
+        return $"blazor.web.{major}.js";
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -70,9 +70,12 @@ internal sealed class BundleService(
         Path.Combine("wwwroot", "css", "app.css"),
         Path.Combine("wwwroot", "css", "highlight.css"),
         Path.Combine("wwwroot", "css", "markdown.css"),
+        Path.Combine("wwwroot", "_content", "Microsoft.FluentUI.AspNetCore.Components", "css", "reboot.css"),
+        Path.Combine("wwwroot", "Aspire.Dashboard.styles.css"),
         Path.Combine("wwwroot", "js", "app.js"),
         Path.Combine("wwwroot", "js", "app-reconnect.js"),
         Path.Combine("wwwroot", "js", "app-theme.js"),
+        Path.Combine("wwwroot", "_content", "Microsoft.FluentUI.AspNetCore.Components", "Microsoft.FluentUI.AspNetCore.Components.lib.module.js"),
     ];
 
     internal const int DashboardBlazorMinSupportedMajor = 10;

--- a/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
@@ -101,6 +101,43 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
         }
     }
 
+    [Fact]
+    public async Task ExtractAsync_UpToDateMarkerWithIncompleteDashboardAssets_Reextracts()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layoutRoot = workspace.WorkspaceRoot.FullName;
+        var payload = CreateFakeBundlePayload("repaired-bundle");
+        var provider = new TestBundlePayloadProvider(payload);
+
+        var layoutDiscovery = new TestLayoutDiscovery(layoutRoot);
+        var service = CreateService(provider, layoutDiscovery);
+
+        var result1 = await service.ExtractAsync(layoutRoot, force: true);
+        Assert.Equal(BundleExtractResult.Extracted, result1);
+
+        var versionsDir = Path.Combine(layoutRoot, BundleService.VersionsDirectoryName);
+        var activeVersionDir = Assert.Single(Directory.GetDirectories(versionsDir));
+        var appCssPath = Path.Combine(activeVersionDir,
+            BundleDiscovery.ManagedDirectoryName,
+            BundleService.s_requiredManagedDashboardAssets[0]);
+
+        File.Delete(appCssPath);
+        Assert.False(BundleService.IsVersionedLayoutValid(activeVersionDir));
+
+        try
+        {
+            var result2 = await service.ExtractAsync(layoutRoot, force: false);
+
+            Assert.Equal(BundleExtractResult.Extracted, result2);
+            Assert.True(File.Exists(appCssPath), $"Dashboard asset should have been restored at {appCssPath}");
+            Assert.Contains("repaired-bundle", File.ReadAllText(appCssPath));
+        }
+        finally
+        {
+            CleanupReparsePoints(layoutRoot);
+        }
+    }
+
     /// <summary>
     /// Verifies that upgrading from v1 to v2 flips the reparse points to the
     /// new versioned directory and cleans up the old one.
@@ -518,6 +555,8 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
                 DataStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"#!/bin/sh\necho {contentMarker}\n"))
             };
             tar.WriteEntry(managedEntry);
+            WriteFakeDashboardAssetEntries(tar, contentMarker);
+            WriteFakeBlazorFrameworkAssetEntry(tar, contentMarker);
 
             // dcp/ directory with a placeholder file.
             tar.WriteEntry(new PaxTarEntry(TarEntryType.Directory, $"aspire-payload/{BundleDiscovery.DcpDirectoryName}/"));
@@ -530,6 +569,32 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
         }
 
         return ms.ToArray();
+    }
+
+    private static void WriteFakeDashboardAssetEntries(TarWriter tar, string contentMarker)
+    {
+        foreach (var relativeAssetPath in BundleService.s_requiredManagedDashboardAssets)
+        {
+            var tarAssetPath = relativeAssetPath.Replace(Path.DirectorySeparatorChar, '/');
+            var dashboardEntry = new PaxTarEntry(
+                TarEntryType.RegularFile,
+                $"aspire-payload/{BundleDiscovery.ManagedDirectoryName}/{tarAssetPath}")
+            {
+                DataStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"{relativeAssetPath}-{contentMarker}\n"))
+            };
+            tar.WriteEntry(dashboardEntry);
+        }
+    }
+
+    private static void WriteFakeBlazorFrameworkAssetEntry(TarWriter tar, string contentMarker)
+    {
+        var dashboardEntry = new PaxTarEntry(
+            TarEntryType.RegularFile,
+            $"aspire-payload/{BundleDiscovery.ManagedDirectoryName}/wwwroot/framework/{BundleService.GetRequiredDashboardBlazorFrameworkAssetFileName()}")
+        {
+            DataStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"{BundleService.GetRequiredDashboardBlazorFrameworkAssetFileName()}-{contentMarker}\n"))
+        };
+        tar.WriteEntry(dashboardEntry);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
@@ -117,9 +117,11 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
 
         var versionsDir = Path.Combine(layoutRoot, BundleService.VersionsDirectoryName);
         var activeVersionDir = Assert.Single(Directory.GetDirectories(versionsDir));
+        var repairedAssetPath = Path.Combine("wwwroot", "css", "app.css");
+        Assert.Contains(repairedAssetPath, BundleService.s_requiredManagedDashboardAssets);
         var appCssPath = Path.Combine(activeVersionDir,
             BundleDiscovery.ManagedDirectoryName,
-            BundleService.s_requiredManagedDashboardAssets[0]);
+            repairedAssetPath);
 
         File.Delete(appCssPath);
         Assert.False(BundleService.IsVersionedLayoutValid(activeVersionDir));

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -151,6 +151,42 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void IsVersionedLayoutValid_RequiresDashboardAssets()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dir = workspace.WorkspaceRoot.FullName;
+        CreateFakeBundleLayout(dir);
+
+        var managedDir = Path.Combine(dir, BundleDiscovery.ManagedDirectoryName);
+        File.Delete(Path.Combine(managedDir, "wwwroot", "js", "app-theme.js"));
+
+        Assert.False(BundleService.IsVersionedLayoutValid(dir));
+    }
+
+    [Fact]
+    public void IsVersionedLayoutValid_RequiresBlazorFrameworkAsset()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dir = workspace.WorkspaceRoot.FullName;
+        CreateFakeBundleLayout(dir);
+
+        var frameworkDir = Path.Combine(dir, BundleDiscovery.ManagedDirectoryName, "wwwroot", "framework");
+        Directory.Delete(frameworkDir, recursive: true);
+
+        Assert.False(BundleService.IsVersionedLayoutValid(dir));
+    }
+
+    [Theory]
+    [InlineData(8, "blazor.web.10.js")]
+    [InlineData(10, "blazor.web.10.js")]
+    [InlineData(11, "blazor.web.11.js")]
+    [InlineData(12, "blazor.web.11.js")]
+    public void GetRequiredDashboardBlazorFrameworkAssetFileName_MatchesDashboardRuntimeClamp(int runtimeMajor, string expectedFileName)
+    {
+        Assert.Equal(expectedFileName, BundleService.GetRequiredDashboardBlazorFrameworkAssetFileName(runtimeMajor));
+    }
+
+    [Fact]
     public void TryCleanupStaleVersions_RemovesNonActiveVersionsAndStaleTempDirs()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -194,9 +230,24 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
         File.WriteAllText(
             Path.Combine(managedDir, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
             "#!/bin/sh\necho aspire-managed\n");
+        WriteFakeDashboardAssets(managedDir);
 
         var dcpDir = Path.Combine(root, BundleDiscovery.DcpDirectoryName);
         Directory.CreateDirectory(dcpDir);
         File.WriteAllText(Path.Combine(dcpDir, "placeholder"), "dcp");
+    }
+
+    private static void WriteFakeDashboardAssets(string managedDir)
+    {
+        foreach (var relativeAssetPath in BundleService.s_requiredManagedDashboardAssets)
+        {
+            var assetPath = Path.Combine(managedDir, relativeAssetPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(assetPath)!);
+            File.WriteAllText(assetPath, relativeAssetPath);
+        }
+
+        var frameworkAssetPath = Path.Combine(managedDir, "wwwroot", "framework", BundleService.GetRequiredDashboardBlazorFrameworkAssetFileName());
+        Directory.CreateDirectory(Path.GetDirectoryName(frameworkAssetPath)!);
+        File.WriteAllText(frameworkAssetPath, BundleService.GetRequiredDashboardBlazorFrameworkAssetFileName());
     }
 }

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -5,6 +5,8 @@ using Aspire.Cli.Bundles;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Shared;
+using System.Globalization;
+using System.Xml.Linq;
 
 namespace Aspire.Cli.Tests;
 
@@ -163,6 +165,26 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
         Assert.False(BundleService.IsVersionedLayoutValid(dir));
     }
 
+    [Theory]
+    [InlineData("wwwroot/_content/Microsoft.FluentUI.AspNetCore.Components/css/reboot.css")]
+    [InlineData("wwwroot/Aspire.Dashboard.styles.css")]
+    [InlineData("wwwroot/_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js")]
+    public void IsVersionedLayoutValid_RequiresDirectlyReferencedDashboardAssets(string relativeAssetPath)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dir = workspace.WorkspaceRoot.FullName;
+        CreateFakeBundleLayout(dir);
+
+        var managedDir = Path.Combine(dir, BundleDiscovery.ManagedDirectoryName);
+        WriteFakeDashboardAsset(managedDir, relativeAssetPath);
+
+        Assert.True(BundleService.IsVersionedLayoutValid(dir));
+
+        File.Delete(Path.Combine(managedDir, relativeAssetPath.Replace('/', Path.DirectorySeparatorChar)));
+
+        Assert.False(BundleService.IsVersionedLayoutValid(dir));
+    }
+
     [Fact]
     public void IsVersionedLayoutValid_RequiresBlazorFrameworkAsset()
     {
@@ -184,6 +206,25 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
     public void GetRequiredDashboardBlazorFrameworkAssetFileName_MatchesDashboardRuntimeClamp(int runtimeMajor, string expectedFileName)
     {
         Assert.Equal(expectedFileName, BundleService.GetRequiredDashboardBlazorFrameworkAssetFileName(runtimeMajor));
+    }
+
+    [Fact]
+    public void DashboardBlazorSupportedMajorBounds_MatchBlazorAssetsTargets()
+    {
+        var repoRoot = GetRepoRoot();
+        var targetsPath = Path.Combine(repoRoot, "src", "Aspire.Dashboard", "BlazorAssets.targets");
+        var targetDocument = XDocument.Load(targetsPath);
+        var packageMajors = targetDocument
+            .Descendants("BlazorAssetPackage")
+            .Select(e => int.Parse(e.Attribute("Include")!.Value, CultureInfo.InvariantCulture))
+            .Order()
+            .ToArray();
+
+        var expectedPackageMajors = Enumerable.Range(
+            BundleService.DashboardBlazorMinSupportedMajor,
+            BundleService.DashboardBlazorMaxSupportedMajor - BundleService.DashboardBlazorMinSupportedMajor + 1).ToArray();
+
+        Assert.Equal(expectedPackageMajors, packageMajors);
     }
 
     [Fact]
@@ -241,13 +282,21 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
     {
         foreach (var relativeAssetPath in BundleService.s_requiredManagedDashboardAssets)
         {
-            var assetPath = Path.Combine(managedDir, relativeAssetPath);
-            Directory.CreateDirectory(Path.GetDirectoryName(assetPath)!);
-            File.WriteAllText(assetPath, relativeAssetPath);
+            WriteFakeDashboardAsset(managedDir, relativeAssetPath);
         }
 
         var frameworkAssetPath = Path.Combine(managedDir, "wwwroot", "framework", BundleService.GetRequiredDashboardBlazorFrameworkAssetFileName());
         Directory.CreateDirectory(Path.GetDirectoryName(frameworkAssetPath)!);
         File.WriteAllText(frameworkAssetPath, BundleService.GetRequiredDashboardBlazorFrameworkAssetFileName());
     }
+
+    private static void WriteFakeDashboardAsset(string managedDir, string relativeAssetPath)
+    {
+        var assetPath = Path.Combine(managedDir, relativeAssetPath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(assetPath)!);
+        File.WriteAllText(assetPath, relativeAssetPath);
+    }
+
+    private static string GetRepoRoot()
+        => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
 }


### PR DESCRIPTION
## Description

Fixes #17983

Sidecar-less CLI installs such as npm/npx can use Aspire home as the bundle extraction location. If that home cache contains a version marker that matches the current CLI but the active version directory is missing dashboard static assets, layout discovery can still find `aspire-managed` and DCP and the bundle is treated as up to date. The dashboard then serves HTML fallbacks for CSS/JS requests, which shows up as 404s and MIME errors in the browser.

This changes bundle validation so the up-to-date path only returns `AlreadyUpToDate` when the active version directory still has the managed executable, DCP, the dashboard root CSS/JS assets, and the runtime-clamped Blazor framework asset. If a matching-version cache is incomplete, the embedded payload is extracted again and the cache is repaired.

### User-facing usage

Users can keep running the CLI normally:

```bash
npx @microsoft/aspire-cli dashboard run
```

If the selected Aspire home bundle cache is incomplete but the embedded npm/npx CLI has a valid payload, the CLI now repairs the cache instead of reusing it and leaving dashboard asset requests broken.

### Validation

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.BundleServiceTests" --filter-class "*.BundleServiceIntegrationTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
