### PR TITLE
Add DNX AppHost CLI invocation opt-in

### DIFF
--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -13,6 +13,7 @@
 | `ASPIRE008` | Error | '\[ProjectName\]' project requires GenerateAssemblyInfo to be enabled. The Aspire AppHost relies on assembly metadata attributes to locate required dependencies. Please remove &lt;GenerateAssemblyInfo&gt;false&lt;/GenerateAssemblyInfo&gt; from your project file or set it to true. | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets](../src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets) |
 | `ASPIRE009` | Error | '\[ProjectName\]' is configured to use the Aspire CLI bundle, but the bundle could not be resolved. | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets](../src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets) |
 | `ASPIRE010` | Warning | '\[ProjectName\]' is configured with AspireUseCliBundle=false. Some Aspire features may not work when the Aspire CLI bundle is not being used. | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets](../src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets) |
+| `ASPIRE011` | Error | '\[ProjectName\]' is configured with AspireCliInvocationMode=Dnx, but the dnx command could not be found on PATH. | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets](../src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets) |
 
 ## Analyzer Warnings
 

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -16,6 +16,8 @@
   <!-- Use TaskHostFactory when running in the repo so the Aspire.Hosting.Tasks.dll assembly is not locked. -->
   <UsingTask Condition="'$(_AspireUseTaskHostFactory)' != 'true'" TaskName="GetNonExecutableReferences" AssemblyFile="$(_AspireTasksAssembly)" />
   <UsingTask Condition="'$(_AspireUseTaskHostFactory)' == 'true'" TaskName="GetNonExecutableReferences" AssemblyFile="$(_AspireTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <UsingTask Condition="'$(_AspireUseTaskHostFactory)' != 'true'" TaskName="ResolveDnxPath" AssemblyFile="$(_AspireTasksAssembly)" />
+  <UsingTask Condition="'$(_AspireUseTaskHostFactory)' == 'true'" TaskName="ResolveDnxPath" AssemblyFile="$(_AspireTasksAssembly)" TaskFactory="TaskHostFactory" />
   <UsingTask Condition="'$(_AspireUseTaskHostFactory)' != 'true'" TaskName="ResolveAspireCliBundle" AssemblyFile="$(_AspireTasksAssembly)" />
   <UsingTask Condition="'$(_AspireUseTaskHostFactory)' == 'true'" TaskName="ResolveAspireCliBundle" AssemblyFile="$(_AspireTasksAssembly)" TaskFactory="TaskHostFactory" />
 
@@ -184,6 +186,15 @@ namespace Projects%3B
   </Target>
 
   <PropertyGroup>
+    <_AspireCliInvocationMode Condition="'$(AspireCliInvocationMode)' == ''">Path</_AspireCliInvocationMode>
+    <_AspireCliInvocationMode Condition="'$(AspireCliInvocationMode)' != ''">$(AspireCliInvocationMode)</_AspireCliInvocationMode>
+    <_AspireUseDnxCliRunHook Condition="'$(_AspireCliInvocationMode.ToLowerInvariant())' == 'dnx'">true</_AspireUseDnxCliRunHook>
+    <_AspireCliDnxPackageId Condition="'$(AspireCliDnxPackageId)' == ''">aspire.cli</_AspireCliDnxPackageId>
+    <_AspireCliDnxPackageId Condition="'$(AspireCliDnxPackageId)' != ''">$(AspireCliDnxPackageId)</_AspireCliDnxPackageId>
+    <!-- DNX/local-tool launches get DCP/Dashboard paths from the launching CLI's runtime env vars,
+         so a build-time global Aspire CLI is not required unless the project explicitly configured one. -->
+    <_AspireCliBundleResolutionOptional Condition="'$(_AspireUseDnxCliRunHook)' == 'true' and '$(AspireCliPath)' == '' and '$(AspireCliBundlePath)' == ''">true</_AspireCliBundleResolutionOptional>
+
     <!-- Easy extension point for adding new languages' write support. -->
     <WriteAspireProjectMetadataSourcesDependsOn>_CSharpWriteProjectMetadataSources;_CSharpWriteHostProjectMetadataSources;_WarnOnUnsupportedLanguage;_ValidateAspireHostProjectResources</WriteAspireProjectMetadataSourcesDependsOn>
   </PropertyGroup>
@@ -221,7 +232,7 @@ namespace Projects%3B
     </PropertyGroup>
 
     <Error Code="ASPIRE009"
-           Condition="'$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == '')"
+           Condition="'$(_AspireCliBundleResolutionOptional)' != 'true' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))"
            Text="$(_AspireCliBundleNotFoundError)" />
   </Target>
 
@@ -241,7 +252,8 @@ namespace Projects%3B
            same way they do for an interactive shell, and Exec owns the process, timeout, and
            concurrent stream draining. -->
       <_AspireCliVersionCommand Condition="'$(AspireCliPath)' != ''">"$(AspireCliPath)" --version</_AspireCliVersionCommand>
-      <_AspireCliVersionCommand Condition="'$(AspireCliPath)' == ''">aspire --version</_AspireCliVersionCommand>
+      <_AspireCliVersionCommand Condition="'$(AspireCliPath)' == '' and '$(_AspireUseDnxCliRunHook)' == 'true'">dnx $(_AspireCliDnxPackageId) -- --version</_AspireCliVersionCommand>
+      <_AspireCliVersionCommand Condition="'$(AspireCliPath)' == '' and '$(_AspireUseDnxCliRunHook)' != 'true'">aspire --version</_AspireCliVersionCommand>
     </PropertyGroup>
 
     <!-- The probe must never fail the build: IgnoreExitCode + ContinueOnError mean a missing,
@@ -290,8 +302,8 @@ namespace Projects%3B
   </Target>
 
   <Target Name="_AspireComputeRunArguments"
+          DependsOnTargets="_ValidateAspireCliDnxInvocationMode;_AspireCheckCliVersion"
           BeforeTargets="ComputeRunArguments"
-          DependsOnTargets="_AspireCheckCliVersion"
           Condition="'$(IsAspireHost)' == 'true' and '$(AspireUseCliBundle)' == 'true' and '$(_AspireCliRunHookSuppressed)' != 'true'">
     <ItemGroup Condition="'$(_AspireCliVersionSupportsRunHook)' == 'true' and '$(FileBasedProgram)' == 'true'">
       <_AspireFileBasedAppHostPath Include="%(RuntimeHostConfigurationOption.Value)"
@@ -308,22 +320,39 @@ namespace Projects%3B
       <_AspireRunWorkingDirectory>$(MSBuildProjectDirectory)</_AspireRunWorkingDirectory>
       <_AspireRunWorkingDirectory Condition="'$(FileBasedProgram)' == 'true' and '@(_AspireFileBasedAppHostDirectory)' != ''">@(_AspireFileBasedAppHostDirectory)</_AspireRunWorkingDirectory>
       <RunCommand Condition="'$(AspireCliPath)' != ''">$(AspireCliPath)</RunCommand>
+      <RunCommand Condition="'$(AspireCliPath)' == '' and '$(_AspireUseDnxCliRunHook)' == 'true' and '$(OS)' == 'Windows_NT'">cmd</RunCommand>
+      <RunCommand Condition="'$(AspireCliPath)' == '' and '$(_AspireUseDnxCliRunHook)' == 'true' and '$(OS)' != 'Windows_NT'">dnx</RunCommand>
       <!-- On Windows, Aspire can be installed as a command shim such as aspire.cmd.
            dotnet run starts RunCommand directly, so use cmd /C for the default PATH
            lookup to get the same PATHEXT resolution as an interactive shell. -->
-      <RunCommand Condition="'$(AspireCliPath)' == '' and '$(OS)' == 'Windows_NT'">cmd</RunCommand>
-      <RunCommand Condition="'$(AspireCliPath)' == '' and '$(OS)' != 'Windows_NT'">aspire</RunCommand>
+      <RunCommand Condition="'$(AspireCliPath)' == '' and '$(_AspireUseDnxCliRunHook)' != 'true' and '$(OS)' == 'Windows_NT'">cmd</RunCommand>
+      <RunCommand Condition="'$(AspireCliPath)' == '' and '$(_AspireUseDnxCliRunHook)' != 'true' and '$(OS)' != 'Windows_NT'">aspire</RunCommand>
       <!-- dotnet run appends application arguments after ComputeRunArguments, so the double-dash separator
            must be present even when RunArguments is initially empty. -->
-      <RunArguments>run --project "$(_AspireRunProject)" --no-build --</RunArguments>
-      <RunArguments Condition="'$(AspireCliPath)' == '' and '$(OS)' == 'Windows_NT'">/C aspire $(RunArguments)</RunArguments>
+      <RunArguments Condition="'$(AspireCliPath)' != '' or '$(_AspireUseDnxCliRunHook)' != 'true'">run --project "$(_AspireRunProject)" --no-build --</RunArguments>
+      <!-- Do not pass dnx -y here. A restored local tool manifest runs without prompting; a missing
+           manifest/tool should fail instead of silently downloading and running an ad-hoc package. -->
+      <RunArguments Condition="'$(AspireCliPath)' == '' and '$(_AspireUseDnxCliRunHook)' == 'true'">$(_AspireCliDnxPackageId) -- run --project "$(_AspireRunProject)" --no-build --</RunArguments>
+      <RunArguments Condition="'$(AspireCliPath)' == '' and '$(_AspireUseDnxCliRunHook)' == 'true' and '$(OS)' == 'Windows_NT'">/C dnx $(RunArguments)</RunArguments>
+      <RunArguments Condition="'$(AspireCliPath)' == '' and '$(_AspireUseDnxCliRunHook)' != 'true' and '$(OS)' == 'Windows_NT'">/C aspire $(RunArguments)</RunArguments>
       <RunArguments Condition="'$(_AspireOriginalRunArguments)' != ''">$(RunArguments) $(_AspireOriginalRunArguments)</RunArguments>
       <RunWorkingDirectory>$(_AspireRunWorkingDirectory)</RunWorkingDirectory>
     </PropertyGroup>
   </Target>
 
+  <Target Name="_ValidateAspireCliDnxInvocationMode"
+          Condition="'$(IsAspireHost)' == 'true' and '$(AspireUseCliBundle)' == 'true' and '$(_AspireUseDnxCliRunHook)' == 'true' and '$(AspireCliPath)' == ''">
+    <ResolveDnxPath>
+      <Output TaskParameter="DnxPath" PropertyName="_AspireDnxPath" />
+    </ResolveDnxPath>
+
+    <Error Code="ASPIRE011"
+           Condition="'$(_AspireDnxPath)' == ''"
+           Text="$(MSBuildProjectName) is configured with AspireCliInvocationMode=Dnx, but the dnx command could not be found on PATH. Install or use the .NET SDK 10.0 or later, run 'dotnet tool restore' if the project uses a local tool manifest, set AspireCliInvocationMode=Path to use the global aspire command, or set AspireCliPath to an explicit Aspire CLI executable." />
+  </Target>
+
   <!-- This target registers the location of the Aspire orchestration dependencies -->
-  <Target Name="SetOrchestrationDiscoveryAttributes" DependsOnTargets="ResolveAspireCliBundlePaths" BeforeTargets="GetAssemblyAttributes" Condition=" '$(DcpDir)' != '' or '$(AspireUseCliBundle)' == 'true' ">
+  <Target Name="SetOrchestrationDiscoveryAttributes" DependsOnTargets="ResolveAspireCliBundlePaths" BeforeTargets="GetAssemblyAttributes" Condition=" '$(DcpDir)' != '' or ('$(AspireUseCliBundle)' == 'true' and '$(_AspireCliBundleResolutionOptional)' != 'true') ">
     <PropertyGroup>
       <DcpDir>$([MSBuild]::EnsureTrailingSlash('$(DcpDir)'))</DcpDir>
       <DcpExtensionsDir Condition=" '$(DcpExtensionsDir)' == '' ">$([MSBuild]::NormalizePath($(DcpDir), 'ext'))</DcpExtensionsDir>
@@ -352,7 +381,7 @@ namespace Projects%3B
     </ItemGroup>
   </Target>
 
-  <Target Name="SetDashboardDiscoveryAttributes" DependsOnTargets="ResolveAspireCliBundlePaths" BeforeTargets="GetAssemblyAttributes" Condition=" '$(AspireDashboardDir)' != '' or '$(AspireDashboardPath)' != '' or '$(AspireUseCliBundle)' == 'true' ">
+  <Target Name="SetDashboardDiscoveryAttributes" DependsOnTargets="ResolveAspireCliBundlePaths" BeforeTargets="GetAssemblyAttributes" Condition=" '$(AspireDashboardDir)' != '' or '$(AspireDashboardPath)' != '' or ('$(AspireUseCliBundle)' == 'true' and '$(_AspireCliBundleResolutionOptional)' != 'true') ">
     <PropertyGroup>
       <AspireDashboardDir Condition=" '$(AspireDashboardDir)' != '' ">$([MSBuild]::EnsureTrailingSlash('$(AspireDashboardDir)'))</AspireDashboardDir>
       <_AspireDashboardPathInferredFromDir Condition=" '$(AspireDashboardPath)' == '' and '$(AspireDashboardDir)' != '' ">true</_AspireDashboardPathInferredFromDir>

--- a/src/Aspire.Hosting.Tasks/ResolveDnxPath.cs
+++ b/src/Aspire.Hosting.Tasks/ResolveDnxPath.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+
+namespace Aspire.Hosting.Tasks;
+
+/// <summary>
+/// Resolves the DNX executable from the current PATH.
+/// </summary>
+public sealed class ResolveDnxPath : Microsoft.Build.Utilities.Task
+{
+    /// <summary>
+    /// The resolved DNX executable path.
+    /// </summary>
+    [Output]
+    public string? DnxPath { get; set; }
+
+    public override bool Execute()
+    {
+        DnxPath = ResolveFromPath();
+        return true;
+    }
+
+    private static string? ResolveFromPath()
+    {
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        var seenPaths = new HashSet<string>(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+        foreach (var pathEntry in path.Split(Path.PathSeparator))
+        {
+            var directory = pathEntry.Trim().Trim('"');
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                continue;
+            }
+
+            foreach (var executableName in GetDnxExecutableNames())
+            {
+                var candidate = Path.Combine(directory, executableName);
+                if (seenPaths.Add(candidate) && File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string[] GetDnxExecutableNames()
+    {
+        return IsWindows()
+            ? ["dnx.exe", "dnx.cmd", "dnx.bat", "dnx"]
+            : ["dnx"];
+    }
+
+    private static bool IsWindows() => Path.DirectorySeparatorChar == '\\';
+}

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -90,6 +90,57 @@ public class AppHostSdkTargetsTests
         Assert.Equal(project.ProjectDirectory, properties["RunWorkingDirectory"]);
     }
 
+    [Theory]
+    [InlineData("Dnx")]
+    [InlineData("dNx")]
+    public async Task ComputeRunArgumentsUsesDnxAspireCliWhenConfigured(string invocationMode)
+    {
+        using var tempDirectory = new TestTempDirectory();
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.Path, "fake-cli"));
+        await CreateFakeDnxAsync(fakeCliDirectory.FullName);
+        var project = await CreateRunHookProjectAsync(tempDirectory.Path, aspireUseCliBundle: true,
+            $$"""
+              <PropertyGroup>
+                <AspireCliInvocationMode>{{invocationMode}}</AspireCliInvocationMode>
+              </PropertyGroup>
+            """);
+        var environment = CreatePathEnvironment(fakeCliDirectory.FullName);
+
+        var properties = await GetComputeRunArgumentsPropertiesAsync(project, ["-p:RunArguments=--custom foo"], environment);
+
+        Assert.Equal(GetExpectedDnxRunCommand(), properties["RunCommand"]);
+        Assert.Equal(GetExpectedDnxRunArguments(project, "--custom foo"), properties["RunArguments"]);
+        Assert.Equal(project.ProjectDirectory, properties["RunWorkingDirectory"]);
+    }
+
+    [Fact]
+    public async Task ComputeRunArgumentsFailsWhenDnxModeIsConfiguredAndDnxIsMissing()
+    {
+        using var tempDirectory = new TestTempDirectory();
+        var emptyPathDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.Path, "empty-path"));
+        var project = await CreateRunHookProjectAsync(tempDirectory.Path, aspireUseCliBundle: true,
+            """
+              <PropertyGroup>
+                <AspireCliInvocationMode>Dnx</AspireCliInvocationMode>
+              </PropertyGroup>
+            """);
+        var environment = CreatePathEnvironment(emptyPathDirectory.FullName, includeCurrentPath: false);
+
+        var result = await RunDotNetWithArgumentsAsync(
+            project.ProjectDirectory,
+            ["msbuild", "-nologo", "-restore", "-t:ComputeRunArguments", project.ProjectFile],
+            environment);
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("ASPIRE011", result.Output);
+        Assert.Contains("AspireCliInvocationMode=Dnx", result.Output);
+        Assert.Contains("dnx command could not be found on PATH", result.Output);
+        Assert.Contains("Install or use the .NET SDK 10.0 or later", result.Output);
+        Assert.Contains("dotnet tool restore", result.Output);
+        Assert.Contains("AspireCliInvocationMode=Path", result.Output);
+        Assert.Contains("AspireCliPath", result.Output);
+    }
+
     [Fact]
     public async Task ComputeRunArgumentsUsesConfiguredAspireCliPathWhenCliBundleIsEnabled()
     {
@@ -102,6 +153,27 @@ public class AppHostSdkTargetsTests
 
         Assert.Equal(aspireCliPath, properties["RunCommand"]);
         Assert.Equal(GetExpectedExplicitAspireRunArguments(project), properties["RunArguments"]);
+    }
+
+    [Fact]
+    public async Task ComputeRunArgumentsUsesConfiguredAspireCliPathWhenDnxModeIsConfigured()
+    {
+        using var tempDirectory = new TestTempDirectory();
+        var emptyPathDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.Path, "empty-path"));
+        var project = await CreateRunHookProjectAsync(tempDirectory.Path, aspireUseCliBundle: true,
+            """
+              <PropertyGroup>
+                <AspireCliInvocationMode>Dnx</AspireCliInvocationMode>
+              </PropertyGroup>
+            """);
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.Path, "fake-cli"));
+        var aspireCliPath = await CreateFakeAspireCliAsync(fakeCliDirectory.FullName);
+        var environment = CreatePathEnvironment(emptyPathDirectory.FullName);
+
+        var properties = await GetComputeRunArgumentsPropertiesAsync(project, [$"-p:AspireCliPath={aspireCliPath}"], environment);
+
+        Assert.Equal(aspireCliPath, properties["RunCommand"]);
+        Assert.Equal($"run --project \"{project.ProjectFile}\" --no-build --", properties["RunArguments"]);
     }
 
     [Fact]
@@ -414,6 +486,7 @@ public class AppHostSdkTargetsTests
                 <AspireUseCliBundle>{{aspireUseCliBundle.ToString().ToLowerInvariant()}}</AspireUseCliBundle>
                 <AspireDashboardPath>$(MSBuildProjectDirectory)/Aspire.Dashboard.dll</AspireDashboardPath>
                 <DcpDir>$(MSBuildProjectDirectory)</DcpDir>
+                <_AspireTasksAssembly>{{SecurityElement.Escape(GetAspireTasksAssemblyPath())}}</_AspireTasksAssembly>
                 <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
                 <SkipValidateAspireHostProjectResources>true</SkipValidateAspireHostProjectResources>
               </PropertyGroup>
@@ -629,6 +702,33 @@ public class AppHostSdkTargetsTests
         File.SetUnixFileMode(aspirePath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
     }
 
+    private static async Task CreateFakeDnxAsync(string fakeCliDirectory)
+    {
+        var dnxPath = Path.Combine(fakeCliDirectory, OperatingSystem.IsWindows() ? "dnx.cmd" : "dnx");
+        await File.WriteAllTextAsync(dnxPath, OperatingSystem.IsWindows()
+            ? """
+                @echo off
+                if "%~1"=="aspire.cli" if "%~2"=="--" if "%~3"=="--version" (
+                    echo 13.5.0
+                    exit /b 0
+                )
+                exit /b 0
+                """
+            : """
+                #!/bin/sh
+                if [ "$1" = "aspire.cli" ] && [ "$2" = "--" ] && [ "$3" = "--version" ]; then
+                    echo "13.5.0"
+                    exit 0
+                fi
+                exit 0
+                """);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(dnxPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
     private static void AssertDashboardAndOrchestrationReferences(string[] packageReferences)
     {
         var dashboardReference = Assert.Single(packageReferences, static packageReference => packageReference.StartsWith("Aspire.Dashboard.Sdk.", StringComparison.Ordinal));
@@ -667,6 +767,8 @@ public class AppHostSdkTargetsTests
 
     private static string GetExpectedAspireRunCommand() => OperatingSystem.IsWindows() ? "cmd" : "aspire";
 
+    private static string GetExpectedDnxRunCommand() => OperatingSystem.IsWindows() ? "cmd" : "dnx";
+
     private static string GetExpectedAspireRunArguments(RunHookProject project, string? extraArguments = null)
         => GetExpectedAspireRunArguments(project.ProjectFile, extraArguments);
 
@@ -681,6 +783,14 @@ public class AppHostSdkTargetsTests
     private static string GetExpectedExplicitAspireRunArguments(RunHookProject project, string? extraArguments = null)
     {
         var arguments = $"run --project \"{project.ProjectFile}\" --no-build --";
+
+        return string.IsNullOrEmpty(extraArguments) ? arguments : $"{arguments} {extraArguments}";
+    }
+
+    private static string GetExpectedDnxRunArguments(RunHookProject project, string? extraArguments = null)
+    {
+        var prefix = OperatingSystem.IsWindows() ? "/C dnx " : string.Empty;
+        var arguments = $"{prefix}aspire.cli -- run --project \"{project.ProjectFile}\" --no-build --";
 
         return string.IsNullOrEmpty(extraArguments) ? arguments : $"{arguments} {extraArguments}";
     }
@@ -806,6 +916,16 @@ public class AppHostSdkTargetsTests
         }
 
         return directory ?? throw new InvalidOperationException("Could not find repository root.");
+    }
+
+    private static string GetAspireTasksAssemblyPath()
+    {
+#if DEBUG
+        const string configuration = "Debug";
+#else
+        const string configuration = "Release";
+#endif
+        return Path.Combine(GetRepoRoot(), "artifacts", "bin", "Aspire.Hosting.Tasks", configuration, "net8.0", "Aspire.Hosting.Tasks.dll");
     }
 
     private sealed record RunHookProject(string ProjectDirectory, string ProjectFile);

--- a/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
+++ b/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
@@ -17,6 +17,11 @@
                       SkipGetTargetFrameworkProperties="true"
                       Private="false"
                       ExcludeAssets="all" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Tasks\Aspire.Hosting.Tasks.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      Private="false"
+                      ExcludeAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -547,6 +547,52 @@ public class MSBuildTests
     }
 
     [Fact]
+    public void CliBundleDnxInvocationAllowsMissingBuildTimeBundle()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var tempDirectory = new TestTempDirectory();
+
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
+            """
+              <AspireCliInvocationMode>Dnx</AspireCliInvocationMode>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        var output = BuildProject(appHostDirectory, new Dictionary<string, string>
+        {
+            ["ASPIRE_HOME"] = Path.Combine(tempDirectory.Path, "empty-aspire-home"),
+            ["PATH"] = GetDotNetOnlyPath()
+        });
+
+        Assert.DoesNotContain("ASPIRE009", output);
+        Assert.DoesNotContain("the bundle could not be resolved", output);
+    }
+
+    [Fact]
+    public void CliBundleDnxInvocationFailsWhenExplicitBundlePathIsInvalid()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var tempDirectory = new TestTempDirectory();
+
+        var missingBundlePath = Path.Combine(tempDirectory.Path, "missing-bundle");
+        var appHostDirectory = CreateSdkBundleAppHostProject(tempDirectory.Path, repoRoot,
+            $"""
+              <AspireCliInvocationMode>Dnx</AspireCliInvocationMode>
+              <AspireCliBundlePath>{missingBundlePath}</AspireCliBundlePath>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        var output = BuildProjectWithFailure(appHostDirectory);
+
+        Assert.Contains("warning", output);
+        Assert.Contains("AspireCliBundlePath", output);
+        Assert.Contains(missingBundlePath, output);
+        Assert.Contains("ASPIRE009", output);
+    }
+
+    [Fact]
     public void CliBundleOptInFailsWhenExplicitCliPathIsInvalid()
     {
         var repoRoot = MSBuildUtils.GetRepoRoot();


### PR DESCRIPTION
## Description

This explores a safer opt-in path for AppHosts that need the Aspire CLI bundle without requiring a global `aspire` command on PATH. The new `AspireCliInvocationMode=Dnx` mode lets a repo route AppHost launch through the repo-local `Aspire.Cli` .NET tool package when that tool has been restored.

### User-facing usage

Projects can opt in with:

```xml
<PropertyGroup>
  <AspireCliInvocationMode>Dnx</AspireCliInvocationMode>
</PropertyGroup>
```

With `Aspire.Cli` declared in the repo's local tool manifest and restored, `dotnet run` computes a launch command shaped like:

```bash
dnx aspire.cli -- run --project "<AppHost>" --no-build -- ...
```

This intentionally does not pass `dnx -y`. A restored local tool manifest runs without prompting; a missing or unrestored tool fails with the .NET local-tool restore message instead of silently downloading and running an ad-hoc package.

### Implementation notes

- Keeps the existing PATH/global CLI behavior as the default.
- Preserves `AspireCliPath` as the highest-precedence explicit override.
- Allows missing build-time CLI bundle metadata only for DNX mode when no explicit `AspireCliPath` or `AspireCliBundlePath` was configured. The launching CLI remains responsible for injecting DCP/Dashboard paths at runtime.
- Keeps explicit invalid CLI or bundle paths failing with `ASPIRE009`.

### Security considerations

This adds an opt-in process-spawning path through `dnx`, which can execute a repo-declared local tool after `dotnet tool restore`. The implementation avoids `dnx -y` so AppHost launch does not silently install or execute an ad-hoc package when the manifest/tool is missing.

### Validation

```bash
./restore.sh
dotnet test --project tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj --no-launch-profile -- --filter-class "*.AppHostSdkTargetsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.MSBuildTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-method "*.CliBundleDnxInvocationAllowsMissingBuildTimeBundle" --filter-method "*.CliBundleDnxInvocationFailsWhenExplicitBundlePathIsInvalid" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No