### PR TITLE
Add agent instructions for optional parameters and test assertions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Instructions for GitHub Copilot and other AI coding agents working with the Aspi
 * Do not use cryptographic hashes such as SHA-256 when the hash is not security-related. Prefer `System.IO.Hashing.XxHash3` when you need a stable non-cryptographic hash.
 * When code needs a temporary directory, prefer the repository temp directory abstractions first (for example `IFileSystemService.TempDirectory` / `ITempFileSystemService`) and otherwise use `Directory.CreateTempSubdirectory()` instead of `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())`; if you need a temporary file path, place it under a securely created temp directory.
 * Don't update files under `*/api/*.cs` (e.g. src/Aspire.Hosting/api/Aspire.Hosting.cs) as they are generated.
+* When adding new parameters to methods, do not make them optional just to avoid updating existing call sites. A parameter should only be optional if it has a sensible default value that makes semantic sense for the API. If a new parameter is logically required for the operation, make it required and update all call sites accordingly.
 
 ## Code Review Instructions
 
@@ -264,6 +265,7 @@ kill <pid>
 * Prefer using shared test service implementations (e.g., project-level `TestServices/` or `Helpers/` directories, or the cross-project `tests/Shared/` folder) rather than creating private implementation classes within individual test files. Reusing existing test fakes and helpers keeps tests consistent, reduces duplication, and makes maintenance easier. Do not create private test classes when a shared one already exists or can be extended.
 * MTP diagnostic args (hang dump, crash dump, exit code handling) are defined in `eng/Testing.props` via `MtpBaseArgs`. Do not hardcode these args in workflow YAML. See [docs/ci/mtp-args-pipeline.md](docs/ci/mtp-args-pipeline.md) for details.
 * Use `Verify` (snapshot testing) for generated artifacts (files, serialized output, structured text). Prefer `await Verify(value, "ext")` over `Assert.Contains` / `Assert.DoesNotContain` / `Assert.Equal` on the same value. Run the test once to generate the `.received.` file, review it, then rename it to `.verified.` to accept it.
+* Avoid `Assert.DoesNotContain` as it is a weak assertion that easily goes out of date — it only proves something is absent without verifying what *is* present. Prefer `Assert.Equal` to check the entire string value, or `Assert.Collection` to verify the complete contents of a collection.
 
 ## Running tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Instructions for GitHub Copilot and other AI coding agents working with the Aspi
 * Do not use cryptographic hashes such as SHA-256 when the hash is not security-related. Prefer `System.IO.Hashing.XxHash3` when you need a stable non-cryptographic hash.
 * When code needs a temporary directory, prefer the repository temp directory abstractions first (for example `IFileSystemService.TempDirectory` / `ITempFileSystemService`) and otherwise use `Directory.CreateTempSubdirectory()` instead of `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())`; if you need a temporary file path, place it under a securely created temp directory.
 * Don't update files under `*/api/*.cs` (e.g. src/Aspire.Hosting/api/Aspire.Hosting.cs) as they are generated.
-* When adding new parameters to methods, do not make them optional just to avoid updating existing call sites. A parameter should only be optional if it has a sensible default value that makes semantic sense for the API. If a new parameter is logically required for the operation, make it required and update all call sites accordingly.
+* Do not make new parameters optional just to avoid updating call sites. A parameter should only be optional when it has a sensible semantic default and the API is frequently used (where call-site brevity outweighs explicitness). If a parameter is logically required, make it required and update all call sites.
 
 ## Code Review Instructions
 


### PR DESCRIPTION
## Description

Adds two new agent instructions to AGENTS.md:

1. **Optional parameters** — Do not make new parameters optional just to avoid updating existing call sites. A parameter should only be optional if it has a sensible default value that makes semantic sense for the API. If a new parameter is logically required, make it required and update all call sites.

2. **Avoid `Assert.DoesNotContain`** — It is a weak assertion that easily goes out of date since it only proves something is absent without verifying what *is* present. Prefer `Assert.Equal` to check the entire string value, or `Assert.Collection` to verify the complete contents of a collection.