### PR TITLE
Fix resource service port collision in --isolated mode

### DIFF
--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -340,11 +340,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             StandardOutputCallback = runOutputCollector.AppendOutput,
             StandardErrorCallback = runOutputCollector.AppendError,
             StartDebugSession = context.StartDebugSession,
-            Debug = context.Debug,
-            // In isolated mode, suppress the launch profile for the dotnet-run fallback path
-            // so that fixed port URLs from the profile don't conflict between instances.
-            // The direct-run path handles this via env var override instead.
-            NoLaunchProfile = context.Isolated
+            Debug = context.Debug
         };
 
         // The backchannel completion source is the contract with RunCommand
@@ -1390,16 +1386,6 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     {
         // Enable port randomization for isolated mode
         env["DcpPublisher__RandomizePorts"] = "true";
-
-        // Clear port-bearing environment variables so the AppHost binds to random ports.
-        // Without this, multiple isolated instances of the same project would all try to
-        // bind to the same fixed ports from the launch profile or user secrets, causing
-        // "address already in use" failures. Setting these to empty causes the hosting
-        // infrastructure to fall back to port 0 (OS-assigned random port).
-        env[KnownConfigNames.AspNetCoreUrls] = "";
-        env[KnownConfigNames.ResourceServiceEndpointUrl] = "";
-        env[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "";
-        env[KnownConfigNames.DashboardOtlpHttpEndpointUrl] = "";
 
         // Get the UserSecretsId from the project and create isolated copy
         var userSecretsId = await QueryUserSecretsIdAsync(appHostFile, cancellationToken);

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -340,7 +340,11 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             StandardOutputCallback = runOutputCollector.AppendOutput,
             StandardErrorCallback = runOutputCollector.AppendError,
             StartDebugSession = context.StartDebugSession,
-            Debug = context.Debug
+            Debug = context.Debug,
+            // In isolated mode, suppress the launch profile for the dotnet-run fallback path
+            // so that fixed port URLs from the profile don't conflict between instances.
+            // The direct-run path handles this via env var override instead.
+            NoLaunchProfile = context.Isolated
         };
 
         // The backchannel completion source is the contract with RunCommand
@@ -1386,6 +1390,16 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     {
         // Enable port randomization for isolated mode
         env["DcpPublisher__RandomizePorts"] = "true";
+
+        // Clear port-bearing environment variables so the AppHost binds to random ports.
+        // Without this, multiple isolated instances of the same project would all try to
+        // bind to the same fixed ports from the launch profile or user secrets, causing
+        // "address already in use" failures. Setting these to empty causes the hosting
+        // infrastructure to fall back to port 0 (OS-assigned random port).
+        env[KnownConfigNames.AspNetCoreUrls] = "";
+        env[KnownConfigNames.ResourceServiceEndpointUrl] = "";
+        env[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "";
+        env[KnownConfigNames.DashboardOtlpHttpEndpointUrl] = "";
 
         // Get the UserSecretsId from the project and create isolated copy
         var userSecretsId = await QueryUserSecretsIdAsync(appHostFile, cancellationToken);

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -146,9 +146,10 @@ internal sealed class DashboardServiceHost : IHostedService
                 kestrelOptions.Listen(IPAddress.Loopback, port: 0, ConfigureListen);
                 _logger.LogDebug("Resource service endpoint not configured. Listening on {Scheme}://127.0.0.1:<random>.", scheme);
             }
-            else if (IPAddress.TryParse(uri.Host, out var ip) && IPAddress.IsLoopback(ip))
+            else if (IPAddress.TryParse(uri.DnsSafeHost, out var ip) && IPAddress.IsLoopback(ip))
             {
                 // Bind to the exact loopback address specified (e.g. 127.0.0.1 or [::1]).
+                // Use DnsSafeHost to strip brackets from IPv6 literals so TryParse succeeds.
                 kestrelOptions.Listen(ip, effectivePort, ConfigureListen);
                 _logger.LogDebug("Resource service endpoint: {Uri} (effective port: {Port})", uri, effectivePort);
             }

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -133,45 +133,19 @@ internal sealed class DashboardServiceHost : IHostedService
             var allowUnsecuredTransport = configuration.GetBool(KnownConfigNames.AllowUnsecuredTransport) ?? false;
             var randomizePorts = dcpOptions.Value.RandomizePorts;
 
-            var scheme = ResolveScheme(uri, allowUnsecuredTransport);
+            var endpoint = ResolveEndpoint(uri, randomizePorts, allowUnsecuredTransport);
 
-            // When randomizePorts is true (e.g. --isolated mode), override a fixed configured
-            // port to 0 so multiple instances don't collide. A configured port of 0 is already
-            // dynamic, so no override is needed.
-            var effectivePort = (randomizePorts && uri is not null && uri.Port != 0) ? 0 : uri?.Port ?? 0;
-
-            if (uri is null)
+            if (endpoint.UseListenLocalhost)
             {
-                // Listen on a random port.
-                kestrelOptions.Listen(IPAddress.Loopback, port: 0, ConfigureListen);
-                _logger.LogDebug("Resource service endpoint not configured. Listening on {Scheme}://127.0.0.1:<random>.", scheme);
-            }
-            else if (IPAddress.TryParse(uri.DnsSafeHost, out var ip) && IPAddress.IsLoopback(ip))
-            {
-                // Bind to the exact loopback address specified (e.g. 127.0.0.1 or [::1]).
-                // Use DnsSafeHost to strip brackets from IPv6 literals so TryParse succeeds.
-                kestrelOptions.Listen(ip, effectivePort, ConfigureListen);
-                _logger.LogDebug("Resource service endpoint: {Uri} (effective port: {Port})", uri, effectivePort);
-            }
-            else if (uri.IsLoopback || IsLocalhostOrLocalhostTld(uri))
-            {
-                // For "localhost" or *.localhost hosts, bind to both IPv4 and IPv6 loopback.
-                // Kestrel does not support ListenLocalhost with port 0, so fall back to
-                // binding on IPv4 loopback when a dynamic port is needed.
-                if (effectivePort == 0)
-                {
-                    kestrelOptions.Listen(IPAddress.Loopback, port: 0, ConfigureListen);
-                }
-                else
-                {
-                    kestrelOptions.ListenLocalhost(effectivePort, ConfigureListen);
-                }
-                _logger.LogDebug("Resource service endpoint: {Uri} (effective port: {Port})", uri, effectivePort);
+                kestrelOptions.ListenLocalhost(endpoint.Port, ConfigureListen);
             }
             else
             {
-                throw new ArgumentException($"{KnownConfigNames.ResourceServiceEndpointUrl} must contain a local loopback address.");
+                kestrelOptions.Listen(endpoint.BindAddress, endpoint.Port, ConfigureListen);
             }
+
+            _logger.LogDebug("Resource service endpoint: configured={Uri}, binding={BindAddress}:{Port}, scheme={Scheme}",
+                uri?.ToString() ?? "(none)", endpoint.BindAddress, endpoint.Port, endpoint.Scheme);
 
             void ConfigureListen(ListenOptions options)
             {
@@ -179,11 +153,55 @@ internal sealed class DashboardServiceHost : IHostedService
                 // which cannot negotiate between HTTP/1.1 and HTTP/2.
                 options.Protocols = HttpProtocols.Http2;
 
-                if (string.Equals(scheme, "https", StringComparison.Ordinal))
+                if (string.Equals(endpoint.Scheme, "https", StringComparison.Ordinal))
                 {
                     options.UseHttps();
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Resolves the endpoint that the resource service should bind to based on the configured URI,
+    /// port randomization settings, and transport security preferences.
+    /// </summary>
+    internal static ResourceServiceEndpointInfo ResolveEndpoint(Uri? configuredUri, bool randomizePorts, bool allowUnsecuredTransport)
+    {
+        var scheme = ResolveScheme(configuredUri, allowUnsecuredTransport);
+
+        // When randomizePorts is true (e.g. --isolated mode), override a fixed configured
+        // port to 0 so multiple instances don't collide. A configured port of 0 is already
+        // dynamic, so no override is needed.
+        var effectivePort = (randomizePorts && configuredUri is not null && configuredUri.Port != 0) ? 0 : configuredUri?.Port ?? 0;
+
+        if (configuredUri is null)
+        {
+            // No configured endpoint — bind to IPv4 loopback on a random port.
+            return new ResourceServiceEndpointInfo(IPAddress.Loopback, Port: 0, UseListenLocalhost: false, scheme);
+        }
+        else if (IPAddress.TryParse(configuredUri.DnsSafeHost, out var ip) && IPAddress.IsLoopback(ip))
+        {
+            // Bind to the exact loopback address specified (e.g. 127.0.0.1 or [::1]).
+            // Use DnsSafeHost to strip brackets from IPv6 literals so TryParse succeeds.
+            return new ResourceServiceEndpointInfo(ip, effectivePort, UseListenLocalhost: false, scheme);
+        }
+        else if (configuredUri.IsLoopback || IsLocalhostOrLocalhostTld(configuredUri))
+        {
+            // For "localhost" or *.localhost hosts, bind to both IPv4 and IPv6 loopback.
+            // Kestrel does not support ListenLocalhost with port 0, so fall back to
+            // binding on IPv4 loopback when a dynamic port is needed.
+            if (effectivePort == 0)
+            {
+                return new ResourceServiceEndpointInfo(IPAddress.Loopback, Port: 0, UseListenLocalhost: false, scheme);
+            }
+            else
+            {
+                return new ResourceServiceEndpointInfo(IPAddress.Loopback, effectivePort, UseListenLocalhost: true, scheme);
+            }
+        }
+        else
+        {
+            throw new ArgumentException($"{KnownConfigNames.ResourceServiceEndpointUrl} must contain a local loopback address.");
         }
     }
 
@@ -262,3 +280,12 @@ internal sealed class DashboardServiceHost : IHostedService
         }
     }
 }
+
+/// <summary>
+/// Describes the resolved endpoint binding for the resource service.
+/// </summary>
+internal readonly record struct ResourceServiceEndpointInfo(
+    IPAddress BindAddress,
+    int Port,
+    bool UseListenLocalhost,
+    string Scheme);

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Net;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dcp;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -40,6 +41,7 @@ internal sealed class DashboardServiceHost : IHostedService
         DistributedApplicationModel applicationModel,
         IConfiguration configuration,
         DistributedApplicationExecutionContext executionContext,
+        IOptions<DcpOptions> dcpOptions,
         ILoggerFactory loggerFactory,
         IConfigureOptions<LoggerFilterOptions> loggerOptions,
         ResourceNotificationService resourceNotificationService,
@@ -129,8 +131,14 @@ internal sealed class DashboardServiceHost : IHostedService
             var uri = configuration.GetUri(KnownConfigNames.ResourceServiceEndpointUrl)
                 ?? configuration.GetUri(KnownConfigNames.Legacy.ResourceServiceEndpointUrl);
             var allowUnsecuredTransport = configuration.GetBool(KnownConfigNames.AllowUnsecuredTransport) ?? false;
+            var randomizePorts = dcpOptions.Value.RandomizePorts;
 
             var scheme = ResolveScheme(uri, allowUnsecuredTransport);
+
+            // When randomizePorts is true (e.g. --isolated mode), override a fixed configured
+            // port to 0 so multiple instances don't collide. A configured port of 0 is already
+            // dynamic, so no override is needed.
+            var effectivePort = (randomizePorts && uri is not null && uri.Port != 0) ? 0 : uri?.Port ?? 0;
 
             if (uri is null)
             {
@@ -141,14 +149,23 @@ internal sealed class DashboardServiceHost : IHostedService
             else if (IPAddress.TryParse(uri.Host, out var ip) && IPAddress.IsLoopback(ip))
             {
                 // Bind to the exact loopback address specified (e.g. 127.0.0.1 or [::1]).
-                kestrelOptions.Listen(ip, uri.Port, ConfigureListen);
-                _logger.LogDebug("Resource service endpoint configured: {Uri}", uri);
+                kestrelOptions.Listen(ip, effectivePort, ConfigureListen);
+                _logger.LogDebug("Resource service endpoint: {Uri} (effective port: {Port})", uri, effectivePort);
             }
             else if (uri.IsLoopback || IsLocalhostOrLocalhostTld(uri))
             {
                 // For "localhost" or *.localhost hosts, bind to both IPv4 and IPv6 loopback.
-                kestrelOptions.ListenLocalhost(uri.Port, ConfigureListen);
-                _logger.LogDebug("Resource service endpoint configured: {Uri}", uri);
+                // Kestrel does not support ListenLocalhost with port 0, so fall back to
+                // binding on IPv4 loopback when a dynamic port is needed.
+                if (effectivePort == 0)
+                {
+                    kestrelOptions.Listen(IPAddress.Loopback, port: 0, ConfigureListen);
+                }
+                else
+                {
+                    kestrelOptions.ListenLocalhost(effectivePort, ConfigureListen);
+                }
+                _logger.LogDebug("Resource service endpoint: {Uri} (effective port: {Port})", uri, effectivePort);
             }
             else
             {

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -731,7 +731,7 @@ internal static class CliE2EAutomatorHelpers
             : "$ASPIRE_E2E_WORKSPACE/_aspire-start.json";
 
         var isolatedFlag = isolated ? " --isolated" : "";
-        var apphostFlag = apphost is not null ? $" --apphost {apphost}" : "";
+        var apphostFlag = apphost is not null ? $" --apphost {AspireCliShellCommandHelpers.QuoteBashArg(apphost)}" : "";
         var startupTimeoutSeconds = Math.Max(1, (int)Math.Ceiling(effectiveTimeout.TotalSeconds));
 
         // Keep aspire start as a single shell pipeline so tee captures the exact JSON emitted to the terminal while
@@ -886,7 +886,7 @@ internal static class CliE2EAutomatorHelpers
         SequenceCounter counter,
         string? apphost = null)
     {
-        var apphostFlag = apphost is not null ? $" --apphost {apphost}" : "";
+        var apphostFlag = apphost is not null ? $" --apphost {AspireCliShellCommandHelpers.QuoteBashArg(apphost)}" : "";
         await auto.TypeAsync($"aspire stop{apphostFlag}");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -719,7 +719,8 @@ internal static class CliE2EAutomatorHelpers
         this Hex1bTerminalAutomator auto,
         SequenceCounter counter,
         TimeSpan? startTimeout = null,
-        bool isolated = false)
+        bool isolated = false,
+        string? apphost = null)
     {
         var effectiveTimeout = startTimeout ?? TimeSpan.FromMinutes(3);
         var expectedCounter = counter.Value;
@@ -730,11 +731,12 @@ internal static class CliE2EAutomatorHelpers
             : "$ASPIRE_E2E_WORKSPACE/_aspire-start.json";
 
         var isolatedFlag = isolated ? " --isolated" : "";
+        var apphostFlag = apphost is not null ? $" --apphost {apphost}" : "";
         var startupTimeoutSeconds = Math.Max(1, (int)Math.Ceiling(effectiveTimeout.TotalSeconds));
 
         // Keep aspire start as a single shell pipeline so tee captures the exact JSON emitted to the terminal while
         // pipefail preserves the real CLI exit code instead of letting tee mask build/startup failures.
-        await auto.TypeAsync($"(set -o pipefail; ASPIRE_CLI_START_TIMEOUT={startupTimeoutSeconds.ToString(CultureInfo.InvariantCulture)} aspire start{isolatedFlag} --format json | tee \"{jsonFile}\")");
+        await auto.TypeAsync($"(set -o pipefail; ASPIRE_CLI_START_TIMEOUT={startupTimeoutSeconds.ToString(CultureInfo.InvariantCulture)} aspire start{isolatedFlag}{apphostFlag} --format json | tee \"{jsonFile}\")");
         await auto.EnterAsync();
 
         // Wait for the command to finish — check for success or error exit.
@@ -881,9 +883,11 @@ internal static class CliE2EAutomatorHelpers
     /// </summary>
     internal static async Task AspireStopAsync(
         this Hex1bTerminalAutomator auto,
-        SequenceCounter counter)
+        SequenceCounter counter,
+        string? apphost = null)
     {
-        await auto.TypeAsync("aspire stop");
+        var apphostFlag = apphost is not null ? $" --apphost {apphost}" : "";
+        await auto.TypeAsync($"aspire stop{apphostFlag}");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
     }

--- a/tests/Aspire.Cli.EndToEnd.Tests/IsolatedInstancesOtelLogsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/IsolatedInstancesOtelLogsTests.cs
@@ -47,15 +47,9 @@ public sealed class IsolatedInstancesOtelLogsTests(ITestOutputHelper output)
         const string appHost1 = "instance1/IsolatedApp.AppHost/IsolatedApp.AppHost.csproj";
         const string appHost2 = "instance2/IsolatedApp.AppHost/IsolatedApp.AppHost.csproj";
 
-        // Start instance1 with --isolated
-        await auto.TypeAsync($"aspire start --isolated --apphost {appHost1}");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Start instance2 with --isolated
-        await auto.TypeAsync($"aspire start --isolated --apphost {appHost2}");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
+        // Start both instances with --isolated
+        await auto.AspireStartAsync(counter, isolated: true, apphost: appHost1);
+        await auto.AspireStartAsync(counter, isolated: true, apphost: appHost2);
 
         // Wait for the apiservice resource in instance1 to be running
         await auto.TypeAsync($"aspire wait apiservice --apphost {appHost1} --status up --timeout 300");
@@ -69,41 +63,43 @@ public sealed class IsolatedInstancesOtelLogsTests(ITestOutputHelper output)
         await auto.WaitUntilTextAsync("is up (running).", timeout: TimeSpan.FromMinutes(6));
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Capture otel logs from instance1
-        await auto.TypeAsync($"aspire otel logs --apphost {appHost1} --format json > /tmp/otel_instance1.json 2>&1");
+        // Capture otel logs from both instances into workspace-relative files
+        // so they are included in [CaptureWorkspaceOnFailure] artifacts.
+        await auto.TypeAsync($"aspire otel logs --apphost {appHost1} --format json > otel_instance1.json 2>&1");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Capture otel logs from instance2
-        await auto.TypeAsync($"aspire otel logs --apphost {appHost2} --format json > /tmp/otel_instance2.json 2>&1");
+        await auto.TypeAsync($"aspire otel logs --apphost {appHost2} --format json > otel_instance2.json 2>&1");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Assert both files have structured log content (resourceLogs key)
-        await auto.TypeAsync("grep -q 'resourceLogs' /tmp/otel_instance1.json && echo 'INSTANCE1_HAS_LOGS' || echo 'INSTANCE1_NO_LOGS'");
+        await auto.TypeAsync("grep -q 'resourceLogs' otel_instance1.json && echo 'INSTANCE1_HAS_LOGS' || echo 'INSTANCE1_NO_LOGS'");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("INSTANCE1_HAS_LOGS", timeout: TimeSpan.FromSeconds(10));
         await auto.WaitForAnyPromptAsync(counter);
 
-        await auto.TypeAsync("grep -q 'resourceLogs' /tmp/otel_instance2.json && echo 'INSTANCE2_HAS_LOGS' || echo 'INSTANCE2_NO_LOGS'");
+        await auto.TypeAsync("grep -q 'resourceLogs' otel_instance2.json && echo 'INSTANCE2_HAS_LOGS' || echo 'INSTANCE2_NO_LOGS'");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("INSTANCE2_HAS_LOGS", timeout: TimeSpan.FromSeconds(10));
         await auto.WaitForAnyPromptAsync(counter);
 
-        // Assert that telemetry from the two instances is different.
-        // Each instance has its own service.instance.id in OTLP, so the JSON payloads differ.
-        await auto.TypeAsync("if ! diff -q /tmp/otel_instance1.json /tmp/otel_instance2.json > /dev/null 2>&1; then echo 'TELEMETRY_DIFFERS'; else echo 'TELEMETRY_SAME'; fi");
+        // Extract the ContentRoot values from each instance's structured logs and verify they
+        // point at the correct instance directory. The OTLP JSON body contains log messages like:
+        //   "Content root path: /workspace/instance1/IsolatedApp.AppHost"
+        // Matching against the instance directory proves each AppHost runs from its own root.
+        await auto.TypeAsync("grep -o 'Content root path: [^\"]*' otel_instance1.json | head -1");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("TELEMETRY_DIFFERS", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitUntilTextAsync("instance1", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        await auto.TypeAsync("grep -o 'Content root path: [^\"]*' otel_instance2.json | head -1");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("instance2", timeout: TimeSpan.FromSeconds(10));
         await auto.WaitForAnyPromptAsync(counter);
 
         // Stop both instances
-        await auto.TypeAsync($"aspire stop --apphost {appHost1}");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        await auto.TypeAsync($"aspire stop --apphost {appHost2}");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.AspireStopAsync(counter, apphost: appHost1);
+        await auto.AspireStopAsync(counter, apphost: appHost2);
     }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/IsolatedInstancesOtelLogsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/IsolatedInstancesOtelLogsTests.cs
@@ -88,14 +88,16 @@ public sealed class IsolatedInstancesOtelLogsTests(ITestOutputHelper output)
         // point at the correct instance directory. The OTLP JSON body contains log messages like:
         //   "Content root path: /workspace/instance1/IsolatedApp.AppHost"
         // Matching against the instance directory proves each AppHost runs from its own root.
-        await auto.TypeAsync("grep -o 'Content root path: [^\"]*' otel_instance1.json | head -1");
+        // Use unique sentinel markers so WaitUntilTextAsync doesn't match pre-existing scrollback
+        // (e.g. from the mv/cp/--apphost commands that also contain "instance1"/"instance2").
+        await auto.TypeAsync("grep -o 'Content root path: [^\"]*' otel_instance1.json | grep -q 'instance1' && echo 'CONTENTROOT1_OK' || echo 'CONTENTROOT1_FAIL'");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("instance1", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitUntilTextAsync("CONTENTROOT1_OK", timeout: TimeSpan.FromSeconds(10));
         await auto.WaitForAnyPromptAsync(counter);
 
-        await auto.TypeAsync("grep -o 'Content root path: [^\"]*' otel_instance2.json | head -1");
+        await auto.TypeAsync("grep -o 'Content root path: [^\"]*' otel_instance2.json | grep -q 'instance2' && echo 'CONTENTROOT2_OK' || echo 'CONTENTROOT2_FAIL'");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("instance2", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitUntilTextAsync("CONTENTROOT2_OK", timeout: TimeSpan.FromSeconds(10));
         await auto.WaitForAnyPromptAsync(counter);
 
         // Stop both instances

--- a/tests/Aspire.Cli.EndToEnd.Tests/IsolatedInstancesOtelLogsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/IsolatedInstancesOtelLogsTests.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests verifying that two isolated Aspire instances produce distinct telemetry.
+/// Each test class runs as a separate CI job for parallelization.
+/// </summary>
+public sealed class IsolatedInstancesOtelLogsTests(ITestOutputHelper output)
+{
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task TwoIsolatedInstancesProduceDifferentOtelLogs()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+
+        using var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // Create a new Starter project (without Redis to avoid extra Docker dependencies)
+        await auto.AspireNewAsync("IsolatedApp", counter, useRedisCache: false);
+
+        // Move the created project into instance1 directory and copy to instance2
+        await auto.TypeAsync("mv IsolatedApp instance1");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("cp -r instance1 instance2");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Define AppHost paths for both instances
+        const string appHost1 = "instance1/IsolatedApp.AppHost/IsolatedApp.AppHost.csproj";
+        const string appHost2 = "instance2/IsolatedApp.AppHost/IsolatedApp.AppHost.csproj";
+
+        // Start instance1 with --isolated
+        await auto.TypeAsync($"aspire start --isolated --apphost {appHost1}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Start instance2 with --isolated
+        await auto.TypeAsync($"aspire start --isolated --apphost {appHost2}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Wait for the apiservice resource in instance1 to be running
+        await auto.TypeAsync($"aspire wait apiservice --apphost {appHost1} --status up --timeout 300");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("is up (running).", timeout: TimeSpan.FromMinutes(6));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Wait for the apiservice resource in instance2 to be running
+        await auto.TypeAsync($"aspire wait apiservice --apphost {appHost2} --status up --timeout 300");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("is up (running).", timeout: TimeSpan.FromMinutes(6));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Capture otel logs from instance1
+        await auto.TypeAsync($"aspire otel logs --apphost {appHost1} --format json > /tmp/otel_instance1.json 2>&1");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Capture otel logs from instance2
+        await auto.TypeAsync($"aspire otel logs --apphost {appHost2} --format json > /tmp/otel_instance2.json 2>&1");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Assert both files have structured log content (resourceLogs key)
+        await auto.TypeAsync("grep -q 'resourceLogs' /tmp/otel_instance1.json && echo 'INSTANCE1_HAS_LOGS' || echo 'INSTANCE1_NO_LOGS'");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("INSTANCE1_HAS_LOGS", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        await auto.TypeAsync("grep -q 'resourceLogs' /tmp/otel_instance2.json && echo 'INSTANCE2_HAS_LOGS' || echo 'INSTANCE2_NO_LOGS'");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("INSTANCE2_HAS_LOGS", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        // Assert that telemetry from the two instances is different.
+        // Each instance has its own service.instance.id in OTLP, so the JSON payloads differ.
+        await auto.TypeAsync("if ! diff -q /tmp/otel_instance1.json /tmp/otel_instance2.json > /dev/null 2>&1; then echo 'TELEMETRY_DIFFERS'; else echo 'TELEMETRY_SAME'; fi");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("TELEMETRY_DIFFERS", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForAnyPromptAsync(counter);
+
+        // Stop both instances
+        await auto.TypeAsync($"aspire stop --apphost {appHost1}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync($"aspire stop --apphost {appHost2}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceHostTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceHostTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using Aspire.Hosting.Dashboard;
 
 namespace Aspire.Hosting.Tests.Dashboard;
@@ -21,5 +22,71 @@ public class DashboardServiceHostTests
         var scheme = DashboardServiceHost.ResolveScheme(configuredUri: uri, allowUnsecuredTransport: allowUnsecuredTransport);
 
         Assert.Equal(expectedScheme, scheme);
+    }
+
+    [Fact]
+    public void ResolveEndpoint_NullUri_BindsToLoopbackPort0()
+    {
+        var result = DashboardServiceHost.ResolveEndpoint(configuredUri: null, randomizePorts: false, allowUnsecuredTransport: false);
+
+        Assert.Equal(IPAddress.Loopback, result.BindAddress);
+        Assert.Equal(0, result.Port);
+        Assert.False(result.UseListenLocalhost);
+        Assert.Equal("https", result.Scheme);
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1:5000", false, "127.0.0.1", 5000, false)]
+    [InlineData("https://127.0.0.1:5001", false, "127.0.0.1", 5001, false)]
+    [InlineData("http://[::1]:5000", false, "::1", 5000, false)]
+    [InlineData("https://[::1]:0", false, "::1", 0, false)]
+    public void ResolveEndpoint_IpLoopback_BindsToExactAddress(string uriString, bool randomizePorts, string expectedHost, int expectedPort, bool expectedUseLocalhost)
+    {
+        var uri = new Uri(uriString);
+
+        var result = DashboardServiceHost.ResolveEndpoint(uri, randomizePorts, allowUnsecuredTransport: false);
+
+        Assert.Equal(IPAddress.Parse(expectedHost), result.BindAddress);
+        Assert.Equal(expectedPort, result.Port);
+        Assert.Equal(expectedUseLocalhost, result.UseListenLocalhost);
+    }
+
+    [Theory]
+    [InlineData("http://localhost:5000", false, 5000, true)]
+    [InlineData("http://localhost:5000", true, 0, false)] // randomizePorts overrides to port 0, falls back from ListenLocalhost
+    [InlineData("http://localhost:0", false, 0, false)] // port 0 already dynamic, falls back from ListenLocalhost
+    [InlineData("http://localhost:0", true, 0, false)] // port 0 + randomize, still dynamic
+    public void ResolveEndpoint_Localhost_BindsCorrectly(string uriString, bool randomizePorts, int expectedPort, bool expectedUseLocalhost)
+    {
+        var uri = new Uri(uriString);
+
+        var result = DashboardServiceHost.ResolveEndpoint(uri, randomizePorts, allowUnsecuredTransport: true);
+
+        Assert.Equal(expectedPort, result.Port);
+        Assert.Equal(expectedUseLocalhost, result.UseListenLocalhost);
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1:5000", true, 0)]
+    [InlineData("http://[::1]:5000", true, 0)]
+    [InlineData("http://127.0.0.1:0", true, 0)] // port 0 stays 0
+    [InlineData("http://[::1]:0", true, 0)] // port 0 stays 0
+    [InlineData("http://127.0.0.1:5000", false, 5000)] // randomize off, port preserved
+    [InlineData("http://[::1]:5000", false, 5000)]
+    public void ResolveEndpoint_RandomizePorts_OverridesNonZeroPort(string uriString, bool randomizePorts, int expectedPort)
+    {
+        var uri = new Uri(uriString);
+
+        var result = DashboardServiceHost.ResolveEndpoint(uri, randomizePorts, allowUnsecuredTransport: true);
+
+        Assert.Equal(expectedPort, result.Port);
+    }
+
+    [Fact]
+    public void ResolveEndpoint_NonLoopbackAddress_Throws()
+    {
+        var uri = new Uri("http://192.168.1.1:5000");
+
+        Assert.Throws<ArgumentException>(() => DashboardServiceHost.ResolveEndpoint(uri, randomizePorts: false, allowUnsecuredTransport: true));
     }
 }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -1443,7 +1443,7 @@ public class DistributedApplicationTests
         var args = new string[] {
             $"{KnownConfigNames.ResourceServiceEndpointUrl}={configuredResourceServiceUrl}"
         };
-        using var testProgram = CreateTestProgram(testName, args: args, disableDashboard: false);
+        using var testProgram = CreateTestProgram(testName, args: args, disableDashboard: false, randomizePorts: false);
 
         await using var app = testProgram.Build();
 
@@ -1454,6 +1454,41 @@ public class DistributedApplicationTests
         {
             var resourceServiceUri = await dashboardServiceHost.GetResourceServiceUriAsync();
             Assert.Equal(configuredResourceServiceUrl, resourceServiceUri.TrimEnd('/'));
+        }
+        finally
+        {
+            await ((IHostedService)dashboardServiceHost).StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Theory]
+    [InlineData("localhost", "127.0.0.1")]
+    [InlineData("127.0.0.1", "127.0.0.1")]
+    [InlineData("[::1]", "[::1]")]
+    public async Task StartAsync_ResourceServiceEndpointUrl_RandomizePortsIgnoresConfiguredPort(string host, string expectedHost)
+    {
+        const string testName = "dashboard-resource-service-randomize-ports";
+        const int hardcodedPort = 5000;
+        var configuredResourceServiceUrl = $"http://{host}:{hardcodedPort}";
+        var args = new string[] {
+            $"{KnownConfigNames.ResourceServiceEndpointUrl}={configuredResourceServiceUrl}"
+        };
+        using var testProgram = CreateTestProgram(testName, args: args, disableDashboard: false, randomizePorts: true);
+
+        await using var app = testProgram.Build();
+
+        var dashboardServiceHost = app.Services.GetRequiredService<DashboardServiceHost>();
+        await ((IHostedService)dashboardServiceHost).StartAsync(CancellationToken.None);
+
+        try
+        {
+            var resourceServiceUri = await dashboardServiceHost.GetResourceServiceUriAsync();
+            var actualUri = new Uri(resourceServiceUri);
+
+            // When RandomizePorts is true (e.g. --isolated mode), the configured port should be
+            // ignored and a dynamic port assigned instead to avoid collisions.
+            Assert.NotEqual(hardcodedPort, actualUri.Port);
+            Assert.Equal(expectedHost, actualUri.Host);
         }
         finally
         {


### PR DESCRIPTION
## Summary

When running multiple AppHost instances with `--isolated`, the resource service endpoint in `DashboardServiceHost` uses the fixed port from `ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL` (e.g. port 22147 from launch profiles/user secrets). This causes an "address already in use" error when the second instance tries to bind to the same port.

## Fix

In `DashboardServiceHost.ConfigureKestrel`, when `DcpOptions.RandomizePorts` is true (set by `--isolated` mode), always bind to port 0 on loopback instead of using the configured port. This lets the OS assign a unique port for each instance.

### Changes

- **`DashboardServiceHost.cs`**: Inject `IOptions<DcpOptions>` and check `RandomizePorts`. When true, bypass the configured URI and listen on `IPAddress.Loopback` with port 0.
- **`CliE2EAutomatorHelpers.cs`**: Add `apphost` parameter to `AspireStartAsync` and `AspireStopAsync` helpers.
- **`IsolatedInstancesOtelLogsTests.cs`**: New E2E test that creates two copies of a Starter project, starts both with `--isolated --apphost`, and verifies each instance's `Content root path` in OTLP structured logs points at the correct instance directory.