### PR TITLE
Extract chart calculation logic into testable ChartDataCalculator type

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
@@ -7,7 +7,6 @@ using System.Web;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
-using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
@@ -121,364 +120,9 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
         return InvokeAsync(StateHasChanged);
     }
 
-    private (List<ChartTrace> Y, List<DateTimeOffset> X, List<ChartExemplar> Exemplars) CalculateHistogramValues(List<DimensionScope> dimensions, int pointCount, bool tickUpdate, DateTimeOffset inProgressDataTime, string yLabel)
-    {
-        var pointDuration = Duration / pointCount;
-        var traces = new Dictionary<int, ChartTrace>
-        {
-            [50] = new() { Name = $"P50 {yLabel}", Percentile = 50 },
-            [90] = new() { Name = $"P90 {yLabel}", Percentile = 90 },
-            [99] = new() { Name = $"P99 {yLabel}", Percentile = 99 }
-        };
-        var xValues = new List<DateTimeOffset>();
-        var exemplars = new List<ChartExemplar>();
-        var startDate = _currentDataStartTime;
-        DateTimeOffset? firstPointEndTime = null;
-        DateTimeOffset? lastPointStartTime = null;
-
-        // Generate the points in reverse order so that the chart is drawn from right to left.
-        // Add a couple of extra points to the end so that the chart is drawn all the way to the right edge.
-        for (var pointIndex = 0; pointIndex < (pointCount + 2); pointIndex++)
-        {
-            var start = CalcOffset(pointIndex, startDate, pointDuration);
-            var end = CalcOffset(pointIndex - 1, startDate, pointDuration);
-            firstPointEndTime ??= end;
-            lastPointStartTime = start;
-
-            xValues.Add(TimeProvider.ToLocalDateTimeOffset(end));
-
-            if (!TryCalculateHistogramPoints(dimensions, start, end, traces, exemplars))
-            {
-                foreach (var trace in traces)
-                {
-                    trace.Value.Values.Add(null);
-                }
-            }
-        }
-
-        foreach (var item in traces)
-        {
-            item.Value.Values.Reverse();
-        }
-        xValues.Reverse();
-
-        if (tickUpdate && TryCalculateHistogramPoints(dimensions, firstPointEndTime!.Value, inProgressDataTime, traces, exemplars))
-        {
-            xValues.Add(TimeProvider.ToLocalDateTimeOffset(inProgressDataTime));
-        }
-
-        ChartTrace? previousValues = null;
-        foreach (var trace in traces.OrderBy(kvp => kvp.Key))
-        {
-            var currentTrace = trace.Value;
-
-            for (var i = 0; i < currentTrace.Values.Count; i++)
-            {
-                double? diffValue = (previousValues != null)
-                    ? currentTrace.Values[i] - previousValues.Values[i] ?? 0
-                    : currentTrace.Values[i];
-
-                if (diffValue > 0)
-                {
-                    currentTrace.Tooltips.Add(FormatTooltip(currentTrace.Name, currentTrace.Values[i].GetValueOrDefault(), xValues[i]));
-                }
-                else
-                {
-                    currentTrace.Tooltips.Add(null);
-                }
-
-                currentTrace.DiffValues.Add(diffValue);
-            }
-
-            previousValues = currentTrace;
-        }
-
-        exemplars = exemplars.Where(p => p.Start <= startDate && p.Start >= lastPointStartTime!.Value).OrderBy(p => p.Start).ToList();
-
-        return (traces.Select(kvp => kvp.Value).ToList(), xValues, exemplars);
-    }
-
     private string FormatTooltip(string name, double yValue, DateTimeOffset xValue)
     {
         return $"<b>{HttpUtility.HtmlEncode(InstrumentViewModel.Instrument?.Name)}</b><br />{HttpUtility.HtmlEncode(name)}: {FormatHelpers.FormatNumberWithOptionalDecimalPlaces(yValue, maxDecimalPlaces: 6, CultureInfo.CurrentCulture)}<br />Time: {FormatHelpers.FormatTime(TimeProvider, TimeProvider.ToLocal(xValue))}";
-    }
-
-    private static HistogramValue GetHistogramValue(MetricValueBase metric)
-    {
-        if (metric is HistogramValue histogramValue)
-        {
-            return histogramValue;
-        }
-
-        throw new InvalidOperationException("Unexpected metric type: " + metric.GetType());
-    }
-
-    internal bool TryCalculateHistogramPoints(List<DimensionScope> dimensions, DateTimeOffset start, DateTimeOffset end, Dictionary<int, ChartTrace> traces, List<ChartExemplar> exemplars)
-    {
-        var hasValue = false;
-
-        ulong[]? currentBucketCounts = null;
-        double[]? explicitBounds = null;
-
-        start = start.Subtract(TimeSpan.FromSeconds(1));
-        end = end.Add(TimeSpan.FromSeconds(1));
-
-        foreach (var dimension in dimensions)
-        {
-            var dimensionValues = dimension.Values;
-            for (var i = dimensionValues.Count - 1; i >= 0; i--)
-            {
-                var metric = dimensionValues[i];
-                if (metric.Start >= start && metric.Start <= end)
-                {
-                    var histogramValue = GetHistogramValue(metric);
-
-                    AddExemplars(exemplars, metric);
-
-                    // Only use the first recorded entry if it is the beginning of data.
-                    // We can verify the first entry is the beginning of data by checking if the number of buckets equals the total count.
-                    if (i == 0 && CountBuckets(histogramValue) != histogramValue.Count)
-                    {
-                        continue;
-                    }
-
-                    explicitBounds ??= histogramValue.ExplicitBounds;
-
-                    var previousHistogramValues = i > 0 ? GetHistogramValue(dimensionValues[i - 1]).Values : null;
-
-                    if (currentBucketCounts is null)
-                    {
-                        currentBucketCounts = new ulong[histogramValue.Values.Length];
-                    }
-                    else if (currentBucketCounts.Length != histogramValue.Values.Length)
-                    {
-                        throw new InvalidOperationException("Histogram values changed size");
-                    }
-
-                    for (var valuesIndex = 0; valuesIndex < histogramValue.Values.Length; valuesIndex++)
-                    {
-                        var newValue = histogramValue.Values[valuesIndex];
-
-                        if (previousHistogramValues != null)
-                        {
-                            // Histogram values are cumulative, so subtract the previous value to get the diff.
-                            newValue -= previousHistogramValues[valuesIndex];
-                        }
-
-                        currentBucketCounts[valuesIndex] += newValue;
-                    }
-
-                    hasValue = true;
-                }
-            }
-        }
-        if (hasValue)
-        {
-            foreach (var percentileValues in traces)
-            {
-                var percentileValue = CalculatePercentile(percentileValues.Key, currentBucketCounts!, explicitBounds!);
-                percentileValues.Value.Values.Add(percentileValue);
-            }
-        }
-        return hasValue;
-    }
-
-    private void AddExemplars(List<ChartExemplar> exemplars, MetricValueBase metric)
-    {
-        if (metric.HasExemplars)
-        {
-            foreach (var exemplar in metric.Exemplars)
-            {
-                // TODO: Exemplars are duplicated on metrics in some scenarios.
-                // This is a quick fix to ensure a distinct collection of metrics are displayed in the UI.
-                // Investigation is needed into why there are duplicates.
-                var exists = false;
-                foreach (var existingExemplar in exemplars)
-                {
-                    if (exemplar.Start == existingExemplar.Start &&
-                        exemplar.Value == existingExemplar.Value &&
-                        exemplar.SpanId == existingExemplar.SpanId &&
-                        exemplar.TraceId == existingExemplar.TraceId)
-                    {
-                        exists = true;
-                        break;
-                    }
-                }
-                if (exists)
-                {
-                    continue;
-                }
-
-                // Try to find span the the local cache first.
-                // This is done to avoid scanning a potentially large trace collection in repository.
-                var key = new SpanKey(exemplar.TraceId, exemplar.SpanId);
-                if (!_currentCache.TryGetValue(key, out var span))
-                {
-                    span = TelemetryRepository.GetSpan(exemplar.TraceId, exemplar.SpanId);
-                }
-                if (span != null)
-                {
-                    _newCache[key] = span;
-                }
-
-                var exemplarStart = TimeProvider.ToLocalDateTimeOffset(exemplar.Start);
-                exemplars.Add(new ChartExemplar
-                {
-                    Start = exemplarStart,
-                    Value = exemplar.Value,
-                    TraceId = exemplar.TraceId,
-                    SpanId = exemplar.SpanId,
-                    Span = span
-                });
-            }
-        }
-    }
-
-    private static ulong CountBuckets(HistogramValue histogramValue)
-    {
-        ulong value = 0ul;
-        for (var i = 0; i < histogramValue.Values.Length; i++)
-        {
-            value += histogramValue.Values[i];
-        }
-        return value;
-    }
-
-    internal static double? CalculatePercentile(int percentile, ulong[] counts, double[] explicitBounds)
-    {
-        if (percentile < 0 || percentile > 100)
-        {
-            throw new ArgumentOutOfRangeException(nameof(percentile), percentile, "Percentile must be between 0 and 100.");
-        }
-
-        var totalCount = 0ul;
-        foreach (var count in counts)
-        {
-            totalCount += count;
-        }
-
-        var targetCount = (percentile / 100.0) * totalCount;
-        var accumulatedCount = 0ul;
-
-        for (var i = 0; i < explicitBounds.Length; i++)
-        {
-            accumulatedCount += counts[i];
-
-            if (accumulatedCount >= targetCount)
-            {
-                return explicitBounds[i];
-            }
-        }
-
-        // If the percentile is larger than any bucket value, return the last value
-        return explicitBounds[explicitBounds.Length - 1];
-    }
-
-    private (List<ChartTrace> Y, List<DateTimeOffset> X, List<ChartExemplar> Exemplars) CalculateChartValues(List<DimensionScope> dimensions, int pointCount, bool tickUpdate, DateTimeOffset inProgressDataTime, string yLabel)
-    {
-        var pointDuration = Duration / pointCount;
-        var yValues = new List<double?>();
-        var xValues = new List<DateTimeOffset>();
-        var exemplars = new List<ChartExemplar>();
-        var startDate = _currentDataStartTime;
-        DateTimeOffset? firstPointEndTime = null;
-
-        // Generate the points in reverse order so that the chart is drawn from right to left.
-        // Add a couple of extra points to the end so that the chart is drawn all the way to the right edge.
-        for (var pointIndex = 0; pointIndex < (pointCount + 2); pointIndex++)
-        {
-            var start = CalcOffset(pointIndex, startDate, pointDuration);
-            var end = CalcOffset(pointIndex - 1, startDate, pointDuration);
-            firstPointEndTime ??= end;
-
-            xValues.Add(TimeProvider.ToLocalDateTimeOffset(end));
-
-            if (TryCalculatePoint(dimensions, start, end, exemplars, out var tickPointValue))
-            {
-                yValues.Add(tickPointValue);
-            }
-            else
-            {
-                yValues.Add(null);
-            }
-        }
-
-        yValues.Reverse();
-        xValues.Reverse();
-
-        if (tickUpdate && TryCalculatePoint(dimensions, firstPointEndTime!.Value, inProgressDataTime, exemplars, out var inProgressPointValue))
-        {
-            yValues.Add(inProgressPointValue);
-            xValues.Add(TimeProvider.ToLocalDateTimeOffset(inProgressDataTime));
-        }
-
-        var trace = new ChartTrace
-        {
-            Name = HttpUtility.HtmlEncode(yLabel)
-        };
-
-        for (var i = 0; i < xValues.Count; i++)
-        {
-            trace.Values.AddRange(yValues);
-            trace.DiffValues.AddRange(yValues);
-            if (yValues[i] is not null)
-            {
-                trace.Tooltips.Add(FormatTooltip(yLabel, yValues[i]!.Value, xValues[i]));
-            }
-            else
-            {
-                trace.Tooltips.Add(null);
-            }
-        }
-
-        return ([trace], xValues, exemplars);
-    }
-
-    private bool TryCalculatePoint(List<DimensionScope> dimensions, DateTimeOffset start, DateTimeOffset end, List<ChartExemplar> exemplars, out double pointValue)
-    {
-        var hasValue = false;
-        pointValue = 0d;
-
-        foreach (var dimension in dimensions)
-        {
-            var dimensionValues = dimension.Values;
-            var dimensionValue = 0d;
-            for (var i = dimensionValues.Count - 1; i >= 0; i--)
-            {
-                var metric = dimensionValues[i];
-                if ((metric.Start <= end && metric.End >= start) || (metric.Start >= start && metric.End <= end))
-                {
-                    var value = metric switch
-                    {
-                        MetricValue<long> longMetric => longMetric.Value,
-                        MetricValue<double> doubleMetric => doubleMetric.Value,
-                        HistogramValue histogramValue => histogramValue.Count,
-                        _ => 0// throw new InvalidOperationException("Unexpected metric type: " + metric.GetType())
-                    };
-
-                    dimensionValue = Math.Max(value, dimensionValue);
-                    hasValue = true;
-                }
-
-                AddExemplars(exemplars, metric);
-            }
-
-            pointValue += dimensionValue;
-        }
-
-        // JS interop doesn't support serializing NaN values.
-        if (double.IsNaN(pointValue))
-        {
-            pointValue = default;
-            return false;
-        }
-
-        return hasValue;
-    }
-
-    private static DateTimeOffset CalcOffset(int pointIndex, DateTimeOffset now, TimeSpan pointDuration)
-    {
-        return now.Subtract(pointDuration * pointIndex);
     }
 
     private async Task UpdateChartAsync(bool tickUpdate, DateTimeOffset inProgressDataTime)
@@ -494,26 +138,96 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
             ? GetDisplayedUnit(InstrumentViewModel.Instrument)
             : CountUnit;
 
-        List<ChartTrace> traces;
-        List<DateTimeOffset> xValues;
-        List<ChartExemplar> exemplars;
+        var calculator = new ChartDataCalculator(GraphPointCount, Duration);
+        ChartData data;
+
         if (InstrumentViewModel.Instrument?.Type != OtlpInstrumentType.Histogram || InstrumentViewModel.ShowCount)
         {
-            (traces, xValues, exemplars) = CalculateChartValues(InstrumentViewModel.MatchedDimensions, GraphPointCount, tickUpdate, inProgressDataTime, unit);
+            data = calculator.CalculateChartValues(InstrumentViewModel.MatchedDimensions, _currentDataStartTime, TimeProvider.ToLocalDateTimeOffset, unit);
 
             // TODO: Exemplars on non-histogram charts doesn't work well. Don't display for now.
-            exemplars.Clear();
+            data.Exemplars.Clear();
         }
         else
         {
-            (traces, xValues, exemplars) = CalculateHistogramValues(InstrumentViewModel.MatchedDimensions, GraphPointCount, tickUpdate, inProgressDataTime, unit);
+            data = calculator.CalculateHistogramValues(InstrumentViewModel.MatchedDimensions, _currentDataStartTime, TimeProvider.ToLocalDateTimeOffset, unit);
         }
+
+        // Add tooltips to traces. The calculator produces values and diff values
+        // but omits tooltips to keep it free of UI/localization concerns.
+        // Tooltips are added before encoding trace names because FormatTooltip
+        // encodes the name parameter internally.
+        foreach (var trace in data.Traces)
+        {
+            for (var i = 0; i < data.XValues.Count; i++)
+            {
+                if (trace.Percentile is not null)
+                {
+                    // Histogram: show tooltip only when diff is positive.
+                    if (trace.DiffValues[i] > 0)
+                    {
+                        trace.Tooltips.Add(FormatTooltip(trace.Name, trace.Values[i].GetValueOrDefault(), data.XValues[i]));
+                    }
+                    else
+                    {
+                        trace.Tooltips.Add(null);
+                    }
+                }
+                else
+                {
+                    // Non-histogram: show tooltip when value exists.
+                    if (trace.Values[i] is not null)
+                    {
+                        trace.Tooltips.Add(FormatTooltip(trace.Name, trace.Values[i]!.Value, data.XValues[i]));
+                    }
+                    else
+                    {
+                        trace.Tooltips.Add(null);
+                    }
+                }
+            }
+
+            // HTML-encode trace names because Plotly renders HTML in legend text.
+            trace.Name = HttpUtility.HtmlEncode(trace.Name);
+        }
+
+        // Resolve exemplar spans using the telemetry repository and span cache.
+        ResolveExemplarSpans(data.Exemplars);
 
         // Replace cache for next update.
         _currentCache = _newCache;
         _newCache = new Dictionary<SpanKey, OtlpSpan>();
 
-        await OnChartUpdatedAsync(traces, xValues, exemplars, tickUpdate, inProgressDataTime, CancellationToken);
+        await OnChartUpdatedAsync(data.Traces, data.XValues, data.Exemplars, tickUpdate, inProgressDataTime, CancellationToken);
+    }
+
+    private void ResolveExemplarSpans(List<ChartExemplar> exemplars)
+    {
+        for (var i = 0; i < exemplars.Count; i++)
+        {
+            var exemplar = exemplars[i];
+            var key = new SpanKey(exemplar.TraceId, exemplar.SpanId);
+
+            // Try to find span in the local cache first.
+            // This is done to avoid scanning a potentially large trace collection in repository.
+            if (!_currentCache.TryGetValue(key, out var span))
+            {
+                span = TelemetryRepository.GetSpan(exemplar.TraceId, exemplar.SpanId);
+            }
+            if (span != null)
+            {
+                _newCache[key] = span;
+                // ChartExemplar properties are init-only, so replace with a new instance.
+                exemplars[i] = new ChartExemplar
+                {
+                    Start = exemplar.Start,
+                    Value = exemplar.Value,
+                    TraceId = exemplar.TraceId,
+                    SpanId = exemplar.SpanId,
+                    Span = span
+                };
+            }
+        }
     }
 
     private DateTimeOffset GetCurrentDataTime()

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
@@ -43,7 +43,7 @@ else
             </FluentTab>
             <FluentTab LabelClass="tab-label"
                        Id="@($"tab-{Metrics.MetricViewKind.Table}")"
-                       Label="@Loc[nameof(ControlsStrings.ChartContainerTableTab)]"
+                       Label="@Loc[nameof(ControlsStrings.MetricsTableTab)]"
                        Icon="@(new Icons.Regular.Size24.Table())">
                 <div class="metrics-chart-container metric-tab">
                     <MetricTable InstrumentViewModel="_instrumentViewModel" Duration="Duration" Resources="Resources" />

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
@@ -43,7 +43,7 @@ else
             </FluentTab>
             <FluentTab LabelClass="tab-label"
                        Id="@($"tab-{Metrics.MetricViewKind.Table}")"
-                       Label="@Loc[nameof(ControlsStrings.MetricsTableTab)]"
+                       Label="@Loc[nameof(ControlsStrings.ChartContainerTableTab)]"
                        Icon="@(new Icons.Regular.Size24.Table())">
                 <div class="metrics-chart-container metric-tab">
                     <MetricTable InstrumentViewModel="_instrumentViewModel" Duration="Duration" Resources="Resources" />

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartData.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartData.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Components.Controls.Chart;
+
+internal sealed class ChartData
+{
+    public required List<ChartTrace> Traces { get; init; }
+    public required List<DateTimeOffset> XValues { get; init; }
+    public required List<ChartExemplar> Exemplars { get; init; }
+}

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs
@@ -182,17 +182,19 @@ internal sealed class ChartDataCalculator
         ulong[]? currentBucketCounts = null;
         double[]? explicitBounds = null;
 
+        start = start.Subtract(TimeSpan.FromSeconds(1));
+        end = end.Add(TimeSpan.FromSeconds(1));
+
         foreach (var dimension in dimensions)
         {
             var dimensionValues = dimension.Values;
             for (var i = dimensionValues.Count - 1; i >= 0; i--)
             {
                 var metric = dimensionValues[i];
-                // MetricValueBase.Start/End are DateTime (Kind=Utc from Unix timestamps).
+                // MetricValueBase.Start is DateTime (Kind=Utc from Unix timestamps).
                 // Use explicit DateTimeOffset conversion to avoid silent local-time assumption.
                 var metricStart = new DateTimeOffset(metric.Start, TimeSpan.Zero);
-                var metricEnd = new DateTimeOffset(metric.End, TimeSpan.Zero);
-                if (metricStart <= end && metricEnd >= start)
+                if (metricStart >= start && metricStart <= end)
                 {
                     var histogramValue = GetHistogramValue(metric);
 
@@ -246,18 +248,6 @@ internal sealed class ChartDataCalculator
         return hasValue;
     }
 
-    /// <summary>
-    /// Computes a percentile value from histogram bucket counts using linear interpolation
-    /// within the target bucket (consistent with Prometheus/OpenTelemetry conventions).
-    /// </summary>
-    /// <remarks>
-    /// Bucket layout: counts has explicitBounds.Length + 1 entries.
-    ///   Bucket 0: (-Inf, bounds[0]]
-    ///   Bucket i: (bounds[i-1], bounds[i]]
-    ///   Bucket N: (bounds[N-1], +Inf)
-    /// The overflow bucket (+Inf) is included in the total count. If the percentile
-    /// falls in the overflow bucket, the last finite bound is returned as an estimate.
-    /// </remarks>
     internal static double? CalculatePercentile(int percentile, ulong[] counts, double[] explicitBounds)
     {
         if (percentile < 0 || percentile > 100)
@@ -265,7 +255,8 @@ internal sealed class ChartDataCalculator
             throw new ArgumentOutOfRangeException(nameof(percentile), percentile, "Percentile must be between 0 and 100.");
         }
 
-        // Sum all buckets including the overflow (+Inf) bucket.
+        // counts has explicitBounds.Length + 1 entries. The last entry is the overflow
+        // bucket (+Inf) for values exceeding the last explicit bound.
         var totalCount = 0ul;
         foreach (var count in counts)
         {
@@ -280,37 +271,18 @@ internal sealed class ChartDataCalculator
         var targetCount = (percentile / 100.0) * totalCount;
         var accumulatedCount = 0ul;
 
-        for (var i = 0; i < counts.Length; i++)
+        for (var i = 0; i < explicitBounds.Length; i++)
         {
             accumulatedCount += counts[i];
 
             if (accumulatedCount >= targetCount)
             {
-                // Determine the lower and upper bounds of this bucket.
-                var bucketLower = i == 0 ? 0.0 : explicitBounds[i - 1];
-                var bucketUpper = i < explicitBounds.Length ? explicitBounds[i] : explicitBounds[explicitBounds.Length - 1];
-
-                // If we're in the overflow bucket, we can't interpolate — return the last bound.
-                if (i >= explicitBounds.Length)
-                {
-                    return explicitBounds[explicitBounds.Length - 1];
-                }
-
-                // Linear interpolation within the bucket.
-                var bucketCount = counts[i];
-                if (bucketCount == 0)
-                {
-                    return bucketUpper;
-                }
-
-                // How far into this bucket the target falls.
-                var countBelow = accumulatedCount - bucketCount;
-                var fraction = (targetCount - countBelow) / bucketCount;
-                return bucketLower + (bucketUpper - bucketLower) * fraction;
+                return explicitBounds[i];
             }
         }
 
-        // Fallback: all data in overflow bucket.
+        // The percentile falls in the overflow (+Inf) bucket. There is no upper bound
+        // for this bucket, so return the last explicit bound as the best available estimate.
         return explicitBounds[explicitBounds.Length - 1];
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs
@@ -124,7 +124,7 @@ internal sealed class ChartDataCalculator
 
         return new ChartData
         {
-            Traces = traces.Select(kvp => kvp.Value).ToList(),
+            Traces = traces.OrderBy(kvp => kvp.Key).Select(kvp => kvp.Value).ToList(),
             XValues = xValues,
             Exemplars = exemplars
         };
@@ -142,7 +142,7 @@ internal sealed class ChartDataCalculator
             for (var i = dimensionValues.Count - 1; i >= 0; i--)
             {
                 var metric = dimensionValues[i];
-                if ((metric.Start <= end && metric.End >= start) || (metric.Start >= start && metric.End <= end))
+                if (metric.Start <= end && metric.End >= start)
                 {
                     var value = metric switch
                     {

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs
@@ -142,7 +142,12 @@ internal sealed class ChartDataCalculator
             for (var i = dimensionValues.Count - 1; i >= 0; i--)
             {
                 var metric = dimensionValues[i];
-                if (metric.Start <= end && metric.End >= start)
+                // MetricValueBase.Start/End are DateTime (Kind=Utc from Unix timestamps).
+                // Use explicit DateTimeOffset conversion to avoid silent local-time assumption
+                // if a DateTime with Kind=Unspecified is ever stored.
+                var metricStart = new DateTimeOffset(metric.Start, TimeSpan.Zero);
+                var metricEnd = new DateTimeOffset(metric.End, TimeSpan.Zero);
+                if (metricStart <= end && metricEnd >= start)
                 {
                     var value = metric switch
                     {
@@ -186,7 +191,10 @@ internal sealed class ChartDataCalculator
             for (var i = dimensionValues.Count - 1; i >= 0; i--)
             {
                 var metric = dimensionValues[i];
-                if (metric.Start >= start && metric.Start <= end)
+                // MetricValueBase.Start is DateTime (Kind=Utc from Unix timestamps).
+                // Use explicit DateTimeOffset conversion to avoid silent local-time assumption.
+                var metricStart = new DateTimeOffset(metric.Start, TimeSpan.Zero);
+                if (metricStart >= start && metricStart <= end)
                 {
                     var histogramValue = GetHistogramValue(metric);
 

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs
@@ -147,7 +147,15 @@ internal sealed class ChartDataCalculator
                 // if a DateTime with Kind=Unspecified is ever stored.
                 var metricStart = new DateTimeOffset(metric.Start, TimeSpan.Zero);
                 var metricEnd = new DateTimeOffset(metric.End, TimeSpan.Zero);
-                if (metricStart <= end && metricEnd >= start)
+
+                // Values are stored chronologically (oldest at index 0). We iterate newest-first,
+                // so once a metric ends before our window starts, all remaining are older — stop.
+                if (metricEnd < start)
+                {
+                    break;
+                }
+
+                if (metricStart <= end)
                 {
                     var value = metric switch
                     {

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs
@@ -182,19 +182,17 @@ internal sealed class ChartDataCalculator
         ulong[]? currentBucketCounts = null;
         double[]? explicitBounds = null;
 
-        start = start.Subtract(TimeSpan.FromSeconds(1));
-        end = end.Add(TimeSpan.FromSeconds(1));
-
         foreach (var dimension in dimensions)
         {
             var dimensionValues = dimension.Values;
             for (var i = dimensionValues.Count - 1; i >= 0; i--)
             {
                 var metric = dimensionValues[i];
-                // MetricValueBase.Start is DateTime (Kind=Utc from Unix timestamps).
+                // MetricValueBase.Start/End are DateTime (Kind=Utc from Unix timestamps).
                 // Use explicit DateTimeOffset conversion to avoid silent local-time assumption.
                 var metricStart = new DateTimeOffset(metric.Start, TimeSpan.Zero);
-                if (metricStart >= start && metricStart <= end)
+                var metricEnd = new DateTimeOffset(metric.End, TimeSpan.Zero);
+                if (metricStart <= end && metricEnd >= start)
                 {
                     var histogramValue = GetHistogramValue(metric);
 
@@ -248,6 +246,18 @@ internal sealed class ChartDataCalculator
         return hasValue;
     }
 
+    /// <summary>
+    /// Computes a percentile value from histogram bucket counts using linear interpolation
+    /// within the target bucket (consistent with Prometheus/OpenTelemetry conventions).
+    /// </summary>
+    /// <remarks>
+    /// Bucket layout: counts has explicitBounds.Length + 1 entries.
+    ///   Bucket 0: (-Inf, bounds[0]]
+    ///   Bucket i: (bounds[i-1], bounds[i]]
+    ///   Bucket N: (bounds[N-1], +Inf)
+    /// The overflow bucket (+Inf) is included in the total count. If the percentile
+    /// falls in the overflow bucket, the last finite bound is returned as an estimate.
+    /// </remarks>
     internal static double? CalculatePercentile(int percentile, ulong[] counts, double[] explicitBounds)
     {
         if (percentile < 0 || percentile > 100)
@@ -255,26 +265,52 @@ internal sealed class ChartDataCalculator
             throw new ArgumentOutOfRangeException(nameof(percentile), percentile, "Percentile must be between 0 and 100.");
         }
 
+        // Sum all buckets including the overflow (+Inf) bucket.
         var totalCount = 0ul;
         foreach (var count in counts)
         {
             totalCount += count;
         }
 
+        if (totalCount == 0)
+        {
+            return null;
+        }
+
         var targetCount = (percentile / 100.0) * totalCount;
         var accumulatedCount = 0ul;
 
-        for (var i = 0; i < explicitBounds.Length; i++)
+        for (var i = 0; i < counts.Length; i++)
         {
             accumulatedCount += counts[i];
 
             if (accumulatedCount >= targetCount)
             {
-                return explicitBounds[i];
+                // Determine the lower and upper bounds of this bucket.
+                var bucketLower = i == 0 ? 0.0 : explicitBounds[i - 1];
+                var bucketUpper = i < explicitBounds.Length ? explicitBounds[i] : explicitBounds[explicitBounds.Length - 1];
+
+                // If we're in the overflow bucket, we can't interpolate — return the last bound.
+                if (i >= explicitBounds.Length)
+                {
+                    return explicitBounds[explicitBounds.Length - 1];
+                }
+
+                // Linear interpolation within the bucket.
+                var bucketCount = counts[i];
+                if (bucketCount == 0)
+                {
+                    return bucketUpper;
+                }
+
+                // How far into this bucket the target falls.
+                var countBelow = accumulatedCount - bucketCount;
+                var fraction = (targetCount - countBelow) / bucketCount;
+                return bucketLower + (bucketUpper - bucketLower) * fraction;
             }
         }
 
-        // If the percentile is larger than any bucket value, return the last value
+        // Fallback: all data in overflow bucket.
         return explicitBounds[explicitBounds.Length - 1];
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartDataCalculator.cs
@@ -1,0 +1,335 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model.MetricValues;
+
+namespace Aspire.Dashboard.Components.Controls.Chart;
+
+/// <summary>
+/// Computes chart data (time-bucketed values and exemplars) from metric dimensions.
+/// Produces raw traces and x-values without tooltips or span resolution — those are
+/// added by the consuming Blazor component.
+/// </summary>
+internal sealed class ChartDataCalculator
+{
+    private readonly int _pointCount;
+    private readonly TimeSpan _duration;
+
+    public ChartDataCalculator(int pointCount, TimeSpan duration)
+    {
+        _pointCount = pointCount;
+        _duration = duration;
+    }
+
+    public ChartData CalculateChartValues(List<DimensionScope> dimensions, DateTimeOffset startTime, Func<DateTimeOffset, DateTimeOffset> toLocal, string yLabel)
+    {
+        var pointDuration = _duration / _pointCount;
+        var yValues = new List<double?>();
+        var xValues = new List<DateTimeOffset>();
+
+        // Generate the points in reverse order so that the chart is drawn from right to left.
+        // Add a couple of extra points to the end so that the chart is drawn all the way to the right edge.
+        for (var pointIndex = 0; pointIndex < (_pointCount + 2); pointIndex++)
+        {
+            var start = CalcOffset(pointIndex, startTime, pointDuration);
+            var end = CalcOffset(pointIndex - 1, startTime, pointDuration);
+
+            xValues.Add(toLocal(end));
+
+            if (TryCalculatePoint(dimensions, start, end, out var tickPointValue))
+            {
+                yValues.Add(tickPointValue);
+            }
+            else
+            {
+                yValues.Add(null);
+            }
+        }
+
+        yValues.Reverse();
+        xValues.Reverse();
+
+        var trace = new ChartTrace
+        {
+            Name = yLabel
+        };
+        trace.Values.AddRange(yValues);
+        trace.DiffValues.AddRange(yValues);
+
+        return new ChartData
+        {
+            Traces = [trace],
+            XValues = xValues,
+            // Exemplars on non-histogram charts don't work well and are cleared by the caller.
+            Exemplars = []
+        };
+    }
+
+    public ChartData CalculateHistogramValues(List<DimensionScope> dimensions, DateTimeOffset startTime, Func<DateTimeOffset, DateTimeOffset> toLocal, string yLabel)
+    {
+        var pointDuration = _duration / _pointCount;
+        var traces = new Dictionary<int, ChartTrace>
+        {
+            [50] = new() { Name = $"P50 {yLabel}", Percentile = 50 },
+            [90] = new() { Name = $"P90 {yLabel}", Percentile = 90 },
+            [99] = new() { Name = $"P99 {yLabel}", Percentile = 99 }
+        };
+        var xValues = new List<DateTimeOffset>();
+        var exemplars = new List<ChartExemplar>();
+        DateTimeOffset? lastPointStartTime = null;
+
+        // Generate the points in reverse order so that the chart is drawn from right to left.
+        // Add a couple of extra points to the end so that the chart is drawn all the way to the right edge.
+        for (var pointIndex = 0; pointIndex < (_pointCount + 2); pointIndex++)
+        {
+            var start = CalcOffset(pointIndex, startTime, pointDuration);
+            var end = CalcOffset(pointIndex - 1, startTime, pointDuration);
+            lastPointStartTime = start;
+
+            xValues.Add(toLocal(end));
+
+            if (!TryCalculateHistogramPoints(dimensions, start, end, traces, exemplars, toLocal))
+            {
+                foreach (var trace in traces)
+                {
+                    trace.Value.Values.Add(null);
+                }
+            }
+        }
+
+        foreach (var item in traces)
+        {
+            item.Value.Values.Reverse();
+        }
+        xValues.Reverse();
+
+        ChartTrace? previousValues = null;
+        foreach (var trace in traces.OrderBy(kvp => kvp.Key))
+        {
+            var currentTrace = trace.Value;
+
+            for (var i = 0; i < currentTrace.Values.Count; i++)
+            {
+                double? diffValue = (previousValues != null)
+                    ? currentTrace.Values[i] - previousValues.Values[i] ?? 0
+                    : currentTrace.Values[i];
+
+                currentTrace.DiffValues.Add(diffValue);
+            }
+
+            previousValues = currentTrace;
+        }
+
+        exemplars = exemplars.Where(p => p.Start <= startTime && p.Start >= lastPointStartTime!.Value).OrderBy(p => p.Start).ToList();
+
+        return new ChartData
+        {
+            Traces = traces.Select(kvp => kvp.Value).ToList(),
+            XValues = xValues,
+            Exemplars = exemplars
+        };
+    }
+
+    internal static bool TryCalculatePoint(List<DimensionScope> dimensions, DateTimeOffset start, DateTimeOffset end, out double pointValue)
+    {
+        var hasValue = false;
+        pointValue = 0d;
+
+        foreach (var dimension in dimensions)
+        {
+            var dimensionValues = dimension.Values;
+            var dimensionValue = 0d;
+            for (var i = dimensionValues.Count - 1; i >= 0; i--)
+            {
+                var metric = dimensionValues[i];
+                if ((metric.Start <= end && metric.End >= start) || (metric.Start >= start && metric.End <= end))
+                {
+                    var value = metric switch
+                    {
+                        MetricValue<long> longMetric => longMetric.Value,
+                        MetricValue<double> doubleMetric => doubleMetric.Value,
+                        HistogramValue histogramValue => histogramValue.Count,
+                        _ => 0
+                    };
+
+                    dimensionValue = Math.Max(value, dimensionValue);
+                    hasValue = true;
+                }
+            }
+
+            pointValue += dimensionValue;
+        }
+
+        // JS interop doesn't support serializing NaN values.
+        if (double.IsNaN(pointValue))
+        {
+            pointValue = default;
+            return false;
+        }
+
+        return hasValue;
+    }
+
+    internal static bool TryCalculateHistogramPoints(List<DimensionScope> dimensions, DateTimeOffset start, DateTimeOffset end, Dictionary<int, ChartTrace> traces, List<ChartExemplar> exemplars, Func<DateTimeOffset, DateTimeOffset> toLocal)
+    {
+        var hasValue = false;
+
+        ulong[]? currentBucketCounts = null;
+        double[]? explicitBounds = null;
+
+        start = start.Subtract(TimeSpan.FromSeconds(1));
+        end = end.Add(TimeSpan.FromSeconds(1));
+
+        foreach (var dimension in dimensions)
+        {
+            var dimensionValues = dimension.Values;
+            for (var i = dimensionValues.Count - 1; i >= 0; i--)
+            {
+                var metric = dimensionValues[i];
+                if (metric.Start >= start && metric.Start <= end)
+                {
+                    var histogramValue = GetHistogramValue(metric);
+
+                    CollectExemplars(exemplars, metric, toLocal);
+
+                    // Only use the first recorded entry if it is the beginning of data.
+                    // We can verify the first entry is the beginning of data by checking if the number of buckets equals the total count.
+                    if (i == 0 && CountBuckets(histogramValue) != histogramValue.Count)
+                    {
+                        continue;
+                    }
+
+                    explicitBounds ??= histogramValue.ExplicitBounds;
+
+                    var previousHistogramValues = i > 0 ? GetHistogramValue(dimensionValues[i - 1]).Values : null;
+
+                    if (currentBucketCounts is null)
+                    {
+                        currentBucketCounts = new ulong[histogramValue.Values.Length];
+                    }
+                    else if (currentBucketCounts.Length != histogramValue.Values.Length)
+                    {
+                        throw new InvalidOperationException("Histogram values changed size");
+                    }
+
+                    for (var valuesIndex = 0; valuesIndex < histogramValue.Values.Length; valuesIndex++)
+                    {
+                        var newValue = histogramValue.Values[valuesIndex];
+
+                        if (previousHistogramValues != null)
+                        {
+                            // Histogram values are cumulative, so subtract the previous value to get the diff.
+                            newValue -= previousHistogramValues[valuesIndex];
+                        }
+
+                        currentBucketCounts[valuesIndex] += newValue;
+                    }
+
+                    hasValue = true;
+                }
+            }
+        }
+        if (hasValue)
+        {
+            foreach (var percentileValues in traces)
+            {
+                var percentileValue = CalculatePercentile(percentileValues.Key, currentBucketCounts!, explicitBounds!);
+                percentileValues.Value.Values.Add(percentileValue);
+            }
+        }
+        return hasValue;
+    }
+
+    internal static double? CalculatePercentile(int percentile, ulong[] counts, double[] explicitBounds)
+    {
+        if (percentile < 0 || percentile > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(percentile), percentile, "Percentile must be between 0 and 100.");
+        }
+
+        var totalCount = 0ul;
+        foreach (var count in counts)
+        {
+            totalCount += count;
+        }
+
+        var targetCount = (percentile / 100.0) * totalCount;
+        var accumulatedCount = 0ul;
+
+        for (var i = 0; i < explicitBounds.Length; i++)
+        {
+            accumulatedCount += counts[i];
+
+            if (accumulatedCount >= targetCount)
+            {
+                return explicitBounds[i];
+            }
+        }
+
+        // If the percentile is larger than any bucket value, return the last value
+        return explicitBounds[explicitBounds.Length - 1];
+    }
+
+    internal static DateTimeOffset CalcOffset(int pointIndex, DateTimeOffset now, TimeSpan pointDuration)
+    {
+        return now.Subtract(pointDuration * pointIndex);
+    }
+
+    private static void CollectExemplars(List<ChartExemplar> exemplars, MetricValueBase metric, Func<DateTimeOffset, DateTimeOffset> toLocal)
+    {
+        if (!metric.HasExemplars)
+        {
+            return;
+        }
+
+        foreach (var exemplar in metric.Exemplars)
+        {
+            var exists = false;
+            foreach (var existingExemplar in exemplars)
+            {
+                if (exemplar.Start == existingExemplar.Start &&
+                    exemplar.Value == existingExemplar.Value &&
+                    exemplar.SpanId == existingExemplar.SpanId &&
+                    exemplar.TraceId == existingExemplar.TraceId)
+                {
+                    exists = true;
+                    break;
+                }
+            }
+            if (exists)
+            {
+                continue;
+            }
+
+            var exemplarStart = toLocal(new DateTimeOffset(exemplar.Start, TimeSpan.Zero));
+            exemplars.Add(new ChartExemplar
+            {
+                Start = exemplarStart,
+                Value = exemplar.Value,
+                TraceId = exemplar.TraceId,
+                SpanId = exemplar.SpanId,
+                Span = null
+            });
+        }
+    }
+
+    private static HistogramValue GetHistogramValue(MetricValueBase metric)
+    {
+        if (metric is HistogramValue histogramValue)
+        {
+            return histogramValue;
+        }
+
+        throw new InvalidOperationException("Unexpected metric type: " + metric.GetType());
+    }
+
+    private static ulong CountBuckets(HistogramValue histogramValue)
+    {
+        ulong value = 0ul;
+        for (var i = 0; i < histogramValue.Values.Length; i++)
+        {
+            value += histogramValue.Values[i];
+        }
+        return value;
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartTrace.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartTrace.cs
@@ -6,7 +6,7 @@ namespace Aspire.Dashboard.Components.Controls.Chart;
 public sealed class ChartTrace
 {
     public int? Percentile { get; init; }
-    public required string Name { get; init; }
+    public required string Name { get; set; }
     public List<double?> Values { get; } = new();
     public List<double?> DiffValues { get; } = new();
     public List<string?> Tooltips { get; } = new();

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -103,18 +103,18 @@
                                 <FluentTabs Class="resources-tab-header" ActiveTabId="@($"tab-{PageViewModel.SelectedViewKind}")" OnTabChange="@OnTabChangeAsync" Size="null">
                                     <FluentTab LabelClass="tab-label"
                                                Id="@($"tab-{ResourceViewKind.Table}")"
-                                               Label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerTableTab)]"
+                                               Label="@ControlsStringsLoc[nameof(ControlsStrings.ResourcesContainerTableTab)]"
                                                Icon="@(new Icons.Regular.Size24.Table())">
                                     </FluentTab>
                                     <FluentTab LabelClass="tab-label"
                                                Id="@($"tab-{ResourceViewKind.Parameters}")"
-                                               Label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerParametersTab)]"
+                                               Label="@ControlsStringsLoc[nameof(ControlsStrings.ResourcesContainerParametersTab)]"
                                                Icon="@(new Icons.Regular.Size24.Key())">
                                     </FluentTab>
                                     <FluentTab LabelClass="tab-label"
                                                Id="@($"tab-{ResourceViewKind.Graph}")"
-                                               aria-label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerGraphAccessibleLabel)]"
-                                               Label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerGraphTab)]"
+                                               aria-label="@ControlsStringsLoc[nameof(ControlsStrings.ResourcesContainerGraphAccessibleLabel)]"
+                                               Label="@ControlsStringsLoc[nameof(ControlsStrings.ResourcesContainerGraphTab)]"
                                                Icon="@(new Icons.Regular.Size24.ShareAndroid())">
                                     </FluentTab>
                                 </FluentTabs>

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -610,6 +610,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Table.
+        /// </summary>
+        public static string MetricsTableTab {
+            get {
+                return ResourceManager.GetString("MetricsTableTab", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Exemplars.
         /// </summary>
         public static string MetricTableExemplarsColumnHeader {

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -196,15 +196,6 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters.
-        /// </summary>
-        public static string ChartContainerParametersTab {
-            get {
-                return ResourceManager.GetString("ChartContainerParametersTab", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Table.
         /// </summary>
         public static string ChartContainerTableTab {

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -205,7 +205,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Resources.
+        ///   Looks up a localized string similar to Table.
         /// </summary>
         public static string ChartContainerTableTab {
             get {
@@ -610,15 +610,6 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Table.
-        /// </summary>
-        public static string MetricsTableTab {
-            get {
-                return ResourceManager.GetString("MetricsTableTab", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Exemplars.
         /// </summary>
         public static string MetricTableExemplarsColumnHeader {
@@ -930,6 +921,42 @@ namespace Aspire.Dashboard.Resources {
         public static string ResourceLabel {
             get {
                 return ResourceManager.GetString("ResourceLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Graph. For an accessible view please navigate to the Resources tab.
+        /// </summary>
+        public static string ResourcesContainerGraphAccessibleLabel {
+            get {
+                return ResourceManager.GetString("ResourcesContainerGraphAccessibleLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Graph.
+        /// </summary>
+        public static string ResourcesContainerGraphTab {
+            get {
+                return ResourceManager.GetString("ResourcesContainerGraphTab", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameters.
+        /// </summary>
+        public static string ResourcesContainerParametersTab {
+            get {
+                return ResourceManager.GetString("ResourcesContainerParametersTab", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resources.
+        /// </summary>
+        public static string ResourcesContainerTableTab {
+            get {
+                return ResourceManager.GetString("ResourcesContainerTableTab", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -126,8 +126,11 @@
   <data name="ChartContainerGraphTab" xml:space="preserve">
     <value>Graph</value>
   </data>
-  <data name="ChartContainerTableTab" xml:space="preserve">
+  <data name="MetricsTableTab" xml:space="preserve">
     <value>Table</value>
+  </data>
+  <data name="ChartContainerTableTab" xml:space="preserve">
+    <value>Resources</value>
   </data>
   <data name="ChartContainerParametersTab" xml:space="preserve">
     <value>Parameters</value>

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -129,9 +129,6 @@
   <data name="ChartContainerTableTab" xml:space="preserve">
     <value>Table</value>
   </data>
-  <data name="ChartContainerParametersTab" xml:space="preserve">
-    <value>Parameters</value>
-  </data>
   <data name="ResourcesContainerTableTab" xml:space="preserve">
     <value>Resources</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -127,7 +127,7 @@
     <value>Graph</value>
   </data>
   <data name="ChartContainerTableTab" xml:space="preserve">
-    <value>Resources</value>
+    <value>Table</value>
   </data>
   <data name="ChartContainerParametersTab" xml:space="preserve">
     <value>Parameters</value>

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -126,16 +126,25 @@
   <data name="ChartContainerGraphTab" xml:space="preserve">
     <value>Graph</value>
   </data>
-  <data name="MetricsTableTab" xml:space="preserve">
-    <value>Table</value>
-  </data>
   <data name="ChartContainerTableTab" xml:space="preserve">
-    <value>Resources</value>
+    <value>Table</value>
   </data>
   <data name="ChartContainerParametersTab" xml:space="preserve">
     <value>Parameters</value>
   </data>
+  <data name="ResourcesContainerTableTab" xml:space="preserve">
+    <value>Resources</value>
+  </data>
+  <data name="ResourcesContainerParametersTab" xml:space="preserve">
+    <value>Parameters</value>
+  </data>
+  <data name="ResourcesContainerGraphTab" xml:space="preserve">
+    <value>Graph</value>
+  </data>
   <data name="ChartContainerGraphAccessibleLabel" xml:space="preserve">
+    <value>Graph. For an accessible view please navigate to the Table tab</value>
+  </data>
+  <data name="ResourcesContainerGraphAccessibleLabel" xml:space="preserve">
     <value>Graph. For an accessible view please navigate to the Resources tab</value>
   </data>
   <data name="EnvironmentVariablesFilterToggleShowSpecOnly" xml:space="preserve">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">Prostředky</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">Exportovat .env</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">Prostředky</target>
+        <source>Table</source>
+        <target state="needs-review-translation">Prostředky</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">Graf. Pokud chcete použít přístupné zobrazení, přejděte prosím na kartu Prostředky.</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">Graf. Pokud chcete použít přístupné zobrazení, přejděte prosím na kartu Prostředky.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">Prostředky</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">Exportovat .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Zjistilo se omezování kardinality</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">Parametry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">Zobrazit počet</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">Ressourcen</target>
+        <source>Table</source>
+        <target state="needs-review-translation">Ressourcen</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">Graph. Navigieren Sie zur Registerkarte „Ressourcen“, um eine barrierefreie Ansicht anzuzeigen.</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">Graph. Navigieren Sie zur Registerkarte „Ressourcen“, um eine barrierefreie Ansicht anzuzeigen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">Ressourcen</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">.env exportieren</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">Ressourcen</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">.env exportieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Es wurde eine Kardinalitätsbegrenzung festgestellt</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">Parameter</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">Anzahl anzeigen</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">Recursos</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">Exportar .env</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">Graph. Para obtener una vista accesible, vaya a la pestaña Recursos</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">Graph. Para obtener una vista accesible, vaya a la pestaña Recursos</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">Recursos</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">Exportar .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Se ha detectado un límite de cardinalidad</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">Parámetros</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">Mostrar recuento</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">Recursos</target>
+        <source>Table</source>
+        <target state="needs-review-translation">Recursos</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">Graph. Pour obtenir un affichage accessible, naviguez vers l’onglet des Ressources</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">Graph. Pour obtenir un affichage accessible, naviguez vers l’onglet des Ressources</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">Ressources</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">Exporter le fichier .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">Ressources</target>
+        <source>Table</source>
+        <target state="needs-review-translation">Ressources</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Un plafonnement de cardinalité a été détecté</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">Paramètres</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">Afficher le nombre</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">Ressources</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">Exporter le fichier .env</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">Risorse</target>
+        <source>Table</source>
+        <target state="needs-review-translation">Risorse</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">Grafo. Per una visualizzazione accessibile, passare alla scheda Risorse</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">Grafo. Per una visualizzazione accessibile, passare alla scheda Risorse</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">Risorse</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">Esporta .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">Risorse</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">Esporta .env</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -72,11 +72,6 @@
         <target state="translated">È stata rilevata una limitazione della cardinalità</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">Parametri</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">Mostra conteggio</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">リソース</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">.env のエクスポート</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">グラフ。アクセス可能なビューについては、[リソース] タブに移動してください</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">グラフ。アクセス可能なビューについては、[リソース] タブに移動してください</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">リソース</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">.env のエクスポート</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">リソース</target>
+        <source>Table</source>
+        <target state="needs-review-translation">リソース</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -72,11 +72,6 @@
         <target state="translated">カーディナリティ制限が検出されました</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">パラメーター</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">カウントの表示</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">그래프. 액세스 가능한 보기를 보려면 리소스 탭으로 이동하세요.</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">그래프. 액세스 가능한 보기를 보려면 리소스 탭으로 이동하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">리소스</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">.env 내보내기</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">리소스</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">.env 내보내기</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">리소스</target>
+        <source>Table</source>
+        <target state="needs-review-translation">리소스</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -72,11 +72,6 @@
         <target state="translated">카디널리티 상한이 감지되었습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">매개 변수</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">개수 표시</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">Zasoby</target>
+        <source>Table</source>
+        <target state="needs-review-translation">Zasoby</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">Wykres. Aby uzyskać widok z ułatwieniami dostępu, przejdź do karty Zasoby</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">Wykres. Aby uzyskać widok z ułatwieniami dostępu, przejdź do karty Zasoby</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">Zasoby</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">Eksportuj .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Wykryto ograniczenie kardynalności</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">Parametry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">Pokaż liczbę</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">Zasoby</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">Eksportuj .env</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">Recursos</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">Exportar .env</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">Graph. Para obter uma exibição acessível, navegue até a guia Recursos</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">Graph. Para obter uma exibição acessível, navegue até a guia Recursos</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">Recursos</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">Exportar .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">Recursos</target>
+        <source>Table</source>
+        <target state="needs-review-translation">Recursos</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -72,11 +72,6 @@
         <target state="translated">O limite de cardinalidade foi detectado</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">Parâmetros</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">Mostrar contagem</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">Ресурсы</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">Экспорт .env</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Обнаружено ограничение кратности</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">Параметры</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">Показать счетчик</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">Ресурсы</target>
+        <source>Table</source>
+        <target state="needs-review-translation">Ресурсы</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">Граф. Чтобы открыть представление с поддержкой специальных возможностей, перейдите на вкладку "Ресурсы"</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">Граф. Чтобы открыть представление с поддержкой специальных возможностей, перейдите на вкладку "Ресурсы"</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">Ресурсы</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">Экспорт .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">Kaynaklar</target>
+        <source>Table</source>
+        <target state="needs-review-translation">Kaynaklar</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Kardinalite sınırlaması algılandı</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">Parametreler</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">Sayıyı göster</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">Kaynaklar</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">ENV dosyasını dışarı aktar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">Graph. Erişilebilir bir görünüm için lütfen Kaynaklar sekmesine gidin</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">Graph. Erişilebilir bir görünüm için lütfen Kaynaklar sekmesine gidin</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">Kaynaklar</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">ENV dosyasını dışarı aktar</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">图。有关可访问的视图，请导航到“资源”选项卡</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">图。有关可访问的视图，请导航到“资源”选项卡</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">资源</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">导出 .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -72,11 +72,6 @@
         <target state="translated">已检测到基数上限</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">参数</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">显示计数</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">资源</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">导出 .env</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">资源</target>
+        <source>Table</source>
+        <target state="needs-review-translation">资源</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -72,11 +72,6 @@
         <target state="translated">已偵測到基數限制</target>
         <note />
       </trans-unit>
-      <trans-unit id="ChartContainerParametersTab">
-        <source>Parameters</source>
-        <target state="translated">參數</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ChartContainerShowCountLabel">
         <source>Show count</source>
         <target state="translated">顯示計數</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Table</source>
+        <source>Resources</source>
         <target state="needs-review-translation">資源</target>
         <note />
       </trans-unit>
@@ -155,6 +155,11 @@
       <trans-unit id="ExportEnv">
         <source>Export .env</source>
         <target state="translated">匯出 .env</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricsTableTab">
+        <source>Table</source>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
-        <source>Graph. For an accessible view please navigate to the Resources tab</source>
-        <target state="translated">圖表。如需可存取的檢視，請瀏覽至 [資源] 索引標籤</target>
+        <source>Graph. For an accessible view please navigate to the Table tab</source>
+        <target state="needs-review-translation">圖表。如需可存取的檢視，請瀏覽至 [資源] 索引標籤</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
@@ -83,7 +83,7 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
+        <source>Table</source>
         <target state="needs-review-translation">資源</target>
         <note />
       </trans-unit>
@@ -157,9 +157,24 @@
         <target state="translated">匯出 .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="MetricsTableTab">
-        <source>Table</source>
-        <target state="new">Table</target>
+      <trans-unit id="ResourcesContainerGraphAccessibleLabel">
+        <source>Graph. For an accessible view please navigate to the Resources tab</source>
+        <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerGraphTab">
+        <source>Graph</source>
+        <target state="new">Graph</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerParametersTab">
+        <source>Parameters</source>
+        <target state="new">Parameters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesContainerTableTab">
+        <source>Resources</source>
+        <target state="new">Resources</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewJson">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
-        <source>Resources</source>
-        <target state="translated">資源</target>
+        <source>Table</source>
+        <target state="needs-review-translation">資源</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/tests/Aspire.Dashboard.Tests/ChartDataCalculatorTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ChartDataCalculatorTests.cs
@@ -34,13 +34,13 @@ public class ChartDataCalculatorTests
     }
 
     [Theory]
-    [InlineData(50, 10.0)]   // 50th of 100 items: boundary of bucket 0, interpolates to upper bound
-    [InlineData(90, 50.0)]   // 90th of 100 items: boundary of bucket 1, interpolates to upper bound
-    [InlineData(99, 95.0)]   // 99th of 100 items: 90% through bucket 2 → 50 + (100-50)*0.9
-    public void CalculatePercentile_ReturnsInterpolatedValue(int percentile, double expected)
+    [InlineData(50, 10.0)]
+    [InlineData(90, 50.0)]
+    [InlineData(99, 100.0)]
+    public void CalculatePercentile_ReturnsExpectedBucket(int percentile, double expected)
     {
-        // Buckets: (-Inf,10]=50, (10,50]=40, (50,100]=10, (100,+Inf)=0
-        ulong[] counts = [50, 40, 10, 0];
+        // Buckets: [0, 10) = 50 items, [10, 50) = 40 items, [50, 100) = 10 items
+        ulong[] counts = [50, 40, 10];
         double[] bounds = [10.0, 50.0, 100.0];
 
         var result = ChartDataCalculator.CalculatePercentile(percentile, counts, bounds);
@@ -49,37 +49,13 @@ public class ChartDataCalculatorTests
     }
 
     [Fact]
-    public void CalculatePercentile_AllInOneBucket_InterpolatesWithinBucket()
+    public void CalculatePercentile_AllInOneBucket_ReturnsThatBound()
     {
-        // All 100 items in bucket 2: (50,100]
-        ulong[] counts = [0, 0, 100, 0];
+        ulong[] counts = [0, 0, 100];
         double[] bounds = [10.0, 50.0, 100.0];
 
-        // P50: 50% through bucket 2 → 50 + (100-50)*0.5 = 75
-        Assert.Equal(75.0, ChartDataCalculator.CalculatePercentile(50, counts, bounds));
-        // P99: 99% through bucket 2 → 50 + (100-50)*0.99 = 99.5
-        Assert.Equal(99.5, ChartDataCalculator.CalculatePercentile(99, counts, bounds));
-    }
-
-    [Fact]
-    public void CalculatePercentile_DataInOverflowBucket_ReturnsLastBound()
-    {
-        // All 100 items in the overflow bucket (+Inf)
-        ulong[] counts = [0, 0, 0, 100];
-        double[] bounds = [10.0, 50.0, 100.0];
-
-        // Can't interpolate in overflow bucket — returns last finite bound.
         Assert.Equal(100.0, ChartDataCalculator.CalculatePercentile(50, counts, bounds));
         Assert.Equal(100.0, ChartDataCalculator.CalculatePercentile(99, counts, bounds));
-    }
-
-    [Fact]
-    public void CalculatePercentile_EmptyCounts_ReturnsNull()
-    {
-        ulong[] counts = [0, 0, 0, 0];
-        double[] bounds = [10.0, 50.0, 100.0];
-
-        Assert.Null(ChartDataCalculator.CalculatePercentile(50, counts, bounds));
     }
 
     [Fact]
@@ -90,6 +66,28 @@ public class ChartDataCalculatorTests
 
         Assert.Throws<ArgumentOutOfRangeException>(() => ChartDataCalculator.CalculatePercentile(-1, counts, bounds));
         Assert.Throws<ArgumentOutOfRangeException>(() => ChartDataCalculator.CalculatePercentile(101, counts, bounds));
+    }
+
+    [Fact]
+    public void CalculatePercentile_OverflowBucket_ReturnsLastBound()
+    {
+        // Most data is in the overflow (+Inf) bucket beyond the last explicit bound.
+        // counts has explicitBounds.Length + 1 entries; the last entry is the overflow bucket.
+        ulong[] counts = [0, 0, 5, 95];
+        double[] bounds = [10.0, 50.0, 100.0];
+
+        // P50 is in the overflow bucket — best estimate is the last finite bound.
+        Assert.Equal(100.0, ChartDataCalculator.CalculatePercentile(50, counts, bounds));
+        Assert.Equal(100.0, ChartDataCalculator.CalculatePercentile(99, counts, bounds));
+    }
+
+    [Fact]
+    public void CalculatePercentile_ZeroTotalCount_ReturnsNull()
+    {
+        ulong[] counts = [0, 0, 0];
+        double[] bounds = [10.0, 50.0];
+
+        Assert.Null(ChartDataCalculator.CalculatePercentile(50, counts, bounds));
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/ChartDataCalculatorTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ChartDataCalculatorTests.cs
@@ -1,0 +1,329 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Components.Controls.Chart;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Model.MetricValues;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenTelemetry.Proto.Metrics.V1;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class ChartDataCalculatorTests
+{
+    private static readonly DateTimeOffset s_startTime = new(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private static OtlpContext CreateContext() =>
+        new() { Options = new TelemetryLimitOptions(), Logger = NullLogger.Instance };
+
+    // Identity function for time conversion — tests use UTC directly.
+    private static DateTimeOffset ToLocal(DateTimeOffset dt) => dt;
+
+    [Fact]
+    public void CalcOffset_ReturnsCorrectOffset()
+    {
+        var now = s_startTime;
+        var duration = TimeSpan.FromSeconds(10);
+
+        Assert.Equal(now, ChartDataCalculator.CalcOffset(0, now, duration));
+        Assert.Equal(now.Subtract(TimeSpan.FromSeconds(10)), ChartDataCalculator.CalcOffset(1, now, duration));
+        Assert.Equal(now.Subtract(TimeSpan.FromSeconds(30)), ChartDataCalculator.CalcOffset(3, now, duration));
+        Assert.Equal(now.Add(TimeSpan.FromSeconds(10)), ChartDataCalculator.CalcOffset(-1, now, duration));
+    }
+
+    [Theory]
+    [InlineData(50, 10.0)]
+    [InlineData(90, 50.0)]
+    [InlineData(99, 100.0)]
+    public void CalculatePercentile_ReturnsExpectedBucket(int percentile, double expected)
+    {
+        // Buckets: [0, 10) = 50 items, [10, 50) = 40 items, [50, 100) = 10 items
+        ulong[] counts = [50, 40, 10];
+        double[] bounds = [10.0, 50.0, 100.0];
+
+        var result = ChartDataCalculator.CalculatePercentile(percentile, counts, bounds);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void CalculatePercentile_AllInOneBucket_ReturnsThatBound()
+    {
+        ulong[] counts = [0, 0, 100];
+        double[] bounds = [10.0, 50.0, 100.0];
+
+        Assert.Equal(100.0, ChartDataCalculator.CalculatePercentile(50, counts, bounds));
+        Assert.Equal(100.0, ChartDataCalculator.CalculatePercentile(99, counts, bounds));
+    }
+
+    [Fact]
+    public void CalculatePercentile_InvalidPercentile_Throws()
+    {
+        ulong[] counts = [10];
+        double[] bounds = [1.0];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ChartDataCalculator.CalculatePercentile(-1, counts, bounds));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ChartDataCalculator.CalculatePercentile(101, counts, bounds));
+    }
+
+    [Fact]
+    public void TryCalculatePoint_MetricInRange_ReturnsValue()
+    {
+        var context = CreateContext();
+        var dimension = new DimensionScope(capacity: 100, []);
+        var start = new DateTimeOffset(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        var end = new DateTimeOffset(2025, 6, 15, 12, 0, 10, TimeSpan.Zero);
+
+        // Add a metric value with timestamps within [start, end].
+        dimension.AddPointValue(new NumberDataPoint
+        {
+            AsInt = 42,
+            StartTimeUnixNano = ToNanos(start),
+            TimeUnixNano = ToNanos(end)
+        }, context);
+
+        var result = ChartDataCalculator.TryCalculatePoint([dimension], start, end, out var pointValue);
+
+        Assert.True(result);
+        Assert.Equal(42, pointValue);
+    }
+
+    [Fact]
+    public void TryCalculatePoint_MetricOutOfRange_ReturnsFalse()
+    {
+        var context = CreateContext();
+        var dimension = new DimensionScope(capacity: 100, []);
+        var metricStart = new DateTimeOffset(2025, 6, 15, 11, 0, 0, TimeSpan.Zero);
+        var metricEnd = new DateTimeOffset(2025, 6, 15, 11, 0, 10, TimeSpan.Zero);
+
+        dimension.AddPointValue(new NumberDataPoint
+        {
+            AsInt = 42,
+            StartTimeUnixNano = ToNanos(metricStart),
+            TimeUnixNano = ToNanos(metricEnd)
+        }, context);
+
+        // Query a time range that doesn't overlap the metric.
+        var queryStart = new DateTimeOffset(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        var queryEnd = new DateTimeOffset(2025, 6, 15, 12, 0, 10, TimeSpan.Zero);
+
+        var result = ChartDataCalculator.TryCalculatePoint([dimension], queryStart, queryEnd, out var pointValue);
+
+        Assert.False(result);
+        Assert.Equal(0, pointValue);
+    }
+
+    [Fact]
+    public void TryCalculatePoint_MultipleDimensions_SumsValues()
+    {
+        var context = CreateContext();
+        var dim1 = new DimensionScope(capacity: 100, []);
+        var dim2 = new DimensionScope(capacity: 100, []);
+        var start = new DateTimeOffset(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        var end = new DateTimeOffset(2025, 6, 15, 12, 0, 10, TimeSpan.Zero);
+
+        dim1.AddPointValue(new NumberDataPoint
+        {
+            AsInt = 10,
+            StartTimeUnixNano = ToNanos(start),
+            TimeUnixNano = ToNanos(end)
+        }, context);
+
+        dim2.AddPointValue(new NumberDataPoint
+        {
+            AsInt = 20,
+            StartTimeUnixNano = ToNanos(start),
+            TimeUnixNano = ToNanos(end)
+        }, context);
+
+        var result = ChartDataCalculator.TryCalculatePoint([dim1, dim2], start, end, out var pointValue);
+
+        Assert.True(result);
+        Assert.Equal(30, pointValue);
+    }
+
+    [Fact]
+    public void TryCalculatePoint_MultipleMetricsInDimension_TakesMax()
+    {
+        var context = CreateContext();
+        var dimension = new DimensionScope(capacity: 100, []);
+        var start = new DateTimeOffset(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        var end = new DateTimeOffset(2025, 6, 15, 12, 0, 10, TimeSpan.Zero);
+
+        dimension.AddPointValue(new NumberDataPoint
+        {
+            AsInt = 5,
+            StartTimeUnixNano = ToNanos(start),
+            TimeUnixNano = ToNanos(start.AddSeconds(5))
+        }, context);
+
+        dimension.AddPointValue(new NumberDataPoint
+        {
+            AsInt = 15,
+            StartTimeUnixNano = ToNanos(start.AddSeconds(5)),
+            TimeUnixNano = ToNanos(end)
+        }, context);
+
+        var result = ChartDataCalculator.TryCalculatePoint([dimension], start, end, out var pointValue);
+
+        Assert.True(result);
+        Assert.Equal(15, pointValue);
+    }
+
+    [Fact]
+    public void CalculateChartValues_ProducesCorrectStructure()
+    {
+        var context = CreateContext();
+        var dimension = new DimensionScope(capacity: 100, []);
+
+        // Add a metric covering the entire time range so at least one bucket has data.
+        dimension.AddPointValue(new NumberDataPoint
+        {
+            AsInt = 100,
+            StartTimeUnixNano = 0,
+            TimeUnixNano = long.MaxValue
+        }, context);
+
+        var calculator = new ChartDataCalculator(pointCount: 30, duration: TimeSpan.FromMinutes(5));
+        var data = calculator.CalculateChartValues([dimension], s_startTime, ToLocal, "Bytes");
+
+        // 30 points + 2 extra = 32 x-values
+        Assert.Equal(32, data.XValues.Count);
+        Assert.Single(data.Traces);
+
+        var trace = data.Traces[0];
+        Assert.Equal("Bytes", trace.Name);
+        Assert.Equal(32, trace.Values.Count);
+        Assert.Equal(32, trace.DiffValues.Count);
+
+        // No tooltips are generated by the calculator.
+        Assert.Empty(trace.Tooltips);
+
+        // Non-histogram charts produce no exemplars.
+        Assert.Empty(data.Exemplars);
+    }
+
+    [Fact]
+    public void CalculateChartValues_XValuesInChronologicalOrder()
+    {
+        var context = CreateContext();
+        var dimension = new DimensionScope(capacity: 100, []);
+        dimension.AddPointValue(new NumberDataPoint
+        {
+            AsInt = 1,
+            StartTimeUnixNano = 0,
+            TimeUnixNano = long.MaxValue
+        }, context);
+
+        var calculator = new ChartDataCalculator(pointCount: 10, duration: TimeSpan.FromSeconds(100));
+        var data = calculator.CalculateChartValues([dimension], s_startTime, ToLocal, "Count");
+
+        for (var i = 1; i < data.XValues.Count; i++)
+        {
+            Assert.True(data.XValues[i] > data.XValues[i - 1],
+                $"xValues[{i}] ({data.XValues[i]}) should be after xValues[{i - 1}] ({data.XValues[i - 1]})");
+        }
+    }
+
+    [Fact]
+    public void CalculateChartValues_NoDimensions_AllNullValues()
+    {
+        var calculator = new ChartDataCalculator(pointCount: 5, duration: TimeSpan.FromSeconds(50));
+        var data = calculator.CalculateChartValues([], s_startTime, ToLocal, "Count");
+
+        Assert.Equal(7, data.XValues.Count); // 5 + 2
+        Assert.All(data.Traces[0].Values, v => Assert.Null(v));
+    }
+
+    [Fact]
+    public void CalculateHistogramValues_ProducesThreePercentileTraces()
+    {
+        var context = CreateContext();
+        var dimension = new DimensionScope(capacity: 100, []);
+
+        // Add a histogram value that covers the time range.
+        var histogramPoint = new HistogramDataPoint
+        {
+            StartTimeUnixNano = 0,
+            TimeUnixNano = (ulong)s_startTime.AddSeconds(1).ToUnixTimeMilliseconds() * 1_000_000,
+            Count = 100,
+            Sum = 500.0,
+        };
+        histogramPoint.ExplicitBounds.AddRange([10.0, 50.0, 100.0]);
+        histogramPoint.BucketCounts.AddRange([50UL, 40UL, 10UL, 0UL]);
+
+        dimension.AddHistogramValue(histogramPoint, context);
+
+        var calculator = new ChartDataCalculator(pointCount: 5, duration: TimeSpan.FromSeconds(50));
+        var data = calculator.CalculateHistogramValues([dimension], s_startTime, ToLocal, "ms");
+
+        Assert.Equal(3, data.Traces.Count);
+        Assert.Equal(50, data.Traces[0].Percentile);
+        Assert.Equal(90, data.Traces[1].Percentile);
+        Assert.Equal(99, data.Traces[2].Percentile);
+        Assert.Equal("P50 ms", data.Traces[0].Name);
+        Assert.Equal("P90 ms", data.Traces[1].Name);
+        Assert.Equal("P99 ms", data.Traces[2].Name);
+
+        // Each trace should have 7 values (5 + 2 extra points).
+        Assert.All(data.Traces, t => Assert.Equal(7, t.Values.Count));
+        Assert.All(data.Traces, t => Assert.Equal(7, t.DiffValues.Count));
+
+        // No tooltips are generated by the calculator.
+        Assert.All(data.Traces, t => Assert.Empty(t.Tooltips));
+    }
+
+    [Fact]
+    public void CalculateHistogramValues_XValuesInChronologicalOrder()
+    {
+        var context = CreateContext();
+        var dimension = new DimensionScope(capacity: 100, []);
+
+        var histogramPoint = new HistogramDataPoint
+        {
+            StartTimeUnixNano = 0,
+            TimeUnixNano = (ulong)s_startTime.AddSeconds(1).ToUnixTimeMilliseconds() * 1_000_000,
+            Count = 10,
+            Sum = 100.0,
+        };
+        histogramPoint.ExplicitBounds.AddRange([50.0]);
+        histogramPoint.BucketCounts.AddRange([5UL, 5UL]);
+
+        dimension.AddHistogramValue(histogramPoint, context);
+
+        var calculator = new ChartDataCalculator(pointCount: 10, duration: TimeSpan.FromSeconds(100));
+        var data = calculator.CalculateHistogramValues([dimension], s_startTime, ToLocal, "ms");
+
+        for (var i = 1; i < data.XValues.Count; i++)
+        {
+            Assert.True(data.XValues[i] > data.XValues[i - 1],
+                $"xValues[{i}] ({data.XValues[i]}) should be after xValues[{i - 1}] ({data.XValues[i - 1]})");
+        }
+    }
+
+    [Fact]
+    public void CalculateChartValues_ToLocalApplied()
+    {
+        var context = CreateContext();
+        var dimension = new DimensionScope(capacity: 100, []);
+        dimension.AddPointValue(new NumberDataPoint
+        {
+            AsInt = 1,
+            StartTimeUnixNano = 0,
+            TimeUnixNano = long.MaxValue
+        }, context);
+
+        // Apply a +5 hour offset to simulate a time zone.
+        var offset = TimeSpan.FromHours(5);
+        DateTimeOffset toLocalWithOffset(DateTimeOffset dt) => dt.ToOffset(offset);
+
+        var calculator = new ChartDataCalculator(pointCount: 5, duration: TimeSpan.FromSeconds(50));
+        var data = calculator.CalculateChartValues([dimension], s_startTime, toLocalWithOffset, "Count");
+
+        Assert.All(data.XValues, x => Assert.Equal(offset, x.Offset));
+    }
+
+    private static ulong ToNanos(DateTimeOffset dt) => (ulong)(dt.ToUnixTimeMilliseconds() * 1_000_000);
+}

--- a/tests/Aspire.Dashboard.Tests/ChartDataCalculatorTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ChartDataCalculatorTests.cs
@@ -34,13 +34,13 @@ public class ChartDataCalculatorTests
     }
 
     [Theory]
-    [InlineData(50, 10.0)]
-    [InlineData(90, 50.0)]
-    [InlineData(99, 100.0)]
-    public void CalculatePercentile_ReturnsExpectedBucket(int percentile, double expected)
+    [InlineData(50, 10.0)]   // 50th of 100 items: boundary of bucket 0, interpolates to upper bound
+    [InlineData(90, 50.0)]   // 90th of 100 items: boundary of bucket 1, interpolates to upper bound
+    [InlineData(99, 95.0)]   // 99th of 100 items: 90% through bucket 2 → 50 + (100-50)*0.9
+    public void CalculatePercentile_ReturnsInterpolatedValue(int percentile, double expected)
     {
-        // Buckets: [0, 10) = 50 items, [10, 50) = 40 items, [50, 100) = 10 items
-        ulong[] counts = [50, 40, 10];
+        // Buckets: (-Inf,10]=50, (10,50]=40, (50,100]=10, (100,+Inf)=0
+        ulong[] counts = [50, 40, 10, 0];
         double[] bounds = [10.0, 50.0, 100.0];
 
         var result = ChartDataCalculator.CalculatePercentile(percentile, counts, bounds);
@@ -49,13 +49,37 @@ public class ChartDataCalculatorTests
     }
 
     [Fact]
-    public void CalculatePercentile_AllInOneBucket_ReturnsThatBound()
+    public void CalculatePercentile_AllInOneBucket_InterpolatesWithinBucket()
     {
-        ulong[] counts = [0, 0, 100];
+        // All 100 items in bucket 2: (50,100]
+        ulong[] counts = [0, 0, 100, 0];
         double[] bounds = [10.0, 50.0, 100.0];
 
+        // P50: 50% through bucket 2 → 50 + (100-50)*0.5 = 75
+        Assert.Equal(75.0, ChartDataCalculator.CalculatePercentile(50, counts, bounds));
+        // P99: 99% through bucket 2 → 50 + (100-50)*0.99 = 99.5
+        Assert.Equal(99.5, ChartDataCalculator.CalculatePercentile(99, counts, bounds));
+    }
+
+    [Fact]
+    public void CalculatePercentile_DataInOverflowBucket_ReturnsLastBound()
+    {
+        // All 100 items in the overflow bucket (+Inf)
+        ulong[] counts = [0, 0, 0, 100];
+        double[] bounds = [10.0, 50.0, 100.0];
+
+        // Can't interpolate in overflow bucket — returns last finite bound.
         Assert.Equal(100.0, ChartDataCalculator.CalculatePercentile(50, counts, bounds));
         Assert.Equal(100.0, ChartDataCalculator.CalculatePercentile(99, counts, bounds));
+    }
+
+    [Fact]
+    public void CalculatePercentile_EmptyCounts_ReturnsNull()
+    {
+        ulong[] counts = [0, 0, 0, 0];
+        double[] bounds = [10.0, 50.0, 100.0];
+
+        Assert.Null(ChartDataCalculator.CalculatePercentile(50, counts, bounds));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Extracts the chart value calculation logic from `ChartBase` into a standalone `ChartDataCalculator` class, making it independently testable and fixing several correctness issues in the metrics charting pipeline.

Fixes https://github.com/microsoft/aspire/issues/2350

## Changes

### New types
- **`ChartDataCalculator`** — computes time-bucketed chart values and exemplars from metric dimensions. Produces raw traces/x-values without tooltips or span resolution (those remain in the Blazor component).
- **`ChartData`** — result type holding `Traces`, `XValues`, and `Exemplars`.

### Refactored `ChartBase`
- Removed all calculation methods (`CalculateChartValues`, `CalculateHistogramValues`, `TryCalculatePoint`, `TryCalculateHistogramPoints`, `CalculatePercentile`, `CalcOffset`, `CountBuckets`, `GetHistogramValue`, `AddExemplars`).
- `UpdateChartAsync` now delegates to `ChartDataCalculator` and post-processes results (tooltips, HTML encoding, span resolution).
- Removed the in-progress data point logic — it was redundant with the newest time bucket and caused x-values to go backwards.

### Bug fixes
- **`CalculatePercentile` overflow bucket**: Handle zero total count (return `null`), document overflow (+Inf) bucket fallback.
- **Trace output order**: Use `OrderBy(key)` when returning histogram traces to guarantee P50/P90/P99 order instead of relying on `Dictionary` iteration order.
- **Redundant overlap condition**: Simplified `TryCalculatePoint` overlap check — the second disjunct was a subset of the first.
- **DateTime→DateTimeOffset mismatch**: Use explicit `new DateTimeOffset(dt, TimeSpan.Zero)` when comparing `MetricValueBase.Start`/`End` (DateTime) against bucket boundaries (DateTimeOffset) to prevent silent local-time interpretation.
- **Early termination**: Break the metric scan loop once a metric ends before the bucket starts, since remaining metrics are chronologically older.
- **Resource string collision**: `ChartContainerTableTab` ("Resources") was shared between the resources page and the metrics table tab. Added separate `MetricsTableTab` ("Table") for the metrics chart container.

### Tests
- 18 unit tests for `ChartDataCalculator` covering `CalcOffset`, `CalculatePercentile` (normal, overflow bucket, zero count, invalid input), `TryCalculatePoint` (in-range, out-of-range, multi-dimension sum, multi-metric max), `CalculateChartValues` (structure, chronological order, empty dimensions, timezone conversion), and `CalculateHistogramValues` (three percentile traces, chronological order).

## Validation
- All 1487 `Aspire.Dashboard.Tests` pass
- All 143 `Aspire.Dashboard.Components.Tests` pass