### PR TITLE
ci: capture Aspire CLI logs in deployment E2E test artifact

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -282,6 +282,18 @@ jobs:
             ${{ matrix.extraTestArgs }} \
             || echo "test_failed=true" >> $GITHUB_OUTPUT
 
+      - name: Collect Aspire CLI logs
+        if: always()
+        run: |
+          # The CLI writes a detailed deployment log (including the underlying ARM error,
+          # e.g. the subcode behind a generic "OperationFailed" provisioning failure) to
+          # ~/.aspire/logs/cli_*.log. That detail is otherwise lost because only testresults/
+          # is uploaded, so copy the logs under testresults/ to capture them in the artifact.
+          if [ -d "$HOME/.aspire/logs" ]; then
+            mkdir -p "${{ github.workspace }}/testresults/aspire-cli-logs"
+            cp -r "$HOME/.aspire/logs/." "${{ github.workspace }}/testresults/aspire-cli-logs/" || true
+          fi
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
## What was missing

Deployment E2E failures surface only a high-level pipeline message. For the recurring `AcaManagedRedis` failure that is:

```
(provision-cache) ✗ Failed to provision cache: Deployment failed:
    Error code = OperationFailed, Message = The operation failed. (171.2s)
❌ Pipeline failed
```

A generic `OperationFailed` with no detail. The real ARM error — the subcode that distinguishes a regional capacity/quota issue from invalid generated Bicep — is written by the CLI to `~/.aspire/logs/cli_*.log` (every failing run prints `📄 See logs at /home/runner/.aspire/logs/cli_…log`). But the `Upload test results` step only uploads `${{ github.workspace }}/testresults/`, so that detail is lost once the runner is gone.

## The fix

Add a `Collect Aspire CLI logs` step (`if: always()`) that copies `~/.aspire/logs` into `testresults/aspire-cli-logs/` just before the existing artifact upload, so the detailed log is captured in the `deployment-test-results-*` artifact.

Pure log collection — no change to test or deployment behavior. The copy is done in a shell step (not the `upload-artifact` `path:`) because `actions/glob` does not expand `~`/`$HOME`; copying under the already-uploaded `testresults/` is the robust way to capture a `$HOME` path.

## Why

This unblocks the next investigation step called out in #17430: capture the underlying ARM deployment error for the recurring `AcaManagedRedis` Managed Redis provisioning failure, to determine whether it is regional capacity/quota in `eastus` (the region this test pins) or a generated-Bicep regression.

## Surprises / call-outs

- The detailed CLI log is currently captured for **all** scenarios, not just `AcaManagedRedis` — it will help diagnose any provisioning failure (e.g. the transient ACR `no such host` races seen on AzureStorage/AcaStarter).
- This workflow only runs on schedule / manual dispatch / `deployment-test/*`, so the change won't be exercised by normal PR CI. The `paths:` triggers don't include this file either; validating end-to-end requires a manual dispatch.
