### PR TITLE
ci: Reduce max wall clock time for internal build

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -228,6 +228,37 @@ extends:
           packageVSCodeExtensionAsPreRelease: ${{ parameters.packageVSCodeExtensionAsPreRelease }}
 
     # ----------------------------------------------------------------
+    # Source indexing for https://source.dot.net. This is self-contained:
+    # the SourceIndexStage1 job runs its OWN full repo build to produce a
+    # binlog and then uploads the resulting index. It consumes nothing from
+    # the other stages and nothing depends on it (dependsOn: []), so it runs
+    # fully in parallel and never gates the publish path — previously it was
+    # an extra job inside the `build` stage, which put its redundant rebuild
+    # on the critical path to `assemble`/publish.
+    # main-only: the whole stage compiles out on PR/non-main builds, matching
+    # the prior `enableSourceIndex` gating. The Azure upload step is already
+    # guarded to internal, non-PR builds inside source-index-stage1-publish.yml.
+    # ----------------------------------------------------------------
+    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+      - stage: source_index
+        displayName: Source Index
+        dependsOn: []
+        jobs:
+        - template: /eng/common/templates-official/jobs/jobs.yml@self
+          parameters:
+            enableMicrobuild: false
+            enablePublishUsingPipelines: false
+            enablePublishBuildAssets: false
+            publishAssetsImmediately: false
+            enableTelemetry: true
+            enablePublishBuildArtifacts: false
+            enablePublishTestResults: false
+            enableSourceIndex: true
+            workspace:
+              clean: all
+            jobs: []
+
+    # ----------------------------------------------------------------
     # This stage performs the managed build, sign, pack, and template
     # tests. It runs IN PARALLEL with build_sign_native and
     # build_extension — the managed compile/sign/pack does not consume
@@ -249,7 +280,10 @@ extends:
           enablePublishBuildAssets: false
           publishAssetsImmediately: false
           enableTelemetry: true
-          enableSourceIndex: ${{ eq(variables['Build.SourceBranch'], 'refs/heads/main') }}
+          # Source indexing is intentionally NOT enabled here. It runs in its own
+          # `source_index` stage (dependsOn: []) so its full repo rebuild stays off
+          # the critical path and never gates the downstream publish.
+          enableSourceIndex: false
           # Publish build logs
           enablePublishBuildArtifacts: true
           # Test results publishing is owned by the template_tests stage —


### PR DESCRIPTION
## What

Moves the `SourceIndexStage1` work out of the `build` stage and into a new
isolated `source_index` stage (`dependsOn: []`) in the internal official
build (`eng/pipelines/azure-pipelines.yml`).

## Why

`SourceIndexStage1` job can some times take longer to run, or even time out with a long CodeQL step, and that currently would block publishing. Spinning that off into a separate stage means that it won't block or delay publishing.

`enableSourceIndex` injected `SourceIndexStage1` as an extra **job inside the
`build` stage**. A stage only completes when all its jobs complete, and both
downstream stages depend on `build`:

- `assemble` (publish) → `dependsOn: [build_sign_native, build, build_extension]`
- `template_tests` → `dependsOn: [build]`

`SourceIndexStage1` does its **own full repo build** (`eng/common/build.ps1
-restore -build -binarylog -ci`) purely to produce a binlog it then uploads —
it consumes nothing from the `build` stage. So that redundant second build sat
on the critical path and delayed publish, despite nothing depending on its
output.

## The change

Source indexing now runs in its own stage that:

- has `dependsOn: []` and is referenced by nothing, so it runs fully in
  parallel and never gates `build` / `assemble` / `template_tests` / installers;
- emits only the `SourceIndexStage1` job (`jobs.yml` with `jobs: []` +
  `enableSourceIndex: true`);
- is wrapped in `${{ if eq(Build.SourceBranch, 'refs/heads/main') }}`, so it
  compiles out on PR/non-main builds — exactly the gating the old inline
  `enableSourceIndex: ${{ eq(... 'refs/heads/main') }}` provided.

Index frequency is unchanged: it still rebuilds the index on every `main`
build, just off the critical path.

> [!NOTE]
> This is the internal AzDO official build, which does not run on public PRs.
> The new stage's pool resolution and run want a manual internal pipeline run
> to confirm before merge.
