### PR TITLE
Dashboard: Use fallback icons for commands with unknown or missing icon names

### DIFF
--- a/playground/Stress/Stress.AppHost/CommandResources.cs
+++ b/playground/Stress/Stress.AppHost/CommandResources.cs
@@ -46,6 +46,61 @@ internal static class CommandResources
                 IconName = "CloudDatabase",
                 IsHighlighted = true
             });
+        // Commands with unknown/missing icons to stress test issue #18385.
+        iconCommands.WithCommand(
+            name: "unknown-icon",
+            displayName: "Unknown icon",
+            executeCommand: (c) =>
+            {
+                return Task.FromResult(CommandResults.Success());
+            },
+            commandOptions: new CommandOptions
+            {
+                IconName = "Bracket"
+            });
+        iconCommands.WithCommand(
+            name: "unknown-icon-highlighted",
+            displayName: "Simulate knockout — prediction phase",
+            executeCommand: (c) =>
+            {
+                return Task.FromResult(CommandResults.Success());
+            },
+            commandOptions: new CommandOptions
+            {
+                IconName = "Bracket",
+                IsHighlighted = true
+            });
+        iconCommands.WithCommand(
+            name: "unknown-icon-highlighted-short",
+            displayName: "Short",
+            executeCommand: (c) =>
+            {
+                return Task.FromResult(CommandResults.Success());
+            },
+            commandOptions: new CommandOptions
+            {
+                IconName = "NotARealIconName",
+                IsHighlighted = true
+            });
+        iconCommands.WithCommand(
+            name: "no-icon",
+            displayName: "No icon at all",
+            executeCommand: (c) =>
+            {
+                return Task.FromResult(CommandResults.Success());
+            },
+            commandOptions: new CommandOptions());
+        iconCommands.WithCommand(
+            name: "no-icon-highlighted",
+            displayName: "No icon highlighted with a very long display name to test overflow",
+            executeCommand: (c) =>
+            {
+                return Task.FromResult(CommandResults.Success());
+            },
+            commandOptions: new CommandOptions
+            {
+                IsHighlighted = true
+            });
 
         var argumentCommands = builder.AddCommandGroup("argument-commands", serviceBuilder.Resource);
         argumentCommands.WithCommand(

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -16,9 +16,17 @@
                 {
                     <FluentIcon Value="@icon" Width="16px" />
                 }
+                else if (!string.IsNullOrEmpty(highlightedCommand.IconName))
+                {
+                    @* Icon name was specified but couldn't be resolved. Show a question-mark so the
+                       button stays icon-sized and the actions row doesn't overflow. *@
+                    <FluentIcon Value="@s_unknownIcon" Width="16px" />
+                }
                 else
                 {
-                    @highlightedCommand.GetDisplayName()
+                    @* No icon name provided. Use a default command icon so highlighted commands
+                       always render as icon buttons and never as text labels. *@
+                    <FluentIcon Value="@s_defaultCommandIcon" Width="16px" />
                 }
             </FluentButton>
         }

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -12,22 +12,7 @@
             var highlightedCommand = _highlightedCommands[i];
 
             <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.GetDisplayDescription()) ? highlightedCommand.GetDisplayDescription() : highlightedCommand.GetDisplayName())" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled || IsCommandExecuting(Resource, highlightedCommand))">
-                @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && IconResolver.ResolveIconName(highlightedCommand.IconName, IconSize.Size16, highlightedCommand.IconVariant) is { } icon)
-                {
-                    <FluentIcon Value="@icon" Width="16px" />
-                }
-                else if (!string.IsNullOrEmpty(highlightedCommand.IconName))
-                {
-                    @* Icon name was specified but couldn't be resolved. Show a question-mark so the
-                       button stays icon-sized and the actions row doesn't overflow. *@
-                    <FluentIcon Value="@s_unknownIcon" Width="16px" />
-                }
-                else
-                {
-                    @* No icon name provided. Use a default command icon so highlighted commands
-                       always render as icon buttons and never as text labels. *@
-                    <FluentIcon Value="@s_defaultCommandIcon" Width="16px" />
-                }
+                <FluentIcon Value="@IconResolver.ResolveHighlightedCommandIcon(highlightedCommand.IconName, highlightedCommand.IconVariant)" Width="16px" />
             </FluentButton>
         }
         else

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -15,6 +15,12 @@ public partial class ResourceActions : ComponentBase
 {
     private static readonly Icon s_consoleLogsIcon = new Icons.Regular.Size16.SlideText();
 
+    // Fallback icon when a command specifies an icon name that can't be resolved to a FluentUI icon.
+    private static readonly Icon s_unknownIcon = new Icons.Regular.Size16.QuestionCircle();
+
+    // Default icon for highlighted commands that don't specify any icon name.
+    private static readonly Icon s_defaultCommandIcon = new Icons.Regular.Size16.Flash();
+
     private AspireMenuButton? _menuButton;
 
     [Inject]

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -15,12 +15,6 @@ public partial class ResourceActions : ComponentBase
 {
     private static readonly Icon s_consoleLogsIcon = new Icons.Regular.Size16.SlideText();
 
-    // Fallback icon when a command specifies an icon name that can't be resolved to a FluentUI icon.
-    private static readonly Icon s_unknownIcon = new Icons.Regular.Size16.QuestionCircle();
-
-    // Default icon for highlighted commands that don't specify any icon name.
-    private static readonly Icon s_defaultCommandIcon = new Icons.Regular.Size16.Flash();
-
     private AspireMenuButton? _menuButton;
 
     [Inject]

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -49,14 +49,7 @@
                                   Disabled="@(command.State == CommandViewModelState.Disabled || DashboardCommandExecutor.IsExecuting(selectedResource.Name, command.Name))"
                                   OnClick="@(() => ExecuteResourceCommandAsync(command))"
                                   Class="highlighted-command">
-                        @if (!string.IsNullOrEmpty(command.IconName) && IconResolver.ResolveIconName(command.IconName, IconSize.Size16, command.IconVariant) is { } icon)
-                        {
-                            <FluentIcon Value="@icon" Width="16px" />
-                        }
-                        else
-                        {
-                            @command.GetDisplayName()
-                        }
+                        <FluentIcon Value="@IconResolver.ResolveHighlightedCommandIcon(command.IconName, command.IconVariant)" Width="16px" />
                     </FluentButton>
                 }
 

--- a/src/Aspire.Dashboard/Model/IconResolver.cs
+++ b/src/Aspire.Dashboard/Model/IconResolver.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Model;
 
@@ -13,6 +14,12 @@ public sealed class IconResolver
     private static readonly List<IconSize> s_iconSizes = [IconSize.Size16, IconSize.Size20, IconSize.Size24];
     private readonly ConcurrentDictionary<IconKey, Icon?> _iconCache = new();
     private readonly ILogger<IconResolver> _logger;
+
+    // Fallback icon when a command specifies an icon name that can't be resolved to a FluentUI icon.
+    private static readonly Icon s_unknownCommandIcon = new Icons.Regular.Size16.QuestionCircle();
+
+    // Default icon for highlighted commands that don't specify any icon name.
+    private static readonly Icon s_defaultHighlightedCommandIcon = new Icons.Regular.Size16.Flash();
 
     public IconResolver(ILogger<IconResolver> logger)
     {
@@ -89,5 +96,28 @@ public sealed class IconResolver
         };
 
         return iconInfo.TryGetInstance(out icon);
+    }
+
+    /// <summary>
+    /// Resolves the icon for a command. Returns the resolved icon, a QuestionCircle fallback
+    /// for unrecognized names, or <see langword="null"/> if no icon name is specified.
+    /// </summary>
+    public Icon? ResolveCommandIcon(string? iconName, IconVariant? iconVariant)
+    {
+        if (!string.IsNullOrEmpty(iconName))
+        {
+            return ResolveIconName(iconName, IconSize.Size16, iconVariant) ?? s_unknownCommandIcon;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves the icon for a highlighted command button. Always returns a non-null icon so
+    /// highlighted commands render as compact icon buttons and never as text labels.
+    /// </summary>
+    public Icon ResolveHighlightedCommandIcon(string? iconName, IconVariant? iconVariant)
+    {
+        return ResolveCommandIcon(iconName, iconVariant) ?? s_defaultHighlightedCommandIcon;
     }
 }

--- a/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
@@ -32,6 +32,9 @@ public sealed class ResourceMenuBuilder
     private static readonly Icon s_bracesIcon = new Icons.Regular.Size16.Braces();
     private static readonly Icon s_exportEnvIcon = new Icons.Regular.Size16.DocumentText();
 
+    // Fallback icon shown in the menu when a command specifies an icon name that can't be resolved.
+    private static readonly Icon s_unknownCommandIcon = new Icons.Regular.Size16.QuestionCircle();
+
     private readonly NavigationManager _navigationManager;
     private readonly TelemetryRepository _telemetryRepository;
     private readonly IAIContextProvider _aiContextProvider;
@@ -333,7 +336,16 @@ public sealed class ResourceMenuBuilder
 
         MenuButtonItem CreateMenuItem(CommandViewModel command)
         {
-            var icon = (!string.IsNullOrEmpty(command.IconName) && _iconResolver.ResolveIconName(command.IconName, IconSize.Size16, command.IconVariant) is { } i) ? i : null;
+            Icon? icon;
+            if (!string.IsNullOrEmpty(command.IconName))
+            {
+                // Use the resolved icon, or fall back to a question-mark when the name is unrecognized.
+                icon = _iconResolver.ResolveIconName(command.IconName, IconSize.Size16, command.IconVariant) ?? s_unknownCommandIcon;
+            }
+            else
+            {
+                icon = null;
+            }
 
             return new MenuButtonItem
             {

--- a/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
@@ -32,9 +32,6 @@ public sealed class ResourceMenuBuilder
     private static readonly Icon s_bracesIcon = new Icons.Regular.Size16.Braces();
     private static readonly Icon s_exportEnvIcon = new Icons.Regular.Size16.DocumentText();
 
-    // Fallback icon shown in the menu when a command specifies an icon name that can't be resolved.
-    private static readonly Icon s_unknownCommandIcon = new Icons.Regular.Size16.QuestionCircle();
-
     private readonly NavigationManager _navigationManager;
     private readonly TelemetryRepository _telemetryRepository;
     private readonly IAIContextProvider _aiContextProvider;
@@ -336,22 +333,11 @@ public sealed class ResourceMenuBuilder
 
         MenuButtonItem CreateMenuItem(CommandViewModel command)
         {
-            Icon? icon;
-            if (!string.IsNullOrEmpty(command.IconName))
-            {
-                // Use the resolved icon, or fall back to a question-mark when the name is unrecognized.
-                icon = _iconResolver.ResolveIconName(command.IconName, IconSize.Size16, command.IconVariant) ?? s_unknownCommandIcon;
-            }
-            else
-            {
-                icon = null;
-            }
-
             return new MenuButtonItem
             {
                 Text = command.GetDisplayName(),
                 Tooltip = command.GetDisplayDescription(),
-                Icon = icon,
+                Icon = _iconResolver.ResolveCommandIcon(command.IconName, command.IconVariant),
                 OnClick = () => commandSelected.InvokeAsync(command),
                 IsDisabled = command.State == CommandViewModelState.Disabled || isCommandExecuting(resource, command)
             };

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceMenuBuilderTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceMenuBuilderTests.cs
@@ -298,6 +298,90 @@ public sealed class ResourceMenuBuilderTests
             e => Assert.Equal("Stop", e.Text));
     }
 
+    [Fact]
+    public void AddMenuItems_UnresolvableIconName_UsesFallbackIcon()
+    {
+        // A command with an icon name that doesn't map to any FluentUI icon should
+        // get a QuestionCircle fallback instead of null, preventing the overflow issue in #18385.
+        var command = new CommandViewModel(
+            "test-command",
+            CommandViewModelState.Enabled,
+            "Test Command",
+            "A command with a bad icon name.",
+            confirmationMessage: "",
+            argumentInputs: [],
+            isHighlighted: false,
+            iconName: "NotARealIconName",
+            iconVariant: IconVariant.Regular);
+        var resource = ModelTestHelpers.CreateResource(commands: [command]);
+        var repository = TelemetryTestHelpers.CreateRepository();
+        var aiContextProvider = new TestAIContextProvider();
+        var resourceMenuBuilder = CreateResourceMenuBuilder(repository, aiContextProvider);
+
+        var menuItems = new List<MenuButtonItem>();
+        resourceMenuBuilder.AddMenuItems(
+            menuItems,
+            resource,
+            new Dictionary<string, ResourceViewModel>(StringComparer.OrdinalIgnoreCase) { [resource.Name] = resource },
+            EventCallback.Empty,
+            EventCallback<CommandViewModel>.Empty,
+            (_, _) => false,
+            showViewDetails: false,
+            showConsoleLogsItem: false,
+            showUrls: false);
+
+        Assert.Collection(menuItems,
+            e => Assert.Equal("Localized:ViewJson", e.Text),
+            e => Assert.True(e.IsDivider),
+            e =>
+            {
+                Assert.Equal("Test Command", e.Text);
+                Assert.IsType<Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size16.QuestionCircle>(e.Icon);
+            });
+    }
+
+    [Fact]
+    public void AddMenuItems_NoIconName_IconIsNull()
+    {
+        // A command with no icon name should have a null icon in the menu
+        // (menu items have text labels so no fallback icon is needed).
+        var command = new CommandViewModel(
+            "test-command",
+            CommandViewModelState.Enabled,
+            "Test Command",
+            "A command with no icon.",
+            confirmationMessage: "",
+            argumentInputs: [],
+            isHighlighted: false,
+            iconName: string.Empty,
+            iconVariant: IconVariant.Regular);
+        var resource = ModelTestHelpers.CreateResource(commands: [command]);
+        var repository = TelemetryTestHelpers.CreateRepository();
+        var aiContextProvider = new TestAIContextProvider();
+        var resourceMenuBuilder = CreateResourceMenuBuilder(repository, aiContextProvider);
+
+        var menuItems = new List<MenuButtonItem>();
+        resourceMenuBuilder.AddMenuItems(
+            menuItems,
+            resource,
+            new Dictionary<string, ResourceViewModel>(StringComparer.OrdinalIgnoreCase) { [resource.Name] = resource },
+            EventCallback.Empty,
+            EventCallback<CommandViewModel>.Empty,
+            (_, _) => false,
+            showViewDetails: false,
+            showConsoleLogsItem: false,
+            showUrls: false);
+
+        Assert.Collection(menuItems,
+            e => Assert.Equal("Localized:ViewJson", e.Text),
+            e => Assert.True(e.IsDivider),
+            e =>
+            {
+                Assert.Equal("Test Command", e.Text);
+                Assert.Null(e.Icon);
+            });
+    }
+
     private sealed class TestNavigationManager : NavigationManager
     {
     }


### PR DESCRIPTION
## Description

When a resource command has `isHighlighted: true` and specifies an `iconName` that isn't a valid FluentUI icon name, the dashboard previously rendered the command's `displayName` as a text label in the inline button slot. A long label could widen the resource row past the viewport, pushing the `...` overflow actions menu off-screen with no way to reach it.

This PR adds fallback icon handling so the actions row never overflows due to unresolvable or missing icon names:

- **Unknown icon name** (e.g. `"Bracket"`): renders a `QuestionCircle` icon instead of the raw display name text.
- **No icon name specified**: highlighted commands now use a default `Flash` icon so they always render as compact icon buttons.

Both the inline highlighted buttons (`ResourceActions.razor`) and the overflow menu items (`ResourceMenuBuilder.cs`) use the same fallback strategy.

### Screenshots / Recordings

<img width="730" height="517" alt="image" src="https://github.com/user-attachments/assets/014ba902-c2e4-4a8a-a376-c376f18cdbe6" />

### Testing

The Stress playground AppHost now includes commands with invalid/missing icon names to exercise all fallback paths:
- `unknown-icon` — invalid icon name `"Bracket"`, not highlighted
- `unknown-icon-highlighted` — invalid icon name, highlighted, long display name (direct repro from issue)
- `unknown-icon-highlighted-short` — invalid icon name, highlighted, short label
- `no-icon` — no icon name, not highlighted
- `no-icon-highlighted` — no icon name, highlighted, very long display name

Fixes #18385

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
