### PR TITLE
Fix doctor command text wrapping under emoji icons

### DIFF
--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -166,15 +166,13 @@ internal sealed class DoctorCommand : BaseCommand
     private void OutputCheckResult(EnvironmentCheckResult result)
     {
         var (icon, color) = GetStatusIconAndColor(result.Status);
-        var iconPrefix = ConsoleHelpers.FormatEmojiPrefix(icon, _ansiConsole, suppressColor: true);
 
-        // Primary grid: icon + message (wrapped lines stay aligned with message text)
-        var messageGrid = new Grid();
-        messageGrid.AddColumn();
-        messageGrid.AddRow(
-            new Markup($"[{color}]{iconPrefix}{result.Message.EscapeMarkup()}[/]"));
+        var messageMarkup = new Markup($"[{color}]{result.Message.EscapeMarkup()}[/]");
 
-        _ansiConsole.Write(new Padder(messageGrid, new Padding(2, 0)));
+        // Use a two-column grid so wrapped message text stays aligned past the icon.
+        var grid = ConsoleHelpers.CreateEmojiGrid(icon, _ansiConsole, messageMarkup);
+
+        _ansiConsole.Write(new Padder(grid, new Padding(2, 0)));
 
         // Secondary grid: details, fix suggestions, and links (indented further than message)
         var hasDetails = !string.IsNullOrEmpty(result.Details);

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -517,19 +517,7 @@ internal class ConsoleInteractionService : IInteractionService
 
         var displayMessage = allowMarkup ? message : message.EscapeMarkup();
 
-        // Use a grid to keep the icon in a fixed first column so long text wraps
-        // without pushing under the emoji prefix.
-        var grid = new Grid();
-        grid.AddColumn();
-        grid.AddColumn();
-        grid.Columns[0].NoWrap = true;
-        grid.Columns[0].Padding = new Padding(0);
-        grid.Columns[1].Padding = new Padding(0);
-
-        grid.AddRow(
-            new Markup(ConsoleHelpers.FormatEmojiPrefix(emoji, target)),
-            new Markup(displayMessage));
-
+        var grid = ConsoleHelpers.CreateEmojiGrid(emoji, target, new Markup(displayMessage));
         target.Write(grid);
     }
 

--- a/src/Aspire.Cli/Utils/ConsoleHelpers.cs
+++ b/src/Aspire.Cli/Utils/ConsoleHelpers.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Interaction;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Utils;
 
@@ -36,6 +37,27 @@ internal static class ConsoleHelpers
         }
 
         return spectreEmojiText + new string(' ', padding);
+    }
+
+    /// <summary>
+    /// Creates a two-column grid with an emoji icon in the first column and content in the second.
+    /// The first column is fixed-width so wrapped text in the second column stays aligned
+    /// without pushing under the icon.
+    /// </summary>
+    public static Grid CreateEmojiGrid(KnownEmoji emoji, IAnsiConsole console, IRenderable content)
+    {
+        var grid = new Grid();
+        grid.AddColumn();
+        grid.AddColumn();
+        grid.Columns[0].NoWrap = true;
+        grid.Columns[0].Padding = new Padding(0);
+        grid.Columns[1].Padding = new Padding(0);
+
+        grid.AddRow(
+            new Markup(FormatEmojiPrefix(emoji, console)),
+            content);
+
+        return grid;
     }
 }
 


### PR DESCRIPTION
## Description

The `aspire doctor` command output wraps long messages under the emoji icon, making them hard to read. For example:

```
  ⚠️ Aspire CLI version 13.5.0-dev (channel: local) is out of date. Latest version is 13.5.0-preview.1.26316.11
  (channel: prerelease)
```

The continuation line `(channel: prerelease)` wraps under the icon instead of aligning with the message text.

This PR extracts the two-column emoji grid layout already used by `ConsoleInteractionService.DisplayMessage` into a shared `ConsoleHelpers.CreateEmojiGrid` helper, then uses it in `DoctorCommand.OutputCheckResult` so wrapped text stays aligned past the icon:

```
  ⚠️ Aspire CLI version 13.5.0-dev (channel: local) is out of date. Latest version is 13.5.0-preview.1.26316.11
     (channel: prerelease)
```

### Screenshots / Recordings

<img width="1077" height="467" alt="image" src="https://github.com/user-attachments/assets/008fbae7-ff14-49f6-9127-fe44b6bea40f" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
