### PR TITLE
Fix flaky CLI test timeouts on loaded CI agents

### DIFF
--- a/tests/Aspire.Cli.Tests/DotNet/ProcessExecutionTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/ProcessExecutionTests.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.DotNet;
@@ -67,7 +68,7 @@ public sealed class ProcessExecutionTests(ITestOutputHelper outputHelper)
 
         Assert.True(execution.Start());
 
-        var exitCode = await execution.WaitForExitAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(30));
+        var exitCode = await execution.WaitForExitAsync(CancellationToken.None).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
         await releaseTask.WaitAsync(TimeSpan.FromSeconds(1));
 
         Assert.Equal(0, exitCode);
@@ -131,7 +132,7 @@ public sealed class ProcessExecutionTests(ITestOutputHelper outputHelper)
 
         Assert.True(execution.Start());
 
-        var exitCode = await execution.WaitForExitAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(30));
+        var exitCode = await execution.WaitForExitAsync(CancellationToken.None).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
         await releaseTask.WaitAsync(TimeSpan.FromSeconds(1));
 
         Assert.Equal(0, exitCode);
@@ -229,7 +230,9 @@ public sealed class ProcessExecutionTests(ITestOutputHelper outputHelper)
             var content =
                 "@echo off" + Environment.NewLine +
                 "echo ready" + Environment.NewLine +
-                "powershell -NoProfile -Command \"Start-Sleep -Seconds 6\"" + Environment.NewLine +
+                // Use ping instead of powershell to avoid variable PowerShell
+                // cold-start overhead on loaded CI agents (can add 10-20s).
+                "ping -n 7 127.0.0.1 > nul" + Environment.NewLine +
                 $"type \"{outputFile.FullName}\"" + Environment.NewLine;
             await File.WriteAllTextAsync(scriptFile.FullName, content);
             return scriptFile;

--- a/tests/Aspire.Cli.Tests/Npm/AspireJsLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Npm/AspireJsLauncherTests.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Aspire.TestUtilities;
+using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Cli.Tests.Npm;
 
@@ -377,7 +378,7 @@ public class AspireJsLauncherTests
         var stdoutTask = process.StandardOutput.ReadToEndAsync();
         var stderrTask = process.StandardError.ReadToEndAsync();
 
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var timeout = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
         try
         {
             process.WaitForExitAsync(timeout.Token).GetAwaiter().GetResult();
@@ -392,7 +393,7 @@ public class AspireJsLauncherTests
             {
             }
 
-            throw new TimeoutException($"Process '{psi.FileName}' did not exit within 30 seconds.");
+            throw new TimeoutException($"Process '{psi.FileName}' did not exit within the timeout.");
         }
 
         var stdout = stdoutTask.GetAwaiter().GetResult();


### PR DESCRIPTION
## Description

Two CLI tests fail intermittently on loaded Windows CI agents due to tight hardcoded timeouts:

- **`ProcessExecutionTests.WaitForExitAsync_AllowsBufferedTailOutputAfterLongIdlePeriod`** — The delayed-output script uses `powershell -NoProfile -Command "Start-Sleep -Seconds 6"` which has variable cold-start overhead (10-20s on loaded agents). Combined with the 30s `WaitAsync` timeout, this exceeds the limit.
- **`AspireJsLauncherTests.LauncherFailsWhenRidPackageVersionMismatchesPointerPackageVersion`** — A trivial Node.js script to detect the current RID exceeds the 30s `RunProcess` timeout under resource pressure.

Observed in: https://github.com/microsoft/aspire/actions/runs/27658757790

### Changes

- **ProcessExecutionTests**: Replace `powershell` sleep with `ping -n 7 127.0.0.1 > nul` (no startup overhead, same ~6s delay). Replace hardcoded `WaitAsync(30s)` / `WaitAsync(60s)` with `DefaultTimeout(LongTimeoutTimeSpan)` (60s local, 180s CI, disabled under debugger).
- **AspireJsLauncherTests**: Replace hardcoded 30s `CancellationTokenSource` in `RunProcess` with `CreateDefaultTimeoutTokenSource(LongTimeoutDuration)` for CI-aware timeout scaling.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No