### PR TITLE
Improve metrics chart filter rendering with many tags

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
@@ -223,7 +223,6 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
                     Name = item.Key
                 };
 
-                var order = 0;
                 dimensionModel.Values.AddRange(item.Value.Select(v =>
                 {
                     var text = v switch
@@ -232,18 +231,11 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
                         { Length: 0 } => Loc[nameof(ControlsStrings.LabelEmpty)],
                         _ => v
                     };
-                    return new
+                    return new DimensionValueViewModel
                     {
                         Text = text,
                         Value = v,
                     };
-                })
-                .OrderBy(v => v.Text)
-                .Select(i => new DimensionValueViewModel
-                {
-                    Text = i.Text,
-                    Value = i.Value,
-                    Order = order++,
                 }));
 
                 filters.Add(dimensionModel);

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterPopover.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterPopover.razor
@@ -1,0 +1,37 @@
+@namespace Aspire.Dashboard.Components
+
+@using Aspire.Dashboard.Components.Controls.Grid
+@using Aspire.Dashboard.Resources
+@inject IStringLocalizer<ControlsStrings> Loc
+
+@{
+    var id = $"typeFilterButton-{Filter.SanitizedHtmlId}-{Guid.NewGuid()}";
+}
+<FluentButton id="@id"
+              IconEnd="@(new Icons.Regular.Size20.Filter())"
+              Appearance="@(Filter.AreAllValuesSelected is true ? Appearance.Stealth : Appearance.Accent)"
+              @onclick="() => Filter.PopupVisible = !Filter.PopupVisible"
+              aria-label="@(Filter.AreAllValuesSelected is true ? Loc[nameof(ControlsStrings.ChartContainerAllTags)] : Loc[nameof(ControlsStrings.ChartContainerFilteredTags)])" />
+@* Each item is approximately 36px tall, plus 48px for the header and container padding. Include the always-rendered "All" checkbox row. The popover body has a CSS max-height of 300px. *@
+<FluentPopover AnchorId="@id" @bind-Open="Filter.PopupVisible" VerticalThreshold="@(Math.Min((Filter.Values.Count + 1) * 36 + 48, 300))" AutoFocus="false">
+    <Header>@Filter.Name</Header>
+    <Body>
+        <FluentStack Orientation="Orientation.Vertical" Class="dimension-popup">
+            <FluentCheckbox Label="@Loc[nameof(ControlsStrings.LabelAll)]"
+                            ThreeState="true"
+                            ShowIndeterminate="false"
+                            ThreeStateOrderUncheckToIntermediate="true"
+                            @bind-CheckState:get="Filter.AreAllValuesSelected"
+                            @bind-CheckState:set="@(v => OnAllValuesSelectionChangedAsync(v))"/>
+            @foreach (var tag in ChartFilterTags.GetOrderedValues(Filter.Values))
+            {
+                var isChecked = Filter.SelectedValues.Contains(tag);
+                <FluentCheckbox Label="@tag.Text"
+                                title="@tag.Text"
+                                @key=tag
+                                @bind-Value:get="isChecked"
+                                @bind-Value:set="c => OnTagSelectionChangedAsync(tag, c)"/>
+            }
+        </FluentStack>
+    </Body>
+</FluentPopover>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterPopover.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterPopover.razor.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Microsoft.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components;
+
+public partial class ChartFilterPopover : IDisposable
+{
+    [Parameter, EditorRequired]
+    public required DimensionFilterViewModel Filter { get; set; }
+
+    [Parameter, EditorRequired]
+    public required EventCallback<DimensionFilterViewModel> OnSelectionChanged { get; set; }
+
+    protected override void OnInitialized()
+    {
+        Filter.NotifyStateChanged += OnFilterStateChanged;
+    }
+
+    private void OnFilterStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnTagSelectionChangedAsync(DimensionValueViewModel tag, bool isChecked)
+    {
+        Filter.OnTagSelectionChanged(tag, isChecked);
+        Filter.NotifyStateChanged?.Invoke();
+        await OnSelectionChanged.InvokeAsync(Filter);
+    }
+
+    private async Task OnAllValuesSelectionChangedAsync(bool? isChecked)
+    {
+        Filter.AreAllValuesSelected = isChecked;
+        Filter.NotifyStateChanged?.Invoke();
+        await OnSelectionChanged.InvokeAsync(Filter);
+    }
+
+    public void Dispose()
+    {
+        Filter.NotifyStateChanged -= OnFilterStateChanged;
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
@@ -1,0 +1,48 @@
+@namespace Aspire.Dashboard.Components
+
+<FluentOverflow Class="dimension-overflow" OnOverflowRaised="@(items => HandleOverflowChanged(items))">
+    <ChildContent>
+        @{
+            var i = 0;
+        }
+        @foreach (var item in Filter.Values.OrderBy(v => v.Order))
+        {
+            var isIncludedInFilters = Filter.SelectedValues.Contains(item);
+            var isIncludedInFiltersClass = isIncludedInFilters ? "included-in-filters" : "";
+            var additionalAttributes = new Dictionary<string, object>()
+            {
+                [KeyForDimensionValue] = item,
+                [KeyForIsIncludedInFilters] = isIncludedInFilters,
+            };
+
+            // Always display the first item by setting a fixed value.
+            <FluentOverflowItem Fixed="@((i == 0) ? OverflowItemFixed.Ellipsis : OverflowItemFixed.None)" AdditionalAttributes="additionalAttributes">
+                <span class="dimension-tag filter-value-tag @isIncludedInFiltersClass"
+                      role="button"
+                      tabindex="0"
+                      @onclick="@(() => OnTagSelectionChangedAsync(item, !Filter.SelectedValues.Contains(item)))"
+                      @onkeydown="@(args => OnTagKeyDownAsync(args, item, !Filter.SelectedValues.Contains(item)))">
+                    @item.Text
+                </span>
+            </FluentOverflowItem>
+            i++;
+        }
+    </ChildContent>
+    <MoreButtonTemplate Context="overflow">
+        @{
+            var isIncludedInFiltersClass = overflow.ItemsOverflow.Any(item => (bool)item.AdditionalAttributes![KeyForIsIncludedInFilters]) ? "included-in-filters" : "";
+        }
+        @* Display must be inline block so the width is correctly calculated. *@
+        <span class="dimension-tag filter-value-tag @isIncludedInFiltersClass"
+              role="button"
+              tabindex="0"
+              style="display:inline-block;"
+              @onclick="@(() => Filter.PopupVisible = true)"
+              @onkeydown="@(args => OnOverflowTagKeyDownAsync(args))">
+            @($"+{overflow.ItemsOverflow.Count()}")
+        </span>
+    </MoreButtonTemplate>
+    <OverflowTemplate Context="overflow">
+        @* Intentionally empty. Don't display an overflow template here. *@
+    </OverflowTemplate>
+</FluentOverflow>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
@@ -30,6 +30,7 @@
                 <span class="dimension-tag filter-value-tag @isIncludedInFiltersClass"
                       role="button"
                       tabindex="0"
+                      aria-pressed="@isIncludedInFilters"
                       @onclick="@(() => OnTagSelectionChangedAsync(item, !Filter.SelectedValues.Contains(item)))"
                       @onkeydown="@(args => OnTagKeyDownAsync(args, item, !Filter.SelectedValues.Contains(item)))">
                     @item.Text

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
@@ -5,7 +5,7 @@
     // browser layout calculations. The visible area fits ~5-7 tags; rendering 20 gives
     // FluentOverflow enough items to measure correctly without creating hundreds of DOM
     // elements that trigger a forced reflow long enough to kill the SignalR connection.
-    var orderedValues = Filter.Values.OrderBy(v => v.Order).ToList();
+    var orderedValues = GetOrderedValues(Filter.Values).ToList();
     var renderedValues = orderedValues.Take(MaxRenderedTags).ToList();
     var preOverflowedCount = orderedValues.Count - renderedValues.Count;
 }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
@@ -1,11 +1,21 @@
 @namespace Aspire.Dashboard.Components
 
+@{
+    // Only render a limited number of items in the FluentOverflow to avoid expensive
+    // browser layout calculations. The visible area fits ~5-7 tags; rendering 20 gives
+    // FluentOverflow enough items to measure correctly without creating hundreds of DOM
+    // elements that trigger a forced reflow long enough to kill the SignalR connection.
+    var orderedValues = Filter.Values.OrderBy(v => v.Order).ToList();
+    var renderedValues = orderedValues.Take(MaxRenderedTags).ToList();
+    var preOverflowedCount = orderedValues.Count - renderedValues.Count;
+}
+
 <FluentOverflow Class="dimension-overflow" OnOverflowRaised="@(items => HandleOverflowChanged(items))">
     <ChildContent>
         @{
             var i = 0;
         }
-        @foreach (var item in Filter.Values.OrderBy(v => v.Order))
+        @foreach (var item in renderedValues)
         {
             var isIncludedInFilters = Filter.SelectedValues.Contains(item);
             var isIncludedInFiltersClass = isIncludedInFilters ? "included-in-filters" : "";
@@ -30,7 +40,13 @@
     </ChildContent>
     <MoreButtonTemplate Context="overflow">
         @{
-            var isIncludedInFiltersClass = overflow.ItemsOverflow.Any(item => (bool)item.AdditionalAttributes![KeyForIsIncludedInFilters]) ? "included-in-filters" : "";
+            var hasSelectedInOverflow = overflow.ItemsOverflow.Any(item => (bool)item.AdditionalAttributes![KeyForIsIncludedInFilters]);
+            if (!hasSelectedInOverflow && preOverflowedCount > 0)
+            {
+                // Check if any items beyond MaxRenderedTags (not in FluentOverflow) are selected.
+                hasSelectedInOverflow = orderedValues.Skip(MaxRenderedTags).Any(v => Filter.SelectedValues.Contains(v));
+            }
+            var isIncludedInFiltersClass = hasSelectedInOverflow ? "included-in-filters" : "";
         }
         @* Display must be inline block so the width is correctly calculated. *@
         <span class="dimension-tag filter-value-tag @isIncludedInFiltersClass"
@@ -39,7 +55,7 @@
               style="display:inline-block;"
               @onclick="@(() => Filter.PopupVisible = true)"
               @onkeydown="@(args => OnOverflowTagKeyDownAsync(args))">
-            @($"+{overflow.ItemsOverflow.Count()}")
+            @($"+{overflow.ItemsOverflow.Count() + preOverflowedCount}")
         </span>
     </MoreButtonTemplate>
     <OverflowTemplate Context="overflow">

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
@@ -54,7 +54,7 @@
               role="button"
               tabindex="0"
               style="display:inline-block;"
-              @onclick="@(() => Filter.PopupVisible = true)"
+              @onclick="@ShowPopover"
               @onkeydown="@(args => OnOverflowTagKeyDownAsync(args))">
             @($"+{overflow.ItemsOverflow.Count() + preOverflowedCount}")
         </span>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
@@ -10,7 +10,7 @@
     var preOverflowedCount = orderedValues.Count - renderedValues.Count;
 }
 
-<FluentOverflow Class="dimension-overflow" OnOverflowRaised="@(items => HandleOverflowChanged(items))">
+<FluentOverflow Class="dimension-overflow">
     <ChildContent>
         @{
             var i = 0;

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
@@ -25,6 +25,12 @@ public partial class ChartFilterTags : IDisposable
     public const string KeyForDimensionValue = "dimensionValue";
     public const string KeyForIsIncludedInFilters = "isIncludedInFilters";
 
+    // Maximum number of tags to render in the FluentOverflow. The visible area fits ~5-7 tags;
+    // rendering 20 gives FluentOverflow enough items to measure correctly. Items beyond this
+    // limit are treated as pre-overflowed and counted in the "+N" badge without being added to
+    // the DOM, avoiding hundreds of elements triggering an expensive forced reflow.
+    private const int MaxRenderedTags = 20;
+
     // When some filter value is selected which is not visible (overflowed)
     // we reorder it to the top of the list. For doing so we use this counter
     // to assign decremental negative number to the Order property of
@@ -106,11 +112,16 @@ public partial class ChartFilterTags : IDisposable
 
     public void HandleOverflowChanged(IEnumerable<FluentOverflowItem> overflowItems)
     {
-        var overflowedValues = overflowItems
+        var overflowedFromComponent = overflowItems
             .Select(i => (DimensionValueViewModel)i.AdditionalAttributes![KeyForDimensionValue])
             .ToArray();
 
-        Filter.OverflowedValues = overflowedValues;
+        // Items beyond MaxRenderedTags are always overflowed since they aren't rendered
+        // in the FluentOverflow. Include them so the reordering logic works when a
+        // pre-overflowed tag is selected via the popover.
+        var preOverflowed = Filter.Values.OrderBy(v => v.Order).Skip(MaxRenderedTags);
+
+        Filter.OverflowedValues = [.. overflowedFromComponent, .. preOverflowed];
     }
 
     public void Dispose()

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components;
+
+/// <summary>
+/// Renders the FluentOverflow tag list for a single dimension filter row.
+/// Owns the inline tag click handlers so that clicking a tag only re-renders
+/// this component, not sibling rows in the grid.
+/// </summary>
+public partial class ChartFilterTags : IDisposable
+{
+    [Parameter, EditorRequired]
+    public required DimensionFilterViewModel Filter { get; set; }
+
+    [Parameter, EditorRequired]
+    public required EventCallback<DimensionFilterViewModel> OnSelectionChanged { get; set; }
+
+    // Prevent magic string for dictionary keys
+    public const string KeyForDimensionValue = "dimensionValue";
+    public const string KeyForIsIncludedInFilters = "isIncludedInFilters";
+
+    // When some filter value is selected which is not visible (overflowed)
+    // we reorder it to the top of the list. For doing so we use this counter
+    // to assign decremental negative number to the Order property of
+    // DimensionValueViewModel
+    private int _reOrderingCounter;
+    private readonly Dictionary<DimensionValueViewModel, int> _originalOrdersByTag = [];
+
+    protected override void OnInitialized()
+    {
+        // Subscribe to external state changes (e.g., popover checkbox toggles)
+        // so this component re-renders when selections change outside of inline tag clicks.
+        Filter.NotifyStateChanged += OnFilterStateChanged;
+    }
+
+    private void OnFilterStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnTagSelectionChangedAsync(DimensionValueViewModel tag, bool isChecked)
+    {
+        if (isChecked)
+        {
+            if (Filter.OverflowedValues.Contains(tag))
+            {
+                // reorder tag
+                _reOrderingCounter++;
+                _originalOrdersByTag.TryAdd(tag, tag.Order);
+                tag.Order = -_reOrderingCounter;
+            }
+        }
+
+        Filter.OnTagSelectionChanged(tag, isChecked);
+        if (Filter.AreAllValuesSelected is true)
+        {
+            RestoreTagOrders(Filter.Values);
+        }
+        else if (!isChecked)
+        {
+            RestoreTagOrder(tag);
+        }
+
+        await OnSelectionChanged.InvokeAsync(Filter);
+    }
+
+    private async Task OnTagKeyDownAsync(KeyboardEventArgs args, DimensionValueViewModel tag, bool isChecked)
+    {
+        if (args.Key is "Enter" or " ")
+        {
+            await OnTagSelectionChangedAsync(tag, isChecked);
+        }
+    }
+
+    private Task OnOverflowTagKeyDownAsync(KeyboardEventArgs args)
+    {
+        if (args.Key is "Enter" or " ")
+        {
+            Filter.PopupVisible = true;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void RestoreTagOrders(IEnumerable<DimensionValueViewModel> tags)
+    {
+        foreach (var tag in tags)
+        {
+            RestoreTagOrder(tag);
+        }
+    }
+
+    private void RestoreTagOrder(DimensionValueViewModel tag)
+    {
+        if (_originalOrdersByTag.Remove(tag, out var originalOrder))
+        {
+            tag.Order = originalOrder;
+        }
+    }
+
+    public void HandleOverflowChanged(IEnumerable<FluentOverflowItem> overflowItems)
+    {
+        var overflowedValues = overflowItems
+            .Select(i => (DimensionValueViewModel)i.AdditionalAttributes![KeyForDimensionValue])
+            .ToArray();
+
+        Filter.OverflowedValues = overflowedValues;
+    }
+
+    public void Dispose()
+    {
+        Filter.NotifyStateChanged -= OnFilterStateChanged;
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Aspire.Dashboard.Model;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -31,13 +32,6 @@ public partial class ChartFilterTags : IDisposable
     // the DOM, avoiding hundreds of elements triggering an expensive forced reflow.
     private const int MaxRenderedTags = 20;
 
-    // When some filter value is selected which is not visible (overflowed)
-    // we reorder it to the top of the list. For doing so we use this counter
-    // to assign decremental negative number to the Order property of
-    // DimensionValueViewModel
-    private int _reOrderingCounter;
-    private readonly Dictionary<DimensionValueViewModel, int> _originalOrdersByTag = [];
-
     protected override void OnInitialized()
     {
         // Subscribe to external state changes (e.g., popover checkbox toggles)
@@ -52,27 +46,7 @@ public partial class ChartFilterTags : IDisposable
 
     private async Task OnTagSelectionChangedAsync(DimensionValueViewModel tag, bool isChecked)
     {
-        if (isChecked)
-        {
-            if (Filter.OverflowedValues.Contains(tag))
-            {
-                // reorder tag
-                _reOrderingCounter++;
-                _originalOrdersByTag.TryAdd(tag, tag.Order);
-                tag.Order = -_reOrderingCounter;
-            }
-        }
-
         Filter.OnTagSelectionChanged(tag, isChecked);
-        if (Filter.AreAllValuesSelected is true)
-        {
-            RestoreTagOrders(Filter.Values);
-        }
-        else if (!isChecked)
-        {
-            RestoreTagOrder(tag);
-        }
-
         await OnSelectionChanged.InvokeAsync(Filter);
     }
 
@@ -94,22 +68,6 @@ public partial class ChartFilterTags : IDisposable
         return Task.CompletedTask;
     }
 
-    private void RestoreTagOrders(IEnumerable<DimensionValueViewModel> tags)
-    {
-        foreach (var tag in tags)
-        {
-            RestoreTagOrder(tag);
-        }
-    }
-
-    private void RestoreTagOrder(DimensionValueViewModel tag)
-    {
-        if (_originalOrdersByTag.Remove(tag, out var originalOrder))
-        {
-            tag.Order = originalOrder;
-        }
-    }
-
     public void HandleOverflowChanged(IEnumerable<FluentOverflowItem> overflowItems)
     {
         var overflowedFromComponent = overflowItems
@@ -117,11 +75,41 @@ public partial class ChartFilterTags : IDisposable
             .ToArray();
 
         // Items beyond MaxRenderedTags are always overflowed since they aren't rendered
-        // in the FluentOverflow. Include them so the reordering logic works when a
-        // pre-overflowed tag is selected via the popover.
-        var preOverflowed = Filter.Values.OrderBy(v => v.Order).Skip(MaxRenderedTags);
+        // in the FluentOverflow. Include them so the pre-overflowed items appear in the
+        // "+N" badge and popover.
+        var preOverflowed = GetOrderedValues(Filter.Values).Skip(MaxRenderedTags);
 
         Filter.OverflowedValues = [.. overflowedFromComponent, .. preOverflowed];
+    }
+
+    /// <summary>
+    /// Orders dimension values numerically if all values are parsable as doubles;
+    /// otherwise orders alphabetically by text.
+    /// </summary>
+    internal static IEnumerable<DimensionValueViewModel> GetOrderedValues(IReadOnlyList<DimensionValueViewModel> values)
+    {
+        var parsed = new double[values.Count];
+        var allNumeric = true;
+
+        for (var i = 0; i < values.Count; i++)
+        {
+            if (double.TryParse(values[i].Value, CultureInfo.InvariantCulture, out var d))
+            {
+                parsed[i] = d;
+            }
+            else
+            {
+                allNumeric = false;
+                break;
+            }
+        }
+
+        if (allNumeric)
+        {
+            return values.Zip(parsed).OrderBy(pair => pair.Second).Select(pair => pair.First);
+        }
+
+        return values.OrderBy(v => v.Text, StringComparer.OrdinalIgnoreCase);
     }
 
     public void Dispose()

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using Aspire.Dashboard.Model;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components;
 
@@ -72,20 +71,6 @@ public partial class ChartFilterTags : IDisposable
         }
 
         return Task.CompletedTask;
-    }
-
-    public void HandleOverflowChanged(IEnumerable<FluentOverflowItem> overflowItems)
-    {
-        var overflowedFromComponent = overflowItems
-            .Select(i => (DimensionValueViewModel)i.AdditionalAttributes![KeyForDimensionValue])
-            .ToArray();
-
-        // Items beyond MaxRenderedTags are always overflowed since they aren't rendered
-        // in the FluentOverflow. Include them so the pre-overflowed items appear in the
-        // "+N" badge and popover.
-        var preOverflowed = GetOrderedValues(Filter.Values).Skip(MaxRenderedTags);
-
-        Filter.OverflowedValues = [.. overflowedFromComponent, .. preOverflowed];
     }
 
     /// <summary>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
@@ -23,8 +23,8 @@ public partial class ChartFilterTags : IDisposable
     public required EventCallback<DimensionFilterViewModel> OnSelectionChanged { get; set; }
 
     // Prevent magic string for dictionary keys
-    public const string KeyForDimensionValue = "dimensionValue";
-    public const string KeyForIsIncludedInFilters = "isIncludedInFilters";
+    private const string KeyForDimensionValue = "dimensionValue";
+    private const string KeyForIsIncludedInFilters = "isIncludedInFilters";
 
     // Maximum number of tags to render in the FluentOverflow. The visible area fits ~5-7 tags;
     // rendering 20 gives FluentOverflow enough items to measure correctly. Items beyond this

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
@@ -58,11 +58,17 @@ public partial class ChartFilterTags : IDisposable
         }
     }
 
+    private void ShowPopover()
+    {
+        Filter.PopupVisible = true;
+        Filter.NotifyStateChanged?.Invoke();
+    }
+
     private Task OnOverflowTagKeyDownAsync(KeyboardEventArgs args)
     {
         if (args.Key is "Enter" or " ")
         {
-            Filter.PopupVisible = true;
+            ShowPopover();
         }
 
         return Task.CompletedTask;

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.css
@@ -1,4 +1,4 @@
-::deep .dimension-tag {
+.dimension-tag {
     border-radius: calc(var(--control-corner-radius)* 1px);
     padding: calc(((var(--design-unit)* 0.5) - var(--stroke-width))* 1px) calc((var(--design-unit) - var(--stroke-width))* 1px);
     border: calc(var(--stroke-width)* 1px) solid transparent;

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.css
@@ -14,6 +14,7 @@
 
 .filter-value-tag {
     cursor: pointer;
+    user-select: none;
 }
 
 .filter-value-tag:hover {

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
@@ -16,53 +16,7 @@
                 <ChildContent>
                     <AspirePropertyColumn Tooltip="true" TooltipText="@(c => c.Name)" Property="@(c => c.Name)"/>
                     <AspireTemplateColumn Tooltip="true" TooltipText="@(c => c.AreAllValuesSelected is true ? Loc[nameof(ControlsStrings.LabelAll)] : string.Join(", ", c.SelectedValues.OrderBy(v => v.Text).Select(v => v.Text)))">
-                        <FluentOverflow Class="dimension-overflow" OnOverflowRaised="@(items => HandleOverflowChanged(context, items))">
-                            <ChildContent>
-                                @{
-                                    var i = 0;
-                                }
-                                @foreach (var item in context.Values.OrderBy(v => v.Order))
-                                {
-                                    var isIncludedInFilters = context.SelectedValues.Contains(item);
-                                    var isIncludedInFiltersClass = isIncludedInFilters ? "included-in-filters" : "";
-                                    var additionalAttributes = new Dictionary<string, object>()
-                                    {
-                                        [KeyForDimensionValue] = item,
-                                        [KeyForIsIncludedInFilters] = isIncludedInFilters,
-                                    };
-
-                                    // Always display the first item by setting a fixed value.
-                                    <FluentOverflowItem Fixed="@((i == 0) ? OverflowItemFixed.Ellipsis : OverflowItemFixed.None)" AdditionalAttributes="additionalAttributes">
-                                        <span class="dimension-tag filter-value-tag @isIncludedInFiltersClass"
-                                              role="button"
-                                              tabindex="0"
-                                              aria-pressed="@isIncludedInFilters"
-                                              @onclick="@(() => OnTagSelectionChangedAsync(context, item, !context.SelectedValues.Contains(item)))"
-                                              @onkeydown="@(args => OnTagKeyDownAsync(args, context, item, !context.SelectedValues.Contains(item)))">
-                                            @item.Text
-                                        </span>
-                                    </FluentOverflowItem>
-                                    i++;
-                                }
-                            </ChildContent>
-                            <MoreButtonTemplate Context="overflow">
-                                @{
-                                    var isIncludedInFiltersClass = overflow.ItemsOverflow.Any(item => (bool)item.AdditionalAttributes![KeyForIsIncludedInFilters]) ? "included-in-filters" : "";
-                                }
-                                @* Display must be inline block so the width is correctly calculated. *@
-                                <span class="dimension-tag filter-value-tag @isIncludedInFiltersClass"
-                                      role="button"
-                                      tabindex="0"
-                                      style="display:inline-block;"
-                                      @onclick="@(() => context.PopupVisible = true)"
-                                      @onkeydown="@(args => OnOverflowTagKeyDownAsync(args, context))">
-                                    @($"+{overflow.ItemsOverflow.Count()}")
-                                </span>
-                            </MoreButtonTemplate>
-                            <OverflowTemplate Context="overflow">
-                                @* Intentionally empty. Don't display an overflow template here. *@
-                            </OverflowTemplate>
-                        </FluentOverflow>
+                        <ChartFilterTags @key="context" Filter="context" OnSelectionChanged="OnDimensionValuesChanged" />
                     </AspireTemplateColumn>
                     <AspireTemplateColumn>
                         @{
@@ -91,7 +45,7 @@
                                                         title="@tag.Text"
                                                         @key=tag
                                                         @bind-Value:get="isChecked"
-                                                        @bind-Value:set="c => OnTagSelectionChangedAsync(context, tag, c)"/>
+                                                        @bind-Value:set="c => OnPopoverTagSelectionChangedAsync(context, tag, c)"/>
                                     }
                                 </FluentStack>
                             </Body>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
@@ -15,7 +15,7 @@
                             RowSize="DataGridRowSize.Medium">
                 <ChildContent>
                     <AspirePropertyColumn Tooltip="true" TooltipText="@(c => c.Name)" Property="@(c => c.Name)"/>
-                    <AspireTemplateColumn Tooltip="true" TooltipText="@(c => c.AreAllValuesSelected is true ? Loc[nameof(ControlsStrings.LabelAll)] : string.Join(", ", ChartFilterTags.GetOrderedValues(c.SelectedValues.ToList()).Select(v => v.Text)))">
+                    <AspireTemplateColumn>
                         <ChartFilterTags @key="context" Filter="context" OnSelectionChanged="OnDimensionValuesChanged" />
                     </AspireTemplateColumn>
                     <AspireTemplateColumn>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
@@ -15,7 +15,7 @@
                             RowSize="DataGridRowSize.Medium">
                 <ChildContent>
                     <AspirePropertyColumn Tooltip="true" TooltipText="@(c => c.Name)" Property="@(c => c.Name)"/>
-                    <AspireTemplateColumn Tooltip="true" TooltipText="@(c => c.AreAllValuesSelected is true ? Loc[nameof(ControlsStrings.LabelAll)] : string.Join(", ", c.SelectedValues.OrderBy(v => v.Text).Select(v => v.Text)))">
+                    <AspireTemplateColumn Tooltip="true" TooltipText="@(c => c.AreAllValuesSelected is true ? Loc[nameof(ControlsStrings.LabelAll)] : string.Join(", ", ChartFilterTags.GetOrderedValues(c.SelectedValues.ToList()).Select(v => v.Text)))">
                         <ChartFilterTags @key="context" Filter="context" OnSelectionChanged="OnDimensionValuesChanged" />
                     </AspireTemplateColumn>
                     <AspireTemplateColumn>
@@ -38,7 +38,7 @@
                                                     ThreeStateOrderUncheckToIntermediate="true"
                                                     @bind-CheckState:get="context.AreAllValuesSelected"
                                                     @bind-CheckState:set="@(v => OnAllValuesSelectionChangedAsync(context, v))"/>
-                                    @foreach (var tag in context.Values.OrderBy(v => v.Text))
+                                    @foreach (var tag in ChartFilterTags.GetOrderedValues(context.Values))
                                     {
                                         var isChecked = context.SelectedValues.Contains(tag);
                                         <FluentCheckbox Label="@tag.Text"

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
@@ -19,37 +19,7 @@
                         <ChartFilterTags @key="context" Filter="context" OnSelectionChanged="OnDimensionValuesChanged" />
                     </AspireTemplateColumn>
                     <AspireTemplateColumn>
-                        @{
-                            var id = $"typeFilterButton-{context.SanitizedHtmlId}-{Guid.NewGuid()}";
-                        }
-                        <FluentButton id="@id"
-                                      IconEnd="@(new Icons.Regular.Size20.Filter())"
-                                      Appearance="@(context.AreAllValuesSelected is true ? Appearance.Stealth : Appearance.Accent)"
-                                      @onclick="() => context.PopupVisible = !context.PopupVisible"
-                                      aria-label="@(context.AreAllValuesSelected is true ? Loc[nameof(ControlsStrings.ChartContainerAllTags)] : Loc[nameof(ControlsStrings.ChartContainerFilteredTags)])" />
-                        @* Each item is approximately 36px tall, plus 48px for the header and container padding. Include the always-rendered "All" checkbox row. The popover body has a CSS max-height of 300px. *@
-                        <FluentPopover AnchorId="@id" @bind-Open="context.PopupVisible" VerticalThreshold="@(Math.Min((context.Values.Count + 1) * 36 + 48, 300))" AutoFocus="false">
-                            <Header>@context.Name</Header>
-                            <Body>
-                                <FluentStack Orientation="Orientation.Vertical" Class="dimension-popup">
-                                    <FluentCheckbox Label="@Loc[nameof(ControlsStrings.LabelAll)]"
-                                                    ThreeState="true"
-                                                    ShowIndeterminate="false"
-                                                    ThreeStateOrderUncheckToIntermediate="true"
-                                                    @bind-CheckState:get="context.AreAllValuesSelected"
-                                                    @bind-CheckState:set="@(v => OnAllValuesSelectionChangedAsync(context, v))"/>
-                                    @foreach (var tag in ChartFilterTags.GetOrderedValues(context.Values))
-                                    {
-                                        var isChecked = context.SelectedValues.Contains(tag);
-                                        <FluentCheckbox Label="@tag.Text"
-                                                        title="@tag.Text"
-                                                        @key=tag
-                                                        @bind-Value:get="isChecked"
-                                                        @bind-Value:set="c => OnPopoverTagSelectionChangedAsync(context, tag, c)"/>
-                                    }
-                                </FluentStack>
-                            </Body>
-                        </FluentPopover>
+                        <ChartFilterPopover @key="context" Filter="context" OnSelectionChanged="OnDimensionValuesChanged" />
                     </AspireTemplateColumn>
                 </ChildContent>
             </FluentDataGrid>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor.cs
@@ -37,24 +37,4 @@ public partial class ChartFilters
     {
         InstrumentViewModel.ShowCount = ShowCounts;
     }
-
-    private async Task OnPopoverTagSelectionChangedAsync(DimensionFilterViewModel context, DimensionValueViewModel tag, bool isChecked)
-    {
-        context.OnTagSelectionChanged(tag, isChecked);
-
-        // Notify the ChartFilterTags component for this row to re-render with updated selections.
-        context.NotifyStateChanged?.Invoke();
-
-        await OnDimensionValuesChanged.InvokeAsync(context);
-    }
-
-    private async Task OnAllValuesSelectionChangedAsync(DimensionFilterViewModel context, bool? isChecked)
-    {
-        context.AreAllValuesSelected = isChecked;
-
-        // Notify the ChartFilterTags component for this row to re-render with updated selections.
-        context.NotifyStateChanged?.Invoke();
-
-        await OnDimensionValuesChanged.InvokeAsync(context);
-    }
 }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor.cs
@@ -5,8 +5,6 @@ using System.Collections.Immutable;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Microsoft.AspNetCore.Components;
-using Microsoft.FluentUI.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 
 namespace Aspire.Dashboard.Components;
 
@@ -26,17 +24,6 @@ public partial class ChartFilters
 
     public bool ShowCounts { get; set; }
 
-    // When some filter value is selected which is not visible (overflowed)
-    // we reorder it to the top of the list. For doing so we use this counter
-    // to assign decremental negative number to the Order property of
-    // DimensionValueViewModel
-    private int _reOrderingCounter;
-    private readonly Dictionary<DimensionValueViewModel, int> _originalOrdersByTag = [];
-
-    // Prevent magic string for dictionary keys
-    private const string KeyForDimensionValue = "dimensionValue";
-    private const string KeyForIsIncludedInFilters = "isIncludedInFilters";
-
     protected override void OnInitialized()
     {
         InstrumentViewModel.DataUpdateSubscriptions.Add(() =>
@@ -51,81 +38,23 @@ public partial class ChartFilters
         InstrumentViewModel.ShowCount = ShowCounts;
     }
 
-    private async Task OnTagSelectionChangedAsync(DimensionFilterViewModel context, DimensionValueViewModel tag, bool isChecked)
+    private async Task OnPopoverTagSelectionChangedAsync(DimensionFilterViewModel context, DimensionValueViewModel tag, bool isChecked)
     {
-        if (isChecked)
-        {
-            if (context.OverflowedValues.Contains(tag))
-            {
-                // reorder tag
-                _reOrderingCounter++;
-                _originalOrdersByTag.TryAdd(tag, tag.Order);
-                tag.Order = -_reOrderingCounter;
-            }
-        }
-
         context.OnTagSelectionChanged(tag, isChecked);
-        if (context.AreAllValuesSelected is true)
-        {
-            RestoreTagOrders(context.Values);
-        }
-        else if (!isChecked)
-        {
-            RestoreTagOrder(tag);
-        }
+
+        // Notify the ChartFilterTags component for this row to re-render with updated selections.
+        context.NotifyStateChanged?.Invoke();
 
         await OnDimensionValuesChanged.InvokeAsync(context);
-    }
-
-    private async Task OnTagKeyDownAsync(KeyboardEventArgs args, DimensionFilterViewModel context, DimensionValueViewModel tag, bool isChecked)
-    {
-        if (IsActivationKey(args))
-        {
-            await OnTagSelectionChangedAsync(context, tag, isChecked);
-        }
-    }
-
-    private static Task OnOverflowTagKeyDownAsync(KeyboardEventArgs args, DimensionFilterViewModel context)
-    {
-        if (IsActivationKey(args))
-        {
-            context.PopupVisible = true;
-        }
-
-        return Task.CompletedTask;
     }
 
     private async Task OnAllValuesSelectionChangedAsync(DimensionFilterViewModel context, bool? isChecked)
     {
         context.AreAllValuesSelected = isChecked;
-        RestoreTagOrders(context.Values);
+
+        // Notify the ChartFilterTags component for this row to re-render with updated selections.
+        context.NotifyStateChanged?.Invoke();
+
         await OnDimensionValuesChanged.InvokeAsync(context);
-    }
-
-    private static bool IsActivationKey(KeyboardEventArgs args) => args.Key is "Enter" or " ";
-
-    private void RestoreTagOrders(IEnumerable<DimensionValueViewModel> tags)
-    {
-        foreach (var tag in tags)
-        {
-            RestoreTagOrder(tag);
-        }
-    }
-
-    private void RestoreTagOrder(DimensionValueViewModel tag)
-    {
-        if (_originalOrdersByTag.Remove(tag, out var originalOrder))
-        {
-            tag.Order = originalOrder;
-        }
-    }
-
-    private static void HandleOverflowChanged(DimensionFilterViewModel context, IEnumerable<FluentOverflowItem> overflowItems)
-    {
-        var overflowedValues = overflowItems
-            .Select(i => (DimensionValueViewModel)i.AdditionalAttributes![KeyForDimensionValue])
-            .ToArray();
-
-        context.OverflowedValues = overflowedValues;
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor.css
@@ -1,0 +1,1 @@
+/* Tag-related styles are in ChartFilterTags.razor.css */

--- a/src/Aspire.Dashboard/Model/DimensionFilterViewModel.cs
+++ b/src/Aspire.Dashboard/Model/DimensionFilterViewModel.cs
@@ -14,7 +14,6 @@ public class DimensionFilterViewModel
     public required string Name { get; init; }
     public List<DimensionValueViewModel> Values { get; } = [];
     public HashSet<DimensionValueViewModel> SelectedValues { get; } = [];
-    public DimensionValueViewModel[] OverflowedValues { get; set; } = [];
     public bool PopupVisible { get; set; }
 
     /// <summary>

--- a/src/Aspire.Dashboard/Model/DimensionFilterViewModel.cs
+++ b/src/Aspire.Dashboard/Model/DimensionFilterViewModel.cs
@@ -77,5 +77,4 @@ public class DimensionValueViewModel
 {
     public required string Text { get; init; }
     public required string? Value { get; init; }
-    public required int Order { get; set; }
 }

--- a/src/Aspire.Dashboard/Model/DimensionFilterViewModel.cs
+++ b/src/Aspire.Dashboard/Model/DimensionFilterViewModel.cs
@@ -17,6 +17,12 @@ public class DimensionFilterViewModel
     public DimensionValueViewModel[] OverflowedValues { get; set; } = [];
     public bool PopupVisible { get; set; }
 
+    /// <summary>
+    /// Invoked when the filter state is modified externally (e.g., from the popover)
+    /// so that subscribed components can re-render.
+    /// </summary>
+    public Action? NotifyStateChanged { get; set; }
+
     public bool? AreAllValuesSelected
     {
         get

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ChartFiltersTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ChartFiltersTests.cs
@@ -18,8 +18,8 @@ public class ChartFiltersTests : DashboardTestContext
     public void AreAllValuesSelected_SetFalse_ClearsOnlyWhenAllValuesAreStored()
     {
         var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
-        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET", Order = 0, });
-        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST", Order = 1, });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET", });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST", });
         dimensionFilter.SelectedValues.Add(dimensionFilter.Values[0]);
         dimensionFilter.SelectedValues.Add(dimensionFilter.Values[1]);
 
@@ -34,8 +34,8 @@ public class ChartFiltersTests : DashboardTestContext
     public void AreAllValuesSelected_SetFalse_DoesNotClearWhenPartiallySelected()
     {
         var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
-        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET", Order = 0, });
-        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST", Order = 1, });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET", });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST", });
         dimensionFilter.SelectedValues.Add(dimensionFilter.Values[0]);
 
         Assert.Null(dimensionFilter.AreAllValuesSelected);
@@ -50,8 +50,8 @@ public class ChartFiltersTests : DashboardTestContext
     public void AreAllValuesSelected_SetTrue_SelectsAllValues()
     {
         var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
-        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET", Order = 0, });
-        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST", Order = 1, });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET", });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST", });
         dimensionFilter.SelectedValues.Add(dimensionFilter.Values[0]);
 
         dimensionFilter.AreAllValuesSelected = true;
@@ -64,8 +64,8 @@ public class ChartFiltersTests : DashboardTestContext
     public void OnTagSelectionChanged_RemovesValue_LeavesOthersSelected()
     {
         var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
-        var getValue = new DimensionValueViewModel { Text = "GET", Value = "GET", Order = 0, };
-        var postValue = new DimensionValueViewModel { Text = "POST", Value = "POST", Order = 1, };
+        var getValue = new DimensionValueViewModel { Text = "GET", Value = "GET", };
+        var postValue = new DimensionValueViewModel { Text = "POST", Value = "POST", };
         dimensionFilter.Values.Add(getValue);
         dimensionFilter.Values.Add(postValue);
         dimensionFilter.SelectedValues.Add(getValue);
@@ -112,22 +112,30 @@ public class ChartFiltersTests : DashboardTestContext
     }
 
     [Fact]
-    public void Render_DeselectedOverflowTag_RestoresOriginalOrder()
+    public void GetOrderedValues_NumericValues_OrdersNumerically()
     {
-        SetupChartFilters();
-        var dimensionFilter = CreateDimensionFilter();
-        var overflowedTag = dimensionFilter.Values.Single(v => v.Text == "POST");
-        dimensionFilter.OverflowedValues = [overflowedTag];
-        var originalOrder = overflowedTag.Order;
+        var dimensionFilter = new DimensionFilterViewModel { Name = "http.status_code" };
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "200", Value = "200", });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "404", Value = "404", });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "50", Value = "50", });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "1000", Value = "1000", });
 
-        var cut = RenderChartFilters(dimensionFilter);
-        cut.FindAll(".filter-value-tag").Single(e => e.TextContent.Trim() == "POST").Click();
+        var ordered = ChartFilterTags.GetOrderedValues(dimensionFilter.Values).Select(v => v.Text).ToList();
 
-        Assert.NotEqual(originalOrder, overflowedTag.Order);
+        Assert.Equal(["50", "200", "404", "1000"], ordered);
+    }
 
-        cut.FindAll(".filter-value-tag").Single(e => e.TextContent.Trim() == "POST").Click();
+    [Fact]
+    public void GetOrderedValues_TextValues_OrdersAlphabetically()
+    {
+        var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST", });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET", });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "DELETE", Value = "DELETE", });
 
-        Assert.Equal(originalOrder, overflowedTag.Order);
+        var ordered = ChartFilterTags.GetOrderedValues(dimensionFilter.Values).Select(v => v.Text).ToList();
+
+        Assert.Equal(["DELETE", "GET", "POST"], ordered);
     }
 
     private IRenderedComponent<ChartFilters> RenderChartFilters(DimensionFilterViewModel dimensionFilter, Action<DimensionFilterViewModel>? onDimensionValuesChanged = null)
@@ -157,8 +165,8 @@ public class ChartFiltersTests : DashboardTestContext
     private static DimensionFilterViewModel CreateDimensionFilter()
     {
         var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
-        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET", Order = 0, });
-        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST", Order = 1, });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET", });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST", });
 
         return dimensionFilter;
     }


### PR DESCRIPTION
## Description

Improves dashboard metrics chart filter rendering when a dimension has many tag values (hundreds). Previously this could cause a SignalR disconnect because `FluentOverflow` rendered all values as DOM elements, triggering an expensive forced browser reflow that blocked the UI thread.

### Key changes

1. **Extract `ChartFilterTags` component** — Moves the per-row FluentOverflow tag list into its own component so that clicking a tag only re-renders that single row, not all sibling rows in the `FluentDataGrid`.

2. **Cap rendered tags at 20** — Only the first 20 ordered values are rendered inside `FluentOverflow`. Items beyond the limit are treated as pre-overflowed and counted in the "+N" badge without being added to the DOM. This prevents hundreds of `FluentOverflowItem` elements from triggering a forced reflow that kills the SignalR connection.

3. **Remove tag reordering, order by number when possible** — Removes the reorder-on-select logic from PR #18199 (`_reOrderingCounter`, `_originalOrdersByTag`, `Order` property). Instead, values are ordered numerically if all values parse as doubles, otherwise alphabetically by text. The same ordering is used consistently in both the inline tags and the filter popup.

4. **Remove `Order` property from `DimensionValueViewModel`** — No longer needed since ordering is computed on-the-fly by `ChartFilterTags.GetOrderedValues`.

### Screenshots / Recordings

<img width="1719" height="811" alt="metrics-tags" src="https://github.com/user-attachments/assets/27803bfc-949d-4a67-9eda-91dbca0c6e11" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
