### PR TITLE
Replace direct AppHostServerSession.Start calls with IAppHostServerSessionFactory

### DIFF
--- a/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
@@ -33,6 +33,7 @@ namespace Aspire.Cli.Commands.Sdk;
 internal sealed class SdkDumpCommand : BaseCommand
 {
     private readonly IAppHostServerProjectFactory _appHostServerProjectFactory;
+    private readonly IAppHostServerSessionFactory _appHostServerSessionFactory;
     private readonly ILogger<SdkDumpCommand> _logger;
 
     private static readonly Argument<string[]> s_integrationArgument = new("integrations")
@@ -55,11 +56,13 @@ internal sealed class SdkDumpCommand : BaseCommand
 
     public SdkDumpCommand(
         IAppHostServerProjectFactory appHostServerProjectFactory,
+        IAppHostServerSessionFactory appHostServerSessionFactory,
         ILogger<SdkDumpCommand> logger,
         CommonCommandServices services)
         : base("dump", "Dump ATS capabilities from Aspire integration libraries.", services)
     {
         _appHostServerProjectFactory = appHostServerProjectFactory;
+        _appHostServerSessionFactory = appHostServerSessionFactory;
         _logger = logger;
 
         Arguments.Add(s_integrationArgument);
@@ -190,11 +193,10 @@ internal sealed class SdkDumpCommand : BaseCommand
                 return CliExitCodes.FailedToBuildArtifacts;
             }
 
-            await using var serverSession = AppHostServerSession.Start(
+            await using var serverSession = _appHostServerSessionFactory.Start(
                 appHostServerProject,
                 environmentVariables: null,
-                debug: false,
-                _logger);
+                debug: false);
 
             // Connect and get capabilities
             var rpcClient = await serverSession.GetRpcClientAsync(cancellationToken);
@@ -289,11 +291,10 @@ internal sealed class SdkDumpCommand : BaseCommand
                 return CliExitCodes.FailedToBuildArtifacts;
             }
 
-            await using var serverSession = AppHostServerSession.Start(
+            await using var serverSession = _appHostServerSessionFactory.Start(
                 appHostServerProject,
                 environmentVariables: null,
-                debug: false,
-                _logger);
+                debug: false);
 
             var rpcClient = await serverSession.GetRpcClientAsync(cancellationToken);
             outputDirectory.Create();

--- a/src/Aspire.Cli/Commands/Sdk/SdkGenerateCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkGenerateCommand.cs
@@ -20,6 +20,7 @@ internal sealed class SdkGenerateCommand : BaseCommand
 {
     private readonly ILanguageDiscovery _languageDiscovery;
     private readonly IAppHostServerProjectFactory _appHostServerProjectFactory;
+    private readonly IAppHostServerSessionFactory _appHostServerSessionFactory;
     private readonly ILogger<SdkGenerateCommand> _logger;
 
     private static readonly Argument<FileInfo> s_integrationArgument = new("integration")
@@ -40,12 +41,14 @@ internal sealed class SdkGenerateCommand : BaseCommand
     public SdkGenerateCommand(
         ILanguageDiscovery languageDiscovery,
         IAppHostServerProjectFactory appHostServerProjectFactory,
+        IAppHostServerSessionFactory appHostServerSessionFactory,
         ILogger<SdkGenerateCommand> logger,
         CommonCommandServices services)
         : base("generate", "Generate typed SDKs from an Aspire integration library for use in other languages.", services)
     {
         _languageDiscovery = languageDiscovery;
         _appHostServerProjectFactory = appHostServerProjectFactory;
+        _appHostServerSessionFactory = appHostServerSessionFactory;
         _logger = logger;
 
         Arguments.Add(s_integrationArgument);
@@ -151,11 +154,10 @@ internal sealed class SdkGenerateCommand : BaseCommand
                 return CliExitCodes.FailedToBuildArtifacts;
             }
 
-            await using var serverSession = AppHostServerSession.Start(
+            await using var serverSession = _appHostServerSessionFactory.Start(
                 appHostServerProject,
                 environmentVariables: null,
-                debug: false,
-                _logger);
+                debug: false);
 
             // Connect and generate code
             var rpcClient = await serverSession.GetRpcClientAsync(cancellationToken);

--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -67,14 +67,14 @@ internal sealed class AppHostServerSession : IAppHostServerSession
     /// <param name="environmentVariables">The environment variables to pass to the server.</param>
     /// <param name="debug">Whether to enable debug logging for the server.</param>
     /// <param name="logger">The logger to use for lifecycle diagnostics.</param>
-    /// <param name="profilingTelemetry">Optional profiling telemetry for the server process lifetime.</param>
+    /// <param name="profilingTelemetry">Profiling telemetry for the server process lifetime.</param>
     /// <returns>The started AppHost server session.</returns>
     internal static AppHostServerSession Start(
         IAppHostServerProject appHostServerProject,
         Dictionary<string, string>? environmentVariables,
         bool debug,
         ILogger logger,
-        ProfilingTelemetry? profilingTelemetry = null)
+        ProfilingTelemetry profilingTelemetry)
     {
         var currentPid = Environment.ProcessId;
         var serverEnvironmentVariables = environmentVariables is null
@@ -84,9 +84,7 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         var authenticationToken = TokenGenerator.GenerateToken();
         serverEnvironmentVariables[KnownConfigNames.RemoteAppHostToken] = authenticationToken;
 
-        var activity = profilingTelemetry is null
-            ? default
-            : profilingTelemetry.StartAppHostServerLifetime(appHostServerProject.GetType().Name);
+        var activity = profilingTelemetry.StartAppHostServerLifetime(appHostServerProject.GetType().Name);
         if (activity.IsRunning)
         {
             activity.AddContextToEnvironment(serverEnvironmentVariables);

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -38,6 +38,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
     };
 
     private readonly IAppHostServerProjectFactory _appHostServerProjectFactory;
+    private readonly IAppHostServerSessionFactory _appHostServerSessionFactory;
     private readonly ILanguageDiscovery _languageDiscovery;
     private readonly IInteractionService _interactionService;
     private readonly ILogger<ScaffoldingService> _logger;
@@ -45,12 +46,14 @@ internal sealed class ScaffoldingService : IScaffoldingService
 
     public ScaffoldingService(
         IAppHostServerProjectFactory appHostServerProjectFactory,
+        IAppHostServerSessionFactory appHostServerSessionFactory,
         ILanguageDiscovery languageDiscovery,
         IInteractionService interactionService,
         ILogger<ScaffoldingService> logger,
         CliExecutionContext executionContext)
     {
         _appHostServerProjectFactory = appHostServerProjectFactory;
+        _appHostServerSessionFactory = appHostServerSessionFactory;
         _languageDiscovery = languageDiscovery;
         _interactionService = interactionService;
         _logger = logger;
@@ -139,11 +142,10 @@ internal sealed class ScaffoldingService : IScaffoldingService
         }
 
         // Step 2: Start the server temporarily for scaffolding and code generation
-        await using var serverSession = AppHostServerSession.Start(
+        await using var serverSession = _appHostServerSessionFactory.Start(
             appHostServerProject,
             environmentVariables: null,
-            debug: false,
-            _logger);
+            debug: false);
 
         // Step 3: Connect to server and get scaffold templates via RPC
         var rpcClient = await serverSession.GetRpcClientAsync(cancellationToken);

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
@@ -33,13 +33,14 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
         {
             ["EXISTING_VALUE"] = "present"
         };
+        using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration());
+        var factory = CreateSessionFactory(profilingTelemetry);
 
         // Act
-        await using var session = AppHostServerSession.Start(
+        await using var session = factory.Start(
             project,
             environmentVariables,
-            debug: false,
-            NullLogger<AppHostServerSession>.Instance);
+            debug: false);
 
         // Assert
         Assert.Equal("present", environmentVariables["EXISTING_VALUE"]);
@@ -62,13 +63,12 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
         using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource);
+        var factory = CreateSessionFactory(profilingTelemetry);
 
-        await using var session = AppHostServerSession.Start(
+        await using var session = factory.Start(
             project,
             environmentVariables,
-            debug: false,
-            NullLogger<AppHostServerSession>.Instance,
-            profilingTelemetry);
+            debug: false);
 
         Assert.Equal("present", environmentVariables["EXISTING_VALUE"]);
         Assert.False(environmentVariables.ContainsKey(KnownConfigNames.RemoteAppHostToken));
@@ -97,16 +97,15 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
         using var listener = ActivityListenerHelper.Create(profilingTelemetry.ActivitySource);
+        var factory = CreateSessionFactory(profilingTelemetry);
 
         using var parentActivity = parentSource.StartActivity("aspire/cli/run");
         Assert.NotNull(parentActivity);
 
-        await using var session = AppHostServerSession.Start(
+        await using var session = factory.Start(
             project,
             environmentVariables: null,
-            debug: false,
-            NullLogger<AppHostServerSession>.Instance,
-            profilingTelemetry);
+            debug: false);
 
         Assert.Same(parentActivity, Activity.Current);
 
@@ -120,12 +119,13 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
         var project = new RecordingAppHostServerProject();
 
         using var loggerFactory = LoggerFactory.Create(builder => builder.AddXunit(outputHelper));
+        using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration());
+        var factory = CreateSessionFactory(profilingTelemetry, loggerFactory.CreateLogger<AppHostServerSession>());
 
-        await using var session = AppHostServerSession.Start(
+        await using var session = factory.Start(
             project,
             environmentVariables: null,
-            debug: false,
-            loggerFactory.CreateLogger<AppHostServerSession>());
+            debug: false);
 
         // Wait for the process to exit so the stopwatch measures only the early-exit detection
         // latency, not the variable execution time of "dotnet --version" on loaded CI machines.
@@ -205,6 +205,15 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
         return new ConfigurationBuilder()
             .AddInMemoryCollection(values.Select(value => new KeyValuePair<string, string?>(value.Key, value.Value)))
             .Build();
+    }
+
+    private static AppHostServerSessionFactory CreateSessionFactory(ProfilingTelemetry profilingTelemetry, ILogger<AppHostServerSession>? logger = null)
+    {
+        var projectFactory = CreateAppHostServerProjectFactory();
+        return new AppHostServerSessionFactory(
+            projectFactory,
+            logger ?? NullLogger<AppHostServerSession>.Instance,
+            profilingTelemetry);
     }
 
     private static AppHostServerProjectFactory CreateAppHostServerProjectFactory()

--- a/tests/Aspire.Cli.Tests/Scaffolding/ChannelReseedTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/ChannelReseedTests.cs
@@ -85,6 +85,7 @@ public class ChannelReseedTests(ITestOutputHelper outputHelper)
             {
                 CreateAsyncCallback = (_, _) => Task.FromResult<IAppHostServerProject>(appHostServerProject)
             },
+            appHostServerSessionFactory: new TestAppHostServerSessionFactory(),
             languageDiscovery: new TestLanguageDiscovery(language),
             interactionService: new TestInteractionService(),
             logger: NullLogger<ScaffoldingService>.Instance,
@@ -115,6 +116,7 @@ public class ChannelReseedTests(ITestOutputHelper outputHelper)
     {
         return new ScaffoldingService(
             appHostServerProjectFactory: new TestAppHostServerProjectFactory(),
+            appHostServerSessionFactory: new TestAppHostServerSessionFactory(),
             languageDiscovery: new TestLanguageDiscovery(s_testLanguage),
             interactionService: new TestInteractionService(),
             logger: NullLogger<ScaffoldingService>.Instance,

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -485,11 +485,12 @@ internal sealed class CliServiceCollectionTestOptions
     public Func<IServiceProvider, IScaffoldingService> ScaffoldingServiceFactory { get; set; } = (IServiceProvider serviceProvider) =>
     {
         var appHostServerProjectFactory = serviceProvider.GetRequiredService<IAppHostServerProjectFactory>();
+        var appHostServerSessionFactory = serviceProvider.GetRequiredService<IAppHostServerSessionFactory>();
         var languageDiscovery = serviceProvider.GetRequiredService<ILanguageDiscovery>();
         var interactionService = serviceProvider.GetRequiredService<IInteractionService>();
         var logger = serviceProvider.GetRequiredService<ILogger<ScaffoldingService>>();
         var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
-        return new ScaffoldingService(appHostServerProjectFactory, languageDiscovery, interactionService, logger, executionContext);
+        return new ScaffoldingService(appHostServerProjectFactory, appHostServerSessionFactory, languageDiscovery, interactionService, logger, executionContext);
     };
 
     public Func<IServiceProvider, IProcessExecutionFactory> DotNetCliExecutionFactoryFactory { get; set; } = (IServiceProvider serviceProvider) =>


### PR DESCRIPTION
## Summary

Replaces all direct calls to `AppHostServerSession.Start` with `IAppHostServerSessionFactory` for improved testability and consistency.

## Changes

- **ScaffoldingService**: Inject `IAppHostServerSessionFactory` and use it instead of calling the static method directly
- **SdkGenerateCommand**: Inject `IAppHostServerSessionFactory` and use it instead of calling the static method directly
- **SdkDumpCommand**: Inject `IAppHostServerSessionFactory` and use it instead of calling the static method directly (2 call sites)
- **AppHostServerSession.Start**: Make `ProfilingTelemetry` parameter non-optional since all callers now go through the factory which always provides it
- **Tests**: Update `AppHostServerSessionTests`, `ChannelReseedTests`, and `CliTestHelper` to use the factory

## Motivation

All production callers of `AppHostServerSession.Start` were passing a logger and sometimes profiling telemetry manually. Since `IAppHostServerSessionFactory` already encapsulates these dependencies and is registered in DI, the callers should use the factory for consistency and testability.