### PR TITLE
Add OS information to aspire doctor

### DIFF
--- a/docs/specs/cli-output-formats.md
+++ b/docs/specs/cli-output-formats.md
@@ -427,6 +427,18 @@ The JSON form includes secret values. Do not redirect it to logs or files unless
 {
   "checks": [
     {
+      "category": "environment",
+      "name": "operating-system",
+      "status": "pass",
+      "message": "Operating system: Linux Ubuntu 24.04",
+      "metadata": {
+        "osType": "Linux",
+        "displayName": "Linux Ubuntu",
+        "version": "24.04",
+        "description": "Ubuntu 24.04.2 LTS"
+      }
+    },
+    {
       "category": "sdk",
       "name": "dotnet-sdk",
       "status": "pass",
@@ -442,7 +454,7 @@ The JSON form includes secret values. Do not redirect it to logs or files unless
     }
   ],
   "summary": {
-    "passed": 1,
+    "passed": 2,
     "warnings": 1,
     "failed": 0
   }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -509,6 +509,7 @@ public class Program
 
         // Environment checking services.
         builder.Services.AddSingleton<IEnvironmentCheck, AspireVersionCheck>();
+        builder.Services.AddSingleton<IEnvironmentCheck, OperatingSystemCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, WslEnvironmentCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, DotNetSdkCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, TypeScriptAppHostToolingCheck>();

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -159,6 +159,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Operating system: {0}.
+        /// </summary>
+        public static string OperatingSystemMessageFormat {
+            get {
+                return ResourceManager.GetString("OperatingSystemMessageFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to unknown.
         /// </summary>
         public static string VersionUnknown {

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -92,6 +92,10 @@
   <data name="CheckingPrerequisites" xml:space="preserve">
     <value>Checking Aspire environment...</value>
   </data>
+  <data name="OperatingSystemMessageFormat" xml:space="preserve">
+    <value>Operating system: {0}</value>
+    <comment>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</comment>
+  </data>
   <data name="VersionUnknown" xml:space="preserve">
     <value>unknown</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">Sada .NET SDK</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET-SDK</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">SDK de .NET</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">Kit de développement logiciel (SDK) .NET</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">SDK do .NET</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">Пакет SDK .NET</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -224,6 +224,11 @@ The legacy file continues to work — this is a non-blocking warning.</target>
         <target state="new">Legacy .aspire/settings.json detected at {0}</target>
         <note>{0} is the full path to the legacy settings file.</note>
       </trans-unit>
+      <trans-unit id="OperatingSystemMessageFormat">
+        <source>Operating system: {0}</source>
+        <target state="new">Operating system: {0}</target>
+        <note>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</note>
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
@@ -23,6 +23,9 @@ internal sealed class AspireVersionCheck(
     CliExecutionContext executionContext,
     ILogger<AspireVersionCheck> logger) : IEnvironmentCheck
 {
+    internal const string AppHostVersionCheckName = "apphost-version";
+    internal const string CliVersionCheckName = "cli-version";
+
     // Version checks should appear first so users immediately see which Aspire bits
     // produced the rest of the doctor output before reading environment diagnostics.
     public int Order => 0;
@@ -49,8 +52,8 @@ internal sealed class AspireVersionCheck(
 
             appHostVersionCheck = new EnvironmentCheckResult
             {
-                Category = "apphost",
-                Name = "apphost-version",
+                Category = EnvironmentCheckCategories.AppHost,
+                Name = AppHostVersionCheckName,
                 Status = EnvironmentCheckStatus.Warning,
                 Message = DoctorCommandStrings.AppHostVersionCheckFailedMessage,
                 Details = ex.Message
@@ -88,8 +91,8 @@ internal sealed class AspireVersionCheck(
             {
                 return new EnvironmentCheckResult
                 {
-                    Category = "aspire",
-                    Name = "cli-version",
+                    Category = EnvironmentCheckCategories.Aspire,
+                    Name = CliVersionCheckName,
                     Status = EnvironmentCheckStatus.Warning,
                     Message = FormatCliVersionMessage(currentVersion, identityChannel),
                     Details = $"{DoctorCommandStrings.CliVersionUpdateCheckFailedMessage}: {updateCheckError}",
@@ -101,8 +104,8 @@ internal sealed class AspireVersionCheck(
             {
                 return new EnvironmentCheckResult
                 {
-                    Category = "aspire",
-                    Name = "cli-version",
+                    Category = EnvironmentCheckCategories.Aspire,
+                    Name = CliVersionCheckName,
                     Status = EnvironmentCheckStatus.Warning,
                     // Both versions get their channel inline next to them so
                     // the message is unambiguous:
@@ -124,8 +127,8 @@ internal sealed class AspireVersionCheck(
 
             return new EnvironmentCheckResult
             {
-                Category = "aspire",
-                Name = "cli-version",
+                Category = EnvironmentCheckCategories.Aspire,
+                Name = CliVersionCheckName,
                 Status = EnvironmentCheckStatus.Pass,
                 Message = FormatCliVersionMessage(currentVersion, identityChannel),
                 Metadata = BuildCliVersionMetadata(currentVersion, latestVersion: null, status.UpdateCommand, updateCheckError: null, identityChannel, latestVersionChannel: null)
@@ -141,8 +144,8 @@ internal sealed class AspireVersionCheck(
 
             return new EnvironmentCheckResult
             {
-                Category = "aspire",
-                Name = "cli-version",
+                Category = EnvironmentCheckCategories.Aspire,
+                Name = CliVersionCheckName,
                 Status = EnvironmentCheckStatus.Warning,
                 Message = DoctorCommandStrings.CliVersionUpdateCheckFailedMessage,
                 Details = ex.Message,
@@ -226,8 +229,8 @@ internal sealed class AspireVersionCheck(
         {
             return new EnvironmentCheckResult
             {
-                Category = "apphost",
-                Name = "apphost-version",
+                Category = EnvironmentCheckCategories.AppHost,
+                Name = AppHostVersionCheckName,
                 Status = EnvironmentCheckStatus.Warning,
                 Message = DoctorCommandStrings.AppHostVersionCheckFailedMessage,
                 Details = ex.Message
@@ -239,8 +242,8 @@ internal sealed class AspireVersionCheck(
 
             return new EnvironmentCheckResult
             {
-                Category = "apphost",
-                Name = "apphost-version",
+                Category = EnvironmentCheckCategories.AppHost,
+                Name = AppHostVersionCheckName,
                 Status = EnvironmentCheckStatus.Warning,
                 Message = DoctorCommandStrings.AppHostVersionCheckFailedMessage,
                 Details = ex.Message
@@ -273,8 +276,8 @@ internal sealed class AspireVersionCheck(
                 {
                     return new EnvironmentCheckResult
                     {
-                        Category = "apphost",
-                        Name = "apphost-version",
+                        Category = EnvironmentCheckCategories.AppHost,
+                        Name = AppHostVersionCheckName,
                         Status = EnvironmentCheckStatus.Warning,
                         Message = AppendChannelSuffix(
                             string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.AppHostVersionUnknownMessageFormat, relativePath),
@@ -285,8 +288,8 @@ internal sealed class AspireVersionCheck(
 
                 return new EnvironmentCheckResult
                 {
-                    Category = "apphost",
-                    Name = "apphost-version",
+                    Category = EnvironmentCheckCategories.AppHost,
+                    Name = AppHostVersionCheckName,
                     Status = EnvironmentCheckStatus.Pass,
                     // Channel goes inline next to the version, not at the
                     // end of the message: "AppHost version 13.0.0 (channel: stable) (path/to/AppHost.csproj)"
@@ -312,8 +315,8 @@ internal sealed class AspireVersionCheck(
 
                 return new EnvironmentCheckResult
                 {
-                    Category = "apphost",
-                    Name = "apphost-version",
+                    Category = EnvironmentCheckCategories.AppHost,
+                    Name = AppHostVersionCheckName,
                     Status = EnvironmentCheckStatus.Warning,
                     Message = DoctorCommandStrings.AppHostVersionCheckFailedMessage,
                     Details = ex.Message,

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/ContainerRuntimeCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/ContainerRuntimeCheck.cs
@@ -11,6 +11,7 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// </summary>
 internal sealed class ContainerRuntimeCheck(ILogger<ContainerRuntimeCheck> logger) : IEnvironmentCheck
 {
+    internal const string CheckName = "container-runtime";
 
     /// <summary>
     /// Minimum Docker version required for Aspire.
@@ -70,8 +71,8 @@ internal sealed class ContainerRuntimeCheck(ILogger<ContainerRuntimeCheck> logge
             {
                 results.Add(new EnvironmentCheckResult
                 {
-                    Category = "container",
-                    Name = "container-runtime",
+                    Category = EnvironmentCheckCategories.Container,
+                    Name = CheckName,
                     Status = EnvironmentCheckStatus.Fail,
                     Message = "No container runtime detected",
                     Fix = "Install Docker Desktop: https://www.docker.com/products/docker-desktop or Podman: https://podman.io/getting-started/installation",
@@ -86,8 +87,8 @@ internal sealed class ContainerRuntimeCheck(ILogger<ContainerRuntimeCheck> logge
             logger.LogDebug(ex, "Error checking container runtime");
             return [new EnvironmentCheckResult
             {
-                Category = "container",
-                Name = "container-runtime",
+                Category = EnvironmentCheckCategories.Container,
+                Name = CheckName,
                 Status = EnvironmentCheckStatus.Fail,
                 Message = "Failed to check container runtime",
                 Details = ex.Message
@@ -125,8 +126,8 @@ internal sealed class ContainerRuntimeCheck(ILogger<ContainerRuntimeCheck> logge
             var runtimeName = info.IsDockerDesktop ? "Docker Desktop" : "Docker";
             return new EnvironmentCheckResult
             {
-                Category = "container",
-                Name = "container-runtime",
+                Category = EnvironmentCheckCategories.Container,
+                Name = CheckName,
                 Status = EnvironmentCheckStatus.Fail,
                 Message = $"{runtimeName} is running in Windows container mode",
                 Details = "Aspire requires Linux containers. Windows containers are not supported.",
@@ -140,8 +141,8 @@ internal sealed class ContainerRuntimeCheck(ILogger<ContainerRuntimeCheck> logge
 
     private static EnvironmentCheckResult WarningResult(string message, string fix) => new()
     {
-        Category = "container",
-        Name = "container-runtime",
+        Category = EnvironmentCheckCategories.Container,
+        Name = CheckName,
         Status = EnvironmentCheckStatus.Warning,
         Message = message,
         Fix = fix,
@@ -161,7 +162,7 @@ internal sealed class ContainerRuntimeCheck(ILogger<ContainerRuntimeCheck> logge
             // Only reached for explicitly configured runtimes
             return new EnvironmentCheckResult
             {
-                Category = "container",
+                Category = EnvironmentCheckCategories.Container,
                 Name = info.Executable,
                 Status = EnvironmentCheckStatus.Fail,
                 Message = $"{info.Name}: not found (configured via ASPIRE_CONTAINER_RUNTIME={configuredRuntime})",
@@ -173,7 +174,7 @@ internal sealed class ContainerRuntimeCheck(ILogger<ContainerRuntimeCheck> logge
         {
             return new EnvironmentCheckResult
             {
-                Category = "container",
+                Category = EnvironmentCheckCategories.Container,
                 Name = info.Executable,
                 Status = EnvironmentCheckStatus.Warning,
                 Message = $"{info.Name}: installed but not running{selectedSuffix}",
@@ -209,7 +210,7 @@ internal sealed class ContainerRuntimeCheck(ILogger<ContainerRuntimeCheck> logge
 
         return new EnvironmentCheckResult
         {
-            Category = "container",
+            Category = EnvironmentCheckCategories.Container,
             Name = info.Executable,
             Status = EnvironmentCheckStatus.Pass,
             Message = $"{info.Name}{versionSuffix}: running ({reason}){selectedSuffix}"

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DeprecatedAgentConfigCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DeprecatedAgentConfigCheck.cs
@@ -15,6 +15,8 @@ internal sealed class DeprecatedAgentConfigCheck : IEnvironmentCheck
 {
     private readonly CliExecutionContext _executionContext;
 
+    internal static string GetCheckName(string agentName) => $"agent-config-{agentName.ToLowerInvariant().Replace(" ", "-")}";
+
     // Define the agent config locations and their detection patterns
     private static readonly AgentConfigLocation[] s_configLocations =
     [
@@ -62,8 +64,8 @@ internal sealed class DeprecatedAgentConfigCheck : IEnvironmentCheck
                 {
                     results.Add(new EnvironmentCheckResult
                     {
-                        Category = "environment",
-                        Name = $"agent-config-{location.AgentName.ToLowerInvariant().Replace(" ", "-")}",
+                        Category = EnvironmentCheckCategories.Environment,
+                        Name = GetCheckName(location.AgentName),
                         Status = EnvironmentCheckStatus.Warning,
                         Message = string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.DeprecatedConfigWarning, location.AgentName),
                         Fix = AgentCommandStrings.DeprecatedConfigFix

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DeprecatedWorkloadCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DeprecatedWorkloadCheck.cs
@@ -15,6 +15,8 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// </remarks>
 internal sealed class DeprecatedWorkloadCheck(ILogger<DeprecatedWorkloadCheck> logger) : IEnvironmentCheck
 {
+    internal const string CheckName = "aspire-workload";
+
     private static readonly TimeSpan s_processTimeout = TimeSpan.FromSeconds(10);
 
     public int Order => 32; // After SDK check (30), before dev certs (35)
@@ -72,8 +74,8 @@ internal sealed class DeprecatedWorkloadCheck(ILogger<DeprecatedWorkloadCheck> l
             {
                 return [new EnvironmentCheckResult
                 {
-                    Category = "sdk",
-                    Name = "aspire-workload",
+                    Category = EnvironmentCheckCategories.Sdk,
+                    Name = CheckName,
                     Status = EnvironmentCheckStatus.Fail,
                     Message = "Deprecated 'aspire' workload is installed",
                     Details = "The 'aspire' workload has been deprecated and causes conflicts with modern Aspire projects.",

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -15,6 +15,9 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// </summary>
 internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateToolRunner certificateToolRunner) : IEnvironmentCheck
 {
+    internal const string CheckName = "dev-certs";
+    internal const string VersionCheckName = "dev-certs-version";
+
     public int Order => 35; // After SDK check (30), before container checks (40+)
 
     private static readonly string s_trustFixCommand = string.Format(CultureInfo.InvariantCulture, DoctorCommandStrings.DevCertsTrustFixFormat, "aspire certs trust");
@@ -34,8 +37,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             logger.LogDebug(ex, "Error checking dev-certs");
             return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([new EnvironmentCheckResult
             {
-                Category = "environment",
-                Name = "dev-certs",
+                Category = EnvironmentCheckCategories.Environment,
+                Name = CheckName,
                 Status = EnvironmentCheckStatus.Warning,
                 Message = "Unable to check HTTPS development certificate",
                 Details = ex.Message
@@ -55,8 +58,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         {
             return [new EnvironmentCheckResult
             {
-                Category = "environment",
-                Name = "dev-certs",
+                Category = EnvironmentCheckCategories.Environment,
+                Name = CheckName,
                 Status = EnvironmentCheckStatus.Warning,
                 Message = DoctorCommandStrings.DevCertsNoCertificateMessage,
                 Details = DoctorCommandStrings.DevCertsNoCertificateDetails,
@@ -96,8 +99,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             {
                 results.Add(new EnvironmentCheckResult
                 {
-                    Category = "environment",
-                    Name = "dev-certs",
+                    Category = EnvironmentCheckCategories.Environment,
+                    Name = CheckName,
                     Status = EnvironmentCheckStatus.Warning,
                     Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsMultipleNoneTrustedMessageFormat, certInfos.Count),
                     Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsMultipleNoneTrustedDetailsFormat, certDetails),
@@ -110,8 +113,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             {
                 results.Add(new EnvironmentCheckResult
                 {
-                    Category = "environment",
-                    Name = "dev-certs",
+                    Category = EnvironmentCheckCategories.Environment,
+                    Name = CheckName,
                     Status = EnvironmentCheckStatus.Warning,
                     Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsMultipleSomeUntrustedMessageFormat, certInfos.Count),
                     Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsMultipleSomeUntrustedDetailsFormat, certDetails),
@@ -125,8 +128,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             {
                 results.Add(new EnvironmentCheckResult
                 {
-                    Category = "environment",
-                    Name = "dev-certs",
+                    Category = EnvironmentCheckCategories.Environment,
+                    Name = CheckName,
                     Status = EnvironmentCheckStatus.Pass,
                     Message = DoctorCommandStrings.DevCertsTrustedMessage,
                     Metadata = metadata
@@ -139,8 +142,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             var cert = certInfos[0];
             results.Add(new EnvironmentCheckResult
             {
-                Category = "environment",
-                Name = "dev-certs",
+                Category = EnvironmentCheckCategories.Environment,
+                Name = CheckName,
                 Status = EnvironmentCheckStatus.Warning,
                 Message = DoctorCommandStrings.DevCertsNotTrustedMessage,
                 Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsNotTrustedDetailsFormat, cert.Thumbprint ?? "unknown"),
@@ -155,8 +158,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             var devCertsTrustPath = CertificateHelpers.GetDevCertsTrustPath();
             results.Add(new EnvironmentCheckResult
             {
-                Category = "environment",
-                Name = "dev-certs",
+                Category = EnvironmentCheckCategories.Environment,
+                Name = CheckName,
                 Status = EnvironmentCheckStatus.Warning,
                 Message = DoctorCommandStrings.DevCertsPartiallyTrustedMessage,
                 Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsPartiallyTrustedDetailsFormat, devCertsTrustPath),
@@ -170,8 +173,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             // Trusted certificate - success case
             results.Add(new EnvironmentCheckResult
             {
-                Category = "environment",
-                Name = "dev-certs",
+                Category = EnvironmentCheckCategories.Environment,
+                Name = CheckName,
                 Status = EnvironmentCheckStatus.Pass,
                 Message = DoctorCommandStrings.DevCertsTrustedMessage,
                 Metadata = metadata
@@ -184,8 +187,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             var versions = string.Join(", ", oldTrustedVersions.Select(v => $"v{v}"));
             results.Add(new EnvironmentCheckResult
             {
-                Category = "environment",
-                Name = "dev-certs-version",
+                Category = EnvironmentCheckCategories.Environment,
+                Name = VersionCheckName,
                 Status = EnvironmentCheckStatus.Warning,
                 Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOldVersionMessageFormat, versions),
                 Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOldVersionDetailsFormat, CertificateManager.CurrentMinimumAspNetCoreCertificateVersion),

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DotNetSdkCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DotNetSdkCheck.cs
@@ -21,6 +21,8 @@ internal sealed class DotNetSdkCheck(
     CliExecutionContext executionContext,
     ILogger<DotNetSdkCheck> logger) : IEnvironmentCheck
 {
+    internal const string CheckName = "dotnet-sdk";
+
     public int Order => 30; // File system check - slightly more expensive
 
     public async Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
@@ -46,8 +48,8 @@ internal sealed class DotNetSdkCheck(
 
                 return [new EnvironmentCheckResult
                 {
-                    Category = "sdk",
-                    Name = "dotnet-sdk",
+                    Category = EnvironmentCheckCategories.Sdk,
+                    Name = CheckName,
                     Status = EnvironmentCheckStatus.Fail,
                     Message = highestVersion is null
                         ? ".NET SDK not found"
@@ -61,8 +63,8 @@ internal sealed class DotNetSdkCheck(
 
             return [new EnvironmentCheckResult
             {
-                Category = "sdk",
-                Name = "dotnet-sdk",
+                Category = EnvironmentCheckCategories.Sdk,
+                Name = CheckName,
                 Status = EnvironmentCheckStatus.Pass,
                 Message = $".NET {highestVersion} installed ({architecture})"
             }];
@@ -72,8 +74,8 @@ internal sealed class DotNetSdkCheck(
             logger.LogDebug(ex, "Error checking .NET SDK");
             return [new EnvironmentCheckResult
             {
-                Category = "sdk",
-                Name = "dotnet-sdk",
+                Category = EnvironmentCheckCategories.Sdk,
+                Name = CheckName,
                 Status = EnvironmentCheckStatus.Fail,
                 Message = "Error checking .NET SDK",
                 Details = ex.Message

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/EnvironmentCheckResult.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/EnvironmentCheckResult.cs
@@ -9,13 +9,44 @@ using Aspire.Cli.Acquisition;
 namespace Aspire.Cli.Utils.EnvironmentChecker;
 
 /// <summary>
+/// Well-known categories for environment check results.
+/// </summary>
+internal static class EnvironmentCheckCategories
+{
+    /// <summary>
+    /// Checks that report Aspire CLI state.
+    /// </summary>
+    internal const string Aspire = "aspire";
+
+    /// <summary>
+    /// Checks that report AppHost state.
+    /// </summary>
+    internal const string AppHost = "apphost";
+
+    /// <summary>
+    /// Checks that report container runtime state.
+    /// </summary>
+    internal const string Container = "container";
+
+    /// <summary>
+    /// Checks that report local machine environment state.
+    /// </summary>
+    internal const string Environment = "environment";
+
+    /// <summary>
+    /// Checks that report SDK state.
+    /// </summary>
+    internal const string Sdk = "sdk";
+}
+
+/// <summary>
 /// Represents the result of a prerequisite check.
 /// </summary>
 // `aspire doctor --format json` uses this shape; keep docs/specs/cli-output-formats.md in sync when changing it.
 internal sealed class EnvironmentCheckResult
 {
     /// <summary>
-    /// Gets the category of the check (e.g., "sdk", "container", "environment").
+    /// Gets the category of the check.
     /// </summary>
     [JsonPropertyName("category")]
     public string Category { get; init; } = string.Empty;

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/LegacySettingsFileCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/LegacySettingsFileCheck.cs
@@ -20,6 +20,8 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// </remarks>
 internal sealed class LegacySettingsFileCheck(CliExecutionContext executionContext) : IEnvironmentCheck
 {
+    internal const string CheckName = "legacy-settings-file";
+
     /// <inheritdoc />
     public int Order => 101; // Run after core checks and deprecated agent config check (100)
 
@@ -48,8 +50,8 @@ internal sealed class LegacySettingsFileCheck(CliExecutionContext executionConte
                 // Found a legacy file without a sibling modern config — surface the hint.
                 var result = new EnvironmentCheckResult
                 {
-                    Category = "environment",
-                    Name = "legacy-settings-file",
+                    Category = EnvironmentCheckCategories.Environment,
+                    Name = CheckName,
                     Status = EnvironmentCheckStatus.Warning,
                     Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.LegacySettingsDetectedMessageFormat, legacySettingsPath),
                     Fix = DoctorCommandStrings.LegacySettingsDetectedFix

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
@@ -107,7 +107,8 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
             // /etc/os-release uses KEY=VALUE lines, for example:
             //   NAME="Ubuntu"
             //   VERSION_ID="24.04"
-            // Strip surrounding quotes for display, but leave the value content otherwise unchanged.
+            // Strip surrounding quotes for display. Double-quoted values can escape shell-special
+            // characters; remove those escape markers because doctor displays the values as text.
             var line = rawLine.Trim();
             if (line.Length == 0 || line[0] == '#')
             {
@@ -212,7 +213,13 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
             return value;
         }
 
-        return value[1..^1];
+        var unquoted = value[1..^1];
+        return quote == '"'
+            ? unquoted.Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\$", "$", StringComparison.Ordinal)
+                .Replace("\\`", "`", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal)
+            : unquoted;
     }
 }
 

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Resources;
 
@@ -108,7 +107,7 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
             // /etc/os-release uses KEY=VALUE lines, for example:
             //   NAME="Ubuntu"
             //   VERSION_ID="24.04"
-            // Values may be unquoted or quoted with shell-style escapes for '"', '$', '`', and '\'.
+            // Strip surrounding quotes for display, but leave the value content otherwise unchanged.
             var line = rawLine.Trim();
             if (line.Length == 0 || line[0] == '#')
             {
@@ -213,25 +212,7 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
             return value;
         }
 
-        var builder = new StringBuilder(value.Length - 2);
-        for (var i = 1; i < value.Length - 1; i++)
-        {
-            var ch = value[i];
-            if (ch == '\\' && i + 1 < value.Length - 1)
-            {
-                var next = value[i + 1];
-                if (next is '"' or '$' or '`' or '\\')
-                {
-                    builder.Append(next);
-                    i++;
-                    continue;
-                }
-            }
-
-            builder.Append(ch);
-        }
-
-        return builder.ToString();
+        return value[1..^1];
     }
 }
 

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
@@ -14,6 +14,7 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 internal sealed class OperatingSystemCheck : IEnvironmentCheck
 {
     internal const string CheckName = "operating-system";
+    private const string UnknownOperatingSystemMetadataValue = "unknown";
 
     private readonly Func<OperatingSystemDetails> _getOperatingSystemDetails;
 
@@ -36,17 +37,16 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
         cancellationToken.ThrowIfCancellationRequested();
 
         var details = _getOperatingSystemDetails();
+        var messageDisplayName = details.MessageDisplayName ?? details.Name;
         var result = new EnvironmentCheckResult
         {
             Category = EnvironmentCheckCategories.Environment,
             Name = CheckName,
-            Status = details.Type.Equals("Unknown", StringComparison.OrdinalIgnoreCase)
-                ? EnvironmentCheckStatus.Warning
-                : EnvironmentCheckStatus.Pass,
+            Status = details.Status,
             Message = string.Format(
                 CultureInfo.CurrentCulture,
                 DoctorCommandStrings.OperatingSystemMessageFormat,
-                string.IsNullOrWhiteSpace(details.Version) ? details.Name : $"{details.Name} {details.Version}"),
+                string.IsNullOrWhiteSpace(details.Version) ? messageDisplayName : $"{messageDisplayName} {details.Version}"),
             Metadata = BuildMetadata(details)
         };
 
@@ -73,14 +73,20 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
             return CreateLinuxDetails(version, description);
         }
 
-        return new OperatingSystemDetails("Unknown", RuntimeInformation.OSDescription, version.ToString(), description);
+        return new OperatingSystemDetails(
+            UnknownOperatingSystemMetadataValue,
+            UnknownOperatingSystemMetadataValue,
+            version.ToString(),
+            description,
+            EnvironmentCheckStatus.Warning,
+            DoctorCommandStrings.VersionUnknown);
     }
 
     internal static OperatingSystemDetails CreateWindowsDetails(Version version, string description)
-        => new("Windows", "Windows", version.ToString(), description);
+        => new("Windows", "Windows", version.ToString(), description, EnvironmentCheckStatus.Pass);
 
     internal static OperatingSystemDetails CreateMacOSDetails(Version version, string description)
-        => new("macOS", "macOS", version.ToString(), description);
+        => new("macOS", "macOS", version.ToString(), description, EnvironmentCheckStatus.Pass);
 
     internal static OperatingSystemDetails CreateLinuxDetails(Version fallbackVersion, string description)
     {
@@ -95,7 +101,7 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
         var displayName = string.IsNullOrWhiteSpace(distroName) ? "Linux" : $"Linux {distroName}";
         var linuxDescription = string.IsNullOrWhiteSpace(prettyName) ? description : prettyName;
 
-        return new OperatingSystemDetails("Linux", displayName, string.IsNullOrWhiteSpace(version) ? fallbackVersion.ToString() : version, linuxDescription);
+        return new OperatingSystemDetails("Linux", displayName, string.IsNullOrWhiteSpace(version) ? fallbackVersion.ToString() : version, linuxDescription, EnvironmentCheckStatus.Pass);
     }
 
     internal static Dictionary<string, string> ParseLinuxOsRelease(string? contents)
@@ -222,4 +228,10 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
     }
 }
 
-internal sealed record OperatingSystemDetails(string Type, string Name, string Version, string Description);
+internal sealed record OperatingSystemDetails(
+    string Type,
+    string Name,
+    string Version,
+    string Description,
+    EnvironmentCheckStatus Status,
+    string? MessageDisplayName = null);

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Resources;
 
@@ -107,7 +108,7 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
             // /etc/os-release uses KEY=VALUE lines, for example:
             //   NAME="Ubuntu"
             //   VERSION_ID="24.04"
-            // Strip surrounding quotes for display. Double-quoted values can escape shell-special
+            // Strip surrounding quotes for display. Double-quoted values can escape special
             // characters; remove those escape markers because doctor displays the values as text.
             var line = rawLine.Trim();
             if (line.Length == 0 || line[0] == '#')
@@ -214,12 +215,23 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
         }
 
         var unquoted = value[1..^1];
-        return quote == '"'
-            ? unquoted.Replace("\\\"", "\"", StringComparison.Ordinal)
-                .Replace("\\$", "$", StringComparison.Ordinal)
-                .Replace("\\`", "`", StringComparison.Ordinal)
-                .Replace("\\\\", "\\", StringComparison.Ordinal)
-            : unquoted;
+        return quote == '"' ? RemoveEscapeMarkers(unquoted) : unquoted;
+    }
+
+    private static string RemoveEscapeMarkers(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] == '\\' && i + 1 < value.Length)
+            {
+                i++;
+            }
+
+            builder.Append(value[i]);
+        }
+
+        return builder.ToString();
     }
 }
 

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
@@ -1,0 +1,238 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json.Nodes;
+using Aspire.Cli.Resources;
+
+namespace Aspire.Cli.Utils.EnvironmentChecker;
+
+/// <summary>
+/// Reports operating system information for the current environment.
+/// </summary>
+internal sealed class OperatingSystemCheck : IEnvironmentCheck
+{
+    private readonly Func<OperatingSystemDetails> _getOperatingSystemDetails;
+
+    public OperatingSystemCheck()
+        : this(GetCurrentOperatingSystemDetails)
+    {
+    }
+
+    internal OperatingSystemCheck(Func<OperatingSystemDetails> getOperatingSystemDetails)
+    {
+        ArgumentNullException.ThrowIfNull(getOperatingSystemDetails);
+
+        _getOperatingSystemDetails = getOperatingSystemDetails;
+    }
+
+    public int Order => 10; // Fast local check, after Aspire version and before WSL-specific diagnostics.
+
+    public Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var details = _getOperatingSystemDetails();
+        var result = new EnvironmentCheckResult
+        {
+            Category = "environment",
+            Name = "operating-system",
+            Status = EnvironmentCheckStatus.Pass,
+            Message = string.Format(
+                CultureInfo.CurrentCulture,
+                DoctorCommandStrings.OperatingSystemMessageFormat,
+                string.IsNullOrWhiteSpace(details.Version) ? details.Name : $"{details.Name} {details.Version}"),
+            Metadata = BuildMetadata(details)
+        };
+
+        return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([result]);
+    }
+
+    internal static OperatingSystemDetails GetCurrentOperatingSystemDetails()
+    {
+        var version = Environment.OSVersion.Version;
+        var description = RuntimeInformation.OSDescription;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return CreateWindowsDetails(version, description);
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return CreateMacOSDetails(version, description);
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return CreateLinuxDetails(version, description);
+        }
+
+        return new OperatingSystemDetails("Unknown", RuntimeInformation.OSDescription, version.ToString(), description);
+    }
+
+    internal static OperatingSystemDetails CreateWindowsDetails(Version version, string description)
+        => new("Windows", "Windows", version.ToString(), description);
+
+    internal static OperatingSystemDetails CreateMacOSDetails(Version version, string description)
+        => new("macOS", "macOS", version.ToString(), description);
+
+    internal static OperatingSystemDetails CreateLinuxDetails(Version fallbackVersion, string description)
+    {
+        var osReleaseContents = TryReadLinuxOsRelease();
+        var osRelease = ParseLinuxOsRelease(osReleaseContents);
+        osRelease.TryGetValue("NAME", out var name);
+        osRelease.TryGetValue("ID", out var id);
+        osRelease.TryGetValue("VERSION_ID", out var version);
+        osRelease.TryGetValue("PRETTY_NAME", out var prettyName);
+
+        var distroName = NormalizeLinuxDistributionName(name, id);
+        var displayName = string.IsNullOrWhiteSpace(distroName) ? "Linux" : $"Linux {distroName}";
+        var linuxDescription = string.IsNullOrWhiteSpace(prettyName) ? description : prettyName;
+
+        return new OperatingSystemDetails("Linux", displayName, string.IsNullOrWhiteSpace(version) ? fallbackVersion.ToString() : version, linuxDescription);
+    }
+
+    internal static Dictionary<string, string> ParseLinuxOsRelease(string? contents)
+    {
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (string.IsNullOrWhiteSpace(contents))
+        {
+            return values;
+        }
+
+        foreach (var rawLine in contents.Split('\n'))
+        {
+            // /etc/os-release uses KEY=VALUE lines, for example:
+            //   NAME="Ubuntu"
+            //   VERSION_ID="24.04"
+            // Values may be unquoted or quoted with shell-style escapes for '"', '$', '`', and '\'.
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line[0] == '#')
+            {
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf('=');
+            if (separatorIndex <= 0)
+            {
+                continue;
+            }
+
+            var key = line[..separatorIndex];
+            var value = line[(separatorIndex + 1)..].Trim();
+            values[key] = UnquoteOsReleaseValue(value);
+        }
+
+        return values;
+    }
+
+    private static JsonObject BuildMetadata(OperatingSystemDetails details)
+    {
+        var metadata = new JsonObject
+        {
+            ["osType"] = details.Type,
+            ["displayName"] = details.Name,
+            ["version"] = details.Version
+        };
+
+        if (!string.IsNullOrWhiteSpace(details.Description))
+        {
+            metadata["description"] = details.Description;
+        }
+
+        return metadata;
+    }
+
+    private static string? TryReadLinuxOsRelease()
+    {
+        try
+        {
+            return File.ReadAllText("/etc/os-release");
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? NormalizeLinuxDistributionName(string? name, string? id)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return NormalizeLinuxDistributionId(id);
+        }
+
+        var normalizedName = name.Trim();
+        foreach (var suffix in new[] { " GNU/Linux", " Linux" })
+        {
+            if (normalizedName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            {
+                normalizedName = normalizedName[..^suffix.Length];
+                break;
+            }
+        }
+
+        return normalizedName.Equals("Linux", StringComparison.OrdinalIgnoreCase) ? null : normalizedName;
+    }
+
+    private static string? NormalizeLinuxDistributionId(string? id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return null;
+        }
+
+        return id.Trim().ToLowerInvariant() switch
+        {
+            "alpine" => "Alpine",
+            "arch" => "Arch Linux",
+            "centos" => "CentOS",
+            "debian" => "Debian",
+            "fedora" => "Fedora",
+            "linuxmint" => "Linux Mint",
+            "opensuse" or "opensuse-leap" or "opensuse-tumbleweed" => "openSUSE",
+            "rhel" => "Red Hat Enterprise Linux",
+            "ubuntu" => "Ubuntu",
+            var value => CultureInfo.InvariantCulture.TextInfo.ToTitleCase(value.Replace('-', ' '))
+        };
+    }
+
+    private static string UnquoteOsReleaseValue(string value)
+    {
+        if (value.Length < 2)
+        {
+            return value;
+        }
+
+        var quote = value[0];
+        if ((quote != '"' && quote != '\'') || value[^1] != quote)
+        {
+            return value;
+        }
+
+        var builder = new StringBuilder(value.Length - 2);
+        for (var i = 1; i < value.Length - 1; i++)
+        {
+            var ch = value[i];
+            if (ch == '\\' && i + 1 < value.Length - 1)
+            {
+                var next = value[i + 1];
+                if (next is '"' or '$' or '`' or '\\')
+                {
+                    builder.Append(next);
+                    i++;
+                    continue;
+                }
+            }
+
+            builder.Append(ch);
+        }
+
+        return builder.ToString();
+    }
+}
+
+internal sealed record OperatingSystemDetails(string Type, string Name, string Version, string Description);

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
@@ -13,6 +13,8 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// </summary>
 internal sealed class OperatingSystemCheck : IEnvironmentCheck
 {
+    internal const string CheckName = "operating-system";
+
     private readonly Func<OperatingSystemDetails> _getOperatingSystemDetails;
 
     public OperatingSystemCheck()
@@ -36,8 +38,8 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
         var details = _getOperatingSystemDetails();
         var result = new EnvironmentCheckResult
         {
-            Category = "environment",
-            Name = "operating-system",
+            Category = EnvironmentCheckCategories.Environment,
+            Name = CheckName,
             Status = details.Type.Equals("Unknown", StringComparison.OrdinalIgnoreCase)
                 ? EnvironmentCheckStatus.Warning
                 : EnvironmentCheckStatus.Pass,

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
@@ -38,7 +38,9 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
         {
             Category = "environment",
             Name = "operating-system",
-            Status = EnvironmentCheckStatus.Pass,
+            Status = details.Type.Equals("Unknown", StringComparison.OrdinalIgnoreCase)
+                ? EnvironmentCheckStatus.Warning
+                : EnvironmentCheckStatus.Pass,
             Message = string.Format(
                 CultureInfo.CurrentCulture,
                 DoctorCommandStrings.OperatingSystemMessageFormat,

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/OperatingSystemCheck.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Resources;
 
@@ -108,8 +107,8 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
             // /etc/os-release uses KEY=VALUE lines, for example:
             //   NAME="Ubuntu"
             //   VERSION_ID="24.04"
-            // Strip surrounding quotes for display. Double-quoted values can escape special
-            // characters; remove those escape markers because doctor displays the values as text.
+            // Strip surrounding quotes for display. The values doctor surfaces are not expected
+            // to contain shell-special characters, so leave any backslashes unchanged.
             var line = rawLine.Trim();
             if (line.Length == 0 || line[0] == '#')
             {
@@ -215,23 +214,7 @@ internal sealed class OperatingSystemCheck : IEnvironmentCheck
         }
 
         var unquoted = value[1..^1];
-        return quote == '"' ? RemoveEscapeMarkers(unquoted) : unquoted;
-    }
-
-    private static string RemoveEscapeMarkers(string value)
-    {
-        var builder = new StringBuilder(value.Length);
-        for (var i = 0; i < value.Length; i++)
-        {
-            if (value[i] == '\\' && i + 1 < value.Length)
-            {
-                i++;
-            }
-
-            builder.Append(value[i]);
-        }
-
-        return builder.ToString();
+        return unquoted;
     }
 }
 

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/TypeScriptAppHostToolingCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/TypeScriptAppHostToolingCheck.cs
@@ -9,6 +9,9 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 
 internal sealed class TypeScriptAppHostToolingCheck : IEnvironmentCheck
 {
+    internal const string YarnClassicCheckName = "typescript-apphost-yarn-classic";
+    internal const string ToolsCheckName = "typescript-apphost-tools";
+
     private readonly IProjectLocator _projectLocator;
     private readonly ILanguageDiscovery _languageDiscovery;
     private readonly CliExecutionContext _executionContext;
@@ -59,8 +62,8 @@ internal sealed class TypeScriptAppHostToolingCheck : IEnvironmentCheck
             [
                 new EnvironmentCheckResult
                 {
-                    Category = "environment",
-                    Name = "typescript-apphost-yarn-classic",
+                    Category = EnvironmentCheckCategories.Environment,
+                    Name = YarnClassicCheckName,
                     Status = EnvironmentCheckStatus.Fail,
                     Message = "TypeScript AppHost does not support Yarn Classic.",
                     Details = ex.Message,
@@ -86,8 +89,8 @@ internal sealed class TypeScriptAppHostToolingCheck : IEnvironmentCheck
 
             missingResults.Add(new EnvironmentCheckResult
             {
-                Category = "environment",
-                Name = $"typescript-apphost-{command}",
+                Category = EnvironmentCheckCategories.Environment,
+                Name = GetMissingCommandCheckName(command),
                 Status = EnvironmentCheckStatus.Fail,
                 Message = $"TypeScript AppHost requires '{command}'.",
                 Details = errorMessage,
@@ -111,8 +114,8 @@ internal sealed class TypeScriptAppHostToolingCheck : IEnvironmentCheck
         [
             new EnvironmentCheckResult
             {
-                Category = "environment",
-                Name = "typescript-apphost-tools",
+                Category = EnvironmentCheckCategories.Environment,
+                Name = ToolsCheckName,
                 Status = EnvironmentCheckStatus.Pass,
                 Message = $"TypeScript AppHost tooling found ({string.Join(", ", TypeScriptAppHostToolchainResolver.GetRequiredCommands(toolchain))}).",
                 Metadata = new JsonObject
@@ -161,4 +164,6 @@ internal sealed class TypeScriptAppHostToolingCheck : IEnvironmentCheck
             return null;
         }
     }
+
+    internal static string GetMissingCommandCheckName(string command) => $"typescript-apphost-{command}";
 }

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/WslEnvironmentCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/WslEnvironmentCheck.cs
@@ -11,6 +11,8 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// </summary>
 internal sealed class WslEnvironmentCheck : IEnvironmentCheck
 {
+    internal const string CheckName = "wsl";
+
     public int Order => 20; // Fast check - file system reads
 
     public Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
@@ -38,8 +40,8 @@ internal sealed class WslEnvironmentCheck : IEnvironmentCheck
         {
             return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([new EnvironmentCheckResult
             {
-                Category = "environment",
-                Name = "wsl",
+                Category = EnvironmentCheckCategories.Environment,
+                Name = CheckName,
                 Status = EnvironmentCheckStatus.Warning,
                 Message = "WSL1 detected - limited container support",
                 Fix = "Upgrade to WSL2 for best experience: wsl --set-version <distro> 2",
@@ -50,8 +52,8 @@ internal sealed class WslEnvironmentCheck : IEnvironmentCheck
         // WSL2 detected - just informational, not a warning unless there are known issues
         return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([new EnvironmentCheckResult
         {
-            Category = "environment",
-            Name = "wsl",
+            Category = EnvironmentCheckCategories.Environment,
+            Name = CheckName,
             Status = EnvironmentCheckStatus.Pass,
             Message = "WSL2 environment detected",
             Details = "If you experience container connectivity issues, ensure Docker Desktop WSL integration is enabled."

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -47,8 +47,8 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
                 };
             });
 
-        var cliVersionCheck = GetCheckByName(doc, "cli-version");
-        Assert.Equal("aspire", cliVersionCheck.GetProperty("category").GetString());
+        var cliVersionCheck = GetCheckByName(doc, AspireVersionCheck.CliVersionCheckName);
+        Assert.Equal(EnvironmentCheckCategories.Aspire, cliVersionCheck.GetProperty("category").GetString());
         Assert.Equal("warning", cliVersionCheck.GetProperty("status").GetString());
         Assert.Contains("13.0.0", cliVersionCheck.GetProperty("message").GetString()!);
         Assert.Contains("13.1.0", cliVersionCheck.GetProperty("message").GetString()!);
@@ -68,8 +68,8 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
                 options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
             });
 
-        var osCheck = GetCheckByName(doc, "operating-system");
-        Assert.Equal("environment", osCheck.GetProperty("category").GetString());
+        var osCheck = GetCheckByName(doc, OperatingSystemCheck.CheckName);
+        Assert.Equal(EnvironmentCheckCategories.Environment, osCheck.GetProperty("category").GetString());
         Assert.Equal("pass", osCheck.GetProperty("status").GetString());
         Assert.StartsWith("Operating system: ", osCheck.GetProperty("message").GetString(), StringComparison.Ordinal);
         var metadata = osCheck.GetProperty("metadata");
@@ -95,7 +95,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
                 options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
             });
 
-        var osCheck = GetCheckByName(doc, "operating-system");
+        var osCheck = GetCheckByName(doc, OperatingSystemCheck.CheckName);
         var metadata = osCheck.GetProperty("metadata");
         var expectedDisplayName = GetExpectedLinuxDisplayName(name);
 
@@ -176,8 +176,8 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
                 };
             });
 
-        var appHostVersionCheck = GetCheckByName(doc, "apphost-version");
-        Assert.Equal("apphost", appHostVersionCheck.GetProperty("category").GetString());
+        var appHostVersionCheck = GetCheckByName(doc, AspireVersionCheck.AppHostVersionCheckName);
+        Assert.Equal(EnvironmentCheckCategories.AppHost, appHostVersionCheck.GetProperty("category").GetString());
         Assert.Equal("pass", appHostVersionCheck.GetProperty("status").GetString());
         Assert.Contains("13.0.0", appHostVersionCheck.GetProperty("message").GetString()!);
         Assert.Contains("AppHost.csproj", appHostVersionCheck.GetProperty("message").GetString()!);
@@ -225,8 +225,8 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         Assert.False(runnerCalled);
 
-        var appHostVersionCheck = GetCheckByName(doc, "apphost-version");
-        Assert.Equal("apphost", appHostVersionCheck.GetProperty("category").GetString());
+        var appHostVersionCheck = GetCheckByName(doc, AspireVersionCheck.AppHostVersionCheckName);
+        Assert.Equal(EnvironmentCheckCategories.AppHost, appHostVersionCheck.GetProperty("category").GetString());
         Assert.Equal("pass", appHostVersionCheck.GetProperty("status").GetString());
         Assert.Contains("13.1.0", appHostVersionCheck.GetProperty("message").GetString()!);
         Assert.Contains("apphost.ts", appHostVersionCheck.GetProperty("message").GetString()!);
@@ -259,7 +259,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         Assert.False(versionLookupCalled);
         Assert.DoesNotContain(doc.RootElement.GetProperty("checks").EnumerateArray(),
-            check => check.GetProperty("name").GetString() == "apphost-version");
+            check => check.GetProperty("name").GetString() == AspireVersionCheck.AppHostVersionCheckName);
     }
 
     [Fact]
@@ -287,7 +287,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         Assert.False(versionLookupCalled);
         Assert.DoesNotContain(doc.RootElement.GetProperty("checks").EnumerateArray(),
-            check => check.GetProperty("name").GetString() == "apphost-version");
+            check => check.GetProperty("name").GetString() == AspireVersionCheck.AppHostVersionCheckName);
     }
 
     [Fact]
@@ -313,7 +313,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
             });
 
         Assert.DoesNotContain(doc.RootElement.GetProperty("checks").EnumerateArray(),
-            check => check.GetProperty("name").GetString() == "apphost-version");
+            check => check.GetProperty("name").GetString() == AspireVersionCheck.AppHostVersionCheckName);
     }
 
     [Fact]
@@ -340,7 +340,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         Assert.False(versionLookupCalled);
         Assert.DoesNotContain(doc.RootElement.GetProperty("checks").EnumerateArray(),
-            check => check.GetProperty("name").GetString() == "apphost-version");
+            check => check.GetProperty("name").GetString() == AspireVersionCheck.AppHostVersionCheckName);
     }
 
     [Fact]
@@ -363,8 +363,8 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
                 };
             });
 
-        var cliVersionCheck = GetCheckByName(doc, "cli-version");
-        var appHostVersionCheck = GetCheckByName(doc, "apphost-version");
+        var cliVersionCheck = GetCheckByName(doc, AspireVersionCheck.CliVersionCheckName);
+        var appHostVersionCheck = GetCheckByName(doc, AspireVersionCheck.AppHostVersionCheckName);
 
         Assert.Equal("pass", cliVersionCheck.GetProperty("status").GetString());
         Assert.Equal("warning", appHostVersionCheck.GetProperty("status").GetString());
@@ -389,8 +389,8 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
                 };
             });
 
-        var cliVersionCheck = GetCheckByName(doc, "cli-version");
-        var appHostVersionCheck = GetCheckByName(doc, "apphost-version");
+        var cliVersionCheck = GetCheckByName(doc, AspireVersionCheck.CliVersionCheckName);
+        var appHostVersionCheck = GetCheckByName(doc, AspireVersionCheck.AppHostVersionCheckName);
 
         Assert.Equal("pass", cliVersionCheck.GetProperty("status").GetString());
         Assert.Equal("warning", appHostVersionCheck.GetProperty("status").GetString());
@@ -423,8 +423,8 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
                 };
             });
 
-        var appHostVersionCheck = GetCheckByName(doc, "apphost-version");
-        Assert.Equal("apphost", appHostVersionCheck.GetProperty("category").GetString());
+        var appHostVersionCheck = GetCheckByName(doc, AspireVersionCheck.AppHostVersionCheckName);
+        Assert.Equal(EnvironmentCheckCategories.AppHost, appHostVersionCheck.GetProperty("category").GetString());
         Assert.Equal("pass", appHostVersionCheck.GetProperty("status").GetString());
         Assert.Contains("13.2.0", appHostVersionCheck.GetProperty("message").GetString()!);
         Assert.Contains("AppHost.csproj", appHostVersionCheck.GetProperty("message").GetString()!);
@@ -456,7 +456,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
                 services.AddSingleton<IIdentityChannelReader>(_ => new FakeIdentityChannelReader("staging"));
             });
 
-        var cliVersionCheck = GetCheckByName(doc, "cli-version");
+        var cliVersionCheck = GetCheckByName(doc, AspireVersionCheck.CliVersionCheckName);
         var metadata = cliVersionCheck.GetProperty("metadata");
         Assert.Equal("staging", metadata.GetProperty("identityChannel").GetString());
         Assert.Contains("channel: staging", cliVersionCheck.GetProperty("message").GetString()!);
@@ -482,7 +482,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
             });
 
         // The channel lookup failing is informational; the rest of doctor should still complete.
-        var cliVersionCheck = GetCheckByName(doc, "cli-version");
+        var cliVersionCheck = GetCheckByName(doc, AspireVersionCheck.CliVersionCheckName);
         var metadata = cliVersionCheck.GetProperty("metadata");
         Assert.False(metadata.TryGetProperty("identityChannel", out _));
         Assert.DoesNotContain("channel:", cliVersionCheck.GetProperty("message").GetString()!);
@@ -512,7 +512,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
                 };
             });
 
-        var appHostVersionCheck = GetCheckByName(doc, "apphost-version");
+        var appHostVersionCheck = GetCheckByName(doc, AspireVersionCheck.AppHostVersionCheckName);
         var metadata = appHostVersionCheck.GetProperty("metadata");
         Assert.Equal("daily", metadata.GetProperty("pinnedChannel").GetString());
         Assert.Contains("channel: daily", appHostVersionCheck.GetProperty("message").GetString()!);
@@ -546,7 +546,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
                 };
             });
 
-        var appHostVersionCheck = GetCheckByName(doc, "apphost-version");
+        var appHostVersionCheck = GetCheckByName(doc, AspireVersionCheck.AppHostVersionCheckName);
         var metadata = appHostVersionCheck.GetProperty("metadata");
         Assert.Equal("daily", metadata.GetProperty("pinnedChannel").GetString());
         Assert.Contains("channel: daily", appHostVersionCheck.GetProperty("message").GetString()!);
@@ -571,7 +571,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
                 };
             });
 
-        var appHostVersionCheck = GetCheckByName(doc, "apphost-version");
+        var appHostVersionCheck = GetCheckByName(doc, AspireVersionCheck.AppHostVersionCheckName);
         var metadata = appHostVersionCheck.GetProperty("metadata");
         Assert.False(metadata.TryGetProperty("pinnedChannel", out _));
         Assert.DoesNotContain("channel:", appHostVersionCheck.GetProperty("message").GetString()!);
@@ -604,7 +604,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
                 services.AddSingleton<IIdentityChannelReader>(_ => new FakeIdentityChannelReader("local"));
             });
 
-        var cliVersionCheck = GetCheckByName(doc, "cli-version");
+        var cliVersionCheck = GetCheckByName(doc, AspireVersionCheck.CliVersionCheckName);
 
         // Both channels surface in metadata.
         var metadata = cliVersionCheck.GetProperty("metadata");

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -79,6 +79,42 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    [SkipOnPlatform(TestPlatforms.Windows | TestPlatforms.OSX | TestPlatforms.FreeBSD, "Validates Linux /etc/os-release values.")]
+    public async Task DoctorCommand_Json_OnLinux_UsesOsReleaseValues()
+    {
+        Assert.SkipUnless(File.Exists("/etc/os-release"), "Linux /etc/os-release is required for this test.");
+
+        var osRelease = OperatingSystemCheck.ParseLinuxOsRelease(
+            await File.ReadAllTextAsync("/etc/os-release", TestContext.Current.CancellationToken));
+        Assert.True(TryGetOsReleaseValue(osRelease, "NAME", out var name), "Expected /etc/os-release to include NAME.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var doc = await RunDoctorJsonAsync(workspace,
+            configureOptions: options =>
+            {
+                options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
+            });
+
+        var osCheck = GetCheckByName(doc, "operating-system");
+        var metadata = osCheck.GetProperty("metadata");
+        var expectedDisplayName = GetExpectedLinuxDisplayName(name);
+
+        Assert.Equal("Linux", metadata.GetProperty("osType").GetString());
+        Assert.Equal(expectedDisplayName, metadata.GetProperty("displayName").GetString());
+
+        if (TryGetOsReleaseValue(osRelease, "VERSION_ID", out var version))
+        {
+            Assert.Equal(version, metadata.GetProperty("version").GetString());
+            Assert.Equal($"Operating system: {expectedDisplayName} {version}", osCheck.GetProperty("message").GetString());
+        }
+
+        if (TryGetOsReleaseValue(osRelease, "PRETTY_NAME", out var prettyName))
+        {
+            Assert.Equal(prettyName, metadata.GetProperty("description").GetString());
+        }
+    }
+
+    [Fact]
     public async Task DoctorCommand_Json_VersionUpdateBanner_IsSuppressed()
     {
         // The cli-version environment check already surfaces "newer version available" inside
@@ -1039,5 +1075,32 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         }
 
         return new FileInfo(Path.Combine(directory.FullName, "AppHost.csproj"));
+    }
+
+    private static bool TryGetOsReleaseValue(Dictionary<string, string> osRelease, string key, out string value)
+    {
+        if (osRelease.TryGetValue(key, out var rawValue) && !string.IsNullOrWhiteSpace(rawValue))
+        {
+            value = rawValue;
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    private static string GetExpectedLinuxDisplayName(string osReleaseName)
+    {
+        var name = osReleaseName.Trim();
+        foreach (var suffix in new[] { " GNU/Linux", " Linux" })
+        {
+            if (name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            {
+                name = name[..^suffix.Length];
+                break;
+            }
+        }
+
+        return name.Equals("Linux", StringComparison.OrdinalIgnoreCase) ? "Linux" : $"Linux {name}";
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -59,6 +59,26 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DoctorCommand_Json_IncludesOperatingSystemStatus()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var doc = await RunDoctorJsonAsync(workspace,
+            configureOptions: options =>
+            {
+                options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
+            });
+
+        var osCheck = GetCheckByName(doc, "operating-system");
+        Assert.Equal("environment", osCheck.GetProperty("category").GetString());
+        Assert.Equal("pass", osCheck.GetProperty("status").GetString());
+        Assert.StartsWith("Operating system: ", osCheck.GetProperty("message").GetString(), StringComparison.Ordinal);
+        var metadata = osCheck.GetProperty("metadata");
+        Assert.True(metadata.TryGetProperty("osType", out _));
+        Assert.True(metadata.TryGetProperty("displayName", out _));
+        Assert.True(metadata.TryGetProperty("version", out _));
+    }
+
+    [Fact]
     public async Task DoctorCommand_Json_VersionUpdateBanner_IsSuppressed()
     {
         // The cli-version environment check already surfaces "newer version available" inside
@@ -984,6 +1004,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, configure);
         services.RemoveAll<IEnvironmentCheck>();
         services.AddSingleton<IEnvironmentCheck, AspireVersionCheck>();
+        services.AddSingleton<IEnvironmentCheck, OperatingSystemCheck>();
         UseFakeInstallationDiscovery(
             services,
             self: new InstallationInfo

--- a/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
@@ -54,16 +54,18 @@ public class OperatingSystemCheckTests
     }
 
     [Fact]
-    public void ParseLinuxOsRelease_StripsMatchingQuotesWithoutProcessingEscapes()
+    public void ParseLinuxOsRelease_StripsQuotesAndDoubleQuotedEscapes()
     {
         var values = OperatingSystemCheck.ParseLinuxOsRelease("""
             NAME="Example \"Linux\""
+            PRETTY_NAME="Cost \$1"
             VERSION_ID='1.0'
             PATH='path\\to'
             ID=example-linux
             """);
 
-        Assert.Equal(@"Example \""Linux\""", values["NAME"]);
+        Assert.Equal("Example \"Linux\"", values["NAME"]);
+        Assert.Equal("Cost $1", values["PRETTY_NAME"]);
         Assert.Equal("1.0", values["VERSION_ID"]);
         Assert.Equal(@"path\\to", values["PATH"]);
         Assert.Equal("example-linux", values["ID"]);

--- a/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
@@ -54,7 +54,7 @@ public class OperatingSystemCheckTests
     }
 
     [Fact]
-    public void ParseLinuxOsRelease_StripsQuotesAndDoubleQuotedEscapes()
+    public void ParseLinuxOsRelease_StripsQuotesAndPreservesEscapes()
     {
         var values = OperatingSystemCheck.ParseLinuxOsRelease("""
             NAME="Example \"Linux\""
@@ -64,8 +64,8 @@ public class OperatingSystemCheckTests
             ID=example-linux
             """);
 
-        Assert.Equal("Example \"Linux\"", values["NAME"]);
-        Assert.Equal("Cost $1!", values["PRETTY_NAME"]);
+        Assert.Equal("Example \\\"Linux\\\"", values["NAME"]);
+        Assert.Equal(@"Cost \$1\!", values["PRETTY_NAME"]);
         Assert.Equal("1.0", values["VERSION_ID"]);
         Assert.Equal(@"path\\to", values["PATH"]);
         Assert.Equal("example-linux", values["ID"]);

--- a/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
@@ -54,16 +54,18 @@ public class OperatingSystemCheckTests
     }
 
     [Fact]
-    public void ParseLinuxOsRelease_UnquotesEscapedValues()
+    public void ParseLinuxOsRelease_StripsMatchingQuotesWithoutProcessingEscapes()
     {
         var values = OperatingSystemCheck.ParseLinuxOsRelease("""
             NAME="Example \"Linux\""
             VERSION_ID='1.0'
+            PATH='path\\to'
             ID=example-linux
             """);
 
-        Assert.Equal("Example \"Linux\"", values["NAME"]);
+        Assert.Equal(@"Example \""Linux\""", values["NAME"]);
         Assert.Equal("1.0", values["VERSION_ID"]);
+        Assert.Equal(@"path\\to", values["PATH"]);
         Assert.Equal("example-linux", values["ID"]);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
@@ -29,6 +29,26 @@ public class OperatingSystemCheckTests
         Assert.Equal("Ubuntu 24.04.2 LTS", result.Metadata["description"]!.GetValue<string>());
     }
 
+    [Fact]
+    public async Task CheckAsync_ReturnsWarningForUnknownOperatingSystem()
+    {
+        var check = new OperatingSystemCheck(() => new OperatingSystemDetails(
+            Type: "Unknown",
+            Name: "Unknown OS",
+            Version: "1.2.3",
+            Description: "Unknown OS description"));
+
+        var result = Assert.Single(await check.CheckAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal(EnvironmentCheckStatus.Warning, result.Status);
+        Assert.Equal("Operating system: Unknown OS 1.2.3", result.Message);
+        Assert.NotNull(result.Metadata);
+        Assert.Equal("Unknown", result.Metadata["osType"]!.GetValue<string>());
+        Assert.Equal("Unknown OS", result.Metadata["displayName"]!.GetValue<string>());
+        Assert.Equal("1.2.3", result.Metadata["version"]!.GetValue<string>());
+        Assert.Equal("Unknown OS description", result.Metadata["description"]!.GetValue<string>());
+    }
+
     [Theory]
     [InlineData(10, 0, 19045)]
     [InlineData(10, 0, 22631)]

--- a/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils.EnvironmentChecker;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class OperatingSystemCheckTests
+{
+    [Fact]
+    public async Task CheckAsync_ReturnsEnvironmentResultWithMetadata()
+    {
+        var check = new OperatingSystemCheck(() => new OperatingSystemDetails(
+            Type: "Linux",
+            Name: "Linux Ubuntu",
+            Version: "24.04",
+            Description: "Ubuntu 24.04.2 LTS"));
+
+        var result = Assert.Single(await check.CheckAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("environment", result.Category);
+        Assert.Equal("operating-system", result.Name);
+        Assert.Equal(EnvironmentCheckStatus.Pass, result.Status);
+        Assert.Equal("Operating system: Linux Ubuntu 24.04", result.Message);
+        Assert.NotNull(result.Metadata);
+        Assert.Equal("Linux", result.Metadata["osType"]!.GetValue<string>());
+        Assert.Equal("Linux Ubuntu", result.Metadata["displayName"]!.GetValue<string>());
+        Assert.Equal("24.04", result.Metadata["version"]!.GetValue<string>());
+        Assert.Equal("Ubuntu 24.04.2 LTS", result.Metadata["description"]!.GetValue<string>());
+    }
+
+    [Theory]
+    [InlineData(10, 0, 19045)]
+    [InlineData(10, 0, 22631)]
+    public void CreateWindowsDetails_UsesHighLevelWindowsName(int major, int minor, int build)
+    {
+        var details = OperatingSystemCheck.CreateWindowsDetails(new Version(major, minor, build), "Microsoft Windows");
+
+        Assert.Equal("Windows", details.Type);
+        Assert.Equal("Windows", details.Name);
+        Assert.Equal($"{major}.{minor}.{build}", details.Version);
+    }
+
+    [Theory]
+    [InlineData(26, 0)]
+    [InlineData(15, 1)]
+    public void CreateMacOSDetails_UsesHighLevelMacOSName(int major, int minor)
+    {
+        var details = OperatingSystemCheck.CreateMacOSDetails(new Version(major, minor), "Darwin");
+
+        Assert.Equal("macOS", details.Type);
+        Assert.Equal("macOS", details.Name);
+        Assert.Equal($"{major}.{minor}", details.Version);
+    }
+
+    [Fact]
+    public void ParseLinuxOsRelease_UnquotesEscapedValues()
+    {
+        var values = OperatingSystemCheck.ParseLinuxOsRelease("""
+            NAME="Example \"Linux\""
+            VERSION_ID='1.0'
+            ID=example-linux
+            """);
+
+        Assert.Equal("Example \"Linux\"", values["NAME"]);
+        Assert.Equal("1.0", values["VERSION_ID"]);
+        Assert.Equal("example-linux", values["ID"]);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
@@ -58,14 +58,14 @@ public class OperatingSystemCheckTests
     {
         var values = OperatingSystemCheck.ParseLinuxOsRelease("""
             NAME="Example \"Linux\""
-            PRETTY_NAME="Cost \$1"
+            PRETTY_NAME="Cost \$1\!"
             VERSION_ID='1.0'
             PATH='path\\to'
             ID=example-linux
             """);
 
         Assert.Equal("Example \"Linux\"", values["NAME"]);
-        Assert.Equal("Cost $1", values["PRETTY_NAME"]);
+        Assert.Equal("Cost $1!", values["PRETTY_NAME"]);
         Assert.Equal("1.0", values["VERSION_ID"]);
         Assert.Equal(@"path\\to", values["PATH"]);
         Assert.Equal("example-linux", values["ID"]);

--- a/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Utils.EnvironmentChecker;
+using Aspire.Cli.Resources;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -14,7 +15,8 @@ public class OperatingSystemCheckTests
             Type: "Linux",
             Name: "Linux Ubuntu",
             Version: "24.04",
-            Description: "Ubuntu 24.04.2 LTS"));
+            Description: "Ubuntu 24.04.2 LTS",
+            Status: EnvironmentCheckStatus.Pass));
 
         var result = Assert.Single(await check.CheckAsync(TestContext.Current.CancellationToken));
 
@@ -33,18 +35,20 @@ public class OperatingSystemCheckTests
     public async Task CheckAsync_ReturnsWarningForUnknownOperatingSystem()
     {
         var check = new OperatingSystemCheck(() => new OperatingSystemDetails(
-            Type: "Unknown",
-            Name: "Unknown OS",
+            Type: "unknown",
+            Name: "unknown",
             Version: "1.2.3",
-            Description: "Unknown OS description"));
+            Description: "Unknown OS description",
+            Status: EnvironmentCheckStatus.Warning,
+            MessageDisplayName: DoctorCommandStrings.VersionUnknown));
 
         var result = Assert.Single(await check.CheckAsync(TestContext.Current.CancellationToken));
 
         Assert.Equal(EnvironmentCheckStatus.Warning, result.Status);
-        Assert.Equal("Operating system: Unknown OS 1.2.3", result.Message);
+        Assert.Equal("Operating system: unknown 1.2.3", result.Message);
         Assert.NotNull(result.Metadata);
-        Assert.Equal("Unknown", result.Metadata["osType"]!.GetValue<string>());
-        Assert.Equal("Unknown OS", result.Metadata["displayName"]!.GetValue<string>());
+        Assert.Equal("unknown", result.Metadata["osType"]!.GetValue<string>());
+        Assert.Equal("unknown", result.Metadata["displayName"]!.GetValue<string>());
         Assert.Equal("1.2.3", result.Metadata["version"]!.GetValue<string>());
         Assert.Equal("Unknown OS description", result.Metadata["description"]!.GetValue<string>());
     }

--- a/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/OperatingSystemCheckTests.cs
@@ -18,8 +18,8 @@ public class OperatingSystemCheckTests
 
         var result = Assert.Single(await check.CheckAsync(TestContext.Current.CancellationToken));
 
-        Assert.Equal("environment", result.Category);
-        Assert.Equal("operating-system", result.Name);
+        Assert.Equal(EnvironmentCheckCategories.Environment, result.Category);
+        Assert.Equal(OperatingSystemCheck.CheckName, result.Name);
         Assert.Equal(EnvironmentCheckStatus.Pass, result.Status);
         Assert.Equal("Operating system: Linux Ubuntu 24.04", result.Message);
         Assert.NotNull(result.Metadata);

--- a/tests/Aspire.Cli.Tests/Commands/TypeScriptAppHostToolingCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TypeScriptAppHostToolingCheckTests.cs
@@ -42,7 +42,7 @@ public sealed class TypeScriptAppHostToolingCheckTests(ITestOutputHelper outputH
 
         var result = Assert.Single(results);
         Assert.Equal(EnvironmentCheckStatus.Pass, result.Status);
-        Assert.Equal("typescript-apphost-tools", result.Name);
+        Assert.Equal(TypeScriptAppHostToolingCheck.ToolsCheckName, result.Name);
         foreach (var command in requiredCommands)
         {
             Assert.Contains(command, result.Message, StringComparison.OrdinalIgnoreCase);
@@ -74,7 +74,7 @@ public sealed class TypeScriptAppHostToolingCheckTests(ITestOutputHelper outputH
         Assert.All(results, result =>
         {
             Assert.Equal(EnvironmentCheckStatus.Fail, result.Status);
-            Assert.Equal("environment", result.Category);
+            Assert.Equal(EnvironmentCheckCategories.Environment, result.Category);
             Assert.Equal(expectedInstallLink, result.Link);
             Assert.Equal(
                 $"Install {installDisplayName} tooling and rerun 'aspire doctor'.",
@@ -85,7 +85,7 @@ public sealed class TypeScriptAppHostToolingCheckTests(ITestOutputHelper outputH
 
         foreach (var command in requiredCommands)
         {
-            var commandResult = Assert.Single(results, r => r.Name == $"typescript-apphost-{command}");
+            var commandResult = Assert.Single(results, r => r.Name == TypeScriptAppHostToolingCheck.GetMissingCommandCheckName(command));
             Assert.Contains($"'{command}'", commandResult.Message, StringComparison.Ordinal);
             Assert.Contains(command, commandResult.Details!, StringComparison.Ordinal);
         }
@@ -110,7 +110,7 @@ public sealed class TypeScriptAppHostToolingCheckTests(ITestOutputHelper outputH
 
         var result = Assert.Single(results);
         Assert.Equal(EnvironmentCheckStatus.Fail, result.Status);
-        Assert.Equal($"typescript-apphost-{missingCommand}", result.Name);
+        Assert.Equal(TypeScriptAppHostToolingCheck.GetMissingCommandCheckName(missingCommand), result.Name);
         Assert.Equal("https://nodejs.org/en/download", result.Link);
         Assert.Contains($"'{missingCommand}'", result.Message, StringComparison.Ordinal);
     }
@@ -138,8 +138,8 @@ public sealed class TypeScriptAppHostToolingCheckTests(ITestOutputHelper outputH
 
         var result = Assert.Single(results);
         Assert.Equal(EnvironmentCheckStatus.Fail, result.Status);
-        Assert.Equal("typescript-apphost-yarn-classic", result.Name);
-        Assert.Equal("environment", result.Category);
+        Assert.Equal(TypeScriptAppHostToolingCheck.YarnClassicCheckName, result.Name);
+        Assert.Equal(EnvironmentCheckCategories.Environment, result.Category);
         Assert.Equal("https://yarnpkg.com/getting-started/install", result.Link);
         Assert.Equal("TypeScript AppHost does not support Yarn Classic.", result.Message);
         Assert.Contains("Yarn Classic is not supported", result.Details ?? string.Empty);
@@ -162,8 +162,8 @@ public sealed class TypeScriptAppHostToolingCheckTests(ITestOutputHelper outputH
 
         var result = Assert.Single(results);
         Assert.Equal(EnvironmentCheckStatus.Fail, result.Status);
-        Assert.Equal("typescript-apphost-yarn-classic", result.Name);
-        Assert.Equal("environment", result.Category);
+        Assert.Equal(TypeScriptAppHostToolingCheck.YarnClassicCheckName, result.Name);
+        Assert.Equal(EnvironmentCheckCategories.Environment, result.Category);
         Assert.Equal("https://yarnpkg.com/getting-started/install", result.Link);
         Assert.Contains("yarn.lock", result.Details ?? string.Empty);
     }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -188,6 +188,7 @@ internal static class CliTestHelper
         services.AddSingleton(options.AppHostProjectFactory);
 
         services.AddSingleton<IEnvironmentCheck, AspireVersionCheck>();
+        services.AddSingleton<IEnvironmentCheck, OperatingSystemCheck>();
         services.AddSingleton<IEnvironmentCheck, WslEnvironmentCheck>();
         services.AddSingleton<IEnvironmentCheck, DotNetSdkCheck>();
         services.AddSingleton<IEnvironmentCheck, TypeScriptAppHostToolingCheck>();

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckFixRecommendationTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckFixRecommendationTests.cs
@@ -103,7 +103,7 @@ public class DevCertsCheckFixRecommendationTests
 
         // Should have two results: pass for trust status, warning for old version
         Assert.Equal(2, results.Count);
-        var versionWarning = results.First(r => r.Name == "dev-certs-version");
+        var versionWarning = results.First(r => r.Name == DevCertsCheck.VersionCheckName);
         Assert.Equal(EnvironmentCheckStatus.Warning, versionWarning.Status);
         Assert.NotNull(versionWarning.Fix);
         Assert.Contains("aspire certs clean", versionWarning.Fix);

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -33,7 +33,7 @@ public class DevCertsCheckTests
         var results = DevCertsCheck.EvaluateCertificateResults([]);
 
         var devCertsResult = Assert.Single(results);
-        Assert.Equal("dev-certs", devCertsResult.Name);
+        Assert.Equal(DevCertsCheck.CheckName, devCertsResult.Name);
         Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
         Assert.Contains("No HTTPS development certificate found", devCertsResult.Message);
     }
@@ -49,7 +49,7 @@ public class DevCertsCheckTests
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
 
-        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Pass, devCertsResult.Status);
         Assert.Contains("trusted", devCertsResult.Message);
     }
@@ -65,7 +65,7 @@ public class DevCertsCheckTests
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
 
-        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
         Assert.Contains("none are trusted", devCertsResult.Message);
     }
@@ -81,7 +81,7 @@ public class DevCertsCheckTests
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
 
-        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
         Assert.Contains("Multiple HTTPS development certificates found", devCertsResult.Message);
     }
@@ -96,7 +96,7 @@ public class DevCertsCheckTests
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
 
-        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Pass, devCertsResult.Status);
         Assert.Contains("trusted", devCertsResult.Message);
     }
@@ -111,7 +111,7 @@ public class DevCertsCheckTests
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
 
-        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
         Assert.Contains("not trusted", devCertsResult.Message);
     }
@@ -126,7 +126,7 @@ public class DevCertsCheckTests
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
 
-        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
         Assert.Contains("partially trusted", devCertsResult.Message);
     }
@@ -142,7 +142,7 @@ public class DevCertsCheckTests
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
 
         Assert.Equal(2, results.Count);
-        var versionResult = Assert.Single(results, r => r.Name == "dev-certs-version");
+        var versionResult = Assert.Single(results, r => r.Name == DevCertsCheck.VersionCheckName);
         Assert.Equal(EnvironmentCheckStatus.Warning, versionResult.Status);
         Assert.Contains("older version", versionResult.Message);
     }
@@ -160,7 +160,7 @@ public class DevCertsCheckTests
 
         // Should only have the pass result, no version warning
         var devCertsResult = Assert.Single(results);
-        Assert.Equal("dev-certs", devCertsResult.Name);
+        Assert.Equal(DevCertsCheck.CheckName, devCertsResult.Name);
         Assert.Equal(EnvironmentCheckStatus.Pass, devCertsResult.Status);
     }
 
@@ -177,7 +177,7 @@ public class DevCertsCheckTests
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
 
         // Should not have a "Multiple certs" warning since all are trusted
-        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.NotEqual(EnvironmentCheckStatus.Warning, devCertsResult.Status);
     }
 
@@ -193,7 +193,7 @@ public class DevCertsCheckTests
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
 
-        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
         Assert.Contains("3 certificates", devCertsResult.Message);
     }
@@ -208,7 +208,7 @@ public class DevCertsCheckTests
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
 
-        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.NotNull(devCertsResult.Metadata);
         Assert.True(devCertsResult.Metadata.ContainsKey("certificates"));
 

--- a/tests/Aspire.Cli.Tests/Utils/LegacySettingsFileCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/LegacySettingsFileCheckTests.cs
@@ -27,8 +27,8 @@ public class LegacySettingsFileCheckTests(ITestOutputHelper outputHelper)
         var results = await check.CheckAsync();
 
         var result = Assert.Single(results);
-        Assert.Equal("environment", result.Category);
-        Assert.Equal("legacy-settings-file", result.Name);
+        Assert.Equal(EnvironmentCheckCategories.Environment, result.Category);
+        Assert.Equal(LegacySettingsFileCheck.CheckName, result.Name);
         Assert.Equal(EnvironmentCheckStatus.Warning, result.Status);
         Assert.Contains(".aspire", result.Message);
         Assert.Contains("settings.json", result.Message);


### PR DESCRIPTION
## Description

`aspire doctor` should make basic host environment details easy to inspect alongside the existing SDK, container, certificate, and configuration checks. This adds an Environment check that reports the current operating system in both human-readable and JSON output.

The check reports high-level Windows/macOS names with the OS version, and includes Linux distro details from `/etc/os-release` when available. JSON output includes structured metadata for tooling: `osType`, `displayName`, `version`, and `description`.

### User-facing usage

Human-readable output includes the OS row in the Environment section:

```text
Environment
  ✅ Operating system: macOS 26.5.1
```

JSON output includes the same check:

```json
{
  "category": "environment",
  "name": "operating-system",
  "status": "pass",
  "message": "Operating system: Linux Ubuntu 24.04",
  "metadata": {
    "osType": "Linux",
    "displayName": "Linux Ubuntu",
    "version": "24.04",
    "description": "Ubuntu 24.04.2 LTS"
  }
}
```

Validation:
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.OperatingSystemCheckTests" --filter-class "*.DoctorCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build /t:UpdateXlf src/Aspire.Cli/Aspire.Cli.csproj`
- Local smoke check of `aspire doctor --format json`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No