### PR TITLE
Simplify lambda to method group in OtlpResource.AddMetrics (IDE0200)

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
@@ -70,7 +70,7 @@ public class OtlpResource : IOtlpResource
             {
                 if (!OtlpHelpers.TryGetOrAddScope(_meters, sm.Scope, Context, TelemetryType.Metrics, out var scope))
                 {
-                    context.FailureCount += sm.Metrics.Sum(m => GetMetricDataPointCount(m));
+                    context.FailureCount += sm.Metrics.Sum(GetMetricDataPointCount);
                     continue;
                 }
 


### PR DESCRIPTION
## Description

**Why:** The IDE0200 analyzer ('Lambda expression can be removed') fires nondeterministically in command-line builds and was breaking local builds with `-warnaserror`. This removes that latent build break.

This is a trivial one-line method-group simplification in `src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs` (`AddMetrics`):

- Before: `context.FailureCount += sm.Metrics.Sum(m => GetMetricDataPointCount(m));`
- After:  `context.FailureCount += sm.Metrics.Sum(GetMetricDataPointCount);`

No behavior change. Extracted out of #18340 (the Bun toolchain work) to keep that PR focused.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No