### PR TITLE
Add WithHiddenOnCompletion() to installer and migration resources

### DIFF
--- a/src/Aspire.Hosting.EntityFrameworkCore/EFResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.EntityFrameworkCore/EFResourceBuilderExtensions.cs
@@ -191,6 +191,7 @@ public static class EFResourceBuilderExtensions
                 State = new ResourceStateSnapshot(KnownResourceStates.NotStarted, KnownResourceStateStyles.Info)
             })
             .WithIconName("Database")
+            .WithHiddenOnCompletion()
             .WithPipelineStepFactory(CreateMigrationPipelineStep);
 
         AddEFMigrationCommands(innerBuilder, migrationResource, dbContextTypeName);

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -2157,7 +2157,8 @@ public static class JavaScriptHostingExtensions
             var installerBuilder = resource.ApplicationBuilder.AddResource(installer)
                 .WithParentRelationship(resource.Resource)
                 .ExcludeFromManifest()
-                .WithCertificateTrustScope(CertificateTrustScope.None);
+                .WithCertificateTrustScope(CertificateTrustScope.None)
+                .WithHiddenOnCompletion();
 
             resource.ApplicationBuilder.OnBeforeStart((_, _) =>
             {

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -3037,7 +3037,8 @@ public static partial class JavaScriptHostingExtensions
             var installerBuilder = resource.ApplicationBuilder.AddResource(installer)
                 .WithParentRelationship(resource.Resource)
                 .ExcludeFromManifest()
-                .WithCertificateTrustScope(CertificateTrustScope.None);
+                .WithCertificateTrustScope(CertificateTrustScope.None)
+                .WithHiddenOnCompletion();
 
             resource.ApplicationBuilder.OnBeforeStart((_, _) =>
             {

--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -1344,7 +1344,8 @@ public static class PythonAppResourceBuilderExtensions
             var installerBuilder = builder.ApplicationBuilder.AddResource(installer)
                 .WithParentRelationship(builder.Resource)
                 .ExcludeFromManifest()
-                .WithCertificateTrustScope(CertificateTrustScope.None);
+                .WithCertificateTrustScope(CertificateTrustScope.None)
+                .WithHiddenOnCompletion();
 
             if (!install)
             {

--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -1319,7 +1319,8 @@ public static class PythonAppResourceBuilderExtensions
             var installerBuilder = builder.ApplicationBuilder.AddResource(installer)
                 .WithParentRelationship(builder.Resource)
                 .ExcludeFromManifest()
-                .WithCertificateTrustScope(CertificateTrustScope.None);
+                .WithCertificateTrustScope(CertificateTrustScope.None)
+                .WithHiddenOnCompletion();
 
             if (!install)
             {

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -146,6 +146,7 @@
     <InternalsVisibleTo Include="Aspire.Hosting.Testing.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Containers.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.EntityFrameworkCore" />
+    <InternalsVisibleTo Include="Aspire.Hosting.EntityFrameworkCore.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Radius.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.RemoteHost.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Foundry.Tests" />

--- a/tests/Aspire.Hosting.EntityFrameworkCore.Tests/AddEFMigrationsTests.cs
+++ b/tests/Aspire.Hosting.EntityFrameworkCore.Tests/AddEFMigrationsTests.cs
@@ -258,6 +258,18 @@ public class AddEFMigrationsTests
         Assert.Equal("{db1.connectionString}", Assert.Contains("ConnectionStrings__db1", env));
     }
 
+    [Fact]
+    public void AddEFMigrationsHasHiddenOnCompletionAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var project = builder.AddProject<Projects.ServiceA>("myproject");
+        var migrations = project.AddEFMigrations("mymigrations", typeof(TestDbContext).FullName!);
+
+        Assert.True(migrations.Resource.TryGetLastAnnotation<HiddenAnnotation>(out var hiddenAnnotation));
+        Assert.Equal(HiddenBehavior.OnCompletion, hiddenAnnotation.Behavior);
+        Assert.Contains(0, hiddenAnnotation.SuccessfulExitCodes);
+    }
+
     // Test classes for DbContext types
     private sealed class TestDbContext { }
     private sealed class AnotherDbContext { }

--- a/tests/Aspire.Hosting.JavaScript.Tests/ResourceCreationTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/ResourceCreationTests.cs
@@ -210,4 +210,26 @@ public class ResourceCreationTests
         Assert.True(installerResource.TryGetLastAnnotation<CertificateAuthorityCollectionAnnotation>(out var certAnnotation));
         Assert.Equal(CertificateTrustScope.None, certAnnotation.Scope);
     }
+
+    [Fact]
+    public void InstallerResourceHasHiddenOnCompletionAnnotation()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var nodeApp = builder.AddJavaScriptApp("test-app", "./test-app");
+        nodeApp.WithNpm(install: true);
+
+        using var app = builder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // Verify the installer resource was created
+        var installerResource = Assert.Single(appModel.Resources.OfType<JavaScriptInstallerResource>());
+        Assert.Equal("test-app-installer", installerResource.Name);
+
+        // Verify the installer has HiddenBehavior.OnCompletion and exit code 0
+        Assert.True(installerResource.TryGetLastAnnotation<HiddenAnnotation>(out var hiddenAnnotation));
+        Assert.Equal(HiddenBehavior.OnCompletion, hiddenAnnotation.Behavior);
+        Assert.Contains(0, hiddenAnnotation.SuccessfulExitCodes);
+    }
 }

--- a/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
+++ b/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
@@ -854,6 +854,30 @@ public class AddPythonAppTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void InstallerResourceHasHiddenOnCompletionAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(outputHelper);
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var scriptName = "main.py";
+
+        var pythonApp = builder.AddPythonApp("pythonProject", workspace.Path, scriptName)
+            .WithPip();
+
+        var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // Verify the installer resource exists
+        var installerResource = appModel.Resources.OfType<PythonInstallerResource>().Single();
+        Assert.Equal("pythonProject-installer", installerResource.Name);
+
+        // Verify the installer has HiddenBehavior.OnCompletion and exit code 0
+        Assert.True(installerResource.TryGetLastAnnotation<HiddenAnnotation>(out var hiddenAnnotation));
+        Assert.Equal(HiddenBehavior.OnCompletion, hiddenAnnotation.Behavior);
+        Assert.Contains(0, hiddenAnnotation.SuccessfulExitCodes);
+    }
+
+    [Fact]
     public void WithPip_AfterWithUv_ReplacesPackageManager()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(outputHelper);


### PR DESCRIPTION
## Description

Adds `WithHiddenOnCompletion()` to JavaScript installer, Python installer, and EF Core migration resources so they are automatically hidden from the dashboard once their execution tasks complete. This keeps the dashboard clean after `npm install`, `pip install`, `uv sync`, database migration tasks, and similar operations finish.

### Changes

- **JavaScriptInstallerResource**: Now hides after npm/yarn/pnpm installation completes
- **PythonInstallerResource**: Now hides after pip/uv installation completes
- **EFMigrationResource**: Now hides after EF Core migration tasks complete
- **Unit Tests**: Added tests asserting `HiddenAnnotation` with `HiddenBehavior.OnCompletion` for JavaScript installer, Python installer, and EF Core migration resources.

Follow on from #16070

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No