### PR TITLE
ci(release): submit WinGet PR ready-for-review instead of draft

### DIFF
--- a/eng/pipelines/templates/publish-winget.yml
+++ b/eng/pipelines/templates/publish-winget.yml
@@ -241,78 +241,6 @@ steps:
         exit 1
       }
 
-      $headers = @{
-        Authorization = "Bearer $token"
-        Accept = "application/vnd.github+json"
-        "User-Agent" = "dotnet-aspire-release-pipeline"
-        "X-GitHub-Api-Version" = "2022-11-28"
-      }
-
-      function Invoke-GitHubApi {
-        param(
-          [string]$Method,
-          [string]$Uri,
-          [object]$Body
-        )
-
-        $params = @{
-          Method = $Method
-          Uri = $Uri
-          Headers = $headers
-          ErrorAction = 'Stop'
-        }
-
-        if ($null -ne $Body) {
-          $params.Body = ($Body | ConvertTo-Json -Depth 10)
-          $params.ContentType = 'application/json'
-        }
-
-        return Invoke-RestMethod @params
-      }
-
-      function Invoke-GitHubGraphQL {
-        param(
-          [string]$Query,
-          [object]$Variables
-        )
-
-        $response = Invoke-GitHubApi -Method Post -Uri 'https://api.github.com/graphql' -Body @{
-          query = $Query
-          variables = $Variables
-        }
-
-        if ($response.errors) {
-          $messages = ($response.errors | ForEach-Object { $_.message }) -join '; '
-          throw "GitHub GraphQL request failed: $messages"
-        }
-
-        return $response.data
-      }
-
-      function Invoke-WithRetry {
-        param(
-          [scriptblock]$ScriptBlock,
-          [string]$Operation,
-          [int]$MaxAttempts = 12,
-          [int]$DelaySeconds = 10
-        )
-
-        for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
-          try {
-            return & $ScriptBlock
-          }
-          catch {
-            if ($attempt -eq $MaxAttempts) {
-              throw
-            }
-
-            Write-Host "$Operation failed on attempt $attempt/$($MaxAttempts): $($_.Exception.Message)"
-            Write-Host "Retrying in $DelaySeconds seconds..."
-            Start-Sleep -Seconds $DelaySeconds
-          }
-        }
-      }
-
       Write-Host "Submitting clean manifest directory to wingetcreate: $manifestDir"
       $output = & "$(Build.StagingDirectory)/wingetcreate.exe" submit $manifestDir `
         --token $token `
@@ -327,47 +255,21 @@ steps:
         exit $exitCode
       }
 
+      # wingetcreate opens a normal (ready-for-review) PR against microsoft/winget-pkgs,
+      # which is what we want. Parse the single PR URL purely for logging/traceability.
       $pullRequestNumbers = @([regex]::Matches($outputText, 'https://github\.com/microsoft/winget-pkgs/pull/(\d+)') |
         ForEach-Object { $_.Groups[1].Value } |
         Select-Object -Unique
       )
 
       if ($pullRequestNumbers.Count -ne 1) {
-        Write-Error "Expected exactly one microsoft/winget-pkgs PR URL in wingetcreate output so it can be converted to draft; found $($pullRequestNumbers.Count)."
+        Write-Error "Expected exactly one microsoft/winget-pkgs PR URL in wingetcreate output; found $($pullRequestNumbers.Count)."
         exit 1
       }
 
       $pullRequestNumber = $pullRequestNumbers[0]
       $pullRequestUrl = "https://github.com/microsoft/winget-pkgs/pull/$pullRequestNumber"
-      $pullRequest = Invoke-WithRetry -Operation "Fetching WinGet PR #$pullRequestNumber" -ScriptBlock {
-        Invoke-GitHubApi -Method Get -Uri "https://api.github.com/repos/microsoft/winget-pkgs/pulls/$pullRequestNumber" -Body $null
-      }
-
-      if (-not [bool]$pullRequest.draft) {
-        Write-Host "Converting WinGet PR #$pullRequestNumber to draft..."
-
-        $convertPullRequestToDraftMutation = 'mutation ConvertPullRequestToDraft($pullRequestId: ID!) {
-          convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
-            pullRequest {
-              number
-              isDraft
-              url
-            }
-          }
-        }'
-
-        $graphQlData = Invoke-WithRetry -Operation "Converting WinGet PR #$pullRequestNumber to draft" -ScriptBlock {
-          Invoke-GitHubGraphQL -Query $convertPullRequestToDraftMutation -Variables @{
-            pullRequestId = $pullRequest.node_id
-          }
-        }
-
-        if (-not $graphQlData.convertPullRequestToDraft.pullRequest.isDraft) {
-          throw "Failed to convert WinGet PR #$pullRequestNumber to draft."
-        }
-      }
-
-      Write-Host "WinGet PR #$pullRequestNumber is draft: $pullRequestUrl"
+      Write-Host "Opened WinGet PR #$pullRequestNumber (ready for review): $pullRequestUrl"
       Write-Host "Successfully submitted WinGet manifest for $packageId $version"
     displayName: '🟣Submit to WinGet'
     # Guard: only submit to WinGet from production branches.


### PR DESCRIPTION
The release pipeline (`release-publish-nuget` → `publish-winget.yml`) submits the `Microsoft.Aspire` manifest PR to `microsoft/winget-pkgs` via `wingetcreate submit`, then explicitly converts that PR to **draft** using the GitHub GraphQL `convertPullRequestToDraft` mutation.

A draft PR doesn't enter the upstream validation/merge queue until a human manually marks it ready, so every release needs a manual "ready for review" click on the winget-pkgs PR.

## Fix

Remove the convert-to-draft step. `wingetcreate submit` already opens a normal ready-for-review PR, which is what we want. The single PR URL is still parsed and logged for traceability.

This also removes the now-unused `Invoke-GitHubApi` / `Invoke-GitHubGraphQL` / `Invoke-WithRetry` helpers and the `$headers` block that existed only to perform the draft conversion.

## Call-outs

- Behavior change is limited to the `🟣Submit to WinGet` step; the submit gating (`dryRun` / `_IsProductionBranch`) is unchanged.
- The "exactly one PR URL" guard is retained — its error text no longer mentions draft conversion.
