### PR TITLE
Route resource command status messages to stderr

### DIFF
--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Backchannel;
+using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
@@ -113,6 +114,13 @@ internal sealed class ResourceCommand : BaseCommand
 
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
+        // Route human-readable status messages to stderr so that structured command output
+        // (e.g., JSON) on stdout remains valid and pipeable (e.g., | jq).
+        // Always do this as we don't know if the caller intends to produce structured output. 
+        // It's safer to risk mixing status messages with structured output than to risk breaking
+        // it by writing status messages to stdout.
+        InteractionService.Console = ConsoleOutput.Error;
+
         var resourceName = parseResult.GetValue(s_resourceArgument)!;
         var commandName = parseResult.GetValue(s_commandArgument)!;
         var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -116,9 +116,8 @@ internal sealed class ResourceCommand : BaseCommand
     {
         // Route human-readable status messages to stderr so that structured command output
         // (e.g., JSON) on stdout remains valid and pipeable (e.g., | jq).
-        // Always do this as we don't know if the caller intends to produce structured output. 
-        // It's safer to risk mixing status messages with structured output than to risk breaking
-        // it by writing status messages to stdout.
+        // Always route to stderr unconditionally because we cannot know ahead of time whether
+        // the resource command will produce structured output.
         InteractionService.Console = ConsoleOutput.Error;
 
         var resourceName = parseResult.GetValue(s_resourceArgument)!;

--- a/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
@@ -71,9 +71,6 @@ internal static class ResourceCommandHelper
     {
         logger.LogDebug("Executing command '{CommandName}' on resource '{ResourceName}'", commandName, resourceName);
 
-        // Route status messages to stderr so command results in stdout remain pipeable (e.g., | jq)
-        interactionService.Console = ConsoleOutput.Error;
-
         var response = await interactionService.ShowStatusAsync(
             $"Validating and executing command '{commandName}' on resource '{resourceName}'...",
             async () => await connection.ExecuteResourceCommandAsync(

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
@@ -4,7 +4,6 @@
 using System.Text.Json.Nodes;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
-using Aspire.Cli.Interaction;
 using Aspire.Cli.Tests.TestServices;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
@@ -115,41 +115,6 @@ public class ResourceCommandHelperTests
     }
 
     [Fact]
-    public async Task ExecuteGenericCommandAsync_RoutesStatusToStderr_ResultToStdout()
-    {
-        var connection = new TestAppHostAuxiliaryBackchannel
-        {
-            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
-            {
-                Success = true,
-                Value = new ExecuteResourceCommandResult
-                {
-                    Value = "some output",
-                    Format = CommandResultFormat.Text
-                }
-            }
-        };
-
-        var interactionService = new TestInteractionService
-        {
-            DisplayRawTextCallback = (_) => { }
-        };
-
-        var exitCode = await ResourceCommandHelper.ExecuteGenericCommandAsync(
-            connection,
-            interactionService,
-            NullLogger.Instance,
-            "myResource",
-            "my-command",
-            arguments: null,
-            cancellationToken: CancellationToken.None).DefaultTimeout();
-
-        Assert.Equal(0, exitCode);
-        // Status messages should be routed to stderr
-        Assert.Equal(ConsoleOutput.Error, interactionService.Console);
-    }
-
-    [Fact]
     public async Task ExecuteGenericCommandAsync_WithArguments_PassesArgumentsToBackchannel()
     {
         var connection = new TestAppHostAuxiliaryBackchannel

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
@@ -425,6 +426,49 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
             status => Assert.Equal("Scanning for running AppHosts...", status),
             status => Assert.Equal(statusMessage, status));
         Assert.Equal(successMessage, Assert.Single(interactionService.DisplayedSuccess));
+    }
+
+    [Fact]
+    public async Task ResourceCommand_RoutesStatusToStderrAndResultToStdout()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var consoleOutputPerStatus = new List<(string Message, ConsoleOutput Console)>();
+        TestInteractionService? interactionService = null;
+        interactionService = new TestInteractionService
+        {
+            ShowStatusCallback = msg => consoleOutputPerStatus.Add((msg, interactionService!.Console))
+        };
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = true,
+                Value = new ExecuteResourceCommandResult
+                {
+                    Value = "{\"key\": \"value\"}",
+                    Format = CommandResultFormat.Json
+                }
+            }
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("resource myresource my-command");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        // The "Scanning for running AppHosts..." message must be routed to stderr,
+        // not stdout, so that piped JSON output remains valid (see #18102).
+        var scanningStatus = Assert.Single(consoleOutputPerStatus, s => s.Message == SharedCommandStrings.ScanningForRunningAppHosts);
+        Assert.Equal(ConsoleOutput.Error, scanningStatus.Console);
+
+        // The JSON result must be written to stdout so it can be piped to tools like jq.
+        var (rawText, consoleOverride) = Assert.Single(interactionService.DisplayedRawText);
+        Assert.Equal("{\"key\": \"value\"}", rawText);
+        Assert.Equal(ConsoleOutput.Standard, consoleOverride);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

The `aspire resource` command wrote human-readable status messages (e.g., "Scanning for running AppHosts...") to stdout before the JSON payload, breaking piping to tools like `jq`.

This PR sets `InteractionService.Console = ConsoleOutput.Error` at the start of `ResourceCommand.ExecuteAsync` so all status output routes to stderr while structured command results remain on stdout. The redundant stderr assignment in `ResourceCommandHelper` is removed since the caller now owns that responsibility.

Fixes #18102

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No