### PR TITLE
fix(foundry): retry transient partial/throttled catalog responses in update-ai-foundry-models

### DIFF
--- a/src/Aspire.Hosting.Foundry/tools/GenModel.cs
+++ b/src/Aspire.Hosting.Foundry/tools/GenModel.cs
@@ -1106,9 +1106,18 @@ public class ModelClient : IDisposable
 
     private static void AddPopulatedJsonField(List<string> partialFailureFields, string fieldName, object? value)
     {
-        if (value is JsonElement element && IsPopulatedJsonElement(element))
+        // System.Text.Json materializes any non-null JSON value for an `object?` property into a boxed
+        // JsonElement, so an empty "regionalErrors": [] / {} arrives here as a non-null JsonElement.
+        // Only flag the field as a partial-failure marker when the element actually has content; an
+        // empty collection means "no errors" and must NOT be flagged. Otherwise a clean 200 would be
+        // misread as partial and, now that partial responses are retried, would burn the entire retry
+        // budget before aborting.
+        if (value is JsonElement element)
         {
-            partialFailureFields.Add(fieldName);
+            if (IsPopulatedJsonElement(element))
+            {
+                partialFailureFields.Add(fieldName);
+            }
         }
         else if (value is not null)
         {

--- a/src/Aspire.Hosting.Foundry/tools/GenModel.cs
+++ b/src/Aspire.Hosting.Foundry/tools/GenModel.cs
@@ -915,6 +915,29 @@ public class ModelClient : IDisposable
             var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
+                // A 200 can still carry partial-failure data (regionalErrors / resourceSkipReasons /
+                // shardErrors / numberOfResourcesNotIncludedInSearch). In practice this shows up right
+                // after the catalog API throttles us: the observed sequence is HTTP 429 -> 200 with
+                // populated error/skip fields, i.e. a transient symptom of load/rate-limiting rather
+                // than a stable catalog state. Retry it within the same budget as 429/5xx instead of
+                // hard-aborting, so a single throttled page doesn't fail the whole run. Only once the
+                // retry budget is exhausted do we refuse, preserving the "never overwrite the generated
+                // descriptors with a partial catalog" guarantee. See
+                // https://github.com/microsoft/aspire/issues/18285.
+                var partialFailureFields = TryGetPartialFailureFields(content);
+                if (partialFailureFields is { Count: > 0 })
+                {
+                    if (attempt < MaxRequestAttempts)
+                    {
+                        var partialDelay = GetRetryDelay(response, content, attempt);
+                        Console.WriteLine($"Microsoft Foundry model catalog request returned a partial catalog (populated {string.Join(", ", partialFailureFields)}). Retrying in {partialDelay.TotalSeconds:N0}s (attempt {attempt + 1}/{MaxRequestAttempts}).");
+                        await Task.Delay(partialDelay).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    throw new InvalidOperationException($"The Microsoft Foundry model catalog response included partial failure data in {string.Join(", ", partialFailureFields)}. Refusing to overwrite the generated model descriptors with a partial catalog. Response: {GetResponseSnippet(content)}");
+                }
+
                 return content;
             }
 
@@ -1040,6 +1063,16 @@ public class ModelClient : IDisposable
 
     private static void ValidateSuccessfulCatalogResponse(ApiResponse apiResponse, string pageResponse)
     {
+        var partialFailureFields = GetPartialFailureFields(apiResponse);
+
+        if (partialFailureFields.Count > 0)
+        {
+            throw new InvalidOperationException($"The Microsoft Foundry model catalog response included partial failure data in {string.Join(", ", partialFailureFields)}. Refusing to overwrite the generated model descriptors with a partial catalog. Response: {GetResponseSnippet(pageResponse)}");
+        }
+    }
+
+    private static List<string> GetPartialFailureFields(ApiResponse apiResponse)
+    {
         var partialFailureFields = new List<string>();
 
         AddPopulatedJsonField(partialFailureFields, "regionalErrors", apiResponse.RegionalErrors);
@@ -1051,9 +1084,23 @@ public class ModelClient : IDisposable
             partialFailureFields.Add("numberOfResourcesNotIncludedInSearch");
         }
 
-        if (partialFailureFields.Count > 0)
+        return partialFailureFields;
+    }
+
+    // Inspect a 200 response body for partial-failure markers so the retry loop can treat a transient
+    // partial catalog as retryable. Returns null when the body can't be parsed as the catalog shape, so
+    // the caller falls back to its existing deserialize/validate path (which surfaces a clearer error)
+    // instead of silently retrying unparseable content.
+    private static List<string>? TryGetPartialFailureFields(string content)
+    {
+        try
         {
-            throw new InvalidOperationException($"The Microsoft Foundry model catalog response included partial failure data in {string.Join(", ", partialFailureFields)}. Refusing to overwrite the generated model descriptors with a partial catalog. Response: {GetResponseSnippet(pageResponse)}");
+            var apiResponse = JsonSerializer.Deserialize<ApiResponse>(content);
+            return apiResponse is null ? null : GetPartialFailureFields(apiResponse);
+        }
+        catch (JsonException)
+        {
+            return null;
         }
     }
 


### PR DESCRIPTION
The daily `update-ai-foundry-models` workflow has failed every run for several days and produced no PR. Latest failed run: https://github.com/microsoft/aspire/actions/runs/27670818555

## What broke

The Microsoft Foundry catalog request was throttled (HTTP 429), retried, and then got a 200 that *still* carried partial-failure data. The tool treated that partial 200 as a fatal hard-abort with no retry, killing the whole run (exit code 134):

```
Microsoft Foundry model catalog request failed with HTTP 429 (TooManyRequests). Retrying in ...s (attempt 2/6).
Microsoft Foundry model catalog request failed with HTTP 429 (TooManyRequests). Retrying in ...s (attempt 3/6).
...
System.InvalidOperationException: The Microsoft Foundry model catalog response included partial failure data in regionalErrors, resourceSkipReasons, shardErrors. Refusing to overwrite the generated model descriptors with a partial catalog. Response: ...
```

## Root cause

`ValidateSuccessfulCatalogResponse` in `src/Aspire.Hosting.Foundry/tools/GenModel.cs` was called *after* the HTTP retry loop and threw immediately on any partial-failure field. So the sequence `429 → 200-but-partial → hard abort` had no retry: a transient, throttling-induced partial page was treated as a terminal failure.

The 200 returned 142 entities but also populated `regionalErrors` / `resourceSkipReasons` / `shardErrors` — the expected shape of a partial/throttled response right after the rate-limiting it had just hit.

## The fix

Two parts, both in `GenModel.cs`:

1. **Retry transient partial responses.** Classify a partial-but-200 page as a *retryable* failure inside the existing page-fetch retry loop, reusing the same `MaxRequestAttempts` budget and backoff path (`GetRetryDelay`) already used for 429/5xx. Only once the retry budget is exhausted and the page is *still* partial does it throw the same `InvalidOperationException` as before. The validation is **not** relaxed — partial data is still never written. The "never overwrite the generated descriptors with a partial catalog" guarantee is preserved; transient partial responses just get a chance to recover first.

2. **Don't flag *empty* error collections as partial.** `AddPopulatedJsonField` decides whether `regionalErrors` / `resourceSkipReasons` / `shardErrors` mark the response partial. Because those are `object?` properties, System.Text.Json materializes an empty `"regionalErrors": []` (or `{}`) into a non-null boxed `JsonElement`, which fell through to the `else if (value is not null)` branch and was flagged as partial even though an empty collection means "no errors" — `IsPopulatedJsonElement` was effectively dead for the `JsonElement` case. Latent before, but it becomes user-visible once partial responses are retried: a clean 200 with an empty error collection would be misread as partial and burn the entire retry budget before aborting. The `JsonElement` case is now gated through `IsPopulatedJsonElement`.

## Verification

- `dotnet build src/Aspire.Hosting.Foundry/tools/GenModel.cs` — succeeds (file-based tool compiles).
- `dotnet build src/Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.csproj` — succeeds, 0 warnings.
- System.Text.Json probe over `AddPopulatedJsonField`: empty `[]` / `{}` / `null` → not flagged partial; a populated array (`[{...}]`) → still flagged partial.
- Logic walkthrough of the transient-partial retry path: partial + attempts remaining → delay + retry on the shared budget; partial + budget exhausted → existing `InvalidOperationException` with the same message.

## Surprises / call-outs

- End-to-end exercise of the workflow is CI-only: it hits the external, rate-limited catalog API, so it's intentionally not run locally. No unit-test harness exists for this single-file script tool, so verification is build + the STJ probe + logic walkthrough, per the repo's manual-verification expectations.
- The partial-response retry shares the existing `MaxRequestAttempts` budget with HTTP 429/5xx retries (by design — same transient class), so a page that alternates throttle/partial consumes one shared budget.
- A genuinely *persistent* partial catalog (e.g. a registry down on every attempt) now takes longer to fail — it exhausts the retry budget before throwing — but the terminal outcome is unchanged: it refuses and never overwrites the descriptors.
- The page body is deserialized twice on the success path (once to check for partial fields, once in `GetAllModelsAsync`); negligible for a once-daily tool.

Refs #18285