### PR TITLE
fix(cli): don't add wildcard pattern to private sources with existing mappings

### DIFF
--- a/src/Aspire.Cli/Packaging/NuGetConfigMerger.cs
+++ b/src/Aspire.Cli/Packaging/NuGetConfigMerger.cs
@@ -578,36 +578,10 @@ internal class NuGetConfigMerger
 
             var sourcesWithoutAnyPatterns = existingSourceKeys.Except(sourcesWithPatterns, StringComparer.OrdinalIgnoreCase).ToArray();
 
-            // Only add wildcard patterns to sources that originally had NO patterns at all
-            // Sources that had patterns but lost them due to remapping should be removed entirely
-
-            // Check the original packageSourceMapping to see which sources had patterns originally
-            var originalSourcesWithPatterns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var originalPsm = context.PackageSourceMapping;
-            if (originalPsm != null)
-            {
-                foreach (var ps in originalPsm.Elements("packageSource"))
-                {
-                    var originalSourceKey = (string?)ps.Attribute("key");
-                    if (!string.IsNullOrEmpty(originalSourceKey) && ps.Elements("package").Any())
-                    {
-                        // Add the original key
-                        originalSourcesWithPatterns.Add(originalSourceKey);
-
-                        // Also add the proper key if this was a URL-based key
-                        if (context.UrlToExistingKey.TryGetValue(originalSourceKey, out var properKey))
-                        {
-                            originalSourcesWithPatterns.Add(properKey);
-                        }
-                    }
-                }
-            }
-
             // Only give wildcard patterns to sources that:
             // 1. Have no patterns now
-            // 2. Originally had no patterns either (were unmapped before) OR still have some patterns left
-            // 3. Are not safe to remove (user-defined sources)
-            // 4. Are required by the current channel OR are not Microsoft-controlled sources
+            // 2. Are not safe to remove (user-defined sources)
+            // 3. Are required by the current channel OR are not Microsoft-controlled sources
             foreach (var sourceKey in sourcesWithoutAnyPatterns)
             {
                 // Get the source URL to check if it's safe to give it a wildcard pattern
@@ -634,52 +608,6 @@ internal class NuGetConfigMerger
 
                     packageSourceMapping.Add(packageSourceElement);
                     sourcesInUse.Add(sourceKey);
-                }
-            }
-
-            // Also give wildcard patterns to sources that still have some patterns left but should remain fully functional
-            // when there's a wildcard mapping that could interfere with their ability to serve packages
-            // But only for user-defined sources, not Microsoft-controlled feeds
-            var sourcesWithPatternsLeft = packageSourceMapping.Elements("packageSource")
-                .Where(ps => ps.Elements("package").Any() && !ps.Elements("package").Any(p => (string?)p.Attribute("pattern") == "*"))
-                .Select(ps => (string?)ps.Attribute("key"))
-                .Where(key => !string.IsNullOrEmpty(key))
-                .Cast<string>()
-                .ToArray();
-
-            foreach (var sourceKey in sourcesWithPatternsLeft)
-            {
-                // Get the source URL to check if it's a user-defined source
-                var sourceElement = context.ExistingAdds
-                    .FirstOrDefault(add => string.Equals((string?)add.Attribute("key"), sourceKey, StringComparison.OrdinalIgnoreCase));
-                var sourceValue = (string?)sourceElement?.Attribute("value");
-                var isRequiredByCurrentChannel = context.RequiredSources.Contains(sourceKey, StringComparer.OrdinalIgnoreCase) ||
-                    context.RequiredSources.Contains(sourceValue ?? "", StringComparer.OrdinalIgnoreCase);
-                var requiredSourceHasWildcard = context.Mappings.Any(m =>
-                    m.PackageFilter == PackageMapping.AllPackages &&
-                    (string.Equals(m.Source, sourceKey, StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(m.Source, sourceValue, StringComparison.OrdinalIgnoreCase)));
-
-                if (isRequiredByCurrentChannel && !requiredSourceHasWildcard)
-                {
-                    continue;
-                }
-
-                // For user-defined sources that still have patterns, also give them wildcard patterns
-                // to ensure they can serve other packages too. But skip Microsoft-controlled sources
-                // that have specific patterns as they are intended to serve specific packages only.
-                if (!IsSourceSafeToRemove(sourceKey, sourceValue) && !IsMicrosoftControlledSource(sourceKey, sourceValue))
-                {
-                    var packageSourceElement = packageSourceMapping.Elements("packageSource")
-                        .FirstOrDefault(ps => string.Equals((string?)ps.Attribute("key"), sourceKey, StringComparison.OrdinalIgnoreCase));
-
-                    if (packageSourceElement != null)
-                    {
-                        var wildcardPackage = new XElement("package");
-                        wildcardPackage.SetAttributeValue("pattern", "*");
-                        packageSourceElement.Add(wildcardPackage);
-                        sourcesInUse.Add(sourceKey);
-                    }
                 }
             }
         }

--- a/tests/Aspire.Cli.Tests/Packaging/NuGetConfigMergerTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/NuGetConfigMergerTests.cs
@@ -492,6 +492,60 @@ public class NuGetConfigMergerTests
     }
 
     [Fact]
+    public async Task CreateOrUpdateAsync_DoesNotAddWildcardToPrivateSourceWithExistingPatterns()
+    {
+        using var workspace = TemporaryWorkspace.Create(_outputHelper);
+        var root = workspace.WorkspaceRoot;
+
+        // User has nuget.org with wildcard and a private source with specific patterns
+        await WriteConfigAsync(root,
+            """
+            <?xml version="1.0"?>
+            <configuration>
+                <packageSources>
+                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                    <add key="github" value="https://nuget.pkg.github.com/myorg/index.json" />
+                </packageSources>
+                <packageSourceMapping>
+                    <packageSource key="nuget.org">
+                        <package pattern="*" />
+                    </packageSource>
+                    <packageSource key="github">
+                        <package pattern="myorg.*" />
+                        <package pattern="other" />
+                    </packageSource>
+                </packageSourceMapping>
+            </configuration>
+            """);
+
+        // Stable channel: maps everything to nuget.org
+        var mappings = new[]
+        {
+            new PackageMapping("*", "https://api.nuget.org/v3/index.json")
+        };
+
+        var channel = CreateChannel(mappings);
+        await NuGetConfigMerger.CreateOrUpdateAsync(root, channel).DefaultTimeout();
+
+        var xml = XDocument.Load(Path.Combine(root.FullName, "nuget.config"));
+        var psm = xml.Root!.Element("packageSourceMapping")!;
+
+        // nuget.org should retain the wildcard
+        var nugetMapping = psm.Elements("packageSource")
+            .FirstOrDefault(ps => (string?)ps.Attribute("key") == "nuget.org");
+        Assert.NotNull(nugetMapping);
+        Assert.Contains(nugetMapping.Elements("package"), p => (string?)p.Attribute("pattern") == "*");
+
+        // The private source should keep its original patterns without a wildcard being added
+        var githubMapping = psm.Elements("packageSource")
+            .FirstOrDefault(ps => (string?)ps.Attribute("key") == "github");
+        Assert.NotNull(githubMapping);
+        Assert.Contains(githubMapping.Elements("package"), p => (string?)p.Attribute("pattern") == "myorg.*");
+        Assert.Contains(githubMapping.Elements("package"), p => (string?)p.Attribute("pattern") == "other");
+        Assert.DoesNotContain(githubMapping.Elements("package"), p => (string?)p.Attribute("pattern") == "*");
+    }
+
+    [Fact]
     public async Task CreateOrUpdateAsync_RemovesUnrequiredSources_InsteadOfAddingWildcardPattern()
     {
         using var workspace = TemporaryWorkspace.Create(_outputHelper);
@@ -550,11 +604,12 @@ public class NuGetConfigMergerTests
         Assert.DoesNotContain(psm.Elements("packageSource"), 
             ps => (string?)ps.Attribute("key") == "C:\\Users\\user\\.aspire\\hives\\invalid-pr");
         
-        // The user-defined source should get a wildcard pattern to remain functional
+        // The user-defined source should keep its original patterns without a wildcard being added
         var validExampleMapping = psm.Elements("packageSource")
             .FirstOrDefault(ps => (string?)ps.Attribute("key") == "https://valid.example");
         Assert.NotNull(validExampleMapping);
-        Assert.Contains(validExampleMapping.Elements("package"), p => (string?)p.Attribute("pattern") == "*");
+        Assert.Contains(validExampleMapping.Elements("package"), p => (string?)p.Attribute("pattern") == "ValidPkg*");
+        Assert.DoesNotContain(validExampleMapping.Elements("package"), p => (string?)p.Attribute("pattern") == "*");
         
         // NuGet.org should have all the patterns
         var nugetMapping = psm.Elements("packageSource")

--- a/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
@@ -146,7 +146,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
         Assert.Contains(doc.Root!.Element("packageSources")!.Elements("add"), e => (string?)e.Attribute("value") == "https://project.example/v3/index.json");
         Assert.DoesNotContain(doc.Root!.Element("packageSources")!.Elements("add"), e => (string?)e.Attribute("value") == "https://parent.example/v3/index.json");
         Assert.Equal(["Aspire*"], GetPackagePatternsForSource(doc, sourceOverride));
-        Assert.Equal(["Project.*", PackageMapping.AllPackages], GetPackagePatternsForSource(doc, "project-local"));
+        Assert.Equal(["Project.*"], GetPackagePatternsForSource(doc, "project-local"));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

When `aspire update` runs the NuGet config merger and the channel includes a wildcard mapping (e.g. stable: `*` → nuget.org), the merger was incorrectly adding a `*` pattern to every user-defined source that already had specific patterns configured. This overwrites the user's intentional package source mapping restrictions.

For example, a user with:
```xml
<packageSourceMapping>
    <packageSource key="nuget.org">
        <package pattern="*" />
    </packageSource>
    <packageSource key="github">
        <package pattern="myorg.*" />
        <package pattern="other" />
    </packageSource>
</packageSourceMapping>
```

Would get `*` added to `github` after `aspire update`, making all package lookups hit their private source.

### Root Cause

The second block in `HandleWildcardMappingForExistingSources` (introduced in #11291, modified in #17166) added wildcards to any non-Microsoft user-defined source that had patterns but no wildcard. The rationale was to keep sources "fully functional," but it's wrong — if a user configured specific patterns, they did so deliberately.

### Fix

Remove the second block. The first block correctly handles sources with NO patterns (giving them `*` to remain functional when a `packageSourceMapping` section exists). Sources that already have user-configured patterns should be left untouched — nuget.org's `*` already covers packages not matched by the user's specific patterns.

Fixes #18380

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
