### PR TITLE
test: fix three deterministically-failing Outerloop tests

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/NewWithAgentInitTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/NewWithAgentInitTests.cs
@@ -53,7 +53,10 @@ public sealed class NewWithAgentInitTests(ITestOutputHelper output)
 
         // Run aspire new with the Starter template, going through all prompts manually
         // so we can ACCEPT the agent init prompt instead of declining it.
-        await auto.TypeAsync("aspire new");
+        // Pass --skill-locations and --skills as CLI flags so the test does not depend on
+        // the position or count of entries in the interactive skill-selection menus, which
+        // change whenever the bundle ships a new skill.
+        await auto.TypeAsync("aspire new --skill-locations claudecode --skills playwright-cli");
         await auto.EnterAsync();
 
         // Template selection: accept default Starter App
@@ -107,32 +110,9 @@ public sealed class NewWithAgentInitTests(ITestOutputHelper output)
         await auto.WaitAsync(500);
         await auto.TypeAsync("y");
 
-        // Agent init: skill location - select Claude Code
-        await auto.WaitUntilAsync(
-            s => s.ContainsText("skill files be installed"),
-            timeout: TimeSpan.FromSeconds(60),
-            description: "skill location prompt");
-        await auto.TypeAsync(" "); // Toggle off default Standard location
-        await auto.DownAsync();
-        await auto.TypeAsync(" "); // Toggle on Claude Code location
-        await auto.EnterAsync();
-
-        // Agent init: skill selection - this test validates Playwright acquisition,
-        // so deselect the default Aspire bundle skills and select only Playwright CLI.
-        await auto.WaitUntilAsync(
-            s => s.ContainsText("skills should be installed"),
-            timeout: TimeSpan.FromSeconds(30),
-            description: "skill selection prompt");
-        await auto.TypeAsync(" "); // Toggle off Aspire
-        await auto.DownAsync();
-        await auto.TypeAsync(" "); // Toggle off aspireify
-        await auto.DownAsync();
-        await auto.TypeAsync(" "); // Toggle off aspire-deployment
-        await auto.DownAsync();
-        await auto.TypeAsync(" "); // Toggle on Playwright CLI
-        await auto.EnterAsync();
-
         // Wait for agent init to complete (downloads @playwright/cli from npm).
+        // Skill location and skill selection are provided via --skill-locations/--skills flags
+        // on the aspire new invocation above, so no interactive navigation is needed here.
         // Fail the test immediately if a provenance verification error appears.
         await auto.WaitUntilAsync(s =>
         {

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
@@ -28,7 +28,11 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
     {
         public BrowserTokenDashboardServerWithHttpAndHttpsFixture()
         {
-            Configuration[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://localhost:0;http://localhost:0";
+            // Bind to 127.0.0.1 rather than the "localhost" hostname: Kestrel rejects dynamic-port
+            // binding (":0") on "localhost" with "Dynamic port binding is not supported when binding
+            // to localhost. You must either bind to 127.0.0.1:0 or [::1]:0, or both." The WebKit test
+            // navigates to the resolved address with IgnoreHTTPSErrors, so the loopback IP is fine.
+            Configuration[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0;http://127.0.0.1:0";
             Configuration[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.BrowserToken);
             Configuration[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = "VALID_TOKEN";
         }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -1809,7 +1809,6 @@ public class DistributedApplicationTests
         await clientA.GetStringAsync("/").DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
 
         var s = app.Services.GetRequiredService<IKubernetesService>();
-        var serviceList = await s.ListAsync<Service>().DefaultTimeout();
         var exeList = await s.ListAsync<Executable>().DefaultTimeout();
 
         var service = Assert.Single(exeList, c => $"{testName}-servicea".Equals(c.AppModelResourceName));
@@ -1831,7 +1830,8 @@ public class DistributedApplicationTests
             Assert.Equal(port, Assert.Single(redisContainer.Spec.Ports!).HostPort);
         }
 
-        var otherRedisService = GetEndpointService(serviceList, redisNoPort.Resource, redisNoPort.Resource.PrimaryEndpoint);
+        var otherRedisService = await WaitForAllocatedProxylessServiceAsync(s, redisNoPort.Resource, redisNoPort.Resource.PrimaryEndpoint)
+            .DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         var otherRedisPort = AssertAllocatedProxylessPort(otherRedisService);
         var otherRedisEnv = Assert.Single(service.Spec.Env!, e => e.Name == $"ConnectionStrings__{testName}-redisNoPort");
         sslVal = redisNoPort.Resource.TlsEnabled ? ",ssl=true" : string.Empty;
@@ -1908,7 +1908,8 @@ public class DistributedApplicationTests
             Assert.Equal(port, Assert.Single(redisContainer.Spec.Ports!).HostPort);
         }
 
-        var otherRedisService = GetEndpointService(serviceList, redisNoPort.Resource, redisNoPort.Resource.PrimaryEndpoint);
+        var otherRedisService = await WaitForAllocatedProxylessServiceAsync(s, redisNoPort.Resource, redisNoPort.Resource.PrimaryEndpoint)
+            .DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         var otherRedisPort = AssertAllocatedProxylessPort(otherRedisService);
         var otherRedisEnv = Assert.Single(service.Spec.Env!, e => e.Name == $"ConnectionStrings__{testName}-redisNoPort");
         sslVal = redisNoPort.Resource.TlsEnabled ? ",ssl=true" : string.Empty;
@@ -2304,11 +2305,25 @@ public class DistributedApplicationTests
             .WithImageRegistry(AspireTestContainerRegistry);
     }
 
-    private static Service GetEndpointService(IEnumerable<Service> services, RedisResource redis, EndpointReference endpoint)
+    private static Task<Service> WaitForAllocatedProxylessServiceAsync(IKubernetesService kubernetesService, RedisResource redis, EndpointReference endpoint, CancellationToken cancellationToken = default)
     {
         var hasMultipleEndpoints = redis.Annotations.OfType<EndpointAnnotation>().Count() > 1;
         var expectedServiceName = hasMultipleEndpoints ? $"{redis.Name}-{endpoint.EndpointName}" : redis.Name;
-        return Assert.Single(services, s => string.Equals(s.Metadata.Name, expectedServiceName, StringComparison.Ordinal));
+
+        // A proxyless endpoint's host port is assigned synchronously by Aspire (Service.Spec.Port),
+        // but DCP reports the actually-bound port back asynchronously via Service.Status.EffectivePort.
+        // Orchestrator startup intentionally does NOT wait for DCP to echo the effective address of
+        // proxyless services (they are excluded from the startup address-wait in DcpExecutor) because
+        // connection strings are built from the Aspire-assigned Spec.Port and are usable immediately.
+        // As a result, a fast agent can observe the Service before DCP has populated EffectivePort, so
+        // wait until it appears before asserting on it (otherwise the EffectivePort assertion in
+        // AssertAllocatedProxylessPort races and is null on fast Linux CI agents while passing on Windows).
+        return KubernetesHelper.GetResourceByNameAsync<Service>(
+            kubernetesService,
+            expectedServiceName,
+            string.Empty,
+            service => service.Status?.EffectivePort is not null,
+            cancellationToken);
     }
 
     private static int AssertAllocatedProxylessPort(Service service)


### PR DESCRIPTION
Consolidates three small `[OuterloopTest]` fixes for tests that fail every scheduled Outerloop run (flagged in the workflow-health report #18223). Supersedes #18248, #18246, #18249 — none were approved, so combining them into one review/CI cycle. Each fix is an independent test-only change to a different assembly.

## 1. `AspireNew_WithAgentInit_InstallsPlaywrightWithoutErrors` (CLI e2e)

**Symptom.** The test drove the `aspire agent init` skill-selection menu with hardcoded positional `space`/`down` keystrokes. When the skill bundle gained a new skill, the keystrokes landed on `aspire-orchestration` instead of `playwright-cli`, so `playwright-cli` was never installed and the later `playwright-cli --version` check exited 127.

**Fix.** Pass `--skill-locations claudecode --skills playwright-cli` to `aspire new`; the flags are forwarded to the chained `agent init` and bypass the interactive prompts, making selection deterministic regardless of bundle contents. All verification steps are preserved.

`tests/Aspire.Cli.EndToEnd.Tests/NewWithAgentInitTests.cs`

## 2. `BrowserToken_QueryStringToken_HttpsThenHttp_WebKit_Success` (dashboard)

**Symptom.** The class fixture threw in `InitializeAsync` before any test body ran:

```
Class fixture type 'BrowserTokenDashboardServerWithHttpAndHttpsFixture' threw in InitializeAsync
```

**Root cause.** The fixture bound the frontend to `https://localhost:0;http://localhost:0`. Kestrel doesn't support dynamic-port (`:0`) binding on the `localhost` hostname — the constraint is hostname-based, not scheme-based. The base `DashboardServerFixture` already binds `127.0.0.1:0`.

**Fix.** Bind to `https://127.0.0.1:0;http://127.0.0.1:0`. The WebKit test navigates to the resolved address with `IgnoreHTTPSErrors`, so the loopback IP is fine.

`tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs`

## 3. `ProxylessContainerCanBeReferenced` + `WithEndpointProxySupportDisablesProxies` (hosting)

**Symptom.** Both `[OuterloopTest]` + Docker-required tests fail deterministically on the Linux `Hosting` job (pass on Windows). They assert on a proxyless service's `Status.EffectivePort` immediately after startup.

**Root cause.** #17924 made Aspire pre-assign the proxyless host port synchronously (`Service.Spec.Port`) and excluded proxyless services from the DCP startup address-wait, so `Status.EffectivePort` can still be null right after startup — a race.

**Fix.** Wait for the proxyless service's `EffectivePort` to be populated (via `KubernetesHelper.GetResourceByNameAsync`) before asserting.

`tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs`

## Validation

Outerloop Tests workflow dispatched against the combined change; the net diff is identical to what's under review here.

Fixes #8773
Refs #18223
