### PR TITLE
Hide parameters from resource graph view and type filter

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -412,7 +412,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         }
 
         var activeResources = _resourceByName.Values.Where(Filter).OrderBy(e => e.ResourceType).ThenBy(e => e.Name).ToList();
-        var resources = activeResources.Select(r => ResourceGraphMapper.MapResource(r, _resourceByName, ColumnsLoc, PageViewModel.ShowHiddenResources, IconResolver)).ToList();
+        var resources = activeResources.Select(r => ResourceGraphMapper.MapResource(r, activeResources, _resourceByName, ColumnsLoc, PageViewModel.ShowHiddenResources, IconResolver)).ToList();
         await _jsModule.InvokeVoidAsync("updateResourcesGraph", resources);
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -366,7 +366,12 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             added = _resourceByName.TryAdd(resource.Name, resource);
         }
 
-        PageViewModel.ResourceTypesToVisibility.AddOrUpdate(resource.ResourceType, resourceTypeVisible(resource.ResourceType), (_, _) => resourceTypeVisible(resource.ResourceType));
+        // Don't add Parameter to resource type filters. Parameters have their own dedicated view
+        // and are excluded from the Table and Graph views regardless of the type filter.
+        if (!resource.IsParameter)
+        {
+            PageViewModel.ResourceTypesToVisibility.AddOrUpdate(resource.ResourceType, resourceTypeVisible(resource.ResourceType), (_, _) => resourceTypeVisible(resource.ResourceType));
+        }
         PageViewModel.ResourceStatesToVisibility.AddOrUpdate(resource.State ?? string.Empty, stateVisible(resource.State ?? string.Empty), (_, _) => stateVisible(resource.State ?? string.Empty));
         PageViewModel.ResourceHealthStatusesToVisibility.AddOrUpdate(resource.HealthStatus?.Humanize() ?? string.Empty, healthStatusVisible(resource.HealthStatus?.Humanize() ?? string.Empty), (_, _) => healthStatusVisible(resource.HealthStatus?.Humanize() ?? string.Empty));
 
@@ -917,12 +922,12 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
         public bool Filter(ResourceViewModel resource)
         {
-            // In Parameters view, only show parameters; in Table view, exclude parameters
+            // In Parameters view, only show parameters; in Table and Graph views, exclude parameters
             if (SelectedViewKind == ResourceViewKind.Parameters && !resource.IsParameter)
             {
                 return false;
             }
-            if (SelectedViewKind == ResourceViewKind.Table && resource.IsParameter)
+            if (SelectedViewKind is ResourceViewKind.Table or ResourceViewKind.Graph && resource.IsParameter)
             {
                 return false;
             }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -685,14 +685,14 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 break;
             }
 
-            if (PageViewModel.SelectedViewKind == ResourceViewKind.Graph)
+            var resourceViewKind = GetVisibleViewKindForSelectedResource(PageViewModel.SelectedViewKind, resource);
+            if (resourceViewKind == ResourceViewKind.Graph)
             {
                 await UpdateResourceGraphSelectedAsync();
             }
             else
             {
                 // Parameters have their own view. If required, switch view so the selected resource is visible.
-                var resourceViewKind = (resource.IsParameter) ? ResourceViewKind.Parameters : ResourceViewKind.Table;
                 if (resourceViewKind != PageViewModel.SelectedViewKind)
                 {
                     PageViewModel.SelectedViewKind = resourceViewKind;
@@ -885,6 +885,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     private async Task OnViewChangedAsync(ResourceViewKind newView)
     {
+        newView = GetVisibleViewKindForViewChange(newView, PageViewModel.SelectedResource);
+
         PageViewModel.SelectedViewKind = newView;
         await this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: true);
 
@@ -900,6 +902,23 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             UpdateMaxHighlightedCount();
             await _dataGrid.SafeRefreshDataAsync();
         }
+    }
+
+    internal static ResourceViewKind GetVisibleViewKindForSelectedResource(ResourceViewKind selectedViewKind, ResourceViewModel resource)
+    {
+        return (selectedViewKind, resource.IsParameter) switch
+        {
+            (ResourceViewKind.Graph, false) => ResourceViewKind.Graph,
+            (_, true) => ResourceViewKind.Parameters,
+            _ => ResourceViewKind.Table
+        };
+    }
+
+    internal static ResourceViewKind GetVisibleViewKindForViewChange(ResourceViewKind requestedViewKind, ResourceViewModel? selectedResource)
+    {
+        return requestedViewKind == ResourceViewKind.Graph && selectedResource?.IsParameter == true
+            ? ResourceViewKind.Parameters
+            : requestedViewKind;
     }
 
     private async Task UpdateResourceGraphSelectedAsync()

--- a/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
@@ -12,7 +12,7 @@ namespace Aspire.Dashboard.Model.ResourceGraph;
 
 public static class ResourceGraphMapper
 {
-    public static ResourceDto MapResource(ResourceViewModel r, IDictionary<string, ResourceViewModel> resourcesByName, IStringLocalizer<Columns> columnsLoc, bool showHiddenResources, IconResolver iconResolver)
+    public static ResourceDto MapResource(ResourceViewModel r, IEnumerable<ResourceViewModel> graphResources, IDictionary<string, ResourceViewModel> resourcesByName, IStringLocalizer<Columns> columnsLoc, bool showHiddenResources, IconResolver iconResolver)
     {
         var resolvedNames = new List<string>();
 
@@ -21,7 +21,7 @@ public static class ResourceGraphMapper
 
         foreach (var resourceRelationships in filteredRelationships.GroupBy(r => r.ResourceName, StringComparers.ResourceName))
         {
-            var matches = resourcesByName.Values
+            var matches = graphResources
                 .Where(r => string.Equals(r.DisplayName, resourceRelationships.Key, StringComparisons.ResourceName))
                 .Where(r => !r.IsResourceHidden(showHiddenResources))
                 .ToList();

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -513,7 +513,7 @@ public partial class ResourcesTests : DashboardTestContext
     }
 
     [Fact]
-    public void GraphView_ShowsAllResources()
+    public void GraphView_ExcludesParameters()
     {
         // Arrange
         var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
@@ -539,11 +539,11 @@ public partial class ResourcesTests : DashboardTestContext
         cut.Instance.PageViewModel.SelectedViewKind = Components.Pages.Resources.ResourceViewKind.Graph;
         cut.Render();
 
-        // Assert - Graph view should show all resources (no parameter filtering)
+        // Assert - Graph view should exclude parameters (they have their own dedicated view)
         var filteredResources = cut.Instance.GetFilteredResources().ToList();
-        Assert.Equal(2, filteredResources.Count);
+        Assert.Single(filteredResources);
         Assert.Contains(filteredResources, r => r.Name == "myapp");
-        Assert.Contains(filteredResources, r => r.Name == "myparameter");
+        Assert.DoesNotContain(filteredResources, r => r.Name == "myparameter");
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -442,7 +442,6 @@ public partial class ResourcesTests : DashboardTestContext
         Assert.Equal(2, filteredResources.Count);
         Assert.Contains(filteredResources, r => r.Name == "myapp");
         Assert.Contains(filteredResources, r => r.Name == "mycontainer");
-        Assert.DoesNotContain(filteredResources, r => r.Name == "myparameter");
     }
 
     [Fact]
@@ -474,8 +473,6 @@ public partial class ResourcesTests : DashboardTestContext
         Assert.Equal(2, filteredResources.Count);
         Assert.Contains(filteredResources, r => r.Name == "myparameter1");
         Assert.Contains(filteredResources, r => r.Name == "myparameter2");
-        Assert.DoesNotContain(filteredResources, r => r.Name == "myapp");
-        Assert.DoesNotContain(filteredResources, r => r.Name == "mycontainer");
     }
 
     [Fact]
@@ -509,7 +506,6 @@ public partial class ResourcesTests : DashboardTestContext
         Assert.Equal(2, filteredResources.Count);
         Assert.Contains(filteredResources, r => r.Name == "myparameter1");
         Assert.Contains(filteredResources, r => r.Name == "myparameter2");
-        Assert.DoesNotContain(filteredResources, r => r.Name == "myapp");
     }
 
     [Fact]
@@ -543,7 +539,6 @@ public partial class ResourcesTests : DashboardTestContext
         var filteredResources = cut.Instance.GetFilteredResources().ToList();
         Assert.Single(filteredResources);
         Assert.Contains(filteredResources, r => r.Name == "myapp");
-        Assert.DoesNotContain(filteredResources, r => r.Name == "myparameter");
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -542,6 +542,46 @@ public partial class ResourcesTests : DashboardTestContext
     }
 
     [Fact]
+    public void GetVisibleViewKindForSelectedResource_GraphParameter_ReturnsParameters()
+    {
+        var parameter = CreateResource("myparameter", KnownResourceTypes.Parameter, "Running", null);
+
+        var viewKind = Components.Pages.Resources.GetVisibleViewKindForSelectedResource(Components.Pages.Resources.ResourceViewKind.Graph, parameter);
+
+        Assert.Equal(Components.Pages.Resources.ResourceViewKind.Parameters, viewKind);
+    }
+
+    [Fact]
+    public void GetVisibleViewKindForSelectedResource_GraphNonParameter_ReturnsGraph()
+    {
+        var resource = CreateResource("myapp", "Project", "Running", null);
+
+        var viewKind = Components.Pages.Resources.GetVisibleViewKindForSelectedResource(Components.Pages.Resources.ResourceViewKind.Graph, resource);
+
+        Assert.Equal(Components.Pages.Resources.ResourceViewKind.Graph, viewKind);
+    }
+
+    [Fact]
+    public void GetVisibleViewKindForViewChange_GraphParameter_ReturnsParameters()
+    {
+        var parameter = CreateResource("myparameter", KnownResourceTypes.Parameter, "Running", null);
+
+        var viewKind = Components.Pages.Resources.GetVisibleViewKindForViewChange(Components.Pages.Resources.ResourceViewKind.Graph, parameter);
+
+        Assert.Equal(Components.Pages.Resources.ResourceViewKind.Parameters, viewKind);
+    }
+
+    [Fact]
+    public void GetVisibleViewKindForViewChange_ParametersNonParameter_ReturnsParameters()
+    {
+        var resource = CreateResource("myapp", "Project", "Running", null);
+
+        var viewKind = Components.Pages.Resources.GetVisibleViewKindForViewChange(Components.Pages.Resources.ResourceViewKind.Parameters, resource);
+
+        Assert.Equal(Components.Pages.Resources.ResourceViewKind.Parameters, viewKind);
+    }
+
+    [Fact]
     public void ParametersView_IncludesParametersWithValues()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
@@ -28,7 +28,7 @@ public class ResourceGraphMapperTests
         };
 
         // Act
-        var dto = ResourceGraphMapper.MapResource(resource1, resources, new TestStringLocalizer<Columns>(), showHiddenResources: false, _iconResolver);
+        var dto = ResourceGraphMapper.MapResource(resource1, resources.Values, resources, new TestStringLocalizer<Columns>(), showHiddenResources: false, _iconResolver);
 
         // Assert
         var referencedName = Assert.Single(dto.ReferencedNames);
@@ -50,7 +50,7 @@ public class ResourceGraphMapperTests
         };
 
         // Act
-        var dto = ResourceGraphMapper.MapResource(resource1, resources, new TestStringLocalizer<Columns>(), showHiddenResources: false, _iconResolver);
+        var dto = ResourceGraphMapper.MapResource(resource1, resources.Values, resources, new TestStringLocalizer<Columns>(), showHiddenResources: false, _iconResolver);
 
         // Assert
         Assert.Collection(dto.ReferencedNames,
@@ -69,7 +69,7 @@ public class ResourceGraphMapperTests
         };
 
         // Act
-        var dto = ResourceGraphMapper.MapResource(resource, resources, new TestStringLocalizer<Columns>(), showHiddenResources: false, _iconResolver);
+        var dto = ResourceGraphMapper.MapResource(resource, resources.Values, resources, new TestStringLocalizer<Columns>(), showHiddenResources: false, _iconResolver);
 
         // Assert
         Assert.Empty(dto.ReferencedNames);
@@ -88,7 +88,7 @@ public class ResourceGraphMapperTests
         };
 
         // Act
-        var dto = ResourceGraphMapper.MapResource(resource1, resources, new TestStringLocalizer<Columns>(), showHiddenResources: true, _iconResolver);
+        var dto = ResourceGraphMapper.MapResource(resource1, resources.Values, resources, new TestStringLocalizer<Columns>(), showHiddenResources: true, _iconResolver);
 
         // Assert
         Assert.Contains("hidden-app", dto.ReferencedNames);
@@ -109,7 +109,7 @@ public class ResourceGraphMapperTests
         };
 
         // Act
-        var dto = ResourceGraphMapper.MapResource(resource, resources, new TestStringLocalizer<Columns>(), showHiddenResources: false, _iconResolver);
+        var dto = ResourceGraphMapper.MapResource(resource, resources.Values, resources, new TestStringLocalizer<Columns>(), showHiddenResources: false, _iconResolver);
 
         // Assert
         Assert.Null(dto.EndpointUrl);
@@ -131,9 +131,29 @@ public class ResourceGraphMapperTests
         };
 
         // Act
-        var dto = ResourceGraphMapper.MapResource(resource, resources, new TestStringLocalizer<Columns>(), showHiddenResources: false, _iconResolver);
+        var dto = ResourceGraphMapper.MapResource(resource, resources.Values, resources, new TestStringLocalizer<Columns>(), showHiddenResources: false, _iconResolver);
 
         // Assert - non-parameter resources should always have endpoint text (even if "No endpoints")
         Assert.NotNull(dto.EndpointText);
+    }
+
+    [Fact]
+    public void MapResource_ReferenceToResourceExcludedFromGraph_Ignored()
+    {
+        var resource = ModelTestHelpers.CreateResource("app", displayName: "app", relationships: [new RelationshipViewModel("api-key", "Reference")]);
+        var parameter = ModelTestHelpers.CreateResource(
+            "api-key",
+            displayName: "api-key",
+            resourceType: KnownResourceTypes.Parameter,
+            relationships: ImmutableArray<RelationshipViewModel>.Empty);
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            [resource.Name] = resource,
+            [parameter.Name] = parameter,
+        };
+
+        var dto = ResourceGraphMapper.MapResource(resource, [resource], resources, new TestStringLocalizer<Columns>(), showHiddenResources: false, _iconResolver);
+
+        Assert.Empty(dto.ReferencedNames);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourcesViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourcesViewModelTests.cs
@@ -28,6 +28,23 @@ public sealed class ResourcesViewModelTests
     }
 
     [Fact]
+    public void GraphView_ExcludesParameters()
+    {
+        var vm = new ResourcesViewModel
+        {
+            SelectedViewKind = ResourceViewKind.Graph,
+            TextFilter = ""
+        };
+        vm.ResourceTypesToVisibility[KnownResourceTypes.Parameter] = true;
+        vm.ResourceStatesToVisibility[KnownResourceState.Running.ToString()] = true;
+        vm.ResourceHealthStatusesToVisibility["Healthy"] = true;
+
+        var resource = ModelTestHelpers.CreateResource(resourceType: KnownResourceTypes.Parameter, state: KnownResourceState.Running);
+
+        Assert.False(vm.Filter(resource));
+    }
+
+    [Fact]
     public void ParametersView_ShowsOnlyParameters()
     {
         var vm = new ResourcesViewModel


### PR DESCRIPTION
## Description

Exclude parameter resources from the Graph view and the "Resource types" filter. Parameters have their own dedicated view (the Parameters tab) and are not logically the same as regular resources — including them in the graph creates visual clutter and makes it harder to see actual resource dependencies.

Changes:
- Filter out parameters in Graph view, matching the existing Table view behavior
- Skip adding "Parameter" to `ResourceTypesToVisibility` since it serves no functional purpose (parameters are excluded from Table/Graph regardless, and the Parameters view ignores type filtering)
- Add `GraphView_ExcludesParameters` test

Fixes #17290

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No