### PR TITLE
Enable keyboard navigation on dashboard scroll containers

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -8,7 +8,7 @@
 @implements IAsyncDisposable
 
 @* Console logs always have a dark background. Set data-theme="dark" so dark theme accent colors are used *@
-<div id="logScrollContainer" class="log-overflow console-overflow continuous-scroll-overflow" tabindex="0" role="region" aria-label="@Loc[nameof(ConsoleLogs.ConsoleLogsHeader)]" data-theme="dark">
+<div id="@ScrollContainerId" class="log-overflow console-overflow continuous-scroll-overflow" tabindex="0" role="region" aria-label="@Loc[nameof(ConsoleLogs.ConsoleLogsHeader)]" data-theme="dark">
     <div class="@GetLogContainerClass()" id="logContainer">
         @if (LogEntries is { } logEntries)
         {

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -8,7 +8,7 @@
 @implements IAsyncDisposable
 
 @* Console logs always have a dark background. Set data-theme="dark" so dark theme accent colors are used *@
-<div class="log-overflow console-overflow continuous-scroll-overflow" data-theme="dark">
+<div id="logScrollContainer" class="log-overflow console-overflow continuous-scroll-overflow" tabindex="0" role="region" aria-label="@Loc[nameof(ConsoleLogs.ConsoleLogsHeader)]" data-theme="dark">
     <div class="@GetLogContainerClass()" id="logContainer">
         @if (LogEntries is { } logEntries)
         {

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -111,6 +111,7 @@ public sealed partial class LogViewer
             Logger.LogDebug("Initializing log viewer.");
 
             await JS.InvokeVoidAsync("initializeContinuousScroll");
+            await JS.InvokeVoidAsync("focusElement", "logScrollContainer");
             DimensionManager.OnViewportInformationChanged += OnBrowserResize;
         }
     }

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -112,7 +112,9 @@ public sealed partial class LogViewer
             Logger.LogDebug("Initializing log viewer.");
 
             await JS.InvokeVoidAsync("initializeContinuousScroll");
-            await JS.InvokeVoidAsync("focusElement", ScrollContainerId);
+            // Focus the scroll container without showing the focus ring. The container is a large
+            // content area where a visible focus indicator would be visually noisy on initial load.
+            await JS.InvokeVoidAsync("focusElement", ScrollContainerId, true);
             DimensionManager.OnViewportInformationChanged += OnBrowserResize;
         }
     }

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -17,6 +17,7 @@ namespace Aspire.Dashboard.Components;
 /// </summary>
 public sealed partial class LogViewer
 {
+    private const string ScrollContainerId = "logScrollContainer";
     private static readonly MarkupString s_spaceMarkup = new MarkupString("&#32;");
 
     private LogEntries? _logEntries;
@@ -111,7 +112,7 @@ public sealed partial class LogViewer
             Logger.LogDebug("Initializing log viewer.");
 
             await JS.InvokeVoidAsync("initializeContinuousScroll");
-            await JS.InvokeVoidAsync("focusElement", "logScrollContainer");
+            await JS.InvokeVoidAsync("focusElement", ScrollContainerId);
             DimensionManager.OnViewportInformationChanged += OnBrowserResize;
         }
     }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -119,7 +119,7 @@
                                     </FluentTab>
                                 </FluentTabs>
                             }
-                            <div class="resources-grid-container" hidden="@(PageViewModel.SelectedViewKind == ResourceViewKind.Graph)">
+                            <div id="@ScrollContainerId" class="resources-grid-container" tabindex="0" role="region" aria-label="@Loc[nameof(Dashboard.Resources.Resources.ResourcesHeader)]" hidden="@(PageViewModel.SelectedViewKind == ResourceViewKind.Graph)">
                                 <GridColumnManager @ref="_manager" Columns="@_gridColumns">
                                     <FluentDataGrid @ref="_dataGrid"
                                                     ColumnResizeLabels="@_resizeLabels"
@@ -139,7 +139,7 @@
                                                     ShowHover="true"
                                                     TGridItem="ResourceGridViewModel"
                                                     ItemKey="@(r => r.Resource.Name)"
-                                                    OnRowClick="@(r => r.ExecuteOnDefault(d => ShowResourceDetailsAsync(d.Resource, buttonId: null)))"
+                                                    OnRowClick="@(r => r.ExecuteOnDefault(d => ShowResourceDetailsAsync(d.Resource, focusElementId: ScrollContainerId)))"
                                                     Class="main-grid enable-row-click">
                                         <ChildContent>
                                             <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => $"{c.Resource.ResourceType}: {GetResourceName(c.Resource)}")" Class="expand-col">
@@ -208,7 +208,7 @@
                                                 <div class="grid-action-container" @onclick:stopPropagation="true">
                                                     <ResourceActions CommandSelected="async (command) => await ExecuteResourceCommandAsync(context.Resource, command)"
                                                                      IsCommandExecuting="@((resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name))"
-                                                                     OnViewDetails="@((buttonId) => ShowResourceDetailsAsync(context.Resource, buttonId))"
+                                                                     OnViewDetails="@((focusElementId) => ShowResourceDetailsAsync(context.Resource, focusElementId))"
                                                                      Resource="context.Resource"
                                                                      MaxHighlightedCount="_maxHighlightedCount"
                                                                      ResourceByName="@_resourceByName" />

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -223,7 +223,7 @@
                             </div>
                             @if (!_hideResourceGraph)
                             {
-                                <div class="resource-graph-container" hidden="@(PageViewModel.SelectedViewKind != ResourceViewKind.Graph)">
+                                <div id="@GraphContainerId" class="resource-graph-container" tabindex="0" role="region" aria-label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerGraphAccessibleLabel)]" hidden="@(PageViewModel.SelectedViewKind != ResourceViewKind.Graph)">
                                     <svg class="resource-graph">
                                     </svg>
                                     <div class="resource-graph-controls">

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -29,6 +29,7 @@ namespace Aspire.Dashboard.Components.Pages;
 public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncDisposable, IPageWithSessionAndUrlState<Resources.ResourcesViewModel, Resources.ResourcesPageState>
 {
     private const string ScrollContainerId = "resourcesScrollContainer";
+    private const string GraphContainerId = "resourcesGraphContainer";
     private const string TypeColumn = nameof(TypeColumn);
     private const string NameColumn = nameof(NameColumn);
     private const string StateColumn = nameof(StateColumn);
@@ -119,6 +120,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     private bool _isFilterPopupVisible;
     private Task? _resourceSubscriptionTask;
     private string? _elementIdBeforeDetailsViewOpened;
+    private string? _pendingFocusElementId;
     private FluentDataGrid<ResourceGridViewModel> _dataGrid = null!;
     private GridColumnManager _manager = null!;
     private int _maxHighlightedCount;
@@ -387,9 +389,14 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
         if (firstRender)
         {
-            // Focus the scroll container without showing the focus ring. The container is a large
-            // content area where a visible focus indicator would be visually noisy on initial load.
-            await JS.InvokeVoidAsync("focusElement", ScrollContainerId, true);
+            var initialFocusElementId = PageViewModel.SelectedViewKind == ResourceViewKind.Graph ? GraphContainerId : ScrollContainerId;
+            await JS.InvokeVoidAsync("focusElement", initialFocusElementId, true);
+        }
+
+        if (_pendingFocusElementId is { } pendingFocusElementId)
+        {
+            _pendingFocusElementId = null;
+            await JS.InvokeVoidAsync("focusElement", pendingFocusElementId);
         }
 
         if (PageViewModel.SelectedViewKind == ResourceViewKind.Graph && !_graphInitialized)
@@ -712,6 +719,12 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         Logger.LogDebug("Clearing selected resource.");
 
         PageViewModel.SelectedResource = null;
+        if (_elementIdBeforeDetailsViewOpened is not null && causedByUserAction)
+        {
+            _pendingFocusElementId = _elementIdBeforeDetailsViewOpened;
+        }
+
+        _elementIdBeforeDetailsViewOpened = null;
 
         await InvokeAsync(StateHasChanged);
 
@@ -719,13 +732,6 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         {
             await UpdateResourceGraphSelectedAsync();
         }
-
-        if (_elementIdBeforeDetailsViewOpened is not null && causedByUserAction)
-        {
-            await JS.InvokeVoidAsync("focusElement", _elementIdBeforeDetailsViewOpened);
-        }
-
-        _elementIdBeforeDetailsViewOpened = null;
     }
 
     private string GetResourceName(ResourceViewModel resource) => ResourceViewModel.GetResourceName(resource, _resourceByName);

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -28,6 +28,7 @@ namespace Aspire.Dashboard.Components.Pages;
 
 public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncDisposable, IPageWithSessionAndUrlState<Resources.ResourcesViewModel, Resources.ResourcesPageState>
 {
+    private const string ScrollContainerId = "resourcesScrollContainer";
     private const string TypeColumn = nameof(TypeColumn);
     private const string NameColumn = nameof(NameColumn);
     private const string StateColumn = nameof(StateColumn);
@@ -384,6 +385,11 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             StateHasChanged();
         }
 
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("focusElement", ScrollContainerId);
+        }
+
         if (PageViewModel.SelectedViewKind == ResourceViewKind.Graph && !_graphInitialized)
         {
             // Before any awaits, set a flag to indicate the graph is initialized. This prevents the graph being initialized multiple times.
@@ -584,7 +590,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         {
             if (_resourceByName.TryGetValue(ResourceName, out var selectedResource))
             {
-                await ShowResourceDetailsAsync(selectedResource, buttonId: null);
+                await ShowResourceDetailsAsync(selectedResource, focusElementId: null);
             }
             else
             {
@@ -630,7 +636,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 _contextMenuItems,
                 resource,
                 _resourceByName,
-                EventCallback.Factory.Create(this, () => ShowResourceDetailsAsync(resource, buttonId: null)),
+                EventCallback.Factory.Create(this, () => ShowResourceDetailsAsync(resource, focusElementId: null)),
                 EventCallback.Factory.Create<CommandViewModel>(this, (command) => ExecuteResourceCommandAsync(resource, command)),
                 (resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name),
                 showViewDetails: true,
@@ -650,11 +656,11 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         }
     }
 
-    private async Task ShowResourceDetailsAsync(ResourceViewModel resource, string? buttonId)
+    private async Task ShowResourceDetailsAsync(ResourceViewModel resource, string? focusElementId)
     {
         Logger.LogDebug("Showing details for resource {ResourceName}.", resource.Name);
 
-        _elementIdBeforeDetailsViewOpened = buttonId;
+        _elementIdBeforeDetailsViewOpened = focusElementId;
 
         if (string.Equals(PageViewModel.SelectedResource?.Name, resource.Name, StringComparisons.ResourceName))
         {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -387,7 +387,9 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
         if (firstRender)
         {
-            await JS.InvokeVoidAsync("focusElement", ScrollContainerId);
+            // Focus the scroll container without showing the focus ring. The container is a large
+            // content area where a visible focus indicator would be visually noisy on initial load.
+            await JS.InvokeVoidAsync("focusElement", ScrollContainerId, true);
         }
 
         if (PageViewModel.SelectedViewKind == ResourceViewKind.Graph && !_graphInitialized)

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -110,7 +110,7 @@
                 </DetailsTitleTemplate>
                 <Summary>
                     <div class="logs-summary-layout">
-                        <div class="logs-grid-container continuous-scroll-overflow">
+                        <div id="@ScrollContainerId" class="logs-grid-container continuous-scroll-overflow" tabindex="0" role="region" aria-label="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsHeader)]">
                             <GridColumnManager @ref="_manager" Columns="@_gridColumns">
                                 <FluentDataGrid @ref="_dataGrid"
                                                 ColumnResizeLabels="@_resizeLabels"
@@ -129,7 +129,7 @@
                                                 GridTemplateColumns="@_manager.GetGridTemplateColumns()"
                                                 ShowHover="true"
                                                 ItemKey="@(r => r.InternalId)"
-                                                OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, buttonId: null)))"
+                                                OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, focusElementId: ScrollContainerId)))"
                                                 Class="main-grid enable-row-click">
                                     <ChildContent>
                                         <AspireTemplateColumn ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.ResourceView))">
@@ -165,7 +165,7 @@
                                             }
                                             <div class="grid-action-container" @onclick:stopPropagation="true">
                                                 <StructuredLogActions LogEntry="@context"
-                                                                      OnViewDetails="@((buttonId) => OnShowPropertiesAsync(context, buttonId))" />
+                                                                      OnViewDetails="@((focusElementId) => OnShowPropertiesAsync(context, focusElementId))" />
                                             </div>
                                         </AspireTemplateColumn>
                                     </ChildContent>

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -26,6 +26,7 @@ namespace Aspire.Dashboard.Components.Pages;
 
 public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionAndUrlState<StructuredLogs.StructuredLogsPageViewModel, StructuredLogs.StructuredLogsPageState>
 {
+    private const string ScrollContainerId = "structuredLogsScrollContainer";
     private const string ResourceColumn = nameof(ResourceColumn);
     private const string LogLevelColumn = nameof(LogLevelColumn);
     private const string TimestampColumn = nameof(TimestampColumn);
@@ -262,7 +263,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
             var logEntryId = TelemetryRepository.GetLog(LogEntryId.Value);
             if (logEntryId != null)
             {
-                await OnShowPropertiesAsync(logEntryId, buttonId: null);
+                await OnShowPropertiesAsync(logEntryId, focusElementId: null);
             }
 
             // Navigate to remove ?logEntryId=xxx in the URL. A small delay is required here, otherwise the page rendering breaks.
@@ -312,9 +313,9 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         }
     }
 
-    private async Task OnShowPropertiesAsync(OtlpLogEntry entry, string? buttonId)
+    private async Task OnShowPropertiesAsync(OtlpLogEntry entry, string? focusElementId)
     {
-        _elementIdBeforeDetailsViewOpened = buttonId;
+        _elementIdBeforeDetailsViewOpened = focusElementId;
 
         if (PageViewModel.SelectedLogEntry?.LogEntry.InternalId == entry.InternalId)
         {
@@ -452,6 +453,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         if (firstRender)
         {
             await JS.InvokeVoidAsync("initializeContinuousScroll");
+            await JS.InvokeVoidAsync("focusElement", ScrollContainerId);
             DimensionManager.OnViewportInformationChanged += OnBrowserResize;
         }
     }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -453,7 +453,9 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         if (firstRender)
         {
             await JS.InvokeVoidAsync("initializeContinuousScroll");
-            await JS.InvokeVoidAsync("focusElement", ScrollContainerId);
+            // Focus the scroll container without showing the focus ring. The container is a large
+            // content area where a visible focus indicator would be visually noisy on initial load.
+            await JS.InvokeVoidAsync("focusElement", ScrollContainerId, true);
             DimensionManager.OnViewportInformationChanged += OnBrowserResize;
         }
     }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -333,7 +333,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         }
     }
 
-    private async Task ClearSelectedLogEntryAsync(bool causedByUserAction = false)
+    private Task ClearSelectedLogEntryAsync(bool causedByUserAction = false)
     {
         PageViewModel.SelectedLogEntry = null;
 
@@ -343,6 +343,8 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         }
 
         _elementIdBeforeDetailsViewOpened = null;
+
+        return Task.CompletedTask;
     }
 
     private async Task ExplainErrorsAsync()

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -47,6 +47,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     private Subscription? _logsSubscription;
     private bool _resourceChanged;
     private string? _elementIdBeforeDetailsViewOpened;
+    private string? _pendingFocusElementId;
     private AspirePageContentLayout? _contentLayout;
     private string _filter = string.Empty;
     private FluentDataGrid<OtlpLogEntry>? _dataGrid;
@@ -338,7 +339,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
 
         if (_elementIdBeforeDetailsViewOpened is not null && causedByUserAction)
         {
-            await JS.InvokeVoidAsync("focusElement", _elementIdBeforeDetailsViewOpened);
+            _pendingFocusElementId = _elementIdBeforeDetailsViewOpened;
         }
 
         _elementIdBeforeDetailsViewOpened = null;
@@ -457,6 +458,12 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
             // content area where a visible focus indicator would be visually noisy on initial load.
             await JS.InvokeVoidAsync("focusElement", ScrollContainerId, true);
             DimensionManager.OnViewportInformationChanged += OnBrowserResize;
+        }
+
+        if (_pendingFocusElementId is { } pendingFocusElementId)
+        {
+            _pendingFocusElementId = null;
+            await JS.InvokeVoidAsync("focusElement", pendingFocusElementId);
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -156,6 +156,7 @@
                             </div>
                         }
 
+                        <div id="@ScrollContainerId" class="tracedetails-grid-container continuous-scroll-overflow" tabindex="0" role="region" aria-label="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)]">
                         <GridColumnManager @ref="_manager" Columns="@_gridColumns">
                             <FluentDataGrid @ref="_dataGrid"
                                             Virtualize="true"
@@ -170,7 +171,7 @@
                                             OverscanCount="100"
                                             ShowHover="true"
                                             ItemKey="@(r => r.Span.SpanId)"
-                                            OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, buttonId: null)))">
+                                            OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, focusElementId: ScrollContainerId)))">
                                 <ChildContent>
                                     <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailNameHeader)]" Tooltip="true" TooltipText="@(c => c.GetTooltip(_resources))" Class="expand-col">
                                         @{
@@ -364,7 +365,7 @@
 
                                         <div @onclick:stopPropagation="true" style="margin-left: 7px;">
                                             <SpanActions SpanViewModel="@context"
-                                                         OnViewDetails="@((buttonId) => OnShowPropertiesAsync(context, buttonId))"
+                                                         OnViewDetails="@((focusElementId) => OnShowPropertiesAsync(context, focusElementId))"
                                                          OnLaunchGenAI="@OnGenAIClickedAsync" />
                                         </div>
                                     </AspireTemplateColumn>
@@ -374,6 +375,7 @@
                                 </EmptyContent>
                             </FluentDataGrid>
                         </GridColumnManager>
+                        </div>
                     </Summary>
                     <Details>
                         @if (context?.SpanViewModel is { } spanVm)

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -158,222 +158,222 @@
 
                         <div id="@ScrollContainerId" class="tracedetails-grid-container continuous-scroll-overflow" tabindex="0" role="region" aria-label="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)]">
                             <GridColumnManager @ref="_manager" Columns="@_gridColumns">
-                            <FluentDataGrid @ref="_dataGrid"
-                                            Virtualize="true"
-                                            GenerateHeader="GenerateHeaderOption.Sticky"
-                                            Class="main-grid trace-view-grid enable-row-click"
-                                            ResizableColumns="true"
-                                            ItemsProvider="@GetData"
-                                            TGridItem="SpanWaterfallViewModel"
-                                            RowClass="@GetRowClass"
-                                            GridTemplateColumns="@_manager.GetGridTemplateColumns()"
-                                            RowSize="DataGridRowSize.Small"
-                                            OverscanCount="100"
-                                            ShowHover="true"
-                                            ItemKey="@(r => r.Span.SpanId)"
-                                            OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, focusElementId: ScrollContainerId)))">
-                                <ChildContent>
-                                    <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailNameHeader)]" Tooltip="true" TooltipText="@(c => c.GetTooltip(_resources))" Class="expand-col">
-                                        @{
-                                            var isServerOrConsumer = context.Span.Kind == OtlpSpanKind.Server || context.Span.Kind == OtlpSpanKind.Consumer;
-                                            // Indent the span name based on the depth of the span.
-                                            var marginLeft = (context.Depth - 1) * 15;
-
-                                            // We want to have consistent margin for both client and server spans.
-                                            string spanNameContainerStyle;
-                                            if (!isServerOrConsumer)
-                                                {
-                                                    // Client span has 19px extra content:
-                                                    // - 5px extra margin-left
-                                                    // - 5px border
-                                                    // - 9px padding-left
-                                                    spanNameContainerStyle = $"margin-left: 5px; border-left-color: {ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 9px;";
-                                                }
-                                            else
-                                            {
-                                                // Span with icon has 19px extra content:
-                                                // - 16px icon
-                                                // - 3px padding-left
-                                                spanNameContainerStyle = string.Empty;
-                                            }
-                                        }
-
-                                        <div class="span-overview-container">
-                                            <span @onclick:stopPropagation="true" style="margin-left: @(marginLeft)px;" class="main-grid-expand-container @(context.IsCollapsed ? "main-grid-collapsed" : "main-grid-expanded")">
-                                                @if (context.Children.Count > 0)
-                                                {
-                                                    <FluentButton aria-label="@ControlStringsLoc[nameof(ControlsStrings.ToggleNesting)]" Appearance="Appearance.Lightweight" Class="main-grid-expand-button" OnClick="@(() => OnToggleCollapse(context))">
-                                                        <FluentIcon Icon="Icons.Regular.Size12.ChevronRight" Color="Color.Neutral" />
-                                                    </FluentButton>
-                                                }
-                                            </span>
-                                            <span class="span-name-container" style="@spanNameContainerStyle">
-                                                @if (isServerOrConsumer)
-                                                {
-                                                    <FluentIcon Class="span-kind-icon"
-                                                                Color="Color.Custom"
-                                                                CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.Span.Source))"
-                                                                Value="@TraceHelpers.TryGetSpanIcon(context.Span, IconVariant.Filled)"/>
-                                                }
-
-                                                @if (context.IsError)
-                                                {
-                                                    <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon"/>
-                                                }
-                                                <FluentHighlighter HighlightedText="@PageViewModel.Filter" Text="@context.Span.GetDisplaySummary()" />
-                                                @if (context.HasUninstrumentedPeer)
-                                                {
-                                                    <span class="uninstrumented-peer">
-                                                        @{
-                                                            Icon icon;
-                                                            if (context.Span.Attributes.HasKey("db.system"))
-                                                            {
-                                                                icon = new Icons.Filled.Size16.Database();
-                                                            }
-                                                            else if (context.Span.Attributes.HasKey("messaging.system"))
-                                                            {
-                                                                icon = new Icons.Filled.Size16.Mail();
-                                                            }
-                                                            else
-                                                            {
-                                                                // Everything else.
-                                                                icon = new Icons.Filled.Size16.ArrowCircleRight();
-                                                            }
-                                                        }
-                                                        <FluentIcon
-                                                            Style="@($"fill: {ColorGenerator.Instance.GetColorVariableByKey(context.UninstrumentedPeer)};")"
-                                                            Value="icon"
-                                                            Class="uninstrumented-peer-icon"/>
-                                                        <FluentHighlighter HighlightedText="@PageViewModel.Filter" Text="@context.UninstrumentedPeer" />
-                                                    </span>
-                                                }
-                                            </span>
-                                            <span @onclick:stopPropagation="true">
-                                                @if (IsGenAISpan(context))
-                                                {
-                                                    <FluentButton Appearance="Appearance.Lightweight"
-                                                                  Title="@ControlStringsLoc[nameof(ControlsStrings.GenAIDetailsTitle)]"
-                                                                  Class="genai-details-button"
-                                                                  OnClick="() => OnGenAIClickedAsync(context.Span)">
-                                                        <FluentIcon Icon="Icons.Regular.Size20.Sparkle"
-                                                                    Color="Color.Accent" />
-                                                    </FluentButton>
-                                                }
-                                            </span>
-                                        </div>
-                                    </AspireTemplateColumn>
-                                    <AspireTemplateColumn ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailResourceHeader)]" Tooltip="true" TooltipText="@(c => GetResourceName(c.Span.Source))" Class="expand-col">
-                                        <div class="resource-name">
-                                            <FluentHighlighter HighlightedText="@PageViewModel.Filter" Text="@GetResourceName(context.Span.Source)" />
-                                        </div>
-                                    </AspireTemplateColumn>
-                                    <AspireTemplateColumn ColumnId="@TicksColumn" ColumnManager="@_manager">
-                                        <HeaderCellItemTemplate>
-                                            <div class="ticks">
-                                                @* First column starts at 0. We don't want to display the smallest unit (0μs) because that looks odd. Use the unit from the next column *@
-                                                <div class="tick" style="grid-column: 1;"></div>
-                                                <span class="tick-label" style="grid-column: 1;">@($"0{DurationFormatter.GetUnit(trace.Duration / 4)}")</span>
-
-                                                <div class="tick" style="grid-column: 2;"></div>
-                                                <span class="tick-label" style="grid-column: 2;">@DurationFormatter.FormatDuration(trace.Duration / 4, CultureInfo.CurrentCulture)</span>
-
-                                                <div class="tick" style="grid-column: 3;"></div>
-                                                <span class="tick-label" style="grid-column: 3;">@DurationFormatter.FormatDuration(trace.Duration / 4 * 2, CultureInfo.CurrentCulture)</span>
-
-                                                @* Grid column 4 shows two labels. Hide the left aligned label on mobile to avoid them overlapping *@
-                                                <div class="tick" style="grid-column: 4;"></div>
-                                                @if (_manager.ViewportInformation.IsDesktop)
-                                                {
-                                                    <span class="tick-label" style="grid-column: 4;">@DurationFormatter.FormatDuration(trace.Duration / 4 * 3, CultureInfo.CurrentCulture)</span>
-                                                }
-
-                                                <span class="tick-label end-tick" style="grid-column: 4;">@DurationFormatter.FormatDuration(trace.Duration, CultureInfo.CurrentCulture)</span>
-                                                <div class="tick" style="grid-column: 5;"></div>
-                                            </div>
-                                        </HeaderCellItemTemplate>
-                                        <ChildContent>
+                                <FluentDataGrid @ref="_dataGrid"
+                                                Virtualize="true"
+                                                GenerateHeader="GenerateHeaderOption.Sticky"
+                                                Class="main-grid trace-view-grid enable-row-click"
+                                                ResizableColumns="true"
+                                                ItemsProvider="@GetData"
+                                                TGridItem="SpanWaterfallViewModel"
+                                                RowClass="@GetRowClass"
+                                                GridTemplateColumns="@_manager.GetGridTemplateColumns()"
+                                                RowSize="DataGridRowSize.Small"
+                                                OverscanCount="100"
+                                                ShowHover="true"
+                                                ItemKey="@(r => r.Span.SpanId)"
+                                                OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, focusElementId: ScrollContainerId)))">
+                                    <ChildContent>
+                                        <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailNameHeader)]" Tooltip="true" TooltipText="@(c => c.GetTooltip(_resources))" Class="expand-col">
                                             @{
-                                                var spanColor = @ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.Span.Source));
+                                                var isServerOrConsumer = context.Span.Kind == OtlpSpanKind.Server || context.Span.Kind == OtlpSpanKind.Consumer;
+                                                // Indent the span name based on the depth of the span.
+                                                var marginLeft = (context.Depth - 1) * 15;
+
+                                                // We want to have consistent margin for both client and server spans.
+                                                string spanNameContainerStyle;
+                                                if (!isServerOrConsumer)
+                                                    {
+                                                        // Client span has 19px extra content:
+                                                        // - 5px extra margin-left
+                                                        // - 5px border
+                                                        // - 9px padding-left
+                                                        spanNameContainerStyle = $"margin-left: 5px; border-left-color: {ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 9px;";
+                                                    }
+                                                else
+                                                {
+                                                    // Span with icon has 19px extra content:
+                                                    // - 16px icon
+                                                    // - 3px padding-left
+                                                    spanNameContainerStyle = string.Empty;
+                                                }
                                             }
-                                            <div class="ticks">
-                                                <div class="span-container" style="position: relative; grid-template-columns: @context.LeftOffset.ToString("F2", CultureInfo.InvariantCulture)% @context.Width.ToString("F2", CultureInfo.InvariantCulture)% min-content;">
-                                                    <div class="span-button-container">
-                                                        @foreach (var item in context.SpanLogs)
-                                                        {
-                                                            var buttonId = $"{context.Span.SpanId}-{item.LogEntry.InternalId}";
-                                                            var eventName = StructureLogsDetailsViewModel.GetEventName(item.LogEntry, StructuredLogsLoc);
-                                                            var isSelected = SelectedData?.LogEntryViewModel?.LogEntry.InternalId == item.LogEntry.InternalId;
-                                                            var htmlTooltip = item.Index < 500;
-                                                            var buttonColor = item.LogEntry.IsError ? "var(--error)" : spanColor;
 
-                                                            <button id="@buttonId"
-                                                                    title="@(!htmlTooltip ? $"{eventName} - {item.LogEntry.Scope.Name}" : string.Empty)"
-                                                                    aria-label="@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsEntryDetails)]"
-                                                                    class="@($"span-log-entry-button {(isSelected ? "span-log-entry-selected" : null)} {(item.LogEntry.IsError ? "span-log-entry-error" : null)}")"
-                                                                    data-span-color="@spanColor"
-                                                                    style="@($"left: {@item.LeftOffset.ToString("F2", CultureInfo.InvariantCulture)}%; --button-color: {buttonColor};")"
-                                                                    @onclick="@(() => ToggleSpanLogsAsync(item.LogEntry))"
-                                                                    @onclick:stopPropagation="true">
-                                                            </button>
-                                                            @*
-                                                                There is a performance impact to having many tooltips on the page. Limit to 500 tooltips.
-                                                                The button continues to be displayed and clicking on it opens the details view.
-                                                                A standard browser tooltip is displayed instead of the FluentTooltip.
-                                                            *@
-                                                            @if (htmlTooltip)
-                                                            {
-                                                                <FluentTooltip Anchor="@buttonId" MaxWidth="350px">
-                                                                    <div class="log-tooltip-title-container">
-                                                                        <span class="log-tooltip-title">@eventName</span> <span class="log-tooltip-subtitle">@item.LogEntry.Scope.Name</span><br />
-                                                                    </div>
-                                                                    <table class="log-tooltip-table">
-                                                                        <tr>
-                                                                            <td class="label-column">@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]</td>
-                                                                            <td>@item.LogEntry.Severity</td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td class="label-column">@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]</td>
-                                                                            <td>@FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, item.LogEntry.TimeStamp, MillisecondsDisplay.Truncated)</td>
-                                                                        </tr>
-                                                                        <tr>
-                                                                            <td class="label-column">@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]</td>
-                                                                            <td>@FormatHelpers.TruncateText(item.LogEntry.Message, maxLength: 150)</td>
-                                                                        </tr>
-                                                                    </table>
-                                                                </FluentTooltip>
+                                            <div class="span-overview-container">
+                                                <span @onclick:stopPropagation="true" style="margin-left: @(marginLeft)px;" class="main-grid-expand-container @(context.IsCollapsed ? "main-grid-collapsed" : "main-grid-expanded")">
+                                                    @if (context.Children.Count > 0)
+                                                    {
+                                                        <FluentButton aria-label="@ControlStringsLoc[nameof(ControlsStrings.ToggleNesting)]" Appearance="Appearance.Lightweight" Class="main-grid-expand-button" OnClick="@(() => OnToggleCollapse(context))">
+                                                            <FluentIcon Icon="Icons.Regular.Size12.ChevronRight" Color="Color.Neutral" />
+                                                        </FluentButton>
+                                                    }
+                                                </span>
+                                                <span class="span-name-container" style="@spanNameContainerStyle">
+                                                    @if (isServerOrConsumer)
+                                                    {
+                                                        <FluentIcon Class="span-kind-icon"
+                                                                    Color="Color.Custom"
+                                                                    CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.Span.Source))"
+                                                                    Value="@TraceHelpers.TryGetSpanIcon(context.Span, IconVariant.Filled)"/>
+                                                    }
+
+                                                    @if (context.IsError)
+                                                    {
+                                                        <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon"/>
+                                                    }
+                                                    <FluentHighlighter HighlightedText="@PageViewModel.Filter" Text="@context.Span.GetDisplaySummary()" />
+                                                    @if (context.HasUninstrumentedPeer)
+                                                    {
+                                                        <span class="uninstrumented-peer">
+                                                            @{
+                                                                Icon icon;
+                                                                if (context.Span.Attributes.HasKey("db.system"))
+                                                                {
+                                                                    icon = new Icons.Filled.Size16.Database();
+                                                                }
+                                                                else if (context.Span.Attributes.HasKey("messaging.system"))
+                                                                {
+                                                                    icon = new Icons.Filled.Size16.Mail();
+                                                                }
+                                                                else
+                                                                {
+                                                                    // Everything else.
+                                                                    icon = new Icons.Filled.Size16.ArrowCircleRight();
+                                                                }
                                                             }
-                                                        }
-                                                    </div>
-                                                    <div class="span-bar" style="grid-column: 2; background: @spanColor;"></div>
-                                                    <div class="span-bar-label @(context.LabelIsRight ? "span-bar-label-right" : "span-bar-label-left")">
-                                                        <span class="span-bar-label-detail">@SpanWaterfallViewModel.GetTitle(context.Span, _resources)</span>
-                                                        <span>@DurationFormatter.FormatDuration(context.Span.Duration, CultureInfo.CurrentCulture)</span>
-                                                    </div>
-                                                </div>
-                                                <div class="tick" style="grid-column: 1;"></div>
-                                                <div class="tick" style="grid-column: 2;"></div>
-                                                <div class="tick" style="grid-column: 3;"></div>
-                                                <div class="tick" style="grid-column: 4;"></div>
-                                                <div class="tick" style="grid-column: 5;"></div>
+                                                            <FluentIcon
+                                                                Style="@($"fill: {ColorGenerator.Instance.GetColorVariableByKey(context.UninstrumentedPeer)};")"
+                                                                Value="icon"
+                                                                Class="uninstrumented-peer-icon"/>
+                                                            <FluentHighlighter HighlightedText="@PageViewModel.Filter" Text="@context.UninstrumentedPeer" />
+                                                        </span>
+                                                    }
+                                                </span>
+                                                <span @onclick:stopPropagation="true">
+                                                    @if (IsGenAISpan(context))
+                                                    {
+                                                        <FluentButton Appearance="Appearance.Lightweight"
+                                                                    Title="@ControlStringsLoc[nameof(ControlsStrings.GenAIDetailsTitle)]"
+                                                                    Class="genai-details-button"
+                                                                    OnClick="() => OnGenAIClickedAsync(context.Span)">
+                                                            <FluentIcon Icon="Icons.Regular.Size20.Sparkle"
+                                                                        Color="Color.Accent" />
+                                                        </FluentButton>
+                                                    }
+                                                </span>
                                             </div>
-                                        </ChildContent>
-                                    </AspireTemplateColumn>
-                                    <AspireTemplateColumn ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@ControlStringsLoc[nameof(ControlsStrings.ActionsColumnHeader)]" Class="no-ellipsis">
-                                        @{
-                                            var id = context.Span.SpanId;
-                                        }
+                                        </AspireTemplateColumn>
+                                        <AspireTemplateColumn ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailResourceHeader)]" Tooltip="true" TooltipText="@(c => GetResourceName(c.Span.Source))" Class="expand-col">
+                                            <div class="resource-name">
+                                                <FluentHighlighter HighlightedText="@PageViewModel.Filter" Text="@GetResourceName(context.Span.Source)" />
+                                            </div>
+                                        </AspireTemplateColumn>
+                                        <AspireTemplateColumn ColumnId="@TicksColumn" ColumnManager="@_manager">
+                                            <HeaderCellItemTemplate>
+                                                <div class="ticks">
+                                                    @* First column starts at 0. We don't want to display the smallest unit (0μs) because that looks odd. Use the unit from the next column *@
+                                                    <div class="tick" style="grid-column: 1;"></div>
+                                                    <span class="tick-label" style="grid-column: 1;">@($"0{DurationFormatter.GetUnit(trace.Duration / 4)}")</span>
 
-                                        <div @onclick:stopPropagation="true" style="margin-left: 7px;">
-                                            <SpanActions SpanViewModel="@context"
-                                                         OnViewDetails="@((focusElementId) => OnShowPropertiesAsync(context, focusElementId))"
-                                                         OnLaunchGenAI="@OnGenAIClickedAsync" />
-                                        </div>
-                                    </AspireTemplateColumn>
-                                </ChildContent>
-                                <EmptyContent>
-                                    <FluentIcon Icon="Icons.Regular.Size24.GanttChart" />&nbsp;@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailNoSpans)]
-                                </EmptyContent>
-                            </FluentDataGrid>
+                                                    <div class="tick" style="grid-column: 2;"></div>
+                                                    <span class="tick-label" style="grid-column: 2;">@DurationFormatter.FormatDuration(trace.Duration / 4, CultureInfo.CurrentCulture)</span>
+
+                                                    <div class="tick" style="grid-column: 3;"></div>
+                                                    <span class="tick-label" style="grid-column: 3;">@DurationFormatter.FormatDuration(trace.Duration / 4 * 2, CultureInfo.CurrentCulture)</span>
+
+                                                    @* Grid column 4 shows two labels. Hide the left aligned label on mobile to avoid them overlapping *@
+                                                    <div class="tick" style="grid-column: 4;"></div>
+                                                    @if (_manager.ViewportInformation.IsDesktop)
+                                                    {
+                                                        <span class="tick-label" style="grid-column: 4;">@DurationFormatter.FormatDuration(trace.Duration / 4 * 3, CultureInfo.CurrentCulture)</span>
+                                                    }
+
+                                                    <span class="tick-label end-tick" style="grid-column: 4;">@DurationFormatter.FormatDuration(trace.Duration, CultureInfo.CurrentCulture)</span>
+                                                    <div class="tick" style="grid-column: 5;"></div>
+                                                </div>
+                                            </HeaderCellItemTemplate>
+                                            <ChildContent>
+                                                @{
+                                                    var spanColor = @ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.Span.Source));
+                                                }
+                                                <div class="ticks">
+                                                    <div class="span-container" style="position: relative; grid-template-columns: @context.LeftOffset.ToString("F2", CultureInfo.InvariantCulture)% @context.Width.ToString("F2", CultureInfo.InvariantCulture)% min-content;">
+                                                        <div class="span-button-container">
+                                                            @foreach (var item in context.SpanLogs)
+                                                            {
+                                                                var buttonId = $"{context.Span.SpanId}-{item.LogEntry.InternalId}";
+                                                                var eventName = StructureLogsDetailsViewModel.GetEventName(item.LogEntry, StructuredLogsLoc);
+                                                                var isSelected = SelectedData?.LogEntryViewModel?.LogEntry.InternalId == item.LogEntry.InternalId;
+                                                                var htmlTooltip = item.Index < 500;
+                                                                var buttonColor = item.LogEntry.IsError ? "var(--error)" : spanColor;
+
+                                                                <button id="@buttonId"
+                                                                        title="@(!htmlTooltip ? $"{eventName} - {item.LogEntry.Scope.Name}" : string.Empty)"
+                                                                        aria-label="@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsEntryDetails)]"
+                                                                        class="@($"span-log-entry-button {(isSelected ? "span-log-entry-selected" : null)} {(item.LogEntry.IsError ? "span-log-entry-error" : null)}")"
+                                                                        data-span-color="@spanColor"
+                                                                        style="@($"left: {@item.LeftOffset.ToString("F2", CultureInfo.InvariantCulture)}%; --button-color: {buttonColor};")"
+                                                                        @onclick="@(() => ToggleSpanLogsAsync(item.LogEntry))"
+                                                                        @onclick:stopPropagation="true">
+                                                                </button>
+                                                                @*
+                                                                    There is a performance impact to having many tooltips on the page. Limit to 500 tooltips.
+                                                                    The button continues to be displayed and clicking on it opens the details view.
+                                                                    A standard browser tooltip is displayed instead of the FluentTooltip.
+                                                                *@
+                                                                @if (htmlTooltip)
+                                                                {
+                                                                    <FluentTooltip Anchor="@buttonId" MaxWidth="350px">
+                                                                        <div class="log-tooltip-title-container">
+                                                                            <span class="log-tooltip-title">@eventName</span> <span class="log-tooltip-subtitle">@item.LogEntry.Scope.Name</span><br />
+                                                                        </div>
+                                                                        <table class="log-tooltip-table">
+                                                                            <tr>
+                                                                                <td class="label-column">@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]</td>
+                                                                                <td>@item.LogEntry.Severity</td>
+                                                                            </tr>
+                                                                            <tr>
+                                                                                <td class="label-column">@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]</td>
+                                                                                <td>@FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, item.LogEntry.TimeStamp, MillisecondsDisplay.Truncated)</td>
+                                                                            </tr>
+                                                                            <tr>
+                                                                                <td class="label-column">@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]</td>
+                                                                                <td>@FormatHelpers.TruncateText(item.LogEntry.Message, maxLength: 150)</td>
+                                                                            </tr>
+                                                                        </table>
+                                                                    </FluentTooltip>
+                                                                }
+                                                            }
+                                                        </div>
+                                                        <div class="span-bar" style="grid-column: 2; background: @spanColor;"></div>
+                                                        <div class="span-bar-label @(context.LabelIsRight ? "span-bar-label-right" : "span-bar-label-left")">
+                                                            <span class="span-bar-label-detail">@SpanWaterfallViewModel.GetTitle(context.Span, _resources)</span>
+                                                            <span>@DurationFormatter.FormatDuration(context.Span.Duration, CultureInfo.CurrentCulture)</span>
+                                                        </div>
+                                                    </div>
+                                                    <div class="tick" style="grid-column: 1;"></div>
+                                                    <div class="tick" style="grid-column: 2;"></div>
+                                                    <div class="tick" style="grid-column: 3;"></div>
+                                                    <div class="tick" style="grid-column: 4;"></div>
+                                                    <div class="tick" style="grid-column: 5;"></div>
+                                                </div>
+                                            </ChildContent>
+                                        </AspireTemplateColumn>
+                                        <AspireTemplateColumn ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@ControlStringsLoc[nameof(ControlsStrings.ActionsColumnHeader)]" Class="no-ellipsis">
+                                            @{
+                                                var id = context.Span.SpanId;
+                                            }
+
+                                            <div @onclick:stopPropagation="true" style="margin-left: 7px;">
+                                                <SpanActions SpanViewModel="@context"
+                                                            OnViewDetails="@((focusElementId) => OnShowPropertiesAsync(context, focusElementId))"
+                                                            OnLaunchGenAI="@OnGenAIClickedAsync" />
+                                            </div>
+                                        </AspireTemplateColumn>
+                                    </ChildContent>
+                                    <EmptyContent>
+                                        <FluentIcon Icon="Icons.Regular.Size24.GanttChart" />&nbsp;@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailNoSpans)]
+                                    </EmptyContent>
+                                </FluentDataGrid>
                             </GridColumnManager>
                         </div>
                     </Summary>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -156,7 +156,7 @@
                             </div>
                         }
 
-                        <div id="@ScrollContainerId" class="tracedetails-grid-container continuous-scroll-overflow" tabindex="0" role="region" aria-label="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)]">
+                        <div id="@ScrollContainerId" class="tracedetails-grid-container" tabindex="0" role="region" aria-label="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)]">
                             <GridColumnManager @ref="_manager" Columns="@_gridColumns">
                                 <FluentDataGrid @ref="_dataGrid"
                                                 Virtualize="true"

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -182,13 +182,13 @@
                                                 // We want to have consistent margin for both client and server spans.
                                                 string spanNameContainerStyle;
                                                 if (!isServerOrConsumer)
-                                                    {
-                                                        // Client span has 19px extra content:
-                                                        // - 5px extra margin-left
-                                                        // - 5px border
-                                                        // - 9px padding-left
-                                                        spanNameContainerStyle = $"margin-left: 5px; border-left-color: {ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 9px;";
-                                                    }
+                                                {
+                                                    // Client span has 19px extra content:
+                                                    // - 5px extra margin-left
+                                                    // - 5px border
+                                                    // - 9px padding-left
+                                                    spanNameContainerStyle = $"margin-left: 5px; border-left-color: {ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 9px;";
+                                                }
                                                 else
                                                 {
                                                     // Span with icon has 19px extra content:

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -157,7 +157,7 @@
                         }
 
                         <div id="@ScrollContainerId" class="tracedetails-grid-container continuous-scroll-overflow" tabindex="0" role="region" aria-label="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)]">
-                        <GridColumnManager @ref="_manager" Columns="@_gridColumns">
+                            <GridColumnManager @ref="_manager" Columns="@_gridColumns">
                             <FluentDataGrid @ref="_dataGrid"
                                             Virtualize="true"
                                             GenerateHeader="GenerateHeaderOption.Sticky"
@@ -374,7 +374,7 @@
                                     <FluentIcon Icon="Icons.Regular.Size24.GanttChart" />&nbsp;@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailNoSpans)]
                                 </EmptyContent>
                             </FluentDataGrid>
-                        </GridColumnManager>
+                            </GridColumnManager>
                         </div>
                     </Summary>
                     <Details>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -42,6 +42,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     private List<OtlpResource> _resources = default!;
     private readonly List<string> _collapsedSpanIds = [];
     private string? _elementIdBeforeDetailsViewOpened;
+    private string? _pendingFocusElementId;
     private FluentDataGrid<SpanWaterfallViewModel> _dataGrid = null!;
     private GridColumnManager _manager = null!;
     private AIContext? _aiContext;
@@ -270,6 +271,12 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             // content area where a visible focus indicator would be visually noisy on initial load.
             await JS.InvokeVoidAsync("focusElement", ScrollContainerId, true);
         }
+
+        if (_pendingFocusElementId is { } pendingFocusElementId)
+        {
+            _pendingFocusElementId = null;
+            await JS.InvokeVoidAsync("focusElement", pendingFocusElementId);
+        }
     }
 
     private void UpdateDetailViewData()
@@ -441,7 +448,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
 
         if (_elementIdBeforeDetailsViewOpened is not null && causedByUserAction)
         {
-            await JS.InvokeVoidAsync("focusElement", _elementIdBeforeDetailsViewOpened);
+            _pendingFocusElementId = _elementIdBeforeDetailsViewOpened;
         }
 
         _elementIdBeforeDetailsViewOpened = null;

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -26,6 +26,7 @@ namespace Aspire.Dashboard.Components.Pages;
 
 public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisposable
 {
+    private const string ScrollContainerId = "traceDetailScrollContainer";
     private const string NameColumn = nameof(NameColumn);
     private const string ResourceColumn = nameof(ResourceColumn);
     private const string TicksColumn = nameof(TicksColumn);
@@ -226,7 +227,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             var spanVm = PageViewModel.SpanWaterfallViewModels.SingleOrDefault(vm => vm.Span.SpanId == SpanId);
             if (spanVm != null)
             {
-                await OnShowPropertiesAsync(spanVm, buttonId: null);
+                await OnShowPropertiesAsync(spanVm, focusElementId: null);
             }
 
             // Navigate to remove ?spanId=xxx in the URL. A small delay is required here, otherwise the page rendering breaks.
@@ -254,13 +255,18 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         });
     }
 
-    protected override void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         // Check to see whether max item count should be set on every render.
         // This is required because the data grid's virtualize component can be recreated on data change.
         if (_dataGrid != null && FluentDataGridHelper<SpanWaterfallViewModel>.TrySetMaxItemCount(_dataGrid, 10_000))
         {
             StateHasChanged();
+        }
+
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("focusElement", ScrollContainerId);
         }
     }
 
@@ -408,9 +414,9 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         await _layout.CloseMobileToolbarAsync();
     }
 
-    private async Task OnShowPropertiesAsync(SpanWaterfallViewModel viewModel, string? buttonId)
+    private async Task OnShowPropertiesAsync(SpanWaterfallViewModel viewModel, string? focusElementId)
     {
-        _elementIdBeforeDetailsViewOpened = buttonId;
+        _elementIdBeforeDetailsViewOpened = focusElementId;
 
         if (PageViewModel.SelectedData?.SpanViewModel?.Span.SpanId == viewModel.Span.SpanId)
         {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -266,7 +266,9 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
 
         if (firstRender)
         {
-            await JS.InvokeVoidAsync("focusElement", ScrollContainerId);
+            // Focus the scroll container without showing the focus ring. The container is a large
+            // content area where a visible focus indicator would be visually noisy on initial load.
+            await JS.InvokeVoidAsync("focusElement", ScrollContainerId, true);
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -442,7 +442,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         }
     }
 
-    private async Task ClearSelectedSpanAsync(bool causedByUserAction = false)
+    private Task ClearSelectedSpanAsync(bool causedByUserAction = false)
     {
         PageViewModel.SelectedData = null;
 
@@ -452,6 +452,8 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         }
 
         _elementIdBeforeDetailsViewOpened = null;
+
+        return Task.CompletedTask;
     }
 
     private bool HasCollapsedSpans()

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -21,6 +21,10 @@
     line-height: 1;
 }
 
+::deep .tracedetails-grid-container {
+    overflow: auto;
+}
+
 ::deep .trace-view-grid {
 }
 

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -87,7 +87,7 @@
             }
         </ToolbarSection>
         <MainSection>
-            <div id="tracesScrollContainer" class="datagrid-overflow-area continuous-scroll-overflow" tabindex="0" role="region" aria-label="@Loc[nameof(Dashboard.Resources.Traces.TracesHeader)]">
+            <div id="@ScrollContainerId" class="datagrid-overflow-area continuous-scroll-overflow" tabindex="0" role="region" aria-label="@Loc[nameof(Dashboard.Resources.Traces.TracesHeader)]">
                 <GridColumnManager @ref="_manager" Columns="@_gridColumns">
                     <FluentDataGrid @ref="_dataGrid"
                                     ColumnResizeLabels="@_resizeLabels"

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -87,7 +87,7 @@
             }
         </ToolbarSection>
         <MainSection>
-            <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
+            <div id="tracesScrollContainer" class="datagrid-overflow-area continuous-scroll-overflow" tabindex="0" role="region" aria-label="@Loc[nameof(Dashboard.Resources.Traces.TracesHeader)]">
                 <GridColumnManager @ref="_manager" Columns="@_gridColumns">
                     <FluentDataGrid @ref="_dataGrid"
                                     ColumnResizeLabels="@_resizeLabels"

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -283,7 +283,9 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
         if (firstRender)
         {
             await JS.InvokeVoidAsync("initializeContinuousScroll");
-            await JS.InvokeVoidAsync("focusElement", ScrollContainerId);
+            // Focus the scroll container without showing the focus ring. The container is a large
+            // content area where a visible focus indicator would be visually noisy on initial load.
+            await JS.InvokeVoidAsync("focusElement", ScrollContainerId, true);
             DimensionManager.OnViewportInformationChanged += OnBrowserResize;
         }
     }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -282,6 +282,7 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
         if (firstRender)
         {
             await JS.InvokeVoidAsync("initializeContinuousScroll");
+            await JS.InvokeVoidAsync("focusElement", "tracesScrollContainer");
             DimensionManager.OnViewportInformationChanged += OnBrowserResize;
         }
     }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -26,6 +26,7 @@ namespace Aspire.Dashboard.Components.Pages;
 
 public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlState<Traces.TracesPageViewModel, Traces.TracesPageState>
 {
+    private const string ScrollContainerId = "tracesScrollContainer";
     private const string TimestampColumn = nameof(TimestampColumn);
     private const string NameColumn = nameof(NameColumn);
     private const string SpansColumn = nameof(SpansColumn);
@@ -282,7 +283,7 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
         if (firstRender)
         {
             await JS.InvokeVoidAsync("initializeContinuousScroll");
-            await JS.InvokeVoidAsync("focusElement", "tracesScrollContainer");
+            await JS.InvokeVoidAsync("focusElement", ScrollContainerId);
             DimensionManager.OnViewportInformationChanged += OnBrowserResize;
         }
     }

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -669,15 +669,6 @@ fluent-switch.table-switch::part(label) {
     overflow: auto;
 }
 
-.log-overflow:focus,
-.datagrid-overflow-area:focus,
-.logs-grid-container:focus,
-.resources-grid-container:focus,
-.tracedetails-grid-container:focus {
-    outline: none;
-    box-shadow: inset 0 0 0 1px var(--accent-fill-rest);
-}
-
 .log-overflow {
     --console-theme-black: #0C0C0C;
     --console-theme-blue: #0037DA;

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -669,6 +669,14 @@ fluent-switch.table-switch::part(label) {
     overflow: auto;
 }
 
+.log-overflow:focus,
+.datagrid-overflow-area:focus,
+.logs-grid-container:focus,
+.resources-grid-container:focus,
+.tracedetails-grid-container:focus {
+    outline: none;
+}
+
 .log-overflow {
     --console-theme-black: #0C0C0C;
     --console-theme-blue: #0037DA;

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -675,6 +675,7 @@ fluent-switch.table-switch::part(label) {
 .resources-grid-container:focus,
 .tracedetails-grid-container:focus {
     outline: none;
+    box-shadow: inset 0 0 0 1px var(--accent-fill-rest);
 }
 
 .log-overflow {

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -326,7 +326,11 @@ window.getBrowserInfo = function () {
 window.focusElement = function (selector, suppressFocusVisible) {
     const element = document.getElementById(selector);
     if (element) {
-        element.focus({ focusVisible: !suppressFocusVisible });
+        if (suppressFocusVisible) {
+            element.focus({ focusVisible: false });
+        } else {
+            element.focus();
+        }
     }
 };
 

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -326,7 +326,8 @@ window.getBrowserInfo = function () {
 window.focusElement = function (selector) {
     const element = document.getElementById(selector);
     if (element) {
-        element.focus();
+        /* Focus the element without showing the focus ring. */
+        element.focus({ focusVisible: false });
     }
 };
 

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -323,11 +323,10 @@ window.getBrowserInfo = function () {
     };
 };
 
-window.focusElement = function (selector) {
+window.focusElement = function (selector, suppressFocusVisible) {
     const element = document.getElementById(selector);
     if (element) {
-        /* Focus the element without showing the focus ring. */
-        element.focus({ focusVisible: false });
+        element.focus({ focusVisible: !suppressFocusVisible });
     }
 };
 

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/LogViewerTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/LogViewerTests.cs
@@ -6,6 +6,7 @@ using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Shared.ConsoleLogs;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Xunit;
 
 namespace Aspire.Dashboard.Components.Tests.Controls;
@@ -62,6 +63,32 @@ public class LogViewerTests : DashboardTestContext
         });
     }
 
+    [Fact]
+    public void LogViewer_FocusesAccessibleScrollContainerOnInitialRender()
+    {
+        SetupLogViewerServices();
+
+        var cut = RenderComponent<LogViewer>(builder =>
+        {
+            builder.Add(p => p.LogEntries, new LogEntries(maximumEntryCount: int.MaxValue));
+        });
+
+        var scrollContainer = cut.Find("#logScrollContainer");
+        var loc = Services.GetRequiredService<IStringLocalizer<Resources.ConsoleLogs>>();
+
+        Assert.Equal("0", scrollContainer.GetAttribute("tabindex"));
+        Assert.Equal("region", scrollContainer.GetAttribute("role"));
+        Assert.Equal(loc[nameof(Resources.ConsoleLogs.ConsoleLogsHeader)].Value, scrollContainer.GetAttribute("aria-label"));
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains(JSInterop.Invocations, invocation =>
+                invocation.Identifier == "focusElement" &&
+                invocation.Arguments.Count == 2 &&
+                string.Equals(invocation.Arguments[0]?.ToString(), "logScrollContainer", StringComparison.Ordinal) &&
+                string.Equals(invocation.Arguments[1]?.ToString(), bool.TrueString, StringComparison.OrdinalIgnoreCase));
+        });
+    }
+
     private static string GetBackgroundAccentVariableName(string style)
     {
         var background = GetCssPropertyValue(style, "background");
@@ -104,8 +131,8 @@ public class LogViewerTests : DashboardTestContext
         FluentUISetupHelpers.AddCommonDashboardServices(this, browserTimeProvider: new TestTimeProvider());
         Services.AddLogging();
 
-        JSInterop.SetupVoid("initializeContinuousScroll");
-        JSInterop.SetupVoid("resetContinuousScrollPosition");
+        JSInterop.SetupVoid("initializeContinuousScroll").SetVoidResult();
+        JSInterop.SetupVoid("resetContinuousScrollPosition").SetVoidResult();
         JSInterop.SetupVoid("focusElement", _ => true);
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/LogViewerTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/LogViewerTests.cs
@@ -106,5 +106,6 @@ public class LogViewerTests : DashboardTestContext
 
         JSInterop.SetupVoid("initializeContinuousScroll");
         JSInterop.SetupVoid("resetContinuousScrollPosition");
+        JSInterop.SetupVoid("focusElement", _ => true);
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -842,8 +842,8 @@ public partial class ConsoleLogsTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
         FluentUISetupHelpers.SetupFluentToolbar(this);
 
-        JSInterop.SetupVoid("initializeContinuousScroll");
-        JSInterop.SetupVoid("resetContinuousScrollPosition");
+        JSInterop.SetupVoid("initializeContinuousScroll").SetVoidResult();
+        JSInterop.SetupVoid("resetContinuousScrollPosition").SetVoidResult();
         JSInterop.SetupVoid("focusElement", _ => true);
 
         FluentUISetupHelpers.AddCommonDashboardServices(this, browserTimeProvider: timeProvider);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -844,6 +844,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
 
         JSInterop.SetupVoid("initializeContinuousScroll");
         JSInterop.SetupVoid("resetContinuousScrollPosition");
+        JSInterop.SetupVoid("focusElement", _ => true);
 
         FluentUISetupHelpers.AddCommonDashboardServices(this, browserTimeProvider: timeProvider);
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -208,6 +208,9 @@ public partial class ResourcesTests : DashboardTestContext
 
         // Assert
         Assert.Single(initializeGraphInvocationHandler.Invocations);
+        var focusInvocation = JSInterop.Invocations.Single(i => i.Identifier == "focusElement");
+        Assert.Equal("resourcesGraphContainer", focusInvocation.Arguments[0]);
+        Assert.Equal(true, focusInvocation.Arguments[1]);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -14,6 +14,7 @@ using ProtobufValue = Google.Protobuf.WellKnownTypes.Value;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
 
@@ -211,6 +212,34 @@ public partial class ResourcesTests : DashboardTestContext
         var focusInvocation = JSInterop.Invocations.Single(i => i.Identifier == "focusElement");
         Assert.Equal("resourcesGraphContainer", focusInvocation.Arguments[0]);
         Assert.Equal(true, focusInvocation.Arguments[1]);
+    }
+
+    [Fact]
+    public void TableView_FocusesAccessibleScrollContainerOnInitialRender()
+    {
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: [], resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>);
+        ResourceSetupHelpers.SetupResourcesPage(this, viewport, dashboardClient);
+
+        var cut = RenderComponent<Components.Pages.Resources>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+
+        var scrollContainer = cut.Find("#resourcesScrollContainer");
+        var loc = Services.GetRequiredService<IStringLocalizer<Dashboard.Resources.Resources>>();
+
+        Assert.Equal("0", scrollContainer.GetAttribute("tabindex"));
+        Assert.Equal("region", scrollContainer.GetAttribute("role"));
+        Assert.Equal(loc[nameof(Dashboard.Resources.Resources.ResourcesHeader)].Value, scrollContainer.GetAttribute("aria-label"));
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains(JSInterop.Invocations, invocation =>
+                invocation.Identifier == "focusElement" &&
+                invocation.Arguments.Count == 2 &&
+                string.Equals(invocation.Arguments[0]?.ToString(), "resourcesScrollContainer", StringComparison.Ordinal) &&
+                string.Equals(invocation.Arguments[1]?.ToString(), bool.TrueString, StringComparison.OrdinalIgnoreCase));
+        });
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -211,6 +211,7 @@ public partial class StructuredLogsTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
 
         JSInterop.SetupVoid("initializeContinuousScroll");
+        JSInterop.SetupVoid("focusElement", _ => true);
 
         FluentUISetupHelpers.AddCommonDashboardServices(this);
         Services.AddSingleton<ILogger<StructuredLogs>>(NullLogger<StructuredLogs>.Instance);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -14,6 +14,7 @@ using Bunit;
 using Google.Protobuf.Collections;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Proto.Logs.V1;
@@ -198,6 +199,37 @@ public partial class StructuredLogsTests : DashboardTestContext
             });
     }
 
+    [Fact]
+    public void Render_FocusesAccessibleScrollContainerOnInitialRender()
+    {
+        SetupStructureLogsServices();
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var cut = RenderComponent<StructuredLogs>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+
+        var scrollContainer = cut.Find("#structuredLogsScrollContainer");
+        var loc = Services.GetRequiredService<IStringLocalizer<Dashboard.Resources.StructuredLogs>>();
+
+        Assert.Equal("0", scrollContainer.GetAttribute("tabindex"));
+        Assert.Equal("region", scrollContainer.GetAttribute("role"));
+        Assert.Equal(loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsHeader)].Value, scrollContainer.GetAttribute("aria-label"));
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains(JSInterop.Invocations, invocation =>
+                invocation.Identifier == "focusElement" &&
+                invocation.Arguments.Count == 2 &&
+                string.Equals(invocation.Arguments[0]?.ToString(), "structuredLogsScrollContainer", StringComparison.Ordinal) &&
+                string.Equals(invocation.Arguments[1]?.ToString(), bool.TrueString, StringComparison.OrdinalIgnoreCase));
+        });
+    }
+
     private void SetupStructureLogsServices()
     {
         FluentUISetupHelpers.SetupFluentDivider(this);
@@ -210,7 +242,7 @@ public partial class StructuredLogsTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentToolbar(this);
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
 
-        JSInterop.SetupVoid("initializeContinuousScroll");
+        JSInterop.SetupVoid("initializeContinuousScroll").SetVoidResult();
         JSInterop.SetupVoid("focusElement", _ => true);
 
         FluentUISetupHelpers.AddCommonDashboardServices(this);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -12,6 +12,7 @@ using Bunit;
 using Google.Protobuf.Collections;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
@@ -83,6 +84,59 @@ public partial class TraceDetailsTests : DashboardTestContext
         DisposeComponents();
 
         Assert.Empty(telemetryRepository.TracesSubscriptions);
+    }
+
+    [Fact]
+    public void Render_FocusesAccessibleScrollContainerOnInitialRender()
+    {
+        SetupTraceDetailsServices();
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
+        telemetryRepository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10))
+                        }
+                    }
+                }
+            }
+        });
+
+        var traceId = Convert.ToHexString(Encoding.UTF8.GetBytes("1"));
+        var cut = RenderComponent<TraceDetail>(builder =>
+        {
+            builder.Add(p => p.TraceId, traceId);
+            builder.AddCascadingValue(viewport);
+        });
+
+        var scrollContainer = cut.Find("#traceDetailScrollContainer");
+        var loc = Services.GetRequiredService<IStringLocalizer<Dashboard.Resources.TraceDetail>>();
+
+        Assert.Equal("0", scrollContainer.GetAttribute("tabindex"));
+        Assert.Equal("region", scrollContainer.GetAttribute("role"));
+        Assert.Equal(loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)].Value, scrollContainer.GetAttribute("aria-label"));
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains(JSInterop.Invocations, invocation =>
+                invocation.Identifier == "focusElement" &&
+                invocation.Arguments.Count == 2 &&
+                string.Equals(invocation.Arguments[0]?.ToString(), "traceDetailScrollContainer", StringComparison.Ordinal) &&
+                string.Equals(invocation.Arguments[1]?.ToString(), bool.TrueString, StringComparison.OrdinalIgnoreCase));
+        });
     }
 
     [Fact]
@@ -845,7 +899,7 @@ public partial class TraceDetailsTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentToolbar(this);
         FluentUISetupHelpers.SetupFluentMenu(this);
 
-        JSInterop.SetupVoid("initializeContinuousScroll");
+        JSInterop.SetupVoid("initializeContinuousScroll").SetVoidResult();
         JSInterop.SetupVoid("focusElement", _ => true);
 
         loggerFactory ??= NullLoggerFactory.Instance;

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -846,6 +846,7 @@ public partial class TraceDetailsTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentMenu(this);
 
         JSInterop.SetupVoid("initializeContinuousScroll");
+        JSInterop.SetupVoid("focusElement", _ => true);
 
         loggerFactory ??= NullLoggerFactory.Instance;
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -129,6 +129,7 @@ public partial class TraceDetailsTests : DashboardTestContext
         Assert.Equal("0", scrollContainer.GetAttribute("tabindex"));
         Assert.Equal("region", scrollContainer.GetAttribute("role"));
         Assert.Equal(loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)].Value, scrollContainer.GetAttribute("aria-label"));
+        Assert.Equal("tracedetails-grid-container", scrollContainer.GetAttribute("class"));
         cut.WaitForAssertion(() =>
         {
             Assert.Contains(JSInterop.Invocations, invocation =>

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TracesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TracesTests.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Components.Pages;
+using Aspire.Dashboard.Components.Resize;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Model;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Pages;
+
+[UseCulture("en-US")]
+public class TracesTests : DashboardTestContext
+{
+    [Fact]
+    public void Render_FocusesAccessibleScrollContainerOnInitialRender()
+    {
+        SetupTracesServices();
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var cut = RenderComponent<Traces>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+
+        var scrollContainer = cut.Find("#tracesScrollContainer");
+        var loc = Services.GetRequiredService<IStringLocalizer<Dashboard.Resources.Traces>>();
+
+        Assert.Equal("0", scrollContainer.GetAttribute("tabindex"));
+        Assert.Equal("region", scrollContainer.GetAttribute("role"));
+        Assert.Equal(loc[nameof(Dashboard.Resources.Traces.TracesHeader)].Value, scrollContainer.GetAttribute("aria-label"));
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains(JSInterop.Invocations, invocation =>
+                invocation.Identifier == "focusElement" &&
+                invocation.Arguments.Count == 2 &&
+                string.Equals(invocation.Arguments[0]?.ToString(), "tracesScrollContainer", StringComparison.Ordinal) &&
+                string.Equals(invocation.Arguments[1]?.ToString(), bool.TrueString, StringComparison.OrdinalIgnoreCase));
+        });
+    }
+
+    private void SetupTracesServices()
+    {
+        FluentUISetupHelpers.SetupFluentOverflow(this);
+        FluentUISetupHelpers.SetupFluentDivider(this);
+        FluentUISetupHelpers.SetupFluentInputLabel(this);
+        FluentUISetupHelpers.SetupFluentDataGrid(this);
+        FluentUISetupHelpers.SetupFluentList(this);
+        FluentUISetupHelpers.SetupFluentSearch(this);
+        FluentUISetupHelpers.SetupFluentKeyCode(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+        FluentUISetupHelpers.SetupFluentToolbar(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+
+        JSInterop.SetupVoid("initializeContinuousScroll").SetVoidResult();
+        JSInterop.SetupVoid("resetContinuousScrollPosition").SetVoidResult();
+        JSInterop.SetupVoid("focusElement", _ => true);
+
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+        Services.AddSingleton<ILogger<Traces>>(NullLogger<Traces>.Instance);
+        Services.AddSingleton<TracesViewModel>();
+    }
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
@@ -39,6 +39,7 @@ internal static class ResourceSetupHelpers
         FluentUISetupHelpers.SetupFluentMenu(context);
 
         context.JSInterop.SetupVoid("scrollToTop", _ => true);
+        context.JSInterop.SetupVoid("focusElement", _ => true);
     }
 
     public static void SetupResourcesPage(TestContext context, ViewportInformation viewport, IDashboardClient? dashboardClient = null, ILocalStorage? localStorage = null)
@@ -56,6 +57,7 @@ internal static class ResourceSetupHelpers
         FluentUISetupHelpers.SetupFluentMenu(context);
 
         FluentUISetupHelpers.AddCommonDashboardServices(context, localStorage: localStorage);
+        context.JSInterop.SetupVoid("focusElement", _ => true);
         context.Services.AddSingleton<IconResolver>();
         context.Services.AddSingleton<ILogger<StructuredLogs>>(NullLogger<StructuredLogs>.Instance);
         context.Services.AddSingleton<StructuredLogsViewModel>();


### PR DESCRIPTION
## Description

Enable keyboard navigation (Home/End/PgUp/PgDown) on dashboard pages by making scroll containers focusable. Previously, users couldn't use keyboard shortcuts to scroll through resources, logs, traces, or console output without first clicking into the area.

Fixes #18156

### Changes

- Add `tabindex="0"` to scroll container divs on Resources, StructuredLogs, Traces, TraceDetail, and LogViewer pages
- Auto-focus the main scroll container on first render via `focusElement` JS interop
- Add `role="region"` and localized `aria-label` for screen reader accessibility
- Suppress default focus outline on scroll containers (the containers are large content areas where a focus ring would be visually noisy)
- Refactor: introduce `ScrollContainerId` const per page, rename `buttonId` parameter to `focusElementId`, pass scroll container ID in `OnRowClick` so focus returns to the grid area when the details panel closes
- Add overflow wrapper div to TraceDetail page for consistent scroll container pattern

### Screenshots / Recordings

https://github.com/user-attachments/assets/4a20caef-88f6-4ade-adce-762c8dbf4d40

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
