### PR TITLE
Make HiddenAnnotation public

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/HiddenAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HiddenAnnotation.cs
@@ -3,15 +3,38 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
-internal enum HiddenBehavior
+/// <summary>
+/// Specifies when a hidden resource should be omitted from default resource lists.
+/// </summary>
+public enum HiddenBehavior
 {
+    /// <summary>
+    /// Always hide the resource from default resource lists.
+    /// </summary>
     Always,
+
+    /// <summary>
+    /// Hide the resource from default resource lists only after it completes successfully.
+    /// </summary>
     OnCompletion
 }
 
-internal sealed class HiddenAnnotation(HiddenBehavior behavior) : IResourceAnnotation
+/// <summary>
+/// Represents visibility metadata that hides a resource from default resource lists.
+/// </summary>
+/// <param name="behavior">Specifies when the resource should be hidden.</param>
+/// <remarks>
+/// Hidden resources can still be accessed directly by name or included explicitly by tooling that supports showing hidden resources.
+/// </remarks>
+public sealed class HiddenAnnotation(HiddenBehavior behavior) : IResourceAnnotation
 {
+    /// <summary>
+    /// Gets when the resource should be hidden from default resource lists.
+    /// </summary>
     public HiddenBehavior Behavior { get; } = behavior;
 
+    /// <summary>
+    /// Gets the exit codes that are treated as successful completion when <see cref="Behavior"/> is <see cref="HiddenBehavior.OnCompletion"/>.
+    /// </summary>
     public List<int> SuccessfulExitCodes { get; init; } = [0];
 }


### PR DESCRIPTION
## Description

This exposes `HiddenAnnotation` so callers can apply the same visibility annotation that Aspire.Hosting uses internally. Because the constructor and `Behavior` property use `HiddenBehavior`, this also makes `HiddenBehavior` public and adds XML docs for the new public API surface.

No additional dependencies are required.

Follow on from #16070.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No