### PR TITLE
Assign deployment E2E test failure issues to @mitchdenny

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -333,12 +333,31 @@ jobs:
 
             **Workflow Run:** ${runUrl}
 
+            ### Investigation Checklist
+
+            - [ ] Review workflow logs for error details
+            - [ ] Check if failures are timeout-related or deployment failures
+            - [ ] Download test artifacts (logs, asciinema recordings)
+            - [ ] Identify common failure patterns across tests
+            - [ ] Check Azure authentication and resource provisioning status
+
+            ### Resources
+
+            - **Workflow Logs:** See link above for detailed test output
+            - **Test Artifacts:** Download recordings and logs from the workflow run (testresults/recordings, testresults/logs)
+            - **Deployment E2E Tests:** \`tests/Aspire.Deployment.EndToEnd.Tests/\`
+            - **Test Helpers:** \`tests/Shared/Hex1bAutomatorTestHelpers.cs\`
+
             ### Next Steps
+
             1. Check the workflow run for detailed error logs
-            2. Download test artifacts for asciinema recordings
-            3. Investigate and fix the failing tests
+            2. Download test artifacts for asciinema recordings and error logs
+            3. Investigate which specific tests are failing
+            4. Determine if this is a timeout, deployment, or test automation issue
+            5. Implement fix and verify with local test run
 
             ### Labels
+
             This issue was automatically created by the deployment E2E test workflow.
 
             /cc @microsoft/aspire-team
@@ -373,7 +392,8 @@ jobs:
                 repo: context.repo.repo,
                 title: issueTitle,
                 body: issueBody,
-                labels: ['area-testing', 'deployment-e2e']
+                labels: ['area-testing', 'area-deployment', 'deployment-e2e'],
+                assignees: ['mitchdenny']
               });
               console.log(`Created issue: ${issue.data.html_url}`);
             }


### PR DESCRIPTION
## Summary

This PR improves the GitHub Actions workflow that creates issues for deployment E2E test failures, ensuring that issues are automatically assigned to @mitchdenny for better visibility and ownership.

## Changes

### Workflow Improvements (`deployment-tests.yml`)

1. **Added assignee field to issue creation**
   - New deployment E2E test failure issues are now automatically assigned to @mitchdenny
   - Issues will be prioritized in the assignee's inbox

2. **Enhanced issue template with investigation context**
   - Added investigation checklist with specific troubleshooting steps
   - Included resources section with links to:
     - Test file locations
     - Test helper utilities
     - Artifact locations (logs, recordings)
   - Improved next steps for faster root cause analysis

### Existing Issues

All existing unassigned deployment E2E test failure issues have been assigned to @mitchdenny (22 issues):
- #18309, #18299, #18203, #18027, #18028, #18262, #18229, #18206, #18198, #18193, #18143, #17430, #18076, #17739, #18037, #17998, #17515, #17940, #17428, #17427, #17720, #17523

## Benefits

- **Better Issue Routing**: Ensures all deployment E2E test failures are automatically assigned to @mitchdenny
- **Improved Context**: New issue template provides investigation guidance and resource links
- **Faster Triage**: Clearer structure and checklist helps prioritize investigation efforts
- **Consistent Ownership**: Eliminates unassigned issues from falling through the cracks

## Testing

The workflow changes will be tested when the next deployment E2E test failure occurs. The issue creation step should:
1. Create a new issue with the enhanced template
2. Automatically assign it to @mitchdenny
3. Apply the correct labels (area-testing, deployment-e2e)

## Related Issues

Resolves the problem of unassigned deployment E2E test failure issues preventing proper tracking and ownership.

Fixes: #18309