### PR TITLE
Register AppHostConnectionResolver in DI and inject via constructors

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
@@ -130,13 +130,13 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
     public static Task<AppHostAuxiliaryBackchannel> ConnectAsync(
         string socketPath,
         ILogger logger,
-        CancellationToken cancellationToken = default,
-        ProfilingTelemetry? profilingTelemetry = null)
+        ProfilingTelemetry profilingTelemetry,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(logger);
 
         var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath) ?? string.Empty;
-        return CreateFromSocketAsync(hash, socketPath, isInScope: true, logger, socket: null, cancellationToken, profilingTelemetry);
+        return CreateFromSocketAsync(hash, socketPath, isInScope: true, logger, profilingTelemetry, socket: null, cancellationToken);
     }
 
     /// <summary>
@@ -148,18 +148,18 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
     /// <param name="socketPath">The socket path.</param>
     /// <param name="isInScope">Whether this AppHost is within the scope of the working directory.</param>
     /// <param name="socket">Optional already-connected socket. If null, a new connection will be established.</param>
-    /// <param name="logger">Optional logger.</param>
+    /// <param name="logger">Logger.</param>
     /// <param name="cancellationToken">Cancellation token (only used when socket is null).</param>
-    /// <param name="profilingTelemetry">Optional profiling service.</param>
+    /// <param name="profilingTelemetry">Profiling service.</param>
     /// <returns>A connected AppHostAuxiliaryBackchannel instance.</returns>
     internal static async Task<AppHostAuxiliaryBackchannel> CreateFromSocketAsync(
         string hash,
         string socketPath,
         bool isInScope,
         ILogger logger,
-        Socket? socket = null,
-        CancellationToken cancellationToken = default,
-        ProfilingTelemetry? profilingTelemetry = null)
+        ProfilingTelemetry profilingTelemetry,
+        Socket? socket,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(logger);
 

--- a/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
@@ -123,9 +123,9 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
     /// Creates and connects a new auxiliary backchannel to the specified socket path.
     /// </summary>
     /// <param name="socketPath">The path to the Unix domain socket.</param>
-    /// <param name="logger">Optional logger for diagnostic messages.</param>
+    /// <param name="logger">Logger for diagnostic messages.</param>
+    /// <param name="profilingTelemetry">Profiling service.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <param name="profilingTelemetry">Optional profiling service.</param>
     /// <returns>A connected AppHostAuxiliaryBackchannel instance.</returns>
     public static Task<AppHostAuxiliaryBackchannel> ConnectAsync(
         string socketPath,
@@ -147,10 +147,10 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
     /// <param name="hash">The AppHost hash identifier.</param>
     /// <param name="socketPath">The socket path.</param>
     /// <param name="isInScope">Whether this AppHost is within the scope of the working directory.</param>
-    /// <param name="socket">Optional already-connected socket. If null, a new connection will be established.</param>
     /// <param name="logger">Logger.</param>
-    /// <param name="cancellationToken">Cancellation token (only used when socket is null).</param>
     /// <param name="profilingTelemetry">Profiling service.</param>
+    /// <param name="socket">Optional already-connected socket. If null, a new connection will be established.</param>
+    /// <param name="cancellationToken">Cancellation token (only used when socket is null).</param>
     /// <returns>A connected AppHostAuxiliaryBackchannel instance.</returns>
     internal static async Task<AppHostAuxiliaryBackchannel> CreateFromSocketAsync(
         string hash,

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -44,8 +44,8 @@ internal sealed class AppHostConnectionResolver(
     IProjectLocator projectLocator,
     CliExecutionContext executionContext,
     ICliHostEnvironment hostEnvironment,
-    ILogger logger,
-    ProfilingTelemetry? profilingTelemetry = null)
+    ILogger<AppHostConnectionResolver> logger,
+    ProfilingTelemetry profilingTelemetry)
 {
     /// <summary>
     /// Resolves all running AppHost connections using socket-first discovery.
@@ -147,7 +147,7 @@ internal sealed class AppHostConnectionResolver(
                 try
                 {
                     var connection = await AppHostAuxiliaryBackchannel.ConnectAsync(
-                        socketPath, logger, cancellationToken, profilingTelemetry).ConfigureAwait(false);
+                        socketPath, logger, profilingTelemetry, cancellationToken).ConfigureAwait(false);
                     if (connection is not null)
                     {
                         var result = new AppHostConnectionResult { Connection = connection };

--- a/src/Aspire.Cli/Backchannel/AuxiliaryBackchannelMonitor.cs
+++ b/src/Aspire.Cli/Backchannel/AuxiliaryBackchannelMonitor.cs
@@ -484,7 +484,7 @@ internal sealed class AuxiliaryBackchannelMonitor(
 
             // Use the centralized factory to create the connection
             // This ensures capabilities are always fetched
-            var connection = await AppHostAuxiliaryBackchannel.CreateFromSocketAsync(hash, socketPath, isInScope, logger, socket, cancellationToken, profilingTelemetry).ConfigureAwait(false);
+            var connection = await AppHostAuxiliaryBackchannel.CreateFromSocketAsync(hash, socketPath, isInScope, logger, profilingTelemetry, socket, cancellationToken).ConfigureAwait(false);
 
             // Update isInScope based on actual appHostInfo now that we have it
             connection.IsInScope = IsAppHostInScope(connection.AppHostInfo?.AppHostPath);

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -202,7 +202,7 @@ internal sealed class AppHostLauncher(
         {
             // Reuse the shared "RPC stop + wait for termination" flow so capture mode follows the
             // same teardown path as socket-discovered running-instance stops.
-            var manager = new RunningInstanceManager(logger, interactionService, timeProvider);
+            var manager = new RunningInstanceManager(logger, interactionService, timeProvider, profilingTelemetry);
             await manager.StopAndMonitorAsync(result.Backchannel, cancellationToken).ConfigureAwait(false);
         }
 
@@ -238,7 +238,7 @@ internal sealed class AppHostLauncher(
         if (existingSockets.Length > 0)
         {
             logger.LogDebug("Found {Count} running instance(s) for this AppHost, stopping them first.", existingSockets.Length);
-            var manager = new RunningInstanceManager(logger, interactionService, timeProvider);
+            var manager = new RunningInstanceManager(logger, interactionService, timeProvider, profilingTelemetry);
             var stopTasks = existingSockets.Select(socket =>
                 manager.StopRunningInstanceAsync(socket, cancellationToken));
             await Task.WhenAll(stopTasks).ConfigureAwait(false);

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -8,13 +8,11 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Aspire.Dashboard.Utils;
 using Aspire.Shared;
 using Aspire.Shared.Model.Serialization;
-using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
@@ -102,16 +100,14 @@ internal sealed class DescribeCommand : BaseCommand
     };
 
     public DescribeCommand(
-        IAuxiliaryBackchannelMonitor backchannelMonitor,
-        IProjectLocator projectLocator,
+        AppHostConnectionResolver connectionResolver,
         ResourceColorMap resourceColorMap,
-        ILogger<DescribeCommand> logger,
         CommonCommandServices services)
         : base("describe", DescribeCommandStrings.Description, services)
     {
         Aliases.Add("resources");
         _resourceColorMap = resourceColorMap;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
+        _connectionResolver = connectionResolver;
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/ExportCommand.cs
+++ b/src/Aspire.Cli/Commands/ExportCommand.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Utils;
@@ -50,8 +49,7 @@ internal sealed class ExportCommand : BaseCommand
     };
 
     public ExportCommand(
-        IAuxiliaryBackchannelMonitor backchannelMonitor,
-        IProjectLocator projectLocator,
+        AppHostConnectionResolver connectionResolver,
         IHttpClientFactory httpClientFactory,
         TimeProvider timeProvider,
         ILogger<ExportCommand> logger,
@@ -61,7 +59,7 @@ internal sealed class ExportCommand : BaseCommand
         _httpClientFactory = httpClientFactory;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
+        _connectionResolver = connectionResolver;
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -9,9 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
-using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.Shared.ConsoleLogs;
 using Microsoft.Extensions.Logging;
@@ -116,19 +114,17 @@ internal sealed class LogsCommand : BaseCommand
     private readonly ResourceColorMap _resourceColorMap;
 
     public LogsCommand(
-        IAuxiliaryBackchannelMonitor backchannelMonitor,
-        IProjectLocator projectLocator,
+        AppHostConnectionResolver connectionResolver,
         ICliHostEnvironment hostEnvironment,
         ResourceColorMap resourceColorMap,
         ILogger<LogsCommand> logger,
-        ProfilingTelemetry profilingTelemetry,
         CommonCommandServices services)
         : base("logs", LogsCommandStrings.Description, services)
     {
         _resourceColorMap = resourceColorMap;
         _hostEnvironment = hostEnvironment;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger, profilingTelemetry);
+        _connectionResolver = connectionResolver;
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/McpCallCommand.cs
+++ b/src/Aspire.Cli/Commands/McpCallCommand.cs
@@ -5,9 +5,7 @@ using System.CommandLine;
 using System.Globalization;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
-using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 
 namespace Aspire.Cli.Commands;
@@ -39,13 +37,11 @@ internal sealed class McpCallCommand : BaseCommand
     private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", SharedCommandStrings.AppHostOptionDescription);
 
     public McpCallCommand(
-        IAuxiliaryBackchannelMonitor backchannelMonitor,
-        IProjectLocator projectLocator,
-        ILogger<McpCallCommand> logger,
+        AppHostConnectionResolver connectionResolver,
         CommonCommandServices services)
         : base("call", McpCommandStrings.CallCommand_Description, services)
     {
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
+        _connectionResolver = connectionResolver;
 
         Arguments.Add(s_resourceArgument);
         Arguments.Add(s_toolArgument);

--- a/src/Aspire.Cli/Commands/McpToolsCommand.cs
+++ b/src/Aspire.Cli/Commands/McpToolsCommand.cs
@@ -6,9 +6,7 @@ using System.Globalization;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
-using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
@@ -29,13 +27,11 @@ internal sealed class McpToolsCommand : BaseCommand
     };
 
     public McpToolsCommand(
-        IAuxiliaryBackchannelMonitor backchannelMonitor,
-        IProjectLocator projectLocator,
-        ILogger<McpToolsCommand> logger,
+        AppHostConnectionResolver connectionResolver,
         CommonCommandServices services)
         : base("tools", McpCommandStrings.ToolsCommand_Description, services)
     {
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
+        _connectionResolver = connectionResolver;
 
         Options.Add(s_appHostOption);
         Options.Add(s_formatOption);

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -76,13 +76,14 @@ internal sealed class ResourceCommand : BaseCommand
     public ResourceCommand(
         IAuxiliaryBackchannelMonitor backchannelMonitor,
         IProjectLocator projectLocator,
+        AppHostConnectionResolver connectionResolver,
         ILogger<ResourceCommand> logger,
         CommonCommandServices services)
         : base("resource", ResourceCommandStrings.CommandDescription, services)
     {
         _backchannelMonitor = backchannelMonitor;
         _projectLocator = projectLocator;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
+        _connectionResolver = connectionResolver;
         _logger = logger;
 
         Arguments.Add(s_resourceArgument);

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Processes;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
@@ -34,9 +33,7 @@ internal sealed class StopCommand : BaseCommand
     };
 
     public StopCommand(
-        IInteractionService interactionService,
-        IAuxiliaryBackchannelMonitor backchannelMonitor,
-        IProjectLocator projectLocator,
+        AppHostConnectionResolver connectionResolver,
         ICliHostEnvironment hostEnvironment,
         ProcessShutdownService processShutdownService,
         ILogger<StopCommand> logger,
@@ -44,7 +41,7 @@ internal sealed class StopCommand : BaseCommand
         CommonCommandServices services)
         : base("stop", StopCommandStrings.Description, services)
     {
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger, profilingTelemetry);
+        _connectionResolver = connectionResolver;
         _hostEnvironment = hostEnvironment;
         _processShutdownService = processShutdownService;
         _logger = logger;

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -5,7 +5,6 @@ using System.CommandLine;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Aspire.Dashboard.Otlp.Model;
@@ -48,8 +47,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
 
     public TelemetryLogsCommand(
         IInteractionService interactionService,
-        IAuxiliaryBackchannelMonitor backchannelMonitor,
-        IProjectLocator projectLocator,
+        AppHostConnectionResolver connectionResolver,
         ICliHostEnvironment hostEnvironment,
         IHttpClientFactory httpClientFactory,
         ResourceColorMap resourceColorMap,
@@ -64,7 +62,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
+        _connectionResolver = connectionResolver;
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -5,7 +5,6 @@ using System.CommandLine;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Aspire.Dashboard.Otlp.Model;
@@ -41,8 +40,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
     private static readonly Option<string?> s_searchOption = TelemetryCommandHelpers.CreateSearchOption();
 
     public TelemetrySpansCommand(
-        IAuxiliaryBackchannelMonitor backchannelMonitor,
-        IProjectLocator projectLocator,
+        AppHostConnectionResolver connectionResolver,
         IHttpClientFactory httpClientFactory,
         ResourceColorMap resourceColorMap,
         TimeProvider timeProvider,
@@ -54,7 +52,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
+        _connectionResolver = connectionResolver;
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Aspire.Dashboard.Otlp.Model;
@@ -41,8 +40,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
     private static readonly Option<string?> s_searchOption = TelemetryCommandHelpers.CreateSearchOption();
 
     public TelemetryTracesCommand(
-        IAuxiliaryBackchannelMonitor backchannelMonitor,
-        IProjectLocator projectLocator,
+        AppHostConnectionResolver connectionResolver,
         IHttpClientFactory httpClientFactory,
         ResourceColorMap resourceColorMap,
         TimeProvider timeProvider,
@@ -54,7 +52,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         _resourceColorMap = resourceColorMap;
         _timeProvider = timeProvider;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
+        _connectionResolver = connectionResolver;
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/TerminalAttachCommand.cs
+++ b/src/Aspire.Cli/Commands/TerminalAttachCommand.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Net.Sockets;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tui;
 using Microsoft.Extensions.Logging;
@@ -58,15 +57,14 @@ internal sealed class TerminalAttachCommand : BaseCommand
     };
 
     public TerminalAttachCommand(
-        IAuxiliaryBackchannelMonitor backchannelMonitor,
-        IProjectLocator projectLocator,
+        AppHostConnectionResolver connectionResolver,
         ILogger<TerminalAttachCommand> logger,
         CommonCommandServices services)
         : base("attach", "Attach the local terminal to an interactive PTY session for a resource.", services)
     {
         _interactionService = services.InteractionService;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, services.InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
+        _connectionResolver = connectionResolver;
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/TerminalPsCommand.cs
+++ b/src/Aspire.Cli/Commands/TerminalPsCommand.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
@@ -55,15 +54,14 @@ internal sealed class TerminalPsCommand : BaseCommand
     };
 
     public TerminalPsCommand(
-        IAuxiliaryBackchannelMonitor backchannelMonitor,
-        IProjectLocator projectLocator,
+        AppHostConnectionResolver connectionResolver,
         ILogger<TerminalPsCommand> logger,
         CommonCommandServices services)
         : base("ps", "List interactive terminal sessions in the connected AppHost.", services)
     {
         _interactionService = services.InteractionService;
         _logger = logger;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, services.InteractionService, projectLocator, services.ExecutionContext, services.HostEnvironment, logger);
+        _connectionResolver = connectionResolver;
 
         Options.Add(s_appHostOption);
         Options.Add(s_formatOption);

--- a/src/Aspire.Cli/Commands/WaitCommand.cs
+++ b/src/Aspire.Cli/Commands/WaitCommand.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using System.Globalization;
 using Aspire.Cli.Backchannel;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
 
@@ -40,14 +39,13 @@ internal sealed class WaitCommand : BaseCommand
     private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", SharedCommandStrings.AppHostOptionDescription);
 
     public WaitCommand(
-        IAuxiliaryBackchannelMonitor backchannelMonitor,
-        IProjectLocator projectLocator,
+        AppHostConnectionResolver connectionResolver,
         ILogger<WaitCommand> logger,
         CommonCommandServices services,
         TimeProvider? timeProvider = null)
         : base("wait", WaitCommandStrings.Description, services)
     {
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, InteractionService, projectLocator, ExecutionContext, services.HostEnvironment, logger);
+        _connectionResolver = connectionResolver;
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -464,6 +464,7 @@ public class Program
         builder.Services.AddSingleton<AuxiliaryBackchannelMonitor>();
         builder.Services.AddSingleton<IAuxiliaryBackchannelMonitor>(sp => sp.GetRequiredService<AuxiliaryBackchannelMonitor>());
         builder.Services.AddHostedService(sp => sp.GetRequiredService<AuxiliaryBackchannelMonitor>());
+        builder.Services.AddTransient<AppHostConnectionResolver>();
         builder.Services.AddSingleton<ICliUpdateNotifier, CliUpdateNotifier>();
         builder.Services.AddSingleton<IPackagingService, PackagingService>();
         builder.Services.AddSingleton<IBundlePayloadProvider, EmbeddedBundlePayloadProvider>();

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -91,7 +91,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         _configurationService = configurationService;
         _executionContext = executionContext;
         _timeProvider = timeProvider ?? TimeProvider.System;
-        _runningInstanceManager = new RunningInstanceManager(_logger, _interactionService, _timeProvider);
+        _runningInstanceManager = new RunningInstanceManager(_logger, _interactionService, _timeProvider, _profilingTelemetry);
     }
 
     // ═══════════════════════════════════════════════════════════════

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -87,7 +87,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         _fileLoggerProvider = fileLoggerProvider;
         _profilingTelemetry = profilingTelemetry;
         _timeProvider = timeProvider ?? TimeProvider.System;
-        _runningInstanceManager = new RunningInstanceManager(_logger, _interactionService, _timeProvider);
+        _runningInstanceManager = new RunningInstanceManager(_logger, _interactionService, _timeProvider, _profilingTelemetry);
     }
 
     // ═══════════════════════════════════════════════════════════════

--- a/src/Aspire.Cli/Projects/RunningInstanceManager.cs
+++ b/src/Aspire.Cli/Projects/RunningInstanceManager.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Projects;
@@ -23,15 +24,18 @@ internal sealed class RunningInstanceManager
     private readonly ILogger _logger;
     private readonly IInteractionService _interactionService;
     private readonly TimeProvider _timeProvider;
+    private readonly ProfilingTelemetry _profilingTelemetry;
 
     public RunningInstanceManager(
         ILogger logger,
         IInteractionService interactionService,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        ProfilingTelemetry profilingTelemetry)
     {
         _logger = logger;
         _interactionService = interactionService;
         _timeProvider = timeProvider;
+        _profilingTelemetry = profilingTelemetry;
     }
 
     /// <summary>
@@ -45,7 +49,7 @@ internal sealed class RunningInstanceManager
         try
         {
             // Connect to the auxiliary backchannel
-            using var backchannel = await AppHostAuxiliaryBackchannel.ConnectAsync(socketPath, _logger, cancellationToken).ConfigureAwait(false);
+            using var backchannel = await AppHostAuxiliaryBackchannel.ConnectAsync(socketPath, _logger, _profilingTelemetry, cancellationToken).ConfigureAwait(false);
 
             // Get the AppHost information
             var appHostInfo = backchannel.AppHostInfo;

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostAuxiliaryBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostAuxiliaryBackchannelTests.cs
@@ -5,7 +5,9 @@ using System.Net;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using Aspire.Cli.Backchannel;
+using Aspire.Cli.Telemetry;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using StreamJsonRpc;
 
@@ -113,7 +115,7 @@ public class AppHostAuxiliaryBackchannelTests
             _disposables.Add(messageHandler);
             _disposables.Add(serverStream);
 
-            return await AppHostAuxiliaryBackchannel.CreateFromSocketAsync("hash1", "socket.hash1", isInScope: true, NullLogger.Instance, clientSocket).DefaultTimeout();
+            return await AppHostAuxiliaryBackchannel.CreateFromSocketAsync("hash1", "socket.hash1", isInScope: true, NullLogger.Instance, new ProfilingTelemetry(new ConfigurationBuilder().Build()), clientSocket, CancellationToken.None).DefaultTimeout();
         }
 
         public void Dispose()

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -270,7 +270,8 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             new TestProjectLocator(),
             executionContext,
             TestHelpers.CreateInteractiveHostEnvironment(),
-            NullLogger.Instance);
+            NullLogger<AppHostConnectionResolver>.Instance,
+            new ProfilingTelemetry(new ConfigurationBuilder().Build()));
 
         var result = await resolver.ResolveConnectionAsync(
             projectFileViaSymlink,

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -5,10 +5,12 @@ using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Backchannel;
@@ -37,7 +39,8 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             projectLocator,
             executionContext,
             TestHelpers.CreateInteractiveHostEnvironment(),
-            NullLogger.Instance);
+            NullLogger<AppHostConnectionResolver>.Instance,
+            new ProfilingTelemetry(new ConfigurationBuilder().Build()));
 
         var result = await resolver.ResolveConnectionAsync(
             projectFile,
@@ -72,7 +75,8 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             new TestProjectLocator(),
             executionContext,
             TestHelpers.CreateInteractiveHostEnvironment(),
-            NullLogger.Instance);
+            NullLogger<AppHostConnectionResolver>.Instance,
+            new ProfilingTelemetry(new ConfigurationBuilder().Build()));
 
         var result = await resolver.ResolveConnectionAsync(
             projectFile,
@@ -118,7 +122,8 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             projectLocator,
             executionContext,
             TestHelpers.CreateInteractiveHostEnvironment(),
-            NullLogger.Instance);
+            NullLogger<AppHostConnectionResolver>.Instance,
+            new ProfilingTelemetry(new ConfigurationBuilder().Build()));
 
         var result = await resolver.ResolveConnectionAsync(
             new FileInfo(appHostDirectory.FullName),
@@ -151,7 +156,8 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             projectLocator,
             executionContext,
             TestHelpers.CreateInteractiveHostEnvironment(),
-            NullLogger.Instance);
+            NullLogger<AppHostConnectionResolver>.Instance,
+            new ProfilingTelemetry(new ConfigurationBuilder().Build()));
 
         var result = await resolver.ResolveConnectionAsync(
             new FileInfo(appHostDirectory.FullName),
@@ -180,7 +186,8 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             new TestProjectLocator(),
             executionContext,
             TestHelpers.CreateNonInteractiveHostEnvironment(),
-            NullLogger.Instance);
+            NullLogger<AppHostConnectionResolver>.Instance,
+            new ProfilingTelemetry(new ConfigurationBuilder().Build()));
 
         var result = await resolver.ResolveConnectionAsync(
             projectFile: null,
@@ -210,7 +217,8 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
             new TestProjectLocator(),
             executionContext,
             TestHelpers.CreateNonInteractiveHostEnvironment(),
-            NullLogger.Instance);
+            NullLogger<AppHostConnectionResolver>.Instance,
+            new ProfilingTelemetry(new ConfigurationBuilder().Build()));
 
         var result = await resolver.ResolveConnectionAsync(
             projectFile: null,

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -7,9 +7,11 @@ using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using StreamJsonRpc;
@@ -781,7 +783,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
             _disposables.Add(messageHandler);
             _disposables.Add(serverStream);
 
-            return await AppHostAuxiliaryBackchannel.CreateFromSocketAsync("hash1", "socket.hash1", isInScope: true, NullLogger.Instance, clientSocket).DefaultTimeout();
+            return await AppHostAuxiliaryBackchannel.CreateFromSocketAsync("hash1", "socket.hash1", isInScope: true, NullLogger.Instance, new ProfilingTelemetry(new ConfigurationBuilder().Build()), clientSocket, CancellationToken.None).DefaultTimeout();
         }
 
         public void Dispose()

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -215,6 +215,7 @@ internal static class CliTestHelper
 
         services.AddSingleton(new ConsoleCancellationManager(processTerminationTimeout: Timeout.InfiniteTimeSpan));
         services.AddSingleton<CommonCommandServices>();
+        services.AddTransient<AppHostConnectionResolver>();
         services.AddTransient<RootCommand>();
         services.AddTransient<NewCommand>();
         services.AddTransient<InitCommand>();


### PR DESCRIPTION
## Description

Register `AppHostConnectionResolver` in DI and inject it via constructors instead of manually creating it in each command.

Previously, every command that needed an `AppHostConnectionResolver` would take `IAuxiliaryBackchannelMonitor`, `IProjectLocator`, and other dependencies in its constructor solely to pass them to `new AppHostConnectionResolver(...)`. This created unnecessary coupling and parameter bloat.

Now the resolver is registered as a transient service in the DI container and injected directly, allowing commands to remove the parameters they only needed for resolver construction.

**Changes:**
- Register `AppHostConnectionResolver` as transient in `Program.cs`
- Change `AppHostConnectionResolver` to use `ILogger<AppHostConnectionResolver>` for DI compatibility
- Update 13 command classes to receive the resolver via constructor injection
- Remove unused constructor parameters (`backchannelMonitor`, `projectLocator`, `logger`, `profilingTelemetry`) from commands
- Update `RunningInstanceManager` to accept `ProfilingTelemetry` (now required by `ConnectAsync`)
- Update test helper DI registration and fix test files for updated signatures

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
