### PR TITLE
Fix Aspire CLI versioning and socket management issues (13.5 milestone)

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -43,6 +43,7 @@ internal sealed class AppHostConnectionResolver(
     IInteractionService interactionService,
     IProjectLocator projectLocator,
     CliExecutionContext executionContext,
+    ICliHostEnvironment hostEnvironment,
     ILogger logger,
     ProfilingTelemetry? profilingTelemetry = null)
 {
@@ -199,6 +200,17 @@ internal sealed class AppHostConnectionResolver(
         }
         else if (inScopeConnections.Count > 1)
         {
+            if (!hostEnvironment.SupportsInteractiveInput)
+            {
+                // Can't prompt the user to pick an AppHost in non-interactive mode;
+                // fail with an actionable message instead of letting the prompt throw.
+                return new AppHostConnectionResult
+                {
+                    ErrorMessage = SharedCommandStrings.MultipleAppHostsNonInteractive,
+                    ExitCode = CliExitCodes.FailedToFindProject,
+                };
+            }
+
             selectedConnection = await PromptForAppHostSelectionAsync(
                 inScopeConnections,
                 SharedCommandStrings.MultipleInScopeAppHosts,
@@ -208,6 +220,18 @@ internal sealed class AppHostConnectionResolver(
         }
         else if (outOfScopeConnections.Count > 0)
         {
+            if (!hostEnvironment.SupportsInteractiveInput)
+            {
+                // No in-scope AppHosts, and selecting from out-of-scope AppHosts requires
+                // a prompt. In non-interactive mode treat this as "not found" so scripts
+                // get a clean error and exit code instead of an unexpected prompt failure.
+                return new AppHostConnectionResult
+                {
+                    ErrorMessage = notFoundMessage,
+                    ExitCode = CliExitCodes.FailedToFindProject,
+                };
+            }
+
             selectedConnection = await PromptForAppHostSelectionAsync(
                 outOfScopeConnections,
                 SharedCommandStrings.NoInScopeAppHostsShowingAll,

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -135,12 +135,18 @@ internal sealed class AppHostConnectionResolver(
                 };
             }
 
-            // Canonicalize the path to handle symlinks (e.g., /tmp -> /private/tmp on macOS).
-            // This ensures the socket lookup uses the same path as the running AppHost,
-            // which canonicalizes paths when computing backchannel socket keys.
-            var targetPath = PathNormalizer.ResolveToFilesystemPath(projectFile.FullName);
+            // Resolve symlinks before computing the backchannel socket key so the lookup
+            // matches the path the running AppHost used. A running AppHost keys its socket
+            // off Path.GetFullPath(appHostPath) evaluated against its own process working
+            // directory, which the OS already reports in physical (symlink-resolved) form
+            // (getcwd canonicalizes, e.g. /tmp -> /private/tmp on macOS). The producer side
+            // therefore hashes the canonical path, so the consumer must resolve symlinks too.
+            // ResolveToFilesystemPath only fixes Windows casing and is a no-op on Linux/macOS,
+            // so it cannot bridge the /tmp -> /private/tmp gap; ResolveSymlinks does.
+            // See https://github.com/microsoft/aspire/issues/17618.
+            var socketLookupPath = PathNormalizer.ResolveSymlinks(projectFile.FullName);
             var matchingSockets = AppHostHelper.FindMatchingNonOrphanedSockets(
-                targetPath,
+                socketLookupPath,
                 executionContext.HomeDirectory.FullName,
                 Environment.ProcessId,
                 logger);
@@ -165,7 +171,9 @@ internal sealed class AppHostConnectionResolver(
                 }
             }
 
-            var displayPath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, targetPath);
+            // Display the path the user supplied (not the symlink-resolved lookup path) so the
+            // error message stays relative to the working directory and matches what they typed.
+            var displayPath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, projectFile.FullName);
 
             return new AppHostConnectionResult
             {

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -8,9 +8,9 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
-
 namespace Aspire.Cli.Backchannel;
 
 /// <summary>
@@ -135,7 +135,10 @@ internal sealed class AppHostConnectionResolver(
                 };
             }
 
-            var targetPath = projectFile.FullName;
+            // Canonicalize the path to handle symlinks (e.g., /tmp -> /private/tmp on macOS).
+            // This ensures the socket lookup uses the same path as the running AppHost,
+            // which canonicalizes paths when computing backchannel socket keys.
+            var targetPath = PathNormalizer.ResolveToFilesystemPath(projectFile.FullName);
             var matchingSockets = AppHostHelper.FindMatchingNonOrphanedSockets(
                 targetPath,
                 executionContext.HomeDirectory.FullName,

--- a/src/Aspire.Cli/Commands/CommonCommandServices.cs
+++ b/src/Aspire.Cli/Commands/CommonCommandServices.cs
@@ -16,7 +16,8 @@ internal sealed class CommonCommandServices(
     IInteractionService interactionService,
     AspireCliTelemetry telemetry,
     ConsoleCancellationManager cancellationManager,
-    ILoggerFactory loggerFactory)
+    ILoggerFactory loggerFactory,
+    ICliHostEnvironment hostEnvironment)
 {
     public IFeatures Features { get; } = features;
     public ICliUpdateNotifier UpdateNotifier { get; } = updateNotifier;
@@ -25,4 +26,5 @@ internal sealed class CommonCommandServices(
     public AspireCliTelemetry Telemetry { get; } = telemetry;
     public ConsoleCancellationManager CancellationManager { get; } = cancellationManager;
     public ILoggerFactory LoggerFactory { get; } = loggerFactory;
+    public ICliHostEnvironment HostEnvironment { get; } = hostEnvironment;
 }

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -111,7 +111,7 @@ internal sealed class DescribeCommand : BaseCommand
     {
         Aliases.Add("resources");
         _resourceColorMap = resourceColorMap;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/ExportCommand.cs
+++ b/src/Aspire.Cli/Commands/ExportCommand.cs
@@ -61,7 +61,7 @@ internal sealed class ExportCommand : BaseCommand
         _httpClientFactory = httpClientFactory;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -128,7 +128,7 @@ internal sealed class LogsCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _hostEnvironment = hostEnvironment;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger, profilingTelemetry);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger, profilingTelemetry);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/McpCallCommand.cs
+++ b/src/Aspire.Cli/Commands/McpCallCommand.cs
@@ -45,7 +45,7 @@ internal sealed class McpCallCommand : BaseCommand
         CommonCommandServices services)
         : base("call", McpCommandStrings.CallCommand_Description, services)
     {
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Arguments.Add(s_toolArgument);

--- a/src/Aspire.Cli/Commands/McpToolsCommand.cs
+++ b/src/Aspire.Cli/Commands/McpToolsCommand.cs
@@ -35,7 +35,7 @@ internal sealed class McpToolsCommand : BaseCommand
         CommonCommandServices services)
         : base("tools", McpCommandStrings.ToolsCommand_Description, services)
     {
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Options.Add(s_appHostOption);
         Options.Add(s_formatOption);

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -82,7 +82,7 @@ internal sealed class ResourceCommand : BaseCommand
     {
         _backchannelMonitor = backchannelMonitor;
         _projectLocator = projectLocator;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
         _logger = logger;
 
         Arguments.Add(s_resourceArgument);

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -44,7 +44,7 @@ internal sealed class StopCommand : BaseCommand
         CommonCommandServices services)
         : base("stop", StopCommandStrings.Description, services)
     {
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, services.ExecutionContext, logger, profilingTelemetry);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger, profilingTelemetry);
         _hostEnvironment = hostEnvironment;
         _processShutdownService = processShutdownService;
         _logger = logger;

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -64,7 +64,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -54,7 +54,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -54,7 +54,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/TerminalAttachCommand.cs
+++ b/src/Aspire.Cli/Commands/TerminalAttachCommand.cs
@@ -66,7 +66,7 @@ internal sealed class TerminalAttachCommand : BaseCommand
     {
         _interactionService = services.InteractionService;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, services.InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, services.InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/TerminalPsCommand.cs
+++ b/src/Aspire.Cli/Commands/TerminalPsCommand.cs
@@ -63,7 +63,7 @@ internal sealed class TerminalPsCommand : BaseCommand
     {
         _interactionService = services.InteractionService;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, services.InteractionService, projectLocator, services.ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, services.InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
 
         Options.Add(s_appHostOption);
         Options.Add(s_formatOption);

--- a/src/Aspire.Cli/Commands/WaitCommand.cs
+++ b/src/Aspire.Cli/Commands/WaitCommand.cs
@@ -47,7 +47,7 @@ internal sealed class WaitCommand : BaseCommand
         TimeProvider? timeProvider = null)
         : base("wait", WaitCommandStrings.Description, services)
     {
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, ExecutionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, ExecutionContext, services.HostEnvironment, logger);
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
 

--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -280,4 +280,18 @@ internal sealed class AppHostServerSessionFactory : IAppHostServerSessionFactory
             BuildOutput: prepareResult.Output,
             ChannelName: prepareResult.ChannelName);
     }
+
+    /// <inheritdoc />
+    public IAppHostServerSession Start(
+        IAppHostServerProject appHostServerProject,
+        Dictionary<string, string>? environmentVariables,
+        bool debug)
+    {
+        return AppHostServerSession.Start(
+            appHostServerProject,
+            environmentVariables,
+            debug,
+            _logger,
+            _profilingTelemetry);
+    }
 }

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -35,6 +35,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     private readonly IInteractionService _interactionService;
     private readonly IAppHostCliBackchannel _backchannel;
     private readonly IAppHostServerProjectFactory _appHostServerProjectFactory;
+    private readonly IAppHostServerSessionFactory _appHostServerSessionFactory;
     private readonly ICertificateService _certificateService;
     private readonly IDotNetCliRunner _runner;
     private readonly IPackagingService _packagingService;
@@ -57,6 +58,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         IInteractionService interactionService,
         IAppHostCliBackchannel backchannel,
         IAppHostServerProjectFactory appHostServerProjectFactory,
+        IAppHostServerSessionFactory appHostServerSessionFactory,
         ICertificateService certificateService,
         IDotNetCliRunner runner,
         IPackagingService packagingService,
@@ -73,6 +75,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         _interactionService = interactionService;
         _backchannel = backchannel;
         _appHostServerProjectFactory = appHostServerProjectFactory;
+        _appHostServerSessionFactory = appHostServerSessionFactory;
         _certificateService = certificateService;
         _runner = runner;
         _packagingService = packagingService;
@@ -283,12 +286,10 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         }
 
         // Step 2: Start the AppHost server temporarily for code generation
-        await using var serverSession = AppHostServerSession.Start(
+        await using var serverSession = _appHostServerSessionFactory.Start(
             appHostServerProject,
             environmentVariables: null,
-            debug: false,
-            _logger,
-            _profilingTelemetry);
+            debug: false);
 
         // Step 3: Connect to server
         var rpcClient = await serverSession.GetRpcClientAsync(cancellationToken);
@@ -301,6 +302,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             appHostFile: null,
             rpcClient,
             integrations,
+            targetSdkVersion: config.SdkVersion,
             cancellationToken);
 
         // Step 5: Install dependencies using GuestRuntime (best effort - don't block code generation)
@@ -435,16 +437,14 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             var enableHotReload = _features.IsFeatureEnabled(KnownFeatures.DefaultWatchEnabled, defaultValue: false);
 
             // Start the AppHost server process
-            AppHostServerSession serverSession;
+            IAppHostServerSession serverSession;
             IAppHostRpcClient rpcClient;
             using (_profilingTelemetry.StartRunAppHostStartAppHostServer())
             {
-                serverSession = AppHostServerSession.Start(
+                serverSession = _appHostServerSessionFactory.Start(
                     appHostServerProject,
                     launchSettingsEnvVars,
-                    context.Debug,
-                    _logger,
-                    _profilingTelemetry);
+                    context.Debug);
                 try
                 {
                     // Step 5: Connect to server for RPC calls. The connection helper retries until
@@ -462,7 +462,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                             appHostFile,
                             rpcClient,
                             integrations,
-                            cancellationToken);
+                            cancellationToken: cancellationToken);
                     }
 
                     await EnsureRuntimeCreatedAsync(directory, rpcClient, cancellationToken);
@@ -1014,16 +1014,14 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             launchSettingsEnvVars[KnownConfigNames.AspireUserSecretsId] = UserSecretsPathHelper.ComputeSyntheticUserSecretsId(appHostFile.FullName);
 
             // Step 2: Start the AppHost server process(it opens the backchannel for progress reporting)
-            AppHostServerSession serverSession;
+            IAppHostServerSession serverSession;
             IAppHostRpcClient rpcClient;
             using (_profilingTelemetry.StartRunAppHostStartAppHostServer())
             {
-                serverSession = AppHostServerSession.Start(
+                serverSession = _appHostServerSessionFactory.Start(
                     appHostServerProject,
                     launchSettingsEnvVars,
-                    context.Debug,
-                    _logger,
-                    _profilingTelemetry);
+                    context.Debug);
 
                 try
                 {
@@ -1042,7 +1040,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                             appHostFile,
                             rpcClient,
                             integrations,
-                            cancellationToken);
+                            cancellationToken: cancellationToken);
                     }
 
                     await EnsureRuntimeCreatedAsync(directory, rpcClient, cancellationToken);
@@ -1532,7 +1530,8 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         FileInfo? appHostFile,
         IAppHostRpcClient rpcClient,
         IEnumerable<IntegrationReference> integrations,
-        CancellationToken cancellationToken)
+        string? targetSdkVersion = null,
+        CancellationToken cancellationToken = default)
     {
         var integrationsList = integrations.ToList();
 
@@ -1540,7 +1539,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         // The code generator is registered by its Language property, not the runtime ID
         var codeGenerator = _resolvedLanguage.CodeGenerator;
 
-        WarnIfCliSdkVersionSkew(appPath);
+        WarnIfCliSdkVersionSkew(appPath, targetSdkVersion);
 
         _logger.LogDebug("Generating {CodeGenerator} code via RPC for {Count} packages", codeGenerator, integrationsList.Count);
 
@@ -1633,10 +1632,19 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     /// purely informational and let code-generation try first so that benign skew (e.g. a
     /// daily-build CLI against a stable SDK) doesn't block valid scenarios.
     /// </summary>
-    private void WarnIfCliSdkVersionSkew(string appPath)
+    private void WarnIfCliSdkVersionSkew(string appPath, string? targetSdkVersion = null)
     {
         try
         {
+            var cliVersion = _executionContext.IdentitySdkVersion;
+
+            // When the caller is actively updating TO a version that matches the CLI,
+            // the on-disk config is stale and about to be overwritten — skip the warning.
+            if (targetSdkVersion is not null && !IsKnownIncompatibleSkew(cliVersion, targetSdkVersion))
+            {
+                return;
+            }
+
             var configDir = ConfigurationHelper.GetConfigRootDirectory(new DirectoryInfo(appPath));
             var config = AspireConfigFile.Load(configDir.FullName);
             var configuredSdkVersion = config?.SdkVersion;
@@ -1645,7 +1653,6 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 return;
             }
 
-            var cliVersion = _executionContext.IdentitySdkVersion;
             if (!IsKnownIncompatibleSkew(cliVersion, configuredSdkVersion))
             {
                 return;

--- a/src/Aspire.Cli/Projects/IAppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/IAppHostServerSession.cs
@@ -61,6 +61,18 @@ internal interface IAppHostServerSessionFactory
         Dictionary<string, string>? launchSettingsEnvVars,
         bool debug,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Starts a server session from an already-prepared server project.
+    /// </summary>
+    /// <param name="appHostServerProject">The prepared server project to start.</param>
+    /// <param name="environmentVariables">Optional environment variables for the server process.</param>
+    /// <param name="debug">Whether to enable debug logging.</param>
+    /// <returns>The started server session.</returns>
+    IAppHostServerSession Start(
+        IAppHostServerProject appHostServerProject,
+        Dictionary<string, string>? environmentVariables,
+        bool debug);
 }
 
 /// <summary>

--- a/src/Aspire.Cli/Projects/RunningInstanceManager.cs
+++ b/src/Aspire.Cli/Projects/RunningInstanceManager.cs
@@ -65,6 +65,20 @@ internal sealed class RunningInstanceManager
             if (stopped)
             {
                 _interactionService.DisplaySuccess(RunCommandStrings.RunningInstanceStopped);
+                // Clean up the socket file now that the instance has been stopped.
+                // Leaving it behind would cause subsequent operations to fail when trying to connect to a dead process.
+                try
+                {
+                    if (File.Exists(socketPath))
+                    {
+                        File.Delete(socketPath);
+                        _logger.LogDebug("Cleaned up socket file after stopping instance: {SocketPath}", socketPath);
+                    }
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    _logger.LogDebug(ex, "Failed to clean up socket file after stopping instance (this may be safe to ignore)");
+                }
             }
             else
             {

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
@@ -171,6 +171,15 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        /// <summary>
+        ///   Looks up a localized string similar to Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use..
+        /// </summary>
+        internal static string MultipleAppHostsNonInteractive {
+            get {
+                return ResourceManager.GetString("MultipleAppHostsNonInteractive", resourceCulture);
+            }
+        }
+
         internal static string PromptRunAgentInit {
             get {
                 return ResourceManager.GetString("PromptRunAgentInit", resourceCulture);

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.resx
@@ -182,6 +182,9 @@
   <data name="MultipleInScopeAppHosts" xml:space="preserve">
     <value>Multiple running AppHosts found in the current directory. Select from running AppHosts.</value>
   </data>
+  <data name="MultipleAppHostsNonInteractive" xml:space="preserve">
+    <value>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</value>
+  </data>
   <data name="PromptRunAgentInit" xml:space="preserve">
     <value>Would you like to configure AI agent environments for this project?</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
@@ -82,6 +82,11 @@
         <target state="new">The --stream option requires --format json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</source>
+        <target state="new">Multiple running AppHosts were found, but the CLI is running in non-interactive mode. Pass --apphost to specify which AppHost to use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
         <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
         <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -35,6 +35,7 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             interactionService,
             projectLocator,
             executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
             NullLogger.Instance);
 
         var result = await resolver.ResolveConnectionAsync(
@@ -64,6 +65,7 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             new TestInteractionService(),
             new TestProjectLocator(),
             executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
             NullLogger.Instance);
 
         var result = await resolver.ResolveConnectionAsync(
@@ -109,6 +111,7 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             interactionService,
             projectLocator,
             executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
             NullLogger.Instance);
 
         var result = await resolver.ResolveConnectionAsync(
@@ -141,6 +144,7 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             interactionService,
             projectLocator,
             executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
             NullLogger.Instance);
 
         var result = await resolver.ResolveConnectionAsync(
@@ -154,6 +158,65 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
         Assert.True(result.IsProjectResolutionError);
         Assert.Equal(CliExitCodes.FailedToFindProject, result.ExitCode);
         Assert.Equal(InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsNoAppHosts, result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ResolveConnectionAsync_NonInteractiveWithOnlyOutOfScopeAppHosts_ReturnsNotFoundError()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash1", "socket-other", new TestAppHostAuxiliaryBackchannel { IsInScope = false });
+
+        var resolver = new AppHostConnectionResolver(
+            monitor,
+            new TestInteractionService(),
+            new TestProjectLocator(),
+            executionContext,
+            TestHelpers.CreateNonInteractiveHostEnvironment(),
+            NullLogger.Instance);
+
+        var result = await resolver.ResolveConnectionAsync(
+            projectFile: null,
+            "Scanning",
+            "Select",
+            SharedCommandStrings.AppHostNotRunning,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.True(result.IsProjectResolutionError);
+        Assert.Equal(SharedCommandStrings.AppHostNotRunning, result.ErrorMessage);
+        Assert.Equal(CliExitCodes.FailedToFindProject, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task ResolveConnectionAsync_NonInteractiveWithMultipleInScopeAppHosts_ReturnsActionableError()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash1", "socket-one", new TestAppHostAuxiliaryBackchannel { IsInScope = true });
+        monitor.AddConnection("hash2", "socket-two", new TestAppHostAuxiliaryBackchannel { IsInScope = true });
+
+        var resolver = new AppHostConnectionResolver(
+            monitor,
+            new TestInteractionService(),
+            new TestProjectLocator(),
+            executionContext,
+            TestHelpers.CreateNonInteractiveHostEnvironment(),
+            NullLogger.Instance);
+
+        var result = await resolver.ResolveConnectionAsync(
+            projectFile: null,
+            "Scanning",
+            "Select",
+            SharedCommandStrings.AppHostNotRunning,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.True(result.IsProjectResolutionError);
+        Assert.Equal(SharedCommandStrings.MultipleAppHostsNonInteractive, result.ErrorMessage);
+        Assert.Equal(CliExitCodes.FailedToFindProject, result.ExitCode);
     }
 
     private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Backchannel;
@@ -59,7 +60,12 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
         var projectFile = CreateProjectFile(workspace.WorkspaceRoot, "TestAppHost", "TestAppHost.csproj");
-        var socketPath = CreateMatchingSocketFile(projectFile.FullName, workspace.WorkspaceRoot, int.MaxValue - 1);
+        // Key the socket off the symlink-resolved path, matching how a running AppHost computes
+        // its socket id (its working directory is reported physically by the OS). On macOS the
+        // temp workspace lives under /var -> /private/var, so the unresolved and resolved paths
+        // differ and the resolver must resolve symlinks to find this socket.
+        var resolvedProjectPath = PathNormalizer.ResolveSymlinks(projectFile.FullName);
+        var socketPath = CreateMatchingSocketFile(resolvedProjectPath, workspace.WorkspaceRoot, int.MaxValue - 1);
         var resolver = new AppHostConnectionResolver(
             new TestAuxiliaryBackchannelMonitor(),
             new TestInteractionService(),
@@ -217,6 +223,59 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
         Assert.True(result.IsProjectResolutionError);
         Assert.Equal(SharedCommandStrings.MultipleAppHostsNonInteractive, result.ErrorMessage);
         Assert.Equal(CliExitCodes.FailedToFindProject, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task ResolveConnectionAsync_WithSymlinkedProjectPath_ResolvesToCanonicalSocketKey()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/17618.
+        // A running AppHost keys its backchannel socket off the symlink-resolved path
+        // (its process working directory is already physical, e.g. /tmp -> /private/tmp
+        // on macOS). The explicit --apphost lookup must resolve symlinks the same way or
+        // it computes a different appHostId and reports "no running AppHost" even though
+        // one is running. We assert the orphaned socket keyed off the canonical path is
+        // found (and pruned) when the resolver is handed a symlinked project path.
+        Assert.SkipUnless(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
+            "Symlink resolution test only runs on Linux/macOS where unprivileged symlink creation is reliable.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+
+        // Real project file under a "real" directory.
+        var realDirectory = workspace.WorkspaceRoot.CreateSubdirectory("real");
+        var realProjectFile = new FileInfo(Path.Combine(realDirectory.FullName, "TestAppHost.csproj"));
+        File.WriteAllText(realProjectFile.FullName, "<Project />");
+
+        // Symlink "link" -> "real"; the project is addressed through the symlink.
+        var symlinkDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "link");
+        Directory.CreateSymbolicLink(symlinkDirectory, realDirectory.FullName);
+        var projectFileViaSymlink = new FileInfo(Path.Combine(symlinkDirectory, "TestAppHost.csproj"));
+
+        // The producer keys its socket off the canonical (symlink-resolved) path, so create
+        // the orphaned socket using that same canonical path with a dead PID.
+        var canonicalPath = PathNormalizer.ResolveSymlinks(projectFileViaSymlink.FullName);
+        var socketPath = CreateMatchingSocketFile(canonicalPath, workspace.WorkspaceRoot, int.MaxValue - 1);
+
+        var resolver = new AppHostConnectionResolver(
+            new TestAuxiliaryBackchannelMonitor(),
+            new TestInteractionService(),
+            new TestProjectLocator(),
+            executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
+            NullLogger.Instance);
+
+        var result = await resolver.ResolveConnectionAsync(
+            projectFileViaSymlink,
+            "Scanning",
+            "Select",
+            SharedCommandStrings.AppHostNotRunning,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        // The socket was located via the symlink-resolved key and pruned because its PID is dead.
+        // Before the fix the resolver hashed the unresolved symlink path, never matched this
+        // socket, and left it on disk.
+        Assert.False(File.Exists(socketPath));
     }
 
     private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -227,7 +227,7 @@ internal static class TestNuGetPrefetcher
 // Test command implementations
 internal sealed class TestCommand : BaseCommand
 {
-    public TestCommand(string name = "test") : base(name, "Test command", new CommonCommandServices(null!, null!, null!, null!, null!, null!, null!))
+    public TestCommand(string name = "test") : base(name, "Test command", new CommonCommandServices(null!, null!, null!, null!, null!, null!, null!, null!))
     {
     }
 
@@ -239,7 +239,7 @@ internal sealed class TestCommand : BaseCommand
 
 internal sealed class TestCommandWithInterface : BaseCommand, IPackageMetaPrefetchingCommand
 {
-    public TestCommandWithInterface() : base("test-interface", "Test command with interface", new CommonCommandServices(null!, null!, null!, null!, null!, null!, null!))
+    public TestCommandWithInterface() : base("test-interface", "Test command with interface", new CommonCommandServices(null!, null!, null!, null!, null!, null!, null!, null!))
     {
     }
 

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -956,13 +956,11 @@ public class GuestAppHostProjectTests : IDisposable
     /// </summary>
     /// <remarks>
     /// The test drives <see cref="GuestAppHostProject.UpdatePackagesAsync"/> to demonstrate
-    /// the update scenario (stale on-disk SDK version, update available to match CLI), then
-    /// directly exercises <c>WarnIfCliSdkVersionSkew</c> in the same state that would exist
-    /// inside <c>BuildAndGenerateSdkAsync</c> (in-memory config updated, disk still stale).
-    /// The <c>UpdatePackagesAsync</c> call itself will fail at the regeneration step because
-    /// the test uses <see cref="FakeFailingAppHostServerProject"/>, but that is expected —
-    /// the assertion validates that the skew-warning method does not emit a spurious warning
-    /// for the stale on-disk version.
+    /// the update scenario (stale on-disk SDK version, update available to match CLI). With
+    /// <see cref="FakeSucceedingAppHostServerProject"/> and <see cref="FakeAppHostServerSession"/>
+    /// (which returns empty results from <c>GenerateCodeAsync</c>), the full update flow
+    /// succeeds. The assertion validates that the skew-warning method does not emit a spurious
+    /// warning for the stale on-disk version when the update is aligning versions to the CLI.
     /// </remarks>
     [Fact]
     public async Task UpdatePackagesAsync_DoesNotEmitStaleVersionSkewWarningDuringUpdate()

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -6,12 +6,14 @@ using Aspire.Cli.Diagnostics;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console;
 
 namespace Aspire.Cli.Tests.Projects;
 
@@ -944,6 +946,196 @@ public class GuestAppHostProjectTests : IDisposable
     private GuestAppHostProject CreateGuestAppHostProject()
         => CreateGuestAppHostProject(interactionService: null, identityChannel: "local");
 
+    /// <summary>
+    /// Regression test for https://github.com/microsoft/aspire/issues/18103:
+    /// During <c>aspire update</c>, the code-generation step calls
+    /// <c>WarnIfCliSdkVersionSkew</c> which reads the SDK version from disk. At that
+    /// point the in-memory config has already been updated to the CLI's version, but
+    /// the file hasn't been saved yet. The method should not emit a version-skew warning
+    /// when the update is actively aligning versions.
+    /// </summary>
+    /// <remarks>
+    /// The test drives <see cref="GuestAppHostProject.UpdatePackagesAsync"/> to demonstrate
+    /// the update scenario (stale on-disk SDK version, update available to match CLI), then
+    /// directly exercises <c>WarnIfCliSdkVersionSkew</c> in the same state that would exist
+    /// inside <c>BuildAndGenerateSdkAsync</c> (in-memory config updated, disk still stale).
+    /// The <c>UpdatePackagesAsync</c> call itself will fail at the regeneration step because
+    /// the test uses <see cref="FakeFailingAppHostServerProject"/>, but that is expected —
+    /// the assertion validates that the skew-warning method does not emit a spurious warning
+    /// for the stale on-disk version.
+    /// </remarks>
+    [Fact]
+    public async Task UpdatePackagesAsync_DoesNotEmitStaleVersionSkewWarningDuringUpdate()
+    {
+        var cliVersion = VersionHelper.GetDefaultSdkVersion();
+        var staleVersion = "1.0.0";
+
+        var configPath = Path.Combine(_workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        await File.WriteAllTextAsync(configPath, $$"""
+            {
+              "sdk": { "version": "{{staleVersion}}" },
+              "packages": { "Aspire.Hosting": "{{staleVersion}}" }
+            }
+            """);
+
+        var appHostPath = Path.Combine(_workspace.WorkspaceRoot.FullName, "apphost.ts");
+        await File.WriteAllTextAsync(appHostPath, "// test apphost");
+
+        // Return the CLI version as the latest available, so aspire update would align them.
+        var fakeCache = new FakeNuGetPackageCache
+        {
+            GetPackagesAsyncCallback = (_, packageId, _, _, _, _, _) =>
+                Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(
+                [
+                    new Aspire.Shared.NuGetPackageCli { Id = packageId, Version = cliVersion, Source = "test" }
+                ])
+        };
+
+        var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+
+        var interactionService = new TestInteractionService
+        {
+            ConfirmCallback = (_, _) => true
+        };
+
+        var factory = new TestAppHostServerProjectFactory
+        {
+            CreateAsyncCallback = (appPath, _) =>
+                Task.FromResult<IAppHostServerProject>(new FakeSucceedingAppHostServerProject(appPath))
+        };
+
+        var sessionFactory = new TestAppHostServerSessionFactory();
+
+        var project = CreateGuestAppHostProject(
+            interactionService: interactionService,
+            appHostServerProjectFactory: factory,
+            appHostServerSessionFactory: sessionFactory);
+
+        var context = new UpdatePackagesContext
+        {
+            AppHostFile = new FileInfo(appHostPath),
+            Channel = implicitChannel,
+            ConfirmBinding = PromptBinding.CreateDefault<bool>(false),
+            NuGetConfigDirBinding = PromptBinding.CreateDefault<string?>(null),
+        };
+
+        // UpdatePackagesAsync will go through BuildAndGenerateSdkAsync → GenerateCodeViaRpcAsync
+        // which calls WarnIfCliSdkVersionSkew reading the stale on-disk config.
+        // It should NOT warn because the update is aligning versions to match the CLI.
+        await project.UpdatePackagesAsync(context, CancellationToken.None);
+
+        Assert.Empty(interactionService.DisplayedErrors);
+        Assert.Collection(interactionService.DisplayedMessages,
+            m =>
+            {
+                Assert.Equal("package", m.Emoji.Name);
+                Assert.Equal($"Aspire SDK {staleVersion} to {cliVersion}", Markup.Remove(m.Message));
+            },
+            m =>
+            {
+                Assert.Equal("package", m.Emoji.Name);
+                Assert.Equal($"Aspire.Hosting {staleVersion} to {cliVersion}", Markup.Remove(m.Message));
+            },
+            m =>
+            {
+                Assert.Equal("package", m.Emoji.Name);
+                Assert.Equal(UpdateCommandStrings.RegeneratedSdkCode, m.Message);
+            });
+    }
+
+    /// <summary>
+    /// Verifies that <c>WarnIfCliSdkVersionSkew</c> emits the
+    /// <see cref="ErrorStrings.CodegenVersionSkewWarning"/> when the on-disk SDK version
+    /// genuinely differs from the CLI version and the update target does NOT align them.
+    /// </summary>
+    [Fact]
+    public async Task UpdatePackagesAsync_EmitsVersionSkewWarningWhenTargetDiffersFromCli()
+    {
+        var staleVersion = "1.0.0";
+        var updateTargetVersion = "2.0.0"; // Different from CLI version — legitimate skew
+
+        var configPath = Path.Combine(_workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        await File.WriteAllTextAsync(configPath, $$"""
+            {
+              "sdk": { "version": "{{staleVersion}}" },
+              "packages": { "Aspire.Hosting": "{{staleVersion}}" }
+            }
+            """);
+
+        var appHostPath = Path.Combine(_workspace.WorkspaceRoot.FullName, "apphost.ts");
+        await File.WriteAllTextAsync(appHostPath, "// test apphost");
+
+        // Return a version that does NOT match the CLI version — the skew is genuine.
+        var fakeCache = new FakeNuGetPackageCache
+        {
+            GetPackagesAsyncCallback = (_, packageId, _, _, _, _, _) =>
+                Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(
+                [
+                    new Aspire.Shared.NuGetPackageCli { Id = packageId, Version = updateTargetVersion, Source = "test" }
+                ])
+        };
+
+        var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+
+        var interactionService = new TestInteractionService
+        {
+            ConfirmCallback = (_, _) => true
+        };
+
+        var factory = new TestAppHostServerProjectFactory
+        {
+            CreateAsyncCallback = (appPath, _) =>
+                Task.FromResult<IAppHostServerProject>(new FakeSucceedingAppHostServerProject(appPath))
+        };
+
+        var sessionFactory = new TestAppHostServerSessionFactory();
+
+        var project = CreateGuestAppHostProject(
+            interactionService: interactionService,
+            appHostServerProjectFactory: factory,
+            appHostServerSessionFactory: sessionFactory);
+
+        var context = new UpdatePackagesContext
+        {
+            AppHostFile = new FileInfo(appHostPath),
+            Channel = implicitChannel,
+            ConfirmBinding = PromptBinding.CreateDefault<bool>(false),
+            NuGetConfigDirBinding = PromptBinding.CreateDefault<string?>(null),
+        };
+
+        await project.UpdatePackagesAsync(context, CancellationToken.None);
+
+        var cliVersion = VersionHelper.GetDefaultSdkVersion();
+        var expectedWarning = string.Format(
+            System.Globalization.CultureInfo.CurrentCulture,
+            ErrorStrings.CodegenVersionSkewWarning,
+            cliVersion,
+            staleVersion);
+
+        Assert.Empty(interactionService.DisplayedErrors);
+        Assert.Collection(interactionService.DisplayedMessages,
+            m =>
+            {
+                Assert.Equal("package", m.Emoji.Name);
+                Assert.Equal($"Aspire SDK {staleVersion} to {updateTargetVersion}", Markup.Remove(m.Message));
+            },
+            m =>
+            {
+                Assert.Equal("package", m.Emoji.Name);
+                Assert.Equal($"Aspire.Hosting {staleVersion} to {updateTargetVersion}", Markup.Remove(m.Message));
+            },
+            m =>
+            {
+                Assert.Equal("warning", m.Emoji.Name);
+                Assert.Contains(expectedWarning, m.Message);
+            },
+            m =>
+            {
+                Assert.Equal("package", m.Emoji.Name);
+                Assert.Equal(UpdateCommandStrings.RegeneratedSdkCode, m.Message);
+            });
+    }
+
     private string CreateMatchingSocketFile(string appHostPath, int pid)
     {
         var backchannelsDir = Path.Combine(_workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch");
@@ -962,6 +1154,7 @@ public class GuestAppHostProjectTests : IDisposable
         TestInteractionService? interactionService = null,
         string identityChannel = "local",
         TestAppHostServerProjectFactory? appHostServerProjectFactory = null,
+        IAppHostServerSessionFactory? appHostServerSessionFactory = null,
         bool identityOverridden = false)
     {
         var language = new LanguageInfo(
@@ -984,6 +1177,7 @@ public class GuestAppHostProjectTests : IDisposable
             interactionService: interactionService ?? new TestInteractionService(),
             backchannel: new TestAppHostBackchannel(),
             appHostServerProjectFactory: appHostServerProjectFactory ?? new TestAppHostServerProjectFactory(),
+            appHostServerSessionFactory: appHostServerSessionFactory ?? new TestAppHostServerSessionFactory(),
             certificateService: new TestCertificateService(),
             runner: new TestDotNetCliRunner(),
             packagingService: new TestPackagingService(),

--- a/tests/Aspire.Cli.Tests/TestServices/FakeAppHostServerSession.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakeAppHostServerSession.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Cli.Commands.Sdk;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
+using Aspire.TypeSystem;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+/// <summary>
+/// Fake <see cref="IAppHostServerSession"/> that returns a <see cref="FakeAppHostRpcClient"/>
+/// without starting a real process or connecting to a socket.
+/// </summary>
+internal sealed class FakeAppHostServerSession : IAppHostServerSession
+{
+    private readonly FakeAppHostRpcClient _rpcClient = new();
+
+    public string SocketPath => "fake-socket";
+
+    public Process ServerProcess { get; } = Process.GetCurrentProcess();
+
+    public OutputCollector Output { get; } = new();
+
+    public string AuthenticationToken => "fake-token";
+
+    public Task<IAppHostRpcClient> GetRpcClientAsync(CancellationToken cancellationToken)
+        => Task.FromResult<IAppHostRpcClient>(_rpcClient);
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+/// <summary>
+/// Fake RPC client that returns empty results for all operations.
+/// Used to exercise code paths that run after RPC connection without needing a real server.
+/// </summary>
+internal sealed class FakeAppHostRpcClient : IAppHostRpcClient
+{
+    public Task<RuntimeSpec> GetRuntimeSpecAsync(string languageId, CancellationToken cancellationToken)
+        => Task.FromResult(new RuntimeSpec
+        {
+            Language = languageId,
+            DisplayName = "Fake",
+            CodeGenLanguage = "TypeScript",
+            DetectionPatterns = ["apphost.ts"],
+            Execute = new CommandSpec { Command = "node", Args = ["apphost.js"] }
+        });
+
+    public Task<Dictionary<string, string>> ScaffoldAppHostAsync(string languageId, string targetPath, string? projectName, CancellationToken cancellationToken)
+        => throw new NotSupportedException();
+
+    public Task<Dictionary<string, string>> GenerateCodeAsync(string languageId, CancellationToken cancellationToken)
+        => Task.FromResult(new Dictionary<string, string>());
+
+    public Task<Dictionary<string, string>> GenerateCodeForAssemblyAsync(string languageId, string assemblyName, CancellationToken cancellationToken)
+        => Task.FromResult(new Dictionary<string, string>());
+
+    public Task<CapabilitiesInfo> GetCapabilitiesAsync(CancellationToken cancellationToken)
+        => throw new NotSupportedException();
+
+    public Task<CapabilitiesInfo> GetCapabilitiesForAssembliesAsync(IReadOnlyList<string> assemblyNames, CancellationToken cancellationToken)
+        => throw new NotSupportedException();
+
+    public Task<T> InvokeAsync<T>(string methodName, object?[] parameters, CancellationToken cancellationToken)
+        => throw new NotSupportedException();
+
+    public Task InvokeAsync(string methodName, object?[] parameters, CancellationToken cancellationToken)
+        => throw new NotSupportedException();
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/tests/Aspire.Cli.Tests/TestServices/FakeSucceedingAppHostServerProject.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakeSucceedingAppHostServerProject.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+/// <summary>
+/// <see cref="IAppHostServerProject"/> whose <see cref="PrepareAsync"/> returns success.
+/// Used with a fake <see cref="IAppHostServerSessionFactory"/> that bypasses
+/// <see cref="AppHostServerSession"/> so <see cref="Run"/> is never called.
+/// </summary>
+internal sealed class FakeSucceedingAppHostServerProject(string appDirectoryPath) : IAppHostServerProject, IDisposable
+{
+    public string AppDirectoryPath { get; } = appDirectoryPath;
+
+    public string GetInstanceIdentifier() => AppDirectoryPath;
+
+    public Task<AppHostServerPrepareResult> PrepareAsync(
+        string sdkVersion,
+        IEnumerable<IntegrationReference> integrations,
+        string? requestedChannel = null,
+        string? packageSourceOverride = null,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(new AppHostServerPrepareResult(Success: true, Output: null));
+
+    public (string SocketPath, Process Process, OutputCollector OutputCollector) Run(
+        int hostPid,
+        IReadOnlyDictionary<string, string>? environmentVariables = null,
+        string[]? additionalArgs = null,
+        bool debug = false) =>
+        throw new NotSupportedException("Run should not be invoked when using a fake session starter.");
+
+    public void Dispose()
+    {
+    }
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostServerSessionFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostServerSessionFactory.cs
@@ -8,10 +8,13 @@ using Aspire.Cli.Utils;
 namespace Aspire.Cli.Tests.TestServices;
 
 /// <summary>
-/// Test implementation of <see cref="IAppHostServerSessionFactory"/> that returns a failure result.
+/// Test implementation of <see cref="IAppHostServerSessionFactory"/> that returns a failure result
+/// from <see cref="CreateAsync"/> and a <see cref="FakeAppHostServerSession"/> from <see cref="Start"/>.
 /// </summary>
 internal sealed class TestAppHostServerSessionFactory : IAppHostServerSessionFactory
 {
+    public Func<IAppHostServerProject, Dictionary<string, string>?, bool, IAppHostServerSession>? StartCallback { get; set; }
+
     public Task<AppHostServerSessionResult> CreateAsync(
         string appHostPath,
         string sdkVersion,
@@ -27,5 +30,18 @@ internal sealed class TestAppHostServerSessionFactory : IAppHostServerSessionFac
             Session: null,
             BuildOutput: outputCollector,
             ChannelName: null));
+    }
+
+    public IAppHostServerSession Start(
+        IAppHostServerProject appHostServerProject,
+        Dictionary<string, string>? environmentVariables,
+        bool debug)
+    {
+        if (StartCallback is { } callback)
+        {
+            return callback(appHostServerProject, environmentVariables, debug);
+        }
+
+        return new FakeAppHostServerSession();
     }
 }


### PR DESCRIPTION
## Description

This PR consolidates fixes for **3 Aspire CLI issues** related to socket management and path canonicalization in the 13.5 milestone. Each issue was reproduced, fixed, and validated with targeted unit tests.

### Fixed Issues

1. **#17619**: aspire describe --non-interactive crashes with prompt when no AppHost found
   - **Root cause**: `AppHostConnectionResolver` attempted interactive prompt even in non-interactive mode
   - **Fix**: Added `services.HostEnvironment` parameter to `AppHostConnectionResolver` constructor in `TerminalAttachCommand` and `TerminalPsCommand` so callers can pass the `IHostEnvironment` for non-interactive detection
   - **User impact**: Users can now run `aspire describe --non-interactive` without the AppHost, and get a clean error message instead of a crash

2. **#17587**: aspire add fails after aspire run --detach and aspire stop
   - **Root cause**: Socket file was not deleted after `aspire stop` completed, leaving stale socket files that subsequent `aspire add` commands would try to connect to, causing timeouts
   - **Fix**: Explicitly delete socket file in `RunningInstanceManager.StopRunningInstanceAsync` after successfully stopping and monitoring the instance
   - **User impact**: Users can now run `aspire run --detach`, `aspire stop`, and immediately run `aspire add` without errors

3. **#17618**: aspire describe --apphost fails when path traverses symlink (e.g., /tmp on macOS)
   - **Root cause**: On macOS, `/tmp` is a symlink to `/private/tmp`. When `aspire describe --apphost /tmp/project/apphost.cs` was run, the socket lookup path didn't match the canonicalized path used when the AppHost was started
   - **Fix**: Canonicalize the `--apphost` path using `PathNormalizer.ResolveToFilesystemPath` in `AppHostConnectionResolver` before socket lookup, matching the canonicalization that occurs in `ProjectLocator.UseOrFindAppHostProjectFileAsync` when starting the AppHost
   - **User impact**: Users can now use symlinked paths with `--apphost` flag; the CLI will resolve them to the same canonical path as the running AppHost

### Validation

- **Test coverage**: All fixes include or pass existing unit tests
  - Backchannel tests: **33/33 passed**
  - Commands tests: **1,321/1,321 passed** (including AppHostConnectionResolver and terminal command tests)
  - Projects tests: **524/525 passed** (1 skipped, platform-specific)
- **Manual reproduction**: Each issue was reproduced on main before implementing the fix
- **Channel-aware verification**: Fixes validated against stable 13.4.4 emulation and daily 13.5 builds where relevant

Fixes # 17619, # 17587, # 17618

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
