### PR TITLE
Harden VS Code extension AppHost E2E paths

### DIFF
--- a/extension/src/test-e2e/appHostTree.e2e.test.ts
+++ b/extension/src/test-e2e/appHostTree.e2e.test.ts
@@ -4,9 +4,7 @@ import { executeE2eControlCommand, restoreWorkspaceCliPath, runE2eTeardown, setC
 import { getPrimaryAppHostProjectPath } from './helpers/paths';
 import { cancelActiveInput, clickTreeItem, openAspireView, waitForTreeItem } from './helpers/vscode';
 
-// Temporarily disabled until the Aspire view stale-state/refresh path is resilient enough for CI:
-// https://github.com/microsoft/aspire/issues/18054.
-suite.skip('Aspire AppHost tree E2E', function () {
+suite('Aspire AppHost tree E2E', function () {
     this.timeout(240000);
 
     teardown(async () => {

--- a/extension/src/test-e2e/appHostTree.e2e.test.ts
+++ b/extension/src/test-e2e/appHostTree.e2e.test.ts
@@ -4,7 +4,9 @@ import { executeE2eControlCommand, restoreWorkspaceCliPath, runE2eTeardown, setC
 import { getPrimaryAppHostProjectPath } from './helpers/paths';
 import { cancelActiveInput, clickTreeItem, openAspireView, waitForTreeItem } from './helpers/vscode';
 
-suite('Aspire AppHost tree E2E', function () {
+// Temporarily disabled until the Aspire view stale-state/refresh path is resilient enough for CI:
+// https://github.com/microsoft/aspire/issues/18054.
+suite.skip('Aspire AppHost tree E2E', function () {
     this.timeout(240000);
 
     teardown(async () => {

--- a/extension/src/test-e2e/commandPalette.e2e.test.ts
+++ b/extension/src/test-e2e/commandPalette.e2e.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getCommandInvocationCount, getTerminalCommandCount, isSamePath, waitForCommandOutcome, waitForExtensionState, waitForRepositoryIdle, waitForTerminalCommand, waitForWorkspaceAppHost } from './helpers/assertions';
-import { createAdditionalAppHostCandidate, executeE2eControlCommand, removeAdditionalAppHostCandidate, removeWorkspaceAppHostConfig, restoreE2eCliPathForE2E, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, setCliUnavailableForE2E, setE2eCliPathForE2E, setTerminalCommandExecutionSuppressedForE2E, writeWorkspaceCliPath } from './helpers/fixtures';
+import { createAdditionalAppHostCandidate, executeE2eControlCommand, removeAdditionalAppHostCandidate, removeWorkspaceAppHostConfig, restoreE2eCliPathForE2E, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setE2eCliPathForE2E, setTerminalCommandExecutionSuppressedForE2E, writeWorkspaceCliPath } from './helpers/fixtures';
 import { getWorkspaceRoot } from './helpers/paths';
 import { executeCommandFromPalette, openAspireView, waitForEditorTitle, waitForNotificationMessage, waitForTerminalChannel, waitForWorkbenchText } from './helpers/vscode';
 
@@ -10,36 +10,15 @@ suite('Aspire command palette E2E', function () {
     this.timeout(420000);
 
     teardown(async () => {
-        const failures: unknown[] = [];
-        for (const cleanup of [
+        await runE2eTeardown([
             () => executeE2eControlCommand({ name: 'closeAllEditors' }),
             () => setCliUnavailableForE2E(false),
             () => setTerminalCommandExecutionSuppressedForE2E(false),
             () => restoreE2eCliPathForE2E(),
             () => restoreWorkspaceCliPath(),
-        ]) {
-            try {
-                await cleanup();
-            } catch (error) {
-                failures.push(error);
-            }
-        }
-
-        try {
-            restoreWorkspaceAppHostConfig();
-        } catch (error) {
-            failures.push(error);
-        }
-
-        try {
-            removeAdditionalAppHostCandidate();
-        } catch (error) {
-            failures.push(error);
-        }
-
-        if (failures.length > 0) {
-            throw new AggregateError(failures, 'Command palette E2E teardown failed.');
-        }
+            () => restoreWorkspaceAppHostConfig(),
+            () => removeAdditionalAppHostCandidate(),
+        ], 'Command palette E2E teardown failed.');
     });
 
     test('opens an Aspire terminal through the command palette with the configured CLI path', async () => {

--- a/extension/src/test-e2e/discoveryConfiguration.e2e.test.ts
+++ b/extension/src/test-e2e/discoveryConfiguration.e2e.test.ts
@@ -167,15 +167,10 @@ suite('Aspire workspace discovery and configuration E2E', function () {
                 }
             }
 
-            try {
-                restoreWorkspaceAppHostConfig();
-            } catch (error) {
-                failures.push(error);
-            }
-
-            if (failures.length > 0) {
-                throw new AggregateError(failures, 'Discovery configuration E2E test or cleanup failed.');
-            }
+            await runE2eTeardown([
+                ...failures.map(failure => () => { throw failure; }),
+                () => restoreWorkspaceAppHostConfig(),
+            ], 'Discovery configuration E2E test or cleanup failed.');
         }
     });
 });

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -135,7 +135,8 @@ export async function clearBreakpoints(): Promise<void> {
     await executeE2eControlCommand({ name: 'clearBreakpoints' });
 }
 
-export function removeGeneratedProject(projectName: string): void {
+export async function removeGeneratedProject(projectName: string): Promise<void> {
+    await waitForNoRunningAppHostPath(getGeneratedAppHostPath(projectName), 30000);
     removePath(getGeneratedProjectRoot(projectName), { recursive: true, force: true });
 }
 
@@ -347,6 +348,21 @@ async function waitForRunningAppHostProcessExitFromState(appHostPath: string, ti
     }
 
     throw new Error(`Unable to find running AppHost state for ${appHostPath}.`);
+}
+
+async function waitForNoRunningAppHostPath(appHostPath: string, timeoutMs: number): Promise<void> {
+    const started = Date.now();
+    while (Date.now() - started < timeoutMs) {
+        const runningAppHost = getRunningAppHostFromState(appHostPath);
+        if (!runningAppHost || !isProcessRunning(runningAppHost.appHostPid)) {
+            return;
+        }
+
+        await delay(250);
+    }
+
+    const runningAppHost = getRunningAppHostFromState(appHostPath);
+    throw new Error(`Timed out after ${timeoutMs}ms waiting for AppHost process ${runningAppHost?.appHostPid ?? '<unknown>'} to exit before deleting ${path.dirname(appHostPath)}.`);
 }
 
 function getRunningAppHostFromState(appHostPath: string) {

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -144,6 +144,20 @@ export function getRunningAppHostPid(appHostPath: string): number | undefined {
     return getRunningAppHostFromState(appHostPath)?.appHostPid;
 }
 
+export async function waitForRunningAppHostPid(appHostPath: string, timeoutMs: number): Promise<number> {
+    const started = Date.now();
+    while (Date.now() - started < timeoutMs) {
+        const pid = getRunningAppHostPid(appHostPath);
+        if (pid !== undefined) {
+            return pid;
+        }
+
+        await delay(250);
+    }
+
+    throw new Error(`Timed out after ${timeoutMs}ms waiting for AppHost process state before stopping ${appHostPath}.`);
+}
+
 export function removePrimaryAppHostFixture(): void {
     removePath(path.join(getWorkspaceRoot(), 'AspireE2E.AppHost'), { recursive: true, force: true });
     removePath(path.join(getWorkspaceRoot(), 'AspireE2E.Worker'), { recursive: true, force: true });

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -135,9 +135,13 @@ export async function clearBreakpoints(): Promise<void> {
     await executeE2eControlCommand({ name: 'clearBreakpoints' });
 }
 
-export async function removeGeneratedProject(projectName: string): Promise<void> {
-    await waitForNoRunningAppHostPath(getGeneratedAppHostPath(projectName), 30000);
+export async function removeGeneratedProject(projectName: string, knownAppHostPid?: number): Promise<void> {
+    await waitForNoRunningAppHostPath(getGeneratedAppHostPath(projectName), 30000, knownAppHostPid);
     removePath(getGeneratedProjectRoot(projectName), { recursive: true, force: true });
+}
+
+export function getRunningAppHostPid(appHostPath: string): number | undefined {
+    return getRunningAppHostFromState(appHostPath)?.appHostPid;
 }
 
 export function removePrimaryAppHostFixture(): void {
@@ -284,11 +288,13 @@ export async function stopAppHostIfRunning(appHostPath: string): Promise<void> {
             try {
                 const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);
                 if (!runningAppHost) {
+                    await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
                     return;
                 }
 
                 await waitForProcessExit(runningAppHost.appHostPid, 30000);
                 if (!await getRunningAppHostAccordingToCli(appHostPath)) {
+                    await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
                     return;
                 }
 

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -299,24 +299,19 @@ export async function stopAppHostIfRunning(appHostPath: string): Promise<void> {
         }
 
         if (/timed out|Failed to stop/i.test(error.message)) {
-            try {
-                const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);
-                if (!runningAppHost) {
-                    await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
-                    return;
-                }
-
-                await waitForProcessExit(runningAppHost.appHostPid, 30000);
-                if (!await getRunningAppHostAccordingToCli(appHostPath)) {
-                    await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
-                    return;
-                }
-
-                throw new Error(`AppHost is still running according to aspire ps: ${appHostPath}`);
+            const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);
+            if (!runningAppHost) {
+                await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
+                return;
             }
-            catch {
-                throw error;
+
+            await waitForProcessExit(runningAppHost.appHostPid, 30000);
+            if (!await getRunningAppHostAccordingToCli(appHostPath)) {
+                await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
+                return;
             }
+
+            throw new Error(`AppHost is still running according to aspire ps: ${appHostPath}`);
         }
 
         throw error;
@@ -388,7 +383,7 @@ async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string
         await waitForNoRunningAppHostPath(appHostPath, timeoutMs, knownAppHostPid);
     }
     catch (error) {
-        const runningAppHostPid = getRunningAppHostFromState(appHostPath)?.appHostPid ?? knownAppHostPid;
+        const runningAppHostPid = getRunningAppHostFromState(appHostPath)?.appHostPid;
         if (runningAppHostPid === undefined || !isProcessRunning(runningAppHostPid)) {
             throw error;
         }

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -261,12 +261,14 @@ export async function stopPrimaryAppHostIfRunning(): Promise<void> {
 }
 
 export async function stopAppHostIfRunning(appHostPath: string): Promise<void> {
+    const runningAppHostBeforeStop = getRunningAppHostFromState(appHostPath);
+
     try {
         await runProcess(getCliPath(), ['stop', '--non-interactive', '--apphost', appHostPath], {
             cwd: getWorkspaceRoot(),
             timeoutMs: 60000,
         });
-        await waitForRunningAppHostProcessExitFromState(appHostPath, 5000).catch(() => undefined);
+        await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
     }
     catch (error) {
         if (!(error instanceof Error)) {
@@ -274,7 +276,7 @@ export async function stopAppHostIfRunning(appHostPath: string): Promise<void> {
         }
 
         if (/not running|No running AppHost|No AppHost/i.test(error.message)) {
-            await waitForRunningAppHostProcessExitFromState(appHostPath, 5000).catch(() => undefined);
+            await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
             return;
         }
 
@@ -340,21 +342,17 @@ function isPsAppHost(value: unknown): value is PsAppHost {
         && (candidate.status === undefined || typeof candidate.status === 'string');
 }
 
-async function waitForRunningAppHostProcessExitFromState(appHostPath: string, timeoutMs: number): Promise<void> {
-    const runningAppHost = getRunningAppHostFromState(appHostPath);
-    if (runningAppHost) {
-        await waitForProcessExit(runningAppHost.appHostPid, timeoutMs);
-        return;
-    }
-
-    throw new Error(`Unable to find running AppHost state for ${appHostPath}.`);
-}
-
-async function waitForNoRunningAppHostPath(appHostPath: string, timeoutMs: number): Promise<void> {
+async function waitForNoRunningAppHostPath(appHostPath: string, timeoutMs: number, knownAppHostPid?: number): Promise<void> {
     const started = Date.now();
+    let lastKnownAppHostPid = knownAppHostPid;
+
     while (Date.now() - started < timeoutMs) {
         const runningAppHost = getRunningAppHostFromState(appHostPath);
-        if (!runningAppHost || !isProcessRunning(runningAppHost.appHostPid)) {
+        if (runningAppHost) {
+            lastKnownAppHostPid = runningAppHost.appHostPid;
+        }
+
+        if (lastKnownAppHostPid === undefined || !isProcessRunning(lastKnownAppHostPid)) {
             return;
         }
 
@@ -362,7 +360,7 @@ async function waitForNoRunningAppHostPath(appHostPath: string, timeoutMs: numbe
     }
 
     const runningAppHost = getRunningAppHostFromState(appHostPath);
-    throw new Error(`Timed out after ${timeoutMs}ms waiting for AppHost process ${runningAppHost?.appHostPid ?? '<unknown>'} to exit before deleting ${path.dirname(appHostPath)}.`);
+    throw new Error(`Timed out after ${timeoutMs}ms waiting for AppHost process ${runningAppHost?.appHostPid ?? lastKnownAppHostPid ?? '<unknown>'} to exit before deleting ${path.dirname(appHostPath)}.`);
 }
 
 function getRunningAppHostFromState(appHostPath: string) {

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -402,13 +402,20 @@ async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string
         await waitForNoRunningAppHostPath(appHostPath, timeoutMs, knownAppHostPid, actionDescription);
     }
     catch (error) {
-        const runningAppHostPid = getRunningAppHostFromState(appHostPath)?.appHostPid;
-        if (runningAppHostPid === undefined || !isProcessRunning(runningAppHostPid)) {
+        const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);
+        // The extension state file can lag behind the CLI registry after stopDebugging:
+        // it may still contain an AppHost PID even though aspire ps has already dropped
+        // the AppHost. At that point the PID may be stale/reused, so don't SIGTERM it.
+        if (!runningAppHost) {
+            return;
+        }
+
+        if (!isProcessRunning(runningAppHost.appHostPid)) {
             throw error;
         }
 
-        await stopProcess(runningAppHostPid, 30000);
-        await waitForNoRunningAppHostPath(appHostPath, 5000, runningAppHostPid, actionDescription);
+        await stopProcess(runningAppHost.appHostPid, 30000);
+        await waitForNoRunningAppHostPath(appHostPath, 5000, runningAppHost.appHostPid, actionDescription);
     }
 }
 

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -293,12 +293,12 @@ export async function stopAppHostIfRunning(appHostPath: string): Promise<void> {
     const stopError = await tryStopAppHost(appHostPath);
 
     if (!stopError) {
-        await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping');
+        await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping');
         return;
     }
 
     if (/not running|No running AppHost|No AppHost/i.test(stopError.message)) {
-        await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping');
+        await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping');
         return;
     }
 

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -77,18 +77,22 @@ export async function runE2eTeardown(cleanups: ReadonlyArray<() => unknown | Pro
     }
 
     if (failures.length > 0) {
-        throw new AggregateError(failures, formatE2eTeardownFailureMessage(failureMessage, failures));
+        throw new AggregateError(failures.map(redactE2eTeardownFailure), formatE2eTeardownFailureMessage(failureMessage, failures.map(redactE2eTeardownFailure)));
     }
 }
 
-function formatE2eTeardownFailureMessage(failureMessage: string, failures: ReadonlyArray<unknown>): string {
-    const formattedFailures = failures.map((failure, index) => {
-        const error = failure instanceof Error ? failure : undefined;
-        const details = error?.stack ?? error?.message ?? String(failure);
-        return `${index + 1}. ${details}`;
-    });
+function formatE2eTeardownFailureMessage(failureMessage: string, failures: ReadonlyArray<string>): string {
+    const formattedFailures = failures.map((failure, index) => `${index + 1}. ${failure}`);
 
     return `${failureMessage}\n${formattedFailures.join('\n')}`;
+}
+
+function redactE2eTeardownFailure(failure: unknown): string {
+    const details = failure instanceof Error ? `${failure.name}: ${failure.message}` : String(failure);
+
+    return details
+        .replace(/https?:\/\/\S+/g, '<redacted-url>')
+        .replace(/Last state:[\s\S]*/g, 'Last state: <redacted>');
 }
 
 export async function createEmptyAppHostProject(projectName: string): Promise<string> {
@@ -651,5 +655,5 @@ function isRetryableFileSystemError(error: unknown): boolean {
     }
 
     const code = (error as NodeJS.ErrnoException).code;
-    return code === 'EBUSY' || code === 'EPERM' || code === 'EACCES';
+    return code === 'EBUSY' || code === 'EPERM' || code === 'EACCES' || code === 'ENOTEMPTY';
 }

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -286,7 +286,7 @@ export async function stopAppHostIfRunning(appHostPath: string): Promise<void> {
             cwd: getWorkspaceRoot(),
             timeoutMs: 60000,
         });
-        await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
+        await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
     }
     catch (error) {
         if (!(error instanceof Error)) {
@@ -294,7 +294,7 @@ export async function stopAppHostIfRunning(appHostPath: string): Promise<void> {
         }
 
         if (/not running|No running AppHost|No AppHost/i.test(error.message)) {
-            await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
+            await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
             return;
         }
 
@@ -302,13 +302,13 @@ export async function stopAppHostIfRunning(appHostPath: string): Promise<void> {
             try {
                 const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);
                 if (!runningAppHost) {
-                    await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
+                    await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
                     return;
                 }
 
                 await waitForProcessExit(runningAppHost.appHostPid, 30000);
                 if (!await getRunningAppHostAccordingToCli(appHostPath)) {
-                    await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
+                    await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
                     return;
                 }
 
@@ -383,6 +383,21 @@ async function waitForNoRunningAppHostPath(appHostPath: string, timeoutMs: numbe
     throw new Error(`Timed out after ${timeoutMs}ms waiting for AppHost process ${runningAppHost?.appHostPid ?? lastKnownAppHostPid ?? '<unknown>'} to exit before deleting ${path.dirname(appHostPath)}.`);
 }
 
+async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string, timeoutMs: number, knownAppHostPid?: number): Promise<void> {
+    try {
+        await waitForNoRunningAppHostPath(appHostPath, timeoutMs, knownAppHostPid);
+    }
+    catch (error) {
+        const runningAppHostPid = getRunningAppHostFromState(appHostPath)?.appHostPid ?? knownAppHostPid;
+        if (runningAppHostPid === undefined || !isProcessRunning(runningAppHostPid)) {
+            throw error;
+        }
+
+        await stopProcess(runningAppHostPid, 30000);
+        await waitForNoRunningAppHostPath(appHostPath, 5000, runningAppHostPid);
+    }
+}
+
 function getRunningAppHostFromState(appHostPath: string) {
     const state = readStateFile().state;
     return state.workspaceAppHost && isSamePath(state.workspaceAppHost.appHostPath, appHostPath)
@@ -401,6 +416,21 @@ async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void>
     }
 
     throw new Error(`Timed out after ${timeoutMs}ms waiting for process ${pid} to exit.`);
+}
+
+async function stopProcess(pid: number, timeoutMs: number): Promise<void> {
+    try {
+        process.kill(pid, 'SIGTERM');
+    }
+    catch (error) {
+        if (error instanceof Error && 'code' in error && error.code === 'ESRCH') {
+            return;
+        }
+
+        throw error;
+    }
+
+    await waitForProcessExit(pid, timeoutMs);
 }
 
 function isProcessRunning(pid: number): boolean {

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -313,8 +313,22 @@ export async function stopAppHostIfRunning(appHostPath: string): Promise<void> {
             return;
         }
 
-        await waitForProcessExit(runningAppHost.appHostPid, 30000);
+        try {
+            await waitForProcessExit(runningAppHost.appHostPid, 30000);
+        }
+        catch {
+            if (isProcessRunning(runningAppHost.appHostPid)) {
+                await stopProcess(runningAppHost.appHostPid, 30000);
+            }
+        }
+
         if (!await getRunningAppHostAccordingToCli(appHostPath)) {
+            await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping');
+            return;
+        }
+
+        if (isProcessRunning(runningAppHost.appHostPid)) {
+            await stopProcess(runningAppHost.appHostPid, 30000);
             await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping');
             return;
         }

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -150,7 +150,7 @@ export async function clearBreakpoints(): Promise<void> {
 }
 
 export async function removeGeneratedProject(projectName: string, knownAppHostPid?: number): Promise<void> {
-    await waitForNoRunningAppHostPath(getGeneratedAppHostPath(projectName), 30000, knownAppHostPid, 'before deleting');
+    await waitForNoRunningAppHostPathOrStopKnownProcess(getGeneratedAppHostPath(projectName), 30000, knownAppHostPid, 'before deleting');
     removePath(getGeneratedProjectRoot(projectName), { recursive: true, force: true });
 }
 

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -77,8 +77,18 @@ export async function runE2eTeardown(cleanups: ReadonlyArray<() => unknown | Pro
     }
 
     if (failures.length > 0) {
-        throw new AggregateError(failures, failureMessage);
+        throw new AggregateError(failures, formatE2eTeardownFailureMessage(failureMessage, failures));
     }
+}
+
+function formatE2eTeardownFailureMessage(failureMessage: string, failures: ReadonlyArray<unknown>): string {
+    const formattedFailures = failures.map((failure, index) => {
+        const error = failure instanceof Error ? failure : undefined;
+        const details = error?.stack ?? error?.message ?? String(failure);
+        return `${index + 1}. ${details}`;
+    });
+
+    return `${failureMessage}\n${formattedFailures.join('\n')}`;
 }
 
 export async function createEmptyAppHostProject(projectName: string): Promise<string> {
@@ -136,7 +146,7 @@ export async function clearBreakpoints(): Promise<void> {
 }
 
 export async function removeGeneratedProject(projectName: string, knownAppHostPid?: number): Promise<void> {
-    await waitForNoRunningAppHostPath(getGeneratedAppHostPath(projectName), 30000, knownAppHostPid);
+    await waitForNoRunningAppHostPath(getGeneratedAppHostPath(projectName), 30000, knownAppHostPid, 'before deleting');
     removePath(getGeneratedProjectRoot(projectName), { recursive: true, force: true });
 }
 
@@ -280,38 +290,47 @@ export async function stopPrimaryAppHostIfRunning(): Promise<void> {
 
 export async function stopAppHostIfRunning(appHostPath: string): Promise<void> {
     const runningAppHostBeforeStop = getRunningAppHostFromState(appHostPath);
+    const stopError = await tryStopAppHost(appHostPath);
 
+    if (!stopError) {
+        await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping');
+        return;
+    }
+
+    if (/not running|No running AppHost|No AppHost/i.test(stopError.message)) {
+        await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping');
+        return;
+    }
+
+    if (/timed out|Failed to stop/i.test(stopError.message)) {
+        const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);
+        if (!runningAppHost) {
+            await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping');
+            return;
+        }
+
+        await waitForProcessExit(runningAppHost.appHostPid, 30000);
+        if (!await getRunningAppHostAccordingToCli(appHostPath)) {
+            await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping');
+            return;
+        }
+
+        throw new Error(`AppHost is still running according to aspire ps: ${appHostPath}`);
+    }
+
+    throw stopError;
+}
+
+async function tryStopAppHost(appHostPath: string): Promise<Error | undefined> {
     try {
         await runProcess(getCliPath(), ['stop', '--non-interactive', '--apphost', appHostPath], {
             cwd: getWorkspaceRoot(),
             timeoutMs: 60000,
         });
-        await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
-    }
-    catch (error) {
-        if (!(error instanceof Error)) {
-            throw error;
-        }
-
-        if (/not running|No running AppHost|No AppHost/i.test(error.message)) {
-            await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
-            return;
-        }
-
-        if (/timed out|Failed to stop/i.test(error.message)) {
-            const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);
-            if (!runningAppHost) {
-                await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
-                return;
-            }
-
-            await waitForProcessExit(runningAppHost.appHostPid, 30000);
-            if (!await getRunningAppHostAccordingToCli(appHostPath)) {
-                await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);
-                return;
-            }
-
-            throw new Error(`AppHost is still running according to aspire ps: ${appHostPath}`);
+        return undefined;
+    } catch (error) {
+        if (error instanceof Error) {
+            return error;
         }
 
         throw error;
@@ -357,7 +376,7 @@ function isPsAppHost(value: unknown): value is PsAppHost {
         && (candidate.status === undefined || typeof candidate.status === 'string');
 }
 
-async function waitForNoRunningAppHostPath(appHostPath: string, timeoutMs: number, knownAppHostPid?: number): Promise<void> {
+async function waitForNoRunningAppHostPath(appHostPath: string, timeoutMs: number, knownAppHostPid: number | undefined, actionDescription: string): Promise<void> {
     const started = Date.now();
     let lastKnownAppHostPid = knownAppHostPid;
 
@@ -375,12 +394,12 @@ async function waitForNoRunningAppHostPath(appHostPath: string, timeoutMs: numbe
     }
 
     const runningAppHost = getRunningAppHostFromState(appHostPath);
-    throw new Error(`Timed out after ${timeoutMs}ms waiting for AppHost process ${runningAppHost?.appHostPid ?? lastKnownAppHostPid ?? '<unknown>'} to exit before deleting ${path.dirname(appHostPath)}.`);
+    throw new Error(`Timed out after ${timeoutMs}ms waiting for AppHost process ${runningAppHost?.appHostPid ?? lastKnownAppHostPid ?? '<unknown>'} to exit ${actionDescription} ${path.dirname(appHostPath)}.`);
 }
 
-async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string, timeoutMs: number, knownAppHostPid?: number): Promise<void> {
+async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string, timeoutMs: number, knownAppHostPid: number | undefined, actionDescription: string): Promise<void> {
     try {
-        await waitForNoRunningAppHostPath(appHostPath, timeoutMs, knownAppHostPid);
+        await waitForNoRunningAppHostPath(appHostPath, timeoutMs, knownAppHostPid, actionDescription);
     }
     catch (error) {
         const runningAppHostPid = getRunningAppHostFromState(appHostPath)?.appHostPid;
@@ -389,7 +408,7 @@ async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string
         }
 
         await stopProcess(runningAppHostPid, 30000);
-        await waitForNoRunningAppHostPath(appHostPath, 5000, runningAppHostPid);
+        await waitForNoRunningAppHostPath(appHostPath, 5000, runningAppHostPid, actionDescription);
     }
 }
 

--- a/extension/src/test-e2e/treeActions.e2e.test.ts
+++ b/extension/src/test-e2e/treeActions.e2e.test.ts
@@ -113,24 +113,29 @@ suite('Aspire tree action command E2E', function () {
         await waitForResource('e2e-worker');
         await waitForResourceState('e2e-worker', ['Running'], 90000);
 
-        before = getCommandInvocationCount('aspire-vscode.stopResource');
-        let terminalBefore = getTerminalCommandCount();
-        await executeE2eControlCommand({ name: 'stopResource', appHostPath, resourceName: workerResourceName });
-        await waitForCommandOutcome('aspire-vscode.stopResource', 'success', 60000, before);
-        await waitForResourceTerminalCommand(workerResourceName, 'stop', terminalBefore);
-        await waitForResourceState(workerResourceName, ['Stopped', 'Finished', 'Exited'], 90000);
+        await setTerminalCommandExecutionSuppressedForE2E(true);
+        let terminalBefore: number;
+        try {
+            before = getCommandInvocationCount('aspire-vscode.stopResource');
+            terminalBefore = getTerminalCommandCount();
+            await executeE2eControlCommand({ name: 'stopResource', appHostPath, resourceName: workerResourceName });
+            await waitForCommandOutcome('aspire-vscode.stopResource', 'success', 60000, before);
+            await waitForResourceTerminalCommand(workerResourceName, 'stop', terminalBefore);
 
-        before = getCommandInvocationCount('aspire-vscode.startResource');
-        terminalBefore = getTerminalCommandCount();
-        await executeE2eControlCommand({ name: 'startResource', appHostPath, resourceName: workerResourceName });
-        await waitForCommandOutcome('aspire-vscode.startResource', 'success', 60000, before);
-        await waitForResourceTerminalCommand(workerResourceName, 'start', terminalBefore);
+            before = getCommandInvocationCount('aspire-vscode.startResource');
+            terminalBefore = getTerminalCommandCount();
+            await executeE2eControlCommand({ name: 'startResource', appHostPath, resourceName: workerResourceName });
+            await waitForCommandOutcome('aspire-vscode.startResource', 'success', 60000, before);
+            await waitForResourceTerminalCommand(workerResourceName, 'start', terminalBefore);
 
-        before = getCommandInvocationCount('aspire-vscode.restartResource');
-        terminalBefore = getTerminalCommandCount();
-        await executeE2eControlCommand({ name: 'restartResource', appHostPath, resourceName: workerResourceName });
-        await waitForCommandOutcome('aspire-vscode.restartResource', 'success', 60000, before);
-        await waitForResourceTerminalCommand(workerResourceName, 'restart', terminalBefore);
+            before = getCommandInvocationCount('aspire-vscode.restartResource');
+            terminalBefore = getTerminalCommandCount();
+            await executeE2eControlCommand({ name: 'restartResource', appHostPath, resourceName: workerResourceName });
+            await waitForCommandOutcome('aspire-vscode.restartResource', 'success', 60000, before);
+            await waitForResourceTerminalCommand(workerResourceName, 'restart', terminalBefore);
+        } finally {
+            await setTerminalCommandExecutionSuppressedForE2E(false);
+        }
 
         await setTerminalCommandExecutionSuppressedForE2E(true);
         before = getCommandInvocationCount('aspire-vscode.executeResourceCommandItem');

--- a/extension/src/test-e2e/zeroToRunning.e2e.test.ts
+++ b/extension/src/test-e2e/zeroToRunning.e2e.test.ts
@@ -4,9 +4,7 @@ import { getCommandInvocationCount, getTerminalCommandCount, waitForCommandOutco
 import { addIntegrationPackageToAppHost, clearBreakpoints, createEmptyAppHostProject, executeE2eControlCommand, getGeneratedAppHostPath, removeGeneratedProject, removePrimaryAppHostFixture, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setTerminalCommandExecutionSuppressedForE2E, stopAppHostIfRunning, writeWorkspaceAppHostConfigForPath } from './helpers/fixtures';
 import { openAspireView, waitForEditorTitle, waitForTreeItem, waitForWorkbenchTextAfterIntegratedBrowserNavigation } from './helpers/vscode';
 
-// Temporarily disabled until the CI-only reliability failures are understood:
-// https://github.com/microsoft/aspire/issues/18098.
-suite.skip('Aspire zero-to-running E2E', function () {
+suite('Aspire zero-to-running E2E', function () {
     this.timeout(2100000);
 
     const projectName = 'ExtensionZeroToRunningApp';

--- a/extension/src/test-e2e/zeroToRunning.e2e.test.ts
+++ b/extension/src/test-e2e/zeroToRunning.e2e.test.ts
@@ -16,9 +16,8 @@ suite('Aspire zero-to-running E2E', function () {
     });
 
     teardown(async () => {
-        appHostPidBeforeStop ??= getRunningAppHostPid(appHostPath);
-
         await runE2eTeardown([
+            () => appHostPidBeforeStop ??= getRunningAppHostPid(appHostPath),
             () => setCliUnavailableForE2E(false),
             () => setTerminalCommandExecutionSuppressedForE2E(false),
             () => restoreWorkspaceCliPath(),

--- a/extension/src/test-e2e/zeroToRunning.e2e.test.ts
+++ b/extension/src/test-e2e/zeroToRunning.e2e.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import { getCommandInvocationCount, getTerminalCommandCount, waitForCommandOutcome, waitForDebugDashboardUrl, waitForDebugSessionStartup, waitForExtensionState, waitForHttpText, waitForNoDebugSessions, waitForRepositoryIdle, waitForSelectedWorkspaceAppHost, waitForTerminalCommand } from './helpers/assertions';
-import { addIntegrationPackageToAppHost, clearBreakpoints, createEmptyAppHostProject, executeE2eControlCommand, getGeneratedAppHostPath, removeGeneratedProject, removePrimaryAppHostFixture, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setTerminalCommandExecutionSuppressedForE2E, stopAppHostIfRunning, writeWorkspaceAppHostConfigForPath } from './helpers/fixtures';
+import { addIntegrationPackageToAppHost, clearBreakpoints, createEmptyAppHostProject, executeE2eControlCommand, getGeneratedAppHostPath, getRunningAppHostPid, removeGeneratedProject, removePrimaryAppHostFixture, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setTerminalCommandExecutionSuppressedForE2E, stopAppHostIfRunning, writeWorkspaceAppHostConfigForPath } from './helpers/fixtures';
 import { openAspireView, waitForEditorTitle, waitForTreeItem, waitForWorkbenchTextAfterIntegratedBrowserNavigation } from './helpers/vscode';
 
 suite('Aspire zero-to-running E2E', function () {
@@ -11,6 +11,8 @@ suite('Aspire zero-to-running E2E', function () {
     const appHostPath = getGeneratedAppHostPath(projectName);
 
     teardown(async () => {
+        const appHostPidBeforeTeardown = getRunningAppHostPid(appHostPath);
+
         await runE2eTeardown([
             () => setCliUnavailableForE2E(false),
             () => setTerminalCommandExecutionSuppressedForE2E(false),
@@ -20,7 +22,7 @@ suite('Aspire zero-to-running E2E', function () {
             () => stopAppHostIfRunning(appHostPath),
             () => waitForNoDebugSessions().catch(() => undefined),
             () => restoreWorkspaceAppHostConfig(),
-            () => removeGeneratedProject(projectName),
+            () => removeGeneratedProject(projectName, appHostPidBeforeTeardown),
         ], 'Zero-to-running E2E teardown failed.');
     });
 

--- a/extension/src/test-e2e/zeroToRunning.e2e.test.ts
+++ b/extension/src/test-e2e/zeroToRunning.e2e.test.ts
@@ -4,7 +4,9 @@ import { getCommandInvocationCount, getTerminalCommandCount, waitForCommandOutco
 import { addIntegrationPackageToAppHost, clearBreakpoints, createEmptyAppHostProject, executeE2eControlCommand, getGeneratedAppHostPath, removeGeneratedProject, removePrimaryAppHostFixture, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setTerminalCommandExecutionSuppressedForE2E, stopAppHostIfRunning, writeWorkspaceAppHostConfigForPath } from './helpers/fixtures';
 import { openAspireView, waitForEditorTitle, waitForTreeItem, waitForWorkbenchTextAfterIntegratedBrowserNavigation } from './helpers/vscode';
 
-suite('Aspire zero-to-running E2E', function () {
+// Temporarily disabled until the CI-only reliability failures are understood:
+// https://github.com/microsoft/aspire/issues/18098.
+suite.skip('Aspire zero-to-running E2E', function () {
     this.timeout(2100000);
 
     const projectName = 'ExtensionZeroToRunningApp';

--- a/extension/src/test-e2e/zeroToRunning.e2e.test.ts
+++ b/extension/src/test-e2e/zeroToRunning.e2e.test.ts
@@ -11,6 +11,10 @@ suite('Aspire zero-to-running E2E', function () {
     const appHostPath = getGeneratedAppHostPath(projectName);
     let appHostPidBeforeStop: number | undefined;
 
+    setup(() => {
+        appHostPidBeforeStop = undefined;
+    });
+
     teardown(async () => {
         appHostPidBeforeStop ??= getRunningAppHostPid(appHostPath);
 

--- a/extension/src/test-e2e/zeroToRunning.e2e.test.ts
+++ b/extension/src/test-e2e/zeroToRunning.e2e.test.ts
@@ -9,9 +9,10 @@ suite('Aspire zero-to-running E2E', function () {
 
     const projectName = 'ExtensionZeroToRunningApp';
     const appHostPath = getGeneratedAppHostPath(projectName);
+    let appHostPidBeforeStop: number | undefined;
 
     teardown(async () => {
-        const appHostPidBeforeTeardown = getRunningAppHostPid(appHostPath);
+        appHostPidBeforeStop ??= getRunningAppHostPid(appHostPath);
 
         await runE2eTeardown([
             () => setCliUnavailableForE2E(false),
@@ -22,7 +23,7 @@ suite('Aspire zero-to-running E2E', function () {
             () => stopAppHostIfRunning(appHostPath),
             () => waitForNoDebugSessions().catch(() => undefined),
             () => restoreWorkspaceAppHostConfig(),
-            () => removeGeneratedProject(projectName, appHostPidBeforeTeardown),
+            () => removeGeneratedProject(projectName, appHostPidBeforeStop),
         ], 'Zero-to-running E2E teardown failed.');
     });
 
@@ -98,6 +99,7 @@ suite('Aspire zero-to-running E2E', function () {
             assert.ok(browserText.includes('Resources') || browserText.includes(dashboardHost));
         }
 
+        appHostPidBeforeStop = getRunningAppHostPid(appHostPath);
         await executeE2eControlCommand({ name: 'stopDebugging' });
         await waitForNoDebugSessions();
     });

--- a/extension/src/test-e2e/zeroToRunning.e2e.test.ts
+++ b/extension/src/test-e2e/zeroToRunning.e2e.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import { getCommandInvocationCount, getTerminalCommandCount, waitForCommandOutcome, waitForDebugDashboardUrl, waitForDebugSessionStartup, waitForExtensionState, waitForHttpText, waitForNoDebugSessions, waitForRepositoryIdle, waitForSelectedWorkspaceAppHost, waitForTerminalCommand } from './helpers/assertions';
-import { addIntegrationPackageToAppHost, clearBreakpoints, createEmptyAppHostProject, executeE2eControlCommand, getGeneratedAppHostPath, getRunningAppHostPid, removeGeneratedProject, removePrimaryAppHostFixture, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setTerminalCommandExecutionSuppressedForE2E, stopAppHostIfRunning, writeWorkspaceAppHostConfigForPath } from './helpers/fixtures';
+import { addIntegrationPackageToAppHost, clearBreakpoints, createEmptyAppHostProject, executeE2eControlCommand, getGeneratedAppHostPath, getRunningAppHostPid, removeGeneratedProject, removePrimaryAppHostFixture, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setTerminalCommandExecutionSuppressedForE2E, stopAppHostIfRunning, waitForRunningAppHostPid, writeWorkspaceAppHostConfigForPath } from './helpers/fixtures';
 import { openAspireView, waitForEditorTitle, waitForTreeItem, waitForWorkbenchTextAfterIntegratedBrowserNavigation } from './helpers/vscode';
 
 suite('Aspire zero-to-running E2E', function () {
@@ -99,7 +99,7 @@ suite('Aspire zero-to-running E2E', function () {
             assert.ok(browserText.includes('Resources') || browserText.includes(dashboardHost));
         }
 
-        appHostPidBeforeStop = getRunningAppHostPid(appHostPath);
+        appHostPidBeforeStop = await waitForRunningAppHostPid(appHostPath, 30000);
         await executeE2eControlCommand({ name: 'stopDebugging' });
         await waitForNoDebugSessions();
     });

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -352,10 +352,11 @@ suite('E2E launch profile', () => {
         assert.ok(stopAppHost.includes('await waitForProcessExit(runningAppHost.appHostPid, 30000);'));
         assert.ok(stopAppHost.includes('if (!await getRunningAppHostAccordingToCli(appHostPath))'));
         assert.ok(fixtures.includes('export function getRunningAppHostPid(appHostPath: string): number | undefined'));
+        assert.ok(fixtures.includes('export async function waitForRunningAppHostPid(appHostPath: string, timeoutMs: number): Promise<number>'));
         assert.ok(fixtures.includes('removeGeneratedProject(projectName: string, knownAppHostPid?: number)'));
         assert.ok(zeroToRunning.includes('let appHostPidBeforeStop: number | undefined;'));
         assert.ok(zeroToRunning.includes('appHostPidBeforeStop ??= getRunningAppHostPid(appHostPath);'));
-        assert.ok(zeroToRunning.indexOf('appHostPidBeforeStop = getRunningAppHostPid(appHostPath);') < zeroToRunning.lastIndexOf("executeE2eControlCommand({ name: 'stopDebugging' })"));
+        assert.ok(zeroToRunning.indexOf('appHostPidBeforeStop = await waitForRunningAppHostPid(appHostPath, 30000);') < zeroToRunning.lastIndexOf("executeE2eControlCommand({ name: 'stopDebugging' })"));
         assert.ok(zeroToRunning.includes('removeGeneratedProject(projectName, appHostPidBeforeStop)'));
         assert.ok(fixtures.includes("['ps', '--format', 'json']"));
         assert.ok(fixtures.includes('Number.isInteger(candidate.appHostPid)'));

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -347,9 +347,9 @@ suite('E2E launch profile', () => {
         const waitForCapturedPidCalls = stopAppHost.match(/await waitForNoRunningAppHostPathOrStopKnownProcess\(appHostPath, 30000, runningAppHostBeforeStop\?\.appHostPid, 'after stopping'\);/g) ?? [];
 
         assert.ok(stopAppHost.includes('const stopError = await tryStopAppHost(appHostPath);'));
-        assert.ok(stopAppHost.indexOf('if (stopError)') < stopAppHost.indexOf('await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid,'));
+        assert.ok(stopAppHost.indexOf('if (!stopError)') < stopAppHost.indexOf('await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid,'));
         assert.ok(stopAppHost.includes('const runningAppHostBeforeStop = getRunningAppHostFromState(appHostPath);'));
-        assert.ok(waitForCapturedPidCalls.length >= 1);
+        assert.ok(waitForCapturedPidCalls.length >= 3);
         assert.ok(stopAppHost.includes('const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);'));
         assert.ok(stopAppHost.includes('await waitForProcessExit(runningAppHost.appHostPid, 30000);'));
         assert.ok(stopAppHost.includes('if (!await getRunningAppHostAccordingToCli(appHostPath))'));
@@ -365,7 +365,7 @@ suite('E2E launch profile', () => {
         assert.ok(fixtures.includes('let lastKnownAppHostPid = knownAppHostPid;'));
         assert.ok(fixtures.includes('lastKnownAppHostPid = runningAppHost.appHostPid;'));
         assert.ok(!fixtures.includes('terminateProcessTree(runningAppHost.appHostPid'));
-        assert.ok(fixtures.includes("await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping')"));
+        assert.ok(fixtures.includes("await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping')"));
         assert.ok(fixtures.includes("await waitForNoRunningAppHostPath(getGeneratedAppHostPath(projectName), 30000, knownAppHostPid, 'before deleting')"));
         assert.ok(fixtures.includes('async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void>'));
         assert.ok(fixtures.includes('process.kill(pid, 0);'));

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -368,13 +368,16 @@ suite('E2E launch profile', () => {
         assert.ok(stopAppHost.includes('const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);'));
         assert.ok(stopAppHost.includes('await waitForProcessExit(runningAppHost.appHostPid, 30000);'));
         assert.ok(stopAppHost.includes('if (!await getRunningAppHostAccordingToCli(appHostPath))'));
+        assert.ok(stopAppHost.includes('if (isProcessRunning(runningAppHost.appHostPid))'));
+        assert.ok(stopAppHost.includes('await stopProcess(runningAppHost.appHostPid, 30000);'));
         assert.ok(fixtures.includes('export function getRunningAppHostPid(appHostPath: string): number | undefined'));
         assert.ok(fixtures.includes('export async function waitForRunningAppHostPid(appHostPath: string, timeoutMs: number): Promise<number>'));
         assert.ok(fixtures.includes('removeGeneratedProject(projectName: string, knownAppHostPid?: number)'));
         assert.ok(zeroToRunning.includes('let appHostPidBeforeStop: number | undefined;'));
         assert.ok(zeroToRunning.includes('setup(() => {'));
         assert.ok(zeroToRunning.includes('appHostPidBeforeStop = undefined;'));
-        assert.ok(zeroToRunning.includes('appHostPidBeforeStop ??= getRunningAppHostPid(appHostPath);'));
+        assert.ok(zeroToRunning.includes('() => appHostPidBeforeStop ??= getRunningAppHostPid(appHostPath)'));
+        assert.ok(zeroToRunning.indexOf('() => appHostPidBeforeStop ??= getRunningAppHostPid(appHostPath)') > zeroToRunning.indexOf('await runE2eTeardown(['));
         assert.ok(zeroToRunning.indexOf('appHostPidBeforeStop = await waitForRunningAppHostPid(appHostPath, 30000);') < zeroToRunning.lastIndexOf("executeE2eControlCommand({ name: 'stopDebugging' })"));
         assert.ok(zeroToRunning.includes('removeGeneratedProject(projectName, appHostPidBeforeStop)'));
         assert.ok(commandPalette.includes('runE2eTeardown'));

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -339,17 +339,20 @@ suite('E2E launch profile', () => {
         const extensionRoot = path.resolve(__dirname, '..', '..');
         const fixtures = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'helpers', 'fixtures.ts'), 'utf8');
         const stopAppHostStart = fixtures.indexOf('export async function stopAppHostIfRunning');
-        const stopAppHostEnd = fixtures.indexOf('async function waitForRunningAppHostProcessExitFromState');
+        const stopAppHostEnd = fixtures.indexOf('interface PsAppHost');
         assert.ok(stopAppHostStart >= 0);
         assert.ok(stopAppHostEnd > stopAppHostStart);
         const stopAppHost = fixtures.slice(stopAppHostStart, stopAppHostEnd);
 
-        assert.ok(stopAppHost.includes('await waitForRunningAppHostProcessExitFromState(appHostPath, 5000).catch(() => undefined);'));
+        assert.ok(stopAppHost.includes('const runningAppHostBeforeStop = getRunningAppHostFromState(appHostPath);'));
+        assert.ok(stopAppHost.includes('await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);'));
         assert.ok(stopAppHost.includes('const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);'));
         assert.ok(stopAppHost.includes('await waitForProcessExit(runningAppHost.appHostPid, 30000);'));
         assert.ok(stopAppHost.includes('if (!await getRunningAppHostAccordingToCli(appHostPath))'));
         assert.ok(fixtures.includes("['ps', '--format', 'json']"));
         assert.ok(fixtures.includes('Number.isInteger(candidate.appHostPid)'));
+        assert.ok(fixtures.includes('let lastKnownAppHostPid = knownAppHostPid;'));
+        assert.ok(fixtures.includes('lastKnownAppHostPid = runningAppHost.appHostPid;'));
         assert.ok(!fixtures.includes('terminateProcessTree(runningAppHost.appHostPid'));
         assert.ok(fixtures.includes('async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void>'));
         assert.ok(fixtures.includes('process.kill(pid, 0);'));

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -344,10 +344,12 @@ suite('E2E launch profile', () => {
         assert.ok(stopAppHostStart >= 0);
         assert.ok(stopAppHostEnd > stopAppHostStart);
         const stopAppHost = fixtures.slice(stopAppHostStart, stopAppHostEnd);
-        const waitForCapturedPidCalls = stopAppHost.match(/await waitForNoRunningAppHostPathOrStopKnownProcess\(appHostPath, 30000, runningAppHostBeforeStop\?\.appHostPid\);/g) ?? [];
+        const waitForCapturedPidCalls = stopAppHost.match(/await waitForNoRunningAppHostPathOrStopKnownProcess\(appHostPath, 30000, runningAppHostBeforeStop\?\.appHostPid, 'after stopping'\);/g) ?? [];
 
+        assert.ok(stopAppHost.includes('const stopError = await tryStopAppHost(appHostPath);'));
+        assert.ok(stopAppHost.indexOf('if (stopError)') < stopAppHost.indexOf('await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid,'));
         assert.ok(stopAppHost.includes('const runningAppHostBeforeStop = getRunningAppHostFromState(appHostPath);'));
-        assert.ok(waitForCapturedPidCalls.length >= 3);
+        assert.ok(waitForCapturedPidCalls.length >= 1);
         assert.ok(stopAppHost.includes('const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);'));
         assert.ok(stopAppHost.includes('await waitForProcessExit(runningAppHost.appHostPid, 30000);'));
         assert.ok(stopAppHost.includes('if (!await getRunningAppHostAccordingToCli(appHostPath))'));
@@ -363,10 +365,13 @@ suite('E2E launch profile', () => {
         assert.ok(fixtures.includes('let lastKnownAppHostPid = knownAppHostPid;'));
         assert.ok(fixtures.includes('lastKnownAppHostPid = runningAppHost.appHostPid;'));
         assert.ok(!fixtures.includes('terminateProcessTree(runningAppHost.appHostPid'));
+        assert.ok(fixtures.includes("await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping')"));
+        assert.ok(fixtures.includes("await waitForNoRunningAppHostPath(getGeneratedAppHostPath(projectName), 30000, knownAppHostPid, 'before deleting')"));
         assert.ok(fixtures.includes('async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void>'));
         assert.ok(fixtures.includes('process.kill(pid, 0);'));
         assert.ok(fixtures.includes("process.kill(pid, 'SIGTERM');"));
-        assert.ok(fixtures.includes('async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string, timeoutMs: number, knownAppHostPid?: number): Promise<void>'));
+        assert.ok(fixtures.includes('async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string, timeoutMs: number, knownAppHostPid: number | undefined, actionDescription: string): Promise<void>'));
+        assert.ok(fixtures.includes('formatE2eTeardownFailureMessage(failureMessage, failures)'));
         assert.ok(fixtures.includes("error.code === 'EPERM'"));
         assert.ok(fixtures.includes("const maxAttempts = process.platform === 'win32' ? 40 : 1;"));
     });

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -353,8 +353,10 @@ suite('E2E launch profile', () => {
         assert.ok(stopAppHost.includes('if (!await getRunningAppHostAccordingToCli(appHostPath))'));
         assert.ok(fixtures.includes('export function getRunningAppHostPid(appHostPath: string): number | undefined'));
         assert.ok(fixtures.includes('removeGeneratedProject(projectName: string, knownAppHostPid?: number)'));
-        assert.ok(zeroToRunning.includes('const appHostPidBeforeTeardown = getRunningAppHostPid(appHostPath);'));
-        assert.ok(zeroToRunning.includes('removeGeneratedProject(projectName, appHostPidBeforeTeardown)'));
+        assert.ok(zeroToRunning.includes('let appHostPidBeforeStop: number | undefined;'));
+        assert.ok(zeroToRunning.includes('appHostPidBeforeStop ??= getRunningAppHostPid(appHostPath);'));
+        assert.ok(zeroToRunning.indexOf('appHostPidBeforeStop = getRunningAppHostPid(appHostPath);') < zeroToRunning.lastIndexOf("executeE2eControlCommand({ name: 'stopDebugging' })"));
+        assert.ok(zeroToRunning.includes('removeGeneratedProject(projectName, appHostPidBeforeStop)'));
         assert.ok(fixtures.includes("['ps', '--format', 'json']"));
         assert.ok(fixtures.includes('Number.isInteger(candidate.appHostPid)'));
         assert.ok(fixtures.includes('let lastKnownAppHostPid = knownAppHostPid;'));

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -341,9 +341,14 @@ suite('E2E launch profile', () => {
         const zeroToRunning = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'zeroToRunning.e2e.test.ts'), 'utf8');
         const stopAppHostStart = fixtures.indexOf('export async function stopAppHostIfRunning');
         const stopAppHostEnd = fixtures.indexOf('interface PsAppHost');
+        const stopKnownProcessStart = fixtures.indexOf('async function waitForNoRunningAppHostPathOrStopKnownProcess');
+        const stopKnownProcessEnd = fixtures.indexOf('function getRunningAppHostFromState');
         assert.ok(stopAppHostStart >= 0);
         assert.ok(stopAppHostEnd > stopAppHostStart);
+        assert.ok(stopKnownProcessStart >= 0);
+        assert.ok(stopKnownProcessEnd > stopKnownProcessStart);
         const stopAppHost = fixtures.slice(stopAppHostStart, stopAppHostEnd);
+        const stopKnownProcess = fixtures.slice(stopKnownProcessStart, stopKnownProcessEnd);
         const waitForCapturedPidCalls = stopAppHost.match(/await waitForNoRunningAppHostPathOrStopKnownProcess\(appHostPath, 30000, runningAppHostBeforeStop\?\.appHostPid, 'after stopping'\);/g) ?? [];
 
         assert.ok(stopAppHost.includes('const stopError = await tryStopAppHost(appHostPath);'));
@@ -372,6 +377,8 @@ suite('E2E launch profile', () => {
         assert.ok(fixtures.includes("process.kill(pid, 'SIGTERM');"));
         assert.ok(fixtures.includes('async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string, timeoutMs: number, knownAppHostPid: number | undefined, actionDescription: string): Promise<void>'));
         assert.ok(fixtures.includes('formatE2eTeardownFailureMessage(failureMessage, failures)'));
+        assert.ok(stopKnownProcess.indexOf('const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);') < stopKnownProcess.indexOf('await stopProcess(runningAppHost.appHostPid, 30000);'));
+        assert.ok(stopKnownProcess.includes('stale/reused'));
         assert.ok(fixtures.includes("error.code === 'EPERM'"));
         assert.ok(fixtures.includes("const maxAttempts = process.platform === 'win32' ? 40 : 1;"));
     });

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -338,17 +338,23 @@ suite('E2E launch profile', () => {
     test('waits for running AppHost processes to exit before deleting E2E fixture directories', () => {
         const extensionRoot = path.resolve(__dirname, '..', '..');
         const fixtures = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'helpers', 'fixtures.ts'), 'utf8');
+        const zeroToRunning = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'zeroToRunning.e2e.test.ts'), 'utf8');
         const stopAppHostStart = fixtures.indexOf('export async function stopAppHostIfRunning');
         const stopAppHostEnd = fixtures.indexOf('interface PsAppHost');
         assert.ok(stopAppHostStart >= 0);
         assert.ok(stopAppHostEnd > stopAppHostStart);
         const stopAppHost = fixtures.slice(stopAppHostStart, stopAppHostEnd);
+        const waitForCapturedPidCalls = stopAppHost.match(/await waitForNoRunningAppHostPath\(appHostPath, 30000, runningAppHostBeforeStop\?\.appHostPid\);/g) ?? [];
 
         assert.ok(stopAppHost.includes('const runningAppHostBeforeStop = getRunningAppHostFromState(appHostPath);'));
-        assert.ok(stopAppHost.includes('await waitForNoRunningAppHostPath(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid);'));
+        assert.ok(waitForCapturedPidCalls.length >= 3);
         assert.ok(stopAppHost.includes('const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);'));
         assert.ok(stopAppHost.includes('await waitForProcessExit(runningAppHost.appHostPid, 30000);'));
         assert.ok(stopAppHost.includes('if (!await getRunningAppHostAccordingToCli(appHostPath))'));
+        assert.ok(fixtures.includes('export function getRunningAppHostPid(appHostPath: string): number | undefined'));
+        assert.ok(fixtures.includes('removeGeneratedProject(projectName: string, knownAppHostPid?: number)'));
+        assert.ok(zeroToRunning.includes('const appHostPidBeforeTeardown = getRunningAppHostPid(appHostPath);'));
+        assert.ok(zeroToRunning.includes('removeGeneratedProject(projectName, appHostPidBeforeTeardown)'));
         assert.ok(fixtures.includes("['ps', '--format', 'json']"));
         assert.ok(fixtures.includes('Number.isInteger(candidate.appHostPid)'));
         assert.ok(fixtures.includes('let lastKnownAppHostPid = knownAppHostPid;'));

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -339,6 +339,8 @@ suite('E2E launch profile', () => {
         const extensionRoot = path.resolve(__dirname, '..', '..');
         const fixtures = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'helpers', 'fixtures.ts'), 'utf8');
         const zeroToRunning = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'zeroToRunning.e2e.test.ts'), 'utf8');
+        const commandPalette = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'commandPalette.e2e.test.ts'), 'utf8');
+        const discoveryConfiguration = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'discoveryConfiguration.e2e.test.ts'), 'utf8');
         const stopAppHostStart = fixtures.indexOf('export async function stopAppHostIfRunning');
         const stopAppHostEnd = fixtures.indexOf('interface PsAppHost');
         const stopKnownProcessStart = fixtures.indexOf('async function waitForNoRunningAppHostPathOrStopKnownProcess');
@@ -350,9 +352,17 @@ suite('E2E launch profile', () => {
         const stopAppHost = fixtures.slice(stopAppHostStart, stopAppHostEnd);
         const stopKnownProcess = fixtures.slice(stopKnownProcessStart, stopKnownProcessEnd);
         const waitForCapturedPidCalls = stopAppHost.match(/await waitForNoRunningAppHostPathOrStopKnownProcess\(appHostPath, 30000, runningAppHostBeforeStop\?\.appHostPid, 'after stopping'\);/g) ?? [];
+        const stopErrorAssignmentStart = stopAppHost.indexOf('const stopError = await tryStopAppHost(appHostPath);');
+        const successfulStopStart = stopAppHost.indexOf('if (!stopError)');
+        const successfulStopEnd = stopAppHost.indexOf('if (/not running|No running AppHost|No AppHost/i.test(stopError.message))');
+        const successfulStopWait = stopAppHost.indexOf("await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping');", successfulStopStart);
+        const timedOutStopStart = stopAppHost.indexOf('if (/timed out|Failed to stop/i.test(stopError.message))');
 
-        assert.ok(stopAppHost.includes('const stopError = await tryStopAppHost(appHostPath);'));
-        assert.ok(stopAppHost.indexOf('if (!stopError)') < stopAppHost.indexOf('await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid,'));
+        assert.ok(stopErrorAssignmentStart >= 0);
+        assert.ok(successfulStopStart > stopErrorAssignmentStart);
+        assert.ok(successfulStopEnd > successfulStopStart);
+        assert.ok(successfulStopWait > successfulStopStart && successfulStopWait < successfulStopEnd);
+        assert.ok(timedOutStopStart > successfulStopEnd);
         assert.ok(stopAppHost.includes('const runningAppHostBeforeStop = getRunningAppHostFromState(appHostPath);'));
         assert.ok(waitForCapturedPidCalls.length >= 3);
         assert.ok(stopAppHost.includes('const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);'));
@@ -362,9 +372,15 @@ suite('E2E launch profile', () => {
         assert.ok(fixtures.includes('export async function waitForRunningAppHostPid(appHostPath: string, timeoutMs: number): Promise<number>'));
         assert.ok(fixtures.includes('removeGeneratedProject(projectName: string, knownAppHostPid?: number)'));
         assert.ok(zeroToRunning.includes('let appHostPidBeforeStop: number | undefined;'));
+        assert.ok(zeroToRunning.includes('setup(() => {'));
+        assert.ok(zeroToRunning.includes('appHostPidBeforeStop = undefined;'));
         assert.ok(zeroToRunning.includes('appHostPidBeforeStop ??= getRunningAppHostPid(appHostPath);'));
         assert.ok(zeroToRunning.indexOf('appHostPidBeforeStop = await waitForRunningAppHostPid(appHostPath, 30000);') < zeroToRunning.lastIndexOf("executeE2eControlCommand({ name: 'stopDebugging' })"));
         assert.ok(zeroToRunning.includes('removeGeneratedProject(projectName, appHostPidBeforeStop)'));
+        assert.ok(commandPalette.includes('runE2eTeardown'));
+        assert.ok(discoveryConfiguration.includes('runE2eTeardown'));
+        assert.ok(!commandPalette.includes('throw new AggregateError'));
+        assert.ok(!discoveryConfiguration.includes('throw new AggregateError'));
         assert.ok(fixtures.includes("['ps', '--format', 'json']"));
         assert.ok(fixtures.includes('Number.isInteger(candidate.appHostPid)'));
         assert.ok(fixtures.includes('let lastKnownAppHostPid = knownAppHostPid;'));
@@ -376,9 +392,12 @@ suite('E2E launch profile', () => {
         assert.ok(fixtures.includes('process.kill(pid, 0);'));
         assert.ok(fixtures.includes("process.kill(pid, 'SIGTERM');"));
         assert.ok(fixtures.includes('async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string, timeoutMs: number, knownAppHostPid: number | undefined, actionDescription: string): Promise<void>'));
-        assert.ok(fixtures.includes('formatE2eTeardownFailureMessage(failureMessage, failures)'));
         assert.ok(stopKnownProcess.indexOf('const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);') < stopKnownProcess.indexOf('await stopProcess(runningAppHost.appHostPid, 30000);'));
         assert.ok(stopKnownProcess.includes('stale/reused'));
+        assert.ok(fixtures.includes('formatE2eTeardownFailureMessage(failureMessage, failures.map(redactE2eTeardownFailure))'));
+        assert.ok(fixtures.includes('function redactE2eTeardownFailure(failure: unknown): string'));
+        assert.ok(!fixtures.includes('error?.stack'));
+        assert.ok(fixtures.includes("code === 'ENOTEMPTY'"));
         assert.ok(fixtures.includes("error.code === 'EPERM'"));
         assert.ok(fixtures.includes("const maxAttempts = process.platform === 'win32' ? 40 : 1;"));
     });

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -370,4 +370,20 @@ suite('E2E launch profile', () => {
         assert.ok(fixtures.includes("error.code === 'EPERM'"));
         assert.ok(fixtures.includes("const maxAttempts = process.platform === 'win32' ? 40 : 1;"));
     });
+
+    test('keeps tree action resource lifecycle commands as terminal routing assertions', () => {
+        const extensionRoot = path.resolve(__dirname, '..', '..');
+        const treeActions = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'treeActions.e2e.test.ts'), 'utf8');
+        const stopResourceStart = treeActions.indexOf("getCommandInvocationCount('aspire-vscode.stopResource')");
+        const executeResourceCommandStart = treeActions.indexOf("getCommandInvocationCount('aspire-vscode.executeResourceCommandItem')");
+        assert.ok(stopResourceStart >= 0);
+        assert.ok(executeResourceCommandStart > stopResourceStart);
+        const resourceLifecycleSuppressionStart = treeActions.lastIndexOf('await setTerminalCommandExecutionSuppressedForE2E(true);', stopResourceStart);
+        assert.ok(resourceLifecycleSuppressionStart >= 0);
+        const resourceLifecycleCommands = treeActions.slice(resourceLifecycleSuppressionStart, executeResourceCommandStart);
+
+        assert.ok(resourceLifecycleCommands.includes('await setTerminalCommandExecutionSuppressedForE2E(true);'));
+        assert.ok(resourceLifecycleCommands.includes('await setTerminalCommandExecutionSuppressedForE2E(false);'));
+        assert.ok(!resourceLifecycleCommands.includes("['Stopped', 'Finished', 'Exited']"));
+    });
 });

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -387,7 +387,7 @@ suite('E2E launch profile', () => {
         assert.ok(fixtures.includes('lastKnownAppHostPid = runningAppHost.appHostPid;'));
         assert.ok(!fixtures.includes('terminateProcessTree(runningAppHost.appHostPid'));
         assert.ok(fixtures.includes("await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping')"));
-        assert.ok(fixtures.includes("await waitForNoRunningAppHostPath(getGeneratedAppHostPath(projectName), 30000, knownAppHostPid, 'before deleting')"));
+        assert.ok(fixtures.includes("await waitForNoRunningAppHostPathOrStopKnownProcess(getGeneratedAppHostPath(projectName), 30000, knownAppHostPid, 'before deleting')"));
         assert.ok(fixtures.includes('async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void>'));
         assert.ok(fixtures.includes('process.kill(pid, 0);'));
         assert.ok(fixtures.includes("process.kill(pid, 'SIGTERM');"));

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -344,7 +344,7 @@ suite('E2E launch profile', () => {
         assert.ok(stopAppHostStart >= 0);
         assert.ok(stopAppHostEnd > stopAppHostStart);
         const stopAppHost = fixtures.slice(stopAppHostStart, stopAppHostEnd);
-        const waitForCapturedPidCalls = stopAppHost.match(/await waitForNoRunningAppHostPath\(appHostPath, 30000, runningAppHostBeforeStop\?\.appHostPid\);/g) ?? [];
+        const waitForCapturedPidCalls = stopAppHost.match(/await waitForNoRunningAppHostPathOrStopKnownProcess\(appHostPath, 30000, runningAppHostBeforeStop\?\.appHostPid\);/g) ?? [];
 
         assert.ok(stopAppHost.includes('const runningAppHostBeforeStop = getRunningAppHostFromState(appHostPath);'));
         assert.ok(waitForCapturedPidCalls.length >= 3);
@@ -365,6 +365,8 @@ suite('E2E launch profile', () => {
         assert.ok(!fixtures.includes('terminateProcessTree(runningAppHost.appHostPid'));
         assert.ok(fixtures.includes('async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void>'));
         assert.ok(fixtures.includes('process.kill(pid, 0);'));
+        assert.ok(fixtures.includes("process.kill(pid, 'SIGTERM');"));
+        assert.ok(fixtures.includes('async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string, timeoutMs: number, knownAppHostPid?: number): Promise<void>'));
         assert.ok(fixtures.includes("error.code === 'EPERM'"));
         assert.ok(fixtures.includes("const maxAttempts = process.platform === 'win32' ? 40 : 1;"));
     });

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -101,10 +101,31 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
             connectionSetupTcs = _connectionSetupTcs;
         }
 
-        if (!shouldConnect)
+        while (!shouldConnect)
         {
-            await connectionSetupTcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-            return;
+            try
+            {
+                await connectionSetupTcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                lock (_connectionSetupLock)
+                {
+                    if (ReferenceEquals(_connectionSetupTcs, connectionSetupTcs))
+                    {
+                        _connectionSetupTcs = null;
+                    }
+
+                    if (_connectionSetupTcs is null)
+                    {
+                        _connectionSetupTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                        shouldConnect = true;
+                    }
+
+                    connectionSetupTcs = _connectionSetupTcs;
+                }
+            }
         }
 
         var endpoint = _configuration[KnownConfigNames.ExtensionEndpoint];

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -121,6 +121,9 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
+                // The active connector owns the setup task until its token cancels. Waiters with live
+                // tokens take over by installing a new setup task, while the reference check avoids
+                // clearing a replacement task already installed by another waiter.
                 lock (_connectionSetupLock)
                 {
                     if (ReferenceEquals(_connectionSetupTcs, connectionSetupTcs))

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -181,10 +181,10 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
                         ex.RequiredCapability
                         );
 
-                    // If the extension is incompatible then there is no point
-                    // trying to reconnect, we should propagate the exception
-                    // up to the code that needs to back channel so it can display
-                    // an error message to the user.
+                    // Keep the faulted setup task in place for incompatible extensions. This is
+                    // a terminal state for the current CLI process, so future callers should see
+                    // the same compatibility error instead of electing another connector and
+                    // retrying the same unsupported protocol.
                     connectionSetupTcs.TrySetException(ex);
 
                     throw;

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -54,6 +54,7 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
 
     private readonly ActivitySource _activitySource = new(nameof(ExtensionBackchannel));
     private readonly TaskCompletionSource<JsonRpc> _rpcTaskCompletionSource = new();
+    private readonly object _connectionSetupLock = new();
     private readonly string _token;
 
     private TaskCompletionSource? _connectionSetupTcs;
@@ -86,71 +87,89 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
 
     public async Task ConnectAsync(CancellationToken cancellationToken)
     {
-        if (_connectionSetupTcs is not null)
+        TaskCompletionSource connectionSetupTcs;
+        var shouldConnect = false;
+
+        lock (_connectionSetupLock)
         {
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            var cancellationTask = Task.Delay(Timeout.Infinite, linkedCts.Token);
-            await Task.WhenAny(_connectionSetupTcs.Task, cancellationTask).ConfigureAwait(false);
-            return;
+            if (_connectionSetupTcs is null)
+            {
+                _connectionSetupTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                shouldConnect = true;
+            }
+
+            connectionSetupTcs = _connectionSetupTcs;
         }
 
-        _connectionSetupTcs = new TaskCompletionSource();
+        if (!shouldConnect)
+        {
+            await connectionSetupTcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
 
         var endpoint = _configuration[KnownConfigNames.ExtensionEndpoint];
         Debug.Assert(endpoint is not null);
 
-        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(50));
-        var connectionAttempts = 0;
-        _logger.LogDebug("Starting backchannel connection to Aspire extension at {Endpoint}", endpoint);
-
-        var startTime = DateTimeOffset.UtcNow;
-
-        do
+        try
         {
-            connectionAttempts++;
+            using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(50));
+            var connectionAttempts = 0;
+            _logger.LogDebug("Starting backchannel connection to Aspire extension at {Endpoint}", endpoint);
 
-            try
+            var startTime = DateTimeOffset.UtcNow;
+
+            do
             {
-                await ConnectCoreAsync().ConfigureAwait(false);
-                _logger.LogDebug("Connected to ExtensionBackchannel at {Endpoint}", endpoint);
-                _connectionSetupTcs.SetResult();
-                return;
-            }
-            catch (SocketException ex)
-            {
-                var waitingFor = DateTimeOffset.UtcNow - startTime;
-                if (waitingFor > TimeSpan.FromSeconds(10))
+                connectionAttempts++;
+
+                try
                 {
-                    _logger.LogDebug("Slow polling for backchannel connection (attempt {ConnectionAttempts}), {SocketException}", connectionAttempts, ex);
-                    await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
+                    await ConnectCoreAsync().ConfigureAwait(false);
+                    _logger.LogDebug("Connected to ExtensionBackchannel at {Endpoint}", endpoint);
+                    connectionSetupTcs.TrySetResult();
+                    return;
                 }
-                else
+                catch (SocketException ex)
                 {
-                    // We don't want to spam the logs with our early connection attempts.
+                    var waitingFor = DateTimeOffset.UtcNow - startTime;
+                    if (waitingFor > TimeSpan.FromSeconds(10))
+                    {
+                        _logger.LogDebug("Slow polling for backchannel connection (attempt {ConnectionAttempts}), {SocketException}", connectionAttempts, ex);
+                        await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        // We don't want to spam the logs with our early connection attempts.
+                    }
                 }
-            }
-            catch (ExtensionIncompatibleException ex)
-            {
-                _logger.LogError(
-                    "The Aspire extension is incompatible with the CLI and must be updated to a version that supports the {RequiredCapability} capability.",
-                    ex.RequiredCapability
-                    );
+                catch (ExtensionIncompatibleException ex)
+                {
+                    _logger.LogError(
+                        "The Aspire extension is incompatible with the CLI and must be updated to a version that supports the {RequiredCapability} capability.",
+                        ex.RequiredCapability
+                        );
 
-                // If the extension is incompatible then there is no point
-                // trying to reconnect, we should propogate the exception
-                // up to the code that needs to back channel so it can display
-                // and error message to the user.
-                _connectionSetupTcs.SetException(ex);
+                    // If the extension is incompatible then there is no point
+                    // trying to reconnect, we should propagate the exception
+                    // up to the code that needs to back channel so it can display
+                    // an error message to the user.
+                    connectionSetupTcs.TrySetException(ex);
 
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "An unexpected error occurred while trying to connect to the backchannel.");
-                _connectionSetupTcs.SetException(ex);
-                throw;
-            }
-        } while (await timer.WaitForNextTickAsync(cancellationToken));
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "An unexpected error occurred while trying to connect to the backchannel.");
+                    connectionSetupTcs.TrySetException(ex);
+                    throw;
+                }
+            } while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            connectionSetupTcs.TrySetException(ex);
+            throw;
+        }
 
         return;
 

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -157,17 +157,31 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
 
                     throw;
                 }
+                catch (OperationCanceledException ex)
+                {
+                    connectionSetupTcs.TrySetCanceled(ex.CancellationToken);
+                    ClearConnectionSetupIfCurrent(connectionSetupTcs);
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "An unexpected error occurred while trying to connect to the backchannel.");
                     connectionSetupTcs.TrySetException(ex);
+                    ClearConnectionSetupIfCurrent(connectionSetupTcs);
                     throw;
                 }
             } while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false));
         }
+        catch (OperationCanceledException ex)
+        {
+            connectionSetupTcs.TrySetCanceled(ex.CancellationToken);
+            ClearConnectionSetupIfCurrent(connectionSetupTcs);
+            throw;
+        }
         catch (Exception ex)
         {
             connectionSetupTcs.TrySetException(ex);
+            ClearConnectionSetupIfCurrent(connectionSetupTcs);
             throw;
         }
 
@@ -262,6 +276,17 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
                         KnownCapabilities.Baseline),
                     KnownCapabilities.Baseline
                 );
+            }
+        }
+    }
+
+    private void ClearConnectionSetupIfCurrent(TaskCompletionSource connectionSetupTcs)
+    {
+        lock (_connectionSetupLock)
+        {
+            if (ReferenceEquals(_connectionSetupTcs, connectionSetupTcs))
+            {
+                _connectionSetupTcs = null;
             }
         }
     }

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -172,6 +172,10 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
                 }
             } while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false));
         }
+        catch (ExtensionIncompatibleException)
+        {
+            throw;
+        }
         catch (OperationCanceledException ex)
         {
             connectionSetupTcs.TrySetCanceled(ex.CancellationToken);

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -61,12 +61,23 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
     private readonly ILogger<ExtensionBackchannel> _logger;
     private readonly IExtensionRpcTarget _target;
     private readonly IConfiguration _configuration;
+    private readonly Func<CancellationToken, Task>? _connectCoreAsyncOverride;
 
     public ExtensionBackchannel(ILogger<ExtensionBackchannel> logger, IExtensionRpcTarget target, IConfiguration configuration)
+        : this(logger, target, configuration, connectCoreAsyncOverride: null)
+    {
+    }
+
+    internal ExtensionBackchannel(
+        ILogger<ExtensionBackchannel> logger,
+        IExtensionRpcTarget target,
+        IConfiguration configuration,
+        Func<CancellationToken, Task>? connectCoreAsyncOverride)
     {
         _logger = logger;
         _target = target;
         _configuration = configuration;
+        _connectCoreAsyncOverride = connectCoreAsyncOverride;
         _token = configuration[KnownConfigNames.ExtensionToken]
                       ?? throw new InvalidOperationException(ErrorStrings.ExtensionTokenMustBeSet);
 
@@ -214,6 +225,12 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
 
         async Task ConnectCoreAsync()
         {
+            if (_connectCoreAsyncOverride is not null)
+            {
+                await _connectCoreAsyncOverride(cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
             try
             {
                 using var activity = _activitySource.StartActivity();

--- a/tests/Aspire.Cli.Tests/Backchannel/ExtensionBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/ExtensionBackchannelTests.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Sockets;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Hosting;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Backchannel;
+
+public class ExtensionBackchannelTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task ConnectAsync_WhenConnectionSetupIsCanceled_PropagatesCancellationToConcurrentWaiters()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var backchannel = CreateBackchannel(GetUnusedTcpEndpoint(), workspace.CreateExecutionContext());
+
+        using var setupCancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        using var waiterCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var setupTask = backchannel.ConnectAsync(setupCancellation.Token);
+        var waiterTask = backchannel.ConnectAsync(waiterCancellation.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => setupTask).DefaultTimeout();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiterTask).DefaultTimeout();
+    }
+
+    private static ExtensionBackchannel CreateBackchannel(string endpoint, CliExecutionContext executionContext)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [KnownConfigNames.ExtensionEndpoint] = endpoint,
+                [KnownConfigNames.ExtensionToken] = "test-token"
+            })
+            .Build();
+
+        return new ExtensionBackchannel(NullLogger<ExtensionBackchannel>.Instance, new ExtensionRpcTarget(configuration, executionContext), configuration);
+    }
+
+    private static string GetUnusedTcpEndpoint()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        return $"127.0.0.1:{port}";
+    }
+}

--- a/tests/Aspire.Cli.Tests/Backchannel/ExtensionBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/ExtensionBackchannelTests.cs
@@ -22,7 +22,45 @@ public class ExtensionBackchannelTests(ITestOutputHelper outputHelper)
         await Assert.ThrowsAsync<ArgumentException>(() => backchannel.ConnectAsync(CancellationToken.None)).DefaultTimeout();
     }
 
-    private static ExtensionBackchannel CreateBackchannel(string endpoint, CliExecutionContext executionContext)
+    [Fact]
+    public async Task ConnectAsync_WhenConnectionSetupFails_PropagatesFailureToConcurrentWaitersAndAllowsRetry()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var setupEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSetup = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var setupException = new InvalidOperationException("Simulated setup failure.");
+        var backchannel = CreateBackchannel(
+            "127.0.0.1:1",
+            workspace.CreateExecutionContext(),
+            async _ =>
+            {
+                setupEntered.TrySetResult();
+                await releaseSetup.Task;
+                throw setupException;
+            });
+
+        var firstConnectTask = backchannel.ConnectAsync(CancellationToken.None);
+        await setupEntered.Task.DefaultTimeout();
+
+        var waiterTasks = Enumerable.Range(0, 4)
+            .Select(_ => backchannel.ConnectAsync(CancellationToken.None))
+            .ToArray();
+        await Task.Delay(100).DefaultTimeout();
+
+        releaseSetup.SetResult();
+
+        var exceptions = await Task.WhenAll(
+            waiterTasks.Prepend(firstConnectTask).Select(async task => await Record.ExceptionAsync(() => task)))
+            .DefaultTimeout();
+        Assert.All(exceptions, exception => Assert.Same(setupException, exception));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => backchannel.ConnectAsync(CancellationToken.None)).DefaultTimeout();
+    }
+
+    private static ExtensionBackchannel CreateBackchannel(
+        string endpoint,
+        CliExecutionContext executionContext,
+        Func<CancellationToken, Task>? connectCoreAsyncOverride = null)
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -32,7 +70,7 @@ public class ExtensionBackchannelTests(ITestOutputHelper outputHelper)
             })
             .Build();
 
-        return new ExtensionBackchannel(NullLogger<ExtensionBackchannel>.Instance, new ExtensionRpcTarget(configuration, executionContext), configuration);
+        return new ExtensionBackchannel(NullLogger<ExtensionBackchannel>.Instance, new ExtensionRpcTarget(configuration, executionContext), configuration, connectCoreAsyncOverride);
     }
 
 }

--- a/tests/Aspire.Cli.Tests/Backchannel/ExtensionBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/ExtensionBackchannelTests.cs
@@ -97,6 +97,55 @@ public class ExtensionBackchannelTests(ITestOutputHelper outputHelper)
         Assert.Equal(1, connectAttempts);
     }
 
+    [Fact]
+    public async Task ConnectAsync_WhenConnectorIsCanceled_ConcurrentWaiterTakesOverSetup()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var firstConnectorCts = new CancellationTokenSource();
+        var firstSetupEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var takeoverSetupEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseTakeoverSetup = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var setupException = new ExtensionIncompatibleException("Simulated takeover setup failure.", "test-capability");
+        var connectAttempts = 0;
+        var backchannel = CreateBackchannel(
+            "127.0.0.1:1",
+            workspace.CreateExecutionContext(),
+            async cancellationToken =>
+            {
+                var attempt = Interlocked.Increment(ref connectAttempts);
+                if (attempt == 1)
+                {
+                    firstSetupEntered.TrySetResult();
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    return;
+                }
+
+                takeoverSetupEntered.TrySetResult();
+                await releaseTakeoverSetup.Task;
+                throw setupException;
+            });
+
+        var firstConnectTask = backchannel.ConnectAsync(firstConnectorCts.Token);
+        await firstSetupEntered.Task.DefaultTimeout();
+
+        var waiterTasks = Enumerable.Range(0, 4)
+            .Select(_ => backchannel.ConnectAsync(CancellationToken.None))
+            .ToArray();
+        await Task.Delay(100).DefaultTimeout();
+
+        await firstConnectorCts.CancelAsync();
+        await Assert.ThrowsAsync<TaskCanceledException>(() => firstConnectTask).DefaultTimeout();
+        await takeoverSetupEntered.Task.DefaultTimeout();
+
+        releaseTakeoverSetup.SetResult();
+
+        var waiterExceptions = await Task.WhenAll(
+            waiterTasks.Select(async task => await Record.ExceptionAsync(() => task)))
+            .DefaultTimeout();
+        Assert.All(waiterExceptions, exception => Assert.Same(setupException, exception));
+        Assert.Equal(2, connectAttempts);
+    }
+
     private static ExtensionBackchannel CreateBackchannel(
         string endpoint,
         CliExecutionContext executionContext,

--- a/tests/Aspire.Cli.Tests/Backchannel/ExtensionBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/ExtensionBackchannelTests.cs
@@ -54,7 +54,47 @@ public class ExtensionBackchannelTests(ITestOutputHelper outputHelper)
             .DefaultTimeout();
         Assert.All(exceptions, exception => Assert.Same(setupException, exception));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => backchannel.ConnectAsync(CancellationToken.None)).DefaultTimeout();
+        var retryException = await Assert.ThrowsAsync<InvalidOperationException>(() => backchannel.ConnectAsync(CancellationToken.None)).DefaultTimeout();
+        Assert.Same(setupException, retryException);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_WhenExtensionIsIncompatible_PropagatesFailureToConcurrentWaitersWithoutRetrying()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var setupEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSetup = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var setupException = new ExtensionIncompatibleException("Simulated incompatible extension.", "test-capability");
+        var connectAttempts = 0;
+        var backchannel = CreateBackchannel(
+            "127.0.0.1:1",
+            workspace.CreateExecutionContext(),
+            async _ =>
+            {
+                Interlocked.Increment(ref connectAttempts);
+                setupEntered.TrySetResult();
+                await releaseSetup.Task;
+                throw setupException;
+            });
+
+        var firstConnectTask = backchannel.ConnectAsync(CancellationToken.None);
+        await setupEntered.Task.DefaultTimeout();
+
+        var waiterTasks = Enumerable.Range(0, 4)
+            .Select(_ => backchannel.ConnectAsync(CancellationToken.None))
+            .ToArray();
+        await Task.Delay(100).DefaultTimeout();
+
+        releaseSetup.SetResult();
+
+        var exceptions = await Task.WhenAll(
+            waiterTasks.Prepend(firstConnectTask).Select(async task => await Record.ExceptionAsync(() => task)))
+            .DefaultTimeout();
+        Assert.All(exceptions, exception => Assert.Same(setupException, exception));
+
+        var retryException = await Assert.ThrowsAsync<ExtensionIncompatibleException>(() => backchannel.ConnectAsync(CancellationToken.None)).DefaultTimeout();
+        Assert.Same(setupException, retryException);
+        Assert.Equal(1, connectAttempts);
     }
 
     private static ExtensionBackchannel CreateBackchannel(

--- a/tests/Aspire.Cli.Tests/Backchannel/ExtensionBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/ExtensionBackchannelTests.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net;
-using System.Net.Sockets;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Hosting;
@@ -15,19 +13,13 @@ namespace Aspire.Cli.Tests.Backchannel;
 public class ExtensionBackchannelTests(ITestOutputHelper outputHelper)
 {
     [Fact]
-    public async Task ConnectAsync_WhenConnectionSetupIsCanceled_PropagatesCancellationToConcurrentWaiters()
+    public async Task ConnectAsync_WhenConnectionSetupFails_PropagatesFailureAndAllowsRetry()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var backchannel = CreateBackchannel(GetUnusedTcpEndpoint(), workspace.CreateExecutionContext());
+        var backchannel = CreateBackchannel("not-a-valid-endpoint", workspace.CreateExecutionContext());
 
-        using var setupCancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
-        using var waiterCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-
-        var setupTask = backchannel.ConnectAsync(setupCancellation.Token);
-        var waiterTask = backchannel.ConnectAsync(waiterCancellation.Token);
-
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => setupTask).DefaultTimeout();
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiterTask).DefaultTimeout();
+        await Assert.ThrowsAsync<ArgumentException>(() => backchannel.ConnectAsync(CancellationToken.None)).DefaultTimeout();
+        await Assert.ThrowsAsync<ArgumentException>(() => backchannel.ConnectAsync(CancellationToken.None)).DefaultTimeout();
     }
 
     private static ExtensionBackchannel CreateBackchannel(string endpoint, CliExecutionContext executionContext)
@@ -43,12 +35,4 @@ public class ExtensionBackchannelTests(ITestOutputHelper outputHelper)
         return new ExtensionBackchannel(NullLogger<ExtensionBackchannel>.Instance, new ExtensionRpcTarget(configuration, executionContext), configuration);
     }
 
-    private static string GetUnusedTcpEndpoint()
-    {
-        using var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-
-        return $"127.0.0.1:{port}";
-    }
 }


### PR DESCRIPTION
## Description

This hardens the VS Code extension E2E AppHost paths in two places.

First, generated-project cleanup now waits for AppHost processes to actually exit before deleting the project directory. The zero-to-running failure in #18098 was a Windows `EBUSY` during teardown: the test body passed, debugging disconnected, then cleanup raced the AppHost process/file handles. We now keep the last observed AppHost PID and wait for that process even if extension state has already cleared.

Second, the CLI extension backchannel now serializes cold `ConnectAsync` setup and makes concurrent waiters observe setup cancellation/failure. This addresses the AppHost-tree failure where the CLI printed `An attempt was made to transition a task to a final state when it had already completed` while starting the AppHost from the tree.

Addresses #18098

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
