### PR TITLE
Route third-party dashboard logs under ThirdParty category and show Aspire warnings

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -947,13 +947,18 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
     {
         var logger = loggerCache.GetOrAdd(logMessage.Category, static (string category, ILoggerFactory loggerFactory) =>
         {
-            // Looks strange to see Aspire.Hosting.Dashboard.Aspire.Dashboard.Category,
-            // so trim the prefix and append Aspire.Hosting.Why is this important?
-            // Well there are logs emitting from categories that don't start with Aspire.Dashboard so we want to prefix all logs so that they can be controlled by config.
-            var categoryTrimmed = category.StartsWith("Aspire.Dashboard.") ?
-                category["Aspire.Dashboard.".Length..] : category;
+            // Dashboard logs arrive with their original category. Aspire's own categories start with
+            // "Aspire.Dashboard." — trim that prefix so the resulting logger category reads naturally
+            // (e.g. Aspire.Hosting.Dashboard.Model.IconResolver). Third-party categories (e.g.
+            // Microsoft.AspNetCore.Server.Kestrel) get a "ThirdParty" segment so they can be filtered
+            // with a single rule on "Aspire.Hosting.Dashboard.ThirdParty".
+            if (category.StartsWith("Aspire.Dashboard."))
+            {
+                var categoryTrimmed = category["Aspire.Dashboard.".Length..];
+                return loggerFactory.CreateLogger($"Aspire.Hosting.Dashboard.{categoryTrimmed}");
+            }
 
-            return loggerFactory.CreateLogger($"Aspire.Hosting.Dashboard.{categoryTrimmed}");
+            return loggerFactory.CreateLogger($"Aspire.Hosting.Dashboard.ThirdParty.{category}");
         },
         loggerFactory);
 

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -211,14 +211,14 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddSingleton<ILoggerProvider>(sp => sp.GetRequiredService<BackchannelLoggerProvider>());
         _innerBuilder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning);
         _innerBuilder.Logging.AddFilter("Microsoft.AspNetCore.Server.Kestrel", LogLevel.Error);
-        _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard", LogLevel.Warning);
-        // Keep third-party dashboard log categories (e.g. Microsoft.*, Grpc.*, System.*) at Error to avoid noise.
-        // Aspire's own dashboard categories (e.g. Aspire.Hosting.Dashboard.Model) are not prefixed with these
-        // and will use the Warning level from the parent filter above.
-        _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard.Microsoft", LogLevel.Error);
-        _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard.Grpc", LogLevel.Error);
-        _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard.System", LogLevel.Error);
         _innerBuilder.Logging.AddFilter("Grpc.AspNetCore.Server.ServerCallHandler", LogLevel.Error);
+        // Allow warnings from Aspire's dashboard code. We control this code and want to be able to log warnings to help troubleshoot issues in the dashboard.
+        // For example, misconfigured icons from the apphost are logged as warnings, and we want those to be visible to users.
+        // The volume of logs from this category should be low, so it shouldn't cause too much noise.
+        _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard", LogLevel.Warning);
+        // Third-party dashboard categories (e.g. Microsoft.AspNetCore, Grpc) are routed under
+        // Aspire.Hosting.Dashboard.ThirdParty so they can be filtered with a single rule.
+        _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard.ThirdParty", LogLevel.Error);
 
         // This is to reduce log noise when we activate health checks for resources which may not yet be
         // fully initialized. For example a database which is not yet created.

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -211,7 +211,13 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddSingleton<ILoggerProvider>(sp => sp.GetRequiredService<BackchannelLoggerProvider>());
         _innerBuilder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning);
         _innerBuilder.Logging.AddFilter("Microsoft.AspNetCore.Server.Kestrel", LogLevel.Error);
-        _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard", LogLevel.Error);
+        _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard", LogLevel.Warning);
+        // Keep third-party dashboard log categories (e.g. Microsoft.*, Grpc.*, System.*) at Error to avoid noise.
+        // Aspire's own dashboard categories (e.g. Aspire.Hosting.Dashboard.Model) are not prefixed with these
+        // and will use the Warning level from the parent filter above.
+        _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard.Microsoft", LogLevel.Error);
+        _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard.Grpc", LogLevel.Error);
+        _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard.System", LogLevel.Error);
         _innerBuilder.Logging.AddFilter("Grpc.AspNetCore.Server.ServerCallHandler", LogLevel.Error);
 
         // This is to reduce log noise when we activate health checks for resources which may not yet be

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
@@ -14,6 +14,7 @@ using Aspire.Hosting.Tests.Utils;
 using Aspire.Shared.ConsoleLogs;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -78,22 +79,21 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
     public async Task WatchDashboardLogs_AspireDashboardWarningsShown_ThirdPartyWarningsSuppressed(
         string category, LogLevel logLevel, bool expectLogged, string? expectedCategory)
     {
+        // Use the real DistributedApplicationBuilder to set up logging filters so the test
+        // exercises the actual production configuration rather than mirroring it.
         var testSink = new TestSink();
-        var factory = LoggerFactory.Create(b =>
-        {
-            b.SetMinimumLevel(LogLevel.Trace);
-            b.AddProvider(new TestLoggerProvider(testSink));
+        var appBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { DisableDashboard = true });
+        appBuilder.Services.AddSingleton<ILoggerProvider>(new TestLoggerProvider(testSink));
+        using var app = appBuilder.Build();
 
-            // Mirror the production filter configuration from DistributedApplicationBuilder.
-            b.AddFilter("Aspire.Hosting.Dashboard", LogLevel.Warning);
-            b.AddFilter("Aspire.Hosting.Dashboard.ThirdParty", LogLevel.Error);
-        });
+        var factory = app.Services.GetRequiredService<ILoggerFactory>();
+        var resourceLoggerService = app.Services.GetRequiredService<ResourceLoggerService>();
+        var resourceNotificationService = app.Services.GetRequiredService<ResourceNotificationService>();
+        var configuration = app.Services.GetRequiredService<IConfiguration>();
+
         var logChannel = Channel.CreateUnbounded<WriteContext>();
         testSink.MessageLogged += c => logChannel.Writer.TryWrite(c);
 
-        var resourceLoggerService = new ResourceLoggerService();
-        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create(logger: factory.CreateLogger<ResourceNotificationService>());
-        var configuration = new ConfigurationBuilder().Build();
         var hook = CreateHook(resourceLoggerService, resourceNotificationService, configuration, loggerFactory: factory);
 
         var model = new DistributedApplicationModel(new ResourceCollection());
@@ -117,32 +117,28 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
 
         await resourceNotificationService.PublishUpdateAsync(dashboardResource, s => s).DefaultTimeout();
 
+        // Complete the resource logger to drain pending logs, then dispose the hook
+        // to cancel the notification watcher and await all log processing tasks.
+        resourceLoggerService.Complete(resourceId);
+        await hook.DisposeAsync();
+
+        var logs = new List<WriteContext>();
+        while (logChannel.Reader.TryRead(out var logContext))
+        {
+            logs.Add(logContext);
+        }
+
+        var matchingLogs = logs.Where(l => l.Message == $"Test message from {category}").ToList();
+
         if (expectLogged)
         {
-            // Wait for the expected log to arrive.
-            while (true)
-            {
-                var logContext = await logChannel.Reader.ReadAsync().DefaultTimeout();
-                if (logContext.Message == $"Test message from {category}")
-                {
-                    Assert.Equal(logLevel, logContext.LogLevel);
-                    Assert.Equal(expectedCategory, logContext.LoggerName);
-                    break;
-                }
-            }
+            var matchingLog = Assert.Single(matchingLogs);
+            Assert.Equal(logLevel, matchingLog.LogLevel);
+            Assert.Equal(expectedCategory, matchingLog.LoggerName);
         }
         else
         {
-            // Give a short window for any unexpected logs to arrive, then verify nothing matched.
-            await Task.Delay(200);
-
-            var unexpectedLogs = new List<WriteContext>();
-            while (logChannel.Reader.TryRead(out var logContext))
-            {
-                unexpectedLogs.Add(logContext);
-            }
-
-            Assert.DoesNotContain(unexpectedLogs, l => l.Message == $"Test message from {category}");
+            Assert.Empty(matchingLogs);
         }
     }
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
@@ -115,18 +115,36 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
         var dashboardLoggerState = resourceLoggerService.GetResourceLoggerState(resourceId);
         dashboardLoggerState.AddLog(LogEntry.Create(timestamp, messageJson, isErrorMessage: false), inMemorySource: true);
 
+        // Add a sentinel log that always passes filters (Error level under Aspire.Dashboard.*
+        // routes to Aspire.Hosting.Dashboard.Sentinel, which is above the Warning threshold).
+        // Since logs are processed in order, observing the sentinel in the channel guarantees
+        // that the preceding test log has already been processed (either logged or filtered).
+        const string SentinelMessage = "SENTINEL_LOG_SYNC";
+        var sentinelMessage = new DashboardLogMessage
+        {
+            LogLevel = LogLevel.Error,
+            Category = "Aspire.Dashboard.Sentinel",
+            Message = SentinelMessage,
+            Timestamp = timestamp.ToString(KnownFormats.ConsoleLogsTimestampFormat, CultureInfo.InvariantCulture),
+        };
+        var sentinelJson = JsonSerializer.Serialize(sentinelMessage, DashboardLogMessageContext.Default.DashboardLogMessage);
+        dashboardLoggerState.AddLog(LogEntry.Create(timestamp, sentinelJson, isErrorMessage: false), inMemorySource: true);
+
         await resourceNotificationService.PublishUpdateAsync(dashboardResource, s => s).DefaultTimeout();
 
-        // Complete the resource logger to drain pending logs, then dispose the hook
-        // to cancel the notification watcher and await all log processing tasks.
-        resourceLoggerService.Complete(resourceId);
-        await hook.DisposeAsync();
-
+        // Wait for the sentinel to arrive, which confirms all preceding logs have been processed.
         var logs = new List<WriteContext>();
-        while (logChannel.Reader.TryRead(out var logContext))
+        while (true)
         {
+            var logContext = await logChannel.Reader.ReadAsync().DefaultTimeout();
             logs.Add(logContext);
+            if (logContext.Message == SentinelMessage)
+            {
+                break;
+            }
         }
+
+        await hook.DisposeAsync();
 
         var matchingLogs = logs.Where(l => l.Message == $"Test message from {category}").ToList();
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
@@ -73,6 +73,96 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
         }
     }
 
+    [Theory]
+    [MemberData(nameof(LogLevelFilteringData))]
+    public async Task WatchDashboardLogs_AspireDashboardWarningsShown_ThirdPartyWarningsSuppressed(
+        string category, LogLevel logLevel, bool expectLogged)
+    {
+        var testSink = new TestSink();
+        var factory = LoggerFactory.Create(b =>
+        {
+            b.SetMinimumLevel(LogLevel.Trace);
+            b.AddProvider(new TestLoggerProvider(testSink));
+
+            // Mirror the production filter configuration from DistributedApplicationBuilder.
+            b.AddFilter("Aspire.Hosting.Dashboard", LogLevel.Warning);
+            b.AddFilter("Aspire.Hosting.Dashboard.ThirdParty", LogLevel.Error);
+        });
+        var logChannel = Channel.CreateUnbounded<WriteContext>();
+        testSink.MessageLogged += c => logChannel.Writer.TryWrite(c);
+
+        var resourceLoggerService = new ResourceLoggerService();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create(logger: factory.CreateLogger<ResourceNotificationService>());
+        var configuration = new ConfigurationBuilder().Build();
+        var hook = CreateHook(resourceLoggerService, resourceNotificationService, configuration, loggerFactory: factory);
+
+        var model = new DistributedApplicationModel(new ResourceCollection());
+        await hook.OnBeforeStartAsync(new BeforeStartEvent(new TestServiceProvider(), model), CancellationToken.None).DefaultTimeout();
+
+        var dashboardResource = model.Resources.Single(r => string.Equals(r.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName));
+        var resourceId = dashboardResource.GetResolvedResourceNames()[0];
+
+        var timestamp = new DateTime(2001, 12, 29, 23, 59, 59, DateTimeKind.Utc);
+        var message = new DashboardLogMessage
+        {
+            LogLevel = logLevel,
+            Category = category,
+            Message = $"Test message from {category}",
+            Timestamp = timestamp.ToString(KnownFormats.ConsoleLogsTimestampFormat, CultureInfo.InvariantCulture),
+        };
+        var messageJson = JsonSerializer.Serialize(message, DashboardLogMessageContext.Default.DashboardLogMessage);
+
+        var dashboardLoggerState = resourceLoggerService.GetResourceLoggerState(resourceId);
+        dashboardLoggerState.AddLog(LogEntry.Create(timestamp, messageJson, isErrorMessage: false), inMemorySource: true);
+
+        await resourceNotificationService.PublishUpdateAsync(dashboardResource, s => s).DefaultTimeout();
+
+        if (expectLogged)
+        {
+            // Wait for the expected log to arrive.
+            while (true)
+            {
+                var logContext = await logChannel.Reader.ReadAsync().DefaultTimeout();
+                if (logContext.Message == $"Test message from {category}")
+                {
+                    Assert.Equal(logLevel, logContext.LogLevel);
+                    break;
+                }
+            }
+        }
+        else
+        {
+            // Give a short window for any unexpected logs to arrive, then verify nothing matched.
+            await Task.Delay(200);
+
+            var unexpectedLogs = new List<WriteContext>();
+            while (logChannel.Reader.TryRead(out var logContext))
+            {
+                unexpectedLogs.Add(logContext);
+            }
+
+            Assert.DoesNotContain(unexpectedLogs, l => l.Message == $"Test message from {category}");
+        }
+    }
+
+    public static IEnumerable<object[]> LogLevelFilteringData()
+    {
+        // Aspire.Dashboard.* categories: Warning+ should be logged.
+        yield return ["Aspire.Dashboard.Model.IconResolver", LogLevel.Warning, true];
+        yield return ["Aspire.Dashboard.Model.IconResolver", LogLevel.Error, true];
+        yield return ["Aspire.Dashboard.Components.SomePage", LogLevel.Information, false];
+        yield return ["Aspire.Dashboard.Components.SomePage", LogLevel.Debug, false];
+
+        // Third-party categories: only Error+ should be logged.
+        yield return ["Microsoft.AspNetCore.Server.Kestrel", LogLevel.Error, true];
+        yield return ["Microsoft.AspNetCore.Server.Kestrel", LogLevel.Critical, true];
+        yield return ["Microsoft.AspNetCore.Server.Kestrel", LogLevel.Warning, false];
+        yield return ["Microsoft.AspNetCore.Server.Kestrel", LogLevel.Information, false];
+        yield return ["Grpc.AspNetCore.Server", LogLevel.Warning, false];
+        yield return ["Grpc.AspNetCore.Server", LogLevel.Error, true];
+        yield return ["System.Net.Http.HttpClient", LogLevel.Warning, false];
+    }
+
     [Fact]
     public async Task BeforeStartAsync_ExcludeLifecycleCommands_CommandsNotAddedToDashboard()
     {
@@ -687,6 +777,8 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
     public static IEnumerable<object?[]> Data()
     {
         var timestamp = new DateTime(2001, 12, 29, 23, 59, 59, DateTimeKind.Utc);
+
+        // Third-party category (not prefixed with Aspire.Dashboard.) gets routed under ThirdParty.
         var message = new DashboardLogMessage
         {
             LogLevel = LogLevel.Error,
@@ -701,7 +793,7 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
             DateTime.UtcNow,
             messageJson,
             "Hello world",
-            "Aspire.Hosting.Dashboard.TestCategory",
+            "Aspire.Hosting.Dashboard.ThirdParty.TestCategory",
             LogLevel.Error
         };
         yield return new object?[]
@@ -709,10 +801,11 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
             null,
             messageJson,
             "Hello world",
-            "Aspire.Hosting.Dashboard.TestCategory",
+            "Aspire.Hosting.Dashboard.ThirdParty.TestCategory",
             LogLevel.Error
         };
 
+        // Third-party sub-category with exception.
         message = new DashboardLogMessage
         {
             LogLevel = LogLevel.Critical,
@@ -728,8 +821,65 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
             null,
             messageJson,
             $"Error message{Environment.NewLine}System.InvalidOperationException: Error!",
-            "Aspire.Hosting.Dashboard.TestCategory.TestSubCategory",
+            "Aspire.Hosting.Dashboard.ThirdParty.TestCategory.TestSubCategory",
             LogLevel.Critical
+        };
+
+        // Aspire.Dashboard category — prefix is trimmed and no ThirdParty segment is added.
+        message = new DashboardLogMessage
+        {
+            LogLevel = LogLevel.Warning,
+            Category = "Aspire.Dashboard.Model.IconResolver",
+            Message = "Icon could not be resolved",
+            Timestamp = timestamp.ToString(KnownFormats.ConsoleLogsTimestampFormat, CultureInfo.InvariantCulture),
+        };
+        messageJson = JsonSerializer.Serialize(message, DashboardLogMessageContext.Default.DashboardLogMessage);
+
+        yield return new object?[]
+        {
+            null,
+            messageJson,
+            "Icon could not be resolved",
+            "Aspire.Hosting.Dashboard.Model.IconResolver",
+            LogLevel.Warning
+        };
+
+        // Aspire.Dashboard top-level category.
+        message = new DashboardLogMessage
+        {
+            LogLevel = LogLevel.Error,
+            Category = "Aspire.Dashboard.Components.SomePage",
+            Message = "Component error",
+            Timestamp = timestamp.ToString(KnownFormats.ConsoleLogsTimestampFormat, CultureInfo.InvariantCulture),
+        };
+        messageJson = JsonSerializer.Serialize(message, DashboardLogMessageContext.Default.DashboardLogMessage);
+
+        yield return new object?[]
+        {
+            null,
+            messageJson,
+            "Component error",
+            "Aspire.Hosting.Dashboard.Components.SomePage",
+            LogLevel.Error
+        };
+
+        // Third-party Microsoft.AspNetCore category.
+        message = new DashboardLogMessage
+        {
+            LogLevel = LogLevel.Error,
+            Category = "Microsoft.AspNetCore.Server.Kestrel",
+            Message = "Kestrel error",
+            Timestamp = timestamp.ToString(KnownFormats.ConsoleLogsTimestampFormat, CultureInfo.InvariantCulture),
+        };
+        messageJson = JsonSerializer.Serialize(message, DashboardLogMessageContext.Default.DashboardLogMessage);
+
+        yield return new object?[]
+        {
+            null,
+            messageJson,
+            "Kestrel error",
+            "Aspire.Hosting.Dashboard.ThirdParty.Microsoft.AspNetCore.Server.Kestrel",
+            LogLevel.Error
         };
     }
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
@@ -76,7 +76,7 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [MemberData(nameof(LogLevelFilteringData))]
     public async Task WatchDashboardLogs_AspireDashboardWarningsShown_ThirdPartyWarningsSuppressed(
-        string category, LogLevel logLevel, bool expectLogged)
+        string category, LogLevel logLevel, bool expectLogged, string? expectedCategory)
     {
         var testSink = new TestSink();
         var factory = LoggerFactory.Create(b =>
@@ -126,6 +126,7 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
                 if (logContext.Message == $"Test message from {category}")
                 {
                     Assert.Equal(logLevel, logContext.LogLevel);
+                    Assert.Equal(expectedCategory, logContext.LoggerName);
                     break;
                 }
             }
@@ -145,22 +146,22 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
         }
     }
 
-    public static IEnumerable<object[]> LogLevelFilteringData()
+    public static IEnumerable<object?[]> LogLevelFilteringData()
     {
-        // Aspire.Dashboard.* categories: Warning+ should be logged.
-        yield return ["Aspire.Dashboard.Model.IconResolver", LogLevel.Warning, true];
-        yield return ["Aspire.Dashboard.Model.IconResolver", LogLevel.Error, true];
-        yield return ["Aspire.Dashboard.Components.SomePage", LogLevel.Information, false];
-        yield return ["Aspire.Dashboard.Components.SomePage", LogLevel.Debug, false];
+        // Aspire.Dashboard.* categories: Warning+ should be logged. Prefix is trimmed.
+        yield return ["Aspire.Dashboard.Model.IconResolver", LogLevel.Warning, true, "Aspire.Hosting.Dashboard.Model.IconResolver"];
+        yield return ["Aspire.Dashboard.Model.IconResolver", LogLevel.Error, true, "Aspire.Hosting.Dashboard.Model.IconResolver"];
+        yield return ["Aspire.Dashboard.Components.SomePage", LogLevel.Information, false, null];
+        yield return ["Aspire.Dashboard.Components.SomePage", LogLevel.Debug, false, null];
 
-        // Third-party categories: only Error+ should be logged.
-        yield return ["Microsoft.AspNetCore.Server.Kestrel", LogLevel.Error, true];
-        yield return ["Microsoft.AspNetCore.Server.Kestrel", LogLevel.Critical, true];
-        yield return ["Microsoft.AspNetCore.Server.Kestrel", LogLevel.Warning, false];
-        yield return ["Microsoft.AspNetCore.Server.Kestrel", LogLevel.Information, false];
-        yield return ["Grpc.AspNetCore.Server", LogLevel.Warning, false];
-        yield return ["Grpc.AspNetCore.Server", LogLevel.Error, true];
-        yield return ["System.Net.Http.HttpClient", LogLevel.Warning, false];
+        // Third-party categories: only Error+ should be logged. Routed under ThirdParty.
+        yield return ["Microsoft.AspNetCore.Server.Kestrel", LogLevel.Error, true, "Aspire.Hosting.Dashboard.ThirdParty.Microsoft.AspNetCore.Server.Kestrel"];
+        yield return ["Microsoft.AspNetCore.Server.Kestrel", LogLevel.Critical, true, "Aspire.Hosting.Dashboard.ThirdParty.Microsoft.AspNetCore.Server.Kestrel"];
+        yield return ["Microsoft.AspNetCore.Server.Kestrel", LogLevel.Warning, false, null];
+        yield return ["Microsoft.AspNetCore.Server.Kestrel", LogLevel.Information, false, null];
+        yield return ["Grpc.AspNetCore.Server", LogLevel.Warning, false, null];
+        yield return ["Grpc.AspNetCore.Server", LogLevel.Error, true, "Aspire.Hosting.Dashboard.ThirdParty.Grpc.AspNetCore.Server"];
+        yield return ["System.Net.Http.HttpClient", LogLevel.Warning, false, null];
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -734,10 +734,12 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
         // Push some logs through to the dashboard resource.
         var logger = resourceLoggerService.GetLogger("aspire-dashboard-0");
 
-        // The logging watcher expects a JSON payload
+        // The logging watcher expects a JSON payload. Use an "Aspire.Dashboard." prefixed category
+        // so the LogMessage method trims it and routes to "Aspire.Hosting.Dashboard.Test" rather than
+        // "Aspire.Hosting.Dashboard.ThirdParty.Test".
         var dashboardLogMessage = new DashboardLogMessage
         {
-            Category = "Test",
+            Category = "Aspire.Dashboard.Test",
             LogLevel = logLevel,
             Message = "Test dashboard message"
         };


### PR DESCRIPTION
## Description

Dashboard logs forwarded to the AppHost console now distinguish between Aspire's own code and third-party libraries by routing them to different logger category prefixes:

- **Aspire.Dashboard.*** categories (e.g. `Aspire.Dashboard.Model.IconResolver`) → `Aspire.Hosting.Dashboard.Model.IconResolver` — shown at **Warning+**
- **Third-party** categories (e.g. `Microsoft.AspNetCore.Server.Kestrel`) → `Aspire.Hosting.Dashboard.ThirdParty.Microsoft.AspNetCore.Server.Kestrel` — shown at **Error+** only

This makes it easy to filter all third-party dashboard noise with a single log filter rule on `Aspire.Hosting.Dashboard.ThirdParty`, while Aspire's own warnings (like unresolved icon names) are surfaced to help troubleshoot issues.

### Changes

1. **`DashboardEventHandlers.cs`** — `LogMessage` now routes non-`Aspire.Dashboard.` categories under `Aspire.Hosting.Dashboard.ThirdParty.{category}` instead of `Aspire.Hosting.Dashboard.{category}`.
2. **`DistributedApplicationBuilder.cs`** — Lowered the `Aspire.Hosting.Dashboard` filter from `Error` to `Warning`, and added a single `Aspire.Hosting.Dashboard.ThirdParty` filter at `Error` to suppress third-party noise.
3. **`DashboardEventHandlersTests.cs`** — Updated existing test data and added a new parameterized test (`WatchDashboardLogs_AspireDashboardWarningsShown_ThirdPartyWarningsSuppressed`) that mirrors the production filter configuration and verifies the category routing and log level filtering for both Aspire and third-party categories.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
