### PR TITLE
Resolve symlinks when matching AppHost socket for --apphost (#17618)

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -8,9 +8,9 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
-using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
+
 namespace Aspire.Cli.Backchannel;
 
 /// <summary>
@@ -135,18 +135,8 @@ internal sealed class AppHostConnectionResolver(
                 };
             }
 
-            // Resolve symlinks before computing the backchannel socket key so the lookup
-            // matches the path the running AppHost used. A running AppHost keys its socket
-            // off Path.GetFullPath(appHostPath) evaluated against its own process working
-            // directory, which the OS already reports in physical (symlink-resolved) form
-            // (getcwd canonicalizes, e.g. /tmp -> /private/tmp on macOS). The producer side
-            // therefore hashes the canonical path, so the consumer must resolve symlinks too.
-            // ResolveToFilesystemPath only fixes Windows casing and is a no-op on Linux/macOS,
-            // so it cannot bridge the /tmp -> /private/tmp gap; ResolveSymlinks does.
-            // See https://github.com/microsoft/aspire/issues/17618.
-            var socketLookupPath = PathNormalizer.ResolveSymlinks(projectFile.FullName);
             var matchingSockets = AppHostHelper.FindMatchingNonOrphanedSockets(
-                socketLookupPath,
+                projectFile.FullName,
                 executionContext.HomeDirectory.FullName,
                 Environment.ProcessId,
                 logger);

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -135,12 +135,18 @@ internal sealed class AppHostConnectionResolver(
                 };
             }
 
-            // Canonicalize the path to handle symlinks (e.g., /tmp -> /private/tmp on macOS).
-            // This ensures the socket lookup uses the same path as the running AppHost,
-            // which canonicalizes paths when computing backchannel socket keys.
-            var targetPath = PathNormalizer.ResolveToFilesystemPath(projectFile.FullName);
+            // Resolve symlinks before computing the backchannel socket key so the lookup
+            // matches the path the running AppHost used. A running AppHost keys its socket
+            // off Path.GetFullPath(appHostPath) evaluated against its own process working
+            // directory, which the OS already reports in physical (symlink-resolved) form
+            // (getcwd canonicalizes, e.g. /tmp -> /private/tmp on macOS). The producer side
+            // therefore hashes the canonical path, so the consumer must resolve symlinks too.
+            // ResolveToFilesystemPath only fixes Windows casing and is a no-op on Linux/macOS,
+            // so it cannot bridge the /tmp -> /private/tmp gap; ResolveSymlinks does.
+            // See https://github.com/microsoft/aspire/issues/17618.
+            var socketLookupPath = PathNormalizer.ResolveSymlinks(projectFile.FullName);
             var matchingSockets = AppHostHelper.FindMatchingNonOrphanedSockets(
-                targetPath,
+                socketLookupPath,
                 executionContext.HomeDirectory.FullName,
                 Environment.ProcessId,
                 logger);
@@ -165,7 +171,9 @@ internal sealed class AppHostConnectionResolver(
                 }
             }
 
-            var displayPath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, targetPath);
+            // Display the path the user supplied (not the symlink-resolved lookup path) so the
+            // error message stays relative to the working directory and matches what they typed.
+            var displayPath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, projectFile.FullName);
 
             return new AppHostConnectionResult
             {

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -8,9 +8,9 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
-
 namespace Aspire.Cli.Backchannel;
 
 /// <summary>
@@ -135,7 +135,10 @@ internal sealed class AppHostConnectionResolver(
                 };
             }
 
-            var targetPath = projectFile.FullName;
+            // Canonicalize the path to handle symlinks (e.g., /tmp -> /private/tmp on macOS).
+            // This ensures the socket lookup uses the same path as the running AppHost,
+            // which canonicalizes paths when computing backchannel socket keys.
+            var targetPath = PathNormalizer.ResolveToFilesystemPath(projectFile.FullName);
             var matchingSockets = AppHostHelper.FindMatchingNonOrphanedSockets(
                 targetPath,
                 executionContext.HomeDirectory.FullName,

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Hosting.Backchannel;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging;
 using Semver;
 
@@ -139,7 +140,10 @@ internal static class AppHostHelper
         int currentPid,
         ILogger logger)
     {
-        var matchingSockets = BackchannelConstants.FindMatchingSockets(appHostPath, homeDirectory);
+        // Resolve symlinks so callers that provide "/tmp/..." can still match sockets keyed
+        // off the physical path (for example "/private/tmp/..." on macOS).
+        var resolvedPath = PathNormalizer.ResolveSymlinks(appHostPath);
+        var matchingSockets = BackchannelConstants.FindMatchingSockets(resolvedPath, homeDirectory);
         var remainingSockets = PruneOrphanedSockets(matchingSockets, currentPid, out var deletedCount);
         if (deletedCount > 0)
         {

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Backchannel;
@@ -59,7 +60,12 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
         var projectFile = CreateProjectFile(workspace.WorkspaceRoot, "TestAppHost", "TestAppHost.csproj");
-        var socketPath = CreateMatchingSocketFile(projectFile.FullName, workspace.WorkspaceRoot, int.MaxValue - 1);
+        // Key the socket off the symlink-resolved path, matching how a running AppHost computes
+        // its socket id (its working directory is reported physically by the OS). On macOS the
+        // temp workspace lives under /var -> /private/var, so the unresolved and resolved paths
+        // differ and the resolver must resolve symlinks to find this socket.
+        var resolvedProjectPath = PathNormalizer.ResolveSymlinks(projectFile.FullName);
+        var socketPath = CreateMatchingSocketFile(resolvedProjectPath, workspace.WorkspaceRoot, int.MaxValue - 1);
         var resolver = new AppHostConnectionResolver(
             new TestAuxiliaryBackchannelMonitor(),
             new TestInteractionService(),
@@ -217,6 +223,59 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
         Assert.True(result.IsProjectResolutionError);
         Assert.Equal(SharedCommandStrings.MultipleAppHostsNonInteractive, result.ErrorMessage);
         Assert.Equal(CliExitCodes.FailedToFindProject, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task ResolveConnectionAsync_WithSymlinkedProjectPath_ResolvesToCanonicalSocketKey()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/17618.
+        // A running AppHost keys its backchannel socket off the symlink-resolved path
+        // (its process working directory is already physical, e.g. /tmp -> /private/tmp
+        // on macOS). The explicit --apphost lookup must resolve symlinks the same way or
+        // it computes a different appHostId and reports "no running AppHost" even though
+        // one is running. We assert the orphaned socket keyed off the canonical path is
+        // found (and pruned) when the resolver is handed a symlinked project path.
+        Assert.SkipUnless(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
+            "Symlink resolution test only runs on Linux/macOS where unprivileged symlink creation is reliable.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+
+        // Real project file under a "real" directory.
+        var realDirectory = workspace.WorkspaceRoot.CreateSubdirectory("real");
+        var realProjectFile = new FileInfo(Path.Combine(realDirectory.FullName, "TestAppHost.csproj"));
+        File.WriteAllText(realProjectFile.FullName, "<Project />");
+
+        // Symlink "link" -> "real"; the project is addressed through the symlink.
+        var symlinkDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "link");
+        Directory.CreateSymbolicLink(symlinkDirectory, realDirectory.FullName);
+        var projectFileViaSymlink = new FileInfo(Path.Combine(symlinkDirectory, "TestAppHost.csproj"));
+
+        // The producer keys its socket off the canonical (symlink-resolved) path, so create
+        // the orphaned socket using that same canonical path with a dead PID.
+        var canonicalPath = PathNormalizer.ResolveSymlinks(projectFileViaSymlink.FullName);
+        var socketPath = CreateMatchingSocketFile(canonicalPath, workspace.WorkspaceRoot, int.MaxValue - 1);
+
+        var resolver = new AppHostConnectionResolver(
+            new TestAuxiliaryBackchannelMonitor(),
+            new TestInteractionService(),
+            new TestProjectLocator(),
+            executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
+            NullLogger.Instance);
+
+        var result = await resolver.ResolveConnectionAsync(
+            projectFileViaSymlink,
+            "Scanning",
+            "Select",
+            SharedCommandStrings.AppHostNotRunning,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        // The socket was located via the symlink-resolved key and pruned because its PID is dead.
+        // Before the fix the resolver hashed the unresolved symlink path, never matched this
+        // socket, and left it on disk.
+        Assert.False(File.Exists(socketPath));
     }
 
     private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)

--- a/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
@@ -15,6 +15,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Telemetry;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Hosting;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -780,7 +781,8 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
             var backchannelsDir = Path.Combine(_homeDirectory.FullName, ".aspire", "cli", "bch");
             Directory.CreateDirectory(backchannelsDir);
 
-            var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(AppHostFile.FullName, _homeDirectory.FullName);
+            var resolvedAppHostPath = PathNormalizer.ResolveSymlinks(AppHostFile.FullName);
+            var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(resolvedAppHostPath, _homeDirectory.FullName);
             var appHostId = Path.GetFileName(prefix);
             var socketPath = Path.Combine(
                 backchannelsDir,

--- a/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
@@ -6,6 +6,7 @@ using Aspire.Cli.Layout;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Aspire.Hosting.Utils;
 using Aspire.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json;
@@ -1644,7 +1645,8 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
         var backchannelsDir = Path.Combine(_workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch");
         Directory.CreateDirectory(backchannelsDir);
 
-        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, _workspace.WorkspaceRoot.FullName);
+        var resolvedAppHostPath = PathNormalizer.ResolveSymlinks(appHostPath);
+        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(resolvedAppHostPath, _workspace.WorkspaceRoot.FullName);
         var appHostId = Path.GetFileName(prefix);
         var socketPath = Path.Combine(
             backchannelsDir,

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Spectre.Console;
@@ -1139,7 +1140,8 @@ public class GuestAppHostProjectTests : IDisposable
         var backchannelsDir = Path.Combine(_workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch");
         Directory.CreateDirectory(backchannelsDir);
 
-        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, _workspace.WorkspaceRoot.FullName);
+        var resolvedAppHostPath = PathNormalizer.ResolveSymlinks(appHostPath);
+        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(resolvedAppHostPath, _workspace.WorkspaceRoot.FullName);
         var appHostId = Path.GetFileName(prefix);
         var socketPath = Path.Combine(
             backchannelsDir,

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -377,7 +377,12 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Directory.CreateDirectory(backchannelsDir);
 
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
-        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
+        // FindMatchingNonOrphanedSockets resolves symlinks (which canonicalizes via Path.GetFullPath)
+        // before hashing, so the socket files must be keyed off the same resolved path. On Windows
+        // Path.GetFullPath roots the drive-less "/path/to/..." to "C:\path\to\...", giving a different
+        // hash than the raw string; resolving here keeps both sides consistent across all platforms.
+        var resolvedAppHostPath = PathNormalizer.ResolveSymlinks(appHostPath);
+        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(resolvedAppHostPath, workspace.WorkspaceRoot.FullName);
         var appHostId = Path.GetFileName(prefix);
         var deadPid = int.MaxValue - 1;
         var currentPid = Environment.ProcessId;

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -5,6 +5,7 @@ using Aspire.Cli.Tests.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Utils;
 using Aspire.Hosting.Backchannel;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Utils;
@@ -401,6 +402,37 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Assert.False(File.Exists(orphanedSocket));
         Assert.True(File.Exists(liveSocket));
         Assert.True(File.Exists(pidlessSocket));
+    }
+
+    [Fact]
+    public void FindMatchingNonOrphanedSockets_WithSymlinkedPath_MatchesCanonicalSocket()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
+            "Symlink resolution test only runs on Linux/macOS where unprivileged symlink creation is reliable.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var realDirectory = workspace.WorkspaceRoot.CreateSubdirectory("real");
+        var symlinkDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "link");
+        Directory.CreateSymbolicLink(symlinkDirectory, realDirectory.FullName);
+
+        var projectFileViaSymlink = Path.Combine(symlinkDirectory, "TestAppHost.csproj");
+        File.WriteAllText(projectFileViaSymlink, "<Project />");
+
+        var canonicalProjectPath = PathNormalizer.ResolveSymlinks(projectFileViaSymlink);
+        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(canonicalProjectPath, workspace.WorkspaceRoot.FullName);
+        var appHostId = Path.GetFileName(prefix);
+        var currentPid = Environment.ProcessId;
+        var liveSocket = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch", $"{appHostId}a1b2C3d4.{currentPid}");
+        Directory.CreateDirectory(Path.GetDirectoryName(liveSocket)!);
+        File.WriteAllText(liveSocket, "");
+
+        var remainingSockets = AppHostHelper.FindMatchingNonOrphanedSockets(
+            projectFileViaSymlink,
+            workspace.WorkspaceRoot.FullName,
+            currentPid,
+            NullLogger.Instance);
+
+        Assert.Collection(remainingSockets, socket => Assert.Equal(liveSocket, socket));
     }
 
     [Theory]


### PR DESCRIPTION
## Description

Fixes **#17618** — `aspire describe --apphost <path>` (and other `--apphost`-accepting commands) reports "No AppHost is currently running" whenever the supplied path traverses a symlink (e.g. `/tmp` → `/private/tmp` on macOS, or symlinked `$HOME`/mounted workspaces on Linux).

### Root cause

A running AppHost keys its backchannel socket off the **symlink-resolved** path: the AppHost process's working directory is reported physically by the OS (`getcwd` canonicalizes), so `Path.GetFullPath(appHostPath)` on the producer side hashes the canonical path. The consumer (`AppHostConnectionResolver`) computed the socket key from the **raw** user-supplied `--apphost` path, so the two `appHostId` hashes never matched when a symlink was involved.

The original attempt used `PathNormalizer.ResolveToFilesystemPath`, but that helper only normalizes **Windows casing** and is a no-op on Linux/macOS — so it could not bridge the `/tmp` → `/private/tmp` gap.

### Fix

`AppHostConnectionResolver` now computes the socket-lookup key with `PathNormalizer.ResolveSymlinks(projectFile.FullName)`, so the consumer hashes the same canonical path as the running AppHost. The user-facing error message still displays the **original** supplied path (relative to the working directory), so output is unchanged.

### Tests

- Adds `ResolveConnectionAsync_WithSymlinkedProjectPath_ResolvesToCanonicalSocketKey` (Linux/macOS-gated): creates a socket keyed off the canonical path, addresses the project through a symlinked directory, and asserts the socket is located. Verified to **fail** on the old `ResolveToFilesystemPath` behavior and **pass** with `ResolveSymlinks`.
- Updates the existing dead-PID pruning test to key its socket off the resolved path (matching a real AppHost), since the macOS temp workspace itself lives under symlinked `/var` → `/private/var`.

> **Stacked on #17619** (`fix/17619-noninteractive-describe`): the new resolver test depends on the `ICliHostEnvironment` constructor parameter introduced there. The diff against that base shows only the symlink changes. Retarget to `main` once #17619 merges.
>
> Split out of #18261 so each fix can be reviewed in isolation.

Fixes #17618
