### PR TITLE
test(hosting): fix Outerloop tests asserting null proxyless EffectivePort

### DIFF
--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -1809,7 +1809,6 @@ public class DistributedApplicationTests
         await clientA.GetStringAsync("/").DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
 
         var s = app.Services.GetRequiredService<IKubernetesService>();
-        var serviceList = await s.ListAsync<Service>().DefaultTimeout();
         var exeList = await s.ListAsync<Executable>().DefaultTimeout();
 
         var service = Assert.Single(exeList, c => $"{testName}-servicea".Equals(c.AppModelResourceName));
@@ -1831,7 +1830,8 @@ public class DistributedApplicationTests
             Assert.Equal(port, Assert.Single(redisContainer.Spec.Ports!).HostPort);
         }
 
-        var otherRedisService = GetEndpointService(serviceList, redisNoPort.Resource, redisNoPort.Resource.PrimaryEndpoint);
+        var otherRedisService = await WaitForAllocatedProxylessServiceAsync(s, redisNoPort.Resource, redisNoPort.Resource.PrimaryEndpoint)
+            .DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         var otherRedisPort = AssertAllocatedProxylessPort(otherRedisService);
         var otherRedisEnv = Assert.Single(service.Spec.Env!, e => e.Name == $"ConnectionStrings__{testName}-redisNoPort");
         sslVal = redisNoPort.Resource.TlsEnabled ? ",ssl=true" : string.Empty;
@@ -1908,7 +1908,8 @@ public class DistributedApplicationTests
             Assert.Equal(port, Assert.Single(redisContainer.Spec.Ports!).HostPort);
         }
 
-        var otherRedisService = GetEndpointService(serviceList, redisNoPort.Resource, redisNoPort.Resource.PrimaryEndpoint);
+        var otherRedisService = await WaitForAllocatedProxylessServiceAsync(s, redisNoPort.Resource, redisNoPort.Resource.PrimaryEndpoint)
+            .DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         var otherRedisPort = AssertAllocatedProxylessPort(otherRedisService);
         var otherRedisEnv = Assert.Single(service.Spec.Env!, e => e.Name == $"ConnectionStrings__{testName}-redisNoPort");
         sslVal = redisNoPort.Resource.TlsEnabled ? ",ssl=true" : string.Empty;
@@ -2304,11 +2305,25 @@ public class DistributedApplicationTests
             .WithImageRegistry(AspireTestContainerRegistry);
     }
 
-    private static Service GetEndpointService(IEnumerable<Service> services, RedisResource redis, EndpointReference endpoint)
+    private static Task<Service> WaitForAllocatedProxylessServiceAsync(IKubernetesService kubernetesService, RedisResource redis, EndpointReference endpoint, CancellationToken cancellationToken = default)
     {
         var hasMultipleEndpoints = redis.Annotations.OfType<EndpointAnnotation>().Count() > 1;
         var expectedServiceName = hasMultipleEndpoints ? $"{redis.Name}-{endpoint.EndpointName}" : redis.Name;
-        return Assert.Single(services, s => string.Equals(s.Metadata.Name, expectedServiceName, StringComparison.Ordinal));
+
+        // A proxyless endpoint's host port is assigned synchronously by Aspire (Service.Spec.Port),
+        // but DCP reports the actually-bound port back asynchronously via Service.Status.EffectivePort.
+        // Orchestrator startup intentionally does NOT wait for DCP to echo the effective address of
+        // proxyless services (they are excluded from the startup address-wait in DcpExecutor) because
+        // connection strings are built from the Aspire-assigned Spec.Port and are usable immediately.
+        // As a result, a fast agent can observe the Service before DCP has populated EffectivePort, so
+        // wait until it appears before asserting on it (otherwise the EffectivePort assertion in
+        // AssertAllocatedProxylessPort races and is null on fast Linux CI agents while passing on Windows).
+        return KubernetesHelper.GetResourceByNameAsync<Service>(
+            kubernetesService,
+            expectedServiceName,
+            string.Empty,
+            service => service.Status?.EffectivePort is not null,
+            cancellationToken);
     }
 
     private static int AssertAllocatedProxylessPort(Service service)


### PR DESCRIPTION
The Outerloop Tests workflow fails every scheduled night (7/7 this week, flagged in #18223). Two `[OuterloopTest]` + Docker-required Hosting tests fail deterministically on the `Hosting (8-core-ubuntu-latest)` job and pass on `windows-latest`:

- `Aspire.Hosting.Tests.DistributedApplicationTests.ProxylessContainerCanBeReferenced`
- `Aspire.Hosting.Tests.DistributedApplicationTests.WithEndpointProxySupportDisablesProxies`

Both fail the same way:

```
Assert.IsType() Failure: Value is null
Expected: typeof(int)
Actual:   null
  at Aspire.Hosting.Tests.DistributedApplicationTests.AssertAllocatedProxylessPort(Service service)
  at Aspire.Hosting.Tests.DistributedApplicationTests.ProxylessContainerCanBeReferenced() line 1835
```

## Root cause

Both tests assert on the `redisNoPort` proxyless service's `Status.EffectivePort`. PR #17924 ("Add proxyless endpoint port allocator") made Aspire pre-assign the proxyless host port synchronously (`Service.Spec.Port`) and intentionally excluded proxyless services from the startup address-wait in `DcpExecutor` — connection strings are built from the Aspire-assigned `Spec.Port`, which is available immediately, so startup need not block on DCP echoing the bound port.

DCP still reports that port back asynchronously via `Status.EffectivePort`. After `StartAsync()` and the app responding, DCP may not yet have populated `EffectivePort` for the proxyless service. The fast 8-core Linux runner reads the service list before that update lands → null; Windows lands the update first → pass. The unit-test fake sets `EffectivePort = Spec.Port` synchronously, so unit tests never hit the race.

This is a test bug, not a product regression — the orchestrator behavior is correct by design.

## The fix

Test-side only. Both tests now wait for the proxyless service to report a non-null `Status.EffectivePort` (using `KubernetesHelper.GetResourceByNameAsync`, the existing watch-based waiter already used elsewhere in this file) before running `AssertAllocatedProxylessPort`, instead of asserting against a once-fetched service list. This preserves the end-to-end check that DCP actually bound the Aspire-assigned port. No product code changes.

## Call-outs

- `WithEndpointProxySupportDisablesProxies` is not yet tracked by an issue; it shares the exact same root cause and is fixed by the same change.
- Validated on Linux in a Docker container (the environment that fails in CI): both tests fail with the verbatim null error before the change and pass (2/2, ~41s) after it.
- No product code touched; `DcpExecutor`'s intentional proxyless exclusion is unchanged.

Fixes #8773
