### PR TITLE
Detect miscased CLI options and suggest correct spelling

### DIFF
--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -66,6 +66,9 @@ internal abstract class BaseCommand : Command
     {
         // Check for miscased options that would be silently ignored as unmatched tokens
         // when TreatUnmatchedTokensAsErrors is false (e.g. --AppHost instead of --apphost).
+        // This intentionally also applies to resource command: users who want to pass arguments
+        // that collide with CLI option names to the resource command's second-pass parser should
+        // use the "--" separator (e.g. "aspire resource mydb cmd -- --AppHost primary").
         var miscasedOptionError = ParseResultHelper.CheckForMiscasedOptions(this, parseResult);
         if (miscasedOptionError is not null)
         {

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -36,9 +36,6 @@ internal abstract class BaseCommand : Command
 
     protected BaseCommand(string name, string description, CommonCommandServices services) : base(name, description)
     {
-        var features = services.Features;
-        var updateNotifier = services.UpdateNotifier;
-
         _executionContext = services.ExecutionContext;
         InteractionService = services.InteractionService;
         Telemetry = services.Telemetry;
@@ -54,127 +51,142 @@ internal abstract class BaseCommand : Command
                 InteractionService.Console = ConsoleOutput.Error;
             }
 
-            // TODO: SDK install goes here in the future.
-
-            CommandResult result;
-            var stoppingMessageShown = false;
             try
             {
-                var handlerTask = ExecuteAsync(parseResult, cancellationToken);
-                services.CancellationManager.SetStartedHandler(handlerTask);
+                return await HandleCommandAsync(parseResult, cancellationToken, services).ConfigureAwait(false);
+            }
+            finally
+            {
+                await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
+            }
+        }));
+    }
 
-                // Wait for either the handler to complete or a termination signal to trigger cancellation and timeout.
-                var terminationTask = services.CancellationManager.ProcessTerminationCompletionSource.Task;
+    private async Task<int> HandleCommandAsync(ParseResult parseResult, CancellationToken cancellationToken, CommonCommandServices services)
+    {
+        // Check for miscased options that would be silently ignored as unmatched tokens
+        // when TreatUnmatchedTokensAsErrors is false (e.g. --AppHost instead of --apphost).
+        var miscasedOptionError = ParseResultHelper.CheckForMiscasedOptions(this, parseResult);
+        if (miscasedOptionError is not null)
+        {
+            InteractionService.DisplayError(miscasedOptionError);
+            return CliExitCodes.InvalidCommand;
+        }
 
-                // After cancellation is triggered, show "Stopping Aspire..." after 200ms if the
-                // handler hasn't completed yet, so the user knows shutdown is in progress.
-                var stoppingMessageTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                using var stoppingMessageRegistration = cancellationToken.Register(() =>
-                    Task.Delay(200).ContinueWith(_ => stoppingMessageTcs.TrySetResult(), TaskScheduler.Default));
+        CommandResult result;
+        var stoppingMessageShown = false;
+        try
+        {
+            var handlerTask = ExecuteAsync(parseResult, cancellationToken);
+            services.CancellationManager.SetStartedHandler(handlerTask);
 
-                var tasksToAwait = new List<Task> { handlerTask, terminationTask, stoppingMessageTcs.Task };
-                while (true)
+            // Wait for either the handler to complete or a termination signal to trigger cancellation and timeout.
+            var terminationTask = services.CancellationManager.ProcessTerminationCompletionSource.Task;
+
+            // After cancellation is triggered, show "Stopping Aspire..." after 200ms if the
+            // handler hasn't completed yet, so the user knows shutdown is in progress.
+            var stoppingMessageTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var stoppingMessageRegistration = cancellationToken.Register(() =>
+                Task.Delay(200).ContinueWith(_ => stoppingMessageTcs.TrySetResult(), TaskScheduler.Default));
+
+            var tasksToAwait = new List<Task> { handlerTask, terminationTask, stoppingMessageTcs.Task };
+            while (true)
+            {
+                var firstCompletedTask = await Task.WhenAny(tasksToAwait);
+                if (firstCompletedTask == handlerTask)
                 {
-                    var firstCompletedTask = await Task.WhenAny(tasksToAwait);
-                    if (firstCompletedTask == handlerTask)
-                    {
-                        result = await handlerTask;
-                        break;
-                    }
-                    else if (firstCompletedTask == terminationTask)
-                    {
-                        // ProcessTerminationCompletionSource was signaled — either the graceful-shutdown
-                        // timeout elapsed, or a second signal forced immediate termination.
-                        // handlerTask is not awaited because the process is shutting down and we assume the task is hung.
-                        services.LoggerFactory.CreateLogger<BaseCommand>().LogWarning("Termination signal forced process exit.");
-                        var exitCode = await terminationTask;
-                        result = CommandResult.FromExitCode(exitCode);
-                        break;
-                    }
-                    else
-                    {
-                        // 200ms elapsed after cancellation — show stopping message and continue waiting.
-                        stoppingMessageShown = true;
-                        InteractionService.DisplayCancellationMessage();
-                        tasksToAwait.Remove(stoppingMessageTcs.Task);
-                    }
+                    result = await handlerTask;
+                    break;
+                }
+                else if (firstCompletedTask == terminationTask)
+                {
+                    // ProcessTerminationCompletionSource was signaled — either the graceful-shutdown
+                    // timeout elapsed, or a second signal forced immediate termination.
+                    // handlerTask is not awaited because the process is shutting down and we assume the task is hung.
+                    services.LoggerFactory.CreateLogger<BaseCommand>().LogWarning("Termination signal forced process exit.");
+                    var exitCode = await terminationTask;
+                    result = CommandResult.FromExitCode(exitCode);
+                    break;
+                }
+                else
+                {
+                    // 200ms elapsed after cancellation — show stopping message and continue waiting.
+                    stoppingMessageShown = true;
+                    InteractionService.DisplayCancellationMessage();
+                    tasksToAwait.Remove(stoppingMessageTcs.Task);
                 }
             }
-            catch (NonInteractiveException)
-            {
-                // Error messages have already been displayed by the interaction service.
-                result = CommandResult.Failure(CliExitCodes.MissingRequiredArgument);
-            }
-            catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested || ex is ExtensionOperationCanceledException)
-            {
-                result = CommandResult.Cancelled();
-            }
-            catch (Exception ex)
-            {
-                var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message);
-                Telemetry.RecordError(errorMessage, ex);
-                result = CommandResult.Failure(CliExitCodes.InvalidCommand, errorMessage);
-            }
+        }
+        catch (NonInteractiveException)
+        {
+            // Error messages have already been displayed by the interaction service.
+            result = CommandResult.Failure(CliExitCodes.MissingRequiredArgument);
+        }
+        catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested || ex is ExtensionOperationCanceledException)
+        {
+            result = CommandResult.Cancelled();
+        }
+        catch (Exception ex)
+        {
+            var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message);
+            Telemetry.RecordError(errorMessage, ex);
+            result = CommandResult.Failure(CliExitCodes.InvalidCommand, errorMessage);
+        }
 
-            var isErrorExitCode = result.ExitCode != CliExitCodes.Success;
+        var isErrorExitCode = result.ExitCode != CliExitCodes.Success;
 
-            if (result.ErrorMessage is not null)
-            {
-                InteractionService.DisplayError(result.ErrorMessage);
-            }
+        if (result.ErrorMessage is not null)
+        {
+            InteractionService.DisplayError(result.ErrorMessage);
+        }
 
-            if (result.ShouldDisplayHelp)
-            {
-                new HelpAction().Invoke(parseResult);
-                await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
+        if (result.ShouldDisplayHelp)
+        {
+            new HelpAction().Invoke(parseResult);
+            return result.ExitCode;
+        }
 
-                return result.ExitCode;
-            }
+        if (result.ShouldDisplayCancellationMessage && !stoppingMessageShown)
+        {
+            InteractionService.DisplayCancellationMessage(isErrorExitCode ? ConsoleOutput.Error : null);
+        }
 
-            if (result.ShouldDisplayCancellationMessage && !stoppingMessageShown)
-            {
-                InteractionService.DisplayCancellationMessage(isErrorExitCode ? ConsoleOutput.Error : null);
-            }
+        // Display the CLI log file path on non-zero exit codes so the user knows
+        // where to find diagnostic details. Suppress for user-input errors where
+        // the log wouldn't contain useful context (e.g., missing required arguments).
+        if (isErrorExitCode && !s_suppressErrorLogsMessageExitCodes.Contains(result.ExitCode))
+        {
+            InteractionService.DisplayMessage(
+                KnownEmojis.PageFacingUp,
+                string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, _executionContext.LogFilePath)),
+                allowMarkup: true,
+                consoleOverride: ConsoleOutput.Error);
 
-            // Display the CLI log file path on non-zero exit codes so the user knows
-            // where to find diagnostic details. Suppress for user-input errors where
-            // the log wouldn't contain useful context (e.g., missing required arguments).
-            if (isErrorExitCode && !s_suppressErrorLogsMessageExitCodes.Contains(result.ExitCode))
+            // If we connected to a running app host, also display the log file path of
+            // the CLI process that launched it so users can diagnose issues in both processes.
+            if (ExecutionContext.AppHostCliLogFilePath is not null)
             {
                 InteractionService.DisplayMessage(
-                    KnownEmojis.PageFacingUp,
-                    string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, _executionContext.LogFilePath)),
+                    KnownEmojis.MagnifyingGlassTiltedLeft,
+                    string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeAppHostLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.AppHostCliLogFilePath)),
                     allowMarkup: true,
                     consoleOverride: ConsoleOutput.Error);
-
-                // If we connected to a running app host, also display the log file path of
-                // the CLI process that launched it so users can diagnose issues in both processes.
-                if (ExecutionContext.AppHostCliLogFilePath is not null)
-                {
-                    InteractionService.DisplayMessage(
-                        KnownEmojis.MagnifyingGlassTiltedLeft,
-                        string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeAppHostLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.AppHostCliLogFilePath)),
-                        allowMarkup: true,
-                        consoleOverride: ConsoleOutput.Error);
-                }
             }
+        }
 
-            if (UpdateNotificationsEnabled && !IsJsonFormatRequested(parseResult) && features.IsFeatureEnabled(KnownFeatures.UpdateNotificationsEnabled, true))
+        if (UpdateNotificationsEnabled && !IsJsonFormatRequested(parseResult) && services.Features.IsFeatureEnabled(KnownFeatures.UpdateNotificationsEnabled, true))
+        {
+            try
             {
-                try
-                {
-                    updateNotifier.NotifyIfUpdateAvailable();
-                }
-                catch
-                {
-                    // Ignore any errors during update check to avoid impacting the main command
-                }
+                services.UpdateNotifier.NotifyIfUpdateAvailable();
             }
+            catch
+            {
+                // Ignore any errors during update check to avoid impacting the main command
+            }
+        }
 
-            await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
-
-            return result.ExitCode;
-        }));
+        return result.ExitCode;
     }
 
     protected abstract Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken);

--- a/src/Aspire.Cli/Commands/ParseResultHelper.cs
+++ b/src/Aspire.Cli/Commands/ParseResultHelper.cs
@@ -65,10 +65,15 @@ internal static class ParseResultHelper
                 continue;
             }
 
-            if (knownOptions.TryGetValue(token, out var correctName) &&
-                !string.Equals(token, correctName, StringComparison.Ordinal))
+            // Split off the "=value" suffix so that "--AppHost=somepath" is looked up
+            // as "--AppHost" against the known "--apphost" key.
+            var equalsIndex = token.IndexOf('=');
+            var optionName = equalsIndex >= 0 ? token[..equalsIndex] : token;
+
+            if (knownOptions.TryGetValue(optionName, out var correctName) &&
+                !string.Equals(optionName, correctName, StringComparison.Ordinal))
             {
-                return string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.UnrecognizedOptionDidYouMeanFormat, token, correctName);
+                return string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.UnrecognizedOptionDidYouMeanFormat, optionName, correctName);
             }
         }
 

--- a/src/Aspire.Cli/Commands/ParseResultHelper.cs
+++ b/src/Aspire.Cli/Commands/ParseResultHelper.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Globalization;
+using Aspire.Cli.Resources;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Helpers for inspecting a <see cref="ParseResult"/> after parsing.
+/// </summary>
+internal static class ParseResultHelper
+{
+    /// <summary>
+    /// Checks unmatched tokens for options that differ only by case from a known option,
+    /// and returns an error message if found. Returns null when no near-miss is detected.
+    /// Only inspects tokens that appear before the "--" double-dash separator.
+    /// </summary>
+    internal static string? CheckForMiscasedOptions(Command command, ParseResult parseResult)
+    {
+        // Only relevant when TreatUnmatchedTokensAsErrors is false; when true,
+        // System.CommandLine already rejects unrecognized options during parsing.
+        if (command.TreatUnmatchedTokensAsErrors)
+        {
+            return null;
+        }
+
+        var unmatchedTokens = parseResult.UnmatchedTokens;
+        if (unmatchedTokens.Count == 0)
+        {
+            return null;
+        }
+
+        // Only check tokens that appear before the "--" separator. Tokens after "--"
+        // are explicit pass-through arguments (e.g. "aspire run -- --AppHost somepath").
+        // We use a set of pre-"--" values so that a token appearing both before and
+        // after "--" is still checked.
+        var tokensBeforeDoubleDash = GetTokensBeforeDoubleDash(parseResult);
+
+        // Collect all known option names (including aliases) from this command and
+        // recursive parent options. The dictionary maps case-insensitive option name
+        // to its canonical (correctly-cased) form.
+        var knownOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        CollectOptionNames(command.Options, includeOnlyRecursive: false, knownOptions);
+
+        var current = parseResult.CommandResult.Parent;
+        while (current is System.CommandLine.Parsing.CommandResult parentCommandResult)
+        {
+            CollectOptionNames(parentCommandResult.Command.Options, includeOnlyRecursive: true, knownOptions);
+            current = parentCommandResult.Parent;
+        }
+
+        foreach (var token in unmatchedTokens)
+        {
+            if (!token.StartsWith('-'))
+            {
+                continue;
+            }
+
+            // When a "--" separator is present, only check tokens that appeared before it.
+            // When there is no "--", tokensBeforeDoubleDash is null and all tokens are checked.
+            if (tokensBeforeDoubleDash is not null && !tokensBeforeDoubleDash.Contains(token))
+            {
+                continue;
+            }
+
+            if (knownOptions.TryGetValue(token, out var correctName) &&
+                !string.Equals(token, correctName, StringComparison.Ordinal))
+            {
+                return string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.UnrecognizedOptionDidYouMeanFormat, token, correctName);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the set of token values that appear before the "--" double-dash separator,
+    /// or null if no "--" separator is present (meaning all tokens are candidates).
+    /// </summary>
+    private static HashSet<string>? GetTokensBeforeDoubleDash(ParseResult parseResult)
+    {
+        HashSet<string>? result = null;
+
+        foreach (var token in parseResult.Tokens)
+        {
+            if (token.Type == System.CommandLine.Parsing.TokenType.DoubleDash)
+            {
+                // Found "--"; return what we collected (which may be empty).
+                return result ?? [];
+            }
+
+            result ??= new HashSet<string>(StringComparer.Ordinal);
+            result.Add(token.Value);
+        }
+
+        // No "--" found — return null to signal that all tokens are candidates.
+        return null;
+    }
+
+    private static void CollectOptionNames(IList<Option> options, bool includeOnlyRecursive, Dictionary<string, string> knownOptions)
+    {
+        foreach (var option in options)
+        {
+            if (includeOnlyRecursive && !option.Recursive)
+            {
+                continue;
+            }
+
+            // TryAdd so the first (closest in hierarchy) definition wins.
+            knownOptions.TryAdd(option.Name, option.Name);
+            foreach (var alias in option.Aliases)
+            {
+                knownOptions.TryAdd(alias, alias);
+            }
+        }
+    }
+}

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
@@ -227,5 +227,11 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("NonInteractiveRequiresYesFormat", resourceCulture);
             }
         }
+
+        internal static string UnrecognizedOptionDidYouMeanFormat {
+            get {
+                return ResourceManager.GetString("UnrecognizedOptionDidYouMeanFormat", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.resx
@@ -210,4 +210,8 @@
     <value>The {0} command requires --yes when the --non-interactive option is specified.</value>
     <comment>{0} is the command name.</comment>
   </data>
+  <data name="UnrecognizedOptionDidYouMeanFormat" xml:space="preserve">
+    <value>Unrecognized option '{0}'. Did you mean '{1}'?</value>
+    <comment>{0} is the unrecognized option, {1} is the suggested correct option.</comment>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
@@ -142,6 +142,11 @@
         <target state="new">Select an AppHost to {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnrecognizedOptionDidYouMeanFormat">
+        <source>Unrecognized option '{0}'. Did you mean '{1}'?</source>
+        <target state="new">Unrecognized option '{0}'. Did you mean '{1}'?</target>
+        <note>{0} is the unrecognized option, {1} is the suggested correct option.</note>
+      </trans-unit>
       <trans-unit id="UsingAppHost">
         <source>Using AppHost: {0}</source>
         <target state="new">Using AppHost: {0}</target>

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -423,4 +423,136 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
         // since the handler completed before the 200ms timer.
         Assert.Single(testInteractionService.DisplayedCancellations);
     }
+
+    [Theory]
+    [InlineData("run --AppHost somepath", "--AppHost", "--apphost")]
+    [InlineData("run --Apphost somepath", "--Apphost", "--apphost")]
+    [InlineData("run --APPHOST somepath", "--APPHOST", "--apphost")]
+    [InlineData("start --AppHost somepath", "--AppHost", "--apphost")]
+    [InlineData("run --No-Build", "--No-Build", "--no-build")]
+    [InlineData("run --Project somepath", "--Project", "--project")]
+    [InlineData("run --Debug", "--Debug", "--debug")]
+    public async Task BaseCommand_MiscasedOption_ReturnsErrorWithSuggestion(string args, string badOption, string correctOption)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestInteractionService();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(args);
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+        var expectedError = string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.UnrecognizedOptionDidYouMeanFormat, badOption, correctOption);
+        Assert.Single(testInteractionService.DisplayedErrors, expectedError);
+    }
+
+    [Fact]
+    public async Task BaseCommand_CorrectlyCasedOption_DoesNotReturnMiscasedError()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestInteractionService();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        // --apphost is the correct casing — should not trigger the miscased option check
+        var result = command.Parse("run --apphost somepath");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        // The command may still fail for other reasons (e.g. invalid path), but it should
+        // not fail due to a miscased option error.
+        Assert.DoesNotContain(testInteractionService.DisplayedErrors,
+            e => e.Contains("Did you mean", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task BaseCommand_UnrelatedUnmatchedToken_DoesNotReturnMiscasedError()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestInteractionService();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        // --custom-arg is a completely unknown option, not a miscased version of a known option
+        var result = command.Parse("run --custom-arg value");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.DoesNotContain(testInteractionService.DisplayedErrors,
+            e => e.Contains("Did you mean", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task BaseCommand_MiscasedOptionAfterDoubleDash_IsNotFlagged()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestInteractionService();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        // --AppHost after "--" is an intentional pass-through argument, not a typo
+        var result = command.Parse("run -- --AppHost somepath");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.DoesNotContain(testInteractionService.DisplayedErrors,
+            e => e.Contains("Did you mean", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task BaseCommand_MiscasedOptionBeforeDoubleDash_WithSameTokenAfter_IsFlagged()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestInteractionService();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        // --AppHost before "--" is a typo and should be flagged even though
+        // the same token also appears after "--" as a pass-through argument.
+        var result = command.Parse("run --AppHost foo -- --AppHost bar");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+        var expectedError = string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.UnrecognizedOptionDidYouMeanFormat, "--AppHost", "--apphost");
+        Assert.Single(testInteractionService.DisplayedErrors, expectedError);
+    }
+
+    [Fact]
+    public void BaseCommand_TreatUnmatchedTokensAsErrorsTrue_DoesNotCheckMiscasedOptions()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        // "add" has TreatUnmatchedTokensAsErrors = true (the default), so System.CommandLine
+        // handles unrecognized options. The miscased check should not run.
+        var result = command.Parse("add --AppHost somepath");
+
+        // System.CommandLine itself should report the error.
+        Assert.NotEmpty(result.Errors);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -432,6 +432,8 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
     [InlineData("run --No-Build", "--No-Build", "--no-build")]
     [InlineData("run --Project somepath", "--Project", "--project")]
     [InlineData("run --Debug", "--Debug", "--debug")]
+    [InlineData("run --AppHost=somepath", "--AppHost", "--apphost")]
+    [InlineData("run --APPHOST=somepath", "--APPHOST", "--apphost")]
     public async Task BaseCommand_MiscasedOption_ReturnsErrorWithSuggestion(string args, string badOption, string correctOption)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -457,9 +459,15 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var testInteractionService = new TestInteractionService();
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, ct) =>
+                throw new OperationCanceledException(ct)
+        };
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => testInteractionService;
+            options.ProjectLocatorFactory = _ => projectLocator;
         });
         using var provider = services.BuildServiceProvider();
 
@@ -469,10 +477,55 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        // The command may still fail for other reasons (e.g. invalid path), but it should
-        // not fail due to a miscased option error.
-        Assert.DoesNotContain(testInteractionService.DisplayedErrors,
-            e => e.Contains("Did you mean", StringComparison.OrdinalIgnoreCase));
+        Assert.Empty(testInteractionService.DisplayedErrors);
+    }
+
+    [Theory]
+    [InlineData("--apphost", "somepath", false)]
+    [InlineData("--AppHost", "somepath", true)]
+    [InlineData("--APPHOST", "somepath", true)]
+    public async Task BaseCommand_OptionWithEqualsValue_ParsedCorrectlyOrFlaggedAsMiscased(string optionName, string value, bool expectError)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestInteractionService();
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, ct) =>
+                throw new OperationCanceledException(ct)
+        };
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.ProjectLocatorFactory = _ => projectLocator;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"run {optionName}={value}");
+
+        if (expectError)
+        {
+            var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+            Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+            var expectedError = string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.UnrecognizedOptionDidYouMeanFormat, optionName, "--apphost");
+            Assert.Single(testInteractionService.DisplayedErrors, expectedError);
+        }
+        else
+        {
+            // System.CommandLine accepted the --option=value syntax
+            Assert.Empty(result.Errors);
+            Assert.Empty(result.UnmatchedTokens);
+
+            // The option value was parsed correctly
+            var parsedValue = result.GetValue(AppHostLauncher.s_appHostOption);
+            Assert.NotNull(parsedValue);
+            Assert.Equal(value, parsedValue.Name);
+
+            var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+            Assert.Empty(testInteractionService.DisplayedErrors);
+        }
     }
 
     [Fact]
@@ -480,9 +533,15 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var testInteractionService = new TestInteractionService();
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, ct) =>
+                throw new OperationCanceledException(ct)
+        };
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => testInteractionService;
+            options.ProjectLocatorFactory = _ => projectLocator;
         });
         using var provider = services.BuildServiceProvider();
 
@@ -492,8 +551,7 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.DoesNotContain(testInteractionService.DisplayedErrors,
-            e => e.Contains("Did you mean", StringComparison.OrdinalIgnoreCase));
+        Assert.Empty(testInteractionService.DisplayedErrors);
     }
 
     [Fact]
@@ -501,9 +559,15 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var testInteractionService = new TestInteractionService();
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, ct) =>
+                throw new OperationCanceledException(ct)
+        };
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => testInteractionService;
+            options.ProjectLocatorFactory = _ => projectLocator;
         });
         using var provider = services.BuildServiceProvider();
 
@@ -513,8 +577,7 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.DoesNotContain(testInteractionService.DisplayedErrors,
-            e => e.Contains("Did you mean", StringComparison.OrdinalIgnoreCase));
+        Assert.Empty(testInteractionService.DisplayedErrors);
     }
 
     [Fact]
@@ -554,5 +617,29 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
 
         // System.CommandLine itself should report the error.
         Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public async Task BaseCommand_ResourceCommand_MiscasedOptionBeforeDoubleDash_IsFlagged()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestInteractionService();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        // --AppHost before "--" collides case-insensitively with the CLI's --apphost option.
+        // Users who need to pass an argument named AppHost to a resource command should use
+        // the "--" separator to disambiguate.
+        var result = command.Parse("resource myresource mycommand --AppHost primary");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+        var expectedError = string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.UnrecognizedOptionDidYouMeanFormat, "--AppHost", "--apphost");
+        Assert.Single(testInteractionService.DisplayedErrors, expectedError);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -568,6 +568,44 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResourceCommand_ForwardsArgumentAfterDoubleDashThatCollidesWithCliOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "mydb",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument("AppHost")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        // "--AppHost" collides case-insensitively with the CLI's --apphost option, so it
+        // must be placed after "--" to bypass the miscased-option check and reach the
+        // resource command's second-pass parser.
+        var result = command.Parse("resource mydb configure -- --AppHost primary");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("AppHost", "primary"));
+    }
+
+    [Fact]
     public async Task ResourceCommand_LegacyParameterCommandName_UsesCurrentCommandMetadata()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Description

CLI commands that set `TreatUnmatchedTokensAsErrors = false` (e.g., `run`, `start`, `publish`, `deploy`) silently ignore miscased options. For example, `aspire run --AppHost playground\stress` ignores `--AppHost` entirely and scans the whole repo, because System.CommandLine treats option names as case-sensitive and the unmatched token is silently forwarded.

This adds a `ParseResultHelper.CheckForMiscasedOptions` that inspects unmatched tokens before the command handler runs. When an unmatched token matches a known option case-insensitively but not case-sensitively, the CLI now returns an actionable error:

> Unrecognized option '--AppHost'. Did you mean '--apphost'?

Tokens after the `--` separator are excluded from the check since they are intentional pass-through arguments to the AppHost process.

### User-facing usage

Before (silent misbehavior — scans entire repo):
```bash
aspire run --AppHost playground\stress
```

After (clear error with suggestion):
```
Unrecognized option '--AppHost'. Did you mean '--apphost'?
```

Partially addresses #18371 — this covers the miscased-option scenario (`--AppHost` vs `--apphost`). The second scenario described in the issue (bare positional arguments like `aspire run playground\stress` being silently ignored) is not addressed here and can be handled in a follow-up.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
