### PR TITLE
Group the selective-CI test-selector comment by trigger and lead with what runs

### DIFF
--- a/docs/ci/test-trigger-selector-design.md
+++ b/docs/ci/test-trigger-selector-design.md
@@ -119,8 +119,9 @@ carries, per affected project, an ordered chain
 `changed file → directly-changed project → … → affected test`. The selector
 attaches this to each Layer 1 cause (`Cause.Path`), and the renderers surface
 it: the step summary shows the full chain
-(`src/Core/Core.cs → Core → Core.Tests`), the PR comment a terse
-`via graph from <file>`. Only a single representative shortest path per project
+(`src/Core/Core.cs → Core → Core.Tests`), while the PR comment groups every test
+reached from a seed file under that file's heading (in a "via the project graph"
+bucket). Only a single representative shortest path per project
 is tracked — alternate longer paths are not enumerated.
 
 ### Why a HEAD-only graph
@@ -423,11 +424,17 @@ runs the full matrix and all jobs. The summary shows:
 - any `ALL` or kill-switch escalation and why;
 - unattributed changed files that may need curated rules.
 
-The PR comment carries the same selection in a terser form: each test
-project and job is listed with **every** cause that selected it (e.g. a job
-pulled in only because a test runs reads `via test <Name>`), priority-ordered
-and de-duplicated. The full per-item cause list additionally includes the rule
-`reason` text in the step summary. The comment is posted **one per pushed
+The PR comment carries the same selection in a more scannable form. It leads
+with **what runs** — the flat list of selected jobs and the flat list of
+selected test projects — so a reviewer sees the full impact at a glance even
+when many files changed. It then explains **how** the selection was reached,
+grouping the selected projects under each trigger (changed file, affected
+project, or derived test) that pulled them in: a changed file and its graph
+fan-out appear under one heading, so a single edit's whole closure is stated
+once rather than repeated per project, and large fan-outs collapse into a
+`<details>`. Every cause is still shown — a project selected by several
+triggers appears under each — and a per-job table names what triggered each
+job. The comment is posted **one per pushed
 commit** and links the head commit it was computed for: a re-run of the same
 commit updates that commit's comment in place (no duplicate — re-runs are
 common), a new commit posts a fresh comment at the bottom, and comments from

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
@@ -204,6 +204,47 @@ public sealed class SelectTestsCliTests
         });
     }
 
+    // The headline call-out (⚠️ "N of the M ... come from a single change") and the <details> collapse
+    // in RenderProjectList are both threshold-gated (headline: tests >= 10 && largest group >= 5;
+    // collapse: inline limit of 12). A single change that fans out to many projects must trip both.
+    // Failure mode: a refactor silently drops the headline or stops collapsing large buckets, making
+    // big selections unreadable again — the very problem this comment layout exists to solve.
+    [Fact]
+    public void LargeFanOutEmitsHeadlineAndCollapsesProjectList()
+    {
+        var projects = Enumerable.Range(1, 14).Select(i => $"Aspire.Pkg{i:00}.Tests").ToList();
+        var slnx = "<Solution>\n"
+            + string.Join("\n", projects.Select(p => $"  <Project Path=\"tests/{p}/{p}.csproj\" />"))
+            + "\n</Solution>";
+        // One path rule maps a single changed file to all 14 test projects, so they land in one group.
+        var map = "version: 1\npath_rules:\n  - paths: [big.txt]\n    targets: ["
+            + string.Join(", ", projects.Select(p => $"\"test:{p}\""))
+            + "]\n";
+
+        RunInTempRepo((repoRoot, propsPath, _) =>
+        {
+            var commentPath = Path.Combine(repoRoot, "comment.md");
+            var previous = Environment.GetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE");
+            Environment.SetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE", commentPath);
+            try
+            {
+                var changed = WriteChangedFiles(repoRoot, "big.txt");
+
+                Selection.Run(Options(repoRoot, propsPath, changedFilesPath: changed, skipLayer1: true, enforce: true));
+
+                var comment = File.ReadAllText(commentPath);
+                // Headline names the count and the single change that drove it.
+                Assert.Contains("⚠️ 14 of the 14 selected test projects come from a single change — `big.txt`", comment);
+                // The 14-project bucket (over the inline limit of 12) collapses into a <details>.
+                Assert.Contains("<details><summary>show 14</summary>", comment);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE", previous);
+            }
+        }, slnx: slnx, map: map);
+    }
+
     // In audit mode the comment is advisory: the full matrix and all jobs still run, and the lists
     // describe what selective CI WOULD run under enforcement. Pin the "(audit mode)" title qualifier
     // and the explanatory line so the advisory framing can't silently disappear — without it a reader

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
@@ -156,10 +156,10 @@ public sealed class SelectTestsCliTests
                 var comment = File.ReadAllText(commentPath);
                 Assert.StartsWith("## Tests selector", comment);
                 Assert.DoesNotContain("audit mode", comment);
-                Assert.Contains("**Test projects (1 / 2)**", comment);
-                Assert.Contains("- `Aspire.Hosting.Tests`", comment);
-                Assert.Contains("**Jobs (1)**", comment);
-                Assert.Contains("- `extension-e2e`", comment);
+                Assert.Contains("### Selected test projects (1 / 2)", comment);
+                Assert.Contains("`Aspire.Hosting.Tests`", comment);
+                Assert.Contains("### Selected jobs (1)", comment);
+                Assert.Contains("`extension-e2e`", comment);
                 Assert.DoesNotContain("### Options", comment);
                 Assert.DoesNotContain("Changed files", comment);
                 Assert.DoesNotContain("Would have been", comment);
@@ -171,10 +171,11 @@ public sealed class SelectTestsCliTests
         });
     }
 
-    // The PR comment lists EVERY cause that selected an item — not a single "primary" cause with a
-    // "(+N more)" tail. A reviewer must see exactly which changed files / edges pulled each test in.
-    // Here both trigger.txt and prod.txt route to Aspire.Hosting.Tests, so its one comment line must
-    // name both files. Failure mode: truncating to one cause hides why a test was selected.
+    // The PR comment attributes EVERY cause that selected an item — no truncation, no "(+N more)"
+    // tail. A reviewer must see exactly which changed files / edges pulled each test in. Here both
+    // trigger.txt and prod.txt route to Aspire.Hosting.Tests, so the grouped "how chosen" section must
+    // show both files as triggers (the project appears under each). Failure mode: dropping a trigger
+    // hides why a test was selected.
     [Fact]
     public void CommentListsEveryCauseWithoutTruncation()
     {
@@ -190,10 +191,10 @@ public sealed class SelectTestsCliTests
                 Selection.Run(Options(repoRoot, propsPath, changedFilesPath: changed, skipLayer1: true, enforce: true));
 
                 var comment = File.ReadAllText(commentPath);
-                var line = Array.Find(comment.Split('\n'), l => l.Contains("`Aspire.Hosting.Tests`", StringComparison.Ordinal));
-                Assert.NotNull(line);
-                Assert.Contains("`trigger.txt`", line);
-                Assert.Contains("`prod.txt`", line);
+                // Both triggers are named as group headings, and the test they both select appears.
+                Assert.Contains("`trigger.txt`", comment);
+                Assert.Contains("`prod.txt`", comment);
+                Assert.Contains("`Aspire.Hosting.Tests`", comment);
                 Assert.DoesNotContain("more)", comment);
             }
             finally

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsLayer1IntegrationTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsLayer1IntegrationTests.cs
@@ -89,12 +89,15 @@ public sealed class SelectTestsLayer1IntegrationTests
                     BeforeBuildProps: propsPath));
 
                 Assert.Equal(0, exit);
-                // Summary carries the full chain; the terse PR comment names just the seed file.
+                // Summary carries the full chain; the terse PR comment groups the graph fan-out under
+                // the seed file heading instead of repeating the path per project.
                 var summary = File.ReadAllText(System.IO.Path.Combine(fixture.Path, "summary"));
                 Assert.Contains("src/Core/Core.cs → Core → Core.Tests", summary);
 
                 var comment = File.ReadAllText(commentPath);
-                Assert.Contains("via graph from `src/Core/Core.cs`", comment);
+                Assert.Contains("`src/Core/Core.cs`", comment);
+                Assert.Contains("via the project graph", comment);
+                Assert.Contains("`Core.Tests`", comment);
 
                 // The JSON artifact preserves the decision path as a structured array.
                 using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(jsonPath));

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -770,7 +770,7 @@ internal static class Selection
             }
             if (other.Count > 0)
             {
-                sb.AppendLine(CultureInfo.InvariantCulture, $"→ {RenderProjectList(other.Select(p => $"`{p}`").ToList(), "tests")}");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"→ {RenderProjectList(other.Select(p => $"`{p}`").ToList(), other.Count == 1 ? "test" : "tests")}");
             }
             sb.AppendLine();
         }

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -191,7 +191,7 @@ internal static class Selection
         trace.EnterStage("write summary and outputs");
         WriteSummary(options, result, allTestProjects, changedFiles, layer1Affected, excludedFiles);
         WriteJobBooleans(options, result);
-        WriteSelectionComment(options, result, allTestProjects);
+        WriteSelectionComment(options, result, allTestProjects, changedFiles);
         WriteSelectionJson(options, result, allTestProjects, changedFiles, layer1Affected, excludedFiles);
 
         // Enforce + a non-ALL selection restricts the downstream enumerate-tests build to the selected
@@ -611,11 +611,18 @@ internal static class Selection
         }
     }
 
-    // Builds the sticky PR comment: a terse, scannable view of exactly what runs for this PR -- the
-    // selected test projects and the selected jobs, nothing else. Deliberately omits the audit detail
-    // (options, changed files, would-have-skipped) that the job step summary carries; reviewers want a
-    // quick "what runs", not the full trace. Written to SELECT_TESTS_COMMENT_FILE when set.
-    private static void WriteSelectionComment(RunOptions options, SelectionResult result, IReadOnlySet<string> allTestProjects)
+    // Builds the sticky PR comment. Structure: WHAT runs first (the flat lists of selected jobs and
+    // test projects, so a reader sees the full impact at a glance even with many changed files), then
+    // HOW it was chosen (the per-trigger grouping). Grouping by trigger -- rather than listing each
+    // project with its reason appended -- keeps the "why" readable when one change fans out to dozens
+    // of projects: the reason is stated once per trigger, not repeated per project. Deliberately omits
+    // the step-summary audit detail (options, changed-file list, would-have-skipped). Written to
+    // SELECT_TESTS_COMMENT_FILE when set.
+    private static void WriteSelectionComment(
+        RunOptions options,
+        SelectionResult result,
+        IReadOnlySet<string> allTestProjects,
+        IReadOnlyCollection<string> changedFiles)
     {
         var commentPath = Environment.GetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE");
         if (string.IsNullOrEmpty(commentPath))
@@ -641,51 +648,253 @@ internal static class Selection
         if (result.SelectsAll)
         {
             sb.AppendLine(CultureInfo.InvariantCulture, $"**Runs the full test matrix + all jobs (ALL)** — {result.EscalationReason}");
+            sb.AppendLine();
+            WriteCommentFile(commentPath, sb.ToString());
+            return;
         }
-        else
-        {
-            var tests = result.TestProjects.OrderBy(p => p, StringComparer.Ordinal).ToList();
-            // Keep the full job: tokens for cause lookup; strip the prefix only for display.
-            var jobs = result.Jobs.OrderBy(j => j, StringComparer.Ordinal).ToList();
 
-            sb.AppendLine(CultureInfo.InvariantCulture, $"**Test projects ({tests.Count} / {allTestProjects.Count})**");
-            sb.AppendLine();
-            if (tests.Count == 0)
-            {
-                sb.AppendLine("_none — no .NET test projects run for this change._");
-            }
-            else
-            {
-                foreach (var t in tests)
-                {
-                    sb.AppendLine(CultureInfo.InvariantCulture, $"- `{t}`{AllCausesSuffix(result.TestCauses, t)}");
-                }
-            }
-            sb.AppendLine();
+        var tests = result.TestProjects.OrderBy(p => p, StringComparer.Ordinal).ToList();
+        // Keep the full job: tokens for cause lookup; strip the prefix only for display.
+        var jobs = result.Jobs.OrderBy(j => j, StringComparer.Ordinal).ToList();
 
-            sb.AppendLine(CultureInfo.InvariantCulture, $"**Jobs ({jobs.Count})**");
-            sb.AppendLine();
-            if (jobs.Count == 0)
-            {
-                sb.AppendLine("_none_");
-            }
-            else
-            {
-                foreach (var token in jobs)
-                {
-                    var name = token.StartsWith("job:", StringComparison.Ordinal) ? token["job:".Length..] : token;
-                    sb.AppendLine(CultureInfo.InvariantCulture, $"- `{name}`{AllCausesSuffix(result.JobCauses, token)}");
-                }
-            }
-        }
+        var fileWord = changedFiles.Count == 1 ? "changed file" : "changed files";
+        var jobWord = jobs.Count == 1 ? "job" : "jobs";
+        sb.AppendLine(CultureInfo.InvariantCulture,
+            $"**{tests.Count} / {allTestProjects.Count} test projects · {jobs.Count} {jobWord}**, from {changedFiles.Count} {fileWord}.");
         sb.AppendLine();
 
+        // WHAT runs -- the flat lists up front. A reviewer scanning a large selection sees the complete
+        // set of jobs and projects without reading the per-trigger breakdown below.
+        sb.AppendLine(CultureInfo.InvariantCulture, $"### Selected jobs ({jobs.Count})");
+        sb.AppendLine();
+        sb.AppendLine(jobs.Count == 0
+            ? "_none_"
+            : string.Join(", ", jobs.Select(j => $"`{StripJobPrefix(j)}`")));
+        sb.AppendLine();
+
+        sb.AppendLine(CultureInfo.InvariantCulture, $"### Selected test projects ({tests.Count} / {allTestProjects.Count})");
+        sb.AppendLine();
+        sb.AppendLine(tests.Count == 0
+            ? "_none — no .NET test projects run for this change._"
+            : string.Join(", ", tests.Select(t => $"`{t}`")));
+        sb.AppendLine();
+
+        // HOW it was chosen -- the per-trigger grouping.
+        AppendSelectionRationale(sb, result, tests, jobs);
+
+        sb.AppendLine();
+        WriteCommentFile(commentPath, sb.ToString());
+    }
+
+    // Renders the "how these were chosen" section: every selected test project grouped under each
+    // trigger (changed file / affected project / derived test) that pulled it in, plus a per-job
+    // reasons table. Full attribution is preserved -- a project selected by several triggers appears
+    // under each -- so nothing is hidden, but each trigger's reason is written once instead of being
+    // repeated on every project line.
+    private static void AppendSelectionRationale(
+        StringBuilder sb,
+        SelectionResult result,
+        IReadOnlyList<string> tests,
+        IReadOnlyList<string> jobs)
+    {
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("### How these were chosen — grouped by what changed");
+        sb.AppendLine();
+
+        // Invert TestCauses (project -> causes) into trigger groups (trigger -> projects). Causes that
+        // share a trigger collapse into one group: a changed file and its graph fan-out group together
+        // so a single source edit shows its whole closure under one heading.
+        var groups = new Dictionary<string, Dictionary<string, Cause>>(StringComparer.Ordinal);
+        foreach (var project in tests)
+        {
+            if (!result.TestCauses.TryGetValue(project, out var causes))
+            {
+                continue;
+            }
+
+            foreach (var cause in causes)
+            {
+                var key = CauseGroupKey(cause);
+                if (!groups.TryGetValue(key, out var members))
+                {
+                    members = new Dictionary<string, Cause>(StringComparer.Ordinal);
+                    groups[key] = members;
+                }
+
+                // If the same project reaches a group via more than one cause, keep the most direct one
+                // (lowest priority) so its bucket/hop annotation reflects the closest path.
+                if (!members.TryGetValue(project, out var existing) || CausePriority(cause.Kind) < CausePriority(existing.Kind))
+                {
+                    members[project] = cause;
+                }
+            }
+        }
+
+        // Largest group first -- the biggest fan-out is the most useful thing to see when triaging a
+        // large selection. Ties broken by key for a stable order.
+        var orderedGroups = groups
+            .OrderByDescending(g => g.Value.Count)
+            .ThenBy(g => g.Key, StringComparer.Ordinal)
+            .ToList();
+
+        // Headline: when one trigger drives a large share of a big selection, call it out so the reader
+        // immediately sees where the bulk of the work comes from.
+        if (orderedGroups.Count > 0 && tests.Count >= 10 && orderedGroups[0].Value.Count >= 5)
+        {
+            var top = orderedGroups[0];
+            sb.AppendLine(CultureInfo.InvariantCulture,
+                $"⚠️ {top.Value.Count} of the {tests.Count} selected test projects come from a single change — {CauseGroupDescriptor(top.Key)}.");
+            sb.AppendLine();
+        }
+
+        foreach (var (key, members) in orderedGroups)
+        {
+            sb.AppendLine(CauseGroupHeader(key));
+
+            // Within a group, separate the projects whose change is direct (the file lives in them, or
+            // a path rule named them) from those reached transitively through the project graph -- the
+            // two have different review weight, and stating the mechanism once per bucket avoids
+            // repeating it per project.
+            var direct = members.Where(m => m.Value.Kind is CauseKind.Convention or CauseKind.PathRule).Select(m => m.Key).OrderBy(p => p, StringComparer.Ordinal).ToList();
+            var graph = members.Where(m => m.Value.Kind is CauseKind.Layer1Graph).OrderBy(m => m.Key, StringComparer.Ordinal).ToList();
+            var other = members.Where(m => m.Value.Kind is not (CauseKind.Convention or CauseKind.PathRule or CauseKind.Layer1Graph)).Select(m => m.Key).OrderBy(p => p, StringComparer.Ordinal).ToList();
+
+            if (direct.Count > 0)
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"→ {RenderProjectList(direct.Select(p => $"`{p}`").ToList(), "directly")}");
+            }
+            if (graph.Count > 0)
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"→ {RenderProjectList(graph.Select(MemberWithHops).ToList(), "via the project graph")}");
+            }
+            if (other.Count > 0)
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"→ {RenderProjectList(other.Select(p => $"`{p}`").ToList(), "tests")}");
+            }
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("#### Job reasons");
+        sb.AppendLine();
+        if (jobs.Count == 0)
+        {
+            sb.AppendLine("_none_");
+            return;
+        }
+
+        sb.AppendLine("| Job | Triggered by |");
+        sb.AppendLine("|---|---|");
+        foreach (var token in jobs)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture, $"| `{StripJobPrefix(token)}` | {JobCausesText(result.JobCauses, token)} |");
+        }
+    }
+
+    private static string StripJobPrefix(string token)
+        => token.StartsWith("job:", StringComparison.Ordinal) ? token["job:".Length..] : token;
+
+    // Renders a bucket's projects. Small lists go inline (scannable); large ones collapse into a
+    // <details> so a 30-project fan-out doesn't dominate the comment.
+    private static string RenderProjectList(IReadOnlyList<string> items, string label)
+    {
+        const int InlineLimit = 12;
+        var joined = string.Join(", ", items);
+        return items.Count <= InlineLimit
+            ? $"**{items.Count}** {label}: {joined}"
+            : $"**{items.Count}** {label}\n<details><summary>show {items.Count}</summary>\n\n{joined}\n</details>";
+    }
+
+    // A graph-selected project, annotated with its hop count when the change reached it through more
+    // than one project edge (a near vs. far dependency is useful review signal).
+    private static string MemberWithHops(KeyValuePair<string, Cause> member)
+    {
+        if (member.Value is { Kind: CauseKind.Layer1Graph, Path: { Count: > 0 } path })
+        {
+            // path = [seedFile, project0, ..., affectedTest]; edges between projects = count - 2.
+            var hops = path.Count - 2;
+            if (hops > 1)
+            {
+                return $"`{member.Key}` ({hops} hops)";
+            }
+        }
+
+        return $"`{member.Key}`";
+    }
+
+    // The trigger a cause groups under. Direct file matches and graph fan-out from the same seed file
+    // share a "file:" key so they render under one heading; affected-project and derived-test causes
+    // get their own keyed groups.
+    private static string CauseGroupKey(Cause cause) => cause.Kind switch
+    {
+        CauseKind.Convention or CauseKind.PathRule => $"file:{cause.Trigger}",
+        CauseKind.Layer1Graph => $"file:{(cause.Path is { Count: > 0 } path ? path[0] : "(changed source)")}",
+        CauseKind.AffectedProject => $"affected:{cause.Trigger}",
+        CauseKind.DerivedFromTest => $"derived:{cause.Trigger}",
+        _ => $"other:{cause.Trigger}",
+    };
+
+    // The heading shown for a group key.
+    private static string CauseGroupHeader(string key)
+    {
+        var sep = key.IndexOf(':', StringComparison.Ordinal);
+        var (kind, value) = (key[..sep], key[(sep + 1)..]);
+        return kind switch
+        {
+            "file" => $"**{FileEmoji(value)} `{value}`** *({FileChangeKind(value)})*",
+            "affected" => $"**📦 affected project `{value}`**",
+            "derived" => $"**🧪 derived from test `{value}`**",
+            _ => $"**`{value}`**",
+        };
+    }
+
+    // A one-line descriptor of a group key, for the headline call-out.
+    private static string CauseGroupDescriptor(string key)
+    {
+        var sep = key.IndexOf(':', StringComparison.Ordinal);
+        var (kind, value) = (key[..sep], key[(sep + 1)..]);
+        return kind switch
+        {
+            "file" => $"`{value}`",
+            "affected" => $"affected project `{value}`",
+            "derived" => $"derived from test `{value}`",
+            _ => $"`{value}`",
+        };
+    }
+
+    private static string FileChangeKind(string path)
+        => path.StartsWith("src/", StringComparison.Ordinal) ? "changed source"
+            : path.StartsWith("tests/", StringComparison.Ordinal) ? "changed test"
+            : "changed";
+
+    private static string FileEmoji(string path)
+        => path.StartsWith("src/", StringComparison.Ordinal) ? "🔧"
+            : path.StartsWith("tests/", StringComparison.Ordinal) ? "🧪"
+            : "📄";
+
+    private static void WriteCommentFile(string commentPath, string content)
+    {
         var dir = Path.GetDirectoryName(Path.GetFullPath(commentPath));
         if (!string.IsNullOrEmpty(dir))
         {
             Directory.CreateDirectory(dir);
         }
-        File.WriteAllText(commentPath, sb.ToString());
+        File.WriteAllText(commentPath, content);
+    }
+
+    // The full set of causes for one job, de-duplicated and priority-ordered, for the job-reasons
+    // table. Every cause is shown (no truncation) so a reviewer sees exactly what pulled the job in.
+    private static string JobCausesText(IReadOnlyDictionary<string, IReadOnlyList<Cause>> causes, string key)
+    {
+        if (!causes.TryGetValue(key, out var list) || list.Count == 0)
+        {
+            return "_unattributed_";
+        }
+
+        return string.Join(", ", list
+            .OrderBy(c => CausePriority(c.Kind))
+            .Select(ShortCause)
+            .Distinct());
     }
 
     private static void WriteSummary(
@@ -849,25 +1058,6 @@ internal static class Selection
                 Console.Error.Write(markdown);
             }
         }
-    }
-
-    // Renders EVERY cause that selected an item — priority-ordered and de-duplicated — for the PR
-    // comment, so a reviewer sees the full attribution (which changed file / project / edge pulled the
-    // item in) with no truncation. Returns "" when nothing attributed the item (e.g. an ALL selection,
-    // where per-item causes aren't tracked).
-    private static string AllCausesSuffix(IReadOnlyDictionary<string, IReadOnlyList<Cause>> causes, string key)
-    {
-        if (!causes.TryGetValue(key, out var list) || list.Count == 0)
-        {
-            return "";
-        }
-
-        var rendered = list
-            .OrderBy(c => CausePriority(c.Kind))
-            .Select(ShortCause)
-            .Distinct()
-            .ToList();
-        return $" — {string.Join(", ", rendered)}";
     }
 
     // Lower = more "direct" / closer to the change, so it's the cause shown first in the comment and


### PR DESCRIPTION
## What this changes

The **Tests selector** PR comment posted by `tools/SelectTests` (the
selective-CI advisory comment) was hard to read. It listed every selected
test project on its own line with the selection reason appended, so when one
change fans out across the project graph the *same reason repeats on dozens
of lines*. A reviewer couldn't tell at a glance which projects and jobs run,
or which change drove the bulk of the selection.

Example — the old comment on #18332 had 46 near-identical lines like:

```
- `Aspire.Hosting.Azure.Kusto.Tests` — via graph from `tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceHostTests.cs`
- `Aspire.Hosting.Blazor.Tests` — via graph from `tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceHostTests.cs`
- … 30 more identical reasons …
```

## The fix

Restructure the comment into **what runs**, then **how it was chosen**:

- **Lead with what runs** — a flat list of selected jobs, then a flat list of
  selected test projects. Full impact is visible up front, even with many
  changed files.
- **Then how it was chosen** — group the selected projects under each trigger
  (a changed file *and its graph fan-out* under one heading, an affected
  project, or a derived test). Each reason is stated once instead of per
  project; large fan-outs collapse into `<details>`; a per-job table names
  what triggered each job. A headline `⚠️` call-out names the single change
  driving a large share of a big selection.

Rendered on #18332's inputs, the 46 projects collapse to a handful of
trigger groups, with the headline surfacing that **33 of 46 come from one
changed test file**.

## Call-outs

- **Full attribution is preserved** — a project selected by several triggers
  appears under each group, so no "why" is dropped (the old "list every
  cause" guarantee still holds, just inverted).
- Updated the CLI and Layer 1 integration tests to assert the new structure,
  and `docs/ci/test-trigger-selector-design.md` to describe it.
- No change to the selection logic, the job booleans, the step-summary audit
  detail, or the one-comment-per-commit posting behavior — only the comment's
  body layout.
