### PR TITLE
Stop listing agent-skill snippets as AppHosts

### DIFF
--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -579,6 +579,149 @@ suite('AppHost discovery', () => {
             }
         });
 
+        test('filters aspire ls candidates in excluded directories', async () => {
+            stubFileSystemWatchers(sandbox);
+            sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                options?.stdoutCallback?.(JSON.stringify([
+                    {
+                        path: buildPath('workspace', '.agents', 'skills', 'demo', 'snippets', 'apphost.ts'),
+                        language: 'typescript/nodejs',
+                        status: 'buildable',
+                    },
+                    {
+                        path: buildPath('workspace', 'AppHost', 'AppHost.csproj'),
+                        language: 'csharp',
+                        status: 'buildable',
+                    },
+                ]));
+                options?.exitCallback?.(0);
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider());
+
+            try {
+                const result = await service.discover(makeWorkspaceFolder(buildPath('workspace')));
+
+                assert.deepStrictEqual(result, [{
+                    path: buildPath('workspace', 'AppHost', 'AppHost.csproj'),
+                    language: 'csharp',
+                    status: 'buildable',
+                }]);
+            }
+            finally {
+                service.dispose();
+            }
+        });
+
+        test('filters path-scoped agent skill candidates but keeps other .github apphosts', async () => {
+            stubFileSystemWatchers(sandbox);
+            sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                options?.stdoutCallback?.(JSON.stringify([
+                    {
+                        path: buildPath('workspace', '.github', 'skills', 'demo', 'snippets', 'apphost.ts'),
+                        language: 'typescript/nodejs',
+                        status: 'buildable',
+                    },
+                    {
+                        path: buildPath('workspace', '.opencode', 'skill', 'demo', 'snippets', 'apphost.ts'),
+                        language: 'typescript/nodejs',
+                        status: 'buildable',
+                    },
+                    {
+                        path: buildPath('workspace', '.github', 'AppHost', 'AppHost.csproj'),
+                        language: 'csharp',
+                        status: 'buildable',
+                    },
+                ]));
+                options?.exitCallback?.(0);
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider());
+
+            try {
+                const result = await service.discover(makeWorkspaceFolder(buildPath('workspace')));
+
+                assert.deepStrictEqual(result, [{
+                    path: buildPath('workspace', '.github', 'AppHost', 'AppHost.csproj'),
+                    language: 'csharp',
+                    status: 'buildable',
+                }]);
+            }
+            finally {
+                service.dispose();
+            }
+        });
+
+        test('does not include configured apphost candidate in excluded directories', async () => {
+            const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-apphost-discovery-'));
+            try {
+                stubFileSystemWatchers(sandbox);
+                const configPath = path.join(tempDir, 'aspire.config.json');
+                fs.writeFileSync(configPath, JSON.stringify({
+                    appHost: {
+                        path: '.agents/skills/demo/snippets/apphost.ts',
+                    },
+                }));
+                findFilesStub.callsFake(async (include: vscode.GlobPattern) => {
+                    const pattern = typeof include === 'string' ? include : include.pattern;
+                    return pattern.endsWith('aspire.config.json')
+                        ? [vscode.Uri.file(configPath)]
+                        : [];
+                });
+                sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                    options?.stdoutCallback?.('[]');
+                    options?.exitCallback?.(0);
+                    return { kill: () => { } } as any;
+                });
+                const service = new AppHostDiscoveryService(makeTerminalProvider());
+
+                try {
+                    const result = await service.discover(makeWorkspaceFolder(tempDir));
+                    assert.deepStrictEqual(result, []);
+                }
+                finally {
+                    service.dispose();
+                }
+            }
+            finally {
+                fs.rmSync(tempDir, { recursive: true, force: true });
+            }
+        });
+
+        test('keeps aspire ls candidate that resolves outside the workspace folder', async () => {
+            stubFileSystemWatchers(sandbox);
+            // Configured / CLI-sourced AppHost paths can legitimately live outside the workspace folder.
+            // The candidate filter must keep them; only the stricter scan/watcher path treats
+            // out-of-workspace URIs as excluded. Reverting the candidate filter to the strict variant
+            // (excludeOutsideWorkspace=true) would prune this candidate and fail this test.
+            const outsideCandidatePath = buildPath('outside-workspace', 'AppHost', 'AppHost.csproj');
+            sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                options?.stdoutCallback?.(JSON.stringify([
+                    {
+                        path: outsideCandidatePath,
+                        language: 'csharp',
+                        status: 'buildable',
+                    },
+                ]));
+                options?.exitCallback?.(0);
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider());
+
+            try {
+                const result = await service.discover(makeWorkspaceFolder(buildPath('workspace')));
+
+                assert.deepStrictEqual(result, [{
+                    path: outsideCandidatePath,
+                    language: 'csharp',
+                    status: 'buildable',
+                }]);
+            }
+            finally {
+                service.dispose();
+            }
+        });
+
         test('reports both aspire ls and legacy fallback errors when discovery fails', async () => {
             stubFileSystemWatchers(sandbox);
             sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, args = [], options) => {
@@ -757,6 +900,9 @@ suite('AppHost discovery', () => {
                 const excludePattern = String(call.args[1]);
                 assert.ok(excludePattern.includes('**/.worktrees/**'));
                 assert.ok(excludePattern.includes('**/.claude/**'));
+                assert.ok(excludePattern.includes('**/.agents/**'));
+                assert.ok(excludePattern.includes('**/.github/skills/**'));
+                assert.ok(excludePattern.includes('**/.opencode/skill/**'));
                 assert.ok(excludePattern.includes('**/private-checkouts/**'));
                 assert.ok(excludePattern.includes('**/scratch-worktrees/**'));
                 assert.ok(!excludePattern.includes('**/generated-but-enabled/**'));

--- a/extension/src/test/workspace.test.ts
+++ b/extension/src/test/workspace.test.ts
@@ -74,6 +74,9 @@ suite('utils/workspace tests', () => {
         assert.ok(glob.includes('**/.vscode-test/**'), 'Should exclude .vscode-test');
         assert.ok(glob.includes('**/.worktrees/**'), 'Should exclude git worktrees');
         assert.ok(glob.includes('**/.claude/**'), 'Should exclude agent worktrees');
+        assert.ok(glob.includes('**/.agents/**'), 'Should exclude agent skills');
+        assert.ok(glob.includes('**/.github/skills/**'), 'Should exclude GitHub agent skills');
+        assert.ok(glob.includes('**/.opencode/skill/**'), 'Should exclude OpenCode agent skills');
         assert.ok(glob.includes('**/.idea/**'), 'Should exclude .idea');
         assert.ok(glob.includes('**/.git/**'), 'Should exclude .git');
     });

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -8,7 +8,7 @@ import { aspireConfigFileName, getAppHostPathFromConfig, readJsonFile } from './
 import { EnvironmentVariables } from './environment';
 import { extensionLogOutputChannel } from './logging';
 import { getAppHostDiscoveryTimeoutMs } from './settings';
-import { appHostDiscoveryFindFilesMaxResults, getAppHostDiscoveryExcludeGlob, isExcludedDiscoveryUri } from './workspaceFileSearch';
+import { appHostDiscoveryFindFilesMaxResults, getAppHostDiscoveryExcludeGlob, isExcludedDiscoveryCandidate, isExcludedDiscoveryUri } from './workspaceFileSearch';
 
 // Mirrors the `aspire ls --format json` candidate shape documented in
 // docs/specs/cli-output-formats.md. Older CLI fallback results are adapted into
@@ -70,7 +70,8 @@ export class AppHostDiscoveryService implements vscode.Disposable {
             // cancellation outside the cached operation so one cancelled refresh doesn't reject
             // unrelated callers that are awaiting the same workspace discovery.
             const discoveryPromise = this._discoverCore(workspaceFolder)
-                .then(candidates => this._includeConfiguredAppHostCandidate(workspaceFolder, candidates));
+                .then(candidates => this._includeConfiguredAppHostCandidate(workspaceFolder, candidates))
+                .then(candidates => this._filterExcludedCandidates(workspaceFolder, candidates));
             let cachedPromise: Promise<CandidateAppHostDisplayInfo[]>;
             cachedPromise = discoveryPromise.catch(error => {
                 if (this._cache.get(key) === cachedPromise) {
@@ -277,6 +278,16 @@ export class AppHostDiscoveryService implements vscode.Disposable {
                 selected: true,
             },
         ];
+    }
+
+    private _filterExcludedCandidates(workspaceFolder: vscode.WorkspaceFolder, candidates: CandidateAppHostDisplayInfo[]): CandidateAppHostDisplayInfo[] {
+        const filteredCandidates = candidates.filter(candidate => !isExcludedDiscoveryCandidate(workspaceFolder, vscode.Uri.file(candidate.path)));
+        const excludedCandidateCount = candidates.length - filteredCandidates.length;
+        if (excludedCandidateCount > 0) {
+            extensionLogOutputChannel.info(`Filtered ${excludedCandidateCount} AppHost candidate(s) in excluded paths`);
+        }
+
+        return filteredCandidates;
     }
 
     private _runCliForStdout(cliPath: string, args: string[], workingDirectory: string): Promise<string> {

--- a/extension/src/utils/workspaceFileSearch.ts
+++ b/extension/src/utils/workspaceFileSearch.ts
@@ -26,6 +26,10 @@ const commonExcludePatterns = [
     '**/.vscode-test/**',
     '**/.worktrees/**',
     '**/.claude/**',
+    '**/.agents/**',
+    // .github and .opencode hold more than skills, so exclude only the skill subpaths.
+    '**/.github/skills/**',
+    '**/.opencode/skill/**',
     '**/.idea/**',
     '**/.git/**',
     '**/.angular/**',
@@ -46,6 +50,11 @@ const appHostDiscoveryExcludeRules: readonly SegmentExcludeRule[] = [
     // whole tool directory as generated workspace state so discovery doesn't recurse into
     // dozens of nested repo copies and spawn a storm of file-search processes.
     { glob: '**/.claude/**', segments: ['.claude'] },
+    // Agent skill snippets ship apphost.* samples that are not runnable AppHosts. .github/.opencode
+    // hold more than skills, so match only the skill subpath.
+    { glob: '**/.agents/**', segments: ['.agents'] },
+    { glob: '**/.github/skills/**', segments: ['.github', 'skills'] },
+    { glob: '**/.opencode/skill/**', segments: ['.opencode', 'skill'] },
     { glob: '**/.idea/**', segments: ['.idea'] },
     { glob: '**/.aspire/modules/**', segments: ['.aspire', 'modules'] },
 ];
@@ -62,9 +71,17 @@ export function getAppHostDiscoveryExcludeGlob(): string {
 }
 
 export function isExcludedDiscoveryUri(workspaceFolder: vscode.WorkspaceFolder, uri: vscode.Uri): boolean {
+    return isExcludedDiscoveryPath(workspaceFolder, uri, true);
+}
+
+export function isExcludedDiscoveryCandidate(workspaceFolder: vscode.WorkspaceFolder, uri: vscode.Uri): boolean {
+    return isExcludedDiscoveryPath(workspaceFolder, uri, false);
+}
+
+function isExcludedDiscoveryPath(workspaceFolder: vscode.WorkspaceFolder, uri: vscode.Uri, excludeOutsideWorkspace: boolean): boolean {
     const relativePath = path.relative(workspaceFolder.uri.fsPath, uri.fsPath);
     if (relativePath === '' || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
-        return true;
+        return excludeOutsideWorkspace;
     }
 
     const segments = relativePath.split(/[\\/]+/).map(segment => segment.toLowerCase());

--- a/src/Aspire.Cli/Projects/AppHostCandidateFinder.cs
+++ b/src/Aspire.Cli/Projects/AppHostCandidateFinder.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Frozen;
+using System.Collections.Immutable;
 using Aspire.Cli.Git;
 using Aspire.Cli.Telemetry;
 using Microsoft.Extensions.FileSystemGlobbing;
@@ -54,21 +54,25 @@ internal sealed class AppHostCandidateFinder(
     ProfilingTelemetry profilingTelemetry,
     ILogger<AppHostCandidateFinder> logger) : IAppHostCandidateFinder
 {
-    // Directory names that are excluded from AppHost discovery by default. These are
-    // common build outputs, package caches, and tooling directories that should never
-    // contain a user's AppHost. The list is intentionally conservative - it omits
-    // names like "vendor" (Go/PHP first-party), "build" (some repos use as source),
-    // and "packages" (pnpm/Lerna workspace root) because those are sometimes legitimate.
-    // Matching is case-insensitive on every platform; on Linux that means a directory
-    // named "Bin" coincidentally collides with "bin" and gets skipped, which is the
-    // right tradeoff given these are conventional names.
-    private static readonly FrozenSet<string> s_defaultExcludedDirectoryNames = FrozenSet.ToFrozenSet(
+    // Directory names (and path-scoped subpaths) excluded from AppHost discovery by default. These
+    // are common build outputs, package caches, and tooling directories that should never contain a
+    // user's AppHost. The list is intentionally conservative - it omits names like "vendor" (Go/PHP
+    // first-party), "build" (some repos use as source), and "packages" (pnpm/Lerna workspace root)
+    // because those are sometimes legitimate. Matching is case-insensitive on every platform; on
+    // Linux that means a directory named "Bin" coincidentally collides with "bin" and gets skipped,
+    // which is the right tradeoff given these are conventional names.
+    private static readonly ImmutableArray<string> s_defaultExcludedDirectoryNames =
     [
         // Build outputs / artifacts
         "bin", "obj", "dist", "out", "target", "artifacts", "coverage",
 
         // VCS / IDE
         ".git", ".vs", ".idea",
+
+        // Agent skill roots ship apphost.* files as code samples, not runnable AppHosts (see
+        // SkillLocation). .agents and .claude are tool-owned, so the whole directory is excluded;
+        // .github and .opencode hold non-skill content too, so only the skills subpath is excluded.
+        ".agents", ".claude", Path.Combine(".github", "skills"), Path.Combine(".opencode", "skill"),
 
         // JavaScript / TypeScript ecosystems
         "node_modules", ".next", ".nuxt", ".cache", ".turbo", ".svelte-kit",
@@ -80,8 +84,17 @@ internal sealed class AppHostCandidateFinder(
 
         // JVM / other
         ".gradle",
-    ],
-    StringComparer.OrdinalIgnoreCase);
+    ];
+
+    // Segment view of the exclusion list, computed once. A bare name like "bin" becomes a
+    // one-segment sequence and a path-scoped entry like ".github/skills" becomes a multi-segment
+    // sequence; both are matched as a contiguous subsequence of a candidate's directory segments.
+    private static readonly ImmutableArray<ImmutableArray<string>> s_excludedDirectorySegments =
+    [
+        .. s_defaultExcludedDirectoryNames.Select(static name =>
+            name.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries)
+                .ToImmutableArray()),
+    ];
 
     public async Task<AppHostCandidateFileSearchResult> FindCandidateFilesAsync(
         DirectoryInfo searchDirectory,
@@ -138,17 +151,16 @@ internal sealed class AppHostCandidateFinder(
         // don't immediately start the slower fallback filesystem walk over a large repository.
         cancellationToken.ThrowIfCancellationRequested();
 
-        var skipList = scope == AppHostDiscoveryScope.AllFiles
-            ? null
-            : s_defaultExcludedDirectoryNames;
+        // Directory exclusions only apply to the filtered scope; AllFiles opts in to everything.
+        var applyDirectoryExclusions = scope != AppHostDiscoveryScope.AllFiles;
         var enumerationOptions = new EnumerationOptions
         {
             RecurseSubdirectories = true,
             IgnoreInaccessible = true
         };
 
-        using var walkActivity = profilingTelemetry.StartAppHostCandidateFilesystemWalk(searchDirectory, patterns.Count, skipList is not null, nugetCachePath is not null);
-        var searchResult = FindMatchingFiles(searchDirectory, patterns, enumerationOptions, nugetCachePath, skipList, maxDepth, walkActivity, onDirectoryEnumerated, cancellationToken);
+        using var walkActivity = profilingTelemetry.StartAppHostCandidateFilesystemWalk(searchDirectory, patterns.Count, applyDirectoryExclusions, nugetCachePath is not null);
+        var searchResult = FindMatchingFiles(searchDirectory, patterns, enumerationOptions, nugetCachePath, applyDirectoryExclusions, maxDepth, walkActivity, onDirectoryEnumerated, cancellationToken);
         walkActivity.SetAppHostCandidateCount(searchResult.Files.Length);
         discoveryActivity.SetAppHostDiscoverySource(ProfilingTelemetry.Values.AppHostDiscoverySourceFilesystem);
         discoveryActivity.SetAppHostCandidateCount(searchResult.Files.Length);
@@ -269,29 +281,35 @@ internal sealed class AppHostCandidateFinder(
 
     private static bool HasSkipListedDirectorySegment(string rootFullName, string absolutePath)
     {
-        var relative = Path.GetRelativePath(rootFullName, absolutePath);
-
-        if (string.IsNullOrEmpty(relative) || relative == ".")
+        if (Path.GetDirectoryName(absolutePath) is not { Length: > 0 } absoluteDirectory)
         {
             return false;
         }
 
-        // GetRelativePath can return ".." paths if absolutePath is outside rootFullName;
-        // skip such entries defensively (shouldn't happen with a well-formed git output).
-        if (relative.StartsWith("..", StringComparison.Ordinal))
+        // Match against the directory path relative to the search root. Only segments below the root
+        // are considered, so the root's own name (and any ancestor above it) never participates -- a
+        // repo checked out under a folder named like an excluded directory (e.g. C:\obj\repo or a
+        // root literally named "obj") keeps its real AppHosts.
+        var relative = Path.GetRelativePath(rootFullName, absoluteDirectory);
+
+        // GetRelativePath returns ".." when absoluteDirectory is outside the root; nothing to match
+        // in that case (shouldn't happen with well-formed git output rooted under the search root).
+        if (relative == "." || relative.StartsWith("..", StringComparison.Ordinal))
         {
             return false;
         }
 
-        var relativeDirectory = Path.GetDirectoryName(relative);
-        if (string.IsNullOrEmpty(relativeDirectory))
-        {
-            return false;
-        }
+        var segments = relative.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries);
+        return ContainsExcludedSegmentSequence(segments);
+    }
 
-        foreach (var segment in relativeDirectory.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries))
+    // True when any excluded sequence appears as a contiguous run of segments. Single-name entries
+    // are length-1 sequences, so this also covers the plain directory-name exclusions.
+    private static bool ContainsExcludedSegmentSequence(ReadOnlySpan<string> segments)
+    {
+        foreach (var sequence in s_excludedDirectorySegments)
         {
-            if (s_defaultExcludedDirectoryNames.Contains(segment))
+            if (ContainsContiguousSubsequence(segments, sequence.AsSpan()))
             {
                 return true;
             }
@@ -300,12 +318,72 @@ internal sealed class AppHostCandidateFinder(
         return false;
     }
 
+    private static bool ContainsContiguousSubsequence(ReadOnlySpan<string> segments, ReadOnlySpan<string> sequence)
+    {
+        if (sequence.Length == 0 || sequence.Length > segments.Length)
+        {
+            return false;
+        }
+
+        for (var start = 0; start <= segments.Length - sequence.Length; start++)
+        {
+            var matched = true;
+            for (var offset = 0; offset < sequence.Length; offset++)
+            {
+                if (!segments[start + offset].Equals(sequence[offset], StringComparison.OrdinalIgnoreCase))
+                {
+                    matched = false;
+                    break;
+                }
+            }
+
+            if (matched)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Filesystem-walk counterpart: prunes at the directory that IS an excluded root by matching the
+    // directory and its ancestors against an excluded sequence's trailing segments. The walk is
+    // bounded by the sequence length, so ancestors above the matched root are never inspected.
+    private static bool IsExcludedDirectory(DirectoryInfo directory)
+    {
+        foreach (var sequence in s_excludedDirectorySegments)
+        {
+            if (MatchesTrailingSegments(directory, sequence.AsSpan()))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool MatchesTrailingSegments(DirectoryInfo directory, ReadOnlySpan<string> sequence)
+    {
+        DirectoryInfo? current = directory;
+        for (var i = sequence.Length - 1; i >= 0; i--)
+        {
+            if (current is null || !current.Name.Equals(sequence[i], StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            current = current.Parent;
+        }
+
+        return true;
+    }
+
     private static AppHostCandidateFileSearchResult FindMatchingFiles(
         DirectoryInfo searchDirectory,
         IReadOnlyList<string> patterns,
         EnumerationOptions options,
         string? excludePath,
-        FrozenSet<string>? excludedDirectoryNames,
+        bool applyDirectoryExclusions,
         int? maxDepth,
         ProfilingTelemetry.ActivityScope walkActivity,
         Action<int>? onDirectoryEnumerated,
@@ -326,7 +404,7 @@ internal sealed class AppHostCandidateFinder(
         // "**/*.csproj" and let the matcher walk once instead of enumerating once per
         // language detection pattern.
         var counters = new DiscoveryCounters();
-        var directory = new MatcherDirectoryInfo(searchDirectory, options, excludePath, excludedDirectoryNames, pathComparison, counters, onDirectoryEnumerated, depth: 0, maxDepth, cancellationToken);
+        var directory = new MatcherDirectoryInfo(searchDirectory, options, excludePath, applyDirectoryExclusions, pathComparison, counters, onDirectoryEnumerated, depth: 0, maxDepth, cancellationToken);
         var matchedFilePaths = matcher.Execute(directory).Files.Select(match => match.Path).ToArray();
         walkActivity.SetAppHostDiscoveryWalkCounts(counters.FilesEnumerated, counters.DirectoriesEnumerated, counters.DirectoriesSkipped);
 
@@ -432,12 +510,12 @@ internal sealed class AppHostCandidateFinder(
         public int DirectoriesSkipped { get; set; }
     }
 
-    private sealed class MatcherDirectoryInfo(DirectoryInfo directory, EnumerationOptions options, string? excludePath, FrozenSet<string>? excludedDirectoryNames, StringComparison pathComparison, DiscoveryCounters counters, Action<int>? onDirectoryEnumerated, int depth, int? maxDepth, CancellationToken cancellationToken) : DirectoryInfoBase
+    private sealed class MatcherDirectoryInfo(DirectoryInfo directory, EnumerationOptions options, string? excludePath, bool applyDirectoryExclusions, StringComparison pathComparison, DiscoveryCounters counters, Action<int>? onDirectoryEnumerated, int depth, int? maxDepth, CancellationToken cancellationToken) : DirectoryInfoBase
     {
         private readonly DirectoryInfo _directory = directory;
         private readonly EnumerationOptions _options = options;
         private readonly string? _excludePath = excludePath;
-        private readonly FrozenSet<string>? _excludedDirectoryNames = excludedDirectoryNames;
+        private readonly bool _applyDirectoryExclusions = applyDirectoryExclusions;
         private readonly StringComparison _pathComparison = pathComparison;
         private readonly DiscoveryCounters _counters = counters;
         private readonly Action<int>? _onDirectoryEnumerated = onDirectoryEnumerated;
@@ -450,7 +528,7 @@ internal sealed class AppHostCandidateFinder(
         public override string FullName => _directory.FullName;
 
         public override DirectoryInfoBase ParentDirectory => _directory.Parent is { } parent
-            ? new MatcherDirectoryInfo(parent, _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _onDirectoryEnumerated, _depth - 1, _maxDepth, _cancellationToken)
+            ? new MatcherDirectoryInfo(parent, _options, _excludePath, _applyDirectoryExclusions, _pathComparison, _counters, _onDirectoryEnumerated, _depth - 1, _maxDepth, _cancellationToken)
             : null!;
 
         public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos()
@@ -467,7 +545,7 @@ internal sealed class AppHostCandidateFinder(
                     _onDirectoryEnumerated?.Invoke(_counters.DirectoriesEnumerated);
                     if (CanRecurse && !ShouldExcludeDirectory(childDirectory))
                     {
-                        yield return new MatcherDirectoryInfo(childDirectory, _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _onDirectoryEnumerated, _depth + 1, _maxDepth, _cancellationToken);
+                        yield return new MatcherDirectoryInfo(childDirectory, _options, _excludePath, _applyDirectoryExclusions, _pathComparison, _counters, _onDirectoryEnumerated, _depth + 1, _maxDepth, _cancellationToken);
                     }
                     else
                     {
@@ -479,7 +557,7 @@ internal sealed class AppHostCandidateFinder(
                     _counters.FilesEnumerated++;
                     if (CanIncludeFiles)
                     {
-                        yield return new MatcherFileInfo(childFile, _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _onDirectoryEnumerated, _depth, _maxDepth, _cancellationToken);
+                        yield return new MatcherFileInfo(childFile, _options, _excludePath, _applyDirectoryExclusions, _pathComparison, _counters, _onDirectoryEnumerated, _depth, _maxDepth, _cancellationToken);
                     }
                 }
             }
@@ -487,17 +565,18 @@ internal sealed class AppHostCandidateFinder(
 
         public override DirectoryInfoBase GetDirectory(string path)
         {
-            return new MatcherDirectoryInfo(new DirectoryInfo(Path.Combine(_directory.FullName, path)), _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _onDirectoryEnumerated, _depth + 1, _maxDepth, _cancellationToken);
+            return new MatcherDirectoryInfo(new DirectoryInfo(Path.Combine(_directory.FullName, path)), _options, _excludePath, _applyDirectoryExclusions, _pathComparison, _counters, _onDirectoryEnumerated, _depth + 1, _maxDepth, _cancellationToken);
         }
 
         public override FileInfoBase GetFile(string path)
         {
-            return new MatcherFileInfo(new FileInfo(Path.Combine(_directory.FullName, path)), _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _onDirectoryEnumerated, _depth, _maxDepth, _cancellationToken);
+            return new MatcherFileInfo(new FileInfo(Path.Combine(_directory.FullName, path)), _options, _excludePath, _applyDirectoryExclusions, _pathComparison, _counters, _onDirectoryEnumerated, _depth, _maxDepth, _cancellationToken);
         }
 
         private bool ShouldExcludeDirectory(DirectoryInfo directory)
         {
-            if (_excludedDirectoryNames is not null && _excludedDirectoryNames.Contains(directory.Name))
+            // Exclusions are disabled under the AllFiles scope (applyDirectoryExclusions is false).
+            if (_applyDirectoryExclusions && IsExcludedDirectory(directory))
             {
                 return true;
             }
@@ -517,12 +596,12 @@ internal sealed class AppHostCandidateFinder(
         private bool CanIncludeFiles => _maxDepth is null || _depth <= _maxDepth;
     }
 
-    private sealed class MatcherFileInfo(FileInfo file, EnumerationOptions options, string? excludePath, FrozenSet<string>? excludedDirectoryNames, StringComparison pathComparison, DiscoveryCounters counters, Action<int>? onDirectoryEnumerated, int depth, int? maxDepth, CancellationToken cancellationToken) : FileInfoBase
+    private sealed class MatcherFileInfo(FileInfo file, EnumerationOptions options, string? excludePath, bool applyDirectoryExclusions, StringComparison pathComparison, DiscoveryCounters counters, Action<int>? onDirectoryEnumerated, int depth, int? maxDepth, CancellationToken cancellationToken) : FileInfoBase
     {
         private readonly FileInfo _file = file;
         private readonly EnumerationOptions _options = options;
         private readonly string? _excludePath = excludePath;
-        private readonly FrozenSet<string>? _excludedDirectoryNames = excludedDirectoryNames;
+        private readonly bool _applyDirectoryExclusions = applyDirectoryExclusions;
         private readonly StringComparison _pathComparison = pathComparison;
         private readonly DiscoveryCounters _counters = counters;
         private readonly Action<int>? _onDirectoryEnumerated = onDirectoryEnumerated;
@@ -535,7 +614,7 @@ internal sealed class AppHostCandidateFinder(
         public override string FullName => _file.FullName;
 
         public override DirectoryInfoBase ParentDirectory => _file.Directory is { } parent
-            ? new MatcherDirectoryInfo(parent, _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _onDirectoryEnumerated, _depth, _maxDepth, _cancellationToken)
+            ? new MatcherDirectoryInfo(parent, _options, _excludePath, _applyDirectoryExclusions, _pathComparison, _counters, _onDirectoryEnumerated, _depth, _maxDepth, _cancellationToken)
             : null!;
     }
 

--- a/tests/Aspire.Cli.Tests/Projects/AppHostCandidateFinderTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostCandidateFinderTests.cs
@@ -101,6 +101,83 @@ public class AppHostCandidateFinderTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task FindCandidateFilesAsync_DefaultFiltered_GitMode_ExcludesAgentSkillSnippets()
+    {
+        // Skills under .agents/skills and .claude/skills ship apphost.ts files as code samples, not
+        // runnable AppHosts. See https://github.com/microsoft/aspire/issues/18398.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var agentSkillSnippetAppHost = await WriteFileAsync(workspace.WorkspaceRoot, ".agents/skills/demo/snippets/apphost.ts");
+        var claudeSkillSnippetAppHost = await WriteFileAsync(workspace.WorkspaceRoot, ".claude/skills/demo/snippets/apphost.ts");
+        var gitRepository = CreateGitRepository(agentSkillSnippetAppHost.FullName, claudeSkillSnippetAppHost.FullName);
+        var finder = CreateFinder(gitRepository);
+
+        var result = await finder.FindCandidateFilesAsync(workspace.WorkspaceRoot, ["apphost.ts"], nugetCachePath: null, AppHostDiscoveryScope.DefaultFiltered, CancellationToken.None).DefaultTimeout();
+
+        Assert.Empty(result.Files);
+        Assert.Equal(0, result.CountsByPattern["apphost.ts"]);
+    }
+
+    [Fact]
+    public async Task FindCandidateFilesAsync_DefaultFiltered_GitMode_ExcludesPathScopedSkillSnippets()
+    {
+        // .github and .opencode hold more than skills, so only the .github/skills and .opencode/skill
+        // subpaths are excluded; a real AppHost elsewhere under .github is still discovered.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var gitHubSkillSnippetAppHost = await WriteFileAsync(workspace.WorkspaceRoot, ".github/skills/demo/snippets/apphost.ts");
+        var openCodeSkillSnippetAppHost = await WriteFileAsync(workspace.WorkspaceRoot, ".opencode/skill/demo/snippets/apphost.ts");
+        var gitHubNonSkillAppHost = await WriteFileAsync(workspace.WorkspaceRoot, ".github/AppHost/apphost.ts");
+        var gitRepository = CreateGitRepository(gitHubSkillSnippetAppHost.FullName, openCodeSkillSnippetAppHost.FullName, gitHubNonSkillAppHost.FullName);
+        var finder = CreateFinder(gitRepository);
+
+        var result = await finder.FindCandidateFilesAsync(workspace.WorkspaceRoot, ["apphost.ts"], nugetCachePath: null, AppHostDiscoveryScope.DefaultFiltered, CancellationToken.None).DefaultTimeout();
+
+        var path = Assert.Single(result.Files).FullName;
+        Assert.Equal(gitHubNonSkillAppHost.FullName, path);
+        Assert.Equal(1, result.CountsByPattern["apphost.ts"]);
+    }
+
+    [Fact]
+    public async Task FindCandidateFilesAsync_FilesystemFallback_ExcludesPathScopedSkillSnippets()
+    {
+        // The filesystem-walk fallback (no git repository) applies the same subpath exclusions as git mode.
+        // The kept AppHost lives under a non-hidden directory ("src"): on Unix, .NET reports dot-prefixed
+        // directories (.github/.opencode/.agents/.claude) as FileAttributes.Hidden, and the walk's
+        // enumeration skips hidden directories by default, so an AppHost under a dot-directory would not be
+        // discovered there regardless of the skip-list. Git mode (which enumerates tracked dot-directories
+        // on every platform) covers keeping a non-skill AppHost under .github.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        await WriteFileAsync(workspace.WorkspaceRoot, ".github/skills/demo/snippets/apphost.ts");
+        await WriteFileAsync(workspace.WorkspaceRoot, ".opencode/skill/demo/snippets/apphost.ts");
+        var nonSkillAppHost = await WriteFileAsync(workspace.WorkspaceRoot, "src/AppHost/apphost.ts");
+        var finder = CreateFinder();
+
+        var result = await finder.FindCandidateFilesAsync(workspace.WorkspaceRoot, ["apphost.ts"], nugetCachePath: null, AppHostDiscoveryScope.DefaultFiltered, CancellationToken.None).DefaultTimeout();
+
+        var paths = result.Files.Select(file => file.FullName).ToHashSet();
+        var path = Assert.Single(paths);
+        Assert.Equal(nonSkillAppHost.FullName, path);
+        Assert.Equal(1, result.CountsByPattern["apphost.ts"]);
+    }
+
+    [Fact]
+    public async Task FindCandidateFilesAsync_DefaultFiltered_GitMode_DoesNotPruneWhenSearchRootIsNamedLikeExcludedDirectory()
+    {
+        // The skip-list matches only segments below the search root, so a repo checked out under a
+        // folder named like an excluded directory (here the root itself is "obj") keeps its AppHosts.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var searchRoot = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, "obj"));
+        var appHost = await WriteFileAsync(searchRoot, "AppHost/apphost.ts");
+        var gitRepository = CreateGitRepository(appHost.FullName);
+        var finder = CreateFinder(gitRepository);
+
+        var result = await finder.FindCandidateFilesAsync(searchRoot, ["apphost.ts"], nugetCachePath: null, AppHostDiscoveryScope.DefaultFiltered, CancellationToken.None).DefaultTimeout();
+
+        var path = Assert.Single(result.Files).FullName;
+        Assert.Equal(appHost.FullName, path);
+        Assert.Equal(1, result.CountsByPattern["apphost.ts"]);
+    }
+
+    [Fact]
     public async Task FindCandidateFilesAsync_DefaultFiltered_GitMode_DoesNotApplySkipListToFileName()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Description

Agent skills can include apphost snippet files under `.agents/skills/**`, purely as code samples. Both the Aspire CLI and the VS Code extension were treating these snippets as real, runnable AppHosts.

There were two independent root causes, so this fixes both layers:

**CLI** - `aspire ls` default discovery had no `.agents` skip entry, so it emitted snippet apphosts as `buildable` candidates. Added `.agents` to the default discovery skip-list (`AppHostCandidateFinder`). Snippets are now excluded from default/filtered discovery but still included under `--all`.

**Extension** - even with the CLI fixed, the discovery service's configured-path injection (`_includeConfiguredAppHostCandidate` -> `findConfiguredAppHostPaths`) found the snippet's scaffolded `aspire.config.json` and re-injected the `.agents` apphost as a *selected* candidate when `aspire ls` returned none. The fix:

- Adds `.agents` to the centralized discovery exclusions (`workspaceFileSearch.ts`).
- Consolidates exclusion into a single trailing `_filterExcludedCandidates` choke point in the discovery pipeline (after `_discoverCore` -> `_includeConfiguredAppHostCandidate`). This one filter now covers every candidate source: CLI output from `aspire ls` / `aspire extension get-apphosts` (parsed JSON the workspace globs can't reach), the C# file fallback, and the configured-path injection.

### Demo

With the fix, opening the repro workspace shows no AppHosts and the log reports `Discovered 0 AppHost candidate(s) via aspire ls` / `No AppHost projects found in workspace`:

![Aspire AppHosts panel shows no AppHosts detected after the fix](https://github.com/user-attachments/assets/0f00b165-e3f5-4064-ae07-145f0a4d01c0)

Fixes: #18398