### PR TITLE
Fix ASPIREEXPORT001 false positive on C# 14 extension blocks

### DIFF
--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using Aspire.Hosting.Analyzers.Infrastructure;
 using Microsoft.CodeAnalysis;
@@ -172,6 +173,9 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
         // Warn when exported builder methods invoke synchronous callback delegates inline. Deferred callbacks
         // that are stored for later execution are fine, and exports that opt into background-thread dispatch
         // are handled safely by the runtime.
+        // NOTE: This check only covers classic static `this`-parameter extension methods. C# 14 extension
+        // block instance members (method.IsExtensionMethod == false) are not analyzed here yet; missing the
+        // warning is non-blocking and never produces a false positive.
         var inlineDelegateInvocationCache = new ConcurrentDictionary<ISymbol, ImmutableHashSet<int>>(SymbolEqualityComparer.Default);
         context.RegisterOperationBlockStartAction(c =>
         {
@@ -273,8 +277,11 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
         var containingTypeExportAttribute = GetContainingTypeAspireExportAttribute(method.ContainingType, aspireExportAttribute);
 
-        // Rule 1: Method must be static
-        if (!method.IsStatic && containingTypeExportAttribute is null)
+        // Rule 1: Method must be static.
+        // C# 14 extension block members (declared inside `extension(receiver) { ... }`) are surfaced
+        // by Roslyn as non-static instance members even though the compiler lowers them to static
+        // extension methods in IL. They are valid [AspireExport] targets, so they must not trip this rule.
+        if (!method.IsStatic && !IsExtensionBlockMember(method) && containingTypeExportAttribute is null)
         {
             context.ReportDiagnostic(Diagnostic.Create(
                 Diagnostics.s_exportMethodMustBeStatic,
@@ -299,9 +306,17 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
         var normalizedExportId = isExportIdFormatValid ? exportId : null;
         var effectiveExportId = normalizedExportId ?? derivedExportId;
 
+        // Build the effective parameter list used by the receiver/target-type rules below. For classic
+        // `this`-parameter extension methods (and ordinary methods) this is method.Parameters. For C# 14
+        // extension block instance members the receiver lives on the extension container rather than in
+        // Parameters, so GetEffectiveExportParameters prepends it to produce the same [receiver, ...args]
+        // shape, letting the rules treat both extension syntaxes identically.
+        var effectiveParameters = GetEffectiveExportParameters(method);
+
         // Track the runtime capability ID for static exports. Instance exports are tracked from
         // their containing type so ExposeMethods/ExposeProperties semantics match the scanner.
-        if (method.IsStatic && effectiveExportId is not null)
+        // Extension block instance members are static-equivalent exports, so they are tracked here too.
+        if (IsStaticForExport(method) && effectiveExportId is not null)
         {
             AddCapabilityExport(
                 capabilityIds,
@@ -327,7 +342,7 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
         // so only the actionable ASPIREEXPORT009 should appear.
         if (isExportIdFormatValid &&
             string.Equals(exportId, derivedExportId, StringComparison.Ordinal) &&
-            !HasConcreteResourceBuilderTargetParameter(method, wellKnownTypes))
+            !HasConcreteResourceBuilderTargetParameter(method, effectiveParameters, wellKnownTypes))
         {
             context.ReportDiagnostic(Diagnostic.Create(
                 Diagnostics.s_redundantExportId,
@@ -367,9 +382,9 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
         }
 
         // Rule 6 (ASPIREEXPORT007): Track export for duplicate detection
-        if (effectiveExportId is not null && method.IsExtensionMethod && method.Parameters.Length > 0)
+        if (effectiveExportId is not null && IsExtensionLike(method) && effectiveParameters.Length > 0)
         {
-            var targetType = method.Parameters[0].Type;
+            var targetType = effectiveParameters[0].Type;
             var targetTypeName = targetType.ToDisplayString();
             var key = (effectiveExportId, targetTypeName);
             var bag = exportsByKey.GetOrAdd(key, _ => new ConcurrentBag<(IMethodSymbol, Location)>());
@@ -377,9 +392,9 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
         }
 
         // Rule 7 (ASPIREEXPORT009): Warn when export name may collide across integrations
-        if (effectiveExportId is not null && method.IsExtensionMethod && method.Parameters.Length > 0)
+        if (effectiveExportId is not null && IsExtensionLike(method) && effectiveParameters.Length > 0)
         {
-            AnalyzeExportNameUniqueness(context, method, effectiveExportId, wellKnownTypes, location);
+            AnalyzeExportNameUniqueness(context, method, effectiveParameters, effectiveExportId, wellKnownTypes, location);
         }
 
         // Rule 8 (ASPIREEXPORT012): Check that callback parameter types (Action<T>/Func<T>) have [AspireExport]
@@ -681,21 +696,21 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
     /// <c>IResourceBuilder&lt;ConcreteType&gt;</c> parameter), independently of what the export ID is.
     /// Used to suppress ASPIREEXPORT011 when ASPIREEXPORT009 would fire for the same method.
     /// </summary>
-    private static bool HasConcreteResourceBuilderTargetParameter(IMethodSymbol method, WellKnownTypes wellKnownTypes)
+    private static bool HasConcreteResourceBuilderTargetParameter(IMethodSymbol method, ImmutableArray<IParameterSymbol> effectiveParameters, WellKnownTypes wellKnownTypes)
     {
-        if (!method.IsExtensionMethod || method.Parameters.Length < 2)
+        if (!IsExtensionLike(method) || effectiveParameters.Length < 2)
         {
             return false;
         }
 
-        if (!IsOpenGenericResourceBuilder(method.Parameters[0].Type, wellKnownTypes))
+        if (!IsOpenGenericResourceBuilder(effectiveParameters[0].Type, wellKnownTypes))
         {
             return false;
         }
 
-        for (var i = 1; i < method.Parameters.Length; i++)
+        for (var i = 1; i < effectiveParameters.Length; i++)
         {
-            if (GetConcreteResourceBuilderTypeName(method.Parameters[i].Type, wellKnownTypes) is not null)
+            if (GetConcreteResourceBuilderTypeName(effectiveParameters[i].Type, wellKnownTypes) is not null)
             {
                 return true;
             }
@@ -707,13 +722,14 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeExportNameUniqueness(
         SymbolAnalysisContext context,
         IMethodSymbol method,
+        ImmutableArray<IParameterSymbol> effectiveParameters,
         string exportId,
         WellKnownTypes wellKnownTypes,
         Location location)
     {
         // Only applies to extension methods where the first param is IResourceBuilder<T>
         // with T being an open generic type parameter (constrained to IResource)
-        var firstParamType = method.Parameters[0].Type;
+        var firstParamType = effectiveParameters[0].Type;
         if (!IsOpenGenericResourceBuilder(firstParamType, wellKnownTypes))
         {
             return;
@@ -722,9 +738,9 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
         // Look for a parameter (beyond the first) that is IResourceBuilder<ConcreteType>
         // where ConcreteType is a specific resource type (not a type parameter)
         string? concreteTargetTypeName = null;
-        for (var i = 1; i < method.Parameters.Length; i++)
+        for (var i = 1; i < effectiveParameters.Length; i++)
         {
-            concreteTargetTypeName = GetConcreteResourceBuilderTypeName(method.Parameters[i].Type, wellKnownTypes);
+            concreteTargetTypeName = GetConcreteResourceBuilderTypeName(effectiveParameters[i].Type, wellKnownTypes);
             if (concreteTargetTypeName is not null)
             {
                 break;
@@ -1276,12 +1292,13 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
     private static string GetGeneratedTargetTypeName(IMethodSymbol method)
     {
-        if (!method.IsExtensionMethod || method.Parameters.Length == 0)
+        var effectiveParameters = GetEffectiveExportParameters(method);
+        if (!IsExtensionLike(method) || effectiveParameters.Length == 0)
         {
             return "<global>";
         }
 
-        var targetType = method.Parameters[0].Type;
+        var targetType = effectiveParameters[0].Type;
         var targetTypeName = targetType.ToDisplayString();
         if (targetType is not INamedTypeSymbol { IsGenericType: true } namedTargetType)
         {
@@ -1837,6 +1854,118 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
         return type.ContainingNamespace.IsGlobalNamespace
             ? assemblyName
             : type.ContainingNamespace.ToDisplayString();
+    }
+
+    // C# 14 introduced "extension blocks" (extension members). A method declared inside an
+    // `extension(receiver) { ... }` block is surfaced by Roslyn as a non-static instance member whose
+    // ContainingType has IsExtension == true and exposes the receiver via ExtensionParameter. These
+    // members are semantically equivalent to classic static `this`-parameter extension methods (the
+    // compiler lowers them to exactly that in IL), so [AspireExport] is valid on them and
+    // ASPIREEXPORT001 ("must be static") must not fire.
+    //
+    // This analyzer compiles against Roslyn 4.8, which predates extension blocks, so
+    // INamedTypeSymbol.IsExtension / INamedTypeSymbol.ExtensionParameter are not available at compile
+    // time. They DO exist at runtime when the analyzer is loaded into a newer Roslyn host
+    // (.NET 10 SDK / VS 17.14+) that is able to compile this syntax in the first place. We therefore
+    // probe for them via reflection and treat their absence as "not an extension" (older hosts can
+    // never produce extension-block members).
+    // See: https://learn.microsoft.com/dotnet/csharp/whats-new/csharp-14#extension-members
+    //
+    // The cached members are MethodInfo getters (not delegates closing over INamedTypeSymbol) so the
+    // analyzer does not store per-compilation symbol data in its fields (RS1008).
+    private static readonly MethodInfo? s_isExtensionGetter = typeof(INamedTypeSymbol).GetProperty("IsExtension")?.GetGetMethod();
+    private static readonly MethodInfo? s_extensionParameterGetter = typeof(INamedTypeSymbol).GetProperty("ExtensionParameter")?.GetGetMethod();
+
+    private static bool IsExtensionContainer(INamedTypeSymbol type)
+    {
+        if (s_isExtensionGetter is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return s_isExtensionGetter.Invoke(type, null) is true;
+        }
+        catch (TargetInvocationException)
+        {
+            return false;
+        }
+    }
+
+    private static IParameterSymbol? GetExtensionParameter(INamedTypeSymbol type)
+    {
+        if (s_extensionParameterGetter is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return s_extensionParameterGetter.Invoke(type, null) as IParameterSymbol;
+        }
+        catch (TargetInvocationException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns true when the method is an instance member declared inside a C# 14 extension block
+    /// (e.g. <c>extension(IResourceBuilder&lt;T&gt; builder) { public ... Method(...) { } }</c>).
+    /// Such members are equivalent to classic static extension methods and are valid AspireExport targets.
+    /// </summary>
+    private static bool IsExtensionBlockMember(IMethodSymbol method)
+    {
+        return !method.IsStatic &&
+            method.ContainingType is { } containingType &&
+            IsExtensionContainer(containingType) &&
+            GetExtensionParameter(containingType) is not null;
+    }
+
+    /// <summary>
+    /// True when the method participates in ATS as an extension-style export: either a classic static
+    /// <c>this</c>-parameter extension method, or a C# 14 extension block instance member.
+    /// </summary>
+    private static bool IsExtensionLike(IMethodSymbol method)
+    {
+        return method.IsExtensionMethod || IsExtensionBlockMember(method);
+    }
+
+    /// <summary>
+    /// True when the method is treated as a static export for capability/generated-name tracking.
+    /// Extension block instance members are static-equivalent (lowered to static extension methods in IL).
+    /// </summary>
+    private static bool IsStaticForExport(IMethodSymbol method)
+    {
+        return method.IsStatic || IsExtensionBlockMember(method);
+    }
+
+    /// <summary>
+    /// Returns the parameter list used by the receiver/target-type export rules. For classic extension
+    /// methods and ordinary methods this is <see cref="IMethodSymbol.Parameters"/> (the receiver, if any,
+    /// is the first parameter). For C# 14 extension block instance members the receiver lives on the
+    /// extension container rather than in <c>Parameters</c>, so it is prepended to produce the same
+    /// <c>[receiver, ...declaredParameters]</c> shape as a classic extension method.
+    /// </summary>
+    private static ImmutableArray<IParameterSymbol> GetEffectiveExportParameters(IMethodSymbol method)
+    {
+        if (GetExtensionBlockReceiver(method) is { } receiver)
+        {
+            return method.Parameters.Insert(0, receiver);
+        }
+
+        return method.Parameters;
+    }
+
+    private static IParameterSymbol? GetExtensionBlockReceiver(IMethodSymbol method)
+    {
+        if (method.IsStatic || method.ContainingType is not { } containingType || !IsExtensionContainer(containingType))
+        {
+            return null;
+        }
+
+        return GetExtensionParameter(containingType);
     }
 
     private static string GetMethodDisplayString(IMethodSymbol method)

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
@@ -661,7 +661,12 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
         INamedTypeSymbol aspireExportAttribute,
         HashSet<ITypeSymbol> currentAssemblyExportedTypes)
     {
-        // Only check public static extension methods
+        // Only check public static extension methods.
+        // C# 14 extension block instance members are intentionally not covered here yet: they surface as
+        // non-static (IsStatic == false) and IsExtensionMethod == false, so the guard below skips them.
+        // ASPIREEXPORT008 only nudges authors to add a missing [AspireExport], so the gap is non-blocking
+        // (it can cause a missing suggestion, never a false positive). This parallels the ASPIREEXPORT010
+        // limitation; expand coverage here only if extension-block authors need the same nudge.
         if (!method.IsStatic || !method.IsExtensionMethod || method.DeclaredAccessibility != Accessibility.Public)
         {
             return;

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -146,6 +146,88 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
+    public async Task ExtensionBlockMember_NoDiagnostics()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/17604:
+        // a C# 14 extension block instance member must not be flagged as non-static (ASPIREEXPORT001).
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public static class TestExports
+            {
+                extension<T>(IResourceBuilder<T> builder) where T : IResourceWithEnvironment
+                {
+                    [AspireExport]
+                    public IResourceBuilder<T> WithLikeC4Reference(string value) => builder;
+                }
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task StaticMemberInExtensionBlock_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public static class TestExports
+            {
+                extension<T>(IResourceBuilder<T> builder) where T : IResourceWithEnvironment
+                {
+                    [AspireExport]
+                    public static string Describe() => "test";
+                }
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task DuplicateExportIdAcrossExtensionBlockMembers_ReportsASPIREEXPORT007()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicateExportId;
+        var capabilityDiagnostic = AspireExportAnalyzer.Diagnostics.s_duplicatePolyglotCapabilityId;
+
+        // Two extension block members targeting the same receiver type with the same export id must still
+        // be detected as duplicates, proving the receiver is normalized from the extension container.
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public static class TestExports
+            {
+                extension<T>(IResourceBuilder<T> builder) where T : IResource
+                {
+                    [AspireExport]
+                    public void AddThing(string name) { }
+
+                    [AspireExport("addThing")]
+                    public void AddThingWithPort(string name, int port) { }
+                }
+            }
+            """,
+            [
+                new DiagnosticResult(diagnostic).WithLocation(10, 10).WithArguments("addThing", "Aspire.Hosting.ApplicationModel.IResourceBuilder<T>"),
+                CompilerWarning(capabilityDiagnostic.Id).WithLocation(10, 10),
+                new DiagnosticResult(diagnostic).WithLocation(13, 10).WithArguments("addThing", "Aspire.Hosting.ApplicationModel.IResourceBuilder<T>"),
+                CompilerWarning(capabilityDiagnostic.Id).WithLocation(13, 10)
+            ]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
     public async Task InvalidIdFormat_WithSlash_ReportsASPIREEXPORT002()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_invalidExportIdFormat;

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -228,6 +228,70 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
+    public async Task ExportNameMatchesMethodName_WithConcreteTarget_ExtensionBlockMember_ReportsASPIREEXPORT009()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_exportNameShouldBeUnique;
+
+        // An extension block member must surface the same name-uniqueness guidance as a classic static
+        // extension method: the receiver normalized from the extension container is the open generic
+        // IResourceBuilder<T>, and a concrete IResourceBuilder<MyResource> target makes the convention id
+        // ambiguous across resource types.
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+            using System.Collections.Generic;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public class MyResource : IResource
+            {
+                public string Name => "test";
+                public ResourceAnnotationCollection Annotations { get; } = new();
+            }
+
+            public static class TestExports
+            {
+                extension<T>(IResourceBuilder<T> builder) where T : IResource
+                {
+                    [AspireExport("withRoleAssignments")]
+                    public IResourceBuilder<T> WithRoleAssignments(IResourceBuilder<MyResource> target, params string[] roles) => builder;
+                }
+            }
+            """,
+            [new DiagnosticResult(diagnostic).WithLocation(17, 10).WithArguments("withRoleAssignments", "WithRoleAssignments", "MyResource", "withMyRoleAssignments")]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task RedundantExportId_MatchesConvention_ExtensionBlockMember_ReportsASPIREEXPORT011()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_redundantExportId;
+
+        // An extension block member is treated like a classic extension method, so its convention-derived
+        // id is the camelCased method name with no type prefix. An explicit id matching that convention is
+        // redundant and must report ASPIREEXPORT011, just as it does for a static extension method.
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public static class TestExports
+            {
+                extension<T>(IResourceBuilder<T> builder) where T : IResource
+                {
+                    [AspireExport("addRedis")]
+                    public string AddRedis() => "test";
+                }
+            }
+            """,
+            [new DiagnosticResult(diagnostic).WithLocation(10, 10).WithArguments("addRedis", "AddRedis")]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
     public async Task InvalidIdFormat_WithSlash_ReportsASPIREEXPORT002()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_invalidExportIdFormat;


### PR DESCRIPTION
## Description

The `ASPIREEXPORT001` analyzer ("AspireExport method must be static") produced a false positive on C# 14 extension block members. A method like `WithLikeC4Reference` declared inside `extension<T>(IResourceBuilder<T> builder) { ... }` was flagged as non-static, even though the compiler lowers extension block instance members to static extension methods in IL, making them valid `[AspireExport]` targets. The runtime ATS scanner already handled these correctly via reflection; only the compile-time analyzer was wrong.

This change treats extension block instance members as static-extension-method equivalents:

- **ASPIREEXPORT001** no longer fires for extension block members (`!IsExtensionBlockMember(method)`).
- A normalized "effective parameter" view prepends the extension container's receiver to the method's declared parameters, producing the same `[receiver, ...args]` shape as a classic `this`-parameter extension method. This view is threaded through the receiver/target-type rules so they behave identically for both extension syntaxes: **007** (duplicate id), **009** (name uniqueness), **011** (redundant id), and **013/014** (capability/generated-name tracking).

The one thing worth a careful look: the analyzer compiles against Roslyn 4.8, which predates extension blocks, so `INamedTypeSymbol.IsExtension` / `ExtensionParameter` and `TypeKind.Extension` are not available at compile time. They do exist at runtime when the analyzer is loaded into a newer Roslyn host that can compile this syntax in the first place, so they are probed via cached `MethodInfo` reflection and treated as "not an extension" when absent (older hosts can never produce extension-block members). The getters are stored as `MethodInfo` rather than `Func<INamedTypeSymbol, ...>` to avoid RS1008 (no symbol-typed analyzer fields).

Known limitation (documented in code): the ASPIREEXPORT010 inline-delegate-invocation warning still only covers classic static extension methods. Missing that warning on an extension block member is non-blocking and never produces a false positive.

No public API change and no ATS export-coverage change, so `tests/polyglotapphosts` apps are unaffected.

Fixes: #17604

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No