### PR TITLE
Fix flaky ResourceCommand_FailsWhenInteractionServiceIsRequired test

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -109,6 +109,7 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/17485")]
     public async Task ResourceCommand_FailsWhenInteractionServiceIsRequired()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -109,7 +109,6 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
-    [QuarantinedTest("https://github.com/microsoft/aspire/issues/17485")]
     public async Task ResourceCommand_FailsWhenInteractionServiceIsRequired()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -119,11 +118,11 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
 
         var workspace = TemporaryWorkspace.Create(output);
 
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
         var counter = new SequenceCounter();
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
         await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
-        await auto.PrepareDockerEnvironmentAsync(counter, workspace, enableDcpDiagnostics: true);
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
         await auto.AspireNewAsync(projectName, counter, template: AspireTemplate.EmptyAppHost);
 
@@ -133,7 +132,9 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
 
         // Read the generated apphost.cs so we can extract the #:sdk line with the
         // resolved version, then replace the entire file with a minimal AppHost
-        // that has a placeholder resource and a command that uses IInteractionService.
+        // that has a parameter resource and a command that uses IInteractionService.
+        // Using a parameter instead of a container avoids Docker container teardown
+        // flakiness during `aspire stop` in CI (see #17485).
         var appHostFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, projectName, "apphost.cs");
         var content = File.ReadAllText(appHostFilePath);
 
@@ -145,9 +146,9 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
 
             var builder = DistributedApplication.CreateBuilder(args);
 
-            var cache = builder.AddContainer("cache", "redis");
+            var resource = builder.AddParameter("test-resource");
 
-            cache.WithCommand(
+            resource.WithCommand(
                 name: "needs-interaction",
                 displayName: "Needs interaction",
                 executeCommand: async context =>
@@ -187,9 +188,9 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
         await auto.WaitUntilTextAsync(RunCommandStrings.AppHostStartedSuccessfully, timeout: TimeSpan.FromMinutes(3));
         await auto.WaitForSuccessPromptAsync(counter);
 
-        await auto.TypeAsync("aspire resource cache needs-interaction");
+        await auto.TypeAsync("aspire resource test-resource needs-interaction");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("Failed to execute command 'needs-interaction' on resource 'cache'", timeout: TimeSpan.FromSeconds(30));
+        await auto.WaitUntilTextAsync("Failed to execute command 'needs-interaction' on resource 'test-resource'", timeout: TimeSpan.FromSeconds(30));
         await auto.WaitUntilTextAsync("InteractionService is not available", timeout: TimeSpan.FromSeconds(30));
         await auto.WaitUntilTextAsync("See logs at", timeout: TimeSpan.FromSeconds(30));
         await auto.WaitUntilTextAsync("See AppHost logs at", timeout: TimeSpan.FromSeconds(30));


### PR DESCRIPTION
## Summary

Fixes the flaky `ResourceCommand_FailsWhenInteractionServiceIsRequired` E2E test by replacing the Redis container resource with a lightweight parameter resource.

## Problem

The test was flaky because it used `builder.AddContainer("cache", "redis")` which spun up a real Docker container via DCP. On CI runners (`ubuntu-latest`), Docker container teardown during `aspire stop` intermittently took longer than the shutdown timeout, causing the CLI to print "Failed to stop" instead of "stopped successfully" — and the Hex1b `WaitUntilText` assertion would time out.

## Fix

The test only needs *any* resource with a command attached to verify that `IInteractionService` fails properly in non-interactive mode. The specific resource type is irrelevant. Changed to use `builder.AddParameter("test-resource")` which:

- Doesn't require Docker (`mountDockerSocket: true` removed)
- Has no process/container to tear down, so `aspire stop` completes instantly
- Still supports `WithCommand` (constraint is just `IResource`)
- Still appears in resource snapshots so `aspire resource test-resource needs-interaction` resolves correctly

The `[QuarantinedTest]` attribute is kept until this fix is validated in CI. Once CI confirms the test passes reliably, a follow-up will remove the quarantine.

Addresses #17485