### PR TITLE
Fix flaky profiling tests by scoping ActivityListeners to specific instances

### DIFF
--- a/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
@@ -19,6 +19,8 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
 
     private readonly ActivitySource _activitySource = new(ActivitySourceName);
 
+    internal ActivitySource ActivitySource => _activitySource;
+
     /// <summary>
     /// Environment variable names used to propagate profiling state between CLI processes.
     /// </summary>

--- a/src/Aspire.Hosting.RemoteHost/Diagnostics/RemoteHostProfilingTelemetry.cs
+++ b/src/Aspire.Hosting.RemoteHost/Diagnostics/RemoteHostProfilingTelemetry.cs
@@ -17,6 +17,8 @@ internal sealed class RemoteHostProfilingTelemetry(IConfiguration configuration)
 
     private readonly ActivitySource _activitySource = new(ActivitySourceName);
 
+    internal ActivitySource ActivitySource => _activitySource;
+
     internal static class EnvironmentVariables
     {
         public const string Enabled = KnownConfigNames.ProfilingEnabled;

--- a/src/Aspire.Hosting/Diagnostics/ProfilingTelemetry.cs
+++ b/src/Aspire.Hosting/Diagnostics/ProfilingTelemetry.cs
@@ -196,6 +196,9 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration)
     }
 
     private static readonly ActivitySource s_activitySource = new(ActivitySourceName);
+
+    internal static ActivitySource ActivitySource => s_activitySource;
+
     private static readonly ConcurrentQueue<AppHostStartupEvent> s_startupEvents = new();
 
     private readonly IConfiguration _configuration = configuration;

--- a/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
@@ -414,8 +414,8 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
     [Fact]
     public void DetachedChildEnvironment_IncludesProfilingTelemetryContext()
     {
-        using var listener = ActivityListenerHelper.Create("test-detached-child-environment");
         using var source = new ActivitySource("test-detached-child-environment");
+        using var listener = ActivityListenerHelper.Create(source);
         using var activity = source.StartActivity("parent");
         Assert.NotNull(activity);
         activity.SetBaggage(ProfilingTelemetry.Baggage.SessionId, "session-1");
@@ -462,8 +462,8 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
     [Fact]
     public void DetachedChildEnvironment_DoesNotEnableProfilingForNonProfilingActivity()
     {
-        using var listener = ActivityListenerHelper.Create("test-detached-child-environment");
         using var source = new ActivitySource("test-detached-child-environment");
+        using var listener = ActivityListenerHelper.Create(source);
         using var activity = source.StartActivity("parent");
         Assert.NotNull(activity);
 

--- a/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
@@ -441,9 +441,9 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
     [Fact]
     public void DetachedChildEnvironment_IncludesProfilingTelemetryContextFromActiveProfilingSpan()
     {
-        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
+        using var listener = CreateActivityListener(profilingTelemetry.ActivitySource);
 
         using var activity = profilingTelemetry.StartDetachedSpawnChild("aspire", ["run"], childCommand: "run");
         Assert.True(activity.IsRunning);
@@ -639,6 +639,17 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
         var listener = new ActivityListener
         {
             ShouldListenTo = source => source.Name == sourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    private static ActivityListener CreateActivityListener(ActivitySource targetSource)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => ReferenceEquals(source, targetSource),
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
         };
         ActivitySource.AddActivityListener(listener);

--- a/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
@@ -10,6 +10,7 @@ using Aspire.Cli.Layout;
 using Aspire.Cli.Processes;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
+using Aspire.Tests;
 using Aspire.Cli.Utils;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Telemetry;
@@ -413,7 +414,7 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
     [Fact]
     public void DetachedChildEnvironment_IncludesProfilingTelemetryContext()
     {
-        using var listener = CreateActivityListener("test-detached-child-environment");
+        using var listener = ActivityListenerHelper.Create("test-detached-child-environment");
         using var source = new ActivitySource("test-detached-child-environment");
         using var activity = source.StartActivity("parent");
         Assert.NotNull(activity);
@@ -443,7 +444,7 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
     {
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
-        using var listener = CreateActivityListener(profilingTelemetry.ActivitySource);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource);
 
         using var activity = profilingTelemetry.StartDetachedSpawnChild("aspire", ["run"], childCommand: "run");
         Assert.True(activity.IsRunning);
@@ -461,7 +462,7 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
     [Fact]
     public void DetachedChildEnvironment_DoesNotEnableProfilingForNonProfilingActivity()
     {
-        using var listener = CreateActivityListener("test-detached-child-environment");
+        using var listener = ActivityListenerHelper.Create("test-detached-child-environment");
         using var source = new ActivitySource("test-detached-child-environment");
         using var activity = source.StartActivity("parent");
         Assert.NotNull(activity);
@@ -632,28 +633,6 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
                 Assert.Equal(CliLogFormat.Categories.Build, entry.Category);
                 Assert.Equal("Build FAILED.", entry.Message);
             });
-    }
-
-    private static ActivityListener CreateActivityListener(string sourceName)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == sourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
-    }
-
-    private static ActivityListener CreateActivityListener(ActivitySource targetSource)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => ReferenceEquals(source, targetSource),
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 
     private static IConfiguration CreateConfiguration(params (string Key, string? Value)[] values)

--- a/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
@@ -10,6 +10,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Tests;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
@@ -755,12 +756,8 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
     public async Task LsCommand_EmitsProfilingActivities()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        // ActivitySource listeners are process-wide, so this test can observe profiling spans
-        // from other tests running in parallel. Use a unique session id and filter by it instead
-        // of assuming every observed activity belongs to this command invocation.
         var sessionId = $"ls-{Guid.NewGuid():N}";
         var startedActivities = new ConcurrentBag<Activity>();
-        using var listener = CreateProfilingActivityListener(startedActivities.Add);
 
         var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App", "App.AppHost.csproj");
         var projectLocator = new TestProjectLocator
@@ -781,6 +778,8 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
             };
         });
         using var provider = services.BuildServiceProvider();
+        var profilingTelemetry = provider.GetRequiredService<ProfilingTelemetry>();
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Add);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("ls --format json --all");
@@ -804,18 +803,6 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
     {
         return activity.OperationName == operationName &&
             Equals(sessionId, activity.GetTagItem(ProfilingTelemetry.Tags.ProfilingSessionId));
-    }
-
-    private static ActivityListener CreateProfilingActivityListener(Action<Activity> activityStarted)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == ProfilingTelemetry.ActivitySourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStarted = activityStarted
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 
     private static string RenderToPlainConsole(IRenderable renderable)

--- a/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
@@ -779,7 +779,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
         });
         using var provider = services.BuildServiceProvider();
         var profilingTelemetry = provider.GetRequiredService<ProfilingTelemetry>();
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Add);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: startedActivities.Add);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("ls --format json --all");

--- a/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
@@ -12,6 +12,7 @@ using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Hosting;
+using Aspire.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.InternalTesting;
 
@@ -246,7 +247,6 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var stoppedActivities = new ConcurrentQueue<Activity>();
-        using var listener = CreateProfilingActivityListener(stoppedActivities.Enqueue);
 
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var appHostPath1 = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj");
@@ -265,6 +265,8 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
             };
         });
         using var provider = services.BuildServiceProvider();
+        var profilingTelemetry = provider.GetRequiredService<ProfilingTelemetry>();
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, stoppedActivities.Enqueue);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("stop --all");
@@ -339,17 +341,5 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
             .Concat(interactionService.DisplayedErrors)
             .Concat(statusMessages)
             .ToArray();
-    }
-
-    private static ActivityListener CreateProfilingActivityListener(Action<Activity> activityStopped)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == ProfilingTelemetry.ActivitySourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStopped = activityStopped
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
@@ -266,7 +266,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
         });
         using var provider = services.BuildServiceProvider();
         var profilingTelemetry = provider.GetRequiredService<ProfilingTelemetry>();
-        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, stoppedActivities.Enqueue);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStopped: stoppedActivities.Enqueue);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("stop --all");

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -586,7 +586,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var profilingTelemetry = provider.GetRequiredService<ProfilingTelemetry>();
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Enqueue);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: startedActivities.Enqueue);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
         var runner = DotNetCliRunnerTestHelper.Create(
             provider,

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Hosting;
+using Aspire.Tests;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,18 +36,6 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         }
 
         return "dotnet";
-    }
-
-    private static ActivityListener CreateActivityListener(string sourceName, Action<Activity>? activityStarted = null)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == sourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStarted = activityStarted
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 
     [Fact]
@@ -522,7 +511,6 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task RunAsyncPropagatesProcessProfilingContextToChildEnvironment()
     {
-        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName);
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
@@ -536,6 +524,8 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             };
         });
         using var provider = services.BuildServiceProvider();
+        var profilingTelemetry = provider.GetRequiredService<ProfilingTelemetry>();
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource);
 
         var options = new ProcessInvocationOptions();
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
@@ -576,7 +566,6 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
     {
         const string sessionId = "backchannel-parent-session";
         var startedActivities = new ConcurrentQueue<Activity>();
-        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, startedActivities.Enqueue);
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
@@ -597,6 +586,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var profilingTelemetry = provider.GetRequiredService<ProfilingTelemetry>();
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Enqueue);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
         var runner = DotNetCliRunnerTestHelper.Create(
             provider,

--- a/tests/Aspire.Cli.Tests/Git/GitRepositoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Git/GitRepositoryTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using Aspire.Cli.Git;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Tests;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -115,10 +116,10 @@ public class GitRepositoryTests(ITestOutputHelper outputHelper)
         // of assuming every observed activity belongs to this git invocation.
         var sessionId = $"git-{Guid.NewGuid():N}";
         var startedActivities = new ConcurrentBag<Activity>();
-        using var listener = CreateProfilingActivityListener(startedActivities.Add);
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, sessionId));
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Add);
         var executionContext = workspace.CreateExecutionContext();
         var repo = new GitRepository(executionContext, NullLogger<GitRepository>.Instance, profilingTelemetry);
 
@@ -154,18 +155,6 @@ public class GitRepositoryTests(ITestOutputHelper outputHelper)
             .AddInMemoryCollection(values.Select(value => new KeyValuePair<string, string?>(value.Key, value.Value)))
             .Build();
         return new ProfilingTelemetry(configuration);
-    }
-
-    private static ActivityListener CreateProfilingActivityListener(Action<Activity> activityStarted)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == ProfilingTelemetry.ActivitySourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStarted = activityStarted
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 
 }

--- a/tests/Aspire.Cli.Tests/Git/GitRepositoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Git/GitRepositoryTests.cs
@@ -119,7 +119,7 @@ public class GitRepositoryTests(ITestOutputHelper outputHelper)
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, sessionId));
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Add);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: startedActivities.Add);
         var executionContext = workspace.CreateExecutionContext();
         var repo = new GitRepository(executionContext, NullLogger<GitRepository>.Instance, profilingTelemetry);
 

--- a/tests/Aspire.Cli.Tests/Projects/AppHostCandidateFinderTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostCandidateFinderTests.cs
@@ -142,7 +142,7 @@ public class AppHostCandidateFinderTests(ITestOutputHelper outputHelper)
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"));
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Add);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: startedActivities.Add);
 
         var appHost = await WriteFileAsync(workspace.WorkspaceRoot, "App/AppHost.csproj");
         var gitRepository = CreateGitRepository(appHost.FullName);
@@ -198,7 +198,7 @@ public class AppHostCandidateFinderTests(ITestOutputHelper outputHelper)
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"));
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Add);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: startedActivities.Add);
 
         var appHost = await WriteFileAsync(workspace.WorkspaceRoot, "App/AppHost.csproj");
         await WriteFileAsync(workspace.WorkspaceRoot, "node_modules/pkg/AppHost.csproj");

--- a/tests/Aspire.Cli.Tests/Projects/AppHostCandidateFinderTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostCandidateFinderTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Tests;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -138,10 +139,10 @@ public class AppHostCandidateFinderTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var startedActivities = new List<Activity>();
-        using var listener = CreateProfilingActivityListener(startedActivities.Add);
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"));
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Add);
 
         var appHost = await WriteFileAsync(workspace.WorkspaceRoot, "App/AppHost.csproj");
         var gitRepository = CreateGitRepository(appHost.FullName);
@@ -194,10 +195,10 @@ public class AppHostCandidateFinderTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var startedActivities = new List<Activity>();
-        using var listener = CreateProfilingActivityListener(startedActivities.Add);
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"));
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Add);
 
         var appHost = await WriteFileAsync(workspace.WorkspaceRoot, "App/AppHost.csproj");
         await WriteFileAsync(workspace.WorkspaceRoot, "node_modules/pkg/AppHost.csproj");
@@ -549,17 +550,5 @@ public class AppHostCandidateFinderTests(ITestOutputHelper outputHelper)
             .AddInMemoryCollection(values.Select(value => new KeyValuePair<string, string?>(value.Key, value.Value)))
             .Build();
         return new ProfilingTelemetry(configuration);
-    }
-
-    private static ActivityListener CreateProfilingActivityListener(Action<Activity> activityStarted)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == ProfilingTelemetry.ActivitySourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStarted = activityStarted
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
@@ -92,7 +92,7 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
     {
         var project = new RecordingAppHostServerProject();
         using var parentSource = new ActivitySource("test-apphost-server-parent");
-        using var parentListener = ActivityListenerHelper.Create("test-apphost-server-parent");
+        using var parentListener = ActivityListenerHelper.Create(parentSource);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
@@ -14,6 +14,7 @@ using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
 using Aspire.Shared;
+using Aspire.Tests;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -57,10 +58,10 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
         {
             ["EXISTING_VALUE"] = "present"
         };
-        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource);
 
         await using var session = AppHostServerSession.Start(
             project,
@@ -91,11 +92,11 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
     {
         var project = new RecordingAppHostServerProject();
         using var parentSource = new ActivitySource("test-apphost-server-parent");
-        using var parentListener = CreateActivityListener("test-apphost-server-parent");
-        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName);
+        using var parentListener = ActivityListenerHelper.Create("test-apphost-server-parent");
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource);
 
         using var parentActivity = parentSource.StartActivity("aspire/cli/run");
         Assert.NotNull(parentActivity);
@@ -197,17 +198,6 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
         {
             layoutLease.Dispose();
         }
-    }
-
-    private static ActivityListener CreateActivityListener(string sourceName)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == sourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 
     private static IConfiguration CreateConfiguration(params (string Key, string? Value)[] values)

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -248,7 +248,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"));
-        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, stoppedActivities.Add);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStopped: stoppedActivities.Add);
         using var tempDirectory = new TestTempDirectory();
 
         var spec = CreateTestSpec(
@@ -762,7 +762,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"));
-        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, stoppedActivities.Add);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStopped: stoppedActivities.Add);
         using var tempDirectory = new TestTempDirectory();
 
         var launcher = new ProcessGuestLauncher(

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Utils;
+using Aspire.Tests;
 using Aspire.TypeSystem;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -244,10 +245,10 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
     public async Task RunAsync_ProfilingTelemetryRecordsGuestCommandPhasesAndArgs()
     {
         var stoppedActivities = new ConcurrentBag<Activity>();
-        using var listener = CreateProfilingActivityListener(stoppedActivities.Add);
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"));
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, stoppedActivities.Add);
         using var tempDirectory = new TestTempDirectory();
 
         var spec = CreateTestSpec(
@@ -758,10 +759,10 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
     public async Task ProcessGuestLauncher_AnnotatesAmbientGuestProfilingActivity()
     {
         var stoppedActivities = new ConcurrentBag<Activity>();
-        using var listener = CreateProfilingActivityListener(stoppedActivities.Add);
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"));
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, stoppedActivities.Add);
         using var tempDirectory = new TestTempDirectory();
 
         var launcher = new ProcessGuestLauncher(
@@ -1011,17 +1012,5 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             .AddInMemoryCollection(values.Select(value => new KeyValuePair<string, string?>(value.Key, value.Value)))
             .Build();
         return new ProfilingTelemetry(configuration);
-    }
-
-    private static ActivityListener CreateProfilingActivityListener(Action<Activity> activityStopped)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == ProfilingTelemetry.ActivitySourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStopped = activityStopped
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 }

--- a/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryContextTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryContextTests.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using Aspire.Cli.Telemetry;
 using Aspire.Hosting;
+using Aspire.Tests;
 using Microsoft.Extensions.Configuration;
 
 namespace Aspire.Cli.Tests.Telemetry;
@@ -13,8 +14,8 @@ public class ProfilingTelemetryContextTests
     [Fact]
     public void AddActivityContextToEnvironment_EmitsActivityValues()
     {
-        using var listener = CreateActivityListener("test-profiling-context");
         using var source = new ActivitySource("test-profiling-context");
+        using var listener = ActivityListenerHelper.Create(source);
         using var activity = source.StartActivity("parent");
         Assert.NotNull(activity);
 
@@ -47,8 +48,8 @@ public class ProfilingTelemetryContextTests
     [Fact]
     public void AddActivityContextToEnvironment_IgnoresNonProfilingActivity()
     {
-        using var listener = CreateActivityListener("test-profiling-context");
         using var source = new ActivitySource("test-profiling-context");
+        using var listener = ActivityListenerHelper.Create(source);
         using var activity = source.StartActivity("parent");
         Assert.NotNull(activity);
 
@@ -62,12 +63,12 @@ public class ProfilingTelemetryContextTests
     public void StartRunCommand_ContinuesConfiguredRemoteParentAndSession()
     {
         var startedActivities = new List<Activity>();
-        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, startedActivities.Add);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"),
             (ProfilingTelemetry.EnvironmentVariables.TraceParent, "00-0102030405060708090a0b0c0d0e0f10-1112131415161718-01"),
             (ProfilingTelemetry.EnvironmentVariables.TraceState, "state-1")));
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Add);
 
         using var activity = profilingTelemetry.StartRunCommand();
 
@@ -98,12 +99,12 @@ public class ProfilingTelemetryContextTests
     public void StartRunCommand_ReadsLegacyStartupNames()
     {
         var startedActivities = new List<Activity>();
-        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, startedActivities.Add);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (KnownConfigNames.Legacy.StartupProfilingEnabled, "true"),
             (KnownConfigNames.Legacy.StartupOperationId, "session-1"),
             (KnownConfigNames.Legacy.StartupTraceParent, "00-0102030405060708090a0b0c0d0e0f10-1112131415161718-01"),
             (KnownConfigNames.Legacy.StartupTraceState, "state-1")));
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Add);
 
         using var activity = profilingTelemetry.StartRunCommand();
 
@@ -111,18 +112,6 @@ public class ProfilingTelemetryContextTests
         var startedActivity = Assert.Single(startedActivities, activity => activity.OperationName == ProfilingTelemetry.Activities.RunCommand);
         Assert.Equal("0102030405060708090a0b0c0d0e0f10", startedActivity.TraceId.ToString());
         Assert.Equal("session-1", startedActivity.GetBaggageItem(ProfilingTelemetry.Baggage.SessionId));
-    }
-
-    private static ActivityListener CreateActivityListener(string sourceName, Action<Activity>? activityStarted = null)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == sourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStarted = activityStarted
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 
     private static IConfiguration CreateConfiguration(params (string Key, string? Value)[] values)

--- a/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryContextTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryContextTests.cs
@@ -68,7 +68,7 @@ public class ProfilingTelemetryContextTests
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"),
             (ProfilingTelemetry.EnvironmentVariables.TraceParent, "00-0102030405060708090a0b0c0d0e0f10-1112131415161718-01"),
             (ProfilingTelemetry.EnvironmentVariables.TraceState, "state-1")));
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Add);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: startedActivities.Add);
 
         using var activity = profilingTelemetry.StartRunCommand();
 
@@ -104,7 +104,7 @@ public class ProfilingTelemetryContextTests
             (KnownConfigNames.Legacy.StartupOperationId, "session-1"),
             (KnownConfigNames.Legacy.StartupTraceParent, "00-0102030405060708090a0b0c0d0e0f10-1112131415161718-01"),
             (KnownConfigNames.Legacy.StartupTraceState, "state-1")));
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Add);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: startedActivities.Add);
 
         using var activity = profilingTelemetry.StartRunCommand();
 

--- a/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryTests.cs
@@ -5,19 +5,19 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Telemetry;
+using Aspire.Tests;
 using Microsoft.Extensions.Configuration;
 
 namespace Aspire.Cli.Tests.Telemetry;
 
-[Collection(ProfilingTelemetryTestCollection.Name)]
 public class ProfilingTelemetryTests
 {
     [Fact]
     public void StartRunCommand_ReturnsInactiveScopeWhenProfilingIsDisabled()
     {
         Activity? startedActivity = null;
-        using var listener = CreateProfilingActivityListener(activity => startedActivity = activity);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration());
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, activity => startedActivity = activity);
 
         using var activity = profilingTelemetry.StartRunCommand();
 
@@ -29,10 +29,10 @@ public class ProfilingTelemetryTests
     public void StartRunCommand_UsesDedicatedProfilingActivitySource()
     {
         Activity? startedActivity = null;
-        using var listener = CreateProfilingActivityListener(activity => startedActivity = activity);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, activity => startedActivity = activity);
 
         using var activity = profilingTelemetry.StartRunCommand();
 
@@ -48,10 +48,10 @@ public class ProfilingTelemetryTests
     public void ProcessSpansUseConsistentExecutableAndArgumentTags()
     {
         var startedActivities = new ConcurrentQueue<Activity>();
-        using var listener = CreateProfilingActivityListener(startedActivities.Enqueue);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Enqueue);
         var aspirePath = Path.Combine("tools", "aspire");
         var npmPath = Path.Combine("node", "npm");
         var workingDirectory = Directory.GetCurrentDirectory();
@@ -118,10 +118,10 @@ public class ProfilingTelemetryTests
     public void StartAddCommand_CreatesAddSpecificSpans()
     {
         var startedActivities = new ConcurrentQueue<Activity>();
-        using var listener = CreateProfilingActivityListener(startedActivities.Enqueue);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Enqueue);
         var appHostProjectFile = new FileInfo(Path.Combine("AppHost", "AppHost.csproj"));
 
         using (var addActivity = profilingTelemetry.StartAddCommand("redis", "13.4.0", "nuget-source", appHostProjectFile))
@@ -241,12 +241,12 @@ public class ProfilingTelemetryTests
     public void ProfilingSpansReuseSessionFromAmbientActivityBaggage()
     {
         var startedActivities = new ConcurrentQueue<Activity>();
-        using var parentListener = CreateActivityListener("test-parent", _ => { });
-        using var listener = CreateProfilingActivityListener(startedActivities.Enqueue);
-        using var parentSource = new ActivitySource("test-parent");
-        using var parentActivity = parentSource.StartActivity("parent");
+        using var parentListener = ActivityListenerHelper.Create("test-parent");
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Enqueue);
+        using var parentSource = new ActivitySource("test-parent");
+        using var parentActivity = parentSource.StartActivity("parent");
         Assert.NotNull(parentActivity);
 
         parentActivity.SetBaggage(ProfilingTelemetry.Baggage.SessionId, "session-1");
@@ -272,14 +272,14 @@ public class ProfilingTelemetryTests
     public void ProfilingSpansStoreGeneratedSessionOnAmbientAncestorsForSiblings()
     {
         var startedActivities = new ConcurrentQueue<Activity>();
-        using var parentListener = CreateActivityListener("test-parent", _ => { });
-        using var diagnosticListener = CreateActivityListener("test-diagnostic", _ => { });
-        using var listener = CreateProfilingActivityListener(startedActivities.Enqueue);
+        using var parentListener = ActivityListenerHelper.Create("test-parent");
+        using var diagnosticListener = ActivityListenerHelper.Create("test-diagnostic");
+        using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
+            (ProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
+        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Enqueue);
         using var parentSource = new ActivitySource("test-parent");
         using var diagnosticSource = new ActivitySource("test-diagnostic");
         using var parentActivity = parentSource.StartActivity("parent");
-        using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
-            (ProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
         Assert.NotNull(parentActivity);
 
         using (diagnosticSource.StartActivity("diagnostic"))
@@ -307,10 +307,10 @@ public class ProfilingTelemetryTests
     [Fact]
     public void BackchannelTraceContextCarriesActivityBaggage()
     {
-        using var listener = CreateProfilingActivityListener(_ => { });
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource);
 
         using var activity = profilingTelemetry.StartJsonRpcClientCall("aux", "GetCapabilitiesAsync", streaming: false);
         var traceContext = activity.CreateBackchannelTraceContext();
@@ -319,26 +319,9 @@ public class ProfilingTelemetryTests
         Assert.Equal("session-1", traceContext.Baggage[ProfilingTelemetry.Baggage.SessionId]);
     }
 
-    private static ActivityListener CreateProfilingActivityListener(Action<Activity> activityStarted)
-    {
-        return CreateActivityListener(ProfilingTelemetry.ActivitySourceName, activityStarted);
-    }
-
     private static Activity[] GetSessionActivities(IEnumerable<Activity> activities, string sessionId)
     {
         return [.. activities.Where(activity => Equals(sessionId, activity.GetTagItem(ProfilingTelemetry.Tags.ProfilingSessionId)))];
-    }
-
-    private static ActivityListener CreateActivityListener(string sourceName, Action<Activity> activityStarted)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == sourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStarted = activityStarted
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 
     private static IConfiguration CreateConfiguration(params (string Key, string? Value)[] values)
@@ -347,13 +330,4 @@ public class ProfilingTelemetryTests
             .AddInMemoryCollection(values.Select(value => new KeyValuePair<string, string?>(value.Key, value.Value)))
             .Build();
     }
-}
-
-/// <summary>
-/// Disables parallel execution for tests that install process-wide activity listeners.
-/// </summary>
-[CollectionDefinition(Name, DisableParallelization = true)]
-public sealed class ProfilingTelemetryTestCollection
-{
-    public const string Name = "ProfilingTelemetryTests";
 }

--- a/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryTests.cs
@@ -17,7 +17,7 @@ public class ProfilingTelemetryTests
     {
         Activity? startedActivity = null;
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration());
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, activity => startedActivity = activity);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: activity => startedActivity = activity);
 
         using var activity = profilingTelemetry.StartRunCommand();
 
@@ -32,7 +32,7 @@ public class ProfilingTelemetryTests
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, activity => startedActivity = activity);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: activity => startedActivity = activity);
 
         using var activity = profilingTelemetry.StartRunCommand();
 
@@ -51,7 +51,7 @@ public class ProfilingTelemetryTests
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Enqueue);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: startedActivities.Enqueue);
         var aspirePath = Path.Combine("tools", "aspire");
         var npmPath = Path.Combine("node", "npm");
         var workingDirectory = Directory.GetCurrentDirectory();
@@ -121,7 +121,7 @@ public class ProfilingTelemetryTests
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Enqueue);
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: startedActivities.Enqueue);
         var appHostProjectFile = new FileInfo(Path.Combine("AppHost", "AppHost.csproj"));
 
         using (var addActivity = profilingTelemetry.StartAddCommand("redis", "13.4.0", "nuget-source", appHostProjectFile))
@@ -241,11 +241,11 @@ public class ProfilingTelemetryTests
     public void ProfilingSpansReuseSessionFromAmbientActivityBaggage()
     {
         var startedActivities = new ConcurrentQueue<Activity>();
-        using var parentListener = ActivityListenerHelper.Create("test-parent");
+        using var parentSource = new ActivitySource("test-parent");
+        using var parentListener = ActivityListenerHelper.Create(parentSource);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Enqueue);
-        using var parentSource = new ActivitySource("test-parent");
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: startedActivities.Enqueue);
         using var parentActivity = parentSource.StartActivity("parent");
         Assert.NotNull(parentActivity);
 
@@ -272,13 +272,13 @@ public class ProfilingTelemetryTests
     public void ProfilingSpansStoreGeneratedSessionOnAmbientAncestorsForSiblings()
     {
         var startedActivities = new ConcurrentQueue<Activity>();
-        using var parentListener = ActivityListenerHelper.Create("test-parent");
-        using var diagnosticListener = ActivityListenerHelper.Create("test-diagnostic");
+        using var parentSource = new ActivitySource("test-parent");
+        using var parentListener = ActivityListenerHelper.Create(parentSource);
+        using var diagnosticSource = new ActivitySource("test-diagnostic");
+        using var diagnosticListener = ActivityListenerHelper.Create(diagnosticSource);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
-        using var listener = ActivityListenerHelper.CreateWithStarted(profilingTelemetry.ActivitySource, startedActivities.Enqueue);
-        using var parentSource = new ActivitySource("test-parent");
-        using var diagnosticSource = new ActivitySource("test-diagnostic");
+        using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource, onActivityStarted: startedActivities.Enqueue);
         using var parentActivity = parentSource.StartActivity("parent");
         Assert.NotNull(parentActivity);
 

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AssemblyLoaderTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AssemblyLoaderTests.cs
@@ -182,7 +182,7 @@ public class AssemblyLoaderTests
 
         var telemetry = new RemoteHostProfilingTelemetry(configuration);
         var activities = new List<Activity>();
-        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, onActivityStopped: activities.Add);
         var loader = new AssemblyLoader(configuration, NullLogger<AssemblyLoader>.Instance, telemetry);
 
         var assemblies = loader.GetAssemblies();

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AssemblyLoaderTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AssemblyLoaderTests.cs
@@ -171,8 +171,6 @@ public class AssemblyLoaderTests
     [Fact]
     public void GetAssemblies_AddsAssemblyNamesToProfilingSpan()
     {
-        var activities = new List<Activity>();
-        using var listener = CreateActivityListener(RemoteHostProfilingTelemetry.ActivitySourceName, activities.Add);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -181,7 +179,10 @@ public class AssemblyLoaderTests
             })
             .Build();
 
-        var loader = new AssemblyLoader(configuration, NullLogger<AssemblyLoader>.Instance, new RemoteHostProfilingTelemetry(configuration));
+        var telemetry = new RemoteHostProfilingTelemetry(configuration);
+        var activities = new List<Activity>();
+        using var listener = CreateActivityListener(telemetry.ActivitySource, activities.Add);
+        var loader = new AssemblyLoader(configuration, NullLogger<AssemblyLoader>.Instance, telemetry);
 
         var assemblies = loader.GetAssemblies();
 
@@ -240,11 +241,11 @@ public class AssemblyLoaderTests
         return new RemoteHostProfilingTelemetry(new ConfigurationBuilder().Build());
     }
 
-    private static ActivityListener CreateActivityListener(string sourceName, Action<Activity> activityStopped)
+    private static ActivityListener CreateActivityListener(ActivitySource targetSource, Action<Activity> activityStopped)
     {
         var listener = new ActivityListener
         {
-            ShouldListenTo = source => source.Name == sourceName,
+            ShouldListenTo = source => ReferenceEquals(source, targetSource),
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
             ActivityStopped = activityStopped
         };

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AssemblyLoaderTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AssemblyLoaderTests.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Text.Json;
 using Aspire.Hosting.RemoteHost.Diagnostics;
+using Aspire.Tests;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -181,7 +182,7 @@ public class AssemblyLoaderTests
 
         var telemetry = new RemoteHostProfilingTelemetry(configuration);
         var activities = new List<Activity>();
-        using var listener = CreateActivityListener(telemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, activities.Add);
         var loader = new AssemblyLoader(configuration, NullLogger<AssemblyLoader>.Instance, telemetry);
 
         var assemblies = loader.GetAssemblies();
@@ -239,18 +240,5 @@ public class AssemblyLoaderTests
     private static RemoteHostProfilingTelemetry CreateProfilingTelemetry()
     {
         return new RemoteHostProfilingTelemetry(new ConfigurationBuilder().Build());
-    }
-
-    private static ActivityListener CreateActivityListener(ActivitySource targetSource, Action<Activity> activityStopped)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => ReferenceEquals(source, targetSource),
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStopped = activityStopped
-        };
-
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/RemoteHostProfilingTelemetryTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/RemoteHostProfilingTelemetryTests.cs
@@ -30,13 +30,13 @@ public class RemoteHostProfilingTelemetryTests
             traceState = parent.TraceStateString;
         }
 
-        var activities = new List<Activity>();
-        using var listener = CreateActivityListener(RemoteHostProfilingTelemetry.ActivitySourceName, activities.Add);
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration(
             (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (RemoteHostProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"),
             (RemoteHostProfilingTelemetry.EnvironmentVariables.TraceParent, traceParent),
             (RemoteHostProfilingTelemetry.EnvironmentVariables.TraceState, traceState)));
+        var activities = new List<Activity>();
+        using var listener = CreateActivityListener(telemetry.ActivitySource, activities.Add);
 
         using (telemetry.StartRemoteHostRun())
         {
@@ -53,9 +53,9 @@ public class RemoteHostProfilingTelemetryTests
     [Fact]
     public void StartRemoteHostRun_DoesNotStartWhenProfilingIsDisabled()
     {
-        var activities = new List<Activity>();
-        using var listener = CreateActivityListener(RemoteHostProfilingTelemetry.ActivitySourceName, activities.Add);
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration());
+        var activities = new List<Activity>();
+        using var listener = CreateActivityListener(telemetry.ActivitySource, activities.Add);
 
         using (telemetry.StartRemoteHostRun())
         {
@@ -67,10 +67,10 @@ public class RemoteHostProfilingTelemetryTests
     [Fact]
     public void CapabilityScan_AddsLowCardinalityCounts()
     {
-        var activities = new List<Activity>();
-        using var listener = CreateActivityListener(RemoteHostProfilingTelemetry.ActivitySourceName, activities.Add);
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration(
             (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
+        var activities = new List<Activity>();
+        using var listener = CreateActivityListener(telemetry.ActivitySource, activities.Add);
 
         using (var scope = telemetry.StartCapabilityScan(assemblyCount: 3, firstScan: true))
         {
@@ -94,10 +94,10 @@ public class RemoteHostProfilingTelemetryTests
     [Fact]
     public void AssemblyLoad_AddsAssemblyNames()
     {
-        var activities = new List<Activity>();
-        using var listener = CreateActivityListener(RemoteHostProfilingTelemetry.ActivitySourceName, activities.Add);
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration(
             (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
+        var activities = new List<Activity>();
+        using var listener = CreateActivityListener(telemetry.ActivitySource, activities.Add);
 
         using (var scope = telemetry.StartAssemblyLoad(cacheHit: false))
         {
@@ -116,10 +116,10 @@ public class RemoteHostProfilingTelemetryTests
     [Fact]
     public void JsonRpcInvokeCapability_AddsCapabilityAndArgumentShape()
     {
-        var activities = new List<Activity>();
-        using var listener = CreateActivityListener(RemoteHostProfilingTelemetry.ActivitySourceName, activities.Add);
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration(
             (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
+        var activities = new List<Activity>();
+        using var listener = CreateActivityListener(telemetry.ActivitySource, activities.Add);
 
         using (telemetry.StartJsonRpcInvokeCapability(
             "aspire.redis/addRedis@1",
@@ -144,24 +144,23 @@ public class RemoteHostProfilingTelemetryTests
     [Fact]
     public void JsonRpcServerCall_UsesJsonRpcRemoteParent()
     {
+        var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration(
+            (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
+            (RemoteHostProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
         var activities = new List<Activity>();
         using var listener = new ActivityListener
         {
-            ShouldListenTo = source => source.Name is RemoteHostProfilingTelemetry.ActivitySourceName or "test.client" or "test.jsonrpc",
+            ShouldListenTo = source => ReferenceEquals(source, telemetry.ActivitySource) || source.Name is "test.client" or "test.jsonrpc",
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
             ActivityStopped = activity =>
             {
-                if (activity.Source.Name == RemoteHostProfilingTelemetry.ActivitySourceName)
+                if (ReferenceEquals(activity.Source, telemetry.ActivitySource))
                 {
                     activities.Add(activity);
                 }
             }
         };
         ActivitySource.AddActivityListener(listener);
-
-        var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration(
-            (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
-            (RemoteHostProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
         using var clientSource = new ActivitySource("test.client");
         using var jsonRpcSource = new ActivitySource("test.jsonrpc");
         var clientActivity = clientSource.StartActivity("client", ActivityKind.Client);
@@ -200,6 +199,19 @@ public class RemoteHostProfilingTelemetryTests
         var listener = new ActivityListener
         {
             ShouldListenTo = source => source.Name == sourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activityStopped
+        };
+
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    private static ActivityListener CreateActivityListener(ActivitySource targetSource, Action<Activity> activityStopped)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => ReferenceEquals(source, targetSource),
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
             ActivityStopped = activityStopped
         };

--- a/tests/Aspire.Hosting.RemoteHost.Tests/RemoteHostProfilingTelemetryTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/RemoteHostProfilingTelemetryTests.cs
@@ -15,8 +15,8 @@ public class RemoteHostProfilingTelemetryTests
     [Fact]
     public void StartRemoteHostRun_RestoresConfiguredParentAndSession()
     {
-        using var parentListener = ActivityListenerHelper.Create("test-remotehost-parent", _ => { });
         using var parentSource = new ActivitySource("test-remotehost-parent");
+        using var parentListener = ActivityListenerHelper.Create(parentSource, onActivityStopped: _ => { });
         ActivityTraceId parentTraceId;
         ActivitySpanId parentSpanId;
         string traceParent;
@@ -37,7 +37,7 @@ public class RemoteHostProfilingTelemetryTests
             (RemoteHostProfilingTelemetry.EnvironmentVariables.TraceParent, traceParent),
             (RemoteHostProfilingTelemetry.EnvironmentVariables.TraceState, traceState)));
         var activities = new List<Activity>();
-        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, onActivityStopped: activities.Add);
 
         using (telemetry.StartRemoteHostRun())
         {
@@ -56,7 +56,7 @@ public class RemoteHostProfilingTelemetryTests
     {
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration());
         var activities = new List<Activity>();
-        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, onActivityStopped: activities.Add);
 
         using (telemetry.StartRemoteHostRun())
         {
@@ -71,7 +71,7 @@ public class RemoteHostProfilingTelemetryTests
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration(
             (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
         var activities = new List<Activity>();
-        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, onActivityStopped: activities.Add);
 
         using (var scope = telemetry.StartCapabilityScan(assemblyCount: 3, firstScan: true))
         {
@@ -98,7 +98,7 @@ public class RemoteHostProfilingTelemetryTests
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration(
             (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
         var activities = new List<Activity>();
-        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, onActivityStopped: activities.Add);
 
         using (var scope = telemetry.StartAssemblyLoad(cacheHit: false))
         {
@@ -120,7 +120,7 @@ public class RemoteHostProfilingTelemetryTests
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration(
             (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
         var activities = new List<Activity>();
-        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, onActivityStopped: activities.Add);
 
         using (telemetry.StartJsonRpcInvokeCapability(
             "aspire.redis/addRedis@1",

--- a/tests/Aspire.Hosting.RemoteHost.Tests/RemoteHostProfilingTelemetryTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/RemoteHostProfilingTelemetryTests.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.RemoteHost.Diagnostics;
+using Aspire.Tests;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -14,7 +15,7 @@ public class RemoteHostProfilingTelemetryTests
     [Fact]
     public void StartRemoteHostRun_RestoresConfiguredParentAndSession()
     {
-        using var parentListener = CreateActivityListener("test-remotehost-parent", _ => { });
+        using var parentListener = ActivityListenerHelper.Create("test-remotehost-parent", _ => { });
         using var parentSource = new ActivitySource("test-remotehost-parent");
         ActivityTraceId parentTraceId;
         ActivitySpanId parentSpanId;
@@ -36,7 +37,7 @@ public class RemoteHostProfilingTelemetryTests
             (RemoteHostProfilingTelemetry.EnvironmentVariables.TraceParent, traceParent),
             (RemoteHostProfilingTelemetry.EnvironmentVariables.TraceState, traceState)));
         var activities = new List<Activity>();
-        using var listener = CreateActivityListener(telemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, activities.Add);
 
         using (telemetry.StartRemoteHostRun())
         {
@@ -55,7 +56,7 @@ public class RemoteHostProfilingTelemetryTests
     {
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration());
         var activities = new List<Activity>();
-        using var listener = CreateActivityListener(telemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, activities.Add);
 
         using (telemetry.StartRemoteHostRun())
         {
@@ -70,7 +71,7 @@ public class RemoteHostProfilingTelemetryTests
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration(
             (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
         var activities = new List<Activity>();
-        using var listener = CreateActivityListener(telemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, activities.Add);
 
         using (var scope = telemetry.StartCapabilityScan(assemblyCount: 3, firstScan: true))
         {
@@ -97,7 +98,7 @@ public class RemoteHostProfilingTelemetryTests
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration(
             (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
         var activities = new List<Activity>();
-        using var listener = CreateActivityListener(telemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, activities.Add);
 
         using (var scope = telemetry.StartAssemblyLoad(cacheHit: false))
         {
@@ -119,7 +120,7 @@ public class RemoteHostProfilingTelemetryTests
         var telemetry = new RemoteHostProfilingTelemetry(CreateConfiguration(
             (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
         var activities = new List<Activity>();
-        using var listener = CreateActivityListener(telemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(telemetry.ActivitySource, activities.Add);
 
         using (telemetry.StartJsonRpcInvokeCapability(
             "aspire.redis/addRedis@1",
@@ -192,32 +193,6 @@ public class RemoteHostProfilingTelemetryTests
         Assert.False(RemoteHostProfilingTelemetry.ShouldConfigureExporter(CreateConfiguration(
             (RemoteHostProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             ("ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL", "http://localhost:18889"))));
-    }
-
-    private static ActivityListener CreateActivityListener(string sourceName, Action<Activity> activityStopped)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == sourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStopped = activityStopped
-        };
-
-        ActivitySource.AddActivityListener(listener);
-        return listener;
-    }
-
-    private static ActivityListener CreateActivityListener(ActivitySource targetSource, Action<Activity> activityStopped)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => ReferenceEquals(source, targetSource),
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStopped = activityStopped
-        };
-
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 
     private static IConfiguration CreateConfiguration(params (string Key, string? Value)[] values)

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -1157,7 +1157,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
     public async Task GetDashboardUrlsAsync_ReturnsBaseUrl_WhenDashboardAllowsAnonymousAccess()
     {
         var activities = new List<Activity>();
-        using var listener = ActivityListenerHelper.Create(ProfilingTelemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(ProfilingTelemetry.ActivitySource, onActivityStopped: activities.Add);
         using var builder = TestDistributedApplicationBuilder.Create(
             options => options.DisableDashboard = false,
             outputHelper,

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.Diagnostics;
 using Aspire.Hosting.Utils;
+using Aspire.Tests;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -1156,7 +1157,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
     public async Task GetDashboardUrlsAsync_ReturnsBaseUrl_WhenDashboardAllowsAnonymousAccess()
     {
         var activities = new List<Activity>();
-        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, activities.Add);
+        using var listener = ActivityListenerHelper.Create(ProfilingTelemetry.ActivitySource, activities.Add);
         using var builder = TestDistributedApplicationBuilder.Create(
             options => options.DisableDashboard = false,
             outputHelper,
@@ -1874,19 +1875,6 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         var result = await target.GetAppHostInfoAsync().DefaultTimeout();
 
         Assert.Equal("/logs/cli_session.log", result.CliLogFilePath);
-    }
-
-    private static ActivityListener CreateActivityListener(string sourceName, Action<Activity> activityStopped)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == sourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStopped = activityStopped
-        };
-
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 }
 

--- a/tests/Aspire.Hosting.Tests/Backchannel/BackchannelContractTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/BackchannelContractTests.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.Diagnostics;
+using Aspire.Tests;
 using Microsoft.Extensions.Configuration;
 using StreamJsonRpc;
 
@@ -245,8 +246,8 @@ public class BackchannelContractTests
     [Fact]
     public void ActivityTracingStrategy_PropagatesW3CTraceContextOnJsonRpcRequest()
     {
-        using var listener = CreateActivityListener("test-json-rpc-trace");
         using var source = new ActivitySource("test-json-rpc-trace");
+        using var listener = ActivityListenerHelper.Create(source);
         using var clientActivity = source.StartActivity("client", ActivityKind.Client);
         Assert.NotNull(clientActivity);
 
@@ -271,9 +272,9 @@ public class BackchannelContractTests
     public void JsonRpcServerCall_RestoresTraceContextBaggage()
     {
         Activity? startedActivity = null;
-        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, activity => startedActivity = activity);
         var telemetry = new ProfilingTelemetry(CreateConfiguration(
             (KnownConfigNames.ProfilingEnabled, "true")));
+        using var listener = ActivityListenerHelper.CreateWithStarted(ProfilingTelemetry.ActivitySource, activity => startedActivity = activity);
 
         using var activity = telemetry.StartJsonRpcServerCall(
             "GetCapabilitiesAsync",
@@ -297,9 +298,9 @@ public class BackchannelContractTests
     public void DcpRunApplication_UsesConfiguredProfilingParentWhenAmbientActivityIsNotProfiling()
     {
         var activities = new List<Activity>();
-        using var profilingListener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, activities.Add);
+        using var profilingListener = ActivityListenerHelper.CreateWithStarted(ProfilingTelemetry.ActivitySource, activities.Add);
         using var processSource = new ActivitySource("test.process");
-        using var processListener = CreateActivityListener("test.process");
+        using var processListener = ActivityListenerHelper.Create(processSource);
         using var processActivity = processSource.StartActivity("process npx.CMD", ActivityKind.Internal);
         Assert.NotNull(processActivity);
         var traceParent = processActivity.Id;
@@ -308,7 +309,7 @@ public class BackchannelContractTests
         processActivity.Stop();
 
         using var ambientSource = new ActivitySource("test.ambient");
-        using var ambientListener = CreateActivityListener("test.ambient");
+        using var ambientListener = ActivityListenerHelper.Create(ambientSource);
         using var ambientActivity = ambientSource.StartActivity("hidden ambient", ActivityKind.Internal);
         Assert.NotNull(ambientActivity);
 
@@ -413,18 +414,6 @@ public class BackchannelContractTests
             BackchannelTraceContext context => $"{nameof(BackchannelTraceContext)}({context.Baggage.Count} baggage items)",
             _ => value.ToString() ?? string.Empty
         };
-
-    private static ActivityListener CreateActivityListener(string sourceName, Action<Activity>? activityStarted = null)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == sourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStarted = activityStarted
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
-    }
 
     private static IConfiguration CreateConfiguration(params (string Key, string? Value)[] values)
     {

--- a/tests/Aspire.Hosting.Tests/Backchannel/BackchannelContractTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/BackchannelContractTests.cs
@@ -274,7 +274,7 @@ public class BackchannelContractTests
         Activity? startedActivity = null;
         var telemetry = new ProfilingTelemetry(CreateConfiguration(
             (KnownConfigNames.ProfilingEnabled, "true")));
-        using var listener = ActivityListenerHelper.CreateWithStarted(ProfilingTelemetry.ActivitySource, activity => startedActivity = activity);
+        using var listener = ActivityListenerHelper.Create(ProfilingTelemetry.ActivitySource, onActivityStarted: activity => startedActivity = activity);
 
         using var activity = telemetry.StartJsonRpcServerCall(
             "GetCapabilitiesAsync",
@@ -298,7 +298,7 @@ public class BackchannelContractTests
     public void DcpRunApplication_UsesConfiguredProfilingParentWhenAmbientActivityIsNotProfiling()
     {
         var activities = new List<Activity>();
-        using var profilingListener = ActivityListenerHelper.CreateWithStarted(ProfilingTelemetry.ActivitySource, activities.Add);
+        using var profilingListener = ActivityListenerHelper.Create(ProfilingTelemetry.ActivitySource, onActivityStarted: activities.Add);
         using var processSource = new ActivitySource("test.process");
         using var processListener = ActivityListenerHelper.Create(processSource);
         using var processActivity = processSource.StartActivity("process npx.CMD", ActivityKind.Internal);

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpHostNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpHostNotificationTests.cs
@@ -11,6 +11,7 @@ using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Diagnostics;
 using Aspire.Hosting.Resources;
 using Aspire.Hosting.Tests.Utils;
+using Aspire.Tests;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Configuration;
@@ -485,7 +486,7 @@ public sealed class DcpHostNotificationTests
     public async Task CreateDcpProcessSpec_WithDcpDeveloperCertificateDefault_IncludesDeveloperCertificateArguments()
     {
         var activities = new ConcurrentBag<Activity>();
-        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, activities.Add);
+        using var listener = ActivityListenerHelper.Create(ProfilingTelemetry.ActivitySource, activities.Add);
         using var certificate = CreateExportableCertificate();
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -745,18 +746,6 @@ public sealed class DcpHostNotificationTests
         Assert.NotEqual(-1, end);
 
         return arguments[start..end];
-    }
-
-    private static ActivityListener CreateActivityListener(string sourceName, Action<Activity> activityStopped)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == sourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStopped = activityStopped
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpHostNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpHostNotificationTests.cs
@@ -486,7 +486,7 @@ public sealed class DcpHostNotificationTests
     public async Task CreateDcpProcessSpec_WithDcpDeveloperCertificateDefault_IncludesDeveloperCertificateArguments()
     {
         var activities = new ConcurrentBag<Activity>();
-        using var listener = ActivityListenerHelper.Create(ProfilingTelemetry.ActivitySource, activities.Add);
+        using var listener = ActivityListenerHelper.Create(ProfilingTelemetry.ActivitySource, onActivityStopped: activities.Add);
         using var certificate = CreateExportableCertificate();
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>

--- a/tests/Aspire.TestUtilities/ActivityListenerHelper.cs
+++ b/tests/Aspire.TestUtilities/ActivityListenerHelper.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Tests;
+
+/// <summary>
+/// Provides factory methods for creating <see cref="ActivityListener"/> instances scoped to a
+/// specific <see cref="ActivitySource"/>. Using instance-based filtering (via
+/// <see cref="object.ReferenceEquals"/>) instead of name-based filtering prevents activities from
+/// parallel tests that use the same source name from leaking into the listener.
+/// </summary>
+public static class ActivityListenerHelper
+{
+    /// <summary>
+    /// Creates an <see cref="ActivityListener"/> that enables sampling on the specified
+    /// <paramref name="targetSource"/> without capturing activities.
+    /// Use when you only need activity creation to succeed (e.g. <c>Activity.Current</c> must be non-null).
+    /// </summary>
+    public static ActivityListener Create(ActivitySource targetSource)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => ReferenceEquals(source, targetSource),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ActivityListener"/> that enables sampling on the specified
+    /// <paramref name="targetSource"/> and invokes <paramref name="onActivityStopped"/> when
+    /// activities complete.
+    /// </summary>
+    public static ActivityListener Create(ActivitySource targetSource, Action<Activity> onActivityStopped)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => ReferenceEquals(source, targetSource),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = onActivityStopped
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ActivityListener"/> that enables sampling on the specified
+    /// <paramref name="targetSource"/> and invokes <paramref name="onActivityStarted"/> when
+    /// activities start.
+    /// </summary>
+    public static ActivityListener CreateWithStarted(ActivitySource targetSource, Action<Activity> onActivityStarted)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => ReferenceEquals(source, targetSource),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = onActivityStarted
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ActivityListener"/> that enables sampling on the named source.
+    /// Use only for test-specific activity sources with unique names that cannot conflict with
+    /// parallel tests (e.g. <c>"test-my-scenario"</c>).
+    /// </summary>
+    public static ActivityListener Create(string sourceName)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == sourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ActivityListener"/> that enables sampling on the named source and
+    /// invokes <paramref name="onActivityStopped"/> when activities complete.
+    /// Use only for test-specific activity sources with unique names.
+    /// </summary>
+    public static ActivityListener Create(string sourceName, Action<Activity> onActivityStopped)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == sourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = onActivityStopped
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+}

--- a/tests/Aspire.TestUtilities/ActivityListenerHelper.cs
+++ b/tests/Aspire.TestUtilities/ActivityListenerHelper.cs
@@ -15,81 +15,15 @@ public static class ActivityListenerHelper
 {
     /// <summary>
     /// Creates an <see cref="ActivityListener"/> that enables sampling on the specified
-    /// <paramref name="targetSource"/> without capturing activities.
-    /// Use when you only need activity creation to succeed (e.g. <c>Activity.Current</c> must be non-null).
+    /// <paramref name="targetSource"/>, optionally invoking callbacks when activities start or stop.
     /// </summary>
-    public static ActivityListener Create(ActivitySource targetSource)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => ReferenceEquals(source, targetSource),
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
-    }
-
-    /// <summary>
-    /// Creates an <see cref="ActivityListener"/> that enables sampling on the specified
-    /// <paramref name="targetSource"/> and invokes <paramref name="onActivityStopped"/> when
-    /// activities complete.
-    /// </summary>
-    public static ActivityListener Create(ActivitySource targetSource, Action<Activity> onActivityStopped)
+    public static ActivityListener Create(ActivitySource targetSource, Action<Activity>? onActivityStarted = null, Action<Activity>? onActivityStopped = null)
     {
         var listener = new ActivityListener
         {
             ShouldListenTo = source => ReferenceEquals(source, targetSource),
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStopped = onActivityStopped
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
-    }
-
-    /// <summary>
-    /// Creates an <see cref="ActivityListener"/> that enables sampling on the specified
-    /// <paramref name="targetSource"/> and invokes <paramref name="onActivityStarted"/> when
-    /// activities start.
-    /// </summary>
-    public static ActivityListener CreateWithStarted(ActivitySource targetSource, Action<Activity> onActivityStarted)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => ReferenceEquals(source, targetSource),
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStarted = onActivityStarted
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
-    }
-
-    /// <summary>
-    /// Creates an <see cref="ActivityListener"/> that enables sampling on the named source.
-    /// Use only for test-specific activity sources with unique names that cannot conflict with
-    /// parallel tests (e.g. <c>"test-my-scenario"</c>).
-    /// </summary>
-    public static ActivityListener Create(string sourceName)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == sourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
-        };
-        ActivitySource.AddActivityListener(listener);
-        return listener;
-    }
-
-    /// <summary>
-    /// Creates an <see cref="ActivityListener"/> that enables sampling on the named source and
-    /// invokes <paramref name="onActivityStopped"/> when activities complete.
-    /// Use only for test-specific activity sources with unique names.
-    /// </summary>
-    public static ActivityListener Create(string sourceName, Action<Activity> onActivityStopped)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == sourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = onActivityStarted,
             ActivityStopped = onActivityStopped
         };
         ActivitySource.AddActivityListener(listener);


### PR DESCRIPTION
## Description

Fixes flaky CI failure in `AssemblyLoaderTests.GetAssemblies_AddsAssemblyNamesToProfilingSpan` and hardens all profiling telemetry tests against parallel activity leaking.

**Root cause:** Test `ActivityListener` instances were registered globally by source **name** (e.g. `"Aspire.Hosting.RemoteHost.Profiling"`). When other test classes using the same source name ran in parallel, their activities leaked into the listener, causing assertions like `Assert.Single()` to fail with extra items.

**Fix:** Scope all test `ActivityListener` instances to specific `ActivitySource` references using `ReferenceEquals` instead of name-based matching. This ensures only activities from the test's own telemetry instance are captured regardless of parallel execution.

### Changes

- **`ActivityListenerHelper`** (new shared utility in `Aspire.TestUtilities`): Single `Create` method that filters by `ReferenceEquals` on an `ActivitySource` instance, with optional `onActivityStarted`/`onActivityStopped` callbacks.
- **Exposed `ActivitySource` properties** on `ProfilingTelemetry` (CLI, Hosting, RemoteHost) so tests can scope listeners to the specific instance.
- **Replaced all per-class `CreateActivityListener` helpers** across 16 test files with the shared `ActivityListenerHelper.Create`.
- **Removed `[Collection(ProfilingTelemetryTestCollection.Name)]`** from `ProfilingTelemetryTests` — parallel execution is now safe with instance-scoped listeners.

CI failure: https://github.com/microsoft/aspire/actions/runs/27704123774

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code/>` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
