### PR TITLE
Cap rendered items in UrlsColumnDisplay to prevent SignalR disconnect

### DIFF
--- a/playground/Stress/Stress.AppHost/AppHost.cs
+++ b/playground/Stress/Stress.AppHost/AppHost.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -83,6 +84,11 @@ var telemetryBuilder = builder.AddProject<Projects.Stress_TelemetryService>("str
        .WithUrls(c => c.Urls.Add(new() { Url = "https://someplace.com", DisplayText = "Some place" }))
        .WithUrl("https://someotherplace.com/some-path", "Some other place")
        .WithUrl("https://extremely-long-url.com/abcdefghijklmnopqrstuvwxyz/abcdefghijklmnopqrstuvwxyz/abcdefghijklmnopqrstuvwxyz//abcdefghijklmnopqrstuvwxyz/abcdefghijklmnopqrstuvwxyz/abcdefghijklmnopqrstuvwxyz/abcdefghijklmnopqrstuvwxyz/abcdefghijklmno");
+
+for (var i = 0; i < 500; i++)
+{
+    telemetryBuilder.WithUrl($"https://example.com/service-{i.ToString(CultureInfo.InvariantCulture)}", $"Service {i}");
+}
 
 builder.AddCommandResources(serviceBuilder, telemetryBuilder);
 

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
@@ -11,11 +11,18 @@ else if (DisplayedUrls.Count == 1)
 }
 else if (DisplayedUrls.Count > 1)
 {
+    // Only render a limited number of items in the FluentOverflow to avoid expensive
+    // browser layout calculations. Rendering all items as DOM elements triggers a forced
+    // reflow long enough to kill the SignalR connection when there are hundreds of URLs.
+    var maxRenderedUrls = 20;
+    var renderedUrls = DisplayedUrls.Take(maxRenderedUrls).ToList();
+    var preOverflowedCount = DisplayedUrls.Count - renderedUrls.Count;
+
     <FluentOverflow Class="url-overflow">
         <ChildContent>
-            @for (var i = 0; i < DisplayedUrls.Count; i++)
+            @for (var i = 0; i < renderedUrls.Count; i++)
             {
-                var displayedUrl = DisplayedUrls[i];
+                var displayedUrl = renderedUrls[i];
 
                  // Always display the first item by setting a fixed value.
                 <FluentOverflowItem Data="displayedUrl" Fixed="@(i == 0 ? OverflowItemFixed.Ellipsis : OverflowItemFixed.None)">
@@ -26,13 +33,13 @@ else if (DisplayedUrls.Count > 1)
         <MoreButtonTemplate Context="overflow">
             <div @onclick:stopPropagation="true" style="display:inherit;">
                 <FluentButton Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="url-button">
-                    @($"+{overflow.ItemsOverflow.Count()}")
+                    @($"+{overflow.ItemsOverflow.Count() + preOverflowedCount}")
                 </FluentButton>
             </div>
         </MoreButtonTemplate>
         <OverflowTemplate Context="overflow">
             @{
-                var items = overflow.ItemsOverflow.ToList();
+                var items = overflow.ItemsOverflow.Select(i => (DisplayedUrl)i.Data!).Concat(DisplayedUrls.Skip(maxRenderedUrls)).ToList();
             }
             <div @onclick:stopPropagation="true">
                 @* Each item is approximately 36px tall, plus 48px for the header and container padding. The popover body has a CSS max-height of 300px. *@
@@ -44,9 +51,8 @@ else if (DisplayedUrls.Count > 1)
                         <div class="url-popup">
                             @foreach (var item in items)
                             {
-                                var d = (DisplayedUrl)item.Data!;
                                 <div class="url-link">
-                                    @WriteUrl(d)
+                                    @WriteUrl(item)
                                 </div>
                             }
                         </div>

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/UrlsColumnDisplayTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/UrlsColumnDisplayTests.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
+using Aspire.Tests.Shared.DashboardModel;
 using Bunit;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
@@ -23,36 +23,8 @@ public class UrlsColumnDisplayTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentOverflow(this);
         FluentUISetupHelpers.AddCommonDashboardServices(this);
 
-        var displayedUrls = Enumerable.Range(0, totalUrls).Select(i => new DisplayedUrl
-        {
-            Index = i,
-            Name = $"https-{i}",
-            Text = $"Endpoint {i}",
-            Url = $"https://localhost:{5000 + i}",
-            OriginalUrlString = $"https://localhost:{5000 + i}"
-        }).ToList<DisplayedUrl>();
-
-        var resource = new ResourceViewModel
-        {
-            Name = "test-resource",
-            ResourceType = "Project",
-            DisplayName = "test-resource",
-            Uid = "test-resource-uid",
-            ReplicaIndex = 0,
-            State = "Running",
-            KnownState = KnownResourceState.Running,
-            StateStyle = null,
-            CreationTimeStamp = null,
-            StartTimeStamp = null,
-            StopTimeStamp = null,
-            Environment = [],
-            Urls = [],
-            Volumes = [],
-            Relationships = [],
-            Properties = ImmutableDictionary<string, ResourcePropertyViewModel>.Empty,
-            Commands = [],
-            HealthReports = [],
-        };
+        var displayedUrls = CreateDisplayedUrls(totalUrls);
+        var resource = ModelTestHelpers.CreateResource(resourceName: "test-resource", resourceType: "Project", state: KnownResourceState.Running);
 
         // Act
         var cut = RenderComponent<UrlsColumnDisplay>(builder =>
@@ -77,36 +49,8 @@ public class UrlsColumnDisplayTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentOverflow(this);
         FluentUISetupHelpers.AddCommonDashboardServices(this);
 
-        var displayedUrls = Enumerable.Range(0, totalUrls).Select(i => new DisplayedUrl
-        {
-            Index = i,
-            Name = $"https-{i}",
-            Text = $"Endpoint {i}",
-            Url = $"https://localhost:{5000 + i}",
-            OriginalUrlString = $"https://localhost:{5000 + i}"
-        }).ToList<DisplayedUrl>();
-
-        var resource = new ResourceViewModel
-        {
-            Name = "test-resource",
-            ResourceType = "Project",
-            DisplayName = "test-resource",
-            Uid = "test-resource-uid",
-            ReplicaIndex = 0,
-            State = "Running",
-            KnownState = KnownResourceState.Running,
-            StateStyle = null,
-            CreationTimeStamp = null,
-            StartTimeStamp = null,
-            StopTimeStamp = null,
-            Environment = [],
-            Urls = [],
-            Volumes = [],
-            Relationships = [],
-            Properties = ImmutableDictionary<string, ResourcePropertyViewModel>.Empty,
-            Commands = [],
-            HealthReports = [],
-        };
+        var displayedUrls = CreateDisplayedUrls(totalUrls);
+        var resource = ModelTestHelpers.CreateResource(resourceName: "test-resource", resourceType: "Project", state: KnownResourceState.Running);
 
         // Act
         var cut = RenderComponent<UrlsColumnDisplay>(builder =>
@@ -119,5 +63,17 @@ public class UrlsColumnDisplayTests : DashboardTestContext
         // Assert
         var overflowItems = cut.FindComponents<FluentOverflowItem>();
         Assert.Equal(totalUrls, overflowItems.Count);
+    }
+
+    private static List<DisplayedUrl> CreateDisplayedUrls(int count)
+    {
+        return Enumerable.Range(0, count).Select(i => new DisplayedUrl
+        {
+            Index = i,
+            Name = $"https-{i}",
+            Text = $"Endpoint {i}",
+            Url = $"https://localhost:{5000 + i}",
+            OriginalUrlString = $"https://localhost:{5000 + i}"
+        }).ToList<DisplayedUrl>();
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/UrlsColumnDisplayTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/UrlsColumnDisplayTests.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Model;
+using Bunit;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Controls;
+
+public class UrlsColumnDisplayTests : DashboardTestContext
+{
+    [Fact]
+    public void Render_MoreThanMaxUrls_CapsRenderedOverflowItems()
+    {
+        // Arrange
+        const int totalUrls = 30;
+        const int maxRenderedUrls = 20;
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        FluentUISetupHelpers.SetupFluentOverflow(this);
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+
+        var displayedUrls = Enumerable.Range(0, totalUrls).Select(i => new DisplayedUrl
+        {
+            Index = i,
+            Name = $"https-{i}",
+            Text = $"Endpoint {i}",
+            Url = $"https://localhost:{5000 + i}",
+            OriginalUrlString = $"https://localhost:{5000 + i}"
+        }).ToList<DisplayedUrl>();
+
+        var resource = new ResourceViewModel
+        {
+            Name = "test-resource",
+            ResourceType = "Project",
+            DisplayName = "test-resource",
+            Uid = "test-resource-uid",
+            ReplicaIndex = 0,
+            State = "Running",
+            KnownState = KnownResourceState.Running,
+            StateStyle = null,
+            CreationTimeStamp = null,
+            StartTimeStamp = null,
+            StopTimeStamp = null,
+            Environment = [],
+            Urls = [],
+            Volumes = [],
+            Relationships = [],
+            Properties = ImmutableDictionary<string, ResourcePropertyViewModel>.Empty,
+            Commands = [],
+            HealthReports = [],
+        };
+
+        // Act
+        var cut = RenderComponent<UrlsColumnDisplay>(builder =>
+        {
+            builder.Add(p => p.Resource, resource);
+            builder.Add(p => p.HasMultipleReplicas, false);
+            builder.Add(p => p.DisplayedUrls, displayedUrls);
+        });
+
+        // Assert
+        var overflowItems = cut.FindComponents<FluentOverflowItem>();
+        Assert.Equal(maxRenderedUrls, overflowItems.Count);
+    }
+
+    [Fact]
+    public void Render_ExactlyMaxUrls_RendersAllItems()
+    {
+        // Arrange
+        const int totalUrls = 20;
+
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        FluentUISetupHelpers.SetupFluentOverflow(this);
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+
+        var displayedUrls = Enumerable.Range(0, totalUrls).Select(i => new DisplayedUrl
+        {
+            Index = i,
+            Name = $"https-{i}",
+            Text = $"Endpoint {i}",
+            Url = $"https://localhost:{5000 + i}",
+            OriginalUrlString = $"https://localhost:{5000 + i}"
+        }).ToList<DisplayedUrl>();
+
+        var resource = new ResourceViewModel
+        {
+            Name = "test-resource",
+            ResourceType = "Project",
+            DisplayName = "test-resource",
+            Uid = "test-resource-uid",
+            ReplicaIndex = 0,
+            State = "Running",
+            KnownState = KnownResourceState.Running,
+            StateStyle = null,
+            CreationTimeStamp = null,
+            StartTimeStamp = null,
+            StopTimeStamp = null,
+            Environment = [],
+            Urls = [],
+            Volumes = [],
+            Relationships = [],
+            Properties = ImmutableDictionary<string, ResourcePropertyViewModel>.Empty,
+            Commands = [],
+            HealthReports = [],
+        };
+
+        // Act
+        var cut = RenderComponent<UrlsColumnDisplay>(builder =>
+        {
+            builder.Add(p => p.Resource, resource);
+            builder.Add(p => p.HasMultipleReplicas, false);
+            builder.Add(p => p.DisplayedUrls, displayedUrls);
+        });
+
+        // Assert
+        var overflowItems = cut.FindComponents<FluentOverflowItem>();
+        Assert.Equal(totalUrls, overflowItems.Count);
+    }
+}


### PR DESCRIPTION
## Description

`FluentOverflow` renders all `FluentOverflowItem` children as DOM elements, then uses JavaScript interop (MutationObserver/ResizeObserver) to detect which overflow. When a resource has hundreds of URLs, the forced browser reflow blocks the UI thread long enough to kill the Blazor Server SignalR connection.

This applies the same fix pattern used in `ChartFilterTags` (PR #18382): cap the rendered `FluentOverflowItem` elements at 20 and treat the remainder as "pre-overflowed" — counted in the `+N` badge and included in the popover without being added to the DOM.

Related upstream issue: microsoft/fluentui-blazor#4949

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No