### PR TITLE
Update OpenTelemetry.Instrumentation.StackExchangeRedis

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -214,6 +214,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingPreviewVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPreviewVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderPreviewVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesPreviewVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryPreviewVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPreviewVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsFileSystemGlobbingPreviewVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -94,6 +94,7 @@
     <MicrosoftExtensionsCachingMemoryPreviewVersion>10.0.9</MicrosoftExtensionsCachingMemoryPreviewVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPreviewVersion>10.0.9</MicrosoftExtensionsConfigurationAbstractionsPreviewVersion>
     <MicrosoftExtensionsConfigurationBinderPreviewVersion>10.0.9</MicrosoftExtensionsConfigurationBinderPreviewVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPreviewVersion>10.0.9</MicrosoftExtensionsConfigurationEnvironmentVariablesPreviewVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsPreviewVersion>10.0.9</MicrosoftExtensionsDependencyInjectionAbstractionsPreviewVersion>
     <MicrosoftExtensionsFileSystemGlobbingPreviewVersion>10.0.9</MicrosoftExtensionsFileSystemGlobbingPreviewVersion>
     <MicrosoftExtensionsLoggingAbstractionsPreviewVersion>10.0.9</MicrosoftExtensionsLoggingAbstractionsPreviewVersion>

--- a/src/Components/Aspire.StackExchange.Redis/Aspire.StackExchange.Redis.csproj
+++ b/src/Components/Aspire.StackExchange.Redis/Aspire.StackExchange.Redis.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Redis" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.AutoActivation" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />

--- a/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
@@ -159,7 +159,7 @@ public static class AspireRedisExtensions
             builder.Services.AddOpenTelemetry()
                 .WithTracing(t =>
                 {
-                    t.AddSource(StackExchangeRedisConnectionInstrumentation.ActivitySourceName);
+                    t.AddSource(StackExchangeRedisConnectionInstrumentation.ActivitySource.Name);
                     // This ensures the core Redis instrumentation services from OpenTelemetry.Instrumentation.StackExchangeRedis are added
                     t.ConfigureRedisInstrumentation(_ => { });
                     // This ensures that any logic performed by the AddInstrumentation method is executed (this is usually called by AddRedisInstrumentation())

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -2,12 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Net;
+#if NET
+using System.Net.Sockets;
+#endif
 using System.Reflection;
 using System.Reflection.Emit;
 using OpenTelemetry.Trace;
 using StackExchange.Redis.Profiling;
-#if NET6_0_OR_GREATER
+#if NET
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 #endif
@@ -18,8 +22,10 @@ internal static class RedisProfilerEntryToActivityConverter
 {
     private static readonly Lazy<Func<object, (string?, string?)>> MessageDataGetter = new(() =>
     {
-        Type profiledCommandType = Type.GetType("StackExchange.Redis.Profiling.ProfiledCommand, StackExchange.Redis", throwOnError: true)!;
-        Type scriptMessageType = Type.GetType("StackExchange.Redis.RedisDatabase+ScriptEvalMessage, StackExchange.Redis", throwOnError: true)!;
+#pragma warning disable IDE0370 // Suppression is unnecessary
+        var profiledCommandType = Type.GetType("StackExchange.Redis.Profiling.ProfiledCommand, StackExchange.Redis", throwOnError: true)!;
+        var scriptMessageType = Type.GetType("StackExchange.Redis.RedisDatabase+ScriptEvalMessage, StackExchange.Redis", throwOnError: true)!;
+#pragma warning restore IDE0370 // Suppression is unnecessary
 
         var messageDelegate = CreateFieldGetter<object>(profiledCommandType, "Message", BindingFlags.NonPublic | BindingFlags.Instance);
         var scriptDelegate = CreateFieldGetter<string>(scriptMessageType, "script", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -49,21 +55,16 @@ internal static class RedisProfilerEntryToActivityConverter
                 script = scriptDelegate?.Invoke(message);
             }
 
-            if (GetCommandAndKey(commandAndKeyFetcher, message, out var value))
-            {
-                return (value, script);
-            }
+            return GetCommandAndKey(commandAndKeyFetcher, message, out var value) ? (value, script) : (null, script);
 
-            return (null, script);
-
-#if NET6_0_OR_GREATER
+#if NET
             [DynamicDependency("CommandAndKey", "StackExchange.Redis.Message", "StackExchange.Redis")]
             [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The CommandAndKey property is preserved by the above DynamicDependency")]
 #endif
             static bool GetCommandAndKey(
                 PropertyFetcher<string> commandAndKeyFetcher,
                 object message,
-#if NET6_0_OR_GREATER
+#if NET
                 [NotNullWhen(true)]
 #endif
                 out string? value)
@@ -75,17 +76,39 @@ internal static class RedisProfilerEntryToActivityConverter
 
     public static Activity? ProfilerCommandToActivity(Activity? parentActivity, IProfiledCommand command, StackExchangeRedisInstrumentationOptions options)
     {
+        try
+        {
+            if (options.Filter != null && !options.Filter(new(parentActivity, command)))
+            {
+                return null;
+            }
+        }
+        catch
+        {
+            return null;
+        }
+
         var name = command.Command; // Example: SET;
         if (string.IsNullOrEmpty(name))
         {
             name = StackExchangeRedisConnectionInstrumentation.ActivityName;
         }
 
-        var activity = StackExchangeRedisConnectionInstrumentation.ActivitySource.StartActivity(
+        var activitySource =
+            options.EmitNewAttributes && options.EmitOldAttributes ?
+            StackExchangeRedisConnectionInstrumentation.ActivitySourceBoth :
+            options.EmitNewAttributes ?
+            StackExchangeRedisConnectionInstrumentation.ActivitySourceNew :
+            StackExchangeRedisConnectionInstrumentation.ActivitySource;
+
+        var activity = activitySource.StartActivity(
             name,
             ActivityKind.Client,
             parentActivity?.Context ?? default,
-            StackExchangeRedisConnectionInstrumentation.CreationTags,
+            [
+                .. options.EmitOldAttributes ? StackExchangeRedisConnectionInstrumentation.OldCreationTags : [],
+                .. options.EmitNewAttributes ? StackExchangeRedisConnectionInstrumentation.NewCreationTags : [],
+            ],
             startTime: command.CommandCreated);
 
         if (activity == null)
@@ -110,51 +133,80 @@ internal static class RedisProfilerEntryToActivityConverter
             // Total:
             // command.ElapsedTime;             // 00:00:32.4988020
 
-            activity.SetTag(StackExchangeRedisConnectionInstrumentation.RedisFlagsKeyName, command.Flags.ToString());
-
+            string? commandAndKey = null;
+            string? script = null;
             if (options.SetVerboseDatabaseStatements)
             {
-                var (commandAndKey, script) = MessageDataGetter.Value.Invoke(command);
+                (commandAndKey, script) = MessageDataGetter.Value.Invoke(command);
+            }
 
-                if (!string.IsNullOrEmpty(commandAndKey) && !string.IsNullOrEmpty(script))
+            if (options.EmitOldAttributes)
+            {
+                activity.SetTag(StackExchangeRedisConnectionInstrumentation.RedisDatabaseIndexKeyName, command.Db);
+                string? statement = null;
+
+                if (options.SetVerboseDatabaseStatements)
                 {
-                    activity.SetTag(SemanticConventions.AttributeDbStatement, commandAndKey + " " + script);
+                    if (!string.IsNullOrEmpty(commandAndKey))
+                    {
+                        statement = commandAndKey;
+
+                        if (!string.IsNullOrEmpty(script))
+                        {
+                            statement += " " + script;
+                        }
+                    }
                 }
-                else if (!string.IsNullOrEmpty(commandAndKey))
+
+                // Example: "db.statement": SET;
+                statement ??= command.Command;
+
+                if (statement != null)
                 {
-                    activity.SetTag(SemanticConventions.AttributeDbStatement, commandAndKey);
-                }
-                else if (command.Command != null)
-                {
-                    // Example: "db.statement": SET;
-                    activity.SetTag(SemanticConventions.AttributeDbStatement, command.Command);
+                    activity.SetTag(SemanticConventions.AttributeDbStatement, statement);
                 }
             }
-            else if (command.Command != null)
+
+            if (options.EmitNewAttributes)
             {
-                // Example: "db.statement": SET;
-                activity.SetTag(SemanticConventions.AttributeDbStatement, command.Command);
+                string? queryText = command.Command;
+                if (options.SetVerboseDatabaseStatements && !string.IsNullOrEmpty(commandAndKey))
+                {
+                    queryText = commandAndKey;
+
+                    if (!string.IsNullOrEmpty(script))
+                    {
+                        queryText += " " + script;
+                    }
+                }
+
+                activity.SetTag(SemanticConventions.AttributeDbOperationName, command.Command);
+                activity.SetTag(SemanticConventions.AttributeDbNamespace, command.Db.ToString(CultureInfo.InvariantCulture));
+                activity.SetTag(SemanticConventions.AttributeDbQueryText, queryText);
             }
 
             if (command.EndPoint != null)
             {
                 if (command.EndPoint is IPEndPoint ipEndPoint)
                 {
-                    activity.SetTag(SemanticConventions.AttributeNetPeerIp, ipEndPoint.Address.ToString());
-                    activity.SetTag(SemanticConventions.AttributeNetPeerPort, ipEndPoint.Port);
+                    activity.SetTag(SemanticConventions.AttributeServerAddress, ipEndPoint.Address.ToString());
+                    activity.SetTag(SemanticConventions.AttributeServerPort, ipEndPoint.Port);
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, ipEndPoint.Address.ToString());
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, ipEndPoint.Port);
                 }
                 else if (command.EndPoint is DnsEndPoint dnsEndPoint)
                 {
-                    activity.SetTag(SemanticConventions.AttributeNetPeerName, dnsEndPoint.Host);
-                    activity.SetTag(SemanticConventions.AttributeNetPeerPort, dnsEndPoint.Port);
+                    activity.SetTag(SemanticConventions.AttributeServerAddress, dnsEndPoint.Host);
+                    activity.SetTag(SemanticConventions.AttributeServerPort, dnsEndPoint.Port);
                 }
-                else
+#if NET
+                else if (command.EndPoint is UnixDomainSocketEndPoint unixDomainSocketEndPoint)
                 {
-                    activity.SetTag(SemanticConventions.AttributePeerService, command.EndPoint.ToString());
+                    activity.SetTag(SemanticConventions.AttributeServerAddress, unixDomainSocketEndPoint.ToString());
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, unixDomainSocketEndPoint.ToString());
                 }
+#endif
             }
-
-            activity.SetTag(StackExchangeRedisConnectionInstrumentation.RedisDatabaseIndexKeyName, command.Db);
 
             // TODO: deal with the re-transmission
             // command.RetransmissionOf;
@@ -171,7 +223,7 @@ internal static class RedisProfilerEntryToActivityConverter
                 activity.AddEvent(new ActivityEvent("ResponseReceived", response));
             }
 
-            options.Enrich?.Invoke(activity, command);
+            options.Enrich?.Invoke(activity, new(parentActivity, command));
         }
 
         activity.Stop();
@@ -192,26 +244,32 @@ internal static class RedisProfilerEntryToActivityConverter
     /// represented with classType variable.
     /// </summary>
     private static Func<object, TField?>? CreateFieldGetter<TField>(
-#if NET6_0_OR_GREATER
+#if NET
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
+#if NET8_0
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "Guarded by RuntimeFeature.IsDynamicCodeSupported.")]
+#endif
 #endif
         Type classType,
         string fieldName,
         BindingFlags flags)
     {
-        FieldInfo? field = classType.GetField(fieldName, flags);
+        var field = classType.GetField(fieldName, flags);
         if (field != null)
         {
-#if NET6_0_OR_GREATER
+#if NET
             if (RuntimeFeature.IsDynamicCodeSupported)
 #endif
             {
-                string methodName = classType.FullName + ".get_" + field.Name;
-#pragma warning disable IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
-                // TODO: Remove the above disable when the AOT analyzer being used has the fix for https://github.com/dotnet/linker/issues/2715.
-                DynamicMethod getterMethod = new DynamicMethod(methodName, typeof(TField), new[] { typeof(object) }, true);
-#pragma warning restore IL3050
-                ILGenerator generator = getterMethod.GetILGenerator();
+                var methodName = classType.FullName + ".get_" + field.Name;
+#if NET8_0
+#pragma warning disable IL3050 // Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT
+#endif
+                var getterMethod = new DynamicMethod(methodName, typeof(TField), [typeof(object)], true);
+#if NET8_0
+#pragma warning restore IL3050 // Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT
+#endif
+                var generator = getterMethod.GetILGenerator();
                 generator.Emit(OpCodes.Ldarg_0);
                 generator.Emit(OpCodes.Castclass, classType);
                 generator.Emit(OpCodes.Ldfld, field);
@@ -219,7 +277,7 @@ internal static class RedisProfilerEntryToActivityConverter
 
                 return (Func<object, TField>)getterMethod.CreateDelegate(typeof(Func<object, TField>));
             }
-#if NET6_0_OR_GREATER
+#if NET
             else
             {
                 return obj => (TField?)field.GetValue(obj);

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/RedisInstrumentationContext.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/RedisInstrumentationContext.cs
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using StackExchange.Redis.Profiling;
+
+namespace OpenTelemetry.Instrumentation.StackExchangeRedis;
+
+/// <summary>
+/// Represents contextual information about a profiled Redis command off of which an <see cref="Activity"/> can be created.
+/// </summary>
+/// <param name="ParentActivity">
+/// The parent activity associated with the profiled command.
+/// <see cref="Activity.Current"/> is not guaranteed to be the parent activity since commands are profiled asynchronously.
+/// </param>
+/// <param name="ProfiledCommand">
+/// The profiled Redis command.
+/// </param>
+internal readonly record struct RedisInstrumentationContext(
+    Activity? ParentActivity,
+    IProfiledCommand ProfiledCommand);

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared/ActivitySourceFactory.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared/ActivitySourceFactory.cs
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Trace;
+
+internal static class ActivitySourceFactory
+{
+    /// <summary>
+    /// Creates a new <see cref="ActivitySource"/> for the assembly associated
+    /// with the specified type and semantic conventions version.
+    /// </summary>
+    /// <typeparam name="T">The type for which the <see cref="ActivitySource"/> is created for its assembly.</typeparam>
+    /// <param name="semanticConventionsVersion">The version of the semantic conventions.</param>
+    /// <param name="tags">The optional tags to associate with the created <see cref="ActivitySource"/>.</param>
+    /// <returns>A new <see cref="ActivitySource"/> instance.</returns>
+    public static ActivitySource Create<T>(Version? semanticConventionsVersion, IEnumerable<KeyValuePair<string, object?>>? tags = null)
+        => Create(typeof(T), semanticConventionsVersion, tags);
+
+    /// <summary>
+    /// Creates a new <see cref="ActivitySource"/> for the assembly associated
+    /// with the specified type and semantic conventions version.
+    /// </summary>
+    /// <param name="type">The type for which the <see cref="ActivitySource"/> is created for its assembly.</param>
+    /// <param name="semanticConventionsVersion">The version of the semantic conventions.</param>
+    /// <param name="tags">The optional tags to associate with the created <see cref="ActivitySource"/>.</param>
+    /// <param name="name">The optional name to use for the <see cref="ActivitySource"/> instead of the assembly name associated with <paramref name="type"/>.</param>
+    /// <returns>A new <see cref="ActivitySource"/> instance.</returns>
+    public static ActivitySource Create(Type type, Version? semanticConventionsVersion, IEnumerable<KeyValuePair<string, object?>>? tags = null, string? name = null)
+    {
+        Guard.ThrowIfNull(type);
+
+        var assembly = type.Assembly;
+        var assemblyName = assembly.GetName();
+        var version = assembly.GetPackageVersion();
+
+#pragma warning disable IDE0370 // Suppression is unnecessary
+        name ??= assemblyName.Name!;
+#pragma warning restore IDE0370 // Suppression is unnecessary
+
+        var options = new ActivitySourceOptions(name)
+        {
+            Version = version,
+        };
+
+        if (tags is not null)
+        {
+            options.Tags = tags;
+        }
+
+        if (semanticConventionsVersion is not null)
+        {
+            options.TelemetrySchemaUrl = $"https://opentelemetry.io/schemas/{semanticConventionsVersion.ToString(3)}";
+        }
+
+        return new(options);
+    }
+}

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared/AssemblyVersionExtensions.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared/AssemblyVersionExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Reflection;
+
+namespace OpenTelemetry.Internal;
+
+internal static class AssemblyVersionExtensions
+{
+    public static string GetPackageVersion(this Assembly assembly)
+    {
+        // MinVer https://github.com/adamralph/minver?tab=readme-ov-file#version-numbers
+        // together with Microsoft.SourceLink.GitHub https://github.com/dotnet/sourcelink
+        // fills AssemblyInformationalVersionAttribute by
+        // {majorVersion}.{minorVersion}.{patchVersion}.{pre-release label}.{pre-release version}.{gitHeight}+{Git SHA of current commit}
+        // Ex: 1.5.0-alpha.1.40+807f703e1b4d9874a92bd86d9f2d4ebe5b5d52e4
+        // The following parts are optional: pre-release label, pre-release version, git height, Git SHA of current commit
+        // For package version, value of AssemblyInformationalVersionAttribute without commit hash is returned.
+
+        var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        Debug.Assert(!string.IsNullOrEmpty(informationalVersion), "AssemblyInformationalVersionAttribute was not found in assembly");
+
+#if NET || NETSTANDARD2_1_OR_GREATER
+        var indexOfPlusSign = informationalVersion.IndexOf('+', StringComparison.Ordinal);
+#else
+        var indexOfPlusSign = informationalVersion!.IndexOf('+');
+#endif
+        return indexOfPlusSign > 0
+            ? informationalVersion.Substring(0, indexOfPlusSign)
+            : informationalVersion;
+    }
+}

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared/DatabaseSemanticConventionHelper.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared/DatabaseSemanticConventionHelper.cs
@@ -1,0 +1,185 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if INCLUDE_SQL_QUERY_PARSER
+using System.Diagnostics;
+#endif
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Configuration;
+#if INCLUDE_SQL_QUERY_PARSER
+using OpenTelemetry.Instrumentation;
+using OpenTelemetry.Trace;
+#endif
+
+namespace OpenTelemetry.Internal;
+
+/// <summary>
+/// Helper class for Database Semantic Conventions.
+/// </summary>
+/// <remarks>
+/// Due to a breaking change in the semantic convention, affected instrumentation libraries
+/// must inspect an environment variable to determine which attributes to emit.
+/// This is expected to be removed when the instrumentation libraries reach Stable.
+/// <see href="https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-spans.md"/>.
+/// </remarks>
+internal static class DatabaseSemanticConventionHelper
+{
+    internal const string SemanticConventionOptInKeyName = "OTEL_SEMCONV_STABILITY_OPT_IN";
+    internal static readonly char[] Separator = [',', ' '];
+
+    [Flags]
+    internal enum DatabaseSemanticConvention
+    {
+        /// <summary>
+        /// Instructs an instrumentation library to emit the old experimental Database attributes.
+        /// </summary>
+        Old = 0x1,
+
+        /// <summary>
+        /// Instructs an instrumentation library to emit the new, v1.28.0 Database attributes.
+        /// </summary>
+        New = 0x2,
+
+        /// <summary>
+        /// Instructs an instrumentation library to emit both the old and new attributes.
+        /// </summary>
+        Dupe = Old | New,
+    }
+
+    public static DatabaseSemanticConvention GetSemanticConventionOptIn(IConfiguration configuration)
+    {
+        if (TryGetConfiguredValues(configuration, out var values))
+        {
+            if (values.Contains("database/dup"))
+            {
+                return DatabaseSemanticConvention.Dupe;
+            }
+            else if (values.Contains("database"))
+            {
+                return DatabaseSemanticConvention.New;
+            }
+        }
+
+        return DatabaseSemanticConvention.Old;
+    }
+
+#if INCLUDE_SQL_QUERY_PARSER
+    public static void ApplyConventionsForQueryText(
+        Activity activity,
+        string? commandText,
+        bool emitOldAttributes,
+        bool emitNewAttributes,
+        bool sanitizeQuery = true)
+    {
+        var queryText = commandText ?? string.Empty;
+        var querySummary = string.Empty;
+
+        if (sanitizeQuery)
+        {
+            var sqlStatementInfo = SqlProcessor.GetSanitizedSql(commandText);
+
+            queryText = sqlStatementInfo.SanitizedSql;
+            querySummary = sqlStatementInfo.DbQuerySummary;
+        }
+
+        if (emitOldAttributes)
+        {
+            activity.SetTag(SemanticConventions.AttributeDbStatement, queryText);
+        }
+
+        if (emitNewAttributes)
+        {
+            activity.SetTag(SemanticConventions.AttributeDbQueryText, queryText);
+
+            if (!string.IsNullOrEmpty(querySummary))
+            {
+                activity.SetTag(SemanticConventions.AttributeDbQuerySummary, querySummary);
+                activity.DisplayName = querySummary;
+            }
+        }
+    }
+
+    public static void AddTagsForSamplingAndUpdateActivityNameForQueryText(
+        ref TagList tagList,
+        string? commandText,
+        ref string activityName,
+        bool sanitizeQuery = true)
+    {
+        var queryText = commandText ?? string.Empty;
+        var querySummary = string.Empty;
+
+        if (sanitizeQuery)
+        {
+            var sqlStatementInfo = SqlProcessor.GetSanitizedSql(commandText);
+            queryText = sqlStatementInfo.SanitizedSql;
+            querySummary = sqlStatementInfo.DbQuerySummary;
+        }
+
+        tagList.Add(SemanticConventions.AttributeDbQueryText, queryText);
+
+        if (!string.IsNullOrEmpty(querySummary))
+        {
+            tagList.Add(SemanticConventions.AttributeDbQuerySummary, querySummary);
+            activityName = querySummary;
+        }
+    }
+
+    public static void ApplyConventionsForStoredProcedure(
+        Activity activity,
+        string? commandText,
+        bool emitOldAttributes,
+        bool emitNewAttributes)
+    {
+        if (emitOldAttributes)
+        {
+            activity.SetTag(SemanticConventions.AttributeDbStatement, commandText);
+        }
+
+        if (emitNewAttributes)
+        {
+            activity.SetTag(SemanticConventions.AttributeDbOperationName, "EXECUTE");
+            activity.SetTag(SemanticConventions.AttributeDbStoredProcedureName, commandText);
+            var dbQuerySummary = $"EXECUTE {commandText}";
+            activity.SetTag(SemanticConventions.AttributeDbQuerySummary, dbQuerySummary);
+            activity.DisplayName = dbQuerySummary;
+        }
+    }
+
+    public static void AddTagsForSamplingAndUpdateActivityNameForStoredProcedure(
+        ref TagList tagsList,
+        string? commandText,
+        ref string activityName)
+    {
+        tagsList.Add(SemanticConventions.AttributeDbOperationName, "EXECUTE");
+        tagsList.Add(SemanticConventions.AttributeDbStoredProcedureName, commandText);
+        var dbQuerySummary = $"EXECUTE {commandText}";
+        tagsList.Add(SemanticConventions.AttributeDbQuerySummary, dbQuerySummary);
+        activityName = dbQuerySummary;
+    }
+#endif
+
+    private static bool TryGetConfiguredValues(IConfiguration configuration, [NotNullWhen(true)] out HashSet<string>? values)
+    {
+        try
+        {
+            var stringValue = configuration[SemanticConventionOptInKeyName];
+
+            if (string.IsNullOrWhiteSpace(stringValue))
+            {
+                values = null;
+                return false;
+            }
+
+#pragma warning disable IDE0370 // Suppression is unnecessary
+            var stringValues = stringValue!.Split(separator: Separator, options: StringSplitOptions.RemoveEmptyEntries);
+#pragma warning restore IDE0370 // Suppression is unnecessary
+            values = new HashSet<string>(stringValues, StringComparer.OrdinalIgnoreCase);
+            return true;
+        }
+        catch
+        {
+            values = null;
+            return false;
+        }
+    }
+}

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared/Guard.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared/Guard.cs
@@ -1,27 +1,20 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
-// Note: When implicit usings are enabled in a project this file will generate
-// warnings/errors without this suppression.
-#pragma warning disable IDE0005 // Using directive is unnecessary.
-
 // Note: For some targets this file will contain more than one type/namespace.
 #pragma warning disable IDE0161 // Convert to file-scoped namespace
 
-using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1403 // File may only contain a single namespace
 #pragma warning disable SA1649 // File name should match first type name
+#pragma warning disable IDE0022 // Use expression body for method
 
-#if !NET6_0_OR_GREATER
+#if !NET
 namespace System.Runtime.CompilerServices
 {
     /// <summary>Allows capturing of the expressions passed to a method.</summary>
@@ -38,7 +31,7 @@ namespace System.Runtime.CompilerServices
 }
 #endif
 
-#if !NET6_0_OR_GREATER && !NETSTANDARD2_1_OR_GREATER
+#if !NET && !NETSTANDARD2_1_OR_GREATER
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>Specifies that an output is not <see langword="null"/> even if
@@ -67,10 +60,14 @@ namespace OpenTelemetry.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ThrowIfNull([NotNull] object? value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
         {
+#if NET
+            ArgumentNullException.ThrowIfNull(value, paramName);
+#else
             if (value is null)
             {
                 throw new ArgumentNullException(paramName, "Must not be null");
             }
+#endif
         }
 
         /// <summary>
@@ -83,10 +80,14 @@ namespace OpenTelemetry.Internal
         public static void ThrowIfNullOrEmpty([NotNull] string? value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
 #pragma warning disable CS8777 // Parameter must have a non-null value when exiting.
         {
+#if NET
+            ArgumentException.ThrowIfNullOrEmpty(value, paramName);
+#else
             if (string.IsNullOrEmpty(value))
             {
                 throw new ArgumentException("Must not be null or empty", paramName);
             }
+#endif
         }
 #pragma warning restore CS8777 // Parameter must have a non-null value when exiting.
 
@@ -100,10 +101,14 @@ namespace OpenTelemetry.Internal
         public static void ThrowIfNullOrWhitespace([NotNull] string? value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
 #pragma warning disable CS8777 // Parameter must have a non-null value when exiting.
         {
+#if NET
+            ArgumentException.ThrowIfNullOrWhiteSpace(value, paramName);
+#else
             if (string.IsNullOrWhiteSpace(value))
             {
                 throw new ArgumentException("Must not be null or whitespace", paramName);
             }
+#endif
         }
 #pragma warning restore CS8777 // Parameter must have a non-null value when exiting.
 
@@ -117,9 +122,29 @@ namespace OpenTelemetry.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ThrowIfZero(int value, string message = "Must not be zero", [CallerArgumentExpression(nameof(value))] string? paramName = null)
         {
+#if NET
+            ArgumentOutOfRangeException.ThrowIfZero(value, paramName);
+#else
             if (value == 0)
             {
                 throw new ArgumentException(message, paramName);
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Throw an exception if the value is negative.
+        /// </summary>
+        /// <param name="value">The value to check.</param>
+        /// <param name="message">The message to use in the thrown exception.</param>
+        /// <param name="paramName">The parameter name to use in the thrown exception.</param>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNegative(int value, string message = "Must not be negative", [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(paramName, message);
             }
         }
 
@@ -180,12 +205,9 @@ namespace OpenTelemetry.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T ThrowIfNotOfType<T>([NotNull] object? value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
         {
-            if (value is not T result)
-            {
-                throw new InvalidCastException($"Cannot cast '{paramName}' from '{value?.GetType().ToString() ?? "null"}' to '{typeof(T)}'");
-            }
-
-            return result;
+            return value is not T result
+                ? throw new InvalidCastException($"Cannot cast '{paramName}' from '{value?.GetType().ToString() ?? "null"}' to '{typeof(T)}'")
+                : result;
         }
 
         [DebuggerHidden]

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared/PropertyFetcher.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared/PropertyFetcher.cs
@@ -1,17 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable disable
-
 // NOTE: This version of PropertyFetcher is AOT-compatible.
 // Usages of the non-AOT-compatible version can be moved over to this one when they need to support AOT/trimming.
 // Copied from https://github.com/open-telemetry/opentelemetry-dotnet/blob/86a6ba0b7f7ed1f5e84e5a6610e640989cd3ae9f/src/Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs#L30
 
-#nullable enable
-
-#if NETSTANDARD2_1_0_OR_GREATER || NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
-#endif
 using System.Reflection;
 
 namespace OpenTelemetry.Instrumentation;
@@ -22,7 +16,7 @@ namespace OpenTelemetry.Instrumentation;
 /// <typeparam name="T">The type of the property being fetched.</typeparam>
 internal sealed class PropertyFetcher<T>
 {
-#if NET6_0_OR_GREATER
+#if NET
     private const string TrimCompatibilityMessage = "PropertyFetcher is used to access properties on objects dynamically by design and cannot be made trim compatible.";
 #endif
     private readonly string propertyName;
@@ -42,31 +36,37 @@ internal sealed class PropertyFetcher<T>
         : 1 + this.innerFetcher.NumberOfInnerFetchers;
 
     /// <summary>
+    /// Fetch the property from the object.
+    /// </summary>
+    /// <param name="obj">Object to be fetched.</param>
+    /// <returns>Fetched value.</returns>
+#if NET
+    [RequiresUnreferencedCode(TrimCompatibilityMessage)]
+#endif
+    public T Fetch(object? obj)
+        => !this.TryFetch(obj, out var value)
+            ? throw new ArgumentException("Supplied object was null or did not match the expected type.", nameof(obj))
+            : value;
+
+    /// <summary>
     /// Try to fetch the property from the object.
     /// </summary>
     /// <param name="obj">Object to be fetched.</param>
     /// <param name="value">Fetched value.</param>
     /// <returns><see langword= "true"/> if the property was fetched.</returns>
-#if NET6_0_OR_GREATER
+#if NET
     [RequiresUnreferencedCode(TrimCompatibilityMessage)]
 #endif
     public bool TryFetch(
-#if NETSTANDARD2_1_0_OR_GREATER || NET6_0_OR_GREATER
-        [NotNullWhen(true)]
-#endif
         object? obj,
+        [NotNullWhen(true)]
         out T? value)
     {
-        var innerFetcher = this.innerFetcher;
-        if (innerFetcher is null)
-        {
-            return TryFetchRare(obj, this.propertyName, ref this.innerFetcher, out value);
-        }
-
-        return innerFetcher.TryFetch(obj, out value);
+        var localInnerFetcher = this.innerFetcher;
+        return localInnerFetcher is null ? TryFetchRare(obj, this.propertyName, ref this.innerFetcher, out value) : localInnerFetcher.TryFetch(obj, out value);
     }
 
-#if NET6_0_OR_GREATER
+#if NET
     [RequiresUnreferencedCode(TrimCompatibilityMessage)]
 #endif
     private static bool TryFetchRare(object? obj, string propertyName, ref PropertyFetch? destination, out T? value)
@@ -91,7 +91,7 @@ internal sealed class PropertyFetcher<T>
     }
 
     // see https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
-#if NET6_0_OR_GREATER
+#if NET
     [RequiresUnreferencedCode(TrimCompatibilityMessage)]
 #endif
     private abstract class PropertyFetch
@@ -111,46 +111,36 @@ internal sealed class PropertyFetcher<T>
                     return null;
                 }
 
-                var declaringType = propertyInfo.DeclaringType;
-                if (declaringType!.IsValueType)
-                {
-                    throw new NotSupportedException(
-                        $"Type: {declaringType.FullName} is a value type. PropertyFetcher can only operate on reference payload types.");
-                }
+#pragma warning disable IDE0370 // Suppression is unnecessary
+                var declaringType = propertyInfo.DeclaringType!;
+#pragma warning restore IDE0370 // Suppression is unnecessary
 
-                if (declaringType == typeof(object))
-                {
-                    // TODO: REMOVE this if branch when .NET 7 is out of support.
-                    // This branch is never executed and is only needed for .NET 7 AOT-compiler at trimming stage; i.e.,
-                    // this is not needed in .NET 8, because the compiler is improved and call into MakeGenericMethod will be AOT-compatible.
-                    // It is used to force the AOT compiler to create an instantiation of the method with a reference type.
-                    // The code for that instantiation can then be reused at runtime to create instantiation over any other reference.
-                    return CreateInstantiated<object>(propertyInfo);
-                }
-                else
-                {
-                    return DynamicInstantiationHelper(declaringType, propertyInfo);
-                }
+                return declaringType.IsValueType
+                    ? throw new NotSupportedException(
+                        $"Type: {declaringType.FullName} is a value type. PropertyFetcher can only operate on reference payload types.")
+                    : DynamicInstantiationHelper(declaringType, propertyInfo);
 
                 // Separated as a local function to be able to target the suppression to just this call.
                 // IL3050 was generated here because of the call to MakeGenericType, which is problematic in AOT if one of the type parameters is a value type;
                 // because the compiler might need to generate code specific to that type.
                 // If the type parameter is a reference type, there will be no problem; because the generated code can be shared among all reference type instantiations.
-#if NET6_0_OR_GREATER
+#if NET
                 [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "The code guarantees that all the generic parameters are reference types.")]
 #endif
                 static PropertyFetch? DynamicInstantiationHelper(Type declaringType, PropertyInfo propertyInfo)
                 {
+#pragma warning disable IDE0370 // Suppression is unnecessary
                     return (PropertyFetch?)typeof(PropertyFetch)
                         .GetMethod(nameof(CreateInstantiated), BindingFlags.NonPublic | BindingFlags.Static)!
                         .MakeGenericMethod(declaringType) // This is validated in the earlier call chain to be a reference type.
-                        .Invoke(null, new object[] { propertyInfo })!;
+                        .Invoke(null, [propertyInfo]);
+#pragma warning restore IDE0370 // Suppression is unnecessary
                 }
             }
         }
 
         public abstract bool TryFetch(
-#if NETSTANDARD2_1_0_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_0_OR_GREATER || NET
             [NotNullWhen(true)]
 #endif
             object? obj,
@@ -176,9 +166,9 @@ internal sealed class PropertyFetcher<T>
         //    The declared object type is guaranteed to be a reference type (throw on value type.) Thus, MakeGenericMethod is AOT compatible.
         private static PropertyFetchInstantiated<TDeclaredObject> CreateInstantiated<TDeclaredObject>(PropertyInfo propertyInfo)
             where TDeclaredObject : class
-            => new PropertyFetchInstantiated<TDeclaredObject>(propertyInfo);
+            => new(propertyInfo);
 
-#if NET6_0_OR_GREATER
+#if NET
         [RequiresUnreferencedCode(TrimCompatibilityMessage)]
 #endif
         private sealed class PropertyFetchInstantiated<TDeclaredObject> : PropertyFetch
@@ -191,7 +181,11 @@ internal sealed class PropertyFetcher<T>
             public PropertyFetchInstantiated(PropertyInfo property)
             {
                 this.propertyName = property.Name;
-                this.propertyFetch = (Func<TDeclaredObject, T>)property.GetMethod!.CreateDelegate(typeof(Func<TDeclaredObject, T>));
+#if NET
+                this.propertyFetch = property.GetMethod!.CreateDelegate<Func<TDeclaredObject, T>>();
+#else
+                this.propertyFetch = (Func<TDeclaredObject, T>)property.GetMethod.CreateDelegate(typeof(Func<TDeclaredObject, T>));
+#endif
             }
 
             public override int NumberOfInnerFetchers => this.innerFetcher == null
@@ -199,7 +193,7 @@ internal sealed class PropertyFetcher<T>
                 : 1 + this.innerFetcher.NumberOfInnerFetchers;
 
             public override bool TryFetch(
-#if NETSTANDARD2_1_0_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_0_OR_GREATER || NET
                 [NotNullWhen(true)]
 #endif
                 object? obj,
@@ -212,12 +206,7 @@ internal sealed class PropertyFetcher<T>
                 }
 
                 var innerFetcher = this.innerFetcher;
-                if (innerFetcher is null)
-                {
-                    return TryFetchRare(obj, this.propertyName, ref this.innerFetcher, out value);
-                }
-
-                return innerFetcher.TryFetch(obj, out value);
+                return innerFetcher is null ? TryFetchRare(obj, this.propertyName, ref this.innerFetcher, out value) : innerFetcher.TryFetch(obj, out value);
             }
         }
     }

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared/SemanticConventions.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared/SemanticConventions.cs
@@ -11,7 +11,7 @@ internal static class SemanticConventions
 {
     // The set of constants matches the specification as of this commit.
     // https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions
-    // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md
+    // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-spans.md
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public const string AttributeNetTransport = "net.transport";
     public const string AttributeNetPeerIp = "net.peer.ip";
@@ -24,8 +24,6 @@ internal static class SemanticConventions
     public const string AttributeEnduserId = "enduser.id";
     public const string AttributeEnduserRole = "enduser.role";
     public const string AttributeEnduserScope = "enduser.scope";
-
-    public const string AttributePeerService = "peer.service";
 
     public const string AttributeHttpMethod = "http.method";
     public const string AttributeHttpUrl = "http.url";
@@ -44,16 +42,15 @@ internal static class SemanticConventions
     public const string AttributeHttpResponseContentLength = "http.response_content_length";
     public const string AttributeHttpResponseContentLengthUncompressed = "http.response_content_length_uncompressed";
 
-    public const string AttributeDbSystem = "db.system";
     public const string AttributeDbConnectionString = "db.connection_string";
     public const string AttributeDbUser = "db.user";
     public const string AttributeDbMsSqlInstanceName = "db.mssql.instance_name";
     public const string AttributeDbJdbcDriverClassName = "db.jdbc.driver_classname";
     public const string AttributeDbName = "db.name";
     public const string AttributeDbStatement = "db.statement";
+    public const string AttributeDbSystem = "db.system";
     public const string AttributeDbOperation = "db.operation";
     public const string AttributeDbInstance = "db.instance";
-    public const string AttributeDbUrl = "db.url";
     public const string AttributeDbCassandraKeyspace = "db.cassandra.keyspace";
     public const string AttributeDbHBaseNamespace = "db.hbase.namespace";
     public const string AttributeDbRedisDatabaseIndex = "db.redis.database_index";
@@ -63,6 +60,7 @@ internal static class SemanticConventions
     public const string AttributeRpcService = "rpc.service";
     public const string AttributeRpcMethod = "rpc.method";
     public const string AttributeRpcGrpcStatusCode = "rpc.grpc.status_code";
+    public const string AttributeRpcResponseStatusCode = "rpc.response.status_code";
 
     public const string AttributeMessageType = "message.type";
     public const string AttributeMessageId = "message.id";
@@ -95,17 +93,68 @@ internal static class SemanticConventions
     public const string AttributeExceptionType = "exception.type";
     public const string AttributeExceptionMessage = "exception.message";
     public const string AttributeExceptionStacktrace = "exception.stacktrace";
+    public const string AttributeErrorType = "error.type";
 
     // v1.21.0
     // https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-metrics.md#http-server
     public const string AttributeHttpRequestMethod = "http.request.method"; // replaces: "http.method" (AttributeHttpMethod)
+    public const string AttributeHttpRequestMethodOriginal = "http.request.method_original";
     public const string AttributeHttpResponseStatusCode = "http.response.status_code"; // replaces: "http.status_code" (AttributeHttpStatusCode)
     public const string AttributeUrlScheme = "url.scheme"; // replaces: "http.scheme" (AttributeHttpScheme)
+    public const string AttributeUrlFull = "url.full"; // replaces: "http.url" (AttributeHttpUrl)
+    public const string AttributeUrlPath = "url.path"; // replaces: "http.target" (AttributeHttpTarget)
+    public const string AttributeUrlQuery = "url.query"; // replaces: "http.target" (AttributeHttpTarget)
+    public const string AttributeServerSocketAddress = "server.socket.address"; // replaces: "net.peer.ip" (AttributeNetPeerIp)
 
     // v1.23.0
     // https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-metrics.md#http-server
+    public const string AttributeClientAddress = "client.address";
+    public const string AttributeClientPort = "client.port";
     public const string AttributeNetworkProtocolVersion = "network.protocol.version"; // replaces: "http.flavor" (AttributeHttpFlavor)
+    public const string AttributeNetworkProtocolName = "network.protocol.name";
     public const string AttributeServerAddress = "server.address"; // replaces: "net.host.name" (AttributeNetHostName)
     public const string AttributeServerPort = "server.port"; // replaces: "net.host.port" (AttributeNetHostPort)
+    public const string AttributeUserAgentOriginal = "user_agent.original"; // replaces: http.user_agent (AttributeHttpUserAgent)
+
+    // v1.23.0 Database spans
+    // https://github.com/open-telemetry/semantic-conventions/blob/release/v1.23.x/docs/database/database-spans.md
+    public const string AttributeNetworkPeerAddress = "network.peer.address"; // replaces: "net.peer.ip" (AttributeNetPeerIp)
+    public const string AttributeNetworkPeerPort = "network.peer.port"; // replaces: "net.peer.port" (AttributeNetPeerPort)
+
+    // v1.24.0 Messaging spans
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/messaging-spans.md
+    public const string AttributeMessagingClientId = "messaging.client_id";
+    public const string AttributeMessagingDestinationName = "messaging.destination.name";
+
+    // v1.24.0 Messaging metrics
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/messaging-metrics.md
+    public const string MetricMessagingPublishDuration = "messaging.publish.duration";
+    public const string MetricMessagingPublishMessages = "messaging.publish.messages";
+    public const string MetricMessagingReceiveDuration = "messaging.receive.duration";
+    public const string MetricMessagingReceiveMessages = "messaging.receive.messages";
+
+    // v1.24.0 Messaging (Kafka)
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/kafka.md
+    public const string AttributeMessagingKafkaConsumerGroup = "messaging.kafka.consumer.group";
+    public const string AttributeMessagingKafkaDestinationPartition = "messaging.kafka.destination.partition";
+    public const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
+    public const string AttributeMessagingKafkaMessageOffset = "messaging.kafka.message.offset";
+
+    // v1.36.0 database conventions:
+    // https://github.com/open-telemetry/semantic-conventions/tree/v1.36.0/docs/database
+    public const string AttributeDbCollectionName = "db.collection.name";
+    public const string AttributeDbOperationName = "db.operation.name";
+    public const string AttributeDbSystemName = "db.system.name";
+    public const string AttributeDbNamespace = "db.namespace";
+    public const string AttributeDbResponseStatusCode = "db.response.status_code";
+    public const string AttributeDbOperationBatchSize = "db.operation.batch.size";
+    public const string AttributeDbQuerySummary = "db.query.summary";
+    public const string AttributeDbQueryText = "db.query.text";
+    public const string AttributeDbStoredProcedureName = "db.stored_procedure.name";
+
+    // v1.40.0 RPC spans
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.40.0/docs/rpc/rpc-spans.md
+    public const string AttributeRpcSystemName = "rpc.system.name";
+
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
@@ -18,13 +18,14 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
 {
     internal const string RedisDatabaseIndexKeyName = "db.redis.database_index";
 
+    internal const string ActivitySourceName = "OpenTelemetry.Instrumentation.StackExchangeRedis";
     internal static readonly Version SemanticConventionsVersion = new(1, 23, 0);
-    internal static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create<StackExchangeRedisConnectionInstrumentation>(SemanticConventionsVersion);
+    internal static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create(typeof(StackExchangeRedisConnectionInstrumentation), SemanticConventionsVersion, name: ActivitySourceName);
 
     internal static readonly Version SemanticConventionsVersionNew = new(1, 28, 0);
-    internal static readonly ActivitySource ActivitySourceNew = ActivitySourceFactory.Create<StackExchangeRedisConnectionInstrumentation>(SemanticConventionsVersionNew);
+    internal static readonly ActivitySource ActivitySourceNew = ActivitySourceFactory.Create(typeof(StackExchangeRedisConnectionInstrumentation), SemanticConventionsVersionNew, name: ActivitySourceName);
 
-    internal static readonly ActivitySource ActivitySourceBoth = ActivitySourceFactory.Create<StackExchangeRedisConnectionInstrumentation>(null);
+    internal static readonly ActivitySource ActivitySourceBoth = ActivitySourceFactory.Create(typeof(StackExchangeRedisConnectionInstrumentation), null, name: ActivitySourceName);
 
     internal static readonly string ActivityName = $"{ActivitySource.Name}.Execute";
 

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
@@ -17,15 +17,26 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis;
 internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
 {
     internal const string RedisDatabaseIndexKeyName = "db.redis.database_index";
-    internal const string RedisFlagsKeyName = "db.redis.flags";
-    internal const string ActivitySourceName = "OpenTelemetry.Instrumentation.StackExchangeRedis";
-    internal const string ActivityName = ActivitySourceName + ".Execute";
-    internal static readonly Version Version = new Version(1, 0, 0, 13);
-    internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
-    internal static readonly IEnumerable<KeyValuePair<string, object?>> CreationTags = new[]
-    {
-        new KeyValuePair<string, object?>(SemanticConventions.AttributeDbSystem, "redis"),
-    };
+
+    internal static readonly Version SemanticConventionsVersion = new(1, 23, 0);
+    internal static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create<StackExchangeRedisConnectionInstrumentation>(SemanticConventionsVersion);
+
+    internal static readonly Version SemanticConventionsVersionNew = new(1, 28, 0);
+    internal static readonly ActivitySource ActivitySourceNew = ActivitySourceFactory.Create<StackExchangeRedisConnectionInstrumentation>(SemanticConventionsVersionNew);
+
+    internal static readonly ActivitySource ActivitySourceBoth = ActivitySourceFactory.Create<StackExchangeRedisConnectionInstrumentation>(null);
+
+    internal static readonly string ActivityName = $"{ActivitySource.Name}.Execute";
+
+    internal static readonly IEnumerable<KeyValuePair<string, object?>> OldCreationTags =
+    [
+        new(SemanticConventions.AttributeDbSystem, "redis")
+    ];
+
+    internal static readonly IEnumerable<KeyValuePair<string, object?>> NewCreationTags =
+    [
+        new(SemanticConventions.AttributeDbSystemName, "redis")
+    ];
 
     internal readonly ConcurrentDictionary<(ActivityTraceId TraceId, ActivitySpanId SpanId), (Activity Activity, ProfilingSession Session)> Cache
         = new();
@@ -65,34 +76,31 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
     /// Returns session for the Redis calls recording.
     /// </summary>
     /// <returns>Session associated with the current span context to record Redis calls.</returns>
-    public Func<ProfilingSession?> GetProfilerSessionsFactory()
+    public Func<ProfilingSession?> GetProfilerSessionsFactory() => () =>
     {
-        return () =>
+        if (this.stopHandle.WaitOne(0))
         {
-            if (this.stopHandle.WaitOne(0))
-            {
-                return null;
-            }
+            return null;
+        }
 
-            var parent = Activity.Current;
+        var parent = Activity.Current;
 
-            // If no parent use the default session.
-            if (parent == null || parent.IdFormat != ActivityIdFormat.W3C)
-            {
-                return this.defaultSession;
-            }
+        // If no parent use the default session.
+        if (parent == null || parent.IdFormat != ActivityIdFormat.W3C)
+        {
+            return this.defaultSession;
+        }
 
-            // Try to reuse a session for all activities created under the same TraceId+SpanId.
-            var cacheKey = (parent.TraceId, parent.SpanId);
-            if (!this.Cache.TryGetValue(cacheKey, out var session))
-            {
-                session = (parent, new ProfilingSession());
-                this.Cache.TryAdd(cacheKey, session);
-            }
+        // Try to reuse a session for all activities created under the same TraceId+SpanId.
+        var cacheKey = (parent.TraceId, parent.SpanId);
+        if (!this.Cache.TryGetValue(cacheKey, out var session))
+        {
+            session = (parent, new ProfilingSession());
+            this.Cache.TryAdd(cacheKey, session);
+        }
 
-            return session.Session;
-        };
-    }
+        return session.Session;
+    };
 
     /// <inheritdoc/>
     public void Dispose()
@@ -112,15 +120,18 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
         foreach (var entry in this.Cache)
         {
             var parent = entry.Value.Activity;
-            if (parent.Duration == TimeSpan.Zero)
+            var parentCompleted = parent.Duration != TimeSpan.Zero;
+
+            if (this.options.EnableEarlyCommandDrain || parentCompleted)
             {
-                // Activity is still running, don't drain.
-                continue;
+                var session = entry.Value.Session;
+                RedisProfilerEntryToActivityConverter.DrainSession(parent, session.FinishProfiling(), this.options);
             }
 
-            ProfilingSession session = entry.Value.Session;
-            RedisProfilerEntryToActivityConverter.DrainSession(parent, session.FinishProfiling(), this.options);
-            this.Cache.TryRemove((entry.Key.TraceId, entry.Key.SpanId), out _);
+            if (parentCompleted)
+            {
+                this.Cache.TryRemove((entry.Key.TraceId, entry.Key.SpanId), out _);
+            }
         }
     }
 

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentation.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentation.cs
@@ -20,7 +20,7 @@ internal sealed class StackExchangeRedisInstrumentation : IDisposable
         this.options = options;
     }
 
-    internal List<StackExchangeRedisConnectionInstrumentation> InstrumentedConnections { get; } = new();
+    internal List<StackExchangeRedisConnectionInstrumentation> InstrumentedConnections { get; } = [];
 
     /// <summary>
     /// Adds an <see cref="IConnectionMultiplexer"/> to the instrumentation.

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Trace;
-using StackExchange.Redis.Profiling;
+using static OpenTelemetry.Internal.DatabaseSemanticConventionHelper;
 
 namespace OpenTelemetry.Instrumentation.StackExchangeRedis;
 
@@ -13,26 +14,75 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis;
 internal class StackExchangeRedisInstrumentationOptions
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="StackExchangeRedisInstrumentationOptions"/> class.
+    /// </summary>
+    public StackExchangeRedisInstrumentationOptions()
+        : this(new ConfigurationBuilder().AddEnvironmentVariables().Build())
+    {
+    }
+
+    internal StackExchangeRedisInstrumentationOptions(IConfiguration configuration)
+    {
+        var databaseSemanticConvention = GetSemanticConventionOptIn(configuration);
+        this.EmitOldAttributes = databaseSemanticConvention.HasFlag(DatabaseSemanticConvention.Old);
+        this.EmitNewAttributes = databaseSemanticConvention.HasFlag(DatabaseSemanticConvention.New);
+    }
+
+    /// <summary>
     /// Gets or sets the maximum time that should elapse between flushing the internal buffer of Redis profiling sessions and creating <see cref="Activity"/> objects. Default value: 00:00:10.
     /// </summary>
     public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
-    /// Gets or sets a value indicating whether or not the <see cref="StackExchangeRedisConnectionInstrumentation"/> should use reflection to get more detailed <see cref="SemanticConventions.AttributeDbStatement"/> tag values. Default value: False.
+    /// Gets or sets a value indicating whether the <see cref="StackExchangeRedisConnectionInstrumentation"/> should use reflection to get more detailed
+    /// <see cref="SemanticConventions.AttributeDbStatement"/> and <see cref="SemanticConventions.AttributeDbQueryText"/> tag values. Default value:
+    /// <see langword="false"/>.
     /// </summary>
     public bool SetVerboseDatabaseStatements { get; set; }
+
+    /// <summary>
+    /// Gets or sets a callback method allowing to filter out particular <see cref="RedisInstrumentationContext"/> instances.
+    /// </summary>
+    /// <remarks>
+    /// The filter callback receives the <see cref="RedisInstrumentationContext"/> for the
+    /// processed profiled command and returns a boolean indicating whether it should be filtered out.
+    /// <list type="bullet">
+    /// <item>If filter returns <see langword="true"/> the event is collected.</item>
+    /// <item>If filter returns <see langword="false"/> or throws an exception the event is filtered out (NOT collected).</item>
+    /// </list>
+    /// </remarks>
+    public Func<RedisInstrumentationContext, bool>? Filter { get; set; }
 
     /// <summary>
     /// Gets or sets an action to enrich an Activity.
     /// </summary>
     /// <remarks>
     /// <para><see cref="Activity"/>: the activity being enriched.</para>
-    /// <para><see cref="IProfiledCommand"/>: the profiled redis command from which additional information can be extracted to enrich the activity.</para>
+    /// <para><see cref="RedisInstrumentationContext"/>: the profiled redis command from which additional information can be extracted to enrich the activity.</para>
     /// </remarks>
-    public Action<Activity, IProfiledCommand>? Enrich { get; set; }
+    public Action<Activity, RedisInstrumentationContext>? Enrich { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether or not the <see cref="StackExchangeRedisConnectionInstrumentation"/> should enrich Activity with <see cref="ActivityEvent"/> entries about the Redis command processing/lifetime. Defaults to <see cref="bool">true</see>.
+    /// Gets or sets a value indicating whether the <see cref="StackExchangeRedisConnectionInstrumentation"/> should enrich Activity with <see cref="ActivityEvent"/> entries about the Redis command processing/lifetime. Defaults to <see langword="true"/>.
     /// </summary>
     public bool EnrichActivityWithTimingEvents { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the old database attributes should be emitted.
+    /// </summary>
+    internal bool EmitOldAttributes { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the new database attributes should be emitted.
+    /// </summary>
+    internal bool EmitNewAttributes { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether commands should be drained from profiling sessions prior to parent <see cref="Activity"/> completion.
+    /// Filter and Enrich callbacks have historically been passed completed parent <see cref="Activity"/> instances.
+    /// If both callbacks are null, commands may be drained prior to the parent <see cref="Activity"/> completion,
+    /// lowering memory pressure and improving performance.
+    /// If either callback is set, the old behavior is used to ensure the callbacks are passed completed parent <see cref="Activity"/> instances.
+    /// </summary>
+    internal bool EnableEarlyCommandDrain => this.Filter == null && this.Enrich == null;
 }

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/TracerProviderBuilderExtensions.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/TracerProviderBuilderExtensions.cs
@@ -26,7 +26,7 @@ internal static class TracerProviderBuilderExtensions
     /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
     public static TracerProviderBuilder AddRedisInstrumentation(
         this TracerProviderBuilder builder)
-        => AddRedisInstrumentation(builder, name: null, connection: null, configure: null);
+        => AddRedisInstrumentation(builder, name: null, connection: null, configure: null, serviceKey: null);
 
     /// <summary>
     /// Enables automatic data collection of outgoing requests to Redis.
@@ -40,7 +40,42 @@ internal static class TracerProviderBuilderExtensions
     {
         Guard.ThrowIfNull(connection);
 
-        return AddRedisInstrumentation(builder, name: null, connection, configure: null);
+        return AddRedisInstrumentation(builder, name: null, connection, configure: null, serviceKey: null);
+    }
+
+    /// <summary>
+    /// Enables automatic data collection of outgoing requests to Redis.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <param name="serviceKey">Optional service key used to retrieve the <see cref="IConnectionMultiplexer"/> to instrument from the <see cref="IServiceProvider" />.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddRedisInstrumentation(
+        this TracerProviderBuilder builder,
+        object serviceKey)
+    {
+        Guard.ThrowIfNull(serviceKey);
+
+        return AddRedisInstrumentation(builder, name: null, connection: null, serviceKey, configure: null);
+    }
+
+    /// <summary>
+    /// Enables automatic data collection of outgoing requests to Redis.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <param name="name">Optional name which is used when retrieving options.</param>
+    /// <param name="serviceKey">Optional service key used to retrieve the <see cref="IConnectionMultiplexer"/> to instrument from the <see cref="IServiceProvider" />.</param>
+    /// <param name="configure">Callback to configure options.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddRedisInstrumentation(
+        this TracerProviderBuilder builder,
+        string? name,
+        object serviceKey,
+        Action<StackExchangeRedisInstrumentationOptions> configure)
+    {
+        Guard.ThrowIfNull(serviceKey);
+        Guard.ThrowIfNull(configure);
+
+        return AddRedisInstrumentation(builder, name: name, connection: null, serviceKey, configure);
     }
 
     /// <summary>
@@ -59,7 +94,7 @@ internal static class TracerProviderBuilderExtensions
     {
         Guard.ThrowIfNull(configure);
 
-        return AddRedisInstrumentation(builder, name: null, connection: null, configure);
+        return AddRedisInstrumentation(builder, name: null, connection: null, serviceKey: null, configure);
     }
 
     /// <summary>
@@ -77,7 +112,7 @@ internal static class TracerProviderBuilderExtensions
         Guard.ThrowIfNull(connection);
         Guard.ThrowIfNull(configure);
 
-        return AddRedisInstrumentation(builder, name: null, connection, configure);
+        return AddRedisInstrumentation(builder, name: null, connection, serviceKey: null, configure);
     }
 
     /// <summary>
@@ -91,12 +126,14 @@ internal static class TracerProviderBuilderExtensions
     /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
     /// <param name="name">Optional name which is used when retrieving options.</param>
     /// <param name="connection">Optional <see cref="IConnectionMultiplexer"/> to instrument.</param>
+    /// <param name="serviceKey">Optional service key used to retrieve the <see cref="IConnectionMultiplexer"/> to instrument from the <see cref="IServiceProvider" />.</param>
     /// <param name="configure">Optional callback to configure options.</param>
     /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
     public static TracerProviderBuilder AddRedisInstrumentation(
         this TracerProviderBuilder builder,
         string? name,
         IConnectionMultiplexer? connection,
+        object? serviceKey,
         Action<StackExchangeRedisInstrumentationOptions>? configure)
     {
         Guard.ThrowIfNull(builder);
@@ -114,12 +151,14 @@ internal static class TracerProviderBuilderExtensions
         }
 
         return builder
-            .AddSource(StackExchangeRedisConnectionInstrumentation.ActivitySourceName)
+            .AddSource(StackExchangeRedisConnectionInstrumentation.ActivitySource.Name)
             .AddInstrumentation(sp =>
             {
                 var instrumentation = sp.GetRequiredService<StackExchangeRedisInstrumentation>();
 
-                connection ??= sp.GetService<IConnectionMultiplexer>();
+                connection ??= serviceKey == null
+                    ? sp.GetService<IConnectionMultiplexer>()
+                    : sp.GetKeyedService<IConnectionMultiplexer>(serviceKey);
 
                 if (connection != null)
                 {

--- a/src/Vendoring/README.md
+++ b/src/Vendoring/README.md
@@ -23,19 +23,20 @@ git checkout tags/Instrumentation.ConfluentKafka-0.1.0-alpha.2
 ```console
 git clone https://github.com/open-telemetry/opentelemetry-dotnet-contrib.git
 git fetch --tags
-git checkout tags/Instrumentation.StackExchangeRedis-1.0.0-rc9.13
+git checkout tags/Instrumentation.StackExchangeRedis-1.15.1-beta.2
 ```
 
 ### Instructions
 
 - Copy files from `src/OpenTelemetry.Instrumentation.StackExchangeRedis` to `src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis`:
-    - `**\*.cs` minus `AssemblyInfo.cs`
+    - `**\*.cs`
 - Copy files from `src/Shared` to `src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared`:
+    - `ActivitySourceFactory.cs`
+    - `AssemblyVersionExtensions.cs`
+    - `DatabaseSemanticConventionHelper.cs`
     - `Guard.cs`
-    - `PropertyFetcher.AOT.cs`
+    - `PropertyFetcher.cs`
     - `SemanticConventions.cs`
-- In `StackExchangeRedisConnectionInstrumentation.cs` update `ActivitySourceName` to `internal const string ActivitySourceName = "OpenTelemetry.Instrumentation.StackExchangeRedis";` and `Version` to `internal static readonly Version Version = new Version(1, 0, 0, 13);`
-- Apply the changes from https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1625 if necessary.
 
 ## Customizations
 

--- a/src/Vendoring/README.md
+++ b/src/Vendoring/README.md
@@ -29,7 +29,7 @@ git checkout tags/Instrumentation.StackExchangeRedis-1.15.1-beta.2
 ### Instructions
 
 - Copy files from `src/OpenTelemetry.Instrumentation.StackExchangeRedis` to `src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis`:
-    - `**\*.cs`
+    - `**\*.cs` minus `IsExternalInit.cs`
 - Copy files from `src/Shared` to `src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Shared`:
     - `ActivitySourceFactory.cs`
     - `AssemblyVersionExtensions.cs`
@@ -37,6 +37,7 @@ git checkout tags/Instrumentation.StackExchangeRedis-1.15.1-beta.2
     - `Guard.cs`
     - `PropertyFetcher.cs`
     - `SemanticConventions.cs`
+- In `StackExchangeRedisConnectionInstrumentation.cs` ensure that the activity source name is overridden to `OpenTelemetry.Instrumentation.StackExchangeRedis`.
 
 ## Customizations
 


### PR DESCRIPTION
## Description

Updated vendored code for OpenTelemetry.Instrumentation.StackExchangeRedis to [Instrumentation.StackExchangeRedis-1.15.1-beta.2](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/releases/tag/Instrumentation.StackExchangeRedis-1.15.1-beta.2) as I noticed it was quite old.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
