### PR TITLE
CLI: Harden parameter contracts, fix ExtensionInteractionService lifecycle, introduce IEnvironment

### DIFF
--- a/src/Aspire.Cli/Acquisition/IdentityResolver.cs
+++ b/src/Aspire.Cli/Acquisition/IdentityResolver.cs
@@ -24,11 +24,10 @@ namespace Aspire.Cli.Acquisition;
 /// than throwing during DI construction.
 /// </para>
 /// <para>
-/// The env-reader is injected as a delegate rather than read straight from
-/// <see cref="Environment.GetEnvironmentVariable(string)"/> so tests can run
-/// in parallel without racing against a shared process-environment.
-/// Production wiring in <c>Program.cs</c> passes
-/// <c>Environment.GetEnvironmentVariable</c> directly.
+/// Environment variables are read via <see cref="IEnvironment.GetEnvironmentVariable"/>
+/// so the resolver is decoupled from <see cref="CliExecutionContext"/> — both
+/// depend on <see cref="IEnvironment"/> independently, avoiding a circular
+/// dependency.
 /// </para>
 /// </remarks>
 internal sealed class IdentityResolver : IIdentityResolver
@@ -61,7 +60,7 @@ internal sealed class IdentityResolver : IIdentityResolver
     private readonly IInstallSidecarReader _sidecarReader;
     private readonly Assembly _assembly;
     private readonly string? _binaryDir;
-    private readonly Func<string, string?> _envReader;
+    private readonly IEnvironment _environment;
 
     // A single Lazy resolves every identity field together on first use; see the type remarks
     // for why per-field caching is unnecessary and why laziness is still retained.
@@ -71,16 +70,16 @@ internal sealed class IdentityResolver : IIdentityResolver
         IInstallSidecarReader sidecarReader,
         Assembly assembly,
         string? binaryDir,
-        Func<string, string?> envReader)
+        IEnvironment environment)
     {
         ArgumentNullException.ThrowIfNull(sidecarReader);
         ArgumentNullException.ThrowIfNull(assembly);
-        ArgumentNullException.ThrowIfNull(envReader);
+        ArgumentNullException.ThrowIfNull(environment);
 
         _sidecarReader = sidecarReader;
         _assembly = assembly;
         _binaryDir = binaryDir;
-        _envReader = envReader;
+        _environment = environment;
 
         _identity = new Lazy<ResolvedIdentity>(ResolveIdentity, LazyThreadSafetyMode.ExecutionAndPublication);
     }
@@ -301,7 +300,7 @@ internal sealed class IdentityResolver : IIdentityResolver
 
     private bool TryGetEnv(string name, [NotNullWhen(true)] out string? value)
     {
-        var raw = _envReader(name);
+        var raw = _environment.GetEnvironmentVariable(name);
         if (string.IsNullOrEmpty(raw))
         {
             value = null;

--- a/src/Aspire.Cli/Acquisition/IdentityResolver.cs
+++ b/src/Aspire.Cli/Acquisition/IdentityResolver.cs
@@ -71,15 +71,16 @@ internal sealed class IdentityResolver : IIdentityResolver
         IInstallSidecarReader sidecarReader,
         Assembly assembly,
         string? binaryDir,
-        Func<string, string?>? envReader = null)
+        Func<string, string?> envReader)
     {
         ArgumentNullException.ThrowIfNull(sidecarReader);
         ArgumentNullException.ThrowIfNull(assembly);
+        ArgumentNullException.ThrowIfNull(envReader);
 
         _sidecarReader = sidecarReader;
         _assembly = assembly;
         _binaryDir = binaryDir;
-        _envReader = envReader ?? Environment.GetEnvironmentVariable;
+        _envReader = envReader;
 
         _identity = new Lazy<ResolvedIdentity>(ResolveIdentity, LazyThreadSafetyMode.ExecutionAndPublication);
     }

--- a/src/Aspire.Cli/Acquisition/InstallSidecarReader.cs
+++ b/src/Aspire.Cli/Acquisition/InstallSidecarReader.cs
@@ -16,9 +16,9 @@ namespace Aspire.Cli.Acquisition;
 /// </summary>
 internal sealed class InstallSidecarReader : IInstallSidecarReader
 {
-    private readonly ILogger<InstallSidecarReader>? _logger;
+    private readonly ILogger<InstallSidecarReader> _logger;
 
-    public InstallSidecarReader(ILogger<InstallSidecarReader>? logger = null)
+    public InstallSidecarReader(ILogger<InstallSidecarReader> logger)
     {
         _logger = logger;
     }
@@ -44,20 +44,20 @@ internal sealed class InstallSidecarReader : IInstallSidecarReader
     {
         if (string.IsNullOrEmpty(binaryDir))
         {
-            _logger?.LogDebug("Install sidecar read skipped because the binary directory is empty.");
+            _logger.LogDebug("Install sidecar read skipped because the binary directory is empty.");
             return new InstallSidecarReadResult.NotFound(string.Empty);
         }
 
         var sidecarPath = Path.Combine(binaryDir, SidecarFileName);
         if (!File.Exists(sidecarPath))
         {
-            _logger?.LogDebug("Install sidecar file '{SidecarPath}' does not exist.", sidecarPath);
+            _logger.LogDebug("Install sidecar file '{SidecarPath}' does not exist.", sidecarPath);
             return new InstallSidecarReadResult.NotFound(sidecarPath);
         }
 
         if (TryGetOversizedSidecarReason(sidecarPath, out var oversizedReason))
         {
-            _logger?.LogDebug("Install sidecar file '{SidecarPath}' rejected: {Reason}.", sidecarPath, oversizedReason);
+            _logger.LogDebug("Install sidecar file '{SidecarPath}' rejected: {Reason}.", sidecarPath, oversizedReason);
             return new InstallSidecarReadResult.Invalid(sidecarPath, oversizedReason);
         }
 
@@ -65,11 +65,11 @@ internal sealed class InstallSidecarReader : IInstallSidecarReader
         {
             if (error is JsonException)
             {
-                _logger?.LogDebug(error, "Install sidecar file '{SidecarPath}' contains malformed JSON.", sidecarPath);
+                _logger.LogDebug(error, "Install sidecar file '{SidecarPath}' contains malformed JSON.", sidecarPath);
             }
             else
             {
-                _logger?.LogDebug(error, "Install sidecar file '{SidecarPath}' could not be read due to a path, permission, or IO error.", sidecarPath);
+                _logger.LogDebug(error, "Install sidecar file '{SidecarPath}' could not be read due to a path, permission, or IO error.", sidecarPath);
             }
 
             return new InstallSidecarReadResult.Invalid(sidecarPath, error?.Message ?? "Install sidecar file could not be read.");

--- a/src/Aspire.Cli/Acquisition/InstallationDiscovery.cs
+++ b/src/Aspire.Cli/Acquisition/InstallationDiscovery.cs
@@ -36,21 +36,22 @@ internal sealed partial class InstallationDiscovery : IInstallationDiscovery
         IPeerInstallProbe peerProbe,
         CliExecutionContext executionContext,
         ILogger<InstallationDiscovery> logger,
-        IEnumerable<IInstallationCandidateSource>? candidateSources = null)
+        IEnumerable<IInstallationCandidateSource> candidateSources)
     {
         ArgumentNullException.ThrowIfNull(channelReader);
         ArgumentNullException.ThrowIfNull(sidecarReader);
         ArgumentNullException.ThrowIfNull(peerProbe);
         ArgumentNullException.ThrowIfNull(executionContext);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(candidateSources);
 
         _channelReader = channelReader;
         _sidecarReader = sidecarReader;
         _peerProbe = peerProbe;
         _executionContext = executionContext;
         _logger = logger;
-        var sources = candidateSources?.ToArray();
-        _candidateSources = sources is { Length: > 0 } ? sources : CreateDefaultCandidateSources();
+        var sources = candidateSources.ToArray();
+        _candidateSources = sources.Length > 0 ? sources : CreateDefaultCandidateSources();
     }
 
     /// <inheritdoc />

--- a/src/Aspire.Cli/Agents/ClaudeCode/ClaudeCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/ClaudeCode/ClaudeCodeAgentEnvironmentScanner.cs
@@ -197,7 +197,7 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
         CancellationToken cancellationToken)
     {
         var configFilePath = Path.Combine(repoRoot.FullName, McpConfigFileName);
-        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, cancellationToken: cancellationToken);
+        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, null, cancellationToken);
 
         // Ensure "mcpServers" object exists
         if (!config.ContainsKey("mcpServers") || config["mcpServers"] is not JsonObject)

--- a/src/Aspire.Cli/Agents/ClaudeCode/ClaudeCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/ClaudeCode/ClaudeCodeAgentEnvironmentScanner.cs
@@ -197,7 +197,7 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
         CancellationToken cancellationToken)
     {
         var configFilePath = Path.Combine(repoRoot.FullName, McpConfigFileName);
-        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, cancellationToken);
+        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, cancellationToken: cancellationToken);
 
         // Ensure "mcpServers" object exists
         if (!config.ContainsKey("mcpServers") || config["mcpServers"] is not JsonObject)

--- a/src/Aspire.Cli/Agents/CopilotCli/CopilotCliAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/CopilotCli/CopilotCliAgentEnvironmentScanner.cs
@@ -193,7 +193,7 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
             Directory.CreateDirectory(configDirectory);
         }
 
-        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, cancellationToken);
+        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, cancellationToken: cancellationToken);
 
         // Ensure "mcpServers" object exists
         if (!config.ContainsKey("mcpServers") || config["mcpServers"] is not JsonObject)

--- a/src/Aspire.Cli/Agents/CopilotCli/CopilotCliAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/CopilotCli/CopilotCliAgentEnvironmentScanner.cs
@@ -193,7 +193,7 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
             Directory.CreateDirectory(configDirectory);
         }
 
-        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, cancellationToken: cancellationToken);
+        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, null, cancellationToken);
 
         // Ensure "mcpServers" object exists
         if (!config.ContainsKey("mcpServers") || config["mcpServers"] is not JsonObject)

--- a/src/Aspire.Cli/Agents/McpConfigFileHelper.cs
+++ b/src/Aspire.Cli/Agents/McpConfigFileHelper.cs
@@ -61,11 +61,11 @@ internal static class McpConfigFileHelper
     /// Reads an existing MCP config file and parses it into a <see cref="JsonObject"/>, or creates a new one if the file doesn't exist.
     /// </summary>
     /// <param name="configFilePath">The path to the MCP configuration file.</param>
-    /// <param name="cancellationToken">A cancellation token.</param>
     /// <param name="preprocessContent">Optional function to preprocess file content before parsing (e.g., to strip JSONC comments).</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The parsed <see cref="JsonObject"/> from the file, or a new empty <see cref="JsonObject"/> if the file doesn't exist.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the file exists but contains malformed JSON, wrapping the underlying <see cref="JsonException"/>.</exception>
-    public static async Task<JsonObject> ReadConfigAsync(string configFilePath, CancellationToken cancellationToken, Func<string, string>? preprocessContent = null)
+    public static async Task<JsonObject> ReadConfigAsync(string configFilePath, Func<string, string>? preprocessContent = null, CancellationToken cancellationToken = default)
     {
         if (!File.Exists(configFilePath))
         {

--- a/src/Aspire.Cli/Agents/McpConfigFileHelper.cs
+++ b/src/Aspire.Cli/Agents/McpConfigFileHelper.cs
@@ -61,11 +61,11 @@ internal static class McpConfigFileHelper
     /// Reads an existing MCP config file and parses it into a <see cref="JsonObject"/>, or creates a new one if the file doesn't exist.
     /// </summary>
     /// <param name="configFilePath">The path to the MCP configuration file.</param>
-    /// <param name="preprocessContent">Optional function to preprocess file content before parsing (e.g., to strip JSONC comments).</param>
+    /// <param name="preprocessContent">Function to preprocess file content before parsing (e.g., to strip JSONC comments), or null for no preprocessing.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The parsed <see cref="JsonObject"/> from the file, or a new empty <see cref="JsonObject"/> if the file doesn't exist.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the file exists but contains malformed JSON, wrapping the underlying <see cref="JsonException"/>.</exception>
-    public static async Task<JsonObject> ReadConfigAsync(string configFilePath, Func<string, string>? preprocessContent = null, CancellationToken cancellationToken = default)
+    public static async Task<JsonObject> ReadConfigAsync(string configFilePath, Func<string, string>? preprocessContent, CancellationToken cancellationToken)
     {
         if (!File.Exists(configFilePath))
         {

--- a/src/Aspire.Cli/Agents/OpenCode/OpenCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/OpenCode/OpenCodeAgentEnvironmentScanner.cs
@@ -181,7 +181,7 @@ internal sealed class OpenCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
         CancellationToken cancellationToken)
     {
         var configFilePath = Path.Combine(configDirectory.FullName, OpenCodeConfigFileName);
-        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, cancellationToken, RemoveJsonComments);
+        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, RemoveJsonComments, cancellationToken);
 
         // Ensure schema is set for new configs
         if (!config.ContainsKey("$schema"))

--- a/src/Aspire.Cli/Agents/Playwright/PlaywrightCliInstaller.cs
+++ b/src/Aspire.Cli/Agents/Playwright/PlaywrightCliInstaller.cs
@@ -205,8 +205,8 @@ internal sealed class PlaywrightCliInstaller(
                 refInfo => string.Equals(refInfo.Kind, "tags", StringComparison.Ordinal) &&
                            (string.Equals(refInfo.Name, $"{packageInfo.Version}", StringComparison.Ordinal) ||
                             string.Equals(refInfo.Name, $"v{packageInfo.Version}", StringComparison.Ordinal)),
-                sriIntegrity: packageInfo.Integrity,
-                cancellationToken: cancellationToken);
+                packageInfo.Integrity,
+                cancellationToken);
 
             if (!provenanceResult.IsVerified)
             {

--- a/src/Aspire.Cli/Agents/Playwright/PlaywrightCliInstaller.cs
+++ b/src/Aspire.Cli/Agents/Playwright/PlaywrightCliInstaller.cs
@@ -205,8 +205,8 @@ internal sealed class PlaywrightCliInstaller(
                 refInfo => string.Equals(refInfo.Kind, "tags", StringComparison.Ordinal) &&
                            (string.Equals(refInfo.Name, $"{packageInfo.Version}", StringComparison.Ordinal) ||
                             string.Equals(refInfo.Name, $"v{packageInfo.Version}", StringComparison.Ordinal)),
-                cancellationToken,
-                sriIntegrity: packageInfo.Integrity);
+                sriIntegrity: packageInfo.Integrity,
+                cancellationToken: cancellationToken);
 
             if (!provenanceResult.IsVerified)
             {

--- a/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
@@ -237,7 +237,7 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
         }
 
         var mcpConfigPath = Path.Combine(vsCodeFolder.FullName, McpConfigFileName);
-        var config = await McpConfigFileHelper.ReadConfigAsync(mcpConfigPath, cancellationToken: cancellationToken);
+        var config = await McpConfigFileHelper.ReadConfigAsync(mcpConfigPath, null, cancellationToken);
 
         // Ensure "servers" object exists
         if (!config.ContainsKey("servers") || config["servers"] is not JsonObject)

--- a/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
@@ -237,7 +237,7 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
         }
 
         var mcpConfigPath = Path.Combine(vsCodeFolder.FullName, McpConfigFileName);
-        var config = await McpConfigFileHelper.ReadConfigAsync(mcpConfigPath, cancellationToken);
+        var config = await McpConfigFileHelper.ReadConfigAsync(mcpConfigPath, cancellationToken: cancellationToken);
 
         // Ensure "servers" object exists
         if (!config.ContainsKey("servers") || config["servers"] is not JsonObject)

--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -50,10 +50,10 @@ internal sealed class CertificateService(
     AspireCliTelemetry telemetry,
     ICliHostEnvironment hostEnvironment,
     CliExecutionContext executionContext,
-    Func<bool>? isLinux = null) : ICertificateService
+    Func<bool> isLinux) : ICertificateService
 {
     private const string SslCertDirEnvVar = "SSL_CERT_DIR";
-    private readonly Func<bool> _isLinux = isLinux ?? OperatingSystem.IsLinux;
+    private readonly Func<bool> _isLinux = isLinux;
 
     public async Task<EnsureCertificatesTrustedResult> EnsureCertificatesTrustedAsync(CancellationToken cancellationToken)
     {

--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -50,17 +50,16 @@ internal sealed class CertificateService(
     AspireCliTelemetry telemetry,
     ICliHostEnvironment hostEnvironment,
     CliExecutionContext executionContext,
-    Func<bool> isLinux) : ICertificateService
+    IEnvironment environment) : ICertificateService
 {
     private const string SslCertDirEnvVar = "SSL_CERT_DIR";
-    private readonly Func<bool> _isLinux = isLinux ?? throw new ArgumentNullException(nameof(isLinux));
 
     public async Task<EnsureCertificatesTrustedResult> EnsureCertificatesTrustedAsync(CancellationToken cancellationToken)
     {
         using var activity = telemetry.StartDiagnosticActivity(kind: ActivityKind.Client);
 
         var environmentVariables = new Dictionary<string, string>();
-        var isLinux = _isLinux();
+        var isLinux = environment.IsLinux;
 
         // In non-interactive environments on macOS and Windows we can't successfully
         // prompt for trust (macOS Keychain password, Windows trust dialog).

--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -53,7 +53,7 @@ internal sealed class CertificateService(
     Func<bool> isLinux) : ICertificateService
 {
     private const string SslCertDirEnvVar = "SSL_CERT_DIR";
-    private readonly Func<bool> _isLinux = isLinux;
+    private readonly Func<bool> _isLinux = isLinux ?? throw new ArgumentNullException(nameof(isLinux));
 
     public async Task<EnsureCertificatesTrustedResult> EnsureCertificatesTrustedAsync(CancellationToken cancellationToken)
     {

--- a/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
+++ b/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
@@ -10,9 +10,8 @@ namespace Aspire.Cli.Certificates;
 /// <summary>
 /// Certificate tool runner that uses the native CertificateManager directly (no subprocess needed).
 /// </summary>
-internal sealed class NativeCertificateToolRunner(CertificateManager certificateManager, Func<bool> isLinux) : ICertificateToolRunner
+internal sealed class NativeCertificateToolRunner(CertificateManager certificateManager, IEnvironment environment) : ICertificateToolRunner
 {
-    private readonly Func<bool> _isLinux = isLinux ?? throw new ArgumentNullException(nameof(isLinux));
 
     public CertificateTrustResult CheckHttpCertificate()
     {
@@ -74,7 +73,7 @@ internal sealed class NativeCertificateToolRunner(CertificateManager certificate
 
     public EnsureCertificateResult TrustHttpCertificate()
     {
-        if (_isLinux())
+        if (environment.IsLinux)
         {
             var availableCertificates = certificateManager.ListCertificates(
                 StoreName.My, StoreLocation.CurrentUser, isValid: true);

--- a/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
+++ b/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
@@ -10,9 +10,9 @@ namespace Aspire.Cli.Certificates;
 /// <summary>
 /// Certificate tool runner that uses the native CertificateManager directly (no subprocess needed).
 /// </summary>
-internal sealed class NativeCertificateToolRunner(CertificateManager certificateManager, Func<bool>? isLinux = null) : ICertificateToolRunner
+internal sealed class NativeCertificateToolRunner(CertificateManager certificateManager, Func<bool> isLinux) : ICertificateToolRunner
 {
-    private readonly Func<bool> _isLinux = isLinux ?? OperatingSystem.IsLinux;
+    private readonly Func<bool> _isLinux = isLinux;
 
     public CertificateTrustResult CheckHttpCertificate()
     {

--- a/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
+++ b/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
@@ -12,7 +12,7 @@ namespace Aspire.Cli.Certificates;
 /// </summary>
 internal sealed class NativeCertificateToolRunner(CertificateManager certificateManager, Func<bool> isLinux) : ICertificateToolRunner
 {
-    private readonly Func<bool> _isLinux = isLinux;
+    private readonly Func<bool> _isLinux = isLinux ?? throw new ArgumentNullException(nameof(isLinux));
 
     public CertificateTrustResult CheckHttpCertificate()
     {

--- a/src/Aspire.Cli/Commands/LsCommand.cs
+++ b/src/Aspire.Cli/Commands/LsCommand.cs
@@ -45,7 +45,7 @@ internal sealed class LsCommand : BaseCommand
         ConsoleEnvironment consoleEnvironment,
         ProfilingTelemetry profilingTelemetry,
         CommonCommandServices services,
-        TimeProvider? timeProvider = null)
+        TimeProvider timeProvider)
         : base("ls", SharedCommandStrings.LsCommandDescription, services)
     {
         _projectLocator = projectLocator;
@@ -53,7 +53,7 @@ internal sealed class LsCommand : BaseCommand
         _hostEnvironment = hostEnvironment;
         _consoleEnvironment = consoleEnvironment;
         _profilingTelemetry = profilingTelemetry;
-        _timeProvider = timeProvider ?? TimeProvider.System;
+        _timeProvider = timeProvider;
 
         Options.Add(s_formatOption);
         Options.Add(s_allOption);

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -144,7 +144,7 @@ internal sealed class UpdateCommand : BaseCommand
 
             try
             {
-                return await ExecuteSelfUpdateAsync(parseResult, cancellationToken: cancellationToken);
+                return await ExecuteSelfUpdateAsync(parseResult, null, cancellationToken);
             }
             catch (OperationCanceledException)
             {
@@ -394,7 +394,7 @@ internal sealed class UpdateCommand : BaseCommand
 
                     if (shouldUpdateCli)
                     {
-                        return await ExecuteSelfUpdateAsync(parseResult, cancellationToken: cancellationToken);
+                        return await ExecuteSelfUpdateAsync(parseResult, null, cancellationToken);
                     }
                 }
             }
@@ -496,7 +496,7 @@ internal sealed class UpdateCommand : BaseCommand
             || string.Equals(ExecutionContext.IdentityChannel, PackageChannelNames.Staging, StringComparisons.ChannelName);
     }
 
-    private async Task<CommandResult> ExecuteSelfUpdateAsync(ParseResult parseResult, string? selectedChannel = null, CancellationToken cancellationToken = default)
+    private async Task<CommandResult> ExecuteSelfUpdateAsync(ParseResult parseResult, string? selectedChannel, CancellationToken cancellationToken)
     {
         var channel = selectedChannel ?? parseResult.GetValue(_channelOption) ?? parseResult.GetValue(_qualityOption);
 

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -144,7 +144,7 @@ internal sealed class UpdateCommand : BaseCommand
 
             try
             {
-                return await ExecuteSelfUpdateAsync(parseResult, cancellationToken);
+                return await ExecuteSelfUpdateAsync(parseResult, cancellationToken: cancellationToken);
             }
             catch (OperationCanceledException)
             {
@@ -360,7 +360,7 @@ internal sealed class UpdateCommand : BaseCommand
                     }
 
                     // Use the same channel that was selected for the project update
-                    return await ExecuteSelfUpdateAsync(parseResult, cancellationToken, channel.Name);
+                    return await ExecuteSelfUpdateAsync(parseResult, channel.Name, cancellationToken);
                 }
             }
         }
@@ -394,7 +394,7 @@ internal sealed class UpdateCommand : BaseCommand
 
                     if (shouldUpdateCli)
                     {
-                        return await ExecuteSelfUpdateAsync(parseResult, cancellationToken);
+                        return await ExecuteSelfUpdateAsync(parseResult, cancellationToken: cancellationToken);
                     }
                 }
             }
@@ -461,7 +461,7 @@ internal sealed class UpdateCommand : BaseCommand
             return CommandResult.Success();
         }
 
-        var selfUpdateResult = await ExecuteSelfUpdateAsync(parseResult, cancellationToken, channel.Name);
+        var selfUpdateResult = await ExecuteSelfUpdateAsync(parseResult, channel.Name, cancellationToken);
         if (selfUpdateResult.ExitCode == CliExitCodes.Success)
         {
             InteractionService.DisplayMessage(KnownEmojis.Information, UpdateCommandStrings.ProjectUpdateSkippedAfterCliUpdateMessage);
@@ -496,7 +496,7 @@ internal sealed class UpdateCommand : BaseCommand
             || string.Equals(ExecutionContext.IdentityChannel, PackageChannelNames.Staging, StringComparisons.ChannelName);
     }
 
-    private async Task<CommandResult> ExecuteSelfUpdateAsync(ParseResult parseResult, CancellationToken cancellationToken, string? selectedChannel = null)
+    private async Task<CommandResult> ExecuteSelfUpdateAsync(ParseResult parseResult, string? selectedChannel = null, CancellationToken cancellationToken = default)
     {
         var channel = selectedChannel ?? parseResult.GetValue(_channelOption) ?? parseResult.GetValue(_qualityOption);
 

--- a/src/Aspire.Cli/Commands/WaitCommand.cs
+++ b/src/Aspire.Cli/Commands/WaitCommand.cs
@@ -42,12 +42,12 @@ internal sealed class WaitCommand : BaseCommand
         AppHostConnectionResolver connectionResolver,
         ILogger<WaitCommand> logger,
         CommonCommandServices services,
-        TimeProvider? timeProvider = null)
+        TimeProvider timeProvider)
         : base("wait", WaitCommandStrings.Description, services)
     {
         _connectionResolver = connectionResolver;
         _logger = logger;
-        _timeProvider = timeProvider ?? TimeProvider.System;
+        _timeProvider = timeProvider;
 
         Arguments.Add(s_resourceArgument);
         Options.Add(s_statusOption);

--- a/src/Aspire.Cli/HostEnvironment.cs
+++ b/src/Aspire.Cli/HostEnvironment.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli;
+
+/// <summary>
+/// Default <see cref="IEnvironment"/> that delegates to the process
+/// environment and <see cref="OperatingSystem"/> runtime checks.
+/// </summary>
+internal sealed class HostEnvironment : IEnvironment
+{
+    public string? GetEnvironmentVariable(string variable) => Environment.GetEnvironmentVariable(variable);
+
+    public bool IsWindows => OperatingSystem.IsWindows();
+
+    public bool IsLinux => OperatingSystem.IsLinux();
+
+    public bool IsMacOS => OperatingSystem.IsMacOS();
+}

--- a/src/Aspire.Cli/IEnvironment.cs
+++ b/src/Aspire.Cli/IEnvironment.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli;
+
+/// <summary>
+/// Abstracts environment queries so both <see cref="CliExecutionContext"/> and
+/// <see cref="Acquisition.IdentityResolver"/> can read environment variables
+/// and detect the host OS without a circular dependency between them.
+/// </summary>
+internal interface IEnvironment
+{
+    /// <summary>
+    /// Gets the value of an environment variable.
+    /// </summary>
+    /// <param name="variable">The environment variable name.</param>
+    /// <returns>The value, or <see langword="null"/> if not set.</returns>
+    string? GetEnvironmentVariable(string variable);
+
+    /// <summary>
+    /// Gets a value indicating whether the current OS is Windows.
+    /// </summary>
+    bool IsWindows { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the current OS is Linux.
+    /// </summary>
+    bool IsLinux { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the current OS is macOS.
+    /// </summary>
+    bool IsMacOS { get; }
+}

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -26,22 +26,21 @@ internal interface IExtensionInteractionService : IInteractionService
     void ConsoleDisplaySubtleMessage(string message, bool allowMarkup = false);
 }
 
-internal class ExtensionInteractionService : IExtensionInteractionService
+internal class ExtensionInteractionService : IExtensionInteractionService, IDisposable
 {
     private readonly ConsoleInteractionService _consoleInteractionService;
     private readonly bool _extensionPromptEnabled;
-    private readonly CancellationToken _cancellationToken;
+    private readonly CancellationTokenSource _cts = new();
     private readonly Channel<Func<Task>> _extensionTaskChannel;
     private readonly ILogger<ExtensionInteractionService> _logger;
 
     public IExtensionBackchannel Backchannel { get; }
 
-    public ExtensionInteractionService(ConsoleInteractionService consoleInteractionService, IExtensionBackchannel backchannel, bool extensionPromptEnabled, ILogger<ExtensionInteractionService> logger, CancellationToken cancellationToken)
+    public ExtensionInteractionService(ConsoleInteractionService consoleInteractionService, IExtensionBackchannel backchannel, bool extensionPromptEnabled, ILogger<ExtensionInteractionService> logger)
     {
         _consoleInteractionService = consoleInteractionService;
         Backchannel = backchannel;
         _extensionPromptEnabled = extensionPromptEnabled;
-        _cancellationToken = cancellationToken;
         _logger = logger;
         _extensionTaskChannel = Channel.CreateUnbounded<Func<Task>>(new UnboundedChannelOptions
         {
@@ -51,7 +50,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
         _ = Task.Run(async () =>
         {
-            while (await _extensionTaskChannel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false))
+            while (await _extensionTaskChannel.Reader.WaitToReadAsync(_cts.Token).ConfigureAwait(false))
             {
                 try
                 {
@@ -62,7 +61,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 {
                     try
                     {
-                        await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(ex.Message), _cancellationToken);
+                        await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(ex.Message), _cts.Token);
                     }
                     catch (Exception displayErrorException)
                     {
@@ -74,7 +73,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                     _consoleInteractionService.DisplayError(ex.Message);
                 }
             }
-        }, _cancellationToken);
+        }, _cts.Token);
     }
 
     public async Task FlushAsync(CancellationToken cancellationToken = default)
@@ -94,7 +93,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cts.Token));
         Debug.Assert(result);
 
         try
@@ -104,14 +103,14 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         finally
         {
             // Clear the IDE status indicator even if the action threw, to avoid leaving it spinning indefinitely.
-            result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cancellationToken));
+            result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cts.Token));
             Debug.Assert(result);
         }
     }
 
     public async Task<T> ShowDynamicStatusAsync<T>(string initialStatusText, Func<Action<string>, Task<T>> action, KnownEmoji? emoji = null)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(initialStatusText), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(initialStatusText), _cts.Token));
         Debug.Assert(result);
 
         try
@@ -120,7 +119,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 initialStatusText,
                 updateStatus => action(statusText =>
                 {
-                    var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cancellationToken));
+                    var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cts.Token));
                     Debug.Assert(result);
                     updateStatus(statusText);
                 }),
@@ -128,14 +127,14 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         }
         finally
         {
-            result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cancellationToken));
+            result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cts.Token));
             Debug.Assert(result);
         }
     }
 
     public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cts.Token));
         Debug.Assert(result);
 
         try
@@ -145,7 +144,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         finally
         {
             // Clear the IDE status indicator even if the action threw, to avoid leaving it spinning indefinitely.
-            result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cancellationToken));
+            result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cts.Token));
             Debug.Assert(result);
         }
     }
@@ -173,22 +172,22 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                     if (isSecret)
                     {
                         // Check if extension supports the new secret prompts capability
-                        var hasSecretPromptsCapability = await Backchannel.HasCapabilityAsync(KnownCapabilities.SecretPrompts, _cancellationToken).ConfigureAwait(false);
+                        var hasSecretPromptsCapability = await Backchannel.HasCapabilityAsync(KnownCapabilities.SecretPrompts, _cts.Token).ConfigureAwait(false);
 
                         if (hasSecretPromptsCapability)
                         {
                             // Use the new dedicated secret prompt method (no default value for secrets)
-                            result = await Backchannel.PromptForSecretStringAsync(StringUtils.RemoveMarkup(promptText), validator, required, _cancellationToken).ConfigureAwait(false);
+                            result = await Backchannel.PromptForSecretStringAsync(StringUtils.RemoveMarkup(promptText), validator, required, _cts.Token).ConfigureAwait(false);
                         }
                         else
                         {
                             // Fallback to regular prompt for older extension versions
-                            result = await Backchannel.PromptForStringAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
+                            result = await Backchannel.PromptForStringAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, validator, required, _cts.Token).ConfigureAwait(false);
                         }
                     }
                     else
                     {
-                        result = await Backchannel.PromptForStringAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
+                        result = await Backchannel.PromptForStringAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, validator, required, _cts.Token).ConfigureAwait(false);
                     }
 
                     tcs.SetResult(result);
@@ -218,7 +217,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
         if (_extensionPromptEnabled)
         {
-            var hasFilePickersCapability = await Backchannel.HasCapabilityAsync(KnownCapabilities.FilePickers, _cancellationToken).ConfigureAwait(false);
+            var hasFilePickersCapability = await Backchannel.HasCapabilityAsync(KnownCapabilities.FilePickers, _cts.Token).ConfigureAwait(false);
 
             if (hasFilePickersCapability)
             {
@@ -228,7 +227,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 {
                     try
                     {
-                        var result = await Backchannel.PromptForFilePathAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, directory, _cancellationToken).ConfigureAwait(false);
+                        var result = await Backchannel.PromptForFilePathAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, directory, _cts.Token).ConfigureAwait(false);
                         tcs.SetResult(result);
                     }
                     catch (Exception ex)
@@ -282,7 +281,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
             {
                 try
                 {
-                    var result = await Backchannel.ConfirmAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue ?? false, _cancellationToken).ConfigureAwait(false);
+                    var result = await Backchannel.ConfirmAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue ?? false, _cts.Token).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -320,7 +319,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
             {
                 try
                 {
-                    var result = await Backchannel.PromptForSelectionAsync(StringUtils.RemoveMarkup(promptText), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
+                    var result = await Backchannel.PromptForSelectionAsync(StringUtils.RemoveMarkup(promptText), choices, choiceFormatter, _cts.Token).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -361,7 +360,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 {
                     // Note: The extension backchannel protocol does not yet support preSelected items.
                     // Pre-selected items are applied only when falling back to the console interaction service.
-                    var result = await Backchannel.PromptForSelectionsAsync(StringUtils.RemoveMarkup(promptText), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
+                    var result = await Backchannel.PromptForSelectionsAsync(StringUtils.RemoveMarkup(promptText), choices, choiceFormatter, _cts.Token).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -384,7 +383,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingSdkVersion)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayIncompatibleVersionErrorAsync(ex.RequiredCapability, appHostHostingSdkVersion, _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayIncompatibleVersionErrorAsync(ex.RequiredCapability, appHostHostingSdkVersion, _cts.Token));
         Debug.Assert(result);
 
         return _consoleInteractionService.DisplayIncompatibleVersionError(ex, appHostHostingSdkVersion);
@@ -399,7 +398,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         // out-of-order output like an error message preceding the lines that explain it.
         var result = _extensionTaskChannel.Writer.TryWrite(async () =>
         {
-            await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(errorMessage), _cancellationToken);
+            await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(errorMessage), _cts.Token);
             _consoleInteractionService.DisplayError(errorMessage, allowMarkup);
         });
         Debug.Assert(result);
@@ -409,7 +408,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
     {
         var result = _extensionTaskChannel.Writer.TryWrite(async () =>
         {
-            await Backchannel.DisplayMessageAsync(emoji.Name, StringUtils.RemoveMarkup(message), _cancellationToken);
+            await Backchannel.DisplayMessageAsync(emoji.Name, StringUtils.RemoveMarkup(message), _cts.Token);
             _consoleInteractionService.DisplayMessage(emoji, message, allowMarkup, consoleOverride);
         });
         Debug.Assert(result);
@@ -417,14 +416,14 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySuccessAsync(StringUtils.RemoveMarkup(message), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySuccessAsync(StringUtils.RemoveMarkup(message), _cts.Token));
         Debug.Assert(result);
         _consoleInteractionService.DisplaySuccess(message, allowMarkup);
     }
 
     public void DisplaySubtleMessage(string message, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySubtleMessageAsync(StringUtils.RemoveMarkup(message), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySubtleMessageAsync(StringUtils.RemoveMarkup(message), _cts.Token));
         Debug.Assert(result);
         _consoleInteractionService.DisplaySubtleMessage(message, allowMarkup);
     }
@@ -436,7 +435,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void DisplayDashboardUrls(DashboardUrlsState dashboardUrls)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayDashboardUrlsAsync(dashboardUrls, _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayDashboardUrlsAsync(dashboardUrls, _cts.Token));
         Debug.Assert(result);
     }
 
@@ -447,7 +446,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(materialized.Select(line => new DisplayLineState(
             line.Stream == OutputLineStream.StdOut ? "stdout" : "stderr",
-            StringUtils.RemoveMarkup(line.Line))), _cancellationToken));
+            StringUtils.RemoveMarkup(line.Line))), _cts.Token));
         Debug.Assert(result);
 
         // Intentionally do NOT also write to the local console here. Unlike most Display* methods
@@ -460,27 +459,27 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayCancellationMessageAsync(_cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayCancellationMessageAsync(_cts.Token));
         Debug.Assert(result);
         _consoleInteractionService.DisplayCancellationMessage(consoleOverride);
     }
 
     public void DisplayEmptyLine()
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayEmptyLineAsync(_cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayEmptyLineAsync(_cts.Token));
         Debug.Assert(result);
         _consoleInteractionService.DisplayEmptyLine();
     }
 
     public void OpenEditor(string path)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.OpenEditorAsync(path, _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.OpenEditorAsync(path, _cts.Token));
         Debug.Assert(result);
     }
 
     public void DisplayPlainText(string text)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayPlainTextAsync(text, _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayPlainTextAsync(text, _cts.Token));
         Debug.Assert(result);
         _consoleInteractionService.DisplayPlainText(text);
     }
@@ -497,7 +496,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayPlainTextAsync(text, _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayPlainTextAsync(text, _cts.Token));
         Debug.Assert(result);
         _consoleInteractionService.DisplayRawText(text, consoleOverride);
     }
@@ -506,7 +505,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
     {
         // Send raw markdown to extension (it can handle markdown natively)
         // Convert to Spectre markup for console display
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, markdown, _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, markdown, _cts.Token));
         Debug.Assert(result);
         _consoleInteractionService.DisplayMarkdown(markdown, consoleOverride, maxWidth);
     }
@@ -514,7 +513,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
     public void DisplayMarkupLine(string markup)
     {
         // Strip markup for backchannel, display as-is to console
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, StringUtils.RemoveMarkup(markup), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, StringUtils.RemoveMarkup(markup), _cts.Token));
         Debug.Assert(result);
         _consoleInteractionService.DisplayMarkupLine(markup);
     }
@@ -536,13 +535,13 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void LogMessage(LogLevel logLevel, string message)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(logLevel, StringUtils.RemoveMarkup(message), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(logLevel, StringUtils.RemoveMarkup(message), _cts.Token));
         Debug.Assert(result);
     }
 
     public Task LaunchAppHostAsync(string projectFile, List<string> arguments, List<EnvVar> environment, bool debug)
     {
-        return Backchannel.LaunchAppHostAsync(projectFile, arguments, environment, debug, _cancellationToken);
+        return Backchannel.LaunchAppHostAsync(projectFile, arguments, environment, debug, _cts.Token);
     }
 
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false)
@@ -552,7 +551,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public void NotifyAppHostStartupCompleted()
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.NotifyAppHostStartupCompletedAsync(_cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.NotifyAppHostStartupCompletedAsync(_cts.Token));
         Debug.Assert(result);
     }
 
@@ -563,12 +562,18 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
     public Task StartDebugSessionAsync(string workingDirectory, string? projectFile, bool debug, DebugSessionOptions? options = null)
     {
-        return Backchannel.StartDebugSessionAsync(workingDirectory, projectFile, debug, options, _cancellationToken);
+        return Backchannel.StartDebugSessionAsync(workingDirectory, projectFile, debug, options, _cts.Token);
     }
 
     public void WriteDebugSessionMessage(string message, bool stdout, string? textStyle)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(StringUtils.RemoveMarkup(message), stdout, textStyle, _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(StringUtils.RemoveMarkup(message), stdout, textStyle, _cts.Token));
         Debug.Assert(result);
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
     }
 }

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -35,6 +35,12 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
     private readonly Channel<Func<Task>> _extensionTaskChannel;
     private readonly ILogger<ExtensionInteractionService> _logger;
 
+    /// <summary>
+    /// The background pump task that processes queued extension operations.
+    /// Completes when the channel is completed and/or the token is cancelled.
+    /// </summary>
+    internal Task PumpTask { get; }
+
     public IExtensionBackchannel Backchannel { get; }
 
     public ExtensionInteractionService(ConsoleInteractionService consoleInteractionService, IExtensionBackchannel backchannel, bool extensionPromptEnabled, ILogger<ExtensionInteractionService> logger)
@@ -50,7 +56,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
             SingleWriter = true
         });
 
-        _ = Task.Run(async () =>
+        PumpTask = Task.Run(async () =>
         {
             try
             {

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -52,28 +52,39 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
         _ = Task.Run(async () =>
         {
-            while (await _extensionTaskChannel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false))
+            try
             {
-                try
-                {
-                    var taskFunction = await _extensionTaskChannel.Reader.ReadAsync().ConfigureAwait(false);
-                    await taskFunction.Invoke();
-                }
-                catch (Exception ex) when (ex is not ExtensionOperationCanceledException)
+                while (await _extensionTaskChannel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false))
                 {
                     try
                     {
-                        await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(ex.Message), _cancellationToken);
+                        var taskFunction = await _extensionTaskChannel.Reader.ReadAsync().ConfigureAwait(false);
+                        await taskFunction.Invoke();
                     }
-                    catch (Exception displayErrorException)
+                    catch (Exception ex) when (ex is not ExtensionOperationCanceledException)
                     {
-                        // Keep the single-reader pump alive even when the extension connection is
-                        // already broken; otherwise the final flush sentinel can never be processed.
-                        _logger.LogDebug(displayErrorException, "Failed to display an extension operation error through the extension backchannel.");
-                    }
+                        try
+                        {
+                            await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(ex.Message), _cancellationToken);
+                        }
+                        catch (Exception displayErrorException)
+                        {
+                            // Keep the single-reader pump alive even when the extension connection is
+                            // already broken; otherwise the final flush sentinel can never be processed.
+                            _logger.LogDebug(displayErrorException, "Failed to display an extension operation error through the extension backchannel.");
+                        }
 
-                    _consoleInteractionService.DisplayError(ex.Message);
+                        _consoleInteractionService.DisplayError(ex.Message);
+                    }
                 }
+            }
+            catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
+            {
+                // Expected during disposal — the channel was completed and/or the token cancelled.
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error in extension task channel processing loop.");
             }
         }, _cancellationToken);
     }

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -575,6 +575,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
     public void Dispose()
     {
+        _extensionTaskChannel.Writer.TryComplete();
         _cts.Cancel();
         _cts.Dispose();
     }

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -56,43 +56,9 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
             SingleWriter = true
         });
 
-        PumpTask = Task.Run(async () =>
-        {
-            try
-            {
-                while (await _extensionTaskChannel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false))
-                {
-                    try
-                    {
-                        var taskFunction = await _extensionTaskChannel.Reader.ReadAsync().ConfigureAwait(false);
-                        await taskFunction.Invoke();
-                    }
-                    catch (Exception ex) when (ex is not ExtensionOperationCanceledException)
-                    {
-                        try
-                        {
-                            await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(ex.Message), _cancellationToken);
-                        }
-                        catch (Exception displayErrorException)
-                        {
-                            // Keep the single-reader pump alive even when the extension connection is
-                            // already broken; otherwise the final flush sentinel can never be processed.
-                            _logger.LogDebug(displayErrorException, "Failed to display an extension operation error through the extension backchannel.");
-                        }
-
-                        _consoleInteractionService.DisplayError(ex.Message);
-                    }
-                }
-            }
-            catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
-            {
-                // Expected during disposal — the channel was completed and/or the token cancelled.
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Unexpected error in extension task channel processing loop.");
-            }
-        }, _cancellationToken);
+        // Use CancellationToken.None here to avoid the pump task being cancelled before it is scheduled.
+        // Code in the pump task itself will observe the cancellation token to exit gracefully when the service is disposed.
+        PumpTask = Task.Run(ProcessExtensionTaskChannelAsync, CancellationToken.None);
     }
 
     public async Task FlushAsync(CancellationToken cancellationToken = default)
@@ -588,6 +554,44 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
     {
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(StringUtils.RemoveMarkup(message), stdout, textStyle, _cancellationToken));
         Debug.Assert(result);
+    }
+
+    private async Task ProcessExtensionTaskChannelAsync()
+    {
+        try
+        {
+            while (await _extensionTaskChannel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false))
+            {
+                try
+                {
+                    var taskFunction = await _extensionTaskChannel.Reader.ReadAsync().ConfigureAwait(false);
+                    await taskFunction.Invoke();
+                }
+                catch (Exception ex) when (ex is not ExtensionOperationCanceledException)
+                {
+                    try
+                    {
+                        await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(ex.Message), _cancellationToken);
+                    }
+                    catch (Exception displayErrorException)
+                    {
+                        // Keep the single-reader pump alive even when the extension connection is
+                        // already broken; otherwise the final flush sentinel can never be processed.
+                        _logger.LogDebug(displayErrorException, "Failed to display an extension operation error through the extension backchannel.");
+                    }
+
+                    _consoleInteractionService.DisplayError(ex.Message);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
+        {
+            // Expected during disposal — the channel was completed and/or the token cancelled.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error in extension task channel processing loop.");
+        }
     }
 
     public void Dispose()

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -32,16 +32,16 @@ internal class ExtensionInteractionService : IExtensionInteractionService
     private readonly bool _extensionPromptEnabled;
     private readonly CancellationToken _cancellationToken;
     private readonly Channel<Func<Task>> _extensionTaskChannel;
-    private readonly ILogger<ExtensionInteractionService>? _logger;
+    private readonly ILogger<ExtensionInteractionService> _logger;
 
     public IExtensionBackchannel Backchannel { get; }
 
-    public ExtensionInteractionService(ConsoleInteractionService consoleInteractionService, IExtensionBackchannel backchannel, bool extensionPromptEnabled, CancellationToken? cancellationToken = null, ILogger<ExtensionInteractionService>? logger = null)
+    public ExtensionInteractionService(ConsoleInteractionService consoleInteractionService, IExtensionBackchannel backchannel, bool extensionPromptEnabled, ILogger<ExtensionInteractionService> logger, CancellationToken cancellationToken)
     {
         _consoleInteractionService = consoleInteractionService;
         Backchannel = backchannel;
         _extensionPromptEnabled = extensionPromptEnabled;
-        _cancellationToken = cancellationToken ?? CancellationToken.None;
+        _cancellationToken = cancellationToken;
         _logger = logger;
         _extensionTaskChannel = Channel.CreateUnbounded<Func<Task>>(new UnboundedChannelOptions
         {
@@ -51,7 +51,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
 
         _ = Task.Run(async () =>
         {
-            while (await _extensionTaskChannel.Reader.WaitToReadAsync().ConfigureAwait(false))
+            while (await _extensionTaskChannel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false))
             {
                 try
                 {
@@ -68,13 +68,13 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                     {
                         // Keep the single-reader pump alive even when the extension connection is
                         // already broken; otherwise the final flush sentinel can never be processed.
-                        _logger?.LogDebug(displayErrorException, "Failed to display an extension operation error through the extension backchannel.");
+                        _logger.LogDebug(displayErrorException, "Failed to display an extension operation error through the extension backchannel.");
                     }
 
                     _consoleInteractionService.DisplayError(ex.Message);
                 }
             }
-        });
+        }, _cancellationToken);
     }
 
     public async Task FlushAsync(CancellationToken cancellationToken = default)

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -31,6 +31,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
     private readonly ConsoleInteractionService _consoleInteractionService;
     private readonly bool _extensionPromptEnabled;
     private readonly CancellationTokenSource _cts = new();
+    private readonly CancellationToken _cancellationToken;
     private readonly Channel<Func<Task>> _extensionTaskChannel;
     private readonly ILogger<ExtensionInteractionService> _logger;
 
@@ -41,6 +42,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
         _consoleInteractionService = consoleInteractionService;
         Backchannel = backchannel;
         _extensionPromptEnabled = extensionPromptEnabled;
+        _cancellationToken = _cts.Token;
         _logger = logger;
         _extensionTaskChannel = Channel.CreateUnbounded<Func<Task>>(new UnboundedChannelOptions
         {
@@ -50,7 +52,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
         _ = Task.Run(async () =>
         {
-            while (await _extensionTaskChannel.Reader.WaitToReadAsync(_cts.Token).ConfigureAwait(false))
+            while (await _extensionTaskChannel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false))
             {
                 try
                 {
@@ -61,7 +63,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
                 {
                     try
                     {
-                        await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(ex.Message), _cts.Token);
+                        await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(ex.Message), _cancellationToken);
                     }
                     catch (Exception displayErrorException)
                     {
@@ -73,7 +75,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
                     _consoleInteractionService.DisplayError(ex.Message);
                 }
             }
-        }, _cts.Token);
+        }, _cancellationToken);
     }
 
     public async Task FlushAsync(CancellationToken cancellationToken = default)
@@ -93,7 +95,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
     public async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cancellationToken));
         Debug.Assert(result);
 
         try
@@ -103,14 +105,14 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
         finally
         {
             // Clear the IDE status indicator even if the action threw, to avoid leaving it spinning indefinitely.
-            result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cts.Token));
+            result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cancellationToken));
             Debug.Assert(result);
         }
     }
 
     public async Task<T> ShowDynamicStatusAsync<T>(string initialStatusText, Func<Action<string>, Task<T>> action, KnownEmoji? emoji = null)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(initialStatusText), _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(initialStatusText), _cancellationToken));
         Debug.Assert(result);
 
         try
@@ -119,7 +121,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
                 initialStatusText,
                 updateStatus => action(statusText =>
                 {
-                    var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cts.Token));
+                    var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cancellationToken));
                     Debug.Assert(result);
                     updateStatus(statusText);
                 }),
@@ -127,14 +129,14 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
         }
         finally
         {
-            result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cts.Token));
+            result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cancellationToken));
             Debug.Assert(result);
         }
     }
 
     public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(StringUtils.RemoveMarkup(statusText), _cancellationToken));
         Debug.Assert(result);
 
         try
@@ -144,7 +146,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
         finally
         {
             // Clear the IDE status indicator even if the action threw, to avoid leaving it spinning indefinitely.
-            result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cts.Token));
+            result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cancellationToken));
             Debug.Assert(result);
         }
     }
@@ -172,22 +174,22 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
                     if (isSecret)
                     {
                         // Check if extension supports the new secret prompts capability
-                        var hasSecretPromptsCapability = await Backchannel.HasCapabilityAsync(KnownCapabilities.SecretPrompts, _cts.Token).ConfigureAwait(false);
+                        var hasSecretPromptsCapability = await Backchannel.HasCapabilityAsync(KnownCapabilities.SecretPrompts, _cancellationToken).ConfigureAwait(false);
 
                         if (hasSecretPromptsCapability)
                         {
                             // Use the new dedicated secret prompt method (no default value for secrets)
-                            result = await Backchannel.PromptForSecretStringAsync(StringUtils.RemoveMarkup(promptText), validator, required, _cts.Token).ConfigureAwait(false);
+                            result = await Backchannel.PromptForSecretStringAsync(StringUtils.RemoveMarkup(promptText), validator, required, _cancellationToken).ConfigureAwait(false);
                         }
                         else
                         {
                             // Fallback to regular prompt for older extension versions
-                            result = await Backchannel.PromptForStringAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, validator, required, _cts.Token).ConfigureAwait(false);
+                            result = await Backchannel.PromptForStringAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
                         }
                     }
                     else
                     {
-                        result = await Backchannel.PromptForStringAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, validator, required, _cts.Token).ConfigureAwait(false);
+                        result = await Backchannel.PromptForStringAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, validator, required, _cancellationToken).ConfigureAwait(false);
                     }
 
                     tcs.SetResult(result);
@@ -217,7 +219,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
         if (_extensionPromptEnabled)
         {
-            var hasFilePickersCapability = await Backchannel.HasCapabilityAsync(KnownCapabilities.FilePickers, _cts.Token).ConfigureAwait(false);
+            var hasFilePickersCapability = await Backchannel.HasCapabilityAsync(KnownCapabilities.FilePickers, _cancellationToken).ConfigureAwait(false);
 
             if (hasFilePickersCapability)
             {
@@ -227,7 +229,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
                 {
                     try
                     {
-                        var result = await Backchannel.PromptForFilePathAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, directory, _cts.Token).ConfigureAwait(false);
+                        var result = await Backchannel.PromptForFilePathAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue, directory, _cancellationToken).ConfigureAwait(false);
                         tcs.SetResult(result);
                     }
                     catch (Exception ex)
@@ -281,7 +283,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
             {
                 try
                 {
-                    var result = await Backchannel.ConfirmAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue ?? false, _cts.Token).ConfigureAwait(false);
+                    var result = await Backchannel.ConfirmAsync(StringUtils.RemoveMarkup(promptText), binding?.DefaultValue ?? false, _cancellationToken).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -319,7 +321,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
             {
                 try
                 {
-                    var result = await Backchannel.PromptForSelectionAsync(StringUtils.RemoveMarkup(promptText), choices, choiceFormatter, _cts.Token).ConfigureAwait(false);
+                    var result = await Backchannel.PromptForSelectionAsync(StringUtils.RemoveMarkup(promptText), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -360,7 +362,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
                 {
                     // Note: The extension backchannel protocol does not yet support preSelected items.
                     // Pre-selected items are applied only when falling back to the console interaction service.
-                    var result = await Backchannel.PromptForSelectionsAsync(StringUtils.RemoveMarkup(promptText), choices, choiceFormatter, _cts.Token).ConfigureAwait(false);
+                    var result = await Backchannel.PromptForSelectionsAsync(StringUtils.RemoveMarkup(promptText), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)
@@ -383,7 +385,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingSdkVersion)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayIncompatibleVersionErrorAsync(ex.RequiredCapability, appHostHostingSdkVersion, _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayIncompatibleVersionErrorAsync(ex.RequiredCapability, appHostHostingSdkVersion, _cancellationToken));
         Debug.Assert(result);
 
         return _consoleInteractionService.DisplayIncompatibleVersionError(ex, appHostHostingSdkVersion);
@@ -398,7 +400,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
         // out-of-order output like an error message preceding the lines that explain it.
         var result = _extensionTaskChannel.Writer.TryWrite(async () =>
         {
-            await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(errorMessage), _cts.Token);
+            await Backchannel.DisplayErrorAsync(StringUtils.RemoveMarkup(errorMessage), _cancellationToken);
             _consoleInteractionService.DisplayError(errorMessage, allowMarkup);
         });
         Debug.Assert(result);
@@ -408,7 +410,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
     {
         var result = _extensionTaskChannel.Writer.TryWrite(async () =>
         {
-            await Backchannel.DisplayMessageAsync(emoji.Name, StringUtils.RemoveMarkup(message), _cts.Token);
+            await Backchannel.DisplayMessageAsync(emoji.Name, StringUtils.RemoveMarkup(message), _cancellationToken);
             _consoleInteractionService.DisplayMessage(emoji, message, allowMarkup, consoleOverride);
         });
         Debug.Assert(result);
@@ -416,14 +418,14 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySuccessAsync(StringUtils.RemoveMarkup(message), _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySuccessAsync(StringUtils.RemoveMarkup(message), _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplaySuccess(message, allowMarkup);
     }
 
     public void DisplaySubtleMessage(string message, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySubtleMessageAsync(StringUtils.RemoveMarkup(message), _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySubtleMessageAsync(StringUtils.RemoveMarkup(message), _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplaySubtleMessage(message, allowMarkup);
     }
@@ -435,7 +437,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
     public void DisplayDashboardUrls(DashboardUrlsState dashboardUrls)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayDashboardUrlsAsync(dashboardUrls, _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayDashboardUrlsAsync(dashboardUrls, _cancellationToken));
         Debug.Assert(result);
     }
 
@@ -446,7 +448,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(materialized.Select(line => new DisplayLineState(
             line.Stream == OutputLineStream.StdOut ? "stdout" : "stderr",
-            StringUtils.RemoveMarkup(line.Line))), _cts.Token));
+            StringUtils.RemoveMarkup(line.Line))), _cancellationToken));
         Debug.Assert(result);
 
         // Intentionally do NOT also write to the local console here. Unlike most Display* methods
@@ -459,27 +461,27 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
     public void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayCancellationMessageAsync(_cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayCancellationMessageAsync(_cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplayCancellationMessage(consoleOverride);
     }
 
     public void DisplayEmptyLine()
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayEmptyLineAsync(_cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayEmptyLineAsync(_cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplayEmptyLine();
     }
 
     public void OpenEditor(string path)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.OpenEditorAsync(path, _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.OpenEditorAsync(path, _cancellationToken));
         Debug.Assert(result);
     }
 
     public void DisplayPlainText(string text)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayPlainTextAsync(text, _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayPlainTextAsync(text, _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplayPlainText(text);
     }
@@ -496,7 +498,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayPlainTextAsync(text, _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayPlainTextAsync(text, _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplayRawText(text, consoleOverride);
     }
@@ -505,7 +507,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
     {
         // Send raw markdown to extension (it can handle markdown natively)
         // Convert to Spectre markup for console display
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, markdown, _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, markdown, _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplayMarkdown(markdown, consoleOverride, maxWidth);
     }
@@ -513,7 +515,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
     public void DisplayMarkupLine(string markup)
     {
         // Strip markup for backchannel, display as-is to console
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, StringUtils.RemoveMarkup(markup), _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(LogLevel.Information, StringUtils.RemoveMarkup(markup), _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplayMarkupLine(markup);
     }
@@ -535,13 +537,13 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
     public void LogMessage(LogLevel logLevel, string message)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(logLevel, StringUtils.RemoveMarkup(message), _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(logLevel, StringUtils.RemoveMarkup(message), _cancellationToken));
         Debug.Assert(result);
     }
 
     public Task LaunchAppHostAsync(string projectFile, List<string> arguments, List<EnvVar> environment, bool debug)
     {
-        return Backchannel.LaunchAppHostAsync(projectFile, arguments, environment, debug, _cts.Token);
+        return Backchannel.LaunchAppHostAsync(projectFile, arguments, environment, debug, _cancellationToken);
     }
 
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false)
@@ -551,7 +553,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
     public void NotifyAppHostStartupCompleted()
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.NotifyAppHostStartupCompletedAsync(_cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.NotifyAppHostStartupCompletedAsync(_cancellationToken));
         Debug.Assert(result);
     }
 
@@ -562,12 +564,12 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
 
     public Task StartDebugSessionAsync(string workingDirectory, string? projectFile, bool debug, DebugSessionOptions? options = null)
     {
-        return Backchannel.StartDebugSessionAsync(workingDirectory, projectFile, debug, options, _cts.Token);
+        return Backchannel.StartDebugSessionAsync(workingDirectory, projectFile, debug, options, _cancellationToken);
     }
 
     public void WriteDebugSessionMessage(string message, bool stdout, string? textStyle)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(StringUtils.RemoveMarkup(message), stdout, textStyle, _cts.Token));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(StringUtils.RemoveMarkup(message), stdout, textStyle, _cancellationToken));
         Debug.Assert(result);
     }
 

--- a/src/Aspire.Cli/Npm/INpmProvenanceChecker.cs
+++ b/src/Aspire.Cli/Npm/INpmProvenanceChecker.cs
@@ -183,12 +183,12 @@ internal interface INpmProvenanceChecker
     /// with the ref decomposed into its kind and name. If <c>null</c>, the workflow ref gate is skipped.
     /// If the callback returns <c>false</c>, verification fails with <see cref="ProvenanceVerificationOutcome.WorkflowRefMismatch"/>.
     /// </param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <param name="sriIntegrity">
     /// An optional SRI integrity string (e.g., "sha512-...") for the package tarball.
     /// When provided, implementations that perform cryptographic verification can verify
     /// that the attestation covers this specific artifact digest.
     /// </param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A <see cref="ProvenanceVerificationResult"/> indicating the outcome and any extracted provenance data.</returns>
-    Task<ProvenanceVerificationResult> VerifyProvenanceAsync(string packageName, string version, string expectedSourceRepository, string expectedWorkflowPath, string expectedBuildType, Func<WorkflowRefInfo, bool>? validateWorkflowRef, CancellationToken cancellationToken, string? sriIntegrity = null);
+    Task<ProvenanceVerificationResult> VerifyProvenanceAsync(string packageName, string version, string expectedSourceRepository, string expectedWorkflowPath, string expectedBuildType, Func<WorkflowRefInfo, bool>? validateWorkflowRef, string? sriIntegrity = null, CancellationToken cancellationToken = default);
 }

--- a/src/Aspire.Cli/Npm/INpmProvenanceChecker.cs
+++ b/src/Aspire.Cli/Npm/INpmProvenanceChecker.cs
@@ -184,11 +184,11 @@ internal interface INpmProvenanceChecker
     /// If the callback returns <c>false</c>, verification fails with <see cref="ProvenanceVerificationOutcome.WorkflowRefMismatch"/>.
     /// </param>
     /// <param name="sriIntegrity">
-    /// An optional SRI integrity string (e.g., "sha512-...") for the package tarball.
+    /// An SRI integrity string (e.g., "sha512-...") for the package tarball, or null if unavailable.
     /// When provided, implementations that perform cryptographic verification can verify
     /// that the attestation covers this specific artifact digest.
     /// </param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A <see cref="ProvenanceVerificationResult"/> indicating the outcome and any extracted provenance data.</returns>
-    Task<ProvenanceVerificationResult> VerifyProvenanceAsync(string packageName, string version, string expectedSourceRepository, string expectedWorkflowPath, string expectedBuildType, Func<WorkflowRefInfo, bool>? validateWorkflowRef, string? sriIntegrity = null, CancellationToken cancellationToken = default);
+    Task<ProvenanceVerificationResult> VerifyProvenanceAsync(string packageName, string version, string expectedSourceRepository, string expectedWorkflowPath, string expectedBuildType, Func<WorkflowRefInfo, bool>? validateWorkflowRef, string? sriIntegrity, CancellationToken cancellationToken);
 }

--- a/src/Aspire.Cli/Npm/SigstoreNpmProvenanceChecker.cs
+++ b/src/Aspire.Cli/Npm/SigstoreNpmProvenanceChecker.cs
@@ -26,8 +26,8 @@ internal sealed class SigstoreNpmProvenanceChecker(HttpClient httpClient, ILogge
         string expectedWorkflowPath,
         string expectedBuildType,
         Func<WorkflowRefInfo, bool>? validateWorkflowRef,
-        string? sriIntegrity = null,
-        CancellationToken cancellationToken = default)
+        string? sriIntegrity,
+        CancellationToken cancellationToken)
     {
         logger.LogDebug("Verifying provenance for {PackageSpecifier} from {ExpectedSourceRepository}", NpmPackageInfo.FormatPackageSpecifier(packageName, version), expectedSourceRepository);
 

--- a/src/Aspire.Cli/Npm/SigstoreNpmProvenanceChecker.cs
+++ b/src/Aspire.Cli/Npm/SigstoreNpmProvenanceChecker.cs
@@ -26,8 +26,8 @@ internal sealed class SigstoreNpmProvenanceChecker(HttpClient httpClient, ILogge
         string expectedWorkflowPath,
         string expectedBuildType,
         Func<WorkflowRefInfo, bool>? validateWorkflowRef,
-        CancellationToken cancellationToken,
-        string? sriIntegrity = null)
+        string? sriIntegrity = null,
+        CancellationToken cancellationToken = default)
     {
         logger.LogDebug("Verifying provenance for {PackageSpecifier} from {ExpectedSourceRepository}", NpmPackageInfo.FormatPackageSpecifier(packageName, version), expectedSourceRepository);
 

--- a/src/Aspire.Cli/Packaging/PackageChannel.cs
+++ b/src/Aspire.Cli/Packaging/PackageChannel.cs
@@ -9,7 +9,6 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Semver;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
@@ -608,18 +607,18 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
         return isHostingOrCommunityToolkitNamespaced && !isExcluded;
     }
 
-    public static PackageChannel CreateExplicitChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, IFeatures features, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, ILogger? logger = null, string? currentCliVersion = null)
+    public static PackageChannel CreateExplicitChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, IFeatures features, ILogger logger, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, string? currentCliVersion = null)
     {
-        return new PackageChannel(name, quality, mappings, nuGetPackageCache, features, logger ?? NullLogger.Instance, configureGlobalPackagesFolder, cliDownloadBaseUrl, pinnedVersion, currentCliVersion);
+        return new PackageChannel(name, quality, mappings, nuGetPackageCache, features, logger, configureGlobalPackagesFolder, cliDownloadBaseUrl, pinnedVersion, currentCliVersion);
     }
 
-    public static PackageChannel CreateImplicitChannel(INuGetPackageCache nuGetPackageCache, IFeatures features, ILogger? logger = null, string? currentCliVersion = null)
+    public static PackageChannel CreateImplicitChannel(INuGetPackageCache nuGetPackageCache, IFeatures features, ILogger logger, string? currentCliVersion = null)
     {
         // The reason that PackageChannelQuality.Both is because there are situations like
         // in community toolkit where there is a newer beta version available for a package
         // in the case of implicit feeds we want to be able to show that, along side the stable
         // version. Not really an issue for template selection though (unless we start allowing)
         // for broader templating options.
-        return new PackageChannel("default", PackageChannelQuality.Both, null, nuGetPackageCache, features, logger ?? NullLogger.Instance, currentCliVersion: currentCliVersion);
+        return new PackageChannel("default", PackageChannelQuality.Both, null, nuGetPackageCache, features, logger, currentCliVersion: currentCliVersion);
     }
 }

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -147,13 +147,13 @@ internal class PackagingService : IPackagingService
         var stableChannel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Stable, new[]
         {
             new PackageMapping(PackageMapping.AllPackages, nugetOrg)
-        }, _nuGetPackageCache, _features, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/ga/daily", logger: _logger, currentCliVersion: _executionContext.IdentitySdkVersion);
+        }, _nuGetPackageCache, _features, _logger, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/ga/daily", currentCliVersion: _executionContext.IdentitySdkVersion);
 
         var dailyChannel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Daily, PackageChannelQuality.Prerelease, new[]
         {
             new PackageMapping("Aspire*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json"),
             new PackageMapping(PackageMapping.AllPackages, nugetOrg)
-        }, _nuGetPackageCache, _features, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/daily", logger: _logger, currentCliVersion: _executionContext.IdentitySdkVersion);
+        }, _nuGetPackageCache, _features, _logger, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/daily", currentCliVersion: _executionContext.IdentitySdkVersion);
 
         var prPackageChannels = new List<PackageChannel>();
 
@@ -287,7 +287,7 @@ internal class PackagingService : IPackagingService
         {
             new PackageMapping("Aspire*", packagesPath),
             new PackageMapping(PackageMapping.AllPackages, NuGetOrgUrl)
-        }, _nuGetPackageCache, _features, pinnedVersion: pinnedVersion, logger: _logger, currentCliVersion: _executionContext.IdentitySdkVersion);
+        }, _nuGetPackageCache, _features, _logger, pinnedVersion: pinnedVersion, currentCliVersion: _executionContext.IdentitySdkVersion);
     }
 
     internal static DirectoryInfo? TryResolvePrInstallPackagesDirectory(string? processPath, string identityChannel)
@@ -482,7 +482,7 @@ internal class PackagingService : IPackagingService
         {
             new PackageMapping("Aspire*", stagingFeedUrl),
             new PackageMapping(PackageMapping.AllPackages, NuGetOrgUrl)
-        }, _nuGetPackageCache, _features, configureGlobalPackagesFolder: !useSharedFeed, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/rc/daily", pinnedVersion: pinnedVersion, logger: _logger, currentCliVersion: _executionContext.IdentitySdkVersion);
+        }, _nuGetPackageCache, _features, _logger, configureGlobalPackagesFolder: !useSharedFeed, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/rc/daily", pinnedVersion: pinnedVersion, currentCliVersion: _executionContext.IdentitySdkVersion);
 
         // Surface the resolved staging routing so users can see what `--channel staging` actually
         // picked (the "show what was resolved" suggestion from the issue RCA). Pinned version is

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -1149,8 +1149,7 @@ public class Program
                 return new ExtensionInteractionService(consoleInteractionService,
                     provider.GetRequiredService<IExtensionBackchannel>(),
                     extensionPromptEnabled,
-                    logger: provider.GetRequiredService<ILogger<ExtensionInteractionService>>(),
-                    cancellationToken: CancellationToken.None);
+                    logger: provider.GetRequiredService<ILogger<ExtensionInteractionService>>());
             });
         }
         else

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -348,8 +348,18 @@ public class Program
         // CliStartupContext so the channel can be logged at startup before DI is fully wired, and it
         // continues to power that early startup log. `IIdentityResolver` is the richer reader that
         // also resolves sidecar/env overrides for version, commit, and the NuGet service index; it
-        // powers `CliExecutionContext` construction.
+        // powers `CliExecutionContext` identity population.
         builder.Services.AddSingleton<IIdentityChannelReader>(startupContext.IdentityChannelReader);
+        builder.Services.AddSingleton<IEnvironment, HostEnvironment>();
+        if (OperatingSystem.IsWindows())
+        {
+            builder.Services.AddSingleton<IWindowsRegistryReader, WindowsRegistryReader>();
+        }
+        else
+        {
+            builder.Services.AddSingleton<IWindowsRegistryReader, NullWindowsRegistryReader>();
+        }
+        builder.Services.AddSingleton<WingetFirstRunProbe>();
         builder.Services.AddSingleton<IIdentityResolver>(sp =>
         {
             // Binary dir is the directory containing the running executable.
@@ -380,17 +390,8 @@ public class Program
                 sp.GetRequiredService<IInstallSidecarReader>(),
                 typeof(Program).Assembly,
                 binaryDir,
-                Environment.GetEnvironmentVariable);
+                sp.GetRequiredService<IEnvironment>());
         });
-        if (OperatingSystem.IsWindows())
-        {
-            builder.Services.AddSingleton<IWindowsRegistryReader, WindowsRegistryReader>();
-        }
-        else
-        {
-            builder.Services.AddSingleton<IWindowsRegistryReader, NullWindowsRegistryReader>();
-        }
-        builder.Services.AddSingleton<WingetFirstRunProbe>();
         builder.Services.AddSingleton(sp =>
         {
             // Use the resolver overload so env/sidecar overrides apply to
@@ -666,17 +667,6 @@ public class Program
         var homeDirectory = GetUsersAspirePath(processPath);
         var sdksPath = Path.Combine(homeDirectory, "sdks");
         return new DirectoryInfo(sdksPath);
-    }
-
-    internal static CliExecutionContext BuildCliExecutionContext(bool debugMode, string logsDirectory, string logFilePath, string channel, string? processPath = null)
-    {
-        var workingDirectory = new DirectoryInfo(Environment.CurrentDirectory);
-        var hivesDirectory = GetHivesDirectory(processPath);
-        var cacheDirectory = GetCacheDirectory(processPath);
-        var sdksDirectory = GetSdksDirectory(processPath);
-        var packagesDirectory = GetPackagesDirectory(processPath);
-        var aspireHomeDirectory = new DirectoryInfo(GetUsersAspirePath(processPath));
-        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, sdksDirectory, new DirectoryInfo(logsDirectory), logFilePath, identityChannel: channel, debugMode: debugMode, packagesDirectory: packagesDirectory, aspireHomeDirectory: aspireHomeDirectory);
     }
 
     internal static CliExecutionContext BuildCliExecutionContext(bool debugMode, string logsDirectory, string logFilePath, IIdentityResolver identityResolver, string? processPath = null)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -379,7 +379,8 @@ public class Program
             return new IdentityResolver(
                 sp.GetRequiredService<IInstallSidecarReader>(),
                 typeof(Program).Assembly,
-                binaryDir);
+                binaryDir,
+                Environment.GetEnvironmentVariable);
         });
         if (OperatingSystem.IsWindows())
         {
@@ -425,7 +426,13 @@ public class Program
         builder.Services.AddSingleton<ITemplateVersionPrompter>(sp => (ITemplateVersionPrompter)sp.GetRequiredService<INewCommandPrompter>());
         builder.Services.AddSingleton<IAddCommandPrompter, AddCommandPrompter>();
         builder.Services.AddSingleton<IPublishCommandPrompter, PublishCommandPrompter>();
-        builder.Services.AddSingleton<ICertificateService, CertificateService>();
+        builder.Services.AddSingleton<ICertificateService>(sp => new CertificateService(
+            sp.GetRequiredService<ICertificateToolRunner>(),
+            sp.GetRequiredService<IInteractionService>(),
+            sp.GetRequiredService<AspireCliTelemetry>(),
+            sp.GetRequiredService<ICliHostEnvironment>(),
+            sp.GetRequiredService<CliExecutionContext>(),
+            OperatingSystem.IsLinux));
         builder.Services.AddSingleton(BuildConfigurationService);
         builder.Services.AddSingleton<IFeatures, Features>();
         builder.Services.AddTelemetryServices();
@@ -436,7 +443,9 @@ public class Program
 
         // Register certificate tool runner - uses native CertificateManager directly (no subprocess needed)
         builder.Services.AddSingleton(sp => CertificateManager.Create(sp.GetRequiredService<ILogger<NativeCertificateToolRunner>>()));
-        builder.Services.AddSingleton<ICertificateToolRunner, NativeCertificateToolRunner>();
+        builder.Services.AddSingleton<ICertificateToolRunner>(sp => new NativeCertificateToolRunner(
+            sp.GetRequiredService<CertificateManager>(),
+            OperatingSystem.IsLinux));
 
         builder.Services.AddTransient<IDotNetCliRunner, DotNetCliRunner>();
         builder.Services.AddSingleton<IDiskCache, DiskCache>();
@@ -1140,7 +1149,8 @@ public class Program
                 return new ExtensionInteractionService(consoleInteractionService,
                     provider.GetRequiredService<IExtensionBackchannel>(),
                     extensionPromptEnabled,
-                    logger: provider.GetRequiredService<ILogger<ExtensionInteractionService>>());
+                    logger: provider.GetRequiredService<ILogger<ExtensionInteractionService>>(),
+                    cancellationToken: CancellationToken.None);
             });
         }
         else

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -12,6 +12,7 @@ using Aspire.Cli.Agents.AspireSkills;
 using Aspire.Cli.Agents.ClaudeCode;
 using Aspire.Cli.Agents.CopilotCli;
 using Aspire.Cli.Agents.OpenCode;
+using Aspire.Cli.Agents.Playwright;
 using Aspire.Cli.Agents.VsCode;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Bundles;
@@ -28,6 +29,7 @@ using Aspire.Cli.Git;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Mcp;
+using Aspire.Cli.Npm;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Processes;
@@ -427,13 +429,7 @@ public class Program
         builder.Services.AddSingleton<ITemplateVersionPrompter>(sp => (ITemplateVersionPrompter)sp.GetRequiredService<INewCommandPrompter>());
         builder.Services.AddSingleton<IAddCommandPrompter, AddCommandPrompter>();
         builder.Services.AddSingleton<IPublishCommandPrompter, PublishCommandPrompter>();
-        builder.Services.AddSingleton<ICertificateService>(sp => new CertificateService(
-            sp.GetRequiredService<ICertificateToolRunner>(),
-            sp.GetRequiredService<IInteractionService>(),
-            sp.GetRequiredService<AspireCliTelemetry>(),
-            sp.GetRequiredService<ICliHostEnvironment>(),
-            sp.GetRequiredService<CliExecutionContext>(),
-            OperatingSystem.IsLinux));
+        builder.Services.AddSingleton<ICertificateService, CertificateService>();
         builder.Services.AddSingleton(BuildConfigurationService);
         builder.Services.AddSingleton<IFeatures, Features>();
         builder.Services.AddTelemetryServices();
@@ -444,9 +440,7 @@ public class Program
 
         // Register certificate tool runner - uses native CertificateManager directly (no subprocess needed)
         builder.Services.AddSingleton(sp => CertificateManager.Create(sp.GetRequiredService<ILogger<NativeCertificateToolRunner>>()));
-        builder.Services.AddSingleton<ICertificateToolRunner>(sp => new NativeCertificateToolRunner(
-            sp.GetRequiredService<CertificateManager>(),
-            OperatingSystem.IsLinux));
+        builder.Services.AddSingleton<ICertificateToolRunner, NativeCertificateToolRunner>();
 
         builder.Services.AddTransient<IDotNetCliRunner, DotNetCliRunner>();
         builder.Services.AddSingleton<IDiskCache, DiskCache>();
@@ -522,13 +516,13 @@ public class Program
         builder.Services.AddSingleton<ICopilotCliRunner, CopilotCliRunner>();
 
         // Npm and Playwright CLI operations.
-        builder.Services.AddSingleton<Aspire.Cli.Npm.INpmRunner, Aspire.Cli.Npm.NpmRunner>();
-        builder.Services.AddHttpClient<Aspire.Cli.Npm.INpmProvenanceChecker, Aspire.Cli.Npm.SigstoreNpmProvenanceChecker>();
+        builder.Services.AddSingleton<INpmRunner, NpmRunner>();
+        builder.Services.AddHttpClient<INpmProvenanceChecker, SigstoreNpmProvenanceChecker>();
         builder.Services.AddHttpClient<IGitHubArtifactAttestationVerifier, GitHubArtifactAttestationVerifier>();
         builder.Services.AddSingleton<IEmbeddedAspireSkillsBundleProvider, EmbeddedAspireSkillsBundleProvider>();
         builder.Services.AddSingleton<IAspireSkillsInstaller, AspireSkillsInstaller>();
-        builder.Services.AddSingleton<Aspire.Cli.Agents.Playwright.IPlaywrightCliRunner, Aspire.Cli.Agents.Playwright.PlaywrightCliRunner>();
-        builder.Services.AddSingleton<Aspire.Cli.Agents.Playwright.PlaywrightCliInstaller>();
+        builder.Services.AddSingleton<IPlaywrightCliRunner, PlaywrightCliRunner>();
+        builder.Services.AddSingleton<PlaywrightCliInstaller>();
 
         // Agent environment detection.
         builder.Services.AddSingleton<IAgentEnvironmentDetector, AgentEnvironmentDetector>();

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -73,7 +73,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         IAppHostInfoResolver appHostInfoResolver,
         IConfigurationService configurationService,
         CliExecutionContext executionContext,
-        TimeProvider? timeProvider = null)
+        TimeProvider timeProvider)
     {
         _runner = runner;
         _interactionService = interactionService;
@@ -90,7 +90,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         _appHostInfoResolver = appHostInfoResolver;
         _configurationService = configurationService;
         _executionContext = executionContext;
-        _timeProvider = timeProvider ?? TimeProvider.System;
+        _timeProvider = timeProvider;
         _runningInstanceManager = new RunningInstanceManager(_logger, _interactionService, _timeProvider, _profilingTelemetry);
     }
 

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -69,7 +69,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         ILogger<GuestAppHostProject> logger,
         FileLoggerProvider fileLoggerProvider,
         ProfilingTelemetry profilingTelemetry,
-        TimeProvider? timeProvider = null)
+        TimeProvider timeProvider)
     {
         _resolvedLanguage = language;
         _interactionService = interactionService;
@@ -86,7 +86,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         _logger = logger;
         _fileLoggerProvider = fileLoggerProvider;
         _profilingTelemetry = profilingTelemetry;
-        _timeProvider = timeProvider ?? TimeProvider.System;
+        _timeProvider = timeProvider;
         _runningInstanceManager = new RunningInstanceManager(_logger, _interactionService, _timeProvider, _profilingTelemetry);
     }
 
@@ -1830,7 +1830,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(runtimeSpec, toolchain);
             }
 
-            _guestRuntime = new GuestRuntime(runtimeSpec, _logger, _fileLoggerProvider, profilingTelemetry: _profilingTelemetry);
+            _guestRuntime = new GuestRuntime(runtimeSpec, _logger, PathLookupHelper.FindFullPathFromPath, _profilingTelemetry, _fileLoggerProvider);
 
             _logger.LogDebug("Created GuestRuntime for {RuntimeDisplayName}: Execute={Command} {Args}",
                 runtimeSpec.DisplayName,

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -31,6 +31,9 @@ internal sealed class GuestRuntime
     /// <param name="fileLoggerProvider">Optional file logger for writing output to disk.</param>
     public GuestRuntime(RuntimeSpec spec, ILogger logger, Func<string, string?> commandResolver, ProfilingTelemetry profilingTelemetry, FileLoggerProvider? fileLoggerProvider = null)
     {
+        ArgumentNullException.ThrowIfNull(commandResolver);
+        ArgumentNullException.ThrowIfNull(profilingTelemetry);
+
         _spec = spec;
         _logger = logger;
         _fileLoggerProvider = fileLoggerProvider;

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -19,22 +19,22 @@ internal sealed class GuestRuntime
     private readonly ILogger _logger;
     private readonly FileLoggerProvider? _fileLoggerProvider;
     private readonly Func<string, string?> _commandResolver;
-    private readonly ProfilingTelemetry? _profilingTelemetry;
+    private readonly ProfilingTelemetry _profilingTelemetry;
 
     /// <summary>
     /// Creates a new GuestRuntime for the given runtime specification.
     /// </summary>
     /// <param name="spec">The runtime specification describing how to execute the guest language.</param>
     /// <param name="logger">Logger for debugging output.</param>
+    /// <param name="commandResolver">Command resolver used to locate executables on PATH.</param>
+    /// <param name="profilingTelemetry">Profiling telemetry for child-process diagnostics.</param>
     /// <param name="fileLoggerProvider">Optional file logger for writing output to disk.</param>
-    /// <param name="commandResolver">Optional command resolver used to locate executables on PATH.</param>
-    /// <param name="profilingTelemetry">Optional profiling telemetry for child-process diagnostics.</param>
-    public GuestRuntime(RuntimeSpec spec, ILogger logger, FileLoggerProvider? fileLoggerProvider = null, Func<string, string?>? commandResolver = null, ProfilingTelemetry? profilingTelemetry = null)
+    public GuestRuntime(RuntimeSpec spec, ILogger logger, Func<string, string?> commandResolver, ProfilingTelemetry profilingTelemetry, FileLoggerProvider? fileLoggerProvider = null)
     {
         _spec = spec;
         _logger = logger;
         _fileLoggerProvider = fileLoggerProvider;
-        _commandResolver = commandResolver ?? PathLookupHelper.FindFullPathFromPath;
+        _commandResolver = commandResolver;
         _profilingTelemetry = profilingTelemetry;
     }
 
@@ -77,9 +77,7 @@ internal sealed class GuestRuntime
             var environmentVariables = commandSpec.EnvironmentVariables ?? new Dictionary<string, string>();
 
             var launcher = CreateDefaultLauncher();
-            using var activity = _profilingTelemetry is null
-                ? default
-                : _profilingTelemetry.StartGuestInitializeCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args, directory);
+            using var activity = _profilingTelemetry.StartGuestInitializeCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args, directory);
             var (exitCode, output) = await launcher.LaunchAsync(
                 commandSpec.Command,
                 args,
@@ -117,9 +115,7 @@ internal sealed class GuestRuntime
         var environmentVariables = _spec.InstallDependencies.EnvironmentVariables ?? new Dictionary<string, string>();
 
         var launcher = CreateDefaultLauncher();
-        using var activity = _profilingTelemetry is null
-            ? default
-            : _profilingTelemetry.StartGuestInstallDependencies(_spec.Language, _spec.DisplayName, _spec.InstallDependencies.Command, args, directory);
+        using var activity = _profilingTelemetry.StartGuestInstallDependencies(_spec.Language, _spec.DisplayName, _spec.InstallDependencies.Command, args, directory);
         var (exitCode, output) = await launcher.LaunchAsync(
             _spec.InstallDependencies.Command,
             args,
@@ -237,9 +233,7 @@ internal sealed class GuestRuntime
             var mergedEnvironment = MergeEnvironmentVariables(environmentVariables, commandSpec);
 
             _logger.LogDebug("Launching pre-execution command: {Command} {Args}", commandSpec.Command, string.Join(" ", args));
-            using var activity = _profilingTelemetry is null
-                ? default
-                : _profilingTelemetry.StartGuestExecuteCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args, directory, ProfilingTelemetry.Values.GuestCommandPhasePreExecute);
+            using var activity = _profilingTelemetry.StartGuestExecuteCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args, directory, ProfilingTelemetry.Values.GuestCommandPhasePreExecute);
             var (exitCode, output) = await preExecuteLauncher.LaunchAsync(commandSpec.Command, args, directory, mergedEnvironment, cancellationToken);
             activity.SetProcessExitCode(exitCode);
             if (exitCode != 0)
@@ -268,9 +262,7 @@ internal sealed class GuestRuntime
         var mergedEnvironment = MergeEnvironmentVariables(environmentVariables, commandSpec);
 
         _logger.LogDebug("Launching: {Command} {Args}", commandSpec.Command, string.Join(" ", args));
-        using var activity = _profilingTelemetry is null
-            ? default
-            : _profilingTelemetry.StartGuestExecuteCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args, directory, phase);
+        using var activity = _profilingTelemetry.StartGuestExecuteCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args, directory, phase);
         var (exitCode, output) = await launcher.LaunchAsync(commandSpec.Command, args, directory, mergedEnvironment, cancellationToken, afterLaunchAsync: afterLaunchAsync);
         activity.SetProcessExitCode(exitCode);
         if (exitCode != 0)
@@ -322,7 +314,7 @@ internal sealed class GuestRuntime
     /// <summary>
     /// Creates the default process-based launcher for this runtime.
     /// </summary>
-    public ProcessGuestLauncher CreateDefaultLauncher() => new(_spec.Language, _logger, _fileLoggerProvider, _commandResolver);
+    public ProcessGuestLauncher CreateDefaultLauncher() => new(_spec.Language, _logger, _commandResolver, _fileLoggerProvider);
 
     /// <summary>
     /// Replaces placeholders in command arguments with actual values.

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -21,6 +21,8 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
 
     public ProcessGuestLauncher(string language, ILogger logger, Func<string, string?> commandResolver, FileLoggerProvider? fileLoggerProvider = null)
     {
+        ArgumentNullException.ThrowIfNull(commandResolver);
+
         _language = language;
         _logger = logger;
         _fileLoggerProvider = fileLoggerProvider;

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -19,12 +19,12 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
     private readonly FileLoggerProvider? _fileLoggerProvider;
     private readonly Func<string, string?> _commandResolver;
 
-    public ProcessGuestLauncher(string language, ILogger logger, FileLoggerProvider? fileLoggerProvider = null, Func<string, string?>? commandResolver = null)
+    public ProcessGuestLauncher(string language, ILogger logger, Func<string, string?> commandResolver, FileLoggerProvider? fileLoggerProvider = null)
     {
         _language = language;
         _logger = logger;
         _fileLoggerProvider = fileLoggerProvider;
-        _commandResolver = commandResolver ?? PathLookupHelper.FindFullPathFromPath;
+        _commandResolver = commandResolver;
     }
 
     public async Task<(int ExitCode, OutputCollector? Output)> LaunchAsync(

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -166,7 +166,7 @@ internal sealed class ProjectLocator(
     /// <returns>A list of candidate AppHost projects with language metadata sorted by full path.</returns>
     public async Task<List<AppHostProjectCandidate>> FindAppHostProjectsAsync(DirectoryInfo searchDirectory, AppHostDiscoveryScope scope, int? maxDepth, CancellationToken cancellationToken)
     {
-        var allCandidates = await FindAppHostProjectFilesAsync(searchDirectory, stopAfterMultipleBuildableAppHosts: false, displayProgress: false, scope, maxDepth, cancellationToken);
+        var allCandidates = await FindAppHostProjectFilesAsync(searchDirectory, stopAfterMultipleBuildableAppHosts: false, displayProgress: false, scope, maxDepth, cancellationToken: cancellationToken);
         var candidates = allCandidates.BuildableAppHost.Concat(allCandidates.UnbuildableSuspectedAppHostProjects).ToList();
         candidates.Sort((x, y) => string.Compare(x.AppHostFile.FullName, y.AppHostFile.FullName, StringComparison.Ordinal));
         return candidates;
@@ -223,7 +223,7 @@ internal sealed class ProjectLocator(
     {
         try
         {
-            await FindAppHostProjectFilesAsync(searchDirectory, stopAfterMultipleBuildableAppHosts: false, displayProgress: false, scope, maxDepth: null, cancellationToken, candidateWriter, onDirectoryEnumerated).ConfigureAwait(false);
+            await FindAppHostProjectFilesAsync(searchDirectory, stopAfterMultipleBuildableAppHosts: false, displayProgress: false, scope, maxDepth: null, candidateWriter, onDirectoryEnumerated, cancellationToken).ConfigureAwait(false);
             candidateWriter.TryComplete();
         }
         catch (Exception ex)
@@ -275,10 +275,10 @@ internal sealed class ProjectLocator(
 
     private async Task<(List<AppHostProjectCandidate> BuildableAppHost, List<AppHostProjectCandidate> UnbuildableSuspectedAppHostProjects, bool HasUnsupportedProjects)> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, bool stopAfterMultipleBuildableAppHosts, AppHostDiscoveryScope scope, CancellationToken cancellationToken)
     {
-        return await FindAppHostProjectFilesAsync(searchDirectory, stopAfterMultipleBuildableAppHosts, displayProgress: true, scope, maxDepth: null, cancellationToken);
+        return await FindAppHostProjectFilesAsync(searchDirectory, stopAfterMultipleBuildableAppHosts, displayProgress: true, scope, maxDepth: null, cancellationToken: cancellationToken);
     }
 
-    private async Task<(List<AppHostProjectCandidate> BuildableAppHost, List<AppHostProjectCandidate> UnbuildableSuspectedAppHostProjects, bool HasUnsupportedProjects)> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, bool stopAfterMultipleBuildableAppHosts, bool displayProgress, AppHostDiscoveryScope scope, int? maxDepth, CancellationToken cancellationToken, ChannelWriter<AppHostProjectCandidate>? candidateWriter = null, Action<int>? onDirectoryEnumerated = null)
+    private async Task<(List<AppHostProjectCandidate> BuildableAppHost, List<AppHostProjectCandidate> UnbuildableSuspectedAppHostProjects, bool HasUnsupportedProjects)> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, bool stopAfterMultipleBuildableAppHosts, bool displayProgress, AppHostDiscoveryScope scope, int? maxDepth, ChannelWriter<AppHostProjectCandidate>? candidateWriter = null, Action<int>? onDirectoryEnumerated = null, CancellationToken cancellationToken = default)
     {
         using var activity = telemetry.StartDiagnosticActivity();
 

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -352,7 +352,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         return Task.CompletedTask;
     }
 
-    private async Task<NuGetPackageCli?> GetLatestVersionOfPackageAsync(UpdateContext context, string packageId, CancellationToken cancellationToken, bool throwIfNotFound = true)
+    private async Task<NuGetPackageCli?> GetLatestVersionOfPackageAsync(UpdateContext context, string packageId, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
     {
         var cacheKey = $"LatestPackage-{packageId}";
         var latestPackage = await cache.GetOrCreateAsync(cacheKey, async entry =>
@@ -389,7 +389,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         var sdkVersionElement = propertiesElement.GetProperty("AspireHostingSDKVersion");
         var sdkVersion = sdkVersionElement.GetString();
 
-        var latestSdkPackage = await GetLatestVersionOfPackageAsync(context, "Aspire.AppHost.Sdk", cancellationToken);
+        var latestSdkPackage = await GetLatestVersionOfPackageAsync(context, "Aspire.AppHost.Sdk", cancellationToken: cancellationToken);
 
         // Treat unparseable versions (including range expressions) like wildcards - always update them
         // Only skip if the version is a valid semantic version that matches the latest
@@ -1023,7 +1023,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
 
     private async Task AnalyzePackageForTraditionalManagementAsync(string packageId, string packageVersion, FileInfo projectFile, UpdateContext context, CancellationToken cancellationToken)
     {
-        var latestPackage = await GetLatestVersionOfPackageAsync(context, packageId, cancellationToken, throwIfNotFound: false);
+        var latestPackage = await GetLatestVersionOfPackageAsync(context, packageId, throwIfNotFound: false, cancellationToken: cancellationToken);
 
         if (latestPackage is null)
         {
@@ -1059,7 +1059,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
             return;
         }
 
-        var latestPackage = await GetLatestVersionOfPackageAsync(context, packageId, cancellationToken, throwIfNotFound: false);
+        var latestPackage = await GetLatestVersionOfPackageAsync(context, packageId, throwIfNotFound: false, cancellationToken: cancellationToken);
 
         if (latestPackage is null)
         {

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging;
@@ -43,6 +44,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
     private readonly IInteractionService _interactionService;
     private readonly ILogger<ScaffoldingService> _logger;
     private readonly CliExecutionContext _executionContext;
+    private readonly ProfilingTelemetry _profilingTelemetry;
 
     public ScaffoldingService(
         IAppHostServerProjectFactory appHostServerProjectFactory,
@@ -50,7 +52,8 @@ internal sealed class ScaffoldingService : IScaffoldingService
         ILanguageDiscovery languageDiscovery,
         IInteractionService interactionService,
         ILogger<ScaffoldingService> logger,
-        CliExecutionContext executionContext)
+        CliExecutionContext executionContext,
+        ProfilingTelemetry profilingTelemetry)
     {
         _appHostServerProjectFactory = appHostServerProjectFactory;
         _appHostServerSessionFactory = appHostServerSessionFactory;
@@ -58,6 +61,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
         _interactionService = interactionService;
         _logger = logger;
         _executionContext = executionContext;
+        _profilingTelemetry = profilingTelemetry;
     }
 
     /// <inheritdoc />
@@ -411,7 +415,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
             runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(runtimeSpec, toolchain);
         }
 
-        var runtime = new GuestRuntime(runtimeSpec, _logger);
+        var runtime = new GuestRuntime(runtimeSpec, _logger, PathLookupHelper.FindFullPathFromPath, _profilingTelemetry);
 
         var (initResult, initOutput) = await runtime.InitializeAsync(directory, cancellationToken);
         if (initResult != 0)

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DcpConnectionChecker.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DcpConnectionChecker.cs
@@ -312,7 +312,7 @@ internal sealed class DcpConnectionChecker(
         {
             await WaitForKubeconfigFileAsync(cancellationToken).ConfigureAwait(false);
 
-            return await DcpKubeconfig.ReadFileWithRetryAsync(_kubeconfigPath, cancellationToken).ConfigureAwait(false);
+            return await DcpKubeconfig.ReadFileWithRetryAsync(_kubeconfigPath, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         public async Task StopDcpAsync(HttpClient client, DcpKubeconfig kubeconfig, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DcpKubeconfig.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DcpKubeconfig.cs
@@ -20,7 +20,7 @@ internal sealed class DcpKubeconfig : IDisposable
 
     public X509Certificate2? ClientCertificate { get; init; }
 
-    internal static async Task<DcpKubeconfig> ReadFileWithRetryAsync(string path, CancellationToken cancellationToken, Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
+    internal static async Task<DcpKubeconfig> ReadFileWithRetryAsync(string path, Func<TimeSpan, CancellationToken, Task>? delayAsync = null, CancellationToken cancellationToken = default)
     {
         delayAsync ??= Task.Delay;
 

--- a/tests/Aspire.Cli.Tests/Acquisition/IdentityResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/IdentityResolverTests.cs
@@ -25,10 +25,8 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","channel":"staging"}""");
 
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("EnvWins", channel: "stable", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
+        var resolver = CreateResolver(workspace,
+            channel: "stable",
             envReader: name => name == IdentityResolver.ChannelEnvVar ? "pr-12345" : null);
 
         var resolved = resolver.ResolveChannel();
@@ -42,11 +40,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","channel":"staging"}""");
 
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("SidecarWins", channel: "stable", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: _ => null);
+        var resolver = CreateResolver(workspace, channel: "stable");
 
         var resolved = resolver.ResolveChannel();
         Assert.Equal("staging", resolved.Value);
@@ -59,11 +53,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         // No sidecar file written — resolver should skip the sidecar layer.
 
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("AsmFallback", channel: "daily", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: _ => null);
+        var resolver = CreateResolver(workspace, channel: "daily");
 
         var resolved = resolver.ResolveChannel();
         Assert.Equal("daily", resolved.Value);
@@ -75,13 +65,9 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            // Assembly without channel metadata throws inside IdentityChannelReader;
-            // the resolver swallows that and falls through to the terminal default.
-            BuildAssembly("NoChannel", channel: null, informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: _ => null);
+        // Assembly without channel metadata throws inside IdentityChannelReader;
+        // the resolver swallows that and falls through to the terminal default.
+        var resolver = CreateResolver(workspace, channel: null);
 
         var resolved = resolver.ResolveChannel();
         Assert.Equal(PackageChannelNames.Local, resolved.Value);
@@ -97,10 +83,8 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","channel":"staging"}""");
 
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("EmptyEnv", channel: "stable", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
+        var resolver = CreateResolver(workspace,
+            channel: "stable",
             envReader: name => name == IdentityResolver.ChannelEnvVar ? string.Empty : null);
 
         var resolved = resolver.ResolveChannel();
@@ -112,11 +96,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     public void ResolveVersion_SplitsInformationalVersionAtPlus()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("VersionSplit", channel: "local", informationalVersion: "13.4.0-preview.1.25366.3+abcdef0"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: _ => null);
+        var resolver = CreateResolver(workspace, informationalVersion: "13.4.0-preview.1.25366.3+abcdef0");
 
         var version = resolver.ResolveVersion();
         var commit = resolver.ResolveCommit();
@@ -130,11 +110,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     public void ResolveCommit_EmptyWhenInformationalVersionHasNoPlus()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("NoCommit", channel: "local", informationalVersion: "13.4.0"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: _ => null);
+        var resolver = CreateResolver(workspace, informationalVersion: "13.4.0");
 
         Assert.Equal(string.Empty, resolver.ResolveCommit().Value);
         Assert.Equal("13.4.0", resolver.ResolveVersion().Value);
@@ -144,10 +120,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     public void ResolveVersion_EnvOverridesAssembly()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("VerEnv", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
+        var resolver = CreateResolver(workspace,
             envReader: name => name == IdentityResolver.VersionEnvVar ? "99.0.0-test" : null);
 
         var resolved = resolver.ResolveVersion();
@@ -162,10 +135,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     public void ResolveVersion_AcceptsValidSemVer(string version)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("VerValid", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
+        var resolver = CreateResolver(workspace,
             envReader: name => name == IdentityResolver.VersionEnvVar ? version : null);
 
         var resolved = resolver.ResolveVersion();
@@ -184,10 +154,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // immediately with a message naming the env var, not silently corrupt downstream
         // version-keyed decisions.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("VerBad", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
+        var resolver = CreateResolver(workspace,
             envReader: name => name == IdentityResolver.VersionEnvVar ? version : null);
 
         var ex = Assert.Throws<InvalidOperationException>(() => resolver.ResolveVersion());
@@ -200,11 +167,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","version":"garbage"}""");
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("VerScBad", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: _ => null);
+        var resolver = CreateResolver(workspace);
 
         var ex = Assert.Throws<InvalidOperationException>(() => resolver.ResolveVersion());
         Assert.Contains(InstallSidecarReader.SidecarFileName, ex.Message);
@@ -218,10 +181,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     public void ResolveCommit_AcceptsHexSha(string commit)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("CommitOk", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
+        var resolver = CreateResolver(workspace,
             envReader: name => name == IdentityResolver.CommitEnvVar ? commit : null);
 
         var resolved = resolver.ResolveCommit();
@@ -237,10 +197,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     public void ResolveCommit_FromEnv_FailsFast_WhenNotHex(string commit)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("CommitBad", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
+        var resolver = CreateResolver(workspace,
             envReader: name => name == IdentityResolver.CommitEnvVar ? commit : null);
 
         var ex = Assert.Throws<InvalidOperationException>(() => resolver.ResolveCommit());
@@ -253,10 +210,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     public void ResolveNuGetServiceIndexOverride_AcceptsAbsoluteHttpUrl(string url)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("NuGetOk", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
+        var resolver = CreateResolver(workspace,
             envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar ? url : null);
 
         var resolved = resolver.ResolveNuGetServiceIndexOverride();
@@ -271,10 +225,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     public void ResolveNuGetServiceIndexOverride_FromEnv_FailsFast_WhenNotHttpUrl(string url)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("NuGetBad", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
+        var resolver = CreateResolver(workspace,
             envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar ? url : null);
 
         var ex = Assert.Throws<InvalidOperationException>(() => resolver.ResolveNuGetServiceIndexOverride());
@@ -288,11 +239,10 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // "pr-17580" are legitimate overrides. This pins that decision so a future "tighten
         // validation" change can't silently break the override's primary use case.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("ChannelBespoke", channel: "stable", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: name => name == IdentityResolver.ChannelEnvVar ? "totally-made-up" : null);
+        var resolver = CreateResolver(workspace,
+            envReader: name => name == IdentityResolver.ChannelEnvVar ? "totally-made-up" : null,
+            channel: "stable",
+            assemblyName: "ChannelBespoke");
 
         var resolved = resolver.ResolveChannel();
         Assert.Equal("totally-made-up", resolved.Value);
@@ -305,11 +255,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         // No sidecar field, no env var — the override must remain null so
         // callers fall back to PackageSources.NuGetOrg via the `?? canonical` pattern.
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("OverrideNull", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: _ => null);
+        var resolver = CreateResolver(workspace, assemblyName: "OverrideNull");
 
         var resolved = resolver.ResolveNuGetServiceIndexOverride();
         Assert.Null(resolved.Value);
@@ -322,13 +268,11 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","nugetServiceIndexOverride":"http://sidecar/v3/index.json"}""");
 
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("OverrideEnv", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
+        var resolver = CreateResolver(workspace,
             envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar
                 ? "http://env/v3/index.json"
-                : null);
+                : null,
+            assemblyName: "OverrideEnv");
 
         var resolved = resolver.ResolveNuGetServiceIndexOverride();
         Assert.Equal("http://env/v3/index.json", resolved.Value);
@@ -341,11 +285,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","nugetServiceIndexOverride":"http://proxy.local/v3/index.json"}""");
 
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("OverrideSc", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: _ => null);
+        var resolver = CreateResolver(workspace, assemblyName: "OverrideSc");
 
         var resolved = resolver.ResolveNuGetServiceIndexOverride();
         Assert.Equal("http://proxy.local/v3/index.json", resolved.Value);
@@ -358,11 +298,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         // No sidecar field, no env var — the override must remain null so the
         // packaging service does not synthesize an override channel.
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("PackagesNull", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: _ => null);
+        var resolver = CreateResolver(workspace, assemblyName: "PackagesNull");
 
         var resolved = resolver.ResolvePackagesDirectory();
         Assert.Null(resolved.Value);
@@ -375,13 +311,11 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","packages":"/sidecar/packages"}""");
 
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("PackagesEnv", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
+        var resolver = CreateResolver(workspace,
             envReader: name => name == IdentityResolver.PackagesEnvVar
                 ? "/env/packages"
-                : null);
+                : null,
+            assemblyName: "PackagesEnv");
 
         var resolved = resolver.ResolvePackagesDirectory();
         Assert.Equal("/env/packages", resolved.Value);
@@ -394,11 +328,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","packages":"/sidecar/packages"}""");
 
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("PackagesSc", channel: "local", informationalVersion: "13.4.0+abc"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: _ => null);
+        var resolver = CreateResolver(workspace, assemblyName: "PackagesSc");
 
         var resolved = resolver.ResolvePackagesDirectory();
         Assert.Equal("/sidecar/packages", resolved.Value);
@@ -410,11 +340,10 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         // ASPIRE_CLI_VERSION emulation must light up the override notice and feed IdentityVersion.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("EnvVersionOverride", channel: "local", informationalVersion: "13.5.0-dev+local"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: name => name == IdentityResolver.VersionEnvVar ? "13.4.2" : null);
+        var resolver = CreateResolver(workspace,
+            envReader: name => name == IdentityResolver.VersionEnvVar ? "13.4.2" : null,
+            informationalVersion: "13.5.0-dev+local",
+            assemblyName: "EnvVersionOverride");
 
         var context = Program.BuildCliExecutionContext(
             debugMode: false,
@@ -431,11 +360,9 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","channel":"staging"}""");
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("SidecarChannelOverride", channel: "local", informationalVersion: "13.5.0-dev+local"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: _ => null);
+        var resolver = CreateResolver(workspace,
+            informationalVersion: "13.5.0-dev+local",
+            assemblyName: "SidecarChannelOverride");
 
         var context = Program.BuildCliExecutionContext(
             debugMode: false,
@@ -453,11 +380,10 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // No env vars and no sidecar — a real install reads its own assembly stamp, so the
         // notice must stay silent.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("AssemblyOnly", channel: "daily", informationalVersion: "13.5.0-preview.1.25366.3+abcdef0"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: _ => null);
+        var resolver = CreateResolver(workspace,
+            channel: "daily",
+            informationalVersion: "13.5.0-preview.1.25366.3+abcdef0",
+            assemblyName: "AssemblyOnly");
 
         var context = Program.BuildCliExecutionContext(
             debugMode: false,
@@ -475,11 +401,10 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // so PackagingService can synthesize an override channel from it.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var packagesDir = Path.Combine(workspace.WorkspaceRoot.FullName, "shipping");
-        var resolver = new IdentityResolver(
-            CliTestHelper.CreateSidecarReader(outputHelper),
-            BuildAssembly("EnvPackagesOverride", channel: "local", informationalVersion: "13.5.0-dev+local"),
-            workspace.WorkspaceRoot.FullName,
-            envReader: name => name == IdentityResolver.PackagesEnvVar ? packagesDir : null);
+        var resolver = CreateResolver(workspace,
+            envReader: name => name == IdentityResolver.PackagesEnvVar ? packagesDir : null,
+            informationalVersion: "13.5.0-dev+local",
+            assemblyName: "EnvPackagesOverride");
 
         var context = Program.BuildCliExecutionContext(
             debugMode: false,
@@ -514,6 +439,20 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
 
     private static void WriteSidecar(string directory, string json)
         => File.WriteAllText(Path.Combine(directory, InstallSidecarReader.SidecarFileName), json);
+
+    private IdentityResolver CreateResolver(
+        TemporaryWorkspace workspace,
+        Func<string, string?>? envReader = null,
+        string? channel = "local",
+        string informationalVersion = "13.4.0+abc",
+        string assemblyName = "Test")
+    {
+        return new IdentityResolver(
+            CliTestHelper.CreateSidecarReader(outputHelper),
+            BuildAssembly(assemblyName, channel, informationalVersion),
+            workspace.WorkspaceRoot.FullName,
+            envReader ?? (_ => null));
+    }
 
     private static Assembly BuildAssembly(string assemblyName, string? channel, string informationalVersion)
     {

--- a/tests/Aspire.Cli.Tests/Acquisition/IdentityResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/IdentityResolverTests.cs
@@ -6,7 +6,6 @@ using System.Reflection.Emit;
 using Aspire.Cli.Acquisition;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Tests.Utils;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Acquisition;
 
@@ -27,7 +26,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","channel":"staging"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("EnvWins", channel: "stable", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.ChannelEnvVar ? "pr-12345" : null);
@@ -44,7 +43,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","channel":"staging"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("SidecarWins", channel: "stable", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -61,7 +60,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // No sidecar file written — resolver should skip the sidecar layer.
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("AsmFallback", channel: "daily", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -77,7 +76,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             // Assembly without channel metadata throws inside IdentityChannelReader;
             // the resolver swallows that and falls through to the terminal default.
             BuildAssembly("NoChannel", channel: null, informationalVersion: "13.4.0+abc"),
@@ -99,7 +98,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","channel":"staging"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("EmptyEnv", channel: "stable", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.ChannelEnvVar ? string.Empty : null);
@@ -114,7 +113,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("VersionSplit", channel: "local", informationalVersion: "13.4.0-preview.1.25366.3+abcdef0"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -132,7 +131,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("NoCommit", channel: "local", informationalVersion: "13.4.0"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -146,7 +145,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("VerEnv", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.VersionEnvVar ? "99.0.0-test" : null);
@@ -164,7 +163,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("VerValid", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.VersionEnvVar ? version : null);
@@ -186,7 +185,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // version-keyed decisions.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("VerBad", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.VersionEnvVar ? version : null);
@@ -202,7 +201,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","version":"garbage"}""");
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("VerScBad", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -220,7 +219,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("CommitOk", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.CommitEnvVar ? commit : null);
@@ -239,7 +238,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("CommitBad", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.CommitEnvVar ? commit : null);
@@ -255,7 +254,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("NuGetOk", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar ? url : null);
@@ -273,7 +272,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("NuGetBad", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar ? url : null);
@@ -290,7 +289,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // validation" change can't silently break the override's primary use case.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("ChannelBespoke", channel: "stable", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.ChannelEnvVar ? "totally-made-up" : null);
@@ -307,7 +306,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // No sidecar field, no env var — the override must remain null so
         // callers fall back to PackageSources.NuGetOrg via the `?? canonical` pattern.
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("OverrideNull", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -324,7 +323,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","nugetServiceIndexOverride":"http://sidecar/v3/index.json"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("OverrideEnv", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar
@@ -343,7 +342,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","nugetServiceIndexOverride":"http://proxy.local/v3/index.json"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("OverrideSc", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -360,7 +359,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // No sidecar field, no env var — the override must remain null so the
         // packaging service does not synthesize an override channel.
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("PackagesNull", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -377,7 +376,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","packages":"/sidecar/packages"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("PackagesEnv", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.PackagesEnvVar
@@ -396,7 +395,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","packages":"/sidecar/packages"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("PackagesSc", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -412,7 +411,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // ASPIRE_CLI_VERSION emulation must light up the override notice and feed IdentityVersion.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("EnvVersionOverride", channel: "local", informationalVersion: "13.5.0-dev+local"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.VersionEnvVar ? "13.4.2" : null);
@@ -433,7 +432,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","channel":"staging"}""");
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("SidecarChannelOverride", channel: "local", informationalVersion: "13.5.0-dev+local"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -455,7 +454,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // notice must stay silent.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("AssemblyOnly", channel: "daily", informationalVersion: "13.5.0-preview.1.25366.3+abcdef0"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -477,7 +476,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var packagesDir = Path.Combine(workspace.WorkspaceRoot.FullName, "shipping");
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly("EnvPackagesOverride", channel: "local", informationalVersion: "13.5.0-dev+local"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.PackagesEnvVar ? packagesDir : null);

--- a/tests/Aspire.Cli.Tests/Acquisition/IdentityResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/IdentityResolverTests.cs
@@ -27,7 +27,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
 
         var resolver = CreateResolver(workspace,
             channel: "stable",
-            envReader: name => name == IdentityResolver.ChannelEnvVar ? "pr-12345" : null);
+            environmentVariables: new Dictionary<string, string?> { [IdentityResolver.ChannelEnvVar] = "pr-12345" });
 
         var resolved = resolver.ResolveChannel();
         Assert.Equal("pr-12345", resolved.Value);
@@ -85,7 +85,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
 
         var resolver = CreateResolver(workspace,
             channel: "stable",
-            envReader: name => name == IdentityResolver.ChannelEnvVar ? string.Empty : null);
+            environmentVariables: new Dictionary<string, string?> { [IdentityResolver.ChannelEnvVar] = string.Empty });
 
         var resolved = resolver.ResolveChannel();
         Assert.Equal("staging", resolved.Value);
@@ -121,7 +121,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = CreateResolver(workspace,
-            envReader: name => name == IdentityResolver.VersionEnvVar ? "99.0.0-test" : null);
+            environmentVariables: new Dictionary<string, string?> { [IdentityResolver.VersionEnvVar] = "99.0.0-test" });
 
         var resolved = resolver.ResolveVersion();
         Assert.Equal("99.0.0-test", resolved.Value);
@@ -136,7 +136,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = CreateResolver(workspace,
-            envReader: name => name == IdentityResolver.VersionEnvVar ? version : null);
+            environmentVariables: new Dictionary<string, string?> { [IdentityResolver.VersionEnvVar] = version });
 
         var resolved = resolver.ResolveVersion();
         Assert.Equal(version, resolved.Value);
@@ -155,7 +155,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // version-keyed decisions.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = CreateResolver(workspace,
-            envReader: name => name == IdentityResolver.VersionEnvVar ? version : null);
+            environmentVariables: new Dictionary<string, string?> { [IdentityResolver.VersionEnvVar] = version });
 
         var ex = Assert.Throws<InvalidOperationException>(() => resolver.ResolveVersion());
         Assert.Contains(IdentityResolver.VersionEnvVar, ex.Message);
@@ -182,7 +182,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = CreateResolver(workspace,
-            envReader: name => name == IdentityResolver.CommitEnvVar ? commit : null);
+            environmentVariables: new Dictionary<string, string?> { [IdentityResolver.CommitEnvVar] = commit });
 
         var resolved = resolver.ResolveCommit();
         Assert.Equal(commit, resolved.Value);
@@ -198,7 +198,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = CreateResolver(workspace,
-            envReader: name => name == IdentityResolver.CommitEnvVar ? commit : null);
+            environmentVariables: new Dictionary<string, string?> { [IdentityResolver.CommitEnvVar] = commit });
 
         var ex = Assert.Throws<InvalidOperationException>(() => resolver.ResolveCommit());
         Assert.Contains(IdentityResolver.CommitEnvVar, ex.Message);
@@ -211,7 +211,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = CreateResolver(workspace,
-            envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar ? url : null);
+            environmentVariables: new Dictionary<string, string?> { [IdentityResolver.NuGetServiceIndexEnvVar] = url });
 
         var resolved = resolver.ResolveNuGetServiceIndexOverride();
         Assert.Equal(url, resolved.Value);
@@ -226,7 +226,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = CreateResolver(workspace,
-            envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar ? url : null);
+            environmentVariables: new Dictionary<string, string?> { [IdentityResolver.NuGetServiceIndexEnvVar] = url });
 
         var ex = Assert.Throws<InvalidOperationException>(() => resolver.ResolveNuGetServiceIndexOverride());
         Assert.Contains(IdentityResolver.NuGetServiceIndexEnvVar, ex.Message);
@@ -240,7 +240,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // validation" change can't silently break the override's primary use case.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = CreateResolver(workspace,
-            envReader: name => name == IdentityResolver.ChannelEnvVar ? "totally-made-up" : null,
+            environmentVariables: new Dictionary<string, string?> { [IdentityResolver.ChannelEnvVar] = "totally-made-up" },
             channel: "stable",
             assemblyName: "ChannelBespoke");
 
@@ -269,9 +269,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","nugetServiceIndexOverride":"http://sidecar/v3/index.json"}""");
 
         var resolver = CreateResolver(workspace,
-            envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar
-                ? "http://env/v3/index.json"
-                : null,
+            environmentVariables: new Dictionary<string, string?> { [IdentityResolver.NuGetServiceIndexEnvVar] = "http://env/v3/index.json" },
             assemblyName: "OverrideEnv");
 
         var resolved = resolver.ResolveNuGetServiceIndexOverride();
@@ -312,9 +310,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","packages":"/sidecar/packages"}""");
 
         var resolver = CreateResolver(workspace,
-            envReader: name => name == IdentityResolver.PackagesEnvVar
-                ? "/env/packages"
-                : null,
+            environmentVariables: new Dictionary<string, string?> { [IdentityResolver.PackagesEnvVar] = "/env/packages" },
             assemblyName: "PackagesEnv");
 
         var resolved = resolver.ResolvePackagesDirectory();
@@ -340,16 +336,13 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         // ASPIRE_CLI_VERSION emulation must light up the override notice and feed IdentityVersion.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var envVars = new Dictionary<string, string?> { [IdentityResolver.VersionEnvVar] = "13.4.2" };
         var resolver = CreateResolver(workspace,
-            envReader: name => name == IdentityResolver.VersionEnvVar ? "13.4.2" : null,
+            environmentVariables: envVars,
             informationalVersion: "13.5.0-dev+local",
             assemblyName: "EnvVersionOverride");
 
-        var context = Program.BuildCliExecutionContext(
-            debugMode: false,
-            logsDirectory: workspace.WorkspaceRoot.FullName,
-            logFilePath: Path.Combine(workspace.WorkspaceRoot.FullName, "cli.log"),
-            identityResolver: resolver);
+        var context = BuildContextFromResolver(workspace, resolver);
 
         Assert.True(context.IdentityOverridden);
         Assert.Equal("13.4.2", context.IdentityVersion);
@@ -364,11 +357,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
             informationalVersion: "13.5.0-dev+local",
             assemblyName: "SidecarChannelOverride");
 
-        var context = Program.BuildCliExecutionContext(
-            debugMode: false,
-            logsDirectory: workspace.WorkspaceRoot.FullName,
-            logFilePath: Path.Combine(workspace.WorkspaceRoot.FullName, "cli.log"),
-            identityResolver: resolver);
+        var context = BuildContextFromResolver(workspace, resolver);
 
         Assert.True(context.IdentityOverridden);
         Assert.Equal("staging", context.IdentityChannel);
@@ -385,11 +374,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
             informationalVersion: "13.5.0-preview.1.25366.3+abcdef0",
             assemblyName: "AssemblyOnly");
 
-        var context = Program.BuildCliExecutionContext(
-            debugMode: false,
-            logsDirectory: workspace.WorkspaceRoot.FullName,
-            logFilePath: Path.Combine(workspace.WorkspaceRoot.FullName, "cli.log"),
-            identityResolver: resolver);
+        var context = BuildContextFromResolver(workspace, resolver);
 
         Assert.False(context.IdentityOverridden);
     }
@@ -401,16 +386,13 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // so PackagingService can synthesize an override channel from it.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var packagesDir = Path.Combine(workspace.WorkspaceRoot.FullName, "shipping");
+        var envVars = new Dictionary<string, string?> { [IdentityResolver.PackagesEnvVar] = packagesDir };
         var resolver = CreateResolver(workspace,
-            envReader: name => name == IdentityResolver.PackagesEnvVar ? packagesDir : null,
+            environmentVariables: envVars,
             informationalVersion: "13.5.0-dev+local",
             assemblyName: "EnvPackagesOverride");
 
-        var context = Program.BuildCliExecutionContext(
-            debugMode: false,
-            logsDirectory: workspace.WorkspaceRoot.FullName,
-            logFilePath: Path.Combine(workspace.WorkspaceRoot.FullName, "cli.log"),
-            identityResolver: resolver);
+        var context = BuildContextFromResolver(workspace, resolver);
 
         Assert.True(context.IdentityOverridden);
         Assert.NotNull(context.IdentityPackagesDirectory);
@@ -442,16 +424,48 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
 
     private IdentityResolver CreateResolver(
         TemporaryWorkspace workspace,
-        Func<string, string?>? envReader = null,
+        IReadOnlyDictionary<string, string?>? environmentVariables = null,
         string? channel = "local",
         string informationalVersion = "13.4.0+abc",
         string assemblyName = "Test")
     {
+        var environment = new TestEnvironment(environmentVariables);
+
         return new IdentityResolver(
             CliTestHelper.CreateSidecarReader(outputHelper),
             BuildAssembly(assemblyName, channel, informationalVersion),
             workspace.WorkspaceRoot.FullName,
-            envReader ?? (_ => null));
+            environment);
+    }
+
+    /// <summary>
+    /// Resolves identity from the resolver and constructs a <see cref="CliExecutionContext"/>
+    /// with those values — mirroring what <c>Program.BuildCliExecutionContext(resolver)</c> does.
+    /// </summary>
+    private static CliExecutionContext BuildContextFromResolver(TemporaryWorkspace workspace, IIdentityResolver resolver)
+    {
+        var channel = resolver.ResolveChannel();
+        var version = resolver.ResolveVersion();
+        var commit = resolver.ResolveCommit();
+        var nugetOverride = resolver.ResolveNuGetServiceIndexOverride();
+        var packagesOverride = resolver.ResolvePackagesDirectory();
+
+        static bool IsOverride(IdentitySource source) => source is IdentitySource.Environment or IdentitySource.Sidecar;
+        var overridden = IsOverride(channel.Source) || IsOverride(version.Source) || IsOverride(commit.Source) || IsOverride(nugetOverride.Source) || IsOverride(packagesOverride.Source);
+
+        return new CliExecutionContext(
+            workingDirectory: workspace.WorkspaceRoot,
+            hivesDirectory: new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "hives")),
+            cacheDirectory: new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "cache")),
+            sdksDirectory: new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "sdks")),
+            logsDirectory: new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "logs")),
+            logFilePath: Path.Combine(workspace.WorkspaceRoot.FullName, "logs", "test.log"),
+            identityChannel: channel.Value,
+            identityVersion: version.Value,
+            identityCommit: commit.Value,
+            nugetServiceIndexOverride: nugetOverride.Value,
+            identityOverridden: overridden,
+            identityPackagesDirectory: string.IsNullOrWhiteSpace(packagesOverride.Value) ? null : new DirectoryInfo(packagesOverride.Value));
     }
 
     private static Assembly BuildAssembly(string assemblyName, string? channel, string informationalVersion)

--- a/tests/Aspire.Cli.Tests/Acquisition/IdentityResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/IdentityResolverTests.cs
@@ -439,33 +439,17 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     }
 
     /// <summary>
-    /// Resolves identity from the resolver and constructs a <see cref="CliExecutionContext"/>
-    /// with those values — mirroring what <c>Program.BuildCliExecutionContext(resolver)</c> does.
+    /// Exercises the real <c>Program.BuildCliExecutionContext(resolver)</c> production path
+    /// so that the identity-override OR-computation and directory derivation are tested
+    /// against the actual implementation rather than a local copy.
     /// </summary>
     private static CliExecutionContext BuildContextFromResolver(TemporaryWorkspace workspace, IIdentityResolver resolver)
     {
-        var channel = resolver.ResolveChannel();
-        var version = resolver.ResolveVersion();
-        var commit = resolver.ResolveCommit();
-        var nugetOverride = resolver.ResolveNuGetServiceIndexOverride();
-        var packagesOverride = resolver.ResolvePackagesDirectory();
-
-        static bool IsOverride(IdentitySource source) => source is IdentitySource.Environment or IdentitySource.Sidecar;
-        var overridden = IsOverride(channel.Source) || IsOverride(version.Source) || IsOverride(commit.Source) || IsOverride(nugetOverride.Source) || IsOverride(packagesOverride.Source);
-
-        return new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot,
-            hivesDirectory: new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "hives")),
-            cacheDirectory: new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "cache")),
-            sdksDirectory: new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "sdks")),
-            logsDirectory: new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "logs")),
+        return Program.BuildCliExecutionContext(
+            debugMode: false,
+            logsDirectory: Path.Combine(workspace.WorkspaceRoot.FullName, "logs"),
             logFilePath: Path.Combine(workspace.WorkspaceRoot.FullName, "logs", "test.log"),
-            identityChannel: channel.Value,
-            identityVersion: version.Value,
-            identityCommit: commit.Value,
-            nugetServiceIndexOverride: nugetOverride.Value,
-            identityOverridden: overridden,
-            identityPackagesDirectory: string.IsNullOrWhiteSpace(packagesOverride.Value) ? null : new DirectoryInfo(packagesOverride.Value));
+            identityResolver: resolver);
     }
 
     private static Assembly BuildAssembly(string assemblyName, string? channel, string informationalVersion)

--- a/tests/Aspire.Cli.Tests/Acquisition/IdentityResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/IdentityResolverTests.cs
@@ -6,6 +6,7 @@ using System.Reflection.Emit;
 using Aspire.Cli.Acquisition;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Acquisition;
 
@@ -26,7 +27,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","channel":"staging"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("EnvWins", channel: "stable", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.ChannelEnvVar ? "pr-12345" : null);
@@ -43,7 +44,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","channel":"staging"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("SidecarWins", channel: "stable", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -60,7 +61,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // No sidecar file written — resolver should skip the sidecar layer.
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("AsmFallback", channel: "daily", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -76,7 +77,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             // Assembly without channel metadata throws inside IdentityChannelReader;
             // the resolver swallows that and falls through to the terminal default.
             BuildAssembly("NoChannel", channel: null, informationalVersion: "13.4.0+abc"),
@@ -98,7 +99,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","channel":"staging"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("EmptyEnv", channel: "stable", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.ChannelEnvVar ? string.Empty : null);
@@ -113,7 +114,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("VersionSplit", channel: "local", informationalVersion: "13.4.0-preview.1.25366.3+abcdef0"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -131,7 +132,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("NoCommit", channel: "local", informationalVersion: "13.4.0"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -145,7 +146,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("VerEnv", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.VersionEnvVar ? "99.0.0-test" : null);
@@ -163,7 +164,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("VerValid", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.VersionEnvVar ? version : null);
@@ -185,7 +186,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // version-keyed decisions.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("VerBad", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.VersionEnvVar ? version : null);
@@ -201,7 +202,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","version":"garbage"}""");
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("VerScBad", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -219,7 +220,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("CommitOk", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.CommitEnvVar ? commit : null);
@@ -238,7 +239,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("CommitBad", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.CommitEnvVar ? commit : null);
@@ -254,7 +255,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("NuGetOk", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar ? url : null);
@@ -272,7 +273,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("NuGetBad", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar ? url : null);
@@ -289,7 +290,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // validation" change can't silently break the override's primary use case.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("ChannelBespoke", channel: "stable", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.ChannelEnvVar ? "totally-made-up" : null);
@@ -306,7 +307,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // No sidecar field, no env var — the override must remain null so
         // callers fall back to PackageSources.NuGetOrg via the `?? canonical` pattern.
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("OverrideNull", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -323,7 +324,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","nugetServiceIndexOverride":"http://sidecar/v3/index.json"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("OverrideEnv", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar
@@ -342,7 +343,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","nugetServiceIndexOverride":"http://proxy.local/v3/index.json"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("OverrideSc", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -359,7 +360,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // No sidecar field, no env var — the override must remain null so the
         // packaging service does not synthesize an override channel.
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("PackagesNull", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -376,7 +377,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","packages":"/sidecar/packages"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("PackagesEnv", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.PackagesEnvVar
@@ -395,7 +396,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","packages":"/sidecar/packages"}""");
 
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("PackagesSc", channel: "local", informationalVersion: "13.4.0+abc"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -411,7 +412,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // ASPIRE_CLI_VERSION emulation must light up the override notice and feed IdentityVersion.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("EnvVersionOverride", channel: "local", informationalVersion: "13.5.0-dev+local"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.VersionEnvVar ? "13.4.2" : null);
@@ -432,7 +433,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, """{"source":"script","channel":"staging"}""");
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("SidecarChannelOverride", channel: "local", informationalVersion: "13.5.0-dev+local"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -454,7 +455,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         // notice must stay silent.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("AssemblyOnly", channel: "daily", informationalVersion: "13.5.0-preview.1.25366.3+abcdef0"),
             workspace.WorkspaceRoot.FullName,
             envReader: _ => null);
@@ -476,7 +477,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var packagesDir = Path.Combine(workspace.WorkspaceRoot.FullName, "shipping");
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             BuildAssembly("EnvPackagesOverride", channel: "local", informationalVersion: "13.5.0-dev+local"),
             workspace.WorkspaceRoot.FullName,
             envReader: name => name == IdentityResolver.PackagesEnvVar ? packagesDir : null);

--- a/tests/Aspire.Cli.Tests/Acquisition/InstallSidecarReaderTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/InstallSidecarReaderTests.cs
@@ -4,7 +4,6 @@
 using System.Text;
 using Aspire.Cli.Acquisition;
 using Aspire.Cli.Tests.Utils;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Acquisition;
 
@@ -30,7 +29,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, $"{{\"source\":\"{wireValue}\"}}");
 
-        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
+        var reader = CliTestHelper.CreateSidecarReader(outputHelper);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(result);
@@ -44,7 +43,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var expectedPath = Path.Combine(workspace.WorkspaceRoot.FullName, InstallSidecarReader.SidecarFileName);
 
-        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
+        var reader = CliTestHelper.CreateSidecarReader(outputHelper);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var notFound = Assert.IsType<InstallSidecarReadResult.NotFound>(result);
@@ -54,7 +53,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
     [Fact]
     public void TryRead_ReturnsNotFoundForEmptyBinaryDir()
     {
-        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
+        var reader = CliTestHelper.CreateSidecarReader(outputHelper);
 
         var empty = Assert.IsType<InstallSidecarReadResult.NotFound>(reader.TryRead(string.Empty));
         Assert.Equal(string.Empty, empty.SidecarPath);
@@ -80,7 +79,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         {
             File.SetUnixFileMode(sidecarPath, UnixFileMode.None);
 
-            var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
+            var reader = CliTestHelper.CreateSidecarReader(outputHelper);
             var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
             var invalid = Assert.IsType<InstallSidecarReadResult.Invalid>(result);
@@ -99,7 +98,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var sidecarPath = WriteSidecar(workspace.WorkspaceRoot.FullName, "{not valid json");
 
-        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
+        var reader = CliTestHelper.CreateSidecarReader(outputHelper);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var invalid = Assert.IsType<InstallSidecarReadResult.Invalid>(result);
@@ -122,7 +121,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, sidecarBody);
 
-        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
+        var reader = CliTestHelper.CreateSidecarReader(outputHelper);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(result);
@@ -136,7 +135,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, "{\"source\":\"script\"}");
 
-        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
+        var reader = CliTestHelper.CreateSidecarReader(outputHelper);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(result);
@@ -235,7 +234,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         var oversized = new string('a', (int)InstallSidecarReader.MaxSidecarBytes + 1);
         File.WriteAllText(sidecarPath, $"{{\"source\":\"{oversized}\"}}");
 
-        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
+        var reader = CliTestHelper.CreateSidecarReader(outputHelper);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var invalid = Assert.IsType<InstallSidecarReadResult.Invalid>(result);
@@ -267,7 +266,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         var bytes = Encoding.UTF8.GetPreamble().Concat(Encoding.UTF8.GetBytes("{\"source\":\"script\"}")).ToArray();
         File.WriteAllBytes(sidecarPath, bytes);
 
-        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
+        var reader = CliTestHelper.CreateSidecarReader(outputHelper);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(result);
@@ -298,7 +297,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, "{\"source\":\"script\",\"futureField\":\"value\",\"nested\":{\"a\":1,\"b\":[1,2]}}");
 
-        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
+        var reader = CliTestHelper.CreateSidecarReader(outputHelper);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(result);
@@ -327,7 +326,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
             }
             """);
 
-        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
+        var reader = CliTestHelper.CreateSidecarReader(outputHelper);
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(reader.TryRead(workspace.WorkspaceRoot.FullName));
 
         Assert.Equal(InstallSource.Script, ok.Info.Source);
@@ -347,7 +346,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, "{\"source\":\"script\"}");
 
-        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
+        var reader = CliTestHelper.CreateSidecarReader(outputHelper);
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(reader.TryRead(workspace.WorkspaceRoot.FullName));
 
         Assert.Equal(InstallSource.Script, ok.Info.Source);

--- a/tests/Aspire.Cli.Tests/Acquisition/InstallSidecarReaderTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/InstallSidecarReaderTests.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using Aspire.Cli.Acquisition;
 using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Acquisition;
 
@@ -29,7 +30,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, $"{{\"source\":\"{wireValue}\"}}");
 
-        var reader = new InstallSidecarReader();
+        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(result);
@@ -43,7 +44,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var expectedPath = Path.Combine(workspace.WorkspaceRoot.FullName, InstallSidecarReader.SidecarFileName);
 
-        var reader = new InstallSidecarReader();
+        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var notFound = Assert.IsType<InstallSidecarReadResult.NotFound>(result);
@@ -53,7 +54,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
     [Fact]
     public void TryRead_ReturnsNotFoundForEmptyBinaryDir()
     {
-        var reader = new InstallSidecarReader();
+        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
 
         var empty = Assert.IsType<InstallSidecarReadResult.NotFound>(reader.TryRead(string.Empty));
         Assert.Equal(string.Empty, empty.SidecarPath);
@@ -79,7 +80,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         {
             File.SetUnixFileMode(sidecarPath, UnixFileMode.None);
 
-            var reader = new InstallSidecarReader();
+            var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
             var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
             var invalid = Assert.IsType<InstallSidecarReadResult.Invalid>(result);
@@ -98,7 +99,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var sidecarPath = WriteSidecar(workspace.WorkspaceRoot.FullName, "{not valid json");
 
-        var reader = new InstallSidecarReader();
+        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var invalid = Assert.IsType<InstallSidecarReadResult.Invalid>(result);
@@ -121,7 +122,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, sidecarBody);
 
-        var reader = new InstallSidecarReader();
+        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(result);
@@ -135,7 +136,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, "{\"source\":\"script\"}");
 
-        var reader = new InstallSidecarReader();
+        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(result);
@@ -234,7 +235,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         var oversized = new string('a', (int)InstallSidecarReader.MaxSidecarBytes + 1);
         File.WriteAllText(sidecarPath, $"{{\"source\":\"{oversized}\"}}");
 
-        var reader = new InstallSidecarReader();
+        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var invalid = Assert.IsType<InstallSidecarReadResult.Invalid>(result);
@@ -266,7 +267,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         var bytes = Encoding.UTF8.GetPreamble().Concat(Encoding.UTF8.GetBytes("{\"source\":\"script\"}")).ToArray();
         File.WriteAllBytes(sidecarPath, bytes);
 
-        var reader = new InstallSidecarReader();
+        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(result);
@@ -297,7 +298,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, "{\"source\":\"script\",\"futureField\":\"value\",\"nested\":{\"a\":1,\"b\":[1,2]}}");
 
-        var reader = new InstallSidecarReader();
+        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
         var result = reader.TryRead(workspace.WorkspaceRoot.FullName);
 
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(result);
@@ -326,7 +327,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
             }
             """);
 
-        var reader = new InstallSidecarReader();
+        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(reader.TryRead(workspace.WorkspaceRoot.FullName));
 
         Assert.Equal(InstallSource.Script, ok.Info.Source);
@@ -346,7 +347,7 @@ public class InstallSidecarReaderTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         WriteSidecar(workspace.WorkspaceRoot.FullName, "{\"source\":\"script\"}");
 
-        var reader = new InstallSidecarReader();
+        var reader = new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance);
         var ok = Assert.IsType<InstallSidecarReadResult.Ok>(reader.TryRead(workspace.WorkspaceRoot.FullName));
 
         Assert.Equal(InstallSource.Script, ok.Info.Source);

--- a/tests/Aspire.Cli.Tests/Acquisition/InstallationDiscoveryDiscoverAllTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/InstallationDiscoveryDiscoverAllTests.cs
@@ -580,10 +580,11 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
         var capturedLog = new CapturingLogger<InstallationDiscovery>();
         var discovery = new InstallationDiscovery(
             channelReader: new FakeIdentityChannelReader("local"),
-            sidecarReader: new InstallSidecarReader(),
+            sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             peerProbe: new FakePeerInstallProbe(),
             executionContext: CreateExecutionContext(workspace),
-            logger: capturedLog);
+            logger: capturedLog,
+            candidateSources: []);
 
         await discovery.DiscoverAllAsync(TestContext.Current.CancellationToken);
 
@@ -607,10 +608,11 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
         var capturedLog = new CapturingLogger<InstallationDiscovery>();
         var discovery = new InstallationDiscovery(
             channelReader: new FakeIdentityChannelReader("local"),
-            sidecarReader: new InstallSidecarReader(),
+            sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             peerProbe: new FakePeerInstallProbe(),
             executionContext: CreateExecutionContext(workspace),
-            logger: capturedLog);
+            logger: capturedLog,
+            candidateSources: []);
 
         await discovery.DiscoverAllAsync(TestContext.Current.CancellationToken);
 
@@ -641,10 +643,11 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
             var capturedLog = new CapturingLogger<InstallationDiscovery>();
             var discovery = new InstallationDiscovery(
                 channelReader: new FakeIdentityChannelReader("local"),
-                sidecarReader: new InstallSidecarReader(),
+                sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
                 peerProbe: new FakePeerInstallProbe(),
                 executionContext: CreateExecutionContext(workspace),
-                logger: capturedLog);
+                logger: capturedLog,
+                candidateSources: []);
 
             var results = await discovery.DiscoverAllAsync(TestContext.Current.CancellationToken);
 
@@ -682,10 +685,11 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
             var capturedLog = new CapturingLogger<InstallationDiscovery>();
             var discovery = new InstallationDiscovery(
                 channelReader: new FakeIdentityChannelReader("local"),
-                sidecarReader: new InstallSidecarReader(),
+                sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
                 peerProbe: new FakePeerInstallProbe(),
                 executionContext: CreateExecutionContext(workspace),
-                logger: capturedLog);
+                logger: capturedLog,
+                candidateSources: []);
 
             var results = await discovery.DiscoverAllAsync(TestContext.Current.CancellationToken);
 
@@ -810,10 +814,11 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
             aspireHomeDirectory: aspireHome);
         var discovery = new InstallationDiscovery(
             channelReader: new FakeIdentityChannelReader("local"),
-            sidecarReader: new InstallSidecarReader(),
+            sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             peerProbe: probe,
             executionContext: context,
-            logger: NullLogger<InstallationDiscovery>.Instance);
+            logger: NullLogger<InstallationDiscovery>.Instance,
+            candidateSources: []);
 
         var results = await discovery.DiscoverAllAsync(TestContext.Current.CancellationToken);
 
@@ -918,7 +923,7 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
         var hintSource = new FixedCandidateSource(new InstallationDiscoveryCandidate(binary, "test-hint", fakeCanonical));
         var discovery = new InstallationDiscovery(
             channelReader: new FakeIdentityChannelReader("local"),
-            sidecarReader: new InstallSidecarReader(),
+            sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             peerProbe: probe,
             executionContext: CreateExecutionContext(workspace),
             logger: NullLogger<InstallationDiscovery>.Instance,
@@ -956,10 +961,11 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
     {
         return new InstallationDiscovery(
             channelReader: new FakeIdentityChannelReader(identityChannel),
-            sidecarReader: new InstallSidecarReader(),
+            sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             peerProbe: probe,
             executionContext: CreateExecutionContext(workspace),
-            logger: NullLogger<InstallationDiscovery>.Instance);
+            logger: NullLogger<InstallationDiscovery>.Instance,
+            candidateSources: []);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Acquisition/InstallationDiscoveryDiscoverAllTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/InstallationDiscoveryDiscoverAllTests.cs
@@ -580,7 +580,7 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
         var capturedLog = new CapturingLogger<InstallationDiscovery>();
         var discovery = new InstallationDiscovery(
             channelReader: new FakeIdentityChannelReader("local"),
-            sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            sidecarReader: CliTestHelper.CreateSidecarReader(outputHelper),
             peerProbe: new FakePeerInstallProbe(),
             executionContext: CreateExecutionContext(workspace),
             logger: capturedLog,
@@ -608,7 +608,7 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
         var capturedLog = new CapturingLogger<InstallationDiscovery>();
         var discovery = new InstallationDiscovery(
             channelReader: new FakeIdentityChannelReader("local"),
-            sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            sidecarReader: CliTestHelper.CreateSidecarReader(outputHelper),
             peerProbe: new FakePeerInstallProbe(),
             executionContext: CreateExecutionContext(workspace),
             logger: capturedLog,
@@ -643,7 +643,7 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
             var capturedLog = new CapturingLogger<InstallationDiscovery>();
             var discovery = new InstallationDiscovery(
                 channelReader: new FakeIdentityChannelReader("local"),
-                sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+                sidecarReader: CliTestHelper.CreateSidecarReader(outputHelper),
                 peerProbe: new FakePeerInstallProbe(),
                 executionContext: CreateExecutionContext(workspace),
                 logger: capturedLog,
@@ -685,7 +685,7 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
             var capturedLog = new CapturingLogger<InstallationDiscovery>();
             var discovery = new InstallationDiscovery(
                 channelReader: new FakeIdentityChannelReader("local"),
-                sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+                sidecarReader: CliTestHelper.CreateSidecarReader(outputHelper),
                 peerProbe: new FakePeerInstallProbe(),
                 executionContext: CreateExecutionContext(workspace),
                 logger: capturedLog,
@@ -814,7 +814,7 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
             aspireHomeDirectory: aspireHome);
         var discovery = new InstallationDiscovery(
             channelReader: new FakeIdentityChannelReader("local"),
-            sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            sidecarReader: CliTestHelper.CreateSidecarReader(outputHelper),
             peerProbe: probe,
             executionContext: context,
             logger: NullLogger<InstallationDiscovery>.Instance,
@@ -923,7 +923,7 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
         var hintSource = new FixedCandidateSource(new InstallationDiscoveryCandidate(binary, "test-hint", fakeCanonical));
         var discovery = new InstallationDiscovery(
             channelReader: new FakeIdentityChannelReader("local"),
-            sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            sidecarReader: CliTestHelper.CreateSidecarReader(outputHelper),
             peerProbe: probe,
             executionContext: CreateExecutionContext(workspace),
             logger: NullLogger<InstallationDiscovery>.Instance,
@@ -957,11 +957,11 @@ public class InstallationDiscoveryDiscoverAllTests(ITestOutputHelper outputHelpe
         }
     }
 
-    private static InstallationDiscovery NewDiscovery(FakePeerInstallProbe probe, TemporaryWorkspace workspace, string identityChannel = "local")
+    private InstallationDiscovery NewDiscovery(FakePeerInstallProbe probe, TemporaryWorkspace workspace, string identityChannel = "local")
     {
         return new InstallationDiscovery(
             channelReader: new FakeIdentityChannelReader(identityChannel),
-            sidecarReader: new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            sidecarReader: CliTestHelper.CreateSidecarReader(outputHelper),
             peerProbe: probe,
             executionContext: CreateExecutionContext(workspace),
             logger: NullLogger<InstallationDiscovery>.Instance,

--- a/tests/Aspire.Cli.Tests/Agents/ClaudeCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/ClaudeCodeAgentEnvironmentScannerTests.cs
@@ -112,7 +112,7 @@ public class ClaudeCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
         return TestExecutionContextHelper.CreateExecutionContext(
             workingDirectory,
             debugMode: false,
-            environmentVariables: new Dictionary<string, string?>(),
+            environment: new TestEnvironment(),
             homeDirectory: workingDirectory);
     }
 

--- a/tests/Aspire.Cli.Tests/Agents/CopilotCliAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/CopilotCliAgentEnvironmentScannerTests.cs
@@ -194,7 +194,7 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
         return TestExecutionContextHelper.CreateExecutionContext(
             workingDirectory,
             debugMode: false,
-            environmentVariables: new Dictionary<string, string?>(),
+            environment: new TestEnvironment(),
             homeDirectory: workingDirectory);
     }
 
@@ -208,7 +208,7 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
         return TestExecutionContextHelper.CreateExecutionContext(
             workingDirectory,
             debugMode: false,
-            environmentVariables: environmentVariables,
+            environment: new TestEnvironment(environmentVariables),
             homeDirectory: workingDirectory);
     }
 

--- a/tests/Aspire.Cli.Tests/Agents/PlaywrightCliInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/PlaywrightCliInstallerTests.cs
@@ -1079,7 +1079,7 @@ public class PlaywrightCliInstallerTests
         public bool ProvenanceCalled { get; private set; }
         public Func<WorkflowRefInfo, bool>? CapturedValidateWorkflowRef { get; private set; }
 
-        public Task<ProvenanceVerificationResult> VerifyProvenanceAsync(string packageName, string version, string expectedSourceRepository, string expectedWorkflowPath, string expectedBuildType, Func<WorkflowRefInfo, bool>? validateWorkflowRef, CancellationToken cancellationToken, string? sriIntegrity = null)
+        public Task<ProvenanceVerificationResult> VerifyProvenanceAsync(string packageName, string version, string expectedSourceRepository, string expectedWorkflowPath, string expectedBuildType, Func<WorkflowRefInfo, bool>? validateWorkflowRef, string? sriIntegrity = null, CancellationToken cancellationToken = default)
         {
             ProvenanceCalled = true;
             CapturedValidateWorkflowRef = validateWorkflowRef;

--- a/tests/Aspire.Cli.Tests/Agents/PlaywrightCliInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/PlaywrightCliInstallerTests.cs
@@ -1079,7 +1079,7 @@ public class PlaywrightCliInstallerTests
         public bool ProvenanceCalled { get; private set; }
         public Func<WorkflowRefInfo, bool>? CapturedValidateWorkflowRef { get; private set; }
 
-        public Task<ProvenanceVerificationResult> VerifyProvenanceAsync(string packageName, string version, string expectedSourceRepository, string expectedWorkflowPath, string expectedBuildType, Func<WorkflowRefInfo, bool>? validateWorkflowRef, string? sriIntegrity = null, CancellationToken cancellationToken = default)
+        public Task<ProvenanceVerificationResult> VerifyProvenanceAsync(string packageName, string version, string expectedSourceRepository, string expectedWorkflowPath, string expectedBuildType, Func<WorkflowRefInfo, bool>? validateWorkflowRef, string? sriIntegrity, CancellationToken cancellationToken)
         {
             ProvenanceCalled = true;
             CapturedValidateWorkflowRef = validateWorkflowRef;

--- a/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
@@ -397,7 +397,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         return TestExecutionContextHelper.CreateExecutionContext(
             workingDirectory,
             debugMode: false,
-            environmentVariables: environmentVariables,
+            environment: new TestEnvironment(environmentVariables),
             homeDirectory: homeDirectory);
     }
 }

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -514,7 +514,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
                 var executionContext = sp.GetRequiredService<CliExecutionContext>();
-                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, executionContext, isLinux);
+                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, executionContext, isLinux ?? OperatingSystem.IsLinux);
             };
         });
 

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -86,7 +86,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 return EnsureCertificateResult.PartiallyFailedToTrustTheCertificate;
             },
             CheckHttpCertificateCallback = () => CreateTrustResult(CertificateManager.TrustLevel.Partial)
-        }, nonInteractive: false, isLinux: () => true);
+        }, nonInteractive: false, environment: new TestEnvironment { IsLinux = true });
 
         var cs = sp.GetRequiredService<ICertificateService>();
 
@@ -113,7 +113,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 return EnsureCertificateResult.PartiallyFailedToTrustTheCertificate;
             },
             CheckHttpCertificateCallback = () => CreateTrustResult(CertificateManager.TrustLevel.Partial)
-        }, nonInteractive: true, isLinux: () => true);
+        }, nonInteractive: true, environment: new TestEnvironment { IsLinux = true });
 
         var cs = sp.GetRequiredService<ICertificateService>();
 
@@ -324,7 +324,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
                 var executionContext = sp.GetRequiredService<CliExecutionContext>();
-                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, executionContext, isLinux: () => true);
+                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, executionContext, new TestEnvironment { IsLinux = true });
             };
         });
 
@@ -498,7 +498,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
         Assert.Contains(interactionService.DisplayedMessages, m => m.Message == expectedMessage);
     }
 
-    private ServiceProvider CreateServiceProvider(TemporaryWorkspace workspace, TestCertificateToolRunner toolRunner, bool nonInteractive = false, Func<bool>? isLinux = null)
+    private ServiceProvider CreateServiceProvider(TemporaryWorkspace workspace, TestCertificateToolRunner toolRunner, bool nonInteractive = false, IEnvironment? environment = null)
     {
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
@@ -514,7 +514,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
                 var executionContext = sp.GetRequiredService<CliExecutionContext>();
-                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, executionContext, isLinux ?? OperatingSystem.IsLinux);
+                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, executionContext, environment ?? sp.GetRequiredService<IEnvironment>());
             };
         });
 

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -450,7 +450,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 return new CliHostEnvironment(configuration, nonInteractive: true);
             };
             options.CliExecutionContextFactory = _ => TestExecutionContextHelper.CreateExecutionContext(
-                workspace.WorkspaceRoot, environmentVariables: envVars);
+                workspace.WorkspaceRoot, environment: new TestEnvironment(envVars));
             options.InteractionServiceFactory = _ => new TestInteractionService();
         });
 

--- a/tests/Aspire.Cli.Tests/Certificates/NativeCertificateToolRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/NativeCertificateToolRunnerTests.cs
@@ -3,6 +3,7 @@
 
 using System.Security.Cryptography.X509Certificates;
 using Aspire.Cli.Certificates;
+using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -14,7 +15,7 @@ public class NativeCertificateToolRunnerTests
     public void TrustHttpCertificateOnLinux_WithNoCurrentCertificate_CreatesAndTrustsCertificate()
     {
         var certificateManager = new TestCertificateManager();
-        var runner = new NativeCertificateToolRunner(certificateManager, isLinux: () => true);
+        var runner = new NativeCertificateToolRunner(certificateManager, new TestEnvironment { IsLinux = true });
 
         var result = runner.TrustHttpCertificateOnLinux([], DateTimeOffset.UtcNow);
 
@@ -30,7 +31,7 @@ public class NativeCertificateToolRunnerTests
         using var certificate = certificateManager.CreateAspNetCoreHttpsDevelopmentCertificate(
             DateTimeOffset.UtcNow.AddDays(-1),
             DateTimeOffset.UtcNow.AddDays(365));
-        var runner = new NativeCertificateToolRunner(certificateManager, isLinux: () => true);
+        var runner = new NativeCertificateToolRunner(certificateManager, new TestEnvironment { IsLinux = true });
 
         var result = runner.TrustHttpCertificateOnLinux([certificate], DateTimeOffset.UtcNow);
 
@@ -47,7 +48,7 @@ public class NativeCertificateToolRunnerTests
         using var olderCertificate = olderVersionManager.CreateAspNetCoreHttpsDevelopmentCertificate(
             DateTimeOffset.UtcNow.AddDays(-1),
             DateTimeOffset.UtcNow.AddDays(365));
-        var runner = new NativeCertificateToolRunner(currentVersionManager, isLinux: () => true);
+        var runner = new NativeCertificateToolRunner(currentVersionManager, new TestEnvironment { IsLinux = true });
 
         var result = runner.TrustHttpCertificateOnLinux([olderCertificate], DateTimeOffset.UtcNow);
 

--- a/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
+++ b/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests;
 
@@ -157,7 +158,7 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
         // Regression guard: this source was previously omitted from the identityOverridden computation.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             typeof(Program).Assembly,
             binaryDir: null,
             envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar ? "http://localhost:5000/v3/index.json" : null);
@@ -177,7 +178,7 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(),
+            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
             typeof(Program).Assembly,
             binaryDir: null,
             envReader: _ => null);

--- a/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
+++ b/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
@@ -127,15 +127,23 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var installPrefix = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire-pr-test");
-        var binaryPath = WriteBinaryWithSidecar(Path.Combine(installPrefix, "dogfood", "pr-17159", "bin"), InstallSourceExtensions.PrWire);
+        var binaryDir = Path.Combine(installPrefix, "dogfood", "pr-17159", "bin");
+        var binaryPath = WriteBinaryWithSidecar(binaryDir, InstallSourceExtensions.PrWire, channel: "pr-17159");
         var logsDirectory = Path.Combine(installPrefix, "logs");
         var logFilePath = Path.Combine(logsDirectory, "aspire.log");
+
+        var environment = new TestEnvironment();
+        var resolver = new IdentityResolver(
+            CliTestHelper.CreateSidecarReader(outputHelper),
+            typeof(Program).Assembly,
+            binaryDir,
+            environment);
 
         var context = Program.BuildCliExecutionContext(
             debugMode: true,
             logsDirectory: logsDirectory,
             logFilePath: logFilePath,
-            channel: "pr-17159",
+            identityResolver: resolver,
             processPath: binaryPath);
 
         Assert.Equal(Path.Combine(installPrefix, "hives"), context.HivesDirectory.FullName);
@@ -156,11 +164,13 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
         // startup override notice fires and tooling does not mistake a diagnostic run for a real build.
         // Regression guard: this source was previously omitted from the identityOverridden computation.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var envVars = new Dictionary<string, string?> { [IdentityResolver.NuGetServiceIndexEnvVar] = "http://localhost:5000/v3/index.json" };
+        var environment = new TestEnvironment(envVars);
         var resolver = new IdentityResolver(
             CliTestHelper.CreateSidecarReader(outputHelper),
             typeof(Program).Assembly,
             binaryDir: null,
-            envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar ? "http://localhost:5000/v3/index.json" : null);
+            environment);
 
         var context = Program.BuildCliExecutionContext(
             debugMode: false,
@@ -176,11 +186,12 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
     public void BuildCliExecutionContext_NoOverrides_DoesNotMarkIdentityOverridden()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var environment = new TestEnvironment();
         var resolver = new IdentityResolver(
             CliTestHelper.CreateSidecarReader(outputHelper),
             typeof(Program).Assembly,
             binaryDir: null,
-            envReader: _ => null);
+            environment);
 
         var context = Program.BuildCliExecutionContext(
             debugMode: false,
@@ -192,12 +203,13 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
         Assert.Null(context.NuGetServiceIndexOverride);
     }
 
-    private static string WriteBinaryWithSidecar(string binaryDir, string source)
+    private static string WriteBinaryWithSidecar(string binaryDir, string source, string? channel = null)
     {
         Directory.CreateDirectory(binaryDir);
         var binaryPath = Path.Combine(binaryDir, OperatingSystem.IsWindows() ? "aspire.exe" : "aspire");
         File.WriteAllText(binaryPath, string.Empty);
-        File.WriteAllText(Path.Combine(binaryDir, InstallSidecarReader.SidecarFileName), $$"""{"source":"{{source}}"}""");
+        var channelField = channel is not null ? $",\"channel\":\"{channel}\"" : "";
+        File.WriteAllText(Path.Combine(binaryDir, InstallSidecarReader.SidecarFileName), $$"""{"source":"{{source}}"{{channelField}}}""");
 
         return binaryPath;
     }

--- a/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
+++ b/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
@@ -8,7 +8,6 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests;
 
@@ -158,7 +157,7 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
         // Regression guard: this source was previously omitted from the identityOverridden computation.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             typeof(Program).Assembly,
             binaryDir: null,
             envReader: name => name == IdentityResolver.NuGetServiceIndexEnvVar ? "http://localhost:5000/v3/index.json" : null);
@@ -178,7 +177,7 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var resolver = new IdentityResolver(
-            new InstallSidecarReader(NullLogger<InstallSidecarReader>.Instance),
+            CliTestHelper.CreateSidecarReader(outputHelper),
             typeof(Program).Assembly,
             binaryDir: null,
             envReader: _ => null);

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -12,6 +12,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 using Microsoft.AspNetCore.InternalTesting;
 
@@ -419,8 +420,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.PackagingServiceFactory = _ => new TestPackagingService
             {
                 GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
-                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
-                    PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "daily")], dailyCache, new TestFeatures())
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures(), NullLogger.Instance),
+                    PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "daily")], dailyCache, new TestFeatures(), NullLogger.Instance)
                 ])
             };
         });
@@ -491,8 +492,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.PackagingServiceFactory = _ => new TestPackagingService
             {
                 GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
-                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
-                    PackageChannel.CreateExplicitChannel(PackageChannelNames.Staging, PackageChannelQuality.Both, [new PackageMapping("Aspire*", "staging")], stagingCache, new TestFeatures())
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures(), NullLogger.Instance),
+                    PackageChannel.CreateExplicitChannel(PackageChannelNames.Staging, PackageChannelQuality.Both, [new PackageMapping("Aspire*", "staging")], stagingCache, new TestFeatures(), NullLogger.Instance)
                 ])
             };
         });
@@ -578,8 +579,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.PackagingServiceFactory = _ => new TestPackagingService
             {
                 GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
-                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
-                    PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Stable, [new PackageMapping("Aspire*", "stable")], stableCache, new TestFeatures())
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures(), NullLogger.Instance),
+                    PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Stable, [new PackageMapping("Aspire*", "stable")], stableCache, new TestFeatures(), NullLogger.Instance)
                 ])
             };
         });
@@ -673,8 +674,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.PackagingServiceFactory = _ => new TestPackagingService
             {
                 GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
-                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
-                    PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "daily")], dailyCache, new TestFeatures())
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures(), NullLogger.Instance),
+                    PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "daily")], dailyCache, new TestFeatures(), NullLogger.Instance)
                 ])
             };
         });
@@ -784,8 +785,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.PackagingServiceFactory = _ => new TestPackagingService
             {
                 GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
-                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
-                    PackageChannel.CreateExplicitChannel(PackageChannelNames.Staging, PackageChannelQuality.Both, [new PackageMapping("Aspire*", "staging")], stagingCache, new TestFeatures())
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures(), NullLogger.Instance),
+                    PackageChannel.CreateExplicitChannel(PackageChannelNames.Staging, PackageChannelQuality.Both, [new PackageMapping("Aspire*", "staging")], stagingCache, new TestFeatures(), NullLogger.Instance)
                 ])
             };
         });
@@ -926,8 +927,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.PackagingServiceFactory = _ => new TestPackagingService
             {
                 GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
-                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
-                    PackageChannel.CreateExplicitChannel("test-hive", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "test-hive")], explicitCache, new TestFeatures())
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures(), NullLogger.Instance),
+                    PackageChannel.CreateExplicitChannel("test-hive", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "test-hive")], explicitCache, new TestFeatures(), NullLogger.Instance)
                 ])
             };
         });
@@ -2214,7 +2215,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         // Create a fake channel
         var fakeCache = new FakeNuGetPackageCache();
-        var channel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+        var channel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
 
         // Create multiple versions of the same package
         var packages = new[]
@@ -2262,7 +2263,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         // Create a fake channel
         var fakeCache = new FakeNuGetPackageCache();
-        var channel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+        var channel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
 
         // Create multiple versions of the same package from same channel
         var packages = new[]
@@ -2310,10 +2311,10 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         // Create two different channels
         var fakeCache = new FakeNuGetPackageCache();
-        var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+        var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
         
         var mappings = new[] { new PackageMapping("Aspire*", "https://preview-feed") };
-        var explicitChannel = PackageChannel.CreateExplicitChannel("preview", PackageChannelQuality.Prerelease, mappings, fakeCache, new TestFeatures());
+        var explicitChannel = PackageChannel.CreateExplicitChannel("preview", PackageChannelQuality.Prerelease, mappings, fakeCache, new TestFeatures(), NullLogger.Instance);
 
         // Create packages from different channels with different versions
         var packages = new[]
@@ -2366,8 +2367,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         var prompter = new AddCommandPrompter(interactionService);
 
         var fakeCache = new FakeNuGetPackageCache();
-        var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
-        var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "daily")], fakeCache, new TestFeatures());
+        var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
+        var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "daily")], fakeCache, new TestFeatures(), NullLogger.Instance);
 
         // The implicit (ambient) channel surfaces a higher-precedence STABLE version; the pinned daily
         // channel surfaces a PRERELEASE version. Pre-fix the higher stable version was always the default.
@@ -2439,8 +2440,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.PackagingServiceFactory = _ => new TestPackagingService
             {
                 GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
-                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
-                    PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "daily")], dailyCache, new TestFeatures())
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures(), NullLogger.Instance),
+                    PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "daily")], dailyCache, new TestFeatures(), NullLogger.Instance)
                 ])
             };
         });

--- a/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
@@ -100,7 +100,7 @@ public class CertificatesCommandTests(ITestOutputHelper outputHelper)
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
                 var executionContext = sp.GetRequiredService<CliExecutionContext>();
-                return new CertificateService(toolRunner, interactionService, telemetry, hostEnvironment, executionContext, isLinux: () => true);
+                return new CertificateService(toolRunner, interactionService, telemetry, hostEnvironment, executionContext, new TestEnvironment { IsLinux = true });
             };
         });
         using var provider = services.BuildServiceProvider();

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -14,6 +14,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Shared;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -42,7 +43,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                         [new NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "nuget.org", Version = version }])
             };
 
-            var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+            var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
 
             var packagingService = new TestPackagingService
             {
@@ -821,13 +822,13 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                             [new NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "pr-hive", Version = "99.0.0-pr.12345" }])
                 };
 
-                var implicitChannel = PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures());
+                var implicitChannel = PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures(), NullLogger.Instance);
                 var prHiveChannel = PackageChannel.CreateExplicitChannel(
                     "pr-12345",
                     PackageChannelQuality.Both,
                     [new PackageMapping("Aspire*", hivesDir.FullName + "/pr-12345/packages")],
                     prHiveCache,
-                    features: new TestFeatures());
+                    features: new TestFeatures(), NullLogger.Instance);
 
                 return new TestPackagingService
                 {
@@ -887,7 +888,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                     GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
                         throw new NuGetPackageCacheException("Package search failed: simulated network failure")
                 };
-                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
                 return new TestPackagingService
                 {
                     GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel])
@@ -1225,7 +1226,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                     GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
                         Task.FromResult<IEnumerable<NuGetPackageCli>>([])
                 };
-                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
                 return new TestPackagingService
                 {
                     GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel])
@@ -1570,7 +1571,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                         Task.FromResult<IEnumerable<NuGetPackageCli>>(
                             [new NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "nuget.org", Version = "13.3.0" }])
                 };
-                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
                 return new TestPackagingService
                 {
                     GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel])
@@ -2004,7 +2005,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                         Task.FromResult<IEnumerable<NuGetPackageCli>>(
                             [new NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "nuget.org", Version = "13.3.0" }])
                 };
-                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
                 return new TestPackagingService
                 {
                     GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel])
@@ -2128,7 +2129,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
                 PackageChannelQuality.Both,
                 [new PackageMapping("Aspire*", channelSource), new PackageMapping(PackageMapping.AllPackages, fallbackSource)],
                 fakeCache,
-                features: new TestFeatures());
+                features: new TestFeatures(), NullLogger.Instance);
         }).ToArray();
 
         return new TestPackagingService

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -77,7 +78,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
                         Task.FromResult<IEnumerable<NuGetPackage>>(
                             [new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = "13.3.0" }])
                 };
-                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
                 return new TestPackagingService
                 {
                     GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel])
@@ -513,7 +514,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
                 Task.FromResult<IEnumerable<NuGetPackage>>(
                     [new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = "13.3.0" }])
         };
-        var implicitChannel = PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures());
+        var implicitChannel = PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures(), NullLogger.Instance);
 
         // Always register a stable channel — matches what PackagingService advertises in
         // production. Its version (13.5.0) is distinct from Implicit (13.3.0) so a test
@@ -529,7 +530,8 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
             PackageChannelQuality.Stable,
             [new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")],
             stableCache,
-            features: new TestFeatures());
+            features: new TestFeatures(),
+            NullLogger.Instance);
 
         var channels = new List<PackageChannel> { implicitChannel, stableChannel };
 
@@ -555,7 +557,8 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
                     new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json"),
                 ],
                 explicitCache,
-                features: new TestFeatures()));
+                features: new TestFeatures(),
+                NullLogger.Instance));
         }
 
         // PR hives are an additional explicit channel shape (PackageChannelQuality.Both
@@ -578,7 +581,8 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
                     new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json"),
                 ],
                 prCache,
-                features: new TestFeatures()));
+                features: new TestFeatures(),
+                NullLogger.Instance));
         }
 
         return new TestPackagingService

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTemplateConfigPersistenceTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTemplateConfigPersistenceTests.cs
@@ -412,7 +412,7 @@ public class NewCommandTemplateConfigPersistenceTests(ITestOutputHelper outputHe
                 Task.FromResult<IEnumerable<NuGetPackage>>(
                     [new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = "13.3.0" }])
         };
-        var implicitChannel = PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures());
+        var implicitChannel = PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures(), NullLogger.Instance);
 
         var stableCache = new FakeNuGetPackageCache
         {
@@ -425,7 +425,8 @@ public class NewCommandTemplateConfigPersistenceTests(ITestOutputHelper outputHe
             PackageChannelQuality.Stable,
             [new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)],
             stableCache,
-            features: new TestFeatures());
+            features: new TestFeatures(),
+            NullLogger.Instance);
 
         var channels = new List<PackageChannel> { implicitChannel, stableChannel };
 
@@ -453,7 +454,8 @@ public class NewCommandTemplateConfigPersistenceTests(ITestOutputHelper outputHe
                     new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg),
                 ],
                 cache,
-                features: new TestFeatures()));
+                features: new TestFeatures(),
+                NullLogger.Instance));
         }
 
         return new TestPackagingService

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -20,6 +20,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -319,8 +320,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                         return Task.FromResult<IEnumerable<NuGetPackage>>([package]);
                     };
                     
-                    var stableChannel = PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Both, [], stableCache, new TestFeatures());
-                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache, new TestFeatures());
+                    var stableChannel = PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Both, [], stableCache, new TestFeatures(), NullLogger.Instance);
+                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache, new TestFeatures(), NullLogger.Instance);
                     
                     return Task.FromResult<IEnumerable<PackageChannel>>([stableChannel, dailyChannel]);
                 };
@@ -397,7 +398,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                         return Task.FromResult<IEnumerable<NuGetPackage>>(packages);
                     };
                     
-                    var stableChannel = PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Both, [], fakeCache, new TestFeatures());
+                    var stableChannel = PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Both, [], fakeCache, new TestFeatures(), NullLogger.Instance);
                     return Task.FromResult<IEnumerable<PackageChannel>>([stableChannel]);
                 };
                 
@@ -474,7 +475,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                         return Task.FromResult<IEnumerable<NuGetPackage>>(packages);
                     };
 
-                    var prChannel = PackageChannel.CreateExplicitChannel("pr-12345", PackageChannelQuality.Both, [], fakeCache, new TestFeatures());
+                    var prChannel = PackageChannel.CreateExplicitChannel("pr-12345", PackageChannelQuality.Both, [], fakeCache, new TestFeatures(), NullLogger.Instance);
                     return Task.FromResult<IEnumerable<PackageChannel>>([prChannel]);
                 };
 
@@ -1596,7 +1597,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                         return Task.FromResult<IEnumerable<NuGetPackage>>([package]);
                     };
 
-                    var stableChannel = PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Both, [], stableCache, new TestFeatures());
+                    var stableChannel = PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Both, [], stableCache, new TestFeatures(), NullLogger.Instance);
                     return Task.FromResult<IEnumerable<PackageChannel>>([stableChannel]);
                 };
 
@@ -1793,7 +1794,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                         }
                     };
 
-                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache, new TestFeatures());
+                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache, new TestFeatures(), NullLogger.Instance);
                     return Task.FromResult<IEnumerable<PackageChannel>>([dailyChannel]);
                 }
             };
@@ -1868,7 +1869,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                         }
                     };
 
-                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache, new TestFeatures());
+                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache, new TestFeatures(), NullLogger.Instance);
                     return Task.FromResult<IEnumerable<PackageChannel>>([dailyChannel]);
                 }
             };
@@ -1919,7 +1920,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                             return Task.FromResult<IEnumerable<NuGetPackage>>([package]);
                         }
                     };
-                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache, new TestFeatures());
+                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache, new TestFeatures(), NullLogger.Instance);
                     return Task.FromResult<IEnumerable<PackageChannel>>([dailyChannel]);
                 }
             };
@@ -2015,7 +2016,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                             return Task.FromResult<IEnumerable<NuGetPackage>>([package]);
                         }
                     };
-                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache, new TestFeatures());
+                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache, new TestFeatures(), NullLogger.Instance);
                     return Task.FromResult<IEnumerable<PackageChannel>>([dailyChannel]);
                 }
             };
@@ -3202,7 +3203,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                     GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
                         throw new NuGetPackageCacheException("Package search failed: simulated network failure")
                 };
-                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
                 return new TestPackagingService
                 {
                     GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel])

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1975,7 +1975,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
                 var logBufferContext = sp.GetRequiredService<ConsoleLogBufferContext>();
                 var consoleInteractionService = new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory, logBufferContext);
 
-                return new ExtensionInteractionService(consoleInteractionService, extensionBackchannel, extensionPromptEnabled: false, logger: NullLogger<ExtensionInteractionService>.Instance, cancellationToken: CancellationToken.None);
+                return new ExtensionInteractionService(consoleInteractionService, extensionBackchannel, extensionPromptEnabled: false, logger: NullLogger<ExtensionInteractionService>.Instance);
             };
             options.ConfigurationCallback += config =>
             {

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1975,7 +1975,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
                 var logBufferContext = sp.GetRequiredService<ConsoleLogBufferContext>();
                 var consoleInteractionService = new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory, logBufferContext);
 
-                return new ExtensionInteractionService(consoleInteractionService, extensionBackchannel, extensionPromptEnabled: false);
+                return new ExtensionInteractionService(consoleInteractionService, extensionBackchannel, extensionPromptEnabled: false, logger: NullLogger<ExtensionInteractionService>.Instance, cancellationToken: CancellationToken.None);
             };
             options.ConfigurationCallback += config =>
             {

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -282,6 +282,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                         new[] { new PackageMapping("Aspire*", "https://api.nuget.org/v3/index.json") },
                         null!,
                         features: new TestFeatures(),
+                        NullLogger.Instance,
                         configureGlobalPackagesFolder: false,
                         cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/ga/daily");
                     return Task.FromResult<IEnumerable<PackageChannel>>(new[] { stableChannel });
@@ -524,6 +525,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                         new[] { new PackageMapping("Aspire*", "https://api.nuget.org/v3/index.json") },
                         null!,
                         features: new TestFeatures(),
+                        NullLogger.Instance,
                         configureGlobalPackagesFolder: false,
                         cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/ga/daily");
                     return Task.FromResult<IEnumerable<PackageChannel>>(new[] { stableChannel });
@@ -600,6 +602,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                         new[] { new PackageMapping("Aspire*", "https://api.nuget.org/v3/index.json") },
                         null!,
                         features: new TestFeatures(),
+                        NullLogger.Instance,
                         configureGlobalPackagesFolder: false,
                         cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/ga/daily");
                     return Task.FromResult<IEnumerable<PackageChannel>>(new[] { stableChannel });
@@ -675,6 +678,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                         new[] { new PackageMapping("Aspire*", "https://api.nuget.org/v3/index.json") },
                         null!,
                         features: new TestFeatures(),
+                        NullLogger.Instance,
                         configureGlobalPackagesFolder: false,
                         cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/ga/daily");
                     return Task.FromResult<IEnumerable<PackageChannel>>(new[] { stableChannel });
@@ -840,6 +844,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                         new[] { new PackageMapping("Aspire*", "/path/to/pr/hive") },
                         null!,
                         features: new TestFeatures(),
+                        NullLogger.Instance,
                         configureGlobalPackagesFolder: false,
                         cliDownloadBaseUrl: null); // No CLI download URL for PR channels
                     return Task.FromResult<IEnumerable<PackageChannel>>(new[] { prChannel });
@@ -1466,7 +1471,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 GetChannelsAsyncCallback = (ct) =>
                 {
                     var fakeCache = new FakeNuGetPackageCache();
-                    var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+                    var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
                     return Task.FromResult<IEnumerable<PackageChannel>>(new[] { implicitChannel });
                 }
             };
@@ -1621,7 +1626,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                     var fakeCache = new FakeNuGetPackageCache();
                     return Task.FromResult<IEnumerable<PackageChannel>>(new[]
                     {
-                        PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures()),
+                        PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance),
                     });
                 }
             };
@@ -1679,8 +1684,8 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                     var fakeCache = new FakeNuGetPackageCache();
                     return Task.FromResult<IEnumerable<PackageChannel>>(new[]
                     {
-                        PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures()),
-                        PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, mappings: null, fakeCache, new TestFeatures()),
+                        PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance),
+                        PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, mappings: null, fakeCache, new TestFeatures(), NullLogger.Instance),
                     });
                 },
                 GetStagingChannelUnavailableReasonCallback = () => unavailableReason
@@ -1907,10 +1912,10 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 GetChannelsAsyncCallback = (ct) =>
                 {
                     var fakeCache = new FakeNuGetPackageCache();
-                    var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
-                    var stableChannel = PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Stable, mappings: null, fakeCache, new TestFeatures());
-                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, mappings: null, fakeCache, new TestFeatures());
-                    var hiveChannel = PackageChannel.CreateExplicitChannel("pr-12345", PackageChannelQuality.Both, mappings: null, fakeCache, new TestFeatures());
+                    var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
+                    var stableChannel = PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Stable, mappings: null, fakeCache, new TestFeatures(), NullLogger.Instance);
+                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, mappings: null, fakeCache, new TestFeatures(), NullLogger.Instance);
+                    var hiveChannel = PackageChannel.CreateExplicitChannel("pr-12345", PackageChannelQuality.Both, mappings: null, fakeCache, new TestFeatures(), NullLogger.Instance);
                     return Task.FromResult<IEnumerable<PackageChannel>>(new[] { implicitChannel, stableChannel, dailyChannel, hiveChannel });
                 }
             };
@@ -2319,9 +2324,9 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 GetChannelsAsyncCallback = (ct) =>
                 {
                     var fakeCache = new FakeNuGetPackageCache();
-                    var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
-                    var stagingChannel = PackageChannel.CreateExplicitChannel("staging", PackageChannelQuality.Stable, mappings: null, fakeCache, new TestFeatures());
-                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, mappings: null, fakeCache, new TestFeatures());
+                    var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
+                    var stagingChannel = PackageChannel.CreateExplicitChannel("staging", PackageChannelQuality.Stable, mappings: null, fakeCache, new TestFeatures(), NullLogger.Instance);
+                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, mappings: null, fakeCache, new TestFeatures(), NullLogger.Instance);
                     var channels = new List<PackageChannel> { implicitChannel, stagingChannel, dailyChannel };
 
                     // Optional pr-* and local channels for identity-channel tests. Production
@@ -2334,14 +2339,14 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                         {
                             if (hive.Name.StartsWith("pr-", StringComparison.OrdinalIgnoreCase))
                             {
-                                channels.Add(PackageChannel.CreateExplicitChannel(hive.Name, PackageChannelQuality.Both, mappings: null, fakeCache, new TestFeatures()));
+                                channels.Add(PackageChannel.CreateExplicitChannel(hive.Name, PackageChannelQuality.Both, mappings: null, fakeCache, new TestFeatures(), NullLogger.Instance));
                             }
                         }
                     }
 
                     if (includeLocalInChannels)
                     {
-                        channels.Add(PackageChannel.CreateExplicitChannel(PackageChannelNames.Local, PackageChannelQuality.Both, mappings: null, fakeCache, new TestFeatures()));
+                        channels.Add(PackageChannel.CreateExplicitChannel(PackageChannelNames.Local, PackageChannelQuality.Both, mappings: null, fakeCache, new TestFeatures(), NullLogger.Instance));
                     }
 
                     return Task.FromResult<IEnumerable<PackageChannel>>(channels);
@@ -2858,6 +2863,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             [new PackageMapping("Aspire*", "https://api.nuget.org/v3/index.json")],
             fakeCache,
             features: new TestFeatures(),
+            NullLogger.Instance,
             configureGlobalPackagesFolder: false,
             cliDownloadBaseUrl: cliDownloadBaseUrl);
     }

--- a/tests/Aspire.Cli.Tests/Configuration/DotNetBasedAppHostServerChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/DotNetBasedAppHostServerChannelResolutionTests.cs
@@ -131,7 +131,8 @@ public class DotNetBasedAppHostServerChannelResolutionTests(ITestOutputHelper ou
                         PackageChannelQuality.Both,
                         mappings: [],
                         cache,
-                        new TestFeatures()))
+                        new TestFeatures(),
+                        NullLogger.Instance))
                     .ToArray();
                 return Task.FromResult<IEnumerable<PackageChannel>>(channels);
             }

--- a/tests/Aspire.Cli.Tests/Interaction/ExtensionInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ExtensionInteractionServiceTests.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Spectre.Console;
 
@@ -56,5 +57,38 @@ public class ExtensionInteractionServiceTests(ITestOutputHelper outputHelper)
         Assert.Contains(logFilePath, outputString);
         Assert.DoesNotContain("\u001b]8;", outputString);
         Assert.DoesNotContain("file://", outputString);
+    }
+
+    [Fact]
+    public async Task Dispose_StopsBackgroundPump()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.TrueColor,
+            Out = new AnsiConsoleOutput(new StringWriter(output)),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
+        });
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var logFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "cli [extension].log");
+        var executionContext = workspace.CreateExecutionContext(logFilePath: logFilePath);
+        var consoleInteractionService = new ConsoleInteractionService(
+            new ConsoleEnvironment(console, console),
+            executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
+            NullLoggerFactory.Instance,
+            new ConsoleLogBufferContext());
+        var extensionInteractionService = new ExtensionInteractionService(
+            consoleInteractionService,
+            new TestExtensionBackchannel(),
+            extensionPromptEnabled: false,
+            logger: NullLogger<ExtensionInteractionService>.Instance);
+
+        extensionInteractionService.Dispose();
+
+        // The background pump should exit promptly after disposal.
+        await extensionInteractionService.PumpTask.DefaultTimeout();
     }
 }

--- a/tests/Aspire.Cli.Tests/Interaction/ExtensionInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ExtensionInteractionServiceTests.cs
@@ -42,8 +42,7 @@ public class ExtensionInteractionServiceTests(ITestOutputHelper outputHelper)
             consoleInteractionService,
             new TestExtensionBackchannel(),
             extensionPromptEnabled: false,
-            logger: NullLogger<ExtensionInteractionService>.Instance,
-            cancellationToken: CancellationToken.None);
+            logger: NullLogger<ExtensionInteractionService>.Instance);
 
         var fileLinkMarkup = MarkupHelpers.SafeFileLink(extensionInteractionService, logFilePath);
         extensionInteractionService.DisplayMessage(

--- a/tests/Aspire.Cli.Tests/Interaction/ExtensionInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ExtensionInteractionServiceTests.cs
@@ -41,7 +41,9 @@ public class ExtensionInteractionServiceTests(ITestOutputHelper outputHelper)
         var extensionInteractionService = new ExtensionInteractionService(
             consoleInteractionService,
             new TestExtensionBackchannel(),
-            extensionPromptEnabled: false);
+            extensionPromptEnabled: false,
+            logger: NullLogger<ExtensionInteractionService>.Instance,
+            cancellationToken: CancellationToken.None);
 
         var fileLinkMarkup = MarkupHelpers.SafeFileLink(extensionInteractionService, logFilePath);
         extensionInteractionService.DisplayMessage(

--- a/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Packaging;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Mcp;
 
@@ -24,7 +25,7 @@ internal static class MockPackagingServiceFactory
                     GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
                         Task.FromResult<IEnumerable<NuGetPackageCli>>(packages)
                 };
-                return Task.FromResult<IEnumerable<PackageChannel>>([PackageChannel.CreateImplicitChannel(cache, new TestFeatures())]);
+                return Task.FromResult<IEnumerable<PackageChannel>>([PackageChannel.CreateImplicitChannel(cache, new TestFeatures(), NullLogger.Instance)]);
             }
         };
     }

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetSignatureVerificationEnablerTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetSignatureVerificationEnablerTests.cs
@@ -12,7 +12,7 @@ public class NuGetSignatureVerificationEnablerTests
     private static CliExecutionContext CreateContext(Dictionary<string, string?>? envVars = null)
     {
         var dir = new DirectoryInfo(Path.GetTempPath());
-        return TestExecutionContextHelper.CreateExecutionContext(dir, environmentVariables: envVars);
+        return TestExecutionContextHelper.CreateExecutionContext(dir, environment: new TestEnvironment(envVars));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Packaging/NuGetConfigMergerTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/NuGetConfigMergerTests.cs
@@ -7,6 +7,7 @@ using System.Xml;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Packaging;
 
@@ -26,7 +27,7 @@ public class NuGetConfigMergerTests
         return new FileInfo(path);
     }
 
-    private static PackageChannel CreateChannel(PackageMapping[] mappings) => PackageChannel.CreateExplicitChannel("test", PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache(), new TestFeatures());
+    private static PackageChannel CreateChannel(PackageMapping[] mappings) => PackageChannel.CreateExplicitChannel("test", PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache(), new TestFeatures(), NullLogger.Instance);
 
     [Fact]
     public async Task CreateOrUpdateAsync_CreatesConfigFromMappings_WhenNoExistingConfig()
@@ -191,7 +192,7 @@ public class NuGetConfigMergerTests
             new PackageMapping("Aspire.*", stableSource)
         };
 
-        var channel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache(), new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache(), new TestFeatures(), NullLogger.Instance);
         await NuGetConfigMerger.CreateOrUpdateAsync(root, channel).DefaultTimeout();
 
         var xml = XDocument.Load(Path.Combine(root.FullName, "nuget.config"));

--- a/tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Packaging;
 
@@ -19,7 +20,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
         var cache = new FakeNuGetPackageCache();
 
         // Act
-        var channel = PackageChannel.CreateImplicitChannel(cache, new TestFeatures());
+        var channel = PackageChannel.CreateImplicitChannel(cache, new TestFeatures(), NullLogger.Instance);
 
         // Assert
         Assert.Equal(PackagingStrings.BasedOnNuGetConfig, channel.SourceDetails);
@@ -39,7 +40,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
         };
 
         // Act
-        var channel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Prerelease, mappings, cache, new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Prerelease, mappings, cache, new TestFeatures(), NullLogger.Instance);
 
         // Assert
         Assert.Equal(aspireSource, channel.SourceDetails);
@@ -59,7 +60,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
         };
 
         // Act
-        var channel = PackageChannel.CreateExplicitChannel("pr-10981", PackageChannelQuality.Prerelease, mappings, cache, new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel("pr-10981", PackageChannelQuality.Prerelease, mappings, cache, new TestFeatures(), NullLogger.Instance);
 
         // Assert
         Assert.Equal(prHivePath, channel.SourceDetails);
@@ -79,7 +80,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
         };
 
         // Act
-        var channel = PackageChannel.CreateExplicitChannel("staging", PackageChannelQuality.Stable, mappings, cache, new TestFeatures(), configureGlobalPackagesFolder: true);
+        var channel = PackageChannel.CreateExplicitChannel("staging", PackageChannelQuality.Stable, mappings, cache, new TestFeatures(), NullLogger.Instance, configureGlobalPackagesFolder: true);
 
         // Assert
         Assert.Equal(stagingUrl, channel.SourceDetails);
@@ -95,7 +96,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
         var mappings = Array.Empty<PackageMapping>();
 
         // Act
-        var channel = PackageChannel.CreateExplicitChannel("empty", PackageChannelQuality.Stable, mappings, cache, new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel("empty", PackageChannelQuality.Stable, mappings, cache, new TestFeatures(), NullLogger.Instance);
 
         // Assert
         Assert.Equal(PackagingStrings.BasedOnNuGetConfig, channel.SourceDetails);
@@ -145,7 +146,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
             new PackageMapping("Aspire*", packageSource),
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
         };
-        var channel = PackageChannel.CreateExplicitChannel("local", PackageChannelQuality.Both, mappings, cache, new TestFeatures(), pinnedVersion: pinnedVersion);
+        var channel = PackageChannel.CreateExplicitChannel("local", PackageChannelQuality.Both, mappings, cache, new TestFeatures(), NullLogger.Instance, pinnedVersion: pinnedVersion);
 
         var packages = (await channel.GetIntegrationPackagesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout()).ToArray();
 
@@ -263,7 +264,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
         };
 
-        var channel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Stable, mappings, cache, new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Stable, mappings, cache, new TestFeatures(), NullLogger.Instance);
 
         Assert.False(channel.ShouldPersistChannelName());
         Assert.False(channel.ShouldCreateNuGetConfig());
@@ -279,7 +280,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
         };
 
-        var channel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Prerelease, mappings, cache, new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Prerelease, mappings, cache, new TestFeatures(), NullLogger.Instance);
 
         Assert.True(channel.ShouldPersistChannelName());
         Assert.True(channel.ShouldCreateNuGetConfig());
@@ -295,7 +296,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
         };
 
-        var channel = PackageChannel.CreateExplicitChannel("staging", PackageChannelQuality.Stable, mappings, cache, new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel("staging", PackageChannelQuality.Stable, mappings, cache, new TestFeatures(), NullLogger.Instance);
 
         Assert.True(channel.ShouldPersistChannelName());
         Assert.True(channel.ShouldCreateNuGetConfig());
@@ -311,7 +312,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
         };
 
-        var channel = PackageChannel.CreateExplicitChannel("pr-12345", PackageChannelQuality.Prerelease, mappings, cache, new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel("pr-12345", PackageChannelQuality.Prerelease, mappings, cache, new TestFeatures(), NullLogger.Instance);
 
         Assert.True(channel.ShouldPersistChannelName());
         Assert.True(channel.ShouldCreateNuGetConfig());
@@ -322,7 +323,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
     {
         var cache = new FakeNuGetPackageCache();
 
-        var channel = PackageChannel.CreateImplicitChannel(cache, new TestFeatures());
+        var channel = PackageChannel.CreateImplicitChannel(cache, new TestFeatures(), NullLogger.Instance);
 
         Assert.False(channel.ShouldPersistChannelName());
         Assert.False(channel.ShouldCreateNuGetConfig());
@@ -336,7 +337,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
         // otherwise be persisted.
         var cache = new FakeNuGetPackageCache();
 
-        var channel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Prerelease, [], cache, new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Prerelease, [], cache, new TestFeatures(), NullLogger.Instance);
 
         Assert.True(channel.ShouldPersistChannelName());
         Assert.False(channel.ShouldCreateNuGetConfig());
@@ -359,7 +360,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
         };
 
-        var channel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Both, mappings, cache, new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Both, mappings, cache, new TestFeatures(), NullLogger.Instance);
 
         Assert.True(channel.IsBackedByLocalPackageDirectory);
     }
@@ -374,7 +375,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
         };
 
-        var channel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Stable, mappings, cache, new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Stable, mappings, cache, new TestFeatures(), NullLogger.Instance);
 
         Assert.False(channel.IsBackedByLocalPackageDirectory);
     }
@@ -390,7 +391,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
         };
 
-        var channel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Prerelease, mappings, cache, new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Prerelease, mappings, cache, new TestFeatures(), NullLogger.Instance);
 
         Assert.False(channel.IsBackedByLocalPackageDirectory);
     }
@@ -409,7 +410,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
         };
 
-        var channel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Both, mappings, cache, new TestFeatures());
+        var channel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Both, mappings, cache, new TestFeatures(), NullLogger.Instance);
 
         Assert.False(channel.IsBackedByLocalPackageDirectory);
     }
@@ -419,7 +420,7 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
     {
         var cache = new FakeNuGetPackageCache();
 
-        var channel = PackageChannel.CreateImplicitChannel(cache, new TestFeatures());
+        var channel = PackageChannel.CreateImplicitChannel(cache, new TestFeatures(), NullLogger.Instance);
 
         Assert.False(channel.IsBackedByLocalPackageDirectory);
     }
@@ -437,6 +438,6 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
         };
 
-        return PackageChannel.CreateExplicitChannel("local", quality, mappings, cache, features ?? new TestFeatures());
+        return PackageChannel.CreateExplicitChannel("local", quality, mappings, cache, features ?? new TestFeatures(), NullLogger.Instance);
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
@@ -286,15 +286,15 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
                 {
                     new PackageMapping("Aspire*", prOldHivePath),
                     new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
-                }, nugetCache, new TestFeatures());
+                }, nugetCache, new TestFeatures(), NullLogger.Instance);
 
                 var prNewChannel = PackageChannel.CreateExplicitChannel("pr-new", PackageChannelQuality.Prerelease, new[]
                 {
                     new PackageMapping("Aspire*", prNewHivePath),
                     new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
-                }, nugetCache, new TestFeatures());
+                }, nugetCache, new TestFeatures(), NullLogger.Instance);
 
-                var implicitChannel = PackageChannel.CreateImplicitChannel(nugetCache, new TestFeatures());
+                var implicitChannel = PackageChannel.CreateImplicitChannel(nugetCache, new TestFeatures(), NullLogger.Instance);
 
                 return Task.FromResult<IEnumerable<PackageChannel>>(new[] { implicitChannel, prOldChannel, prNewChannel });
             }
@@ -379,7 +379,7 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
         {
             new PackageMapping("Aspire*", "https://pkgs.dev.azure.com/fake/v3/index.json"),
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
-        }, nugetCache, new TestFeatures());
+        }, nugetCache, new TestFeatures(), NullLogger.Instance);
         var packagingService = new TestPackagingService
         {
             GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>(new[] { dailyChannel })
@@ -431,7 +431,7 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
         var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Prerelease, new[]
         {
             new PackageMapping("Aspire*", channelFeed)
-        }, nugetCache, new TestFeatures());
+        }, nugetCache, new TestFeatures(), NullLogger.Instance);
         var packagingService = new TestPackagingService
         {
             GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>(new[] { dailyChannel })

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -599,7 +599,7 @@ public class GuestAppHostProjectTests : IDisposable
                 ])
         };
 
-        var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+        var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
 
         var interactionService = new TestInteractionService
         {
@@ -723,7 +723,7 @@ public class GuestAppHostProjectTests : IDisposable
             PackageChannelQuality.Both,
             [new PackageMapping("Aspire.*", "stable")],
             stableCache,
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
 
         var interactionService = new TestInteractionService
         {
@@ -778,7 +778,7 @@ public class GuestAppHostProjectTests : IDisposable
             PackageChannelQuality.Both,
             [new PackageMapping("Aspire*", "staging")],
             stagingCache,
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
 
         var interactionService = new TestInteractionService
         {
@@ -834,7 +834,7 @@ public class GuestAppHostProjectTests : IDisposable
             PackageChannelQuality.Both,
             [new PackageMapping("Aspire.*", "stable")],
             stableCache,
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
 
         var project = CreateGuestAppHostProject();
 
@@ -990,7 +990,7 @@ public class GuestAppHostProjectTests : IDisposable
                 ])
         };
 
-        var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+        var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
 
         var interactionService = new TestInteractionService
         {
@@ -1074,7 +1074,7 @@ public class GuestAppHostProjectTests : IDisposable
                 ])
         };
 
-        var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+        var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures(), NullLogger.Instance);
 
         var interactionService = new TestInteractionService
         {
@@ -1187,7 +1187,8 @@ public class GuestAppHostProjectTests : IDisposable
             executionContext: executionContext,
             logger: NullLogger<GuestAppHostProject>.Instance,
             fileLoggerProvider: new FileLoggerProvider(logFilePath, new TestStartupErrorWriter()),
-            profilingTelemetry: _profilingTelemetry);
+            profilingTelemetry: _profilingTelemetry,
+            timeProvider: TimeProvider.System);
     }
 
 }

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -27,8 +27,8 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         return new GuestRuntime(
             spec ?? CreateTestSpec(),
             _loggerFactory.CreateLogger<GuestRuntime>(),
-            commandResolver: commandResolver,
-            profilingTelemetry: profilingTelemetry);
+            commandResolver ?? PathLookupHelper.FindFullPathFromPath,
+            profilingTelemetry ?? new ProfilingTelemetry(new ConfigurationBuilder().Build()));
     }
 
     private static RuntimeSpec CreateTestSpec(
@@ -717,8 +717,8 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             var launcher = new ProcessGuestLauncher(
                 "test",
                 _loggerFactory.CreateLogger<ProcessGuestLauncher>(),
-                fileLoggerProvider,
-                commandResolver: cmd => cmd == "dotnet" ? "dotnet" : null);
+                commandResolver: cmd => cmd == "dotnet" ? "dotnet" : null,
+                fileLoggerProvider: fileLoggerProvider);
 
             var (exitCode, output) = await launcher.LaunchAsync(
                 "dotnet",
@@ -818,7 +818,8 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         // appears to hang while it waits for the AppHost system to exit.
         var launcher = new ProcessGuestLauncher(
             "test",
-            _loggerFactory.CreateLogger<ProcessGuestLauncher>());
+            _loggerFactory.CreateLogger<ProcessGuestLauncher>(),
+            PathLookupHelper.FindFullPathFromPath);
 
         // Use a long-running cross-platform command. We pick something the OS resolves through PATH
         // so the launcher's CommandPathResolver succeeds without any fake.

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -439,6 +439,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             mappings: mappings,
             nuGetPackageCache: new FakeNuGetPackageCache(),
             features: new TestFeatures(),
+            NullLogger.Instance,
             configureGlobalPackagesFolder: true);
         var server = CreateServerWithChannel(workspace, stagingChannel, executionContext);
 
@@ -585,7 +586,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
                 new PackageMapping(PackageMapping.AllPackages, NuGetOrgSource)
             ],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var server = CreateServerWithChannel(workspace, explicitChannel, CreateContextWithIdentityChannel("pr-12345"));
 
         using var result = await InvokeTryCreateTemporaryNuGetConfigAsync(
@@ -612,6 +613,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             mappings: [new PackageMapping("CommunityToolkit*", channelSource)],
             nuGetPackageCache: new FakeNuGetPackageCache(),
             features: new TestFeatures(),
+            NullLogger.Instance,
             configureGlobalPackagesFolder: true);
         var executionContext = CreateContextWithIdentityChannel("pr-12345");
         var server = CreateServerWithChannel(workspace, stagingChannel, executionContext);
@@ -660,7 +662,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             quality: PackageChannelQuality.Both,
             mappings: [new PackageMapping("Aspire*", channelSource), new PackageMapping(PackageMapping.AllPackages, NuGetOrgSource)],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var server = CreateServerWithChannel(workspace, stagingChannel, CreateContextWithIdentityChannel("pr-12345"));
 
         using var result = await InvokeTryCreateTemporaryNuGetConfigAsync(
@@ -706,7 +708,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             quality: PackageChannelQuality.Both,
             mappings: [new PackageMapping(PackageMapping.AllPackages, channelSource)],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var server = CreateServerWithChannel(workspace, stagingChannel, CreateContextWithIdentityChannel("pr-12345"));
 
         using var result = await InvokeTryCreateTemporaryNuGetConfigAsync(
@@ -760,7 +762,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             quality: PackageChannelQuality.Both,
             mappings: [new PackageMapping("Aspire*", channelSource)],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var server = CreateServerWithChannel(workspace, stagingChannel, CreateContextWithIdentityChannel("pr-12345"));
 
         var sources = await InvokeGetNuGetSourcesAsync(server, requestedChannel: "staging", packageSourceOverride: packageSourceOverride);
@@ -782,7 +784,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             quality: PackageChannelQuality.Both,
             mappings: [new PackageMapping("CommunityToolkit*", channelSource)],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var server = CreateServerWithChannel(workspace, stagingChannel, CreateContextWithIdentityChannel("pr-12345"));
 
         var sources = await InvokeGetNuGetSourcesAsync(server, requestedChannel: "staging", packageSourceOverride: packageSourceOverride);
@@ -806,7 +808,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             quality: PackageChannelQuality.Both,
             mappings: [new PackageMapping(PackageMapping.AllPackages, channelSource)],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var server = CreateServerWithChannel(workspace, stagingChannel, CreateContextWithIdentityChannel("pr-12345"));
 
         var sources = await InvokeGetNuGetSourcesAsync(server, requestedChannel: "staging", packageSourceOverride: packageSourceOverride);
@@ -900,7 +902,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             new PackageMapping(PackageMapping.AllPackages, "https://pkgs.dev.azure.com/fake/v3/index.json")
         };
         var dailyChannel = PackageChannel.CreateExplicitChannel(
-            "daily", PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache(), new TestFeatures());
+            "daily", PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache(), new TestFeatures(), NullLogger.Instance);
         var packagingService = new TestPackagingService
         {
             GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([dailyChannel]),
@@ -945,7 +947,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             new PackageMapping(PackageMapping.AllPackages, "https://pkgs.dev.azure.com/fake/v3/index.json")
         };
         var dailyChannel = PackageChannel.CreateExplicitChannel(
-            "daily", PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache(), new TestFeatures());
+            "daily", PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache(), new TestFeatures(), NullLogger.Instance);
 
         var packagingService = new TestPackagingService
         {
@@ -993,7 +995,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             new PackageMapping(PackageMapping.AllPackages, "https://pkgs.dev.azure.com/fake/v3/index.json")
         };
         var channel = PackageChannel.CreateExplicitChannel(
-            channelName, PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache(), new TestFeatures());
+            channelName, PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache(), new TestFeatures(), NullLogger.Instance);
         return CreateServerWithChannel(workspace, channel, executionContext);
     }
 
@@ -1266,7 +1268,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             quality: PackageChannelQuality.Both,
             mappings: [new PackageMapping("Aspire*", packageSource.FullName)],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var packagingService = new TestPackagingService
         {
             GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([channel])
@@ -1330,7 +1332,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
                 new PackageMapping(PackageMapping.AllPackages, channelSource)
             ],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var packagingService = new TestPackagingService
         {
             GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([channel])
@@ -1385,7 +1387,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             quality: PackageChannelQuality.Both,
             mappings: [new PackageMapping("Aspire*", channelSource)],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var packagingService = new TestPackagingService
         {
             GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([channel])
@@ -1500,7 +1502,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             quality: PackageChannelQuality.Both,
             mappings: [new PackageMapping("Aspire*", missingPackageSource)],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var packagingService = new TestPackagingService
         {
             GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([channel])
@@ -1569,7 +1571,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
                 new PackageMapping(PackageMapping.AllPackages, NuGetOrgSource)
             ],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var packagingService = new TestPackagingService
         {
             GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([dailyChannel])
@@ -1751,7 +1753,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             quality: PackageChannelQuality.Both,
             mappings: [new PackageMapping("Aspire*", channelSource)],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var packagingService = new TestPackagingService
         {
             GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([dailyChannel])
@@ -1831,7 +1833,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             quality: PackageChannelQuality.Both,
             mappings: [new PackageMapping("Aspire*", localHive)],
             nuGetPackageCache: new FakeNuGetPackageCache(),
-            features: new TestFeatures());
+            features: new TestFeatures(), NullLogger.Instance);
         var packagingService = new TestPackagingService
         {
             GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([prChannel])
@@ -1996,7 +1998,8 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
                 new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
             ],
             new FakeNuGetPackageCache(),
-            new TestFeatures());
+            new TestFeatures(),
+            NullLogger.Instance);
         var packagingService = new TestPackagingService
         {
             GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([stagingChannel])

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -27,7 +27,7 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
     {
         return TestExecutionContextHelper.CreateExecutionContext(
             workingDirectory,
-            environmentVariables: environmentVariables);
+            environment: new TestEnvironment(environmentVariables));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Scaffolding/ChannelReseedTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/ChannelReseedTests.cs
@@ -4,9 +4,11 @@
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Scaffolding;
+using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Diagnostics;
 
@@ -89,7 +91,8 @@ public class ChannelReseedTests(ITestOutputHelper outputHelper)
             languageDiscovery: new TestLanguageDiscovery(language),
             interactionService: new TestInteractionService(),
             logger: NullLogger<ScaffoldingService>.Instance,
-            executionContext: workspace.CreateExecutionContext());
+            executionContext: workspace.CreateExecutionContext(),
+            profilingTelemetry: new ProfilingTelemetry(new ConfigurationBuilder().Build()));
 
         var context = new ScaffoldContext(
             Language: language,
@@ -120,7 +123,8 @@ public class ChannelReseedTests(ITestOutputHelper outputHelper)
             languageDiscovery: new TestLanguageDiscovery(s_testLanguage),
             interactionService: new TestInteractionService(),
             logger: NullLogger<ScaffoldingService>.Instance,
-            executionContext: workspace.CreateExecutionContext());
+            executionContext: workspace.CreateExecutionContext(),
+            profilingTelemetry: new ProfilingTelemetry(new ConfigurationBuilder().Build()));
     }
 
     private sealed class CapturingAppHostServerProject(string appDirectoryPath) : IAppHostServerProject

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -13,6 +13,7 @@ using Aspire.Cli.Packaging;
 using Aspire.Cli.Templating;
 using Aspire.Cli.Tests.Telemetry;
 using Aspire.Cli.Tests.TestServices;
+using Microsoft.Extensions.Logging.Abstractions;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Shared;
@@ -31,7 +32,7 @@ public class DotNetTemplateFactoryTests
     }
 
     private static PackageChannel CreateExplicitChannel(PackageMapping[] mappings) =>
-        PackageChannel.CreateExplicitChannel("test", PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache(), new TestFeatures());
+        PackageChannel.CreateExplicitChannel("test", PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache(), new TestFeatures(), NullLogger.Instance);
 
     private static async Task WriteNuGetConfigAsync(DirectoryInfo dir, string content)
     {
@@ -218,7 +219,7 @@ public class DotNetTemplateFactoryTests
         var workingDir = workspace.WorkspaceRoot;
         var outputDir = Directory.CreateDirectory(Path.Combine(workingDir.FullName, "MyProject"));
 
-        var channel = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache(), new TestFeatures());
+        var channel = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache(), new TestFeatures(), NullLogger.Instance);
 
         // Act
         await NuGetConfigMerger.CreateOrUpdateAsync(outputDir, channel).DefaultTimeout();

--- a/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.Xml.Linq;
 
 namespace Aspire.Cli.Tests.Templating;
@@ -90,7 +91,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
                         new PackageMapping(PackageMapping.AllPackages, fallbackSource),
                     ],
                     new FakeNuGetPackageCache(),
-                    features: new TestFeatures());
+                    features: new TestFeatures(), NullLogger.Instance);
                 return Task.FromResult<IEnumerable<PackageChannel>>([channel]);
             }
         };
@@ -226,7 +227,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
                 var implicitCh = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache
                 {
                     GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult(Enumerable.Empty<Aspire.Shared.NuGetPackageCli>())
-                }, new TestFeatures());
+                }, new TestFeatures(), NullLogger.Instance);
                 return Task.FromResult<IEnumerable<PackageChannel>>([implicitCh]);
             }
         };
@@ -259,7 +260,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
         {
             GetChannelsAsyncCallback = _ =>
             {
-                var implicitCh = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache(), new TestFeatures());
+                var implicitCh = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache(), new TestFeatures(), NullLogger.Instance);
                 return Task.FromResult<IEnumerable<PackageChannel>>([implicitCh]);
             }
         };
@@ -286,7 +287,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
         {
             GetChannelsAsyncCallback = _ =>
             {
-                var implicitCh = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache(), new TestFeatures());
+                var implicitCh = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache(), new TestFeatures(), NullLogger.Instance);
                 var stableCh = PackageChannel.CreateExplicitChannel(
                     "stable",
                     PackageChannelQuality.Both,
@@ -298,7 +299,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
                             new Aspire.Shared.NuGetPackageCli { Id = TemplateNuGetConfigService.TemplatesPackageName, Version = "13.3.0", Source = "stable-src" }
                         ])
                     },
-                    features: new TestFeatures());
+                    features: new TestFeatures(), NullLogger.Instance);
                 return Task.FromResult<IEnumerable<PackageChannel>>([implicitCh, stableCh]);
             }
         };
@@ -328,7 +329,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
         {
             GetChannelsAsyncCallback = _ =>
             {
-                var implicitCh = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache(), new TestFeatures());
+                var implicitCh = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache(), new TestFeatures(), NullLogger.Instance);
                 return Task.FromResult<IEnumerable<PackageChannel>>([implicitCh]);
             }
         };
@@ -389,13 +390,14 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
                     [
                         new Aspire.Shared.NuGetPackageCli { Id = TemplateNuGetConfigService.TemplatesPackageName, Version = "1.0.0", Source = "implicit-src" }
                     ])
-                }, new TestFeatures());
+                }, new TestFeatures(), NullLogger.Instance);
                 var hiveCh = PackageChannel.CreateExplicitChannel(
                     "pr-12345",
                     PackageChannelQuality.Both,
                     [new PackageMapping("Aspire*", "pr-src")],
                     new FakeNuGetPackageCache(),
                     features: new TestFeatures(),
+                    NullLogger.Instance,
                     pinnedVersion: "2.0.0");
                 return Task.FromResult<IEnumerable<PackageChannel>>([implicitCh, hiveCh]);
             }
@@ -455,13 +457,14 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
                     [
                         new Aspire.Shared.NuGetPackageCli { Id = TemplateNuGetConfigService.TemplatesPackageName, Version = "13.4.3", Source = "nuget.org" }
                     ])
-                }, new TestFeatures());
+                }, new TestFeatures(), NullLogger.Instance);
                 var localStableCh = PackageChannel.CreateExplicitChannel(
                     "stable",
                     PackageChannelQuality.Both,
                     [new PackageMapping("Aspire*", packagesDir.FullName.Replace('\\', '/'))],
                     new FakeNuGetPackageCache(),
                     features: new TestFeatures(),
+                    NullLogger.Instance,
                     pinnedVersion: "13.5.0");
                 return Task.FromResult<IEnumerable<PackageChannel>>([implicitCh, localStableCh]);
             }
@@ -519,7 +522,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
                         new PackageMapping("*", "https://api.nuget.org/v3/index.json")
                     ],
                     new FakeNuGetPackageCache(),
-                    features: new TestFeatures());
+                    features: new TestFeatures(), NullLogger.Instance);
                 return Task.FromResult<IEnumerable<PackageChannel>>([dailyCh]);
             }
         };
@@ -557,7 +560,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
                     PackageChannelQuality.Stable,
                     [new PackageMapping("*", "https://api.nuget.org/v3/index.json")],
                     new FakeNuGetPackageCache(),
-                    features: new TestFeatures());
+                    features: new TestFeatures(), NullLogger.Instance);
                 return Task.FromResult<IEnumerable<PackageChannel>>([stableCh]);
             }
         };
@@ -602,7 +605,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
                     PackageChannelQuality.Stable,
                     [new PackageMapping("*", "https://api.nuget.org/v3/index.json")],
                     new FakeNuGetPackageCache(),
-                    features: new TestFeatures());
+                    features: new TestFeatures(), NullLogger.Instance);
                 return Task.FromResult<IEnumerable<PackageChannel>>([stableCh]);
             }
         };
@@ -659,7 +662,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
                     PackageChannelQuality.Stable,
                     [new PackageMapping("*", "https://api.nuget.org/v3/index.json")],
                     new FakeNuGetPackageCache(),
-                    features: new TestFeatures());
+                    features: new TestFeatures(), NullLogger.Instance);
                 return Task.FromResult<IEnumerable<PackageChannel>>([stableCh]);
             }
         };

--- a/tests/Aspire.Cli.Tests/TestServices/FakePlaywrightServices.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakePlaywrightServices.cs
@@ -36,7 +36,7 @@ internal sealed class FakeNpmRunner : INpmRunner
 /// </summary>
 internal sealed class FakeNpmProvenanceChecker : INpmProvenanceChecker
 {
-    public Task<ProvenanceVerificationResult> VerifyProvenanceAsync(string packageName, string version, string expectedSourceRepository, string expectedWorkflowPath, string expectedBuildType, Func<WorkflowRefInfo, bool>? validateWorkflowRef, string? sriIntegrity = null, CancellationToken cancellationToken = default)
+    public Task<ProvenanceVerificationResult> VerifyProvenanceAsync(string packageName, string version, string expectedSourceRepository, string expectedWorkflowPath, string expectedBuildType, Func<WorkflowRefInfo, bool>? validateWorkflowRef, string? sriIntegrity, CancellationToken cancellationToken)
         => Task.FromResult(new ProvenanceVerificationResult
         {
             Outcome = ProvenanceVerificationOutcome.Verified,

--- a/tests/Aspire.Cli.Tests/TestServices/FakePlaywrightServices.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakePlaywrightServices.cs
@@ -36,7 +36,7 @@ internal sealed class FakeNpmRunner : INpmRunner
 /// </summary>
 internal sealed class FakeNpmProvenanceChecker : INpmProvenanceChecker
 {
-    public Task<ProvenanceVerificationResult> VerifyProvenanceAsync(string packageName, string version, string expectedSourceRepository, string expectedWorkflowPath, string expectedBuildType, Func<WorkflowRefInfo, bool>? validateWorkflowRef, CancellationToken cancellationToken, string? sriIntegrity = null)
+    public Task<ProvenanceVerificationResult> VerifyProvenanceAsync(string packageName, string version, string expectedSourceRepository, string expectedWorkflowPath, string expectedBuildType, Func<WorkflowRefInfo, bool>? validateWorkflowRef, string? sriIntegrity = null, CancellationToken cancellationToken = default)
         => Task.FromResult(new ProvenanceVerificationResult
         {
             Outcome = ProvenanceVerificationOutcome.Verified,

--- a/tests/Aspire.Cli.Tests/TestServices/TestPackagingService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestPackagingService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Packaging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.TestServices;
 
@@ -28,7 +29,7 @@ internal sealed class TestPackagingService : IPackagingService
         }
 
         // Default: Return a fake channel with template packages
-        var testChannel = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache(), new TestFeatures());
+        var testChannel = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache(), new TestFeatures(), NullLogger.Instance);
         return Task.FromResult<IEnumerable<PackageChannel>>(new[] { testChannel });
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -48,6 +48,12 @@ namespace Aspire.Cli.Tests.Utils;
 
 internal static class CliTestHelper
 {
+    public static InstallSidecarReader CreateSidecarReader(ITestOutputHelper outputHelper)
+    {
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddXunit(outputHelper));
+        return new InstallSidecarReader(loggerFactory.CreateLogger<InstallSidecarReader>());
+    }
+
     public static IServiceCollection CreateServiceCollection(TemporaryWorkspace workspace, ITestOutputHelper outputHelper, Action<CliServiceCollectionTestOptions>? configure = null)
     {
         var options = new CliServiceCollectionTestOptions(outputHelper, workspace.WorkspaceRoot);

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -183,6 +183,7 @@ internal static class CliTestHelper
         // IdentityChannelReader for AspireVersionCheck (doctor) — uses the same
         // pattern as production wiring in Program.cs.
         services.AddSingleton<IIdentityChannelReader>(_ => new IdentityChannelReader(typeof(Program).Assembly));
+        services.AddSingleton<IEnvironment, TestEnvironment>();
         services.AddSingleton<ProfileCaptureService>();
 
         // AppHost project handlers - must match Program.cs registration pattern
@@ -486,7 +487,7 @@ internal sealed class CliServiceCollectionTestOptions
         var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
         var hostEnvironment = serviceProvider.GetRequiredService<ICliHostEnvironment>();
         var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
-        return new CertificateService(certificateToolRunner, interactiveService, telemetry, hostEnvironment, executionContext, OperatingSystem.IsLinux);
+        return new CertificateService(certificateToolRunner, interactiveService, telemetry, hostEnvironment, executionContext, serviceProvider.GetRequiredService<IEnvironment>());
     };
 
     public Func<IServiceProvider, IScaffoldingService> ScaffoldingServiceFactory { get; set; } = (IServiceProvider serviceProvider) =>

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -480,7 +480,7 @@ internal sealed class CliServiceCollectionTestOptions
         var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
         var hostEnvironment = serviceProvider.GetRequiredService<ICliHostEnvironment>();
         var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
-        return new CertificateService(certificateToolRunner, interactiveService, telemetry, hostEnvironment, executionContext);
+        return new CertificateService(certificateToolRunner, interactiveService, telemetry, hostEnvironment, executionContext, OperatingSystem.IsLinux);
     };
 
     public Func<IServiceProvider, IScaffoldingService> ScaffoldingServiceFactory { get; set; } = (IServiceProvider serviceProvider) =>
@@ -491,7 +491,7 @@ internal sealed class CliServiceCollectionTestOptions
         var interactionService = serviceProvider.GetRequiredService<IInteractionService>();
         var logger = serviceProvider.GetRequiredService<ILogger<ScaffoldingService>>();
         var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
-        return new ScaffoldingService(appHostServerProjectFactory, appHostServerSessionFactory, languageDiscovery, interactionService, logger, executionContext);
+        return new ScaffoldingService(appHostServerProjectFactory, appHostServerSessionFactory, languageDiscovery, interactionService, logger, executionContext, serviceProvider.GetRequiredService<ProfilingTelemetry>());
     };
 
     public Func<IServiceProvider, IProcessExecutionFactory> DotNetCliExecutionFactoryFactory { get; set; } = (IServiceProvider serviceProvider) =>

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -50,7 +50,7 @@ internal static class CliTestHelper
 {
     public static InstallSidecarReader CreateSidecarReader(ITestOutputHelper outputHelper)
     {
-        using var loggerFactory = LoggerFactory.Create(builder => builder.AddXunit(outputHelper));
+        var loggerFactory = LoggerFactory.Create(builder => builder.AddXunit(outputHelper));
         return new InstallSidecarReader(loggerFactory.CreateLogger<InstallSidecarReader>());
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/DcpConnectionHealthCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DcpConnectionHealthCheckTests.cs
@@ -162,7 +162,7 @@ public class DcpConnectionHealthCheckTests(ITestOutputHelper outputHelper)
             return File.WriteAllTextAsync(kubeconfigPath, completeKubeconfig, cancellationToken);
         }
 
-        using var parsed = await DcpKubeconfig.ReadFileWithRetryAsync(kubeconfigPath, TestContext.Current.CancellationToken, DelayAsync);
+        using var parsed = await DcpKubeconfig.ReadFileWithRetryAsync(kubeconfigPath, DelayAsync, TestContext.Current.CancellationToken);
 
         Assert.Equal(1, retryCount);
         Assert.Equal(new Uri("https://127.0.0.1:12345"), parsed.Server);

--- a/tests/Aspire.Cli.Tests/Utils/TestEnvironment.cs
+++ b/tests/Aspire.Cli.Tests/Utils/TestEnvironment.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Tests.Utils;
+
+/// <summary>
+/// Test <see cref="IEnvironment"/> backed by a dictionary so tests can inject
+/// specific environment variable values without touching the process environment.
+/// </summary>
+internal sealed class TestEnvironment : IEnvironment
+{
+    public IReadOnlyDictionary<string, string?> Variables { get; }
+
+    public TestEnvironment(IReadOnlyDictionary<string, string?>? variables = null)
+    {
+        Variables = variables ?? new Dictionary<string, string?>();
+    }
+
+    public string? GetEnvironmentVariable(string variable)
+    {
+        return Variables.TryGetValue(variable, out var value) ? value : null;
+    }
+
+    public bool IsWindows => OperatingSystem.IsWindows();
+
+    public bool IsLinux => OperatingSystem.IsLinux();
+
+    public bool IsMacOS => OperatingSystem.IsMacOS();
+}

--- a/tests/Aspire.Cli.Tests/Utils/TestEnvironment.cs
+++ b/tests/Aspire.Cli.Tests/Utils/TestEnvironment.cs
@@ -21,9 +21,9 @@ internal sealed class TestEnvironment : IEnvironment
         return Variables.TryGetValue(variable, out var value) ? value : null;
     }
 
-    public bool IsWindows => OperatingSystem.IsWindows();
+    public bool IsWindows { get; init; } = OperatingSystem.IsWindows();
 
-    public bool IsLinux => OperatingSystem.IsLinux();
+    public bool IsLinux { get; init; } = OperatingSystem.IsLinux();
 
-    public bool IsMacOS => OperatingSystem.IsMacOS();
+    public bool IsMacOS { get; init; } = OperatingSystem.IsMacOS();
 }

--- a/tests/Aspire.Cli.Tests/Utils/TestExecutionContextHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/TestExecutionContextHelper.cs
@@ -28,7 +28,7 @@ internal static class TestExecutionContextHelper
         return CreateExecutionContext(
             workspace.WorkspaceRoot,
             identityChannel: identityChannel,
-            environmentVariables: environmentVariables,
+            environment: new TestEnvironment(environmentVariables),
             logFilePath: logFilePath,
             identityVersion: identityVersion,
             identityCommit: identityCommit,
@@ -45,7 +45,7 @@ internal static class TestExecutionContextHelper
         string identityChannel = "local",
         DirectoryInfo? homeDirectory = null,
         DirectoryInfo? hivesDirectory = null,
-        IReadOnlyDictionary<string, string?>? environmentVariables = null,
+        IEnvironment? environment = null,
         DirectoryInfo? packagesDirectory = null,
         bool debugMode = false,
         string? logFilePath = null,
@@ -76,7 +76,7 @@ internal static class TestExecutionContextHelper
             identityOverridden: identityOverridden,
             identityPackagesDirectory: identityPackagesDirectory,
             debugMode: debugMode,
-            environmentVariables: environmentVariables,
+            environmentVariables: (environment as TestEnvironment)?.Variables,
             homeDirectory: homeDirectory,
             packagesDirectory: packagesDirectory);
     }


### PR DESCRIPTION
## Summary

Three categories of cleanup in the Aspire CLI.

### 1. Make optional parameters required where appropriate

Parameters that were declared optional but always supplied by every caller are now required. This makes API contracts explicit and eliminates hidden defaults that were never exercised.

**Affected:**
- `IdentityResolver` — `IEnvironment` replaces optional `Func<string, string?>? envReader`
- `ExtensionInteractionService` — `ILogger` made required
- `INpmProvenanceChecker.VerifyProvenanceAsync` — `packageSourceUrl` and `checksumValidator` made required
- `InstallSidecarReader.ReadConfigAsync` — path parameter made required
- Constructors/methods in `ProjectLocator`, `ProjectUpdater`, `PackagingService`, `ScaffoldingService`, `GuestRuntime`, `GuestAppHostProject`, `DotNetAppHostProject`, `UpdateCommand`, `WaitCommand`, `LsCommand`, `ProcessGuestLauncher`, `DcpConnectionChecker`, `PlaywrightCliInstaller`, agent environment scanners, and others

### 2. Fix ExtensionInteractionService lifecycle

- **Own its CancellationToken**: replaced the externally-supplied `CancellationToken?` constructor parameter with an internally-owned `CancellationTokenSource`. The service controls its own cancellation rather than relying on a caller-provided token that may outlive or underscope it.
- **Implement IDisposable**: completes the task channel writer and cancels/disposes the CTS on disposal, ensuring the background pump shuts down cleanly.
- **Guard the background pump**: wrapped the channel-reading loop in a try/catch so `OperationCanceledException` during disposal is expected and swallowed, while unexpected exceptions are logged at `Error` level instead of becoming unobserved task exceptions.

### 3. Introduce IEnvironment abstraction

- New `IEnvironment` interface (`GetEnvironmentVariable`, `IsWindows`, `IsLinux`, `IsMacOS`) with `HostEnvironment` implementation wrapping `System.Environment`/`OperatingSystem`.
- `IdentityResolver` takes `IEnvironment` instead of `Func<string, string?>`, breaking the circular dependency between `IdentityResolver` and `CliExecutionContext` — both now depend on `IEnvironment` independently.
- `CertificateService` and `NativeCertificateToolRunner` use `IEnvironment.IsLinux` instead of `Func<bool> isLinux`.
- Removed the unused `BuildCliExecutionContext(string? channel)` overload — the `IIdentityResolver` overload is the single production entry point.
