### PR TITLE
Fix dashboard endpoint tooltip to show the hovered URL instead of all endpoints

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -199,7 +199,7 @@
                                                     <span class="empty-data"></span>
                                                 }
                                             </AspireTemplateColumn>
-                                            <AspireTemplateColumn ColumnId="@UrlsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesUrlsColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetUrlsTooltip(ctx.Resource))">
+                                            <AspireTemplateColumn ColumnId="@UrlsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesUrlsColumnHeader)]" Tooltip="false">
                                                 <UrlsColumnDisplay Resource="context.Resource"
                                                                    HasMultipleReplicas="HasMultipleReplicas(context.Resource)"
                                                                    DisplayedUrls="GetDisplayedUrls(context.Resource)" />

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -199,7 +199,7 @@
                                                     <span class="empty-data"></span>
                                                 }
                                             </AspireTemplateColumn>
-                                            <AspireTemplateColumn ColumnId="@UrlsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesUrlsColumnHeader)]" Tooltip="false">
+                                            <AspireTemplateColumn ColumnId="@UrlsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesUrlsColumnHeader)]">
                                                 <UrlsColumnDisplay Resource="context.Resource"
                                                                    HasMultipleReplicas="HasMultipleReplicas(context.Resource)"
                                                                    DisplayedUrls="GetDisplayedUrls(context.Resource)" />

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Globalization;
-using System.Text;
 using Aspire.Dashboard.Components.Layout;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Extensions;
@@ -764,31 +762,6 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             return (value, property.IsValueSensitive, isUnresolved);
         }
         return (null, false, isUnresolved);
-    }
-
-    private static string GetUrlsTooltip(ResourceViewModel resource)
-    {
-        var displayedUrls = GetDisplayedUrls(resource);
-
-        if (displayedUrls.Count == 0)
-        {
-            return string.Empty;
-        }
-
-        if (displayedUrls.Count == 1)
-        {
-            return displayedUrls[0].Text;
-        }
-
-        var maxShownUrls = 3;
-        var tooltipBuilder = new StringBuilder(string.Join(", ", displayedUrls.Take(maxShownUrls).Select(url => url.Text)));
-
-        if (displayedUrls.Count > maxShownUrls)
-        {
-            tooltipBuilder.Append(CultureInfo.CurrentCulture, $" + {displayedUrls.Count - maxShownUrls}");
-        }
-
-        return tooltipBuilder.ToString();
     }
 
     private async Task OnToggleCollapse(ResourceGridViewModel viewModel)

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
@@ -67,11 +67,11 @@ else if (DisplayedUrls.Count > 1)
     {
         if (displayedUrl.Url != null)
         {
-            return @<a href="@displayedUrl.Url" target="_blank" @onclick:stopPropagation="true">@displayedUrl.Text</a>;
+            return @<a href="@displayedUrl.Url" target="_blank" title="@GetTooltipText(displayedUrl)" @onclick:stopPropagation="true">@displayedUrl.Text</a>;
         }
         else
         {
-            return @<span title="@displayedUrl.Text">@displayedUrl.Text</span>;
+            return @<span title="@GetTooltipText(displayedUrl)">@displayedUrl.Text</span>;
         }
     }
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor.cs
@@ -10,6 +10,11 @@ namespace Aspire.Dashboard.Components;
 
 public partial class UrlsColumnDisplay
 {
+    internal static string GetTooltipText(DisplayedUrl displayedUrl)
+    {
+        return displayedUrl.Url ?? displayedUrl.OriginalUrlString;
+    }
+
     [Parameter, EditorRequired]
     public required ResourceViewModel Resource { get; set; }
 

--- a/tests/Aspire.Dashboard.Tests/Components/UrlsColumnDisplayTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Components/UrlsColumnDisplayTests.cs
@@ -5,7 +5,7 @@ using Aspire.Dashboard.Components;
 using Aspire.Dashboard.Model;
 using Xunit;
 
-namespace Aspire.Dashboard.Tests;
+namespace Aspire.Dashboard.Tests.Components;
 
 public sealed class UrlsColumnDisplayTests
 {

--- a/tests/Aspire.Dashboard.Tests/Components/UrlsColumnDisplayTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Components/UrlsColumnDisplayTests.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Components;
+using Aspire.Dashboard.Model;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public sealed class UrlsColumnDisplayTests
+{
+    [Fact]
+    public void GetTooltipText_UsesUrl()
+    {
+        var displayedUrl = new DisplayedUrl
+        {
+            Index = 0,
+            Name = "https",
+            Text = "Api endpoint",
+            Url = "https://localhost:17174",
+            OriginalUrlString = "https://localhost:17174"
+        };
+
+        Assert.Equal("https://localhost:17174", UrlsColumnDisplay.GetTooltipText(displayedUrl));
+    }
+
+    [Fact]
+    public void GetTooltipText_FallsBackToOriginalUrlStringWhenUrlIsNull()
+    {
+        var displayedUrl = new DisplayedUrl
+        {
+            Index = 0,
+            Name = "grpc",
+            Text = "Grpc endpoint",
+            Url = null,
+            OriginalUrlString = "grpc://localhost:17175"
+        };
+
+        Assert.Equal("grpc://localhost:17175", UrlsColumnDisplay.GetTooltipText(displayedUrl));
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/CreateResourceSelectModelsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/CreateResourceSelectModelsTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Tests.Shared.DashboardModel;
+using DashboardComponents = Aspire.Dashboard.Components;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests.ConsoleLogsTests;
@@ -27,7 +28,7 @@ public class CreateResourceSelectModelsTests
         var allResourceViewModel = new SelectViewModel<ResourceTypeDetails> { Id = null, Name = allResourceText };
 
         // Act
-        var viewModels = Components.Pages.ConsoleLogs.GetConsoleLogResourceSelectViewModels(resourcesByName, allResourceViewModel, unknownStateText, false, out var optionToSelect);
+        var viewModels = DashboardComponents.Pages.ConsoleLogs.GetConsoleLogResourceSelectViewModels(resourcesByName, allResourceViewModel, unknownStateText, false, out var optionToSelect);
 
         // Assert
         Assert.NotNull(optionToSelect);
@@ -70,7 +71,7 @@ public class CreateResourceSelectModelsTests
         var allResourceViewModel = new SelectViewModel<ResourceTypeDetails> { Id = null, Name = allResourceText };
 
         // Act
-        var viewModels = Components.Pages.ConsoleLogs.GetConsoleLogResourceSelectViewModels(resourcesByName, allResourceViewModel, unknownStateText, false, out var optionToSelect);
+        var viewModels = DashboardComponents.Pages.ConsoleLogs.GetConsoleLogResourceSelectViewModels(resourcesByName, allResourceViewModel, unknownStateText, false, out var optionToSelect);
 
         // Assert
         Assert.Null(optionToSelect);
@@ -151,7 +152,7 @@ public class CreateResourceSelectModelsTests
         var allResourceViewModel = new SelectViewModel<ResourceTypeDetails> { Id = null, Name = allResourceText };
 
         // Act
-        var viewModels = Components.Pages.ConsoleLogs.GetConsoleLogResourceSelectViewModels(
+        var viewModels = DashboardComponents.Pages.ConsoleLogs.GetConsoleLogResourceSelectViewModels(
             resourcesByName,
             allResourceViewModel,
             unknownStateText,
@@ -184,7 +185,7 @@ public class CreateResourceSelectModelsTests
         var allResourceViewModel = new SelectViewModel<ResourceTypeDetails> { Id = null, Name = allResourceText };
 
         // Act
-        var viewModels = Components.Pages.ConsoleLogs.GetConsoleLogResourceSelectViewModels(
+        var viewModels = DashboardComponents.Pages.ConsoleLogs.GetConsoleLogResourceSelectViewModels(
             resourcesByName,
             allResourceViewModel,
             unknownStateText,
@@ -199,3 +200,4 @@ public class CreateResourceSelectModelsTests
         Assert.Equal(allResourceViewModel, viewModels[0]);
     }
 }
+

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/CreateResourceSelectModelsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/CreateResourceSelectModelsTests.cs
@@ -200,4 +200,3 @@ public class CreateResourceSelectModelsTests
         Assert.Equal(allResourceViewModel, viewModels[0]);
     }
 }
-


### PR DESCRIPTION
## Description

When hovering over an endpoint link in the **URLs** column of the Resources page, the tooltip showed a combined list of _all_ endpoint texts (e.g. "https, https") regardless of which link was being hovered. This was confusing when resources had endpoints with custom display names set via `WithUrl` / `WithUrls` (e.g. `"Some other place"`, `"Online store (https)"`), because you couldn't tell which URL clicking would actually navigate to.

**Before:** column-level tooltip joined all endpoint display texts together.  
**After:** each endpoint anchor/span shows its own `title` attribute containing the actual URL it navigates to, so hovering reveals the specific destination.

### User-facing usage

Resources with custom endpoint display names (e.g. the `stress-telemetryservice` in `playground/Stress`):

```csharp
builder.AddProject<Projects.Stress_TelemetryService>("stress-telemetryservice")
    .WithUrls(c => c.Urls.Add(new() { Url = "https://someplace.com", DisplayText = "Some place" }))
    .WithUrl("https://someotherplace.com/some-path", "Some other place")
    .WithUrl("https://extremely-long-url.com/...");
```

Previously hovering "Some place" showed `"Some place, Some other place, https://extremely-long-url.com/..."`.  
Now hovering "Some place" shows `"https://someplace.com"`.

### Screenshots / Recordings


Before:
Hovering over a single endpoint would list all endpoints in it's tooltip
<img width="359" height="134" alt="image" src="https://github.com/user-attachments/assets/c9ee9e27-c3d1-4dd0-a503-0e6ce582e60a" />
<img width="550" height="188" alt="image" src="https://github.com/user-attachments/assets/9149d4db-2913-4789-a4b9-b553670ba82f" />

After:
Hovering over over a url shows a tooltip for that specific url
<img width="252" height="114" alt="image" src="https://github.com/user-attachments/assets/57739ef7-39fe-4288-bca8-869d49b3a7ed" />
<img width="355" height="201" alt="image" src="https://github.com/user-attachments/assets/5a7f16fb-b2e8-4095-a6e6-a16eb4454d7a" />


### Implementation

- Removed the column-level `GetUrlsTooltip` aggregate from `Resources.razor` / `Resources.razor.cs` (deleted `~25 lines` including the `StringBuilder`/`CultureInfo` usages).
- Set `Tooltip="false"` on the `UrlsColumn` `AspireTemplateColumn` to suppress the grid-level tooltip.
- Added `title="@GetTooltipText(displayedUrl)"` on both the `<a>` and `<span>` in `UrlsColumnDisplay.WriteUrl`.
- Added `internal static GetTooltipText(DisplayedUrl)` helper (returns `Url ?? OriginalUrlString`) to keep the logic testable.
- Added unit tests covering the URL-present and URL-null (unsupported scheme) cases.

Part of #11604. 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
