### PR TITLE
Re-enable OneLocBuild

### DIFF
--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -73,7 +73,7 @@ jobs:
         displayName: Generate LocProject.json
         condition: ${{ parameters.condition }}
 
-    - task: OneLocBuild@3
+    - task: OneLocBuild@2
       displayName: OneLocBuild
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -73,7 +73,7 @@ jobs:
         displayName: Generate LocProject.json
         condition: ${{ parameters.condition }}
 
-    - task: OneLocBuild@2
+    - task: OneLocBuild@3
       displayName: OneLocBuild
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -357,6 +357,9 @@ extends:
             LclSource: lclFilesfromPackage
             LclPackageId: 'LCL-JUNO-PROD-ASPIRE'
             CreatePr: false
+            GitHubOrg: microsoft
+            MirrorRepo: aspire
+            MirrorBranch: main
 
     # ----------------------------------------------------------------
     # Template tests: validate that the packed Aspire.* nupkgs produce

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -351,16 +351,12 @@ extends:
                   path: '$(Build.SourcesDirectory)/artifacts/DashboardArtifacts/$(_BuildConfig)'
                   artifactName: managed_dashboard_artifacts
 
-      # OneLocBuild is temporarily disabled while we work with the loc team
-      # to reconfigure it after the repo migration from dotnet/aspire to microsoft/aspire.
-      # - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-      #   - template: /eng/common/templates-official/job/onelocbuild.yml@self
-      #     parameters:
-      #       LclSource: lclFilesfromPackage
-      #       LclPackageId: 'LCL-JUNO-PROD-ASPIRE'
-      #       GitHubOrg: microsoft
-      #       MirrorRepo: aspire
-      #       MirrorBranch: main
+      - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+        - template: /eng/common/templates-official/job/onelocbuild.yml@self
+          parameters:
+            LclSource: lclFilesfromPackage
+            LclPackageId: 'LCL-JUNO-PROD-ASPIRE'
+            CreatePr: false
 
     # ----------------------------------------------------------------
     # Template tests: validate that the packed Aspire.* nupkgs produce


### PR DESCRIPTION
## Description

Re-enables the OneLocBuild job after the repository migration from `dotnet/aspire` to `microsoft/aspire`.

This restores the main-branch OneLocBuild job in the official pipeline while preserving the existing GitHub mirror configuration (`GitHubOrg`, `MirrorRepo`, and `MirrorBranch`). For now, the job publishes the localization drop but does not create the localized-files PR automatically (`CreatePr: false`). This keeps the change scoped to the repo-owned pipeline YAML and avoids modifying `eng/common`, which is normally controlled by Arcade.

The earlier diagnostic run showed that OneLocBuild generated the loc payload successfully, but failed in the GitHub check-in path with an Octokit 404 while running from the internal Azure Repos mirror. Disabling PR creation isolated that failure path and allowed the OneLocBuild task plus `Publish Localization Files` step to succeed and produce the `Loc` artifact.

Validation:
- Queued internal diagnostic build `2996351` from `joperezr/onelocbuild-v3-test`.
- `Generate LocProject.json`: succeeded.
- `OneLocBuild`: succeeded.
- `Publish Localization Files`: succeeded.
- `Loc` artifact was published.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
