### PR TITLE
fix(ci): skip full matrix on metadata-only PRs; clearer selector job reasons

### DIFF
--- a/eng/github-ci/ci-skip-entirely-patterns.txt
+++ b/eng/github-ci/ci-skip-entirely-patterns.txt
@@ -74,3 +74,18 @@ Aspire-Core.slnf
 start-code.sh
 localhive.*
 dogfood.sh
+
+# Repository metadata with no build or test impact. Without these, a PR touching only one of them
+# would fall through the selective-CI run-all fallback and force the FULL test matrix (the fallback
+# escalates any file it cannot attribute -- see tools/SelectTests/TestSelector.cs). Issue forms,
+# CODEOWNERS, and the repo-root .gitignore cannot change what builds or how a test behaves.
+#
+# Deliberately NOT listed (each can change build/test outcomes, so they must still run CI):
+#   .editorconfig    -- analyzer severities feed TreatWarningsAsErrors
+#   .gitattributes   -- checkout normalization (line endings) can affect fixture-sensitive tests
+# The pattern below is the repo-ROOT .gitignore only (anchored, no '**'): nested .gitignore files
+# under src/Aspire.Cli/Templating/Templates/** and tests/** are shipped/owned assets that Layer 1 and
+# the conventions route to their projects -- they must not skip CI.
+.gitignore
+.github/CODEOWNERS
+.github/ISSUE_TEMPLATE/**

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -535,7 +535,8 @@ public sealed class SelectTestsAcceptanceTests : IDisposable
     public void DerivedJobCauseNamesTheTriggeringTestProject()
     {
         // A job pulled in purely because a test project is selected: tests/CliTests/** -> test:CliTests
-        // (convention) -> job:cli-starter (derived_targets). The cause must say "via test CliTests".
+        // (convention) -> job:cli-starter (derived_targets). The cause is DerivedFromTest naming CliTests
+        // (rendered "selected test CliTests" in the job-reasons cell).
         var r = Select(["tests/CliTests/Foo.cs"]);
 
         var cause = Assert.Single(r.JobCauses["job:cli-starter"]);
@@ -815,6 +816,19 @@ public sealed class SelectTestsAcceptanceTests : IDisposable
         Assert.True(filter.IsExcluded(".agents/skills/foo/SKILL.md"));
         Assert.True(filter.IsExcluded("Aspire-Core.slnf"));
         Assert.True(filter.IsExcluded("localhive.ps1"));                 // localhive.* -> localhive\.[^/]*
+
+        // Repository metadata with no build/test impact: a PR touching only these must not force the
+        // full matrix via the run-all fallback (the reason they are in the skip-gate patterns file).
+        Assert.True(filter.IsExcluded(".gitignore"));                    // repo-ROOT .gitignore (anchored)
+        Assert.True(filter.IsExcluded(".github/CODEOWNERS"));
+        Assert.True(filter.IsExcluded(".github/ISSUE_TEMPLATE/10_bug_report.yml"));
+
+        // Safety carve-outs: NOT dropped, because they can change build/test outcomes -- nested .gitignore
+        // files are shipped CLI-template assets (Layer 1 / conventions route them to their projects), and
+        // .editorconfig / .gitattributes affect the build and checkout.
+        Assert.False(filter.IsExcluded("src/Aspire.Cli/Templating/Templates/ts-starter/.gitignore"));
+        Assert.False(filter.IsExcluded(".editorconfig"));
+        Assert.False(filter.IsExcluded(".gitattributes"));
 
         // Kept: real source the patterns file does not list.
         Assert.False(filter.IsExcluded("src/Aspire.Cli/Program.cs"));

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
@@ -224,6 +224,56 @@ public sealed class SelectTestsCliTests
         });
     }
 
+    // A job pulled in by SEVERAL independent triggers must render each as its OWN bulleted line, not
+    // comma-joined: a comma between e.g. "affected project X" and a selected-test reason reads as a
+    // single causal chain when they are unrelated. Here job:multi is hit by a path rule (a.txt) AND a
+    // derived_targets pull from the selected test Aspire.Cli.Tests; the cell must bullet the two and
+    // name the trigger as "selected test" (a noun, parallel to "affected project"). Failure mode:
+    // regressing to comma-joining makes "affected project X, selected test Y" look like one chain.
+    [Fact]
+    public void JobWithIndependentCausesRendersEachReasonOnItsOwnLine()
+    {
+        const string slnx = """
+            <Solution>
+              <Project Path="tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj" />
+            </Solution>
+            """;
+        const string map = """
+            version: 1
+            path_rules:
+              - paths: [a.txt]
+                targets: ["job:multi"]
+              - paths: [b.txt]
+                targets: ["test:Aspire.Cli.Tests"]
+            derived_targets:
+              - tests: [test:Aspire.Cli.Tests]
+                targets: [job:multi]
+            """;
+
+        RunInTempRepo((repoRoot, propsPath, _) =>
+        {
+            var commentPath = Path.Combine(repoRoot, "comment.md");
+            var previous = Environment.GetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE");
+            Environment.SetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE", commentPath);
+            try
+            {
+                var changed = WriteChangedFiles(repoRoot, "a.txt", "b.txt");
+
+                Selection.Run(Options(repoRoot, propsPath, changedFilesPath: changed, skipLayer1: true, enforce: true));
+
+                var comment = File.ReadAllText(commentPath);
+                // The two independent triggers are bulleted on separate lines (<br>), and the derived
+                // pull reads "selected test" -- pinning the bullets, the separation, and the wording in
+                // one exact cell match.
+                Assert.Contains("| `multi` | • `a.txt`<br>• selected test `Aspire.Cli.Tests` |", comment);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE", previous);
+            }
+        }, slnx: slnx, map: map);
+    }
+
     // The headline call-out (⚠️ "N of the M ... come from a single change") and the <details> collapse
     // in RenderProjectList are both threshold-gated (headline: tests >= 10 && largest group >= 5;
     // collapse: inline limit of 12). A single change that fans out to many projects must trip both.

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -893,6 +893,13 @@ internal static class Selection
 
     // The full set of causes for one job, de-duplicated and priority-ordered, for the job-reasons
     // table. Every cause is shown (no truncation) so a reviewer sees exactly what pulled the job in.
+    //
+    // A job is often pulled in by several INDEPENDENT triggers (e.g. a changed path rule AND an affected
+    // production project AND a selected test that derives it). Comma-joining those on one line reads as a
+    // single causal chain -- "affected project Aspire.Cli, selected test Aspire.Cli.Tests" looks like one
+    // flows through the other, when they are unrelated reasons. So render each independent trigger as its
+    // own bulleted line, collapsing only the homogeneous changed-file causes (every path that matched a
+    // rule/convention) into one comma-joined segment. A single trigger needs no bullet.
     private static string JobCausesText(IReadOnlyDictionary<string, IReadOnlyList<Cause>> causes, string key)
     {
         if (!causes.TryGetValue(key, out var list) || list.Count == 0)
@@ -900,10 +907,34 @@ internal static class Selection
             return "_unattributed_";
         }
 
-        return string.Join(", ", list
-            .OrderBy(c => CausePriority(c.Kind))
+        var ordered = list.OrderBy(c => CausePriority(c.Kind)).ToList();
+
+        // Changed-file causes (a path matched a convention/path rule) are the same KIND of reason, so
+        // they read fine comma-joined as one segment. Distinct kinds (affected project, selected test)
+        // each get their own line.
+        var fileCauses = ordered
+            .Where(c => c.Kind is CauseKind.Convention or CauseKind.PathRule)
             .Select(ShortCause)
-            .Distinct());
+            .Distinct()
+            .ToList();
+        var otherCauses = ordered
+            .Where(c => c.Kind is not (CauseKind.Convention or CauseKind.PathRule))
+            .Select(ShortCause)
+            .Distinct()
+            .ToList();
+
+        var segments = new List<string>();
+        if (fileCauses.Count > 0)
+        {
+            segments.Add(string.Join(", ", fileCauses));
+        }
+        segments.AddRange(otherCauses);
+
+        // A single trigger reads fine on its own; 2+ get "• " bullets so they cannot run together (a
+        // literal bullet glyph -- a markdown "-" list does not render inside a GitHub table cell).
+        return segments.Count == 1
+            ? segments[0]
+            : string.Join("<br>", segments.Select(s => $"• {s}"));
     }
 
     private static void WriteSummary(
@@ -1091,7 +1122,11 @@ internal static class Selection
         // Name the seed changed file (and hop count) rather than the full chain, which the summary
         // carries -- the comment stays scannable. Falls back to a generic label when no path was tracked.
         CauseKind.Layer1Graph => Layer1ShortCause(cause),
-        CauseKind.DerivedFromTest => $"via test `{cause.Trigger}`",
+        // "selected test" (a noun phrase parallel to "affected project") names the trigger: a
+        // derived_targets rule pulls this job in because that test project was selected. Phrasing it as a
+        // noun -- not "derived from test X" -- avoids a dangling "from" that reads as if the line above it
+        // in the job-reasons cell flows through this test.
+        CauseKind.DerivedFromTest => $"selected test `{cause.Trigger}`",
         _ => cause.Trigger,
     };
 


### PR DESCRIPTION
Two selective-CI selector fixes.

## 1. Job-reason attribution reads clearly

A job pulled in by two independent triggers was comma-joined into a false causal chain.

**Before:**

```
| cli-starter | affected project Aspire.Cli, via test Aspire.Cli.Tests |
```

**Now:**

```
| cli-starter | • affected project Aspire.Cli       |
|             | • selected test Aspire.Cli.Tests    |
```

Each independent trigger is its own bulleted line; `selected test X` is parallel to `affected project X`. Bullets only when 2+ triggers — single-trigger cells stay plain.

## 2. Trigger-pattern changes

A PR changing only `.gitignore`, an issue template, or `CODEOWNERS` used to hit the run-all fallback and select the full matrix (e.g. #18377, #18360). These now drop before selection — added to `eng/github-ci/ci-skip-entirely-patterns.txt` (the prefilter shared by the selector and the top-level CI-skip gate):

```
.gitignore            # repo-ROOT only (anchored, no **)
.github/CODEOWNERS
.github/ISSUE_TEMPLATE/**
```

Deliberately **not** added — each can change build/test outcomes: `.editorconfig` (analyzer severities feed TreatWarningsAsErrors), `.gitattributes` (checkout normalization). Nested `.gitignore` files under `src/.../Templates/**` and `tests/**` are shipped assets routed by Layer 1, so only the root one is listed.

No selection-logic change — same projects/jobs selected; only the comment layout and the prefilter set change.
