### PR TITLE
Add watch tool to Aspire bundle

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -24,4 +24,4 @@ jobs:
       run: |
         echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
         npm i -g markdownlint-cli@0.45.0
-        markdownlint --ignore '.dotnet/' --ignore 'tools/' --ignore '**/AnalyzerReleases.*.md' '**/*.md'
+        markdownlint --ignore '.dotnet/' --ignore 'tools/' --ignore '**/AnalyzerReleases.*.md' --ignore 'docs/plans/**' '**/*.md'

--- a/docs/plans/project-v2-csharpprogram-watch.md
+++ b/docs/plans/project-v2-csharpprogram-watch.md
@@ -1,0 +1,402 @@
+# Project v2 stage 1 (`CSharpProgram`) + `aspire watch` — Initial Implementation Plan
+
+> **Scope:** The "improved watch as initial vertical slice" of Project Resource v2
+> (issue [#16386](https://github.com/microsoft/aspire/issues/16386), comment
+> [4300445417](https://github.com/microsoft/aspire/issues/16386#issuecomment-4300445417);
+> tracking issue [#15710](https://github.com/microsoft/aspire/issues/15710)).
+> Everything is marked **experimental**.
+
+---
+
+## 1. Goal
+
+Deliver a minimal-but-real vertical slice of Project v2:
+
+1. A new experimental **`CSharpProgram`** resource that represents a C# program added **by path**
+   (no app-host project reference, polyglot-friendly).
+2. **`aspire watch`** — run the app host normally while **C# service projects hot-reload** via the
+   `Microsoft.DotNet.HotReload.Watch.Aspire` tool, using a **hidden "watch server" system resource**
+   plus per-service `resource` processes.
+3. The Aspire app model **builds** the C# programs itself (coordinated via a temporary `.slnx`),
+   because — unlike Project v1 — the app host no longer references and builds them.
+
+The design must not preclude the full Project v2 vision (partial runs, persistent execution,
+container execution, debugging-under-watch, programmatic build config, events/callbacks redesign).
+
+---
+
+## 2. Decisions locked in with the requester (do not re-litigate)
+
+| # | Decision |
+|---|----------|
+| D1 | **`CSharpProgram` is the new v2 base type.** The existing experimental `CSharpAppResource` becomes a **thin derived/compat alias** (`CSharpAppResource : CSharpProgram`). |
+| D2 | **`CSharpProgram` is an "ordinary" resource — NOT derived from `ProjectResource`.** It implements the same *interfaces* (`IResourceWithEnvironment`, `IResourceWithArgs`, `IResourceWithEndpoints`, `IResourceWithServiceDiscovery`, `IResourceWithWaitSupport`, `IResourceWithProbes`) but sheds v1 baggage (container build/push pipeline steps, `IComputeResource`, `IContainerFilesDestinationResource`). `CSharpAppResource` ceasing to be a `ProjectResource` is an accepted breaking change for the experimental surface. |
+| D3 | **`aspire watch` = services only** at this stage. The app host runs normally (NOT itself under `dotnet watch`); only `CSharpProgram` services hot-reload. The POC's `host` command is not used. |
+| D4 | **The watch tool is bundled** with the Aspire CLI/SDK (no restore/download at watch time). The CLI resolves the bundled tool path + SDK dir and hands them to the app host (mirroring the existing **TerminalHost** bundling pattern). |
+| D5 | **Coordinated temp-`.slnx` build is in scope now, for both watch and non-watch run paths.** The app model performs the initial coordinated build; the watch server takes over incremental builds. Library: `Microsoft.VisualStudio.SolutionPersistence` (vs-solutionpersistence). |
+| D6 | **Out of MVP, but kept forward-compatible:** partial runs / launch groups, persistent execution (survive app-host restart), container execution, debugging `CSharpProgram` *while under watch*, and the full model-events/callbacks redesign. **Non-watch debugging/F5 is preserved** so `CSharpAppResource` doesn't regress. |
+| D7 | **Watch tool version:** pin `Microsoft.DotNet.HotReload.Watch.Aspire` **`10.0.301`** (stable). |
+| D8 | **Verification priority:** TypeScript-based app host first, C#-based app host second. |
+
+### Additional assumptions (flag if wrong)
+- **A1.** The watch server's `server`/`resource` commands perform incremental builds and shared-library
+  change handling; the **initial** build is done by the app model's coordinated `.slnx` build (D5).
+- **A2.** The type is named **`CSharpProgram`** (no `Resource` suffix) per explicit instruction, deviating
+  from the `*Resource` naming convention (`ProjectResource`, `ExecutableResource`, `NodeAppResource`).
+  The builder entry point is `AddCSharpProgram`. *(Experimental API, can be changed later)*
+- **A3.** Watch mode is signaled from CLI → app host via configuration/env; the **app model** (not the CLI)
+  adds the hidden watch-server resource and rewrites each `CSharpProgram`'s launch to the watch modality.
+- **A4.** `vs-solutionpersistence` (`Microsoft.VisualStudio.SolutionPersistence`, MIT) is available on an
+  approved internal feed mirror (dotnet-public). If not, it must be mirrored before Session 2.
+- **A5.** The watch tool (Microsoft.DotNet.HotReload.Watch.Aspire`) does not (and will not) do the initial application build; there will always be a need for coordinated build resource (created in Session 2).
+
+---
+
+## 3. How it works today (research baseline)
+
+### 3.1 The watch tool protocol (from the `karolz-ms/aspire-watch` POC)
+Tool = `Microsoft.DotNet.HotReload.Watch.Aspire`; launched as `dotnet <tool>.dll <command> …`.
+Three commands:
+
+```
+server   --sdk <sdkDir> --server <pipe> --status-pipe <pipe> --control-pipe <pipe> --verbose \
+         --resource <projA.csproj> --resource <projB.csproj> …
+resource --server <serverPipe> --entrypoint <proj.csproj> --no-launch-profile --verbose -e KEY=VALUE …
+host     --sdk <sdkDir> --entrypoint <apphost.csproj> --verbose [-- forwardedArgs]      # NOT used (D3)
+```
+
+POC model (the pattern we follow): the app host adds a **`watch-server` executable** (told about all
+resource project paths up front), and each service runs as a **`resource` executable** that connects to
+the server pipe; services `WaitForStart(watchServer)`. Status/control are named pipes held open by a
+hosted service. Pipe names are random (`server-/status-/control-` + suffix).
+
+### 3.2 Existing Aspire infrastructure we will REUSE if possible
+| Need | Reuse | Location |
+|------|-------|----------|
+| Hidden DCP "build" executable + stop→build→restart command | **`ProjectRebuilderResource`** + the **rebuild command** | `ApplicationModel/ProjectRebuilderResource.cs`, `ApplicationModel/CommandsConfigurationExtensions.cs` |
+| Hidden / system resource | `WithHidden()` / `HiddenAnnotation(HiddenBehavior.Always)` | `ResourceBuilderExtensions.cs`, `ApplicationModel/HiddenAnnotation.cs` |
+| Don't auto-start a resource | `WithExplicitStart()` / `ExplicitStartupAnnotation` | `ResourceBuilderExtensions.cs` |
+| Order start (resource after server) | `WaitForStart(dependency)` | `ResourceBuilderExtensions.cs:2494` |
+| Base process resource | `ExecutableResource` + `AddExecutable` | `ApplicationModel/ExecutableResource.cs`, `ExecutableResourceBuilderExtensions.cs` |
+| C#-program-by-path resource (today) | **`CSharpAppResource`** + `AddCSharpApp` (+ polyglot `addCSharpApp`) | `ApplicationModel/CSharpAppResource.cs`, `ProjectResourceBuilderExtensions.cs:354–454` |
+| Project metadata by path | `ProjectMetadata` / `IProjectMetadata` | `IProjectMetadata.cs` |
+| Project defaults (OTEL, `ASPNETCORE_URLS`, endpoints, ports, certs, rebuilder) | `WithProjectDefaults`, `SetAspNetCoreUrls`, `AddRebuilderResource` | `ProjectResourceBuilderExtensions.cs` |
+| Debug/launch-profile launch | `WithDebugSupport(producer, "project")` + `ProjectLaunchConfiguration` | `ResourceBuilderExtensions.cs:4769`, `Dcp/Model/ExecutableLaunchConfiguration.cs` |
+| DCP executable translation | `Dcp/ExecutableCreator.cs` (`PrepareProjectExecutables`, `PreparePlainExecutables`) | `Dcp/ExecutableCreator.cs` |
+| Bundled sidecar tool path → app host (env var injection) | **Terminal host pattern**: `BundleDiscovery.*PathEnvVar`, `DcpOptions`, CLI injection | `Shared/BundleDiscovery.cs`, `Dcp/DcpOptions.cs`, `Aspire.Cli/Projects/DotNetAppHostProject.cs:1296+` |
+| Temp build artifacts dir | `IAspireStore` / `IFileSystemService.TempDirectory` | `Aspire.Hosting` |
+| CLI run/launch/backchannel | `RunCommand`, `AppHostLauncher`, `IAppHostAuxiliaryBackchannel`, `DotNetCliRunner` | `Aspire.Cli/…` |
+| Polyglot/TS exposure | `[AspireExport]` + codegen | `Aspire.Hosting.RemoteHost`, `Aspire.Hosting.CodeGeneration.TypeScript` |
+| Resource lifecycle ops from a command | `ApplicationOrchestrator.Start/StopResourceAsync`, `ResourceNotificationService`, `KnownResourceStates` | `Aspire.Hosting` |
+
+### 3.3 The key constraint that drives most of the work
+DCP categorization is **type-driven**:
+`PrepareProjectExecutables()` iterates `model.Resources.OfType<ProjectResource>()` and
+`PreparePlainExecutables()` iterates `OfType<ExecutableResource>()`
+(`Dcp/ExecutableCreator.cs:183,336`). Because `CSharpProgram` (per D2) is **neither** a `ProjectResource`
+**nor** an `ExecutableResource`, **today's DCP layer would never launch it.** The plan must add/generalize
+a DCP launch path for `CSharpProgram` (Session 1B).
+
+---
+
+## 4. Target architecture
+
+### 4.1 Component view (watch mode)
+
+```mermaid
+flowchart TD
+    CLI["aspire watch (CLI)"] -->|"locate app host; inject<br/>ASPIRE_WATCH=1, ASPIRE_WATCH_TOOL_PATH,<br/>SDK dir; launch normally + backchannel"| AH["App host process (C# or TypeScript)"]
+    AH --> Model["Aspire app model (Aspire.Hosting)"]
+    Model -->|"coordinated initial build"| SLNX["temp .slnx → dotnet build<br/>(vs-solutionpersistence)"]
+    Model -->|"adds hidden system resource"| WS["watch-server (Executable, hidden)<br/>dotnet tool server --resource projA --resource projB …"]
+    Model -->|"launch modality = watch"| P1["csharp-program A<br/>dotnet tool resource --entrypoint projA --server pipe"]
+    Model -->|"launch modality = watch"| P2["csharp-program B<br/>dotnet tool resource --entrypoint projB --server pipe"]
+    P1 -. "WaitForStart" .-> WS
+    P2 -. "WaitForStart" .-> WS
+    P1 <-->|named pipe| WS
+    P2 <-->|named pipe| WS
+    WS -->|"incremental rebuild on file change<br/>(service + shared library)"| P1
+    WS --> P2
+```
+
+### 4.2 Launch modality (forward-compatible with #8984)
+A `CSharpProgram` can be launched two ways. We model this as an **annotation-selected launch modality**
+so it composes with the future annotation-based "RunAs/PublishAs" union
+([#8984](https://github.com/microsoft/aspire/issues/8984)):
+
+- **`project` (default, non-watch):** behaves like `CSharpAppResource` today — DCP IDE/process launch via
+  `ProjectLaunchConfiguration` (`dotnet run --project|--file …`), launch-profile + **debugging preserved**.
+- **`watch`:** DCP plain executable launch of `dotnet <watchTool> resource --entrypoint <proj> --server <pipe> …`.
+
+The modality is chosen at build time from configuration (`ASPIRE_WATCH`) + annotations, **not** hard-coded
+in the type — this is the seam that #8984 will later generalize into RunAs/PublishAs. Per D6, the watch
+modality is no-debug for the MVP.
+
+---
+
+## 5. New & changed types (with the most important members)
+
+> Namespaces follow existing placement: resources in `Aspire.Hosting.ApplicationModel`, builder
+> extensions in `Aspire.Hosting`. All new public surface carries an `[Experimental(...)]` attribute.
+
+### 5.1 `CSharpProgram` (new) — the v2 base resource
+`Aspire.Hosting.ApplicationModel/CSharpProgram.cs`
+```csharp
+public class CSharpProgram : Resource,
+    IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints,
+    IResourceWithServiceDiscovery, IResourceWithWaitSupport, IResourceWithProbes
+{
+    public CSharpProgram(string name) : base(name) { }
+    // Project path is carried by the IProjectMetadata annotation (reused), surfaced for convenience.
+    // NOTE: today's GetProjectMetadata() helper is typed to ProjectResource; Session 1A generalizes it
+    // (or reads Annotations.OfType<IProjectMetadata>().Single()) so CSharpProgram can reuse it.
+    public string ProjectPath => this.GetProjectMetadata().ProjectPath;
+}
+```
+- **Does NOT** add the container build/push `PipelineStepAnnotation` / `ContainerBuildOptionsCallbackAnnotation`
+  that `ProjectResource` adds in its ctor (that's the v1 baggage we shed).
+- **Fit:** it's an ordinary resource. It participates in env/endpoints/service-discovery/wait/probes via the
+  same interfaces `ProjectResource` uses, so existing reference/wiring code keeps working.
+
+### 5.2 `CSharpAppResource` (changed) — thin compat alias
+`Aspire.Hosting.ApplicationModel/CSharpAppResource.cs`
+```csharp
+public class CSharpAppResource(string name) : CSharpProgram(name) { }   // was : ProjectResource(name)
+```
+
+### 5.3 Builder extensions (new + retargeted)
+`Aspire.Hosting/CSharpProgramBuilderExtensions.cs` (new file; or extend `ProjectResourceBuilderExtensions`)
+```csharp
+[Experimental("ASPIRECSHARPPROGRAM001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public static IResourceBuilder<CSharpProgram> AddCSharpProgram(
+    this IDistributedApplicationBuilder builder, [ResourceName] string name, string path,
+    Action<CSharpProgramOptions>? configure = null);
+
+// Retarget existing AddCSharpApp to build on CSharpProgram, returning the alias for back-compat:
+public static IResourceBuilder<CSharpAppResource> AddCSharpApp(/* …unchanged signatures… */);
+
+// Polyglot export (new) — TS/other hosts:
+[AspireExport("addCSharpProgram")]
+internal static IResourceBuilder<CSharpProgram> AddCSharpProgramForPolyglot(/* … */);
+```
+- **Most important internals (reused/generalized from `WithProjectDefaults`):** apply OTEL, `ASPNETCORE_URLS`,
+  endpoints from launch settings/Kestrel, ports, certs, and the hidden rebuilder; attach `ProjectMetadata`;
+  `WithDebugSupport(mode => new ProjectLaunchConfiguration{…}, "project")` for the non-watch modality;
+  validate `.csproj`/`.cs` in `OnBeforeResourceStarted` (moved from `AddCSharpApp`).
+- **Key refactor:** today these helpers are typed to `IResourceBuilder<ProjectResource>`. Session 1A
+  **generalizes** them (to `IResourceWithEndpoints & IResourceWithEnvironment` + the `IProjectMetadata`
+  annotation, or a shared internal interface) so both `ProjectResource` and `CSharpProgram` can reuse them.
+
+### 5.4 `CSharpWatchServerResource` (new, internal) — hidden system resource
+`Aspire.Hosting.ApplicationModel/CSharpWatchServerResource.cs` — mirrors `ProjectRebuilderResource`.
+```csharp
+internal sealed class CSharpWatchServerResource : ExecutableResource
+{
+    public CSharpWatchServerResource(string name, string dotnetPath, string workingDirectory)
+        : base(name, dotnetPath, workingDirectory) { }
+    public WatchPipeNames Pipes { get; init; }              // server/status/control pipe names
+    public IReadOnlyList<string> ResourceProjectPaths { get; init; }   // --resource <path> …
+}
+```
+- Added via the standard builder with: `WithArgs(server …)`, `WithHidden()`, `WithExplicitStart()` (started
+  before services), `ExcludeFromManifest()`, `ExcludeLifecycleCommandsAnnotation`, initial `NotStarted` snapshot —
+  exactly the annotation set `AddRebuilderResource` already uses.
+- One watch server per app run (MVP). Reuses a small `PipeNameFactory` helper (ported from POC).
+
+### 5.5 `CSharpProgramBuildOrchestrator` (new, internal) — coordinated build
+`Aspire.Hosting/Dcp` or `Aspire.Hosting/CSharp/…`
+```csharp
+internal sealed class CSharpProgramBuildOrchestrator
+{
+    // Generates a temp .slnx containing all CSharpProgram projects (vs-solutionpersistence),
+    // runs a single coordinated `dotnet build <temp>.slnx`, surfaces logs/state.
+    Task BuildAllAsync(IReadOnlyList<CSharpProgram> programs, CancellationToken ct);
+}
+```
+- Runs as a **lifecycle/run-sequence step before resources start** (both watch and non-watch).
+- Reuses `IAspireStore`/temp-dir abstractions for the `.slnx`; reuses the `ProjectRebuilderResource`-style
+  DCP-executable-for-build approach for log capture + cleanup. File-based apps (`.cs`) are excluded from the
+  `.slnx` (built/run individually as today).
+
+### 5.6 Watch options + bundling plumbing (new)
+- `BundleDiscovery`: add `WatchToolPathEnvVar = "ASPIRE_WATCH_TOOL_PATH"` (+ `watch/` layout dir +
+  `TryDiscoverWatchTool…`).
+- Hosting options: add `WatchToolPath` (+ resolved SDK dir) to `DcpOptions` *or* a new `CSharpWatchOptions`
+  bound from configuration/env — same shape as `TerminalHostPath`/`TerminalHostInvocationArgs`.
+- CLI: inject `ASPIRE_WATCH_TOOL_PATH` (and `ASPIRE_WATCH=1`, SDK dir) when launching the app host under
+  `aspire watch`, in the same spots terminal-host vars are injected
+  (`DotNetAppHostProject`, `DotNetBasedAppHostServerProject`, `PrebuiltAppHostServer`, guest/TS host launch).
+
+### 5.7 `WatchCommand` (new) — `aspire watch`
+`Aspire.Cli/Commands/WatchCommand.cs`
+```csharp
+internal sealed class WatchCommand : BaseCommand   // sibling of RunCommand
+{
+    protected override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken ct);
+}
+```
+- Reuses `RunCommand`'s machinery (project location, `AppHostLauncher`, backchannel, monitor). Difference vs
+  `run`: sets `ASPIRE_WATCH=1` + watch-tool env, and **does not** wrap the app host in `dotnet watch`/nodemon
+  (app host runs normally — D3). Registered in `RootCommand` + DI (`Program.cs`).
+
+---
+
+## 6. How the new types fit the existing app model
+
+1. **Authoring:** `builder.AddCSharpProgram("svc", "../Svc/Svc.csproj")` (C#) or `builder.addCSharpProgram(...)`
+   (TypeScript) creates a `CSharpProgram` with a `ProjectMetadata` annotation — *just like* `AddCSharpApp`
+   today, minus the `ProjectResource` base. `.WithReference`, `.WaitFor`, `.WithHttpEndpoint`,
+   `.WithEnvironment`, service discovery, probes all work via the implemented interfaces.
+2. **Build:** during the run sequence the `CSharpProgramBuildOrchestrator` performs one coordinated
+   `.slnx` build of all `CSharpProgram` projects (shared libraries built once, no parallel conflicts).
+3. **Launch (non-watch):** `CSharpProgram` flows through the **generalized** DCP project-launch path
+   (`ProjectLaunchConfiguration`, IDE/debug preserved) — parity with `CSharpAppResource` today.
+4. **Launch (watch):** when `ASPIRE_WATCH=1`, the app model adds the hidden `CSharpWatchServerResource`
+   (told all project paths), and each `CSharpProgram` is launched as `dotnet <tool> resource …` with
+   `WaitForStart(watchServer)`. Incremental rebuilds (service + shared lib) are handled by the watch server.
+5. **Dashboard/CLI:** the watch server is hidden (`IsHidden`); services appear as normal resources with logs
+   and start/stop. `aspire resource <svc> restart` etc. keep working via the existing backchannel.
+
+---
+
+## 7. Work breakdown — agentic coding sessions
+
+> Sequential unless noted. Every session ends **green**: `./build.sh` clean + targeted tests, and
+> (where applicable) a manual run against the **TypeScript** app host first, then a C# app host (D8).
+> Keep all new surface `[Experimental]`. Do **not** hand-edit `api/*.cs` (generated).
+
+### Session 0 — Bundle the watch tool + hosting plumbing *(foundational; no user-visible behavior)*
+**Deliverables**
+- Pin `Microsoft.DotNet.HotReload.Watch.Aspire` `10.0.301` (D7) and include it as a **bundle component**
+  (new `watch/` dir) in the CLI/SDK layout, alongside `dcp/` and `managed/`.
+- `BundleDiscovery`: `WatchToolPathEnvVar`, `WatchDirectoryName`, `TryDiscoverWatchTool*` (mirror DCP/managed).
+- Hosting: `WatchToolPath` (+ SDK dir) option bound from config/env (mirror `TerminalHostPath`).
+- CLI: inject the watch-tool env var(s) at app-host launch (all launch paths, incl. TS/guest).
+**Reuse:** `BundleDiscovery`, `DcpOptions`, terminal-host injection in `DotNetAppHostProject`.
+**Verify:** unit test discovery; from a dev build, confirm `dotnet "$ASPIRE_WATCH_TOOL_PATH" --help` runs and
+the env var reaches a launched app host (C# and TS).
+
+### Session 1A — `CSharpProgram` type + generalize project-defaults wiring
+**Deliverables**
+- `CSharpProgram` resource (§5.1); `CSharpAppResource : CSharpProgram` (§5.2).
+- `AddCSharpProgram` (+ `CSharpProgramOptions`) and retarget `AddCSharpApp` onto `CSharpProgram`.
+- Generalize `WithProjectDefaults`/`SetAspNetCoreUrls`/`AddRebuilderResource`/launch-settings-endpoint logic
+  so they operate on `CSharpProgram` (and still on `ProjectResource`).
+- Migrate consumers of the (now non-`ProjectResource`) alias: `Aspire.Hosting.Blazor` gateway, polyglot
+  `addCSharpApp`, add polyglot `addCSharpProgram`; regenerate the TypeScript SDK.
+- New diagnostic id `ASPIRECSHARPPROGRAM001` (keep `ASPIRECSHARPAPPS001` on the alias surface).
+**Reuse:** all of `ProjectResourceBuilderExtensions` defaults; `ProjectMetadata`; `WithDebugSupport`.
+**Verify:** hosting unit tests (resource builds, annotations, endpoints, env). *Depends on: none (can start now).* 
+
+### Session 1B — DCP launch path for `CSharpProgram` (non-watch parity)
+**Deliverables**
+- Generalize DCP categorization so `CSharpProgram` is launched via the **project** path (today keyed on
+  `OfType<ProjectResource>()`). Preferred: drive off the **`IProjectMetadata` annotation + "project" launch
+  config** rather than the concrete type; fall back to a dedicated `PrepareCSharpProgramExecutables()` if a
+  generalized predicate proves too invasive.
+- Preserve IDE/debug + launch-profile behavior for non-watch `CSharpProgram` (no regression vs `CSharpAppResource`).
+**Reuse:** `ExecutableCreator`, `ProjectLaunchConfiguration`, `SupportsDebuggingAnnotation`,
+`CreateProjectLaunchConfiguration`.
+**Verify:** run a `CSharpProgram` (no watch) from a **TS** app host (extend `RpsArena`) and a C# app host;
+endpoints/env/service discovery/debug all work; `CSharpAppResource` regression suite passes.
+*Depends on: 1A.*
+
+### Session 2 — Coordinated temp-`.slnx` build (vs-solutionpersistence)
+**Deliverables**
+- Add `Microsoft.VisualStudio.SolutionPersistence` dependency (verify/mirror to approved feed first — A4).
+- `CSharpProgramBuildOrchestrator` (§5.5): collect all `CSharpProgram` `.csproj` paths → generate temp `.slnx`
+  → one coordinated `dotnet build` before resources start (both run modes). Exclude `.cs` file-based apps.
+- Hook into the run sequence ahead of resource creation; stream build logs; fail fast on build error.
+**Reuse:** `ProjectRebuilderResource` DCP-build pattern, `IAspireStore`/temp-dir abstractions, `DotNetCliRunner`/
+`dotnet build` invocation conventions.
+**Verify:** multi-project app **with a shared library** builds once, coordinated, no shared-lib write conflicts,
+from a TS app host then a C# app host. *Depends on: 1A (resource exists). Parallelizable with 1B.*
+
+### Session 3 — Watch server system resource + `CSharpProgram` watch modality
+**Deliverables**
+- `CSharpWatchServerResource` (§5.4): hidden, explicit-start `dotnet <tool> server --sdk … --server <pipe>
+  --status-pipe … --control-pipe … --resource <proj> …`. `PipeNameFactory` helper (ported from POC).
+- Launch-modality seam (§4.2): when `ASPIRE_WATCH=1`, the app model (a) adds the watch server with all
+  `CSharpProgram` project paths, (b) rewrites each `CSharpProgram` to launch `dotnet <tool> resource
+  --entrypoint <proj> --server <pipe> --no-launch-profile -e K=V …` as a DCP executable, (c)
+  `WaitForStart(watchServer)`.
+- Initial coordinated build (Session 2) runs first; watch server then owns incremental builds.
+- Optional: status-pipe monitor (hosted/background service) surfacing watch status into resource logs/state
+  (port of `WatchPipeMonitorHostedService`).
+**Reuse:** `WithHidden`, `WithExplicitStart`, `WaitForStart`, `ExcludeFromManifest`,
+`ExcludeLifecycleCommandsAnnotation`, `ExecutableResource`, env-callback annotations; watch-tool path + SDK
+dir from Session 0.
+**Verify (TS first):** under a watch harness, edit a service file → that service hot-reloads; edit the shared
+library → both services reload. Then repeat with a C# app host. *Depends on: 1B, 2, 0.*
+
+### Session 4 — `aspire watch` CLI command
+**Deliverables**
+- `WatchCommand` (§5.7) registered in `RootCommand`/DI. Locates the app host (any language), launches it
+  **normally** with `ASPIRE_WATCH=1` + watch-tool env, connects the backchannel, streams logs/state.
+- Guardrails/strings (e.g. interplay with the existing `--watch` app-host feature), `--help`, telemetry.
+**Reuse:** `RunCommand`/`AppHostLauncher`/backchannel/monitor; Session 0 env injection.
+**Verify (TS first):** `aspire watch` against the TS `RpsArena`-style playground → services start under watch,
+edits hot-reload end-to-end; then a C# app host. *Depends on: 3, 0.*
+
+### Session 5 — Tests, playground & docs
+**Deliverables**
+- TypeScript playground (extend `playground/TypeScriptApps/RpsArena` or add one) using `addCSharpProgram`
+  under watch; a parallel C# app-host sample.
+- CLI e2e test for `aspire watch` (hex1b / `cli-e2e-testing`); hosting tests for `CSharpProgram`, watch-server
+  wiring, launch-modality switch, and the `.slnx` build; verify-snapshot updates as needed.
+- Docs: experimental `CSharpProgram` + `aspire watch` usage, limitations (no watch-debug, no partial runs yet),
+  the `ASPIRECSHARPPROGRAM001` diagnostic.
+**Reuse:** `dashboard-testing`/`cli-e2e-testing` patterns, existing playground scaffolding.
+**Verify:** new tests green in CI (exclude quarantined/outerloop locally). *Depends on: 4.*
+
+### Dependency graph
+```
+0 ─┬─────────────► 3 ──► 4 ──► 5
+1A ┬► 1B ─────────► 3
+   └► 2 ──────────► 3
+```
+1A is the only session with no prerequisites; 1B and 2 can run in parallel after 1A.
+
+---
+
+## 8. Compatibility with the annotation-based RunAs/PublishAs proposal (#8984)
+- The **launch modality** (§4.2) is annotation/config-selected, not type-bound — the natural insertion point
+  for a future `RunAsWatch()` / `RunAsProject()` / `RunAsContainer()` union.
+- `CSharpProgram` returns a strongly-typed builder while behavior is annotation-driven, matching #8984's
+  "proxy reflects base + modality" goal.
+- We avoid hard-coding "watch" into the type or DCP; the watch server + resource wiring keys off annotations,
+  so adding modalities (container, persistent) later is additive. Per the requester, #8984 alignment is
+  best-effort and must not compromise the core Project v2 vision.
+
+## 9. Events / callbacks (noted, redesign deferred — D6)
+The slice touches: `BeforeResourceStartedEvent` (path/SDK validation, env materialization),
+`WaitForStart` ordering (server → services), and env/args callbacks (materialized into the `resource`
+command line). For the MVP we **document** current ordering/cardinality but do **not** redesign the contracts.
+Risk to watch out for: env/args callbacks may need to run for build/closure even when a resource isn't
+"running" (an explicit future concern in #16386).
+
+## 10. Risks & open items
+- **R1 — DCP generalization blast radius (Session 1B):** changing `OfType<ProjectResource>()` categorization
+  could affect Azure Functions / file-based-app paths. Mitigate with an annotation-driven predicate +
+  regression tests; fall back to a dedicated prepare path.
+- **R2 — Generalizing `WithProjectDefaults` (Session 1A):** heavily `ProjectResource`-typed; the refactor is
+  the riskiest reuse. Consider a shared internal interface implemented by both types.
+- **R3 — Watch tool ↔ SDK coupling:** `dotnet <tool> --sdk <dir>` must match the active SDK; bundling pins
+  `10.0.301` but the user's SDK may differ. Confirm acceptable matrix; resolve SDK dir via `dotnet --info`.
+- **R4 — Named pipes cross-platform:** verify `PipeOptions.CurrentUserOnly` semantics on macOS/Linux (POC ran
+  Windows-centric). TS-first verification will exercise non-Windows.
+- **R5 — `vs-solutionpersistence` feed availability (A4).**
+- **R6 — `aspire watch` vs existing app-host `--watch`:** ensure the two "watch" concepts don't collide in CLI
+  UX/strings.
+- **O1 — Naming:** `CSharpProgram` vs `CSharpProgramResource` vs something else (A2).
+
+
+  ## References 
+
+  | Description | Reference |
+  |---------|------|
+  | Project v2 vision and roadmap | https://github.com/microsoft/aspire/issues/16386 |
+  | Stage 1 (Aspire 13.5) scope for Project v2 (tracking issue) | https://github.com/microsoft/aspire/issues/15710 |
+  | Aspire watch prototype | https://github.com/karolz-ms/aspire-watch |
+  | Solution file editing library | https://github.com/microsoft/vs-solutionpersistence |
+  | Annotation-bases resource flavoring proposal | https://github.com/microsoft/aspire/issues/8984 |

--- a/docs/plans/project-v2-csharpprogram-watch.md
+++ b/docs/plans/project-v2-csharpprogram-watch.md
@@ -236,7 +236,7 @@ internal sealed class CSharpProgramBuildOrchestrator
 ### 5.6 Watch options + bundling plumbing (new) — ✅ implemented in Session 0
 - `BundleDiscovery` (final): `WatchToolPathEnvVar = "ASPIRE_WATCH_TOOL_PATH"`,
   `WatchSdkPathEnvVar = "ASPIRE_WATCH_SDK_PATH"`, `WatchDirectoryName = "watch"`,
-  `WatchToolEntryPointName = "Microsoft.DotNet.HotReload.Watch.Aspire.dll"`
+  `WatchToolDllName = "Microsoft.DotNet.HotReload.Watch.Aspire.dll"`
 - Hosting options (final): `WatchToolPath` **and** `WatchSdkPath` were added to **`DcpOptions`**, 
   bound in `ConfigureDefaultDcpOptions` with the established
   precedence `env → dcpPublisher config → assembly metadata` — same shape as `TerminalHostPath`.

--- a/docs/plans/project-v2-csharpprogram-watch.md
+++ b/docs/plans/project-v2-csharpprogram-watch.md
@@ -35,10 +35,11 @@ container execution, debugging-under-watch, programmatic build config, events/ca
 | D4 | **The watch tool is bundled** with the Aspire CLI/SDK (no restore/download at watch time). The CLI resolves the bundled tool path + SDK dir and hands them to the app host (mirroring the existing **TerminalHost** bundling pattern). |
 | D5 | **Coordinated temp-`.slnx` build is in scope now, for both watch and non-watch run paths.** The app model performs the initial coordinated build; the watch server takes over incremental builds. Library: `Microsoft.VisualStudio.SolutionPersistence` (vs-solutionpersistence). |
 | D6 | **Out of MVP, but kept forward-compatible:** partial runs / launch groups, persistent execution (survive app-host restart), container execution, debugging `CSharpProgram` *while under watch*, and the full model-events/callbacks redesign. **Non-watch debugging/F5 is preserved** so `CSharpAppResource` doesn't regress. |
-| D7 | **Watch tool version:** pin `Microsoft.DotNet.HotReload.Watch.Aspire` **`10.0.301`** (stable). |
+| D7 | **Watch tool version:** pin `Microsoft.DotNet.HotReload.Watch.Aspire` to`10.0.301` (stable). |
 | D8 | **Verification priority:** TypeScript-based app host first, C#-based app host second. |
+| D9 | **`watch/` is a top-level bundle component** — a peer of `dcp/` and `managed/`, **not** nested under `managed/`. Rationale: like `dcp/`, the watch tool is an *externally-sourced* bundled package (`Microsoft.DotNet.HotReload.Watch.Aspire`, pinned independently via `MicrosoftDotNetHotReloadWatchAspireVersion`); it is **framework-dependent** and needs an **external SDK** (`ASPIRE_WATCH_SDK_PATH`), unlike the **self-contained** `aspire-managed` binary; and it is **RID-agnostic** (one copy serves every RID) whereas `managed/`/`dcp/` are RID-specific. `managed/` is concretely the single self-contained binary, not a generic "managed tools" bucket. Top-level placement matches the existing peer-component model (`LayoutComponent.Watch`, `ASPIRE_WATCH_TOOL_PATH`, `TryDiscoverWatchTool*`) and avoids coupling an independently-versioned external tool to the managed binary's extract/cleanup lifecycle (which cleans/replaces `managed/` + `dcp/` as units). |
 
-### Additional assumptions (flag if wrong)
+### Additional assumptions
 - **A1.** The watch server's `server`/`resource` commands perform incremental builds and shared-library
   change handling; the **initial** build is done by the app model's coordinated `.slnx` build (D5).
 - **A2.** The type is named **`CSharpProgram`** (no `Resource` suffix) per explicit instruction, deviating
@@ -48,7 +49,18 @@ container execution, debugging-under-watch, programmatic build config, events/ca
   adds the hidden watch-server resource and rewrites each `CSharpProgram`'s launch to the watch modality.
 - **A4.** `vs-solutionpersistence` (`Microsoft.VisualStudio.SolutionPersistence`, MIT) is available on an
   approved internal feed mirror (dotnet-public). If not, it must be mirrored before Session 2.
-- **A5.** The watch tool (Microsoft.DotNet.HotReload.Watch.Aspire`) does not (and will not) do the initial application build; there will always be a need for coordinated build resource (created in Session 2).
+- **A5.** The watch tool (`Microsoft.DotNet.HotReload.Watch.Aspire`) does not (and will not) do the initial application build; there will always be a need for coordinated build resource (created in Session 2).
+- **A6.** The watch tool **does not self-resolve the .NET SDK base path**: it requires a valid
+  `--sdk <basePath>` to be supplied by the app model. When the CLI's directory-probing fast path
+  (`ASPIRE_WATCH_SDK_PATH`, see §5.6) cannot derive it, the **app model** (Aspire.Hosting) — *not* the
+  watch tool — resolves it by running `dotnet --info` and parsing the `Base Path:` line. That probe is
+  lazy (run at the latest moment, right before the watch server is launched), memoized (at most once per
+  application run), and is **never** invoked when watch mode is inactive or no `CSharpProgram` exists.
+- **A7.** From the next Aspire release the bundled watch tool is a **mandatory** CLI bundle component. 
+  The bundle build fails without it (`tools/CreateLayout` `CopyWatch()`), and the
+  CLI rejects a freshly-extracted bundle that lacks `watch/` (`BundleService.IsVersionedLayoutValid` →
+  `aspire setup --force`). Discovery of externally-supplied/legacy `ASPIRE_LAYOUT_PATH` layouts and the
+  inner-loop dev (NuGet-cache) fallback stays tolerant of its absence.
 
 ---
 
@@ -202,6 +214,9 @@ internal sealed class CSharpWatchServerResource : ExecutableResource
   before services), `ExcludeFromManifest()`, `ExcludeLifecycleCommandsAnnotation`, initial `NotStarted` snapshot —
   exactly the annotation set `AddRebuilderResource` already uses.
 - One watch server per app run (MVP). Reuses a small `PipeNameFactory` helper (ported from POC).
+- The `server --sdk <basePath>` argument is materialized at launch via the SDK base-path resolver
+  (Session 3 deliverable): fast path `DcpOptions.WatchSdkPath`, else a lazy/memoized `dotnet --info`
+  fallback. The watch tool does **not** self-resolve the SDK (A6).
 
 ### 5.5 `CSharpProgramBuildOrchestrator` (new, internal) — coordinated build
 `Aspire.Hosting/Dcp` or `Aspire.Hosting/CSharp/…`
@@ -218,14 +233,26 @@ internal sealed class CSharpProgramBuildOrchestrator
   DCP-executable-for-build approach for log capture + cleanup. File-based apps (`.cs`) are excluded from the
   `.slnx` (built/run individually as today).
 
-### 5.6 Watch options + bundling plumbing (new)
-- `BundleDiscovery`: add `WatchToolPathEnvVar = "ASPIRE_WATCH_TOOL_PATH"` (+ `watch/` layout dir +
-  `TryDiscoverWatchTool…`).
-- Hosting options: add `WatchToolPath` (+ resolved SDK dir) to `DcpOptions` *or* a new `CSharpWatchOptions`
-  bound from configuration/env — same shape as `TerminalHostPath`/`TerminalHostInvocationArgs`.
-- CLI: inject `ASPIRE_WATCH_TOOL_PATH` (and `ASPIRE_WATCH=1`, SDK dir) when launching the app host under
-  `aspire watch`, in the same spots terminal-host vars are injected
-  (`DotNetAppHostProject`, `DotNetBasedAppHostServerProject`, `PrebuiltAppHostServer`, guest/TS host launch).
+### 5.6 Watch options + bundling plumbing (new) — ✅ implemented in Session 0
+- `BundleDiscovery` (final): `WatchToolPathEnvVar = "ASPIRE_WATCH_TOOL_PATH"`,
+  `WatchSdkPathEnvVar = "ASPIRE_WATCH_SDK_PATH"`, `WatchDirectoryName = "watch"`,
+  `WatchToolEntryPointName = "Microsoft.DotNet.HotReload.Watch.Aspire.dll"`
+- Hosting options (final): `WatchToolPath` **and** `WatchSdkPath` were added to **`DcpOptions`**, 
+  bound in `ConfigureDefaultDcpOptions` with the established
+  precedence `env → dcpPublisher config → assembly metadata` — same shape as `TerminalHostPath`.
+  They are intentionally **not** added to `ValidateDcpOptions`: the watch *tool* is a mandatory CLI
+  **bundle** component (A7), but the hosting options stay optional because non-CLI / publish / test
+  hosts legitimately don't set them.
+- CLI (final): inject `ASPIRE_WATCH_TOOL_PATH` (+ `ASPIRE_WATCH_SDK_PATH` when a private SDK install is
+  resolvable) **unconditionally** at every app-host launch path.
+  Activation (`ASPIRE_WATCH=1`) is deferred to `aspire watch` (Session 4); 
+  the path vars are inert on a normal `aspire run`. 
+  Preference order per site: pre-existing env (user override) → repo-local NuGet-cache
+  probe (dev) → bundle `watch/` directory. 
+  `ASPIRE_WATCH_SDK_PATH` is only the **fast path** (pure path math; no process spawn). When it can't be
+  derived (the common ambient-`dotnet` case) it is omitted, and the **app model** resolves the SDK base
+  path itself via a single, memoized `dotnet --info` at watch-server launch (§5.4 / Session 3) — the watch
+  tool does **not** self-resolve it (A6).
 
 ### 5.7 `WatchCommand` (new) — `aspire watch`
 `Aspire.Cli/Commands/WatchCommand.cs`
@@ -265,16 +292,41 @@ internal sealed class WatchCommand : BaseCommand   // sibling of RunCommand
 > (where applicable) a manual run against the **TypeScript** app host first, then a C# app host (D8).
 > Keep all new surface `[Experimental]`. Do **not** hand-edit `api/*.cs` (generated).
 
-### Session 0 — Bundle the watch tool + hosting plumbing *(foundational; no user-visible behavior)*
-**Deliverables**
-- Pin `Microsoft.DotNet.HotReload.Watch.Aspire` `10.0.301` (D7) and include it as a **bundle component**
-  (new `watch/` dir) in the CLI/SDK layout, alongside `dcp/` and `managed/`.
-- `BundleDiscovery`: `WatchToolPathEnvVar`, `WatchDirectoryName`, `TryDiscoverWatchTool*` (mirror DCP/managed).
-- Hosting: `WatchToolPath` (+ SDK dir) option bound from config/env (mirror `TerminalHostPath`).
-- CLI: inject the watch-tool env var(s) at app-host launch (all launch paths, incl. TS/guest).
-**Reuse:** `BundleDiscovery`, `DcpOptions`, terminal-host injection in `DotNetAppHostProject`.
-**Verify:** unit test discovery; from a dev build, confirm `dotnet "$ASPIRE_WATCH_TOOL_PATH" --help` runs and
-the env var reaches a launched app host (C# and TS).
+### Session 0 — Bundle the watch tool + hosting plumbing *(foundational; no user-visible behavior)* — ✅ implemented
+**Deliverables (as built)**
+- Pinned `Microsoft.DotNet.HotReload.Watch.Aspire` in `eng/Versions.props` as
+  `MicrosoftDotNetHotReloadWatchAspireVersion` and included it as a **bundle component** (new `watch/`
+  dir) in the CLI layout, alongside `dcp/` and `managed/`. `tools/CreateLayout` downloads it via
+  `PackageDownload` and `CopyWatch()` copies the whole `tools/net10.0/any/` directory (the package is
+  **not** dependency-free — it carries Roslyn/MSBuild, locale folders and a `hotreload/` subdir — so the
+  full-directory copy is required). `eng/Bundle.proj` passes `--watch-version $(…)` so the copy is
+  deterministic.
+- `BundleDiscovery`: `WatchToolPathEnvVar` (`ASPIRE_WATCH_TOOL_PATH`), `WatchSdkPathEnvVar`
+  (`ASPIRE_WATCH_SDK_PATH`), `WatchDirectoryName` (`watch`), `WatchToolEntryPointName`
+  (`Microsoft.DotNet.HotReload.Watch.Aspire.dll`), and `TryDiscoverWatchTool*` helpers (mirror DCP/managed).
+- CLI layout: `LayoutComponent.Watch` + `LayoutComponents.Watch` (default `watch`), wired into
+  `GetComponentPath`. The watch tool is a **mandatory** bundle component (A7), guaranteed by two
+  halves: the **build** (`tools/CreateLayout` `CopyWatch()` throws if the package is absent) and the
+  **extract** integrity check (`BundleService.IsVersionedLayoutValid` rejects a freshly-extracted
+  bundle that lacks `watch/` → extraction fails → `aspire setup --force`). `LayoutDiscovery.ValidateLayout`
+  intentionally stays `managed + dcp` (it does **not** require `watch`) so externally-supplied/legacy
+  `ASPIRE_LAYOUT_PATH` layouts remain usable in a degraded, watch-less mode; `LayoutConfiguration.GetWatchToolPath()`
+  keeps its defensive `File.Exists` (returns `null` when absent) for those tolerant layouts and the
+  inner-loop dev (NuGet-cache) fallback.
+- Hosting: `WatchToolPath` + `WatchSdkPath` on **`DcpOptions`**, bound in `ConfigureDefaultDcpOptions`
+  (env → dcpPublisher config → assembly metadata). 
+- CLI: inject the watch-tool env var(s) **unconditionally** at all launch paths (incl. TS/guest), only when
+  not already present (user override wins); `ASPIRE_WATCH_SDK_PATH` added best-effort when a private SDK
+  install is resolvable, otherwise omitted (no `dotnet --info` on the launch path). When omitted, the
+  **app model** resolves the SDK base path via a single, memoized `dotnet --info` at watch-server launch
+  (Session 3) — the watch tool does **not** self-resolve it (A6).
+**Startup-perf guardrail (for Sessions 3–4):** the app-host launch path must **not** gain a `dotnet --info`
+(or any process spawn) when wiring `--sdk`; resolve the SDK dir with pure path math (as Session 0 does), or
+omit `ASPIRE_WATCH_SDK_PATH` and let the **app model** resolve it lazily via a single, memoized `dotnet --info`
+at watch-server launch — only in watch mode with ≥1 `CSharpProgram`, so a normal `aspire run` never spawns it.
+**Verified:** discovery/binding/injection unit tests (16 new, green) + no regressions in
+`DotNetAppHostProjectTests`; real `CreateLayout` run produces `watch/` with the entry DLL and its deps; the
+bundled entry DLL launches (`dotnet <dll>` reaches the tool's own arg parser).
 
 ### Session 1A — `CSharpProgram` type + generalize project-defaults wiring
 **Deliverables**
@@ -316,6 +368,15 @@ from a TS app host then a C# app host. *Depends on: 1A (resource exists). Parall
 **Deliverables**
 - `CSharpWatchServerResource` (§5.4): hidden, explicit-start `dotnet <tool> server --sdk … --server <pipe>
   --status-pipe … --control-pipe … --resource <proj> …`. `PipeNameFactory` helper (ported from POC).
+- **SDK base-path resolver** (Aspire.Hosting; new internal service, e.g. `IWatchSdkPathResolver`): supplies
+  the watch server's `--sdk` value. Fast path = `DcpOptions.WatchSdkPath` (CLI directory-probing via
+  `ASPIRE_WATCH_SDK_PATH`); when empty, fall back to running `dotnet --info` from the app host's working
+  directory and parsing the `Base Path:` line. **Lazy + memoized** (`Lazy<Task<string>>`,
+  `ExecutionAndPublication`) so the probe runs at most once per run and only when first awaited; the watch
+  server's arg/env callback (or `BeforeResourceStartedEvent`) is the only awaiter, so it is invoked at the
+  latest moment and never on a normal `aspire run` (A6). Force `DOTNET_CLI_UI_LANGUAGE=en-US` for stable
+  (non-localized) `Base Path:` parsing. On non-zero exit / unparseable output, fail the watch server
+  startup with a clear, actionable error (no launching the tool with an empty/garbage `--sdk`).
 - Launch-modality seam (§4.2): when `ASPIRE_WATCH=1`, the app model (a) adds the watch server with all
   `CSharpProgram` project paths, (b) rewrites each `CSharpProgram` to launch `dotnet <tool> resource
   --entrypoint <proj> --server <pipe> --no-launch-profile -e K=V …` as a DCP executable, (c)
@@ -324,8 +385,8 @@ from a TS app host then a C# app host. *Depends on: 1A (resource exists). Parall
 - Optional: status-pipe monitor (hosted/background service) surfacing watch status into resource logs/state
   (port of `WatchPipeMonitorHostedService`).
 **Reuse:** `WithHidden`, `WithExplicitStart`, `WaitForStart`, `ExcludeFromManifest`,
-`ExcludeLifecycleCommandsAnnotation`, `ExecutableResource`, env-callback annotations; watch-tool path + SDK
-dir from Session 0.
+`ExcludeLifecycleCommandsAnnotation`, `ExecutableResource`, env-callback annotations; `IProcessRunner`
+(`Dcp/Process`) for the `dotnet --info` fallback; watch-tool path + SDK fast-path dir from Session 0.
 **Verify (TS first):** under a watch harness, edit a service file → that service hot-reloads; edit the shared
 library → both services reload. Then repeat with a C# app host. *Depends on: 1B, 2, 0.*
 
@@ -381,16 +442,20 @@ Risk to watch out for: env/args callbacks may need to run for build/closure even
   regression tests; fall back to a dedicated prepare path.
 - **R2 — Generalizing `WithProjectDefaults` (Session 1A):** heavily `ProjectResource`-typed; the refactor is
   the riskiest reuse. Consider a shared internal interface implemented by both types.
-- **R3 — Watch tool ↔ SDK coupling:** `dotnet <tool> --sdk <dir>` must match the active SDK; bundling pins
-  `10.0.301` but the user's SDK may differ. Confirm acceptable matrix; resolve SDK dir via `dotnet --info`.
+- **R3 — Watch tool ↔ SDK coupling:** `dotnet <tool> --sdk <dir>` must match the active SDK; the bundled tool
+  is pinned (currently `10.0.301`) but the user's SDK may differ. The watch tool does **not** self-resolve the
+  SDK base path (A6), so the app model must always hand it a valid `--sdk`. Two-step resolution:
+  (1) **fast path** — the CLI's pure path-math probe (`ASPIRE_WATCH_SDK_PATH`, Session 0); the *launch path*
+  must not spawn a process (startup-perf guardrail). (2) **fallback** — when the fast path yields nothing,
+  the **app model** (Aspire.Hosting, *not* the watch tool) resolves it via a lazy, memoized `dotnet --info`
+  at watch-server launch (Session 3) — run at most once per app run and only in watch mode with ≥1
+  `CSharpProgram`, so a normal `aspire run` never spawns it.
 - **R4 — Named pipes cross-platform:** verify `PipeOptions.CurrentUserOnly` semantics on macOS/Linux (POC ran
   Windows-centric). TS-first verification will exercise non-Windows.
 - **R5 — `vs-solutionpersistence` feed availability (A4).**
 - **R6 — `aspire watch` vs existing app-host `--watch`:** ensure the two "watch" concepts don't collide in CLI
   UX/strings.
 - **O1 — Naming:** `CSharpProgram` vs `CSharpProgramResource` vs something else (A2).
-
-
   ## References 
 
   | Description | Reference |

--- a/docs/plans/project-v2-csharpprogram-watch.md
+++ b/docs/plans/project-v2-csharpprogram-watch.md
@@ -464,4 +464,4 @@ Risk to watch out for: env/args callbacks may need to run for build/closure even
   | Stage 1 (Aspire 13.5) scope for Project v2 (tracking issue) | https://github.com/microsoft/aspire/issues/15710 |
   | Aspire watch prototype | https://github.com/karolz-ms/aspire-watch |
   | Solution file editing library | https://github.com/microsoft/vs-solutionpersistence |
-  | Annotation-bases resource flavoring proposal | https://github.com/microsoft/aspire/issues/8984 |
+  | Annotation-based resource flavoring proposal | https://github.com/microsoft/aspire/issues/8984 |

--- a/eng/Bundle.proj
+++ b/eng/Bundle.proj
@@ -135,7 +135,7 @@
       <_BundleOutputDirArg>$(BundleOutputDir.TrimEnd('\').TrimEnd('/'))</_BundleOutputDirArg>
       <_ArtifactsDirArg>$(ArtifactsDir.TrimEnd('\').TrimEnd('/'))</_ArtifactsDirArg>
 
-      <_CreateLayoutArgs>--output "$(_BundleOutputDirArg)" --artifacts "$(_ArtifactsDirArg)" --rid $(TargetRid) --bundle-version $(BundleVersion) --verbose --archive</_CreateLayoutArgs>
+      <_CreateLayoutArgs>--output "$(_BundleOutputDirArg)" --artifacts "$(_ArtifactsDirArg)" --rid $(TargetRid) --bundle-version $(BundleVersion) --watch-version $(MicrosoftDotNetHotReloadWatchAspireVersion) --verbose --archive</_CreateLayoutArgs>
     </PropertyGroup>
 
     <Message Importance="high" Text="Creating bundle layout..." />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,6 +35,9 @@
     <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.25.1</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
     <MicrosoftDeveloperControlPlanewindowsamd64Version>0.25.1</MicrosoftDeveloperControlPlanewindowsamd64Version>
     <MicrosoftDeveloperControlPlanewindowsarm64Version>0.25.1</MicrosoftDeveloperControlPlanewindowsarm64Version>
+
+    <!-- Aspire Watch package for hot-reloading C#-based services -->
+    <MicrosoftDotNetHotReloadWatchAspireVersion>10.0.301</MicrosoftDotNetHotReloadWatchAspireVersion>
     <!-- Other -->
     <MicrosoftDotNetRemoteExecutorVersion>10.0.0-beta.26304.4</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitV3ExtensionsVersion>10.0.0-beta.26304.4</MicrosoftDotNetXUnitV3ExtensionsVersion>

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -525,7 +525,8 @@ internal sealed class BundleService(
 
     /// <summary>
     /// Returns <see langword="true"/> if <paramref name="versionDir"/> contains the
-    /// essential bundle components (<c>managed/aspire-managed</c> and a DCP directory).
+    /// essential bundle components: <c>managed/aspire-managed</c>, a DCP directory, and
+    /// the bundled watch tool (<c>watch/Microsoft.DotNet.HotReload.Watch.Aspire.dll</c>).
     /// </summary>
     internal static bool IsVersionedLayoutValid(string versionDir)
     {
@@ -557,6 +558,12 @@ internal sealed class BundleService(
 
         var dcpDir = Path.Combine(versionDir, BundleDiscovery.DcpDirectoryName);
         if (!Directory.Exists(dcpDir))
+        {
+            return false;
+        }
+
+        var watchPath = Path.Combine(versionDir, BundleDiscovery.WatchDirectoryName, BundleDiscovery.WatchToolDllName);
+        if (!File.Exists(watchPath))
         {
             return false;
         }

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -43,6 +43,7 @@ internal interface IDotNetCliRunner
     Task<(int ExitCode, IReadOnlyList<FileInfo> Projects)> GetSolutionProjectsAsync(FileInfo solutionFile, ProcessInvocationOptions options, CancellationToken cancellationToken);
     Task<int> AddProjectReferenceAsync(FileInfo projectFile, FileInfo referencedProject, ProcessInvocationOptions options, CancellationToken cancellationToken);
     Task<int> InitUserSecretsAsync(FileInfo projectFile, ProcessInvocationOptions options, CancellationToken cancellationToken);
+    string? TryGetWatchSdkDirectory();
 }
 
 internal sealed class ProcessInvocationOptions
@@ -371,6 +372,29 @@ internal sealed class DotNetCliRunner(
         }
 
         return "dotnet";
+    }
+
+    public string? TryGetWatchSdkDirectory()
+    {
+        // Mirror ResolveDotNetPath's private-SDK resolution so the watch tool targets the very
+        // same SDK that launches the app host. We deliberately do NOT shell out to `dotnet --info`
+        // here because this runs on the app-host launch hot path.
+        // When this fast path can't resolve the SDK, the app model performs the `dotnet --info`
+        // fallback lazily — only for watch runs that actually need it.
+
+        var sdkVersion = DotNetSdkInstaller.GetEffectiveMinimumSdkVersion(configuration);
+        var sdkInstallPath = Path.Combine(executionContext.SdksDirectory.FullName, "dotnet", sdkVersion);
+        if (!Directory.Exists(sdkInstallPath))
+        {
+            // No private SDK installed — the app host runs under the ambient `dotnet` on PATH.
+            // We might need to run `dotnet --info` at watch-server launch.
+            return null;
+        }
+
+        // The watch tool's --sdk argument wants the SDK "Base Path" — the `sdk/<version>` directory
+        // inside the dotnet installation root (this is the "Base Path" line in `dotnet --info`).
+        var sdkDirectory = Path.Combine(sdkInstallPath, "sdk", sdkVersion);
+        return Directory.Exists(sdkDirectory) ? sdkDirectory : null;
     }
 
     private async Task StartBackchannelAsync(

--- a/src/Aspire.Cli/Layout/LayoutConfiguration.cs
+++ b/src/Aspire.Cli/Layout/LayoutConfiguration.cs
@@ -15,7 +15,9 @@ public enum LayoutComponent
     /// <summary>Developer Control Plane.</summary>
     Dcp,
     /// <summary>Unified managed binary (dashboard, server, nuget).</summary>
-    Managed
+    Managed,
+    /// <summary>Bundled watch tool (Microsoft.DotNet.HotReload.Watch.Aspire).</summary>
+    Watch
 }
 
 /// <summary>
@@ -64,6 +66,7 @@ public sealed class LayoutConfiguration
             LayoutComponent.Cli => Components.Cli,
             LayoutComponent.Dcp => Components.Dcp,
             LayoutComponent.Managed => Components.Managed,
+            LayoutComponent.Watch => Components.Watch,
             _ => null
         };
 
@@ -89,6 +92,23 @@ public sealed class LayoutConfiguration
 
         return Path.Combine(managedDir, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
     }
+
+    /// <summary>
+    /// Gets the path to the bundled watch tool DLL.
+    /// </summary>
+    public string? GetWatchToolPath()
+    {
+        var watchDir = GetComponentPath(LayoutComponent.Watch);
+        if (watchDir is null)
+        {
+            return null;
+        }
+
+        // Watch is a mandatory bundle component for shipping CLI but may not be present 
+        // in externally-supplied or legacy layouts. 
+        var watchToolPath = Path.Combine(watchDir, BundleDiscovery.WatchToolDllName);
+        return File.Exists(watchToolPath) ? watchToolPath : null;
+    }
 }
 
 /// <summary>
@@ -110,4 +130,9 @@ public sealed class LayoutComponents
     /// Path to the unified managed binary directory.
     /// </summary>
     public string? Managed { get; set; } = BundleDiscovery.ManagedDirectoryName;
+
+    /// <summary>
+    /// Path to the bundled watch tool directory.
+    /// </summary>
+    public string? Watch { get; set; } = BundleDiscovery.WatchDirectoryName;
 }

--- a/src/Aspire.Cli/Layout/LayoutDiscovery.cs
+++ b/src/Aspire.Cli/Layout/LayoutDiscovery.cs
@@ -269,6 +269,7 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
                     {
                         Dcp = Path.Combine(BundleDiscovery.BundleDirectoryName, BundleDiscovery.DcpDirectoryName),
                         Managed = Path.Combine(BundleDiscovery.BundleDirectoryName, BundleDiscovery.ManagedDirectoryName),
+                        Watch = Path.Combine(BundleDiscovery.BundleDirectoryName, BundleDiscovery.WatchDirectoryName),
                     }
                 };
             }

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -57,6 +57,13 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     /// </summary>
     internal static Func<string?>? RepoLocalManagedPathProviderOverride { get; set; }
 
+    /// <summary>
+    /// Test seam: overrides <see cref="TryGetRepoLocalWatchToolPath"/>. When set, the override is
+    /// invoked instead of probing the real NuGet cache / Aspire repo checkout, so tests can assert
+    /// watch env-var injection without depending on a restored watch package on the machine.
+    /// </summary>
+    internal static Func<string?>? RepoLocalWatchToolPathProviderOverride { get; set; }
+
     public DotNetAppHostProject(
         IDotNetCliRunner runner,
         IInteractionService interactionService,
@@ -1348,6 +1355,22 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             }
         }
 
+        // Set the watch tool path if it's not already set and if it can be found cheaply
+        // (without launching `dotnet --info`).
+        if (!env.ContainsKey(BundleDiscovery.WatchToolPathEnvVar))
+        {
+            var watchToolPath = TryGetRepoLocalWatchToolPath() ?? layout?.GetWatchToolPath();
+            if (watchToolPath is not null)
+            {
+                env[BundleDiscovery.WatchToolPathEnvVar] = watchToolPath;
+
+                if (!env.ContainsKey(BundleDiscovery.WatchSdkPathEnvVar) && _runner.TryGetWatchSdkDirectory() is { } watchSdkDirectory)
+                {
+                    env[BundleDiscovery.WatchSdkPathEnvVar] = watchSdkDirectory;
+                }
+            }
+        }
+
         layoutLease?.AddEnvironment(env);
     }
 
@@ -1370,6 +1393,21 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
         var repoRoot = AspireRepositoryDetector.DetectRepositoryRoot();
         return BundleDiscovery.TryGetRepoLocalManagedPath(repoRoot);
+    }
+
+    /// <summary>
+    /// Resolves the bundled watch tool from the NuGet cache when the CLI is running 
+    /// from an Aspire repo checkout (typically <c>dotnet run --project src/Aspire.Cli</c>). 
+    /// </summary>
+    private static string? TryGetRepoLocalWatchToolPath()
+    {
+        if (RepoLocalWatchToolPathProviderOverride is { } overrideProvider)
+        {
+            return overrideProvider();
+        }
+
+        var repoRoot = AspireRepositoryDetector.DetectRepositoryRoot();
+        return WatchToolLocator.TryGetRepoLocalWatchToolPath(repoRoot);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -469,6 +469,38 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         string[]? additionalArgs = null,
         bool debug = false)
     {
+        var startInfo = CreateStartInfo(hostPid, environmentVariables, additionalArgs, debug);
+        var process = Process.Start(startInfo)!;
+
+        var outputCollector = new OutputCollector();
+        process.OutputDataReceived += (sender, e) =>
+        {
+            if (e.Data is not null)
+            {
+                _logger.LogTrace("AppHostServer({ProcessId}) stdout: {Line}", process.Id, e.Data);
+                outputCollector.AppendOutput(e.Data);
+            }
+        };
+        process.ErrorDataReceived += (sender, e) =>
+        {
+            if (e.Data is not null)
+            {
+                _logger.LogTrace("AppHostServer({ProcessId}) stderr: {Line}", process.Id, e.Data);
+                outputCollector.AppendError(e.Data);
+            }
+        };
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        return (_socketPath, process, outputCollector);
+    }
+
+    internal ProcessStartInfo CreateStartInfo(
+        int hostPid,
+        IReadOnlyDictionary<string, string>? environmentVariables = null,
+        string[]? additionalArgs = null,
+        bool debug = false)
+    {
         var assemblyPath = Path.Combine(BuildPath, ProjectDllName);
         var dotnetExe = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet";
 
@@ -517,6 +549,19 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
             }
         }
 
+        // Wire the bundled watch tool for guest/polyglot AppHosts running in repo mode.
+        if (WatchToolLocator.TryGetRepoLocalWatchToolPath(_repoRoot) is { } watchToolPath
+            && !ContainsKey(environmentVariables, BundleDiscovery.WatchToolPathEnvVar))
+        {
+            startInfo.Environment[BundleDiscovery.WatchToolPathEnvVar] = watchToolPath;
+
+            if (!ContainsKey(environmentVariables, BundleDiscovery.WatchSdkPathEnvVar)
+                && _dotNetCliRunner.TryGetWatchSdkDirectory() is { } watchSdkDirectory)
+            {
+                startInfo.Environment[BundleDiscovery.WatchSdkPathEnvVar] = watchSdkDirectory;
+            }
+        }
+
         if (environmentVariables is not null)
         {
             foreach (var (key, value) in environmentVariables)
@@ -534,29 +579,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         startInfo.RedirectStandardOutput = true;
         startInfo.RedirectStandardError = true;
 
-        var process = Process.Start(startInfo)!;
-
-        var outputCollector = new OutputCollector();
-        process.OutputDataReceived += (sender, e) =>
-        {
-            if (e.Data is not null)
-            {
-                _logger.LogTrace("AppHostServer({ProcessId}) stdout: {Line}", process.Id, e.Data);
-                outputCollector.AppendOutput(e.Data);
-            }
-        };
-        process.ErrorDataReceived += (sender, e) =>
-        {
-            if (e.Data is not null)
-            {
-                _logger.LogTrace("AppHostServer({ProcessId}) stderr: {Line}", process.Id, e.Data);
-                outputCollector.AppendError(e.Data);
-            }
-        };
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-
-        return (_socketPath, process, outputCollector);
+        return startInfo;
     }
 
     private static string? FindNuGetConfig(string workingDirectory)

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -1029,6 +1029,19 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
             startInfo.Environment[BundleDiscovery.DashboardPathEnvVar] = managedPath;
         }
 
+        // Set the bundled watch tool path + SDK dir.
+        if (!ContainsKey(environmentVariables, BundleDiscovery.WatchToolPathEnvVar) &&
+            _layout.GetWatchToolPath() is { } watchToolPath)
+        {
+            startInfo.Environment[BundleDiscovery.WatchToolPathEnvVar] = watchToolPath;
+
+            if (!ContainsKey(environmentVariables, BundleDiscovery.WatchSdkPathEnvVar) &&
+                _dotNetCliRunner.TryGetWatchSdkDirectory() is { } watchSdkDirectory)
+            {
+                startInfo.Environment[BundleDiscovery.WatchSdkPathEnvVar] = watchSdkDirectory;
+            }
+        }
+
         // Apply environment variables from apphost.run.json
         if (environmentVariables is not null)
         {
@@ -1049,6 +1062,11 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
         startInfo.RedirectStandardError = true;
 
         return startInfo;
+    }
+
+    private static bool ContainsKey(IReadOnlyDictionary<string, string>? env, string key)
+    {
+        return env is not null && env.ContainsKey(key);
     }
 
     /// <inheritdoc />

--- a/src/Aspire.Cli/Projects/WatchToolLocator.cs
+++ b/src/Aspire.Cli/Projects/WatchToolLocator.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml.Linq;
+using Aspire.Shared;
+
+namespace Aspire.Cli.Projects;
+
+/// <summary>
+/// Locates the bundled watch tool (<c>Microsoft.DotNet.HotReload.Watch.Aspire</c>) 
+/// for inner-loop development scenarios where no CLI bundle layout exists 
+/// — e.g. running <c>dotnet run --project src/Aspire.Cli</c> from an Aspire repo checkout. 
+/// In a normal installed CLI the tool ships inside the bundle's <c>watch/</c> directory 
+/// and is resolved from the layout instead.
+/// </summary>
+internal static class WatchToolLocator
+{
+    private const string WatchVersionPropertyName = "MicrosoftDotNetHotReloadWatchAspireVersion";
+
+    /// <summary>
+    /// Resolves the watch tool entry-point DLL from the NuGet global packages cache, 
+    /// pinned to the version declared in the repo's <c>eng/Versions.props</c>. Returns <c>null</c> when
+    /// <paramref name="repoRoot"/> is empty (not running from a repo), or when the pinned package
+    /// has not been restored into the cache yet.
+    /// </summary>
+    /// <param name="repoRoot">The Aspire repository root, or <c>null</c>/empty when not in repo mode.</param>
+    public static string? TryGetRepoLocalWatchToolPath(string? repoRoot)
+    {
+        if (string.IsNullOrEmpty(repoRoot))
+        {
+            return null;
+        }
+
+        var pinnedVersion = TryReadPinnedWatchVersion(repoRoot);
+        return BundleDiscovery.TryGetWatchToolPathFromNuGetCache(pinnedVersion);
+    }
+
+    private static string? TryReadPinnedWatchVersion(string repoRoot)
+    {
+        try
+        {
+            var versionsPropsPath = Path.Combine(repoRoot, "eng", "Versions.props");
+            if (!File.Exists(versionsPropsPath))
+            {
+                return null;
+            }
+
+            var doc = XDocument.Load(versionsPropsPath);
+            return doc.Descendants(WatchVersionPropertyName).FirstOrDefault()?.Value;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -50,6 +50,27 @@ internal sealed class DcpOptions
     public string? TerminalHostInvocationArgs { get; set; }
 
     /// <summary>
+    /// Optional path to the bundled watch tool entry-point DLL
+    /// (<c>Microsoft.DotNet.HotReload.Watch.Aspire.dll</c>). Backs the experimental
+    /// <c>aspire watch</c> hot-reload modality. Resolved from the CLI bundle's <c>watch/</c>
+    /// directory and injected via <see cref="BundleDiscovery.WatchToolPathEnvVar"/>.
+    /// </summary>
+    public string? WatchToolPath { get; set; }
+
+    /// <summary>
+    /// Optional .NET SDK base path passed to the watch tool's <c>--sdk</c> argument so it
+    /// targets the same SDK used to launch the app host. Companion to <see cref="WatchToolPath"/>;
+    /// injected via <see cref="BundleDiscovery.WatchSdkPathEnvVar"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is only the fast path: the CLI sets it via pure path math when the app host runs
+    /// under a private SDK install. When it is empty (the common ambient-<c>dotnet</c> case), the app
+    /// model resolves the SDK base path itself by running <c>dotnet --info</c> (lazily and memoized,
+    /// at watch-server launch). The watch tool does not self-resolve the SDK.
+    /// </remarks>
+    public string? WatchSdkPath { get; set; }
+
+    /// <summary>
     /// Optional container runtime to override default runtime for DCP containers.
     /// </summary>
     /// <example>
@@ -300,6 +321,26 @@ internal class ConfigureDefaultDcpOptions(
             {
                 options.TerminalHostInvocationArgs = "terminalhost";
             }
+        }
+
+        var configWatchToolPath = configuration[BundleDiscovery.WatchToolPathEnvVar];
+        if (!string.IsNullOrEmpty(configWatchToolPath))
+        {
+            options.WatchToolPath = configWatchToolPath;
+        }
+        else if (!string.IsNullOrEmpty(dcpPublisherConfiguration[nameof(options.WatchToolPath)]))
+        {
+            options.WatchToolPath = dcpPublisherConfiguration[nameof(options.WatchToolPath)];
+        }
+
+        var configWatchSdkPath = configuration[BundleDiscovery.WatchSdkPathEnvVar];
+        if (!string.IsNullOrEmpty(configWatchSdkPath))
+        {
+            options.WatchSdkPath = configWatchSdkPath;
+        }
+        else if (!string.IsNullOrEmpty(dcpPublisherConfiguration[nameof(options.WatchSdkPath)]))
+        {
+            options.WatchSdkPath = dcpPublisherConfiguration[nameof(options.WatchSdkPath)];
         }
 
         if (!string.IsNullOrEmpty(dcpPublisherConfiguration[nameof(options.ContainerRuntime)]))

--- a/src/Shared/BundleDiscovery.cs
+++ b/src/Shared/BundleDiscovery.cs
@@ -5,8 +5,11 @@
 // - Aspire.Hosting
 // - Aspire.Cli
 // - Aspire.Managed
+// - CreateLayout
 // Do not add project-specific dependencies.
 
+using System.Globalization;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace Aspire.Shared;
@@ -60,6 +63,23 @@ internal static class BundleDiscovery
     public const string TerminalHostInvocationArgsEnvVar = "ASPIRE_TERMINAL_HOST_INVOCATION_ARGS";
 
     /// <summary>
+    /// Environment variable for the bundled watch tool DLL path 
+    /// (<c>Microsoft.DotNet.HotReload.Watch.Aspire.dll</c>). 
+    /// </summary>
+    public const string WatchToolPathEnvVar = "ASPIRE_WATCH_TOOL_PATH";
+
+    /// <summary>
+    /// Environment variable for the .NET SDK base path the watch tool should target
+    /// (via its <c>--sdk</c> argument). 
+    /// </summary>
+    /// <remarks>
+    /// This injection is best-effort (set only when the CLI can derive it via pure path probing, 
+    /// e.g. a private SDK install). When it is absent, the app model resolves the SDK base path itself 
+    /// via a lazy, memoized <c>dotnet --info</c> command spawned at watch-server launch.
+    /// </remarks>
+    public const string WatchSdkPathEnvVar = "ASPIRE_WATCH_SDK_PATH";
+
+    /// <summary>
     /// Environment variable containing the leased version directory for bundle-owned child processes.
     /// </summary>
     public const string BundleVersionDirectoryEnvVar = "ASPIRE_BUNDLE_VERSION_DIR";
@@ -95,6 +115,12 @@ internal static class BundleDiscovery
     /// </summary>
     public const string BundleDirectoryName = "bundle";
 
+    /// <summary>
+    /// Directory name for the bundled watch tool (Microsoft.DotNet.HotReload.Watch.Aspire)
+    /// in the bundle layout. 
+    /// </summary>
+    public const string WatchDirectoryName = "watch";
+
     // ═══════════════════════════════════════════════════════════════════════
     // EXECUTABLE NAMES (without path, just the file name)
     // ═══════════════════════════════════════════════════════════════════════
@@ -103,6 +129,16 @@ internal static class BundleDiscovery
     /// Executable name for the unified managed binary.
     /// </summary>
     public const string ManagedExecutableName = "aspire-managed";
+
+    /// <summary>
+    /// Assembly file name for the bundled watch tool. 
+    /// </summary>
+    public const string WatchToolDllName = "Microsoft.DotNet.HotReload.Watch.Aspire.dll";
+
+    // Name of the Nuget cache folder where the watch tool is stored.
+    internal const string WatchToolNugetCacheFolder = "microsoft.dotnet.hotreload.watch.aspire";
+    // Watch tool .NET (target) version
+    internal const string WatchToolDotNetVersion = "net10.0";
 
     // ═══════════════════════════════════════════════════════════════════════
     // DISCOVERY METHODS
@@ -253,6 +289,34 @@ internal static class BundleDiscovery
     }
 
     /// <summary>
+    /// Attempts to discover the bundled watch tool DLL from a base directory.
+    /// </summary>
+    /// <param name="baseDirectory">The base directory to search from (e.g., bundle layout root).</param>
+    /// <param name="watchToolPath">The full path to the watch tool entry-point DLL if found.</param>
+    /// <returns>True if the watch tool was found, false otherwise.</returns>
+    public static bool TryDiscoverWatchToolFromDirectory(
+        string baseDirectory,
+        out string? watchToolPath)
+    {
+        watchToolPath = null;
+
+        if (string.IsNullOrEmpty(baseDirectory) || !Directory.Exists(baseDirectory))
+        {
+            return false;
+        }
+
+        var watchPath = Path.Combine(baseDirectory, WatchDirectoryName, WatchToolDllName);
+
+        if (File.Exists(watchPath))
+        {
+            watchToolPath = watchPath;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns the path to <c>aspire-managed</c> inside an Aspire repo checkout when the
     /// normal repo build has produced it under <c>artifacts/bin/Aspire.Managed/{Configuration}/{tfm}/</c>.
     /// Used by callers that want to point dev-mode child processes at the repo's just-built
@@ -280,6 +344,233 @@ internal static class BundleDiscovery
             "net10.0",
             GetExecutableFileName(ManagedExecutableName));
         return File.Exists(managedPath) ? managedPath : null;
+    }
+
+    /// <summary>
+    /// Returns the directory containing the watch tool DLL from the NuGet global packages cache.
+    /// Returns <c>null</c> when the cache or package is missing.
+    /// </summary>
+    /// <param name="version">
+    /// Exact package version to probe for. When <c>null</c>, the newest version
+    /// present in the cache is chosen via a single-level directory listing.
+    /// </param>
+    public static string? TryGetWatchToolDirectoryFromNuGetCache(string? version)
+    {
+        var nugetPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+
+        // Lowercased package id is the cache folder name.
+        var packageRoot = Path.Combine(nugetPackages, WatchToolNugetCacheFolder);
+        if (!Directory.Exists(packageRoot))
+        {
+            return null;
+        }
+
+        var versionRoot = !string.IsNullOrEmpty(version)
+            ? Path.Combine(packageRoot, version)
+            : GetNewestNuGetVersionDirectory(packageRoot);
+
+        if (versionRoot is null || !Directory.Exists(versionRoot))
+        {
+            return null;
+        }
+
+        var toolsDir = Path.Combine(versionRoot, "tools", WatchToolDotNetVersion, "any");
+        if (File.Exists(Path.Combine(toolsDir, WatchToolDllName)))
+        {
+            return toolsDir;
+        }
+
+        var fallback = Directory.EnumerateFiles(versionRoot, WatchToolDllName, SearchOption.AllDirectories)
+            .FirstOrDefault();
+        return fallback is not null ? Path.GetDirectoryName(fallback) : null;
+    }
+
+    /// <summary>
+    /// Returns the path to the watch tool DLL from the NuGet global packages cache.
+    /// Returns <c>null</c> when the cache or package is missing.
+    /// </summary>
+    /// <param name="version">
+    /// Exact package version to probe for. When <c>null</c>, the newest version
+    /// present in the cache is chosen via a single-level directory listing.
+    /// </param>
+    public static string? TryGetWatchToolPathFromNuGetCache(string? version)
+    {
+        var watchToolDirectory = TryGetWatchToolDirectoryFromNuGetCache(version);
+        return watchToolDirectory is not null ? Path.Combine(watchToolDirectory, WatchToolDllName) : null;
+    }
+
+    private static string? GetNewestNuGetVersionDirectory(string packageRoot)
+    {
+        string? newestPath = null;
+        var hasNewestVersion = false;
+        var newestVersion = default(ParsedNuGetPackageVersion);
+
+        foreach (var directory in Directory.GetDirectories(packageRoot))
+        {
+            var directoryName = Path.GetFileName(directory);
+            if (!ParsedNuGetPackageVersion.TryParse(directoryName, out var candidateVersion))
+            {
+                continue;
+            }
+
+            if (!hasNewestVersion || candidateVersion.CompareTo(newestVersion) > 0)
+            {
+                newestPath = directory;
+                newestVersion = candidateVersion;
+                hasNewestVersion = true;
+            }
+        }
+
+        return newestPath;
+    }
+
+    private readonly record struct ParsedNuGetPackageVersion(int Major, int Minor, int Patch, int Revision, string? Prerelease) : IComparable<ParsedNuGetPackageVersion>
+    {
+        public static bool TryParse(string? version, out ParsedNuGetPackageVersion parsed)
+        {
+            parsed = default;
+
+            if (string.IsNullOrEmpty(version))
+            {
+                return false;
+            }
+
+            // NuGet global-package cache directories use normalized package versions, for example:
+            //   10.0.301
+            //   10.0.301-preview.1
+            //   10.0.301-preview.1+sha.abc123
+            // System.Version rejects prerelease labels, so parse enough SemVer/NuGet precedence
+            // here to select the newest cached package without taking a NuGet dependency in every
+            // project that source-links this shared file.
+            var metadataIndex = version.IndexOf('+', StringComparison.Ordinal);
+            var versionWithoutMetadata = metadataIndex >= 0 ? version[..metadataIndex] : version;
+
+            var prereleaseIndex = versionWithoutMetadata.IndexOf('-', StringComparison.Ordinal);
+            var releasePart = prereleaseIndex >= 0 ? versionWithoutMetadata[..prereleaseIndex] : versionWithoutMetadata;
+            var prerelease = prereleaseIndex >= 0 ? versionWithoutMetadata[(prereleaseIndex + 1)..] : null;
+            if (prerelease is "")
+            {
+                return false;
+            }
+
+            var releaseComponents = releasePart.Split('.');
+            if (releaseComponents.Length is < 1 or > 4)
+            {
+                return false;
+            }
+
+            Span<int> components = stackalloc int[4];
+            for (var i = 0; i < releaseComponents.Length; i++)
+            {
+                if (!int.TryParse(releaseComponents[i], NumberStyles.None, CultureInfo.InvariantCulture, out var component) ||
+                    component < 0)
+                {
+                    return false;
+                }
+
+                components[i] = component;
+            }
+
+            parsed = new ParsedNuGetPackageVersion(components[0], components[1], components[2], components[3], prerelease);
+            return true;
+        }
+
+        public int CompareTo(ParsedNuGetPackageVersion other)
+        {
+            var result = Major.CompareTo(other.Major);
+            if (result != 0)
+            {
+                return result;
+            }
+
+            result = Minor.CompareTo(other.Minor);
+            if (result != 0)
+            {
+                return result;
+            }
+
+            result = Patch.CompareTo(other.Patch);
+            if (result != 0)
+            {
+                return result;
+            }
+
+            result = Revision.CompareTo(other.Revision);
+            return result != 0 ? result : ComparePrerelease(Prerelease, other.Prerelease);
+        }
+
+        private static int ComparePrerelease(string? left, string? right)
+        {
+            if (left is null)
+            {
+                return right is null ? 0 : 1;
+            }
+
+            if (right is null)
+            {
+                return -1;
+            }
+
+            var leftIdentifiers = left.Split('.');
+            var rightIdentifiers = right.Split('.');
+            var count = Math.Min(leftIdentifiers.Length, rightIdentifiers.Length);
+
+            for (var i = 0; i < count; i++)
+            {
+                var result = ComparePrereleaseIdentifier(leftIdentifiers[i], rightIdentifiers[i]);
+                if (result != 0)
+                {
+                    return result;
+                }
+            }
+
+            return leftIdentifiers.Length.CompareTo(rightIdentifiers.Length);
+        }
+
+        private static int ComparePrereleaseIdentifier(string left, string right)
+        {
+            var leftNumeric = TryNormalizeNumericIdentifier(left, out var normalizedLeft);
+            var rightNumeric = TryNormalizeNumericIdentifier(right, out var normalizedRight);
+
+            if (leftNumeric && rightNumeric && normalizedLeft is not null && normalizedRight is not null)
+            {
+                var lengthResult = normalizedLeft.Length.CompareTo(normalizedRight.Length);
+                return lengthResult != 0 ? lengthResult : string.CompareOrdinal(normalizedLeft, normalizedRight);
+            }
+
+            if (leftNumeric != rightNumeric)
+            {
+                return leftNumeric ? -1 : 1;
+            }
+
+            return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool TryNormalizeNumericIdentifier(string identifier, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? normalized)
+        {
+            normalized = null;
+            if (identifier.Length == 0)
+            {
+                return false;
+            }
+
+            foreach (var ch in identifier)
+            {
+                if (!char.IsAsciiDigit(ch))
+                {
+                    return false;
+                }
+            }
+
+            normalized = identifier.TrimStart('0');
+            if (normalized.Length == 0)
+            {
+                normalized = "0";
+            }
+
+            return true;
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
@@ -527,6 +527,15 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
                 DataStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"dcp-{contentMarker}\n"))
             };
             tar.WriteEntry(dcpEntry);
+
+            // watch/ directory + tool DLL. 
+            tar.WriteEntry(new PaxTarEntry(TarEntryType.Directory, $"aspire-payload/{BundleDiscovery.WatchDirectoryName}/"));
+
+            var watchEntry = new PaxTarEntry(TarEntryType.RegularFile, $"aspire-payload/{BundleDiscovery.WatchDirectoryName}/{BundleDiscovery.WatchToolDllName}")
+            {
+                DataStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"watch-{contentMarker}\n"))
+            };
+            tar.WriteEntry(watchEntry);
         }
 
         return ms.ToArray();

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -151,6 +151,18 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void IsVersionedLayoutValid_RequiresWatchTool()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dir = workspace.WorkspaceRoot.FullName;
+        CreateFakeBundleLayout(dir);
+
+        // The watch tool is a mandatory bundle component: removing it invalidates the layout.
+        Directory.Delete(Path.Combine(dir, BundleDiscovery.WatchDirectoryName), recursive: true);
+        Assert.False(BundleService.IsVersionedLayoutValid(dir));
+    }
+
+    [Fact]
     public void TryCleanupStaleVersions_RemovesNonActiveVersionsAndStaleTempDirs()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -198,5 +210,10 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
         var dcpDir = Path.Combine(root, BundleDiscovery.DcpDirectoryName);
         Directory.CreateDirectory(dcpDir);
         File.WriteAllText(Path.Combine(dcpDir, "placeholder"), "dcp");
+
+        // The watch tool is a mandatory bundle component, so a valid layout must include it.
+        var watchDir = Path.Combine(root, BundleDiscovery.WatchDirectoryName);
+        Directory.CreateDirectory(watchDir);
+        File.WriteAllText(Path.Combine(watchDir, BundleDiscovery.WatchToolDllName), "watch");
     }
 }

--- a/tests/Aspire.Cli.Tests/Layout/WatchLayoutTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/WatchLayoutTests.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Layout;
+using Aspire.Cli.Tests.Acquisition;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Shared;
+
+namespace Aspire.Cli.Tests.LayoutTests;
+
+/// <summary>
+/// Covers discovery of the bundled watch tool (<c>Microsoft.DotNet.HotReload.Watch.Aspire</c>) from a bundle layout. 
+/// </summary>
+public class WatchLayoutTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public void TryDiscoverWatchToolFromDirectory_FindsEntryPoint_WhenWatchDirectoryExists()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var baseDir = workspace.WorkspaceRoot.FullName;
+
+        var watchDir = Path.Combine(baseDir, BundleDiscovery.WatchDirectoryName);
+        Directory.CreateDirectory(watchDir);
+        var entryPoint = Path.Combine(watchDir, BundleDiscovery.WatchToolDllName);
+        File.WriteAllText(entryPoint, "stub");
+
+        Assert.True(BundleDiscovery.TryDiscoverWatchToolFromDirectory(baseDir, out var watchToolPath));
+        Assert.Equal(entryPoint, watchToolPath);
+    }
+
+    [Fact]
+    public void TryDiscoverWatchToolFromDirectory_ReturnsFalse_WhenWatchDirectoryMissing()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var baseDir = workspace.WorkspaceRoot.FullName;
+
+        Assert.False(BundleDiscovery.TryDiscoverWatchToolFromDirectory(baseDir, out var watchToolPath));
+        Assert.Null(watchToolPath);
+    }
+
+    [Fact]
+    public void GetWatchToolPath_ReturnsEntryPoint_WhenWatchComponentPresent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layoutRoot = workspace.WorkspaceRoot.FullName;
+
+        var watchDir = Path.Combine(layoutRoot, BundleDiscovery.WatchDirectoryName);
+        Directory.CreateDirectory(watchDir);
+        var entryPoint = Path.Combine(watchDir, BundleDiscovery.WatchToolDllName);
+        File.WriteAllText(entryPoint, "stub");
+
+        var layout = new LayoutConfiguration { LayoutPath = layoutRoot };
+
+        Assert.Equal(entryPoint, layout.GetWatchToolPath());
+    }
+
+    [Fact]
+    public void GetWatchToolPath_ReturnsNull_WhenWatchEntryPointMissing()
+    {
+        // Externally-supplied/legacy layouts (and the inner-loop dev path) may lack a watch/ directory.
+        // GetWatchToolPath must return null in that case so callers don't inject a dangling
+        // ASPIRE_WATCH_TOOL_PATH pointing at a non-existent DLL.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layout = new LayoutConfiguration { LayoutPath = workspace.WorkspaceRoot.FullName };
+
+        Assert.Null(layout.GetWatchToolPath());
+    }
+
+    [Fact]
+    public void GetWatchToolPath_ReturnsNull_WhenLayoutPathUnset()
+    {
+        var layout = new LayoutConfiguration();
+
+        Assert.Null(layout.GetWatchToolPath());
+    }
+}
+
+/// <summary>
+/// Covers the inner-loop dev fallback that resolves the watch tool from the NuGet global
+/// packages cache (used when running <c>dotnet run --project src/Aspire.Cli</c> with no CLI
+/// bundle present). These tests mutate the process-wide <c>NUGET_PACKAGES</c> variable, which
+/// <see cref="BundleDiscovery.TryGetWatchToolPathFromNuGetCache(string?)"/> reads, so they join
+/// <see cref="EnvVarMutatingTestCollection"/> to serialize against other env-var-mutating suites.
+/// </summary>
+[Collection(EnvVarMutatingTestCollection.Name)]
+public class WatchNuGetCacheDiscoveryTests(ITestOutputHelper outputHelper)
+{
+    // Intentionally a far-into-the-future package version for testing
+    private const string TestWatchPackageVersion = "20.0.100";
+
+    [Fact]
+    public void TryGetWatchToolPathFromNuGetCache_FindsEntryPoint_ForPinnedVersion()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var cacheRoot = workspace.WorkspaceRoot.FullName;
+
+        var toolsDir = Path.Combine(cacheRoot, BundleDiscovery.WatchToolNugetCacheFolder, TestWatchPackageVersion, "tools", BundleDiscovery.WatchToolDotNetVersion, "any");
+        Directory.CreateDirectory(toolsDir);
+        var entryPoint = Path.Combine(toolsDir, BundleDiscovery.WatchToolDllName);
+        File.WriteAllText(entryPoint, "stub");
+
+        var original = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        try
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", cacheRoot);
+            Assert.Equal(entryPoint, BundleDiscovery.TryGetWatchToolPathFromNuGetCache(TestWatchPackageVersion));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", original);
+        }
+    }
+
+    [Fact]
+    public void TryGetWatchToolPathFromNuGetCache_FindsPrereleaseEntryPoint_WhenVersionUnspecified()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var cacheRoot = workspace.WorkspaceRoot.FullName;
+        var prereleaseVersion = $"{TestWatchPackageVersion}-preview.1";
+
+        var toolsDir = Path.Combine(cacheRoot, BundleDiscovery.WatchToolNugetCacheFolder, prereleaseVersion, "tools", BundleDiscovery.WatchToolDotNetVersion, "any");
+        Directory.CreateDirectory(toolsDir);
+        var entryPoint = Path.Combine(toolsDir, BundleDiscovery.WatchToolDllName);
+        File.WriteAllText(entryPoint, "stub");
+
+        var original = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        try
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", cacheRoot);
+            Assert.Equal(toolsDir, BundleDiscovery.TryGetWatchToolDirectoryFromNuGetCache(version: null));
+            Assert.Equal(entryPoint, BundleDiscovery.TryGetWatchToolPathFromNuGetCache(version: null));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", original);
+        }
+    }
+
+    [Fact]
+    public void TryGetWatchToolPathFromNuGetCache_ReturnsNull_WhenPackageMissing()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var cacheRoot = workspace.WorkspaceRoot.FullName;
+
+        var original = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        try
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", cacheRoot);
+            Assert.Null(BundleDiscovery.TryGetWatchToolPathFromNuGetCache(TestWatchPackageVersion));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", original);
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.InternalTesting;
 using System.Security.Cryptography;
 using System.Text;
 using System.Xml.Linq;
+using Aspire.Cli.Tests.Acquisition;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
@@ -12,6 +13,7 @@ using Aspire.Cli.Utils;
 using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -473,6 +475,162 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
         foreach (var dir in dirInfo.GetDirectories())
         {
             DumpDirectoryTree(dir.FullName, output, indent + "  ");
+        }
+    }
+}
+
+[Collection(EnvVarMutatingTestCollection.Name)]
+public class AppHostServerProjectWatchEnvironmentTests(ITestOutputHelper outputHelper) : IDisposable
+{
+    private const string TestWatchPackageVersion = "20.0.100-preview.1";
+    private readonly TemporaryWorkspace _workspace = TemporaryWorkspace.Create(outputHelper);
+
+    public void Dispose()
+    {
+        _workspace.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void CreateStartInfo_InjectsWatchToolAndSdkPathFromRepoCache()
+    {
+        var (repoRoot, cacheRoot, watchToolPath) = CreateRepoLocalWatchPackage(TestWatchPackageVersion);
+        var watchSdkDir = Path.Combine(_workspace.WorkspaceRoot.FullName, "fake-sdk", "sdk", "20.0.100");
+        var runner = new TestDotNetCliRunner
+        {
+            TryGetWatchSdkDirectoryCallback = () => watchSdkDir
+        };
+
+        RunWithNuGetPackages(cacheRoot, () =>
+        {
+            var project = CreateProject(runner, repoRoot);
+
+            var startInfo = project.CreateStartInfo(hostPid: 123);
+
+            Assert.Equal(watchToolPath, startInfo.Environment[BundleDiscovery.WatchToolPathEnvVar]);
+            Assert.Equal(watchSdkDir, startInfo.Environment[BundleDiscovery.WatchSdkPathEnvVar]);
+        });
+    }
+
+    [Fact]
+    public void CreateStartInfo_OmitsWatchSdkPathWhenSdkDirectoryUnavailable()
+    {
+        var (repoRoot, cacheRoot, watchToolPath) = CreateRepoLocalWatchPackage(TestWatchPackageVersion);
+        var runner = new TestDotNetCliRunner
+        {
+            TryGetWatchSdkDirectoryCallback = () => null
+        };
+
+        RunWithNuGetPackages(cacheRoot, () =>
+        {
+            var project = CreateProject(runner, repoRoot);
+
+            var startInfo = project.CreateStartInfo(hostPid: 123);
+
+            Assert.Equal(watchToolPath, startInfo.Environment[BundleDiscovery.WatchToolPathEnvVar]);
+            Assert.False(startInfo.Environment.ContainsKey(BundleDiscovery.WatchSdkPathEnvVar));
+        });
+    }
+
+    [Fact]
+    public void CreateStartInfo_OmitsWatchEnvironmentWhenRepoCacheHasNoWatchPackage()
+    {
+        var repoRoot = CreateRepoRoot(TestWatchPackageVersion);
+        var cacheRoot = Path.Combine(_workspace.WorkspaceRoot.FullName, "empty-cache");
+        Directory.CreateDirectory(cacheRoot);
+        var runner = new TestDotNetCliRunner
+        {
+            TryGetWatchSdkDirectoryCallback = () => Path.Combine(_workspace.WorkspaceRoot.FullName, "fake-sdk", "sdk", "20.0.100")
+        };
+
+        RunWithNuGetPackages(cacheRoot, () =>
+        {
+            var project = CreateProject(runner, repoRoot);
+
+            var startInfo = project.CreateStartInfo(hostPid: 123);
+
+            Assert.False(startInfo.Environment.ContainsKey(BundleDiscovery.WatchToolPathEnvVar));
+            Assert.False(startInfo.Environment.ContainsKey(BundleDiscovery.WatchSdkPathEnvVar));
+        });
+    }
+
+    [Fact]
+    public void CreateStartInfo_PreservesExplicitWatchToolPath()
+    {
+        var (repoRoot, cacheRoot, _) = CreateRepoLocalWatchPackage(TestWatchPackageVersion);
+        var customWatchTool = Path.Combine(_workspace.WorkspaceRoot.FullName, "custom-watch", BundleDiscovery.WatchToolDllName);
+        var runner = new TestDotNetCliRunner
+        {
+            TryGetWatchSdkDirectoryCallback = () => Path.Combine(_workspace.WorkspaceRoot.FullName, "fake-sdk", "sdk", "20.0.100")
+        };
+
+        RunWithNuGetPackages(cacheRoot, () =>
+        {
+            var project = CreateProject(runner, repoRoot);
+
+            var startInfo = project.CreateStartInfo(
+                hostPid: 123,
+                environmentVariables: new Dictionary<string, string>
+                {
+                    [BundleDiscovery.WatchToolPathEnvVar] = customWatchTool
+                });
+
+            Assert.Equal(customWatchTool, startInfo.Environment[BundleDiscovery.WatchToolPathEnvVar]);
+            Assert.False(startInfo.Environment.ContainsKey(BundleDiscovery.WatchSdkPathEnvVar));
+        });
+    }
+
+    private DotNetBasedAppHostServerProject CreateProject(TestDotNetCliRunner runner, string repoRoot)
+    {
+        return new DotNetBasedAppHostServerProject(
+            _workspace.WorkspaceRoot.FullName,
+            "test.sock",
+            repoRoot,
+            runner,
+            MockPackagingServiceFactory.Create(),
+            NullLogger<DotNetBasedAppHostServerProject>.Instance);
+    }
+
+    private (string RepoRoot, string CacheRoot, string WatchToolPath) CreateRepoLocalWatchPackage(string version)
+    {
+        var repoRoot = CreateRepoRoot(version);
+        var cacheRoot = Path.Combine(_workspace.WorkspaceRoot.FullName, "nuget-cache");
+        var toolsDir = Path.Combine(cacheRoot, BundleDiscovery.WatchToolNugetCacheFolder, version, "tools", BundleDiscovery.WatchToolDotNetVersion, "any");
+        Directory.CreateDirectory(toolsDir);
+
+        var watchToolPath = Path.Combine(toolsDir, BundleDiscovery.WatchToolDllName);
+        File.WriteAllText(watchToolPath, "stub");
+
+        return (repoRoot, cacheRoot, watchToolPath);
+    }
+
+    private string CreateRepoRoot(string watchVersion)
+    {
+        var repoRoot = Path.Combine(_workspace.WorkspaceRoot.FullName, "repo");
+        var engDir = Path.Combine(repoRoot, "eng");
+        Directory.CreateDirectory(engDir);
+        File.WriteAllText(Path.Combine(engDir, "Versions.props"), $$"""
+            <Project>
+              <PropertyGroup>
+                <MicrosoftDotNetHotReloadWatchAspireVersion>{{watchVersion}}</MicrosoftDotNetHotReloadWatchAspireVersion>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        return repoRoot;
+    }
+
+    private static void RunWithNuGetPackages(string cacheRoot, Action action)
+    {
+        var original = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        try
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", cacheRoot);
+            action();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", original);
         }
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
@@ -24,12 +24,16 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
         // of the in-repo aspire-managed discovery; otherwise the repo's real built artifact
         // shadows the fake bundle path the test pre-stamped into the layout.
         DotNetAppHostProject.RepoLocalManagedPathProviderOverride = () => null;
+
+        // Likewise neutralize the repo-local watch tool probe. Individual watch tests set this explicitly.
+        DotNetAppHostProject.RepoLocalWatchToolPathProviderOverride = () => null;
         return this;
     }
 
     public void Dispose()
     {
         DotNetAppHostProject.RepoLocalManagedPathProviderOverride = null;
+        DotNetAppHostProject.RepoLocalWatchToolPathProviderOverride = null;
 
         foreach (var serviceProvider in _serviceProviders)
         {
@@ -473,6 +477,177 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             {
                 [BundleDiscovery.TerminalHostPathEnvVar] = customTerminalHost
             }
+        }, CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProjectAppHostInjectsWatchToolAndSdkPathFromBundle()
+    {
+        UseFakeRepoRoot();
+        var appHostFile = CreateProjectAppHost();
+        var bundleRoot = CreateCliBundle(out var layout, includeWatch: true);
+        var watchSdkDir = Path.Combine(_workspace.WorkspaceRoot.FullName, "fake-sdk", "sdk", "20.0.100");
+
+        var runner = CreateCliBundleRunner();
+        runner.TryGetWatchSdkDirectoryCallback = () => watchSdkDir;
+        var project = CreateDotNetAppHostProject(runner, layout);
+
+        var expectedWatchToolPath = Path.Combine(
+            bundleRoot.FullName, BundleDiscovery.WatchDirectoryName, BundleDiscovery.WatchToolDllName);
+
+        runner.RunAsyncCallback = (_, _, _, _, _, env, _, _, _) =>
+        {
+            Assert.Equal(expectedWatchToolPath, env![BundleDiscovery.WatchToolPathEnvVar]);
+            Assert.Equal(watchSdkDir, env[BundleDiscovery.WatchSdkPathEnvVar]);
+            return Task.FromResult(0);
+        };
+
+        var exitCode = await project.RunAsync(new AppHostProjectContext
+        {
+            AppHostFile = appHostFile,
+            NoBuild = false,
+            NoRestore = false,
+            WorkingDirectory = _workspace.WorkspaceRoot,
+            EnvironmentVariables = new Dictionary<string, string>()
+        }, CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProjectAppHostOmitsWatchSdkPathWhenSdkDirectoryUnavailable()
+    {
+        // No private SDK install (TryGetWatchSdkDirectory returns null): the tool path is still
+        // injected, but ASPIRE_WATCH_SDK_PATH is omitted so the watch host resolves it itself.
+        UseFakeRepoRoot();
+        var appHostFile = CreateProjectAppHost();
+        var bundleRoot = CreateCliBundle(out var layout, includeWatch: true);
+
+        var runner = CreateCliBundleRunner();
+        runner.TryGetWatchSdkDirectoryCallback = () => null;
+        var project = CreateDotNetAppHostProject(runner, layout);
+
+        var expectedWatchToolPath = Path.Combine(
+            bundleRoot.FullName, BundleDiscovery.WatchDirectoryName, BundleDiscovery.WatchToolDllName);
+
+        runner.RunAsyncCallback = (_, _, _, _, _, env, _, _, _) =>
+        {
+            Assert.Equal(expectedWatchToolPath, env![BundleDiscovery.WatchToolPathEnvVar]);
+            Assert.False(env.ContainsKey(BundleDiscovery.WatchSdkPathEnvVar));
+            return Task.FromResult(0);
+        };
+
+        var exitCode = await project.RunAsync(new AppHostProjectContext
+        {
+            AppHostFile = appHostFile,
+            NoBuild = false,
+            NoRestore = false,
+            WorkingDirectory = _workspace.WorkspaceRoot,
+            EnvironmentVariables = new Dictionary<string, string>()
+        }, CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProjectAppHostOmitsWatchEnvironmentWhenBundleHasNoWatchComponent()
+    {
+        // Older bundles extracted before the watch tool shipped have no watch/ directory.
+        // Injection must be skipped entirely rather than pointing at a non-existent DLL.
+        UseFakeRepoRoot();
+        var appHostFile = CreateProjectAppHost();
+        _ = CreateCliBundle(out var layout, includeWatch: false);
+
+        var runner = CreateCliBundleRunner();
+        runner.TryGetWatchSdkDirectoryCallback = () => Path.Combine(_workspace.WorkspaceRoot.FullName, "fake-sdk");
+        var project = CreateDotNetAppHostProject(runner, layout);
+
+        runner.RunAsyncCallback = (_, _, _, _, _, env, _, _, _) =>
+        {
+            Assert.False(env!.ContainsKey(BundleDiscovery.WatchToolPathEnvVar));
+            Assert.False(env.ContainsKey(BundleDiscovery.WatchSdkPathEnvVar));
+            return Task.FromResult(0);
+        };
+
+        var exitCode = await project.RunAsync(new AppHostProjectContext
+        {
+            AppHostFile = appHostFile,
+            NoBuild = false,
+            NoRestore = false,
+            WorkingDirectory = _workspace.WorkspaceRoot,
+            EnvironmentVariables = new Dictionary<string, string>()
+        }, CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProjectAppHostPreservesExplicitWatchToolPath()
+    {
+        // A user side-loading a custom watch build via ASPIRE_WATCH_TOOL_PATH must win: the CLI
+        // must not overwrite it, and because the whole watch block is gated on the path being
+        // absent, it must not append an ASPIRE_WATCH_SDK_PATH the user didn't ask for either.
+        UseFakeRepoRoot();
+        var appHostFile = CreateProjectAppHost();
+        _ = CreateCliBundle(out var layout, includeWatch: true);
+        var customWatchTool = Path.Combine(_workspace.WorkspaceRoot.FullName, "my-custom-watch", BundleDiscovery.WatchToolDllName);
+
+        var runner = CreateCliBundleRunner();
+        runner.TryGetWatchSdkDirectoryCallback = () => Path.Combine(_workspace.WorkspaceRoot.FullName, "fake-sdk");
+        var project = CreateDotNetAppHostProject(runner, layout);
+
+        runner.RunAsyncCallback = (_, _, _, _, _, env, _, _, _) =>
+        {
+            Assert.Equal(customWatchTool, env![BundleDiscovery.WatchToolPathEnvVar]);
+            Assert.False(env.ContainsKey(BundleDiscovery.WatchSdkPathEnvVar));
+            return Task.FromResult(0);
+        };
+
+        var exitCode = await project.RunAsync(new AppHostProjectContext
+        {
+            AppHostFile = appHostFile,
+            NoBuild = false,
+            NoRestore = false,
+            WorkingDirectory = _workspace.WorkspaceRoot,
+            EnvironmentVariables = new Dictionary<string, string>
+            {
+                [BundleDiscovery.WatchToolPathEnvVar] = customWatchTool
+            }
+        }, CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProjectAppHostPrefersRepoLocalWatchToolOverBundle()
+    {
+        // In repo/dev mode the watch tool is resolved from the NuGet cache (repo-local) and must
+        // take precedence over the bundle's watch/ directory, mirroring the repo-local managed
+        // path precedence used for the terminal host.
+        UseFakeRepoRoot();
+        var appHostFile = CreateProjectAppHost();
+        _ = CreateCliBundle(out var layout, includeWatch: true);
+        var repoLocalWatchTool = Path.Combine(_workspace.WorkspaceRoot.FullName, "repo-cache", BundleDiscovery.WatchToolDllName);
+        DotNetAppHostProject.RepoLocalWatchToolPathProviderOverride = () => repoLocalWatchTool;
+
+        var runner = CreateCliBundleRunner();
+        var project = CreateDotNetAppHostProject(runner, layout);
+
+        runner.RunAsyncCallback = (_, _, _, _, _, env, _, _, _) =>
+        {
+            Assert.Equal(repoLocalWatchTool, env![BundleDiscovery.WatchToolPathEnvVar]);
+            return Task.FromResult(0);
+        };
+
+        var exitCode = await project.RunAsync(new AppHostProjectContext
+        {
+            AppHostFile = appHostFile,
+            NoBuild = false,
+            NoRestore = false,
+            WorkingDirectory = _workspace.WorkspaceRoot,
+            EnvironmentVariables = new Dictionary<string, string>()
         }, CancellationToken.None);
 
         Assert.Equal(0, exitCode);
@@ -1745,11 +1920,19 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
         return new FileInfo(appHostPath);
     }
 
-    private DirectoryInfo CreateCliBundle(out LayoutConfiguration layout)
+    private DirectoryInfo CreateCliBundle(out LayoutConfiguration layout, bool includeWatch = false)
     {
         var bundleRoot = Directory.CreateDirectory(Path.Combine(_workspace.WorkspaceRoot.FullName, Guid.NewGuid().ToString()));
         Directory.CreateDirectory(Path.Combine(bundleRoot.FullName, BundleDiscovery.DcpDirectoryName));
         Directory.CreateDirectory(Path.Combine(bundleRoot.FullName, BundleDiscovery.ManagedDirectoryName));
+
+        if (includeWatch)
+        {
+            // Stage the optional watch/ component with its entry-point DLL so the layout's
+            // GetWatchToolPath() File.Exists probe succeeds (older bundles omit this directory).
+            var watchDir = Directory.CreateDirectory(Path.Combine(bundleRoot.FullName, BundleDiscovery.WatchDirectoryName));
+            File.WriteAllText(Path.Combine(watchDir.FullName, BundleDiscovery.WatchToolDllName), "stub");
+        }
 
         layout = new LayoutConfiguration
         {
@@ -1762,6 +1945,28 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
         };
 
         return bundleRoot;
+    }
+
+    private static TestDotNetCliRunner CreateCliBundleRunner()
+    {
+        return new TestDotNetCliRunner
+        {
+            BuildAsyncCallback = (_, _, _, _) => 0,
+            GetProjectItemsAndPropertiesAsyncCallback = (_, _, _, _, _) =>
+            {
+                return (0, JsonDocument.Parse($$"""
+                    {
+                      "Properties": {
+                        "MSBuildVersion": "17.0.0",
+                        "IsAspireHost": "true",
+                        "AspireHostingSDKVersion": "{{VersionHelper.GetDefaultTemplateVersion()}}",
+                        "AspireUseCliBundle": "true"
+                      },
+                      "Items": {}
+                    }
+                    """));
+            }
+        };
     }
 
     private DotNetAppHostProject CreateDotNetAppHostProject(

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -322,6 +322,81 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
         }
     }
 
+    [Fact]
+    public void CreateStartInfo_InjectsWatchToolAndSdkPathFromBundle()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layout = CreateBundleLayout(workspace, includeWatch: true);
+        var watchSdkDir = Path.Combine(workspace.WorkspaceRoot.FullName, "fake-sdk", "sdk", "20.0.100");
+        var runner = new TestDotNetCliRunner
+        {
+            TryGetWatchSdkDirectoryCallback = () => watchSdkDir
+        };
+        var server = CreateServerWithLayout(workspace, layout, runner);
+
+        var startInfo = server.CreateStartInfo(hostPid: 123);
+
+        Assert.Equal(layout.GetWatchToolPath(), startInfo.Environment[BundleDiscovery.WatchToolPathEnvVar]);
+        Assert.Equal(watchSdkDir, startInfo.Environment[BundleDiscovery.WatchSdkPathEnvVar]);
+    }
+
+    [Fact]
+    public void CreateStartInfo_OmitsWatchSdkPathWhenSdkDirectoryUnavailable()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layout = CreateBundleLayout(workspace, includeWatch: true);
+        var runner = new TestDotNetCliRunner
+        {
+            TryGetWatchSdkDirectoryCallback = () => null
+        };
+        var server = CreateServerWithLayout(workspace, layout, runner);
+
+        var startInfo = server.CreateStartInfo(hostPid: 123);
+
+        Assert.Equal(layout.GetWatchToolPath(), startInfo.Environment[BundleDiscovery.WatchToolPathEnvVar]);
+        Assert.False(startInfo.Environment.ContainsKey(BundleDiscovery.WatchSdkPathEnvVar));
+    }
+
+    [Fact]
+    public void CreateStartInfo_OmitsWatchEnvironmentWhenBundleHasNoWatchComponent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layout = CreateBundleLayout(workspace, includeWatch: false);
+        var runner = new TestDotNetCliRunner
+        {
+            TryGetWatchSdkDirectoryCallback = () => Path.Combine(workspace.WorkspaceRoot.FullName, "fake-sdk", "sdk", "20.0.100")
+        };
+        var server = CreateServerWithLayout(workspace, layout, runner);
+
+        var startInfo = server.CreateStartInfo(hostPid: 123);
+
+        Assert.False(startInfo.Environment.ContainsKey(BundleDiscovery.WatchToolPathEnvVar));
+        Assert.False(startInfo.Environment.ContainsKey(BundleDiscovery.WatchSdkPathEnvVar));
+    }
+
+    [Fact]
+    public void CreateStartInfo_PreservesExplicitWatchToolPath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layout = CreateBundleLayout(workspace, includeWatch: true);
+        var customWatchTool = Path.Combine(workspace.WorkspaceRoot.FullName, "custom-watch", BundleDiscovery.WatchToolDllName);
+        var runner = new TestDotNetCliRunner
+        {
+            TryGetWatchSdkDirectoryCallback = () => Path.Combine(workspace.WorkspaceRoot.FullName, "fake-sdk", "sdk", "20.0.100")
+        };
+        var server = CreateServerWithLayout(workspace, layout, runner);
+
+        var startInfo = server.CreateStartInfo(
+            hostPid: 123,
+            environmentVariables: new Dictionary<string, string>
+            {
+                [BundleDiscovery.WatchToolPathEnvVar] = customWatchTool
+            });
+
+        Assert.Equal(customWatchTool, startInfo.Environment[BundleDiscovery.WatchToolPathEnvVar]);
+        Assert.False(startInfo.Environment.ContainsKey(BundleDiscovery.WatchSdkPathEnvVar));
+    }
+
     // PSM-guard cross-product tests.
     // Guard predicate: the resolved channel.Name == "local" — i.e. the *project requested* the
     // local pseudo-channel. The local hive has no real mappings, so emitting PSM would just
@@ -970,6 +1045,54 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             packagingService,
             executionContext,
             NullLogger.Instance);
+    }
+
+    private static PrebuiltAppHostServer CreateServerWithLayout(
+        TemporaryWorkspace workspace,
+        LayoutConfiguration layout,
+        TestDotNetCliRunner runner)
+    {
+        var executionContext = TestExecutionContextFactory.CreateTestContext();
+        var nugetService = new BundleNuGetService(
+            new NullLayoutDiscovery(),
+            new LayoutProcessRunner(new TestProcessExecutionFactory()),
+            new TestFeatures(),
+            executionContext,
+            NullLogger<BundleNuGetService>.Instance);
+
+        return new PrebuiltAppHostServer(
+            workspace.WorkspaceRoot.FullName,
+            "test.sock",
+            layout,
+            nugetService,
+            runner,
+            new TestDotNetSdkInstaller(),
+            MockPackagingServiceFactory.Create(),
+            executionContext,
+            NullLogger.Instance);
+    }
+
+    private static LayoutConfiguration CreateBundleLayout(TemporaryWorkspace workspace, bool includeWatch)
+    {
+        var layoutRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "bundle-layout");
+        Directory.CreateDirectory(layoutRoot);
+
+        var managedDir = Path.Combine(layoutRoot, BundleDiscovery.ManagedDirectoryName);
+        Directory.CreateDirectory(managedDir);
+        File.WriteAllText(
+            Path.Combine(managedDir, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
+            "stub");
+
+        Directory.CreateDirectory(Path.Combine(layoutRoot, BundleDiscovery.DcpDirectoryName));
+
+        if (includeWatch)
+        {
+            var watchDir = Path.Combine(layoutRoot, BundleDiscovery.WatchDirectoryName);
+            Directory.CreateDirectory(watchDir);
+            File.WriteAllText(Path.Combine(watchDir, BundleDiscovery.WatchToolDllName), "stub");
+        }
+
+        return new LayoutConfiguration { LayoutPath = layoutRoot };
     }
 
     private static CliExecutionContext CreateContextWithIdentityChannel(string identityChannel) =>

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -462,6 +462,8 @@ public class DotNetTemplateFactoryTests
 
         public Task<int> InitUserSecretsAsync(FileInfo projectFile, ProcessInvocationOptions options, CancellationToken cancellationToken)
             => Task.FromResult(0);
+
+        public string? TryGetWatchSdkDirectory() => null;
     }
 
     private sealed class TestCertificateService : ICertificateService

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -196,4 +196,9 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
 
     public Task<int> InitUserSecretsAsync(FileInfo projectFile, ProcessInvocationOptions options, CancellationToken cancellationToken)
         => Task.FromResult(0);
+
+    public Func<string?>? TryGetWatchSdkDirectoryCallback { get; set; }
+
+    public string? TryGetWatchSdkDirectory()
+        => TryGetWatchSdkDirectoryCallback?.Invoke();
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/ConfigureDefaultDcpOptionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ConfigureDefaultDcpOptionsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Dcp;
+using Aspire.Shared;
 using Microsoft.Extensions.Configuration;
 
 namespace Aspire.Hosting.Tests.Dcp;
@@ -94,6 +95,78 @@ public class ConfigureDefaultDcpOptionsTests
 
         Assert.Equal(managedPath, options.TerminalHostPath);
         Assert.Equal("custom-subcommand", options.TerminalHostInvocationArgs);
+    }
+
+    [Fact]
+    public void WatchToolPathAndSdkPathBindFromEnvironmentVariables()
+    {
+        // The CLI injects ASPIRE_WATCH_TOOL_PATH / ASPIRE_WATCH_SDK_PATH at app-host launch.
+        // These are read as top-level configuration keys (env vars), not DcpPublisher settings.
+        var watchToolPath = Path.Combine(Path.GetTempPath(), "aspire-fake-bundle", "watch", BundleDiscovery.WatchToolDllName);
+        var watchSdkPath = Path.Combine(Path.GetTempPath(), "fake-sdk", "sdk", "20.0.200");
+
+        var options = ConfigureWithDcpPublisher(new()
+        {
+            ["ASPIRE_WATCH_TOOL_PATH"] = watchToolPath,
+            ["ASPIRE_WATCH_SDK_PATH"] = watchSdkPath,
+        });
+
+        Assert.Equal(watchToolPath, options.WatchToolPath);
+        Assert.Equal(watchSdkPath, options.WatchSdkPath);
+    }
+
+    [Fact]
+    public void WatchToolPathAndSdkPathBindFromDcpPublisherConfiguration()
+    {
+        // Programmatic override path: DcpPublisher:WatchToolPath / WatchSdkPath.
+        var watchToolPath = Path.Combine(Path.GetTempPath(), "custom-watch", BundleDiscovery.WatchToolDllName);
+        var watchSdkPath = Path.Combine(Path.GetTempPath(), "custom-sdk", "sdk", "20.0.200");
+
+        var options = ConfigureWithDcpPublisher(new()
+        {
+            ["DcpPublisher:WatchToolPath"] = watchToolPath,
+            ["DcpPublisher:WatchSdkPath"] = watchSdkPath,
+        });
+
+        Assert.Equal(watchToolPath, options.WatchToolPath);
+        Assert.Equal(watchSdkPath, options.WatchSdkPath);
+    }
+
+    [Fact]
+    public void WatchEnvironmentVariablesTakePrecedenceOverDcpPublisherConfiguration()
+    {
+        // Env var (user/CLI injection) wins over the DcpPublisher programmatic value, mirroring
+        // the established precedence: env var > DcpPublisher config > assembly metadata.
+        var envWatchToolPath = Path.Combine(Path.GetTempPath(), "env-watch", BundleDiscovery.WatchToolDllName);
+        var envWatchSdkPath = Path.Combine(Path.GetTempPath(), "env-sdk", "sdk", "20.0.200");
+
+        var options = ConfigureWithDcpPublisher(new()
+        {
+            ["ASPIRE_WATCH_TOOL_PATH"] = envWatchToolPath,
+            ["ASPIRE_WATCH_SDK_PATH"] = envWatchSdkPath,
+            ["DcpPublisher:WatchToolPath"] = Path.Combine(Path.GetTempPath(), "ignored-watch", "ignored-watch.dll"),
+            ["DcpPublisher:WatchSdkPath"] = Path.Combine(Path.GetTempPath(), "ignored-sdk"),
+        });
+
+        Assert.Equal(envWatchToolPath, options.WatchToolPath);
+        Assert.Equal(envWatchSdkPath, options.WatchSdkPath);
+    }
+
+    [Fact]
+    public void WatchPathsAreNullWhenUnset()
+    {
+        // Watch is an optional, experimental component: a normal `aspire run` with no watch
+        // env vars / config must leave the paths null without breaking options configuration.
+        var managedExe = OperatingSystem.IsWindows() ? "aspire-managed.exe" : "aspire-managed";
+        var managedPath = Path.Combine(Path.GetTempPath(), "aspire-fake-bundle", "managed", managedExe);
+
+        var options = ConfigureWithDcpPublisher(new()
+        {
+            ["DcpPublisher:DashboardPath"] = managedPath,
+        });
+
+        Assert.Null(options.WatchToolPath);
+        Assert.Null(options.WatchSdkPath);
     }
 
     private static DcpOptions ConfigureWithDcpPublisher(Dictionary<string, string?> dcpPublisherSettings)

--- a/tools/CreateLayout/CreateLayout.csproj
+++ b/tools/CreateLayout/CreateLayout.csproj
@@ -18,4 +18,17 @@
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="$(SharedDir)BundleDiscovery.cs" Link="Shared\BundleDiscovery.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      Download (but don't reference) the watch tool so it lands in the NuGet global packages
+      folder before CopyWatch() copies it into the bundle's watch/ directory. 
+      RID-agnostic (net10.0/any), so a single download covers every bundle RID.
+    -->
+    <PackageDownload Include="Microsoft.DotNet.HotReload.Watch.Aspire" Version="[$(MicrosoftDotNetHotReloadWatchAspireVersion)]" />
+  </ItemGroup>
+
 </Project>

--- a/tools/CreateLayout/Program.cs
+++ b/tools/CreateLayout/Program.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.Compression;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aspire.Shared;
 
 namespace Aspire.Tools.CreateLayout;
 
@@ -44,6 +45,13 @@ public static class Program
             DefaultValueFactory = _ => "0.0.0-dev"
         };
 
+        var watchVersionOption = new Option<string>("--watch-version")
+        {
+            Description = "Pinned version of the Microsoft.DotNet.HotReload.Watch.Aspire tool to bundle. " +
+                          "When empty, the newest version found in the NuGet cache is used.",
+            DefaultValueFactory = _ => string.Empty
+        };
+
         var archiveOption = new Option<bool>("--archive")
         {
             Description = "Create archive (zip/tar.gz) after building"
@@ -59,6 +67,7 @@ public static class Program
         rootCommand.Options.Add(artifactsOption);
         rootCommand.Options.Add(ridOption);
         rootCommand.Options.Add(bundleVersionOption);
+        rootCommand.Options.Add(watchVersionOption);
         rootCommand.Options.Add(archiveOption);
         rootCommand.Options.Add(verboseOption);
 
@@ -68,12 +77,13 @@ public static class Program
             var artifactsPath = parseResult.GetValue(artifactsOption)!;
             var rid = parseResult.GetValue(ridOption)!;
             var version = parseResult.GetValue(bundleVersionOption)!;
+            var watchVersion = parseResult.GetValue(watchVersionOption)!;
             var createArchive = parseResult.GetValue(archiveOption);
             var verbose = parseResult.GetValue(verboseOption);
 
             try
             {
-                using var builder = new LayoutBuilder(outputPath, artifactsPath, rid, version, verbose);
+                using var builder = new LayoutBuilder(outputPath, artifactsPath, rid, version, watchVersion, verbose);
                 await builder.BuildAsync().ConfigureAwait(false);
 
                 if (createArchive)
@@ -108,14 +118,16 @@ internal sealed class LayoutBuilder : IDisposable
     private readonly string _artifactsPath;
     private readonly string _rid;
     private readonly string _version;
+    private readonly string _watchVersion;
     private readonly bool _verbose;
 
-    public LayoutBuilder(string outputPath, string artifactsPath, string rid, string version, bool verbose)
+    public LayoutBuilder(string outputPath, string artifactsPath, string rid, string version, string watchVersion, bool verbose)
     {
         _outputPath = Path.GetFullPath(outputPath);
         _artifactsPath = Path.GetFullPath(artifactsPath);
         _rid = rid;
         _version = version;
+        _watchVersion = watchVersion;
         _verbose = verbose;
     }
 
@@ -140,6 +152,7 @@ internal sealed class LayoutBuilder : IDisposable
         // Copy components
         CopyManaged();
         await CopyDcpAsync().ConfigureAwait(false);
+        CopyWatch();
 
         Log("Layout build complete!");
     }
@@ -203,6 +216,31 @@ internal sealed class LayoutBuilder : IDisposable
 
         return Task.CompletedTask;
     }
+
+    private void CopyWatch()
+    {
+        Log("Copying watch tool...");
+
+        // The watch tool (Microsoft.DotNet.HotReload.Watch.Aspire) is downloaded into the NuGet
+        // global packages folder by the PackageDownload in CreateLayout.csproj. It is RID-agnostic
+        // (tools/net10.0/any), so a single copy serves every bundle RID.
+        var watchPath = BundleDiscovery.TryGetWatchToolDirectoryFromNuGetCache(_watchVersion);
+        if (watchPath is null)
+        {
+            throw new InvalidOperationException(
+                $"Watch tool package '{WatchPackageName}' (version '{(string.IsNullOrEmpty(_watchVersion) ? "latest" : _watchVersion)}') not found. " +
+                $"Ensure the package is restored into the NuGet global packages folder before running CreateLayout " +
+                $"(it is downloaded via the PackageDownload in tools/CreateLayout/CreateLayout.csproj).");
+        }
+
+        var watchDir = Path.Combine(_outputPath, "watch");
+        Directory.CreateDirectory(watchDir);
+
+        CopyDirectory(watchPath, watchDir);
+        Log($"  Copied watch tool to watch");
+    }
+
+    private const string WatchPackageName = "Microsoft.DotNet.HotReload.Watch.Aspire";
 
     public async Task<string> CreateArchiveAsync()
     {


### PR DESCRIPTION
## Description

The tool is necessary for (upcoming) Aspire watch command to work with all application host languages.

This grows the Aspire bundle from roughly 107.5 MB to 120.5 MB, a 12% increase in size.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
