### PR TITLE
Fix Outerloop dashboard test: Kestrel rejects dynamic-port bind on "localhost"

### DIFF
--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
@@ -28,7 +28,11 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
     {
         public BrowserTokenDashboardServerWithHttpAndHttpsFixture()
         {
-            Configuration[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://localhost:0;http://localhost:0";
+            // Bind to 127.0.0.1 rather than the "localhost" hostname: Kestrel rejects dynamic-port
+            // binding (":0") on "localhost" with "Dynamic port binding is not supported when binding
+            // to localhost. You must either bind to 127.0.0.1:0 or [::1]:0, or both." The WebKit test
+            // navigates to the resolved address with IgnoreHTTPSErrors, so the loopback IP is fine.
+            Configuration[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0;http://127.0.0.1:0";
             Configuration[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.BrowserToken);
             Configuration[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = "VALID_TOKEN";
         }


### PR DESCRIPTION
**`BrowserToken_QueryStringToken_HttpsThenHttp_WebKit_Success` fails every scheduled Outerloop run** — its class fixture throws before any test body runs:

```
Class fixture type 'BrowserTokenDashboardServerWithHttpAndHttpsFixture' threw in InitializeAsync
---- System.InvalidOperationException : Dynamic port binding is not supported when binding to localhost. You must either bind to 127.0.0.1:0 or [::1]:0, or both.
```

**Root cause.** The fixture binds the dashboard frontend to `https://localhost:0;http://localhost:0`. Kestrel doesn't support dynamic-port (`:0`) binding on the `localhost` hostname — the constraint is hostname-based, independent of scheme. The base `DashboardServerFixture` already binds `127.0.0.1:0` and works.

**Fix.** Bind to `https://127.0.0.1:0;http://127.0.0.1:0`. The WebKit test navigates to the endpoint's resolved address with `IgnoreHTTPSErrors`, so the loopback IP is fine.

Verified locally: a minimal Kestrel app reproduces the exact exception on `localhost:0` and binds successfully on `127.0.0.1:0`; the test project compiles. The Playwright test itself runs only in the browser-enabled Outerloop environment.

Broken since the fixture was added in #17368. Surfaced by workflow-health report #18223.

Refs #18223
