### PR TITLE
ci: enforce selective test selection on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,9 @@ jobs:
       tests_matrix_requires_cli_archive: ${{ steps.split_matrix.outputs.tests_matrix_requires_cli_archive }}
       # Selective CI (see docs/ci/test-trigger-selector-design.md). The audit/enforce knob is the
       # select-tests action's `enforce` input; tests.yml just consumes what the selector returns.
-      # In audit the selector returns run-all (every gate true + the full matrix), so everything runs.
+      # In enforce the selector returns only the gates its trigger map selected for the changed files
+      # (a non-selected gate is false and its job is skipped); the run-full-ci label / non-PR events
+      # still force every gate true via the action's kill switch.
       run_polyglot: ${{ fromJSON(steps.select_tests.outputs.selection).run_polyglot }}
       run_typescript_sdk: ${{ fromJSON(steps.select_tests.outputs.selection).run_typescript_sdk }}
       run_typescript_api_compat: ${{ fromJSON(steps.select_tests.outputs.selection).run_typescript_api_compat }}
@@ -57,15 +59,17 @@ jobs:
 
       # Compute the selected test subset + non-.NET job booleans. The action reuses this job's checkout
       # (checkout=false) so the BeforeBuildProps.props it may write survives for enumerate-tests below,
-      # and does its own minimal SDK bootstrap (setupDotNet=true). enforce: 'false' keeps this audit-only
-      # (the knob is documented on the action's `enforce` input). No job-level actions/setup-dotnet on
-      # purpose -- global.json declares tools.runtimes, so Arcade always uses repo-local .dotnet.
+      # and does its own minimal SDK bootstrap (setupDotNet=true). enforce: 'true' makes the selection
+      # binding: a non-ALL selection writes the restriction props so enumerate-tests builds only the
+      # selected projects and the run_* gates skip the non-selected jobs (the knob is documented on the
+      # action's `enforce` input). No job-level actions/setup-dotnet on purpose -- global.json declares
+      # tools.runtimes, so Arcade always uses repo-local .dotnet.
       - name: Select relevant tests
         id: select_tests
         uses: ./.github/actions/select-tests
         with:
           checkout: 'false'
-          enforce: 'false'
+          enforce: 'true'
           commentFile: ${{ env.SELECT_TESTS_COMMENT_FILE }}
           # Kill switch: the 'run-full-ci' PR label forces the full matrix + all jobs. Read from the event
           # payload snapshot, so adding the label takes effect on the next push (or reopen), not on a
@@ -88,8 +92,9 @@ jobs:
 
       # enumerate-tests reuses this job's checkout + restore (checkout/restore=false) so the props
       # file the selector wrote survives -- a fresh checkout would git-clean it away. When a
-      # restriction was written, beforeBuildPropsPath points enumerate at the selected subset; in
-      # audit mode project_override_props is empty and enumerate builds the full matrix.
+      # restriction was written, beforeBuildPropsPath points enumerate at the selected subset; for an
+      # ALL selection (run-full-ci, non-PR events, or an ALL escalation) project_override_props is empty
+      # and enumerate builds the full matrix.
       #
       # Skipped entirely when the selection has no .NET test projects (has_dotnet_tests=false, e.g. an
       # extension-only / polyglot-only change whose only targets are non-.NET jobs). An empty selection

--- a/docs/ci/test-trigger-selector-design.md
+++ b/docs/ci/test-trigger-selector-design.md
@@ -9,15 +9,17 @@ Companion documents:
 - [`test-trigger-map.md`](./test-trigger-map.md) — the descriptive path → target map.
 - [`eng/github-ci/test-trigger-map.yml`](../../eng/github-ci/test-trigger-map.yml) — its machine-readable form.
 
-**Status: audit.** `tests.yml`'s `setup_for_tests` runs the `select-tests` action
-*before* `enumerate-tests`. When its `enforce: 'true'` and the selection is
+**Status: enforcing.** `tests.yml`'s `setup_for_tests` runs the `select-tests` action
+*before* `enumerate-tests` with `enforce: 'true'`. When the selection is
 not ALL, the selector writes an `OverrideProjectToBuild` props file so
-`enumerate-tests` builds and enumerates only the selected projects; in audit mode
-(`enforce: 'false'`) it writes no props and `enumerate-tests` produces
-the full matrix unchanged while the summary still reports what enforcing would
-have skipped.
+`enumerate-tests` builds and enumerates only the selected projects, and the
+`run_*` gates skip the non-selected non-.NET jobs. An ALL selection (the
+`run-full-ci` kill switch, or a non-PR event with no base) writes no props and
+runs the full matrix. Audit mode (`enforce: 'false'`) remains available as a
+knob: it writes no props and `enumerate-tests` produces the full matrix
+unchanged while the summary still reports what enforcing would have skipped.
 
-Audit mode does not soften Layer 1 failures. If the affected-projects graph
+Enforcing does not soften Layer 1 failures. If the affected-projects graph
 cannot be computed, `SelectTests` fails the step because under-selecting would
 silently skip real tests.
 
@@ -468,9 +470,11 @@ hits a curated rule, the convention backstop, or the run-all fallback.
 
 ## Rollout
 
-1. Run `SelectTests` in audit mode.
-2. Watch the audit summaries and fix unsafe skips in the curated layer.
-3. Flip to enforcing. Keep the kill switch and hard-fail Layer 1 policy.
+1. Run `SelectTests` in audit mode. _(done)_
+2. Watch the audit summaries and fix unsafe skips in the curated layer. _(done)_
+3. Flip to enforcing. Keep the kill switch and hard-fail Layer 1 policy. _(done —
+   `tests.yml` runs the selector with `enforce: 'true'`; the `run-full-ci` label
+   remains the kill switch.)_
 
 ## Future refinement
 

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -263,6 +263,15 @@ path_rules:
     targets: [test:Aspire.Acquisition.Tests]
     reason: Aspire.Acquisition.Tests/Scripts/VerifyCliArchivePowerShellTests invokes eng/scripts/verify-cli-archive.ps1
   - paths:
+      - eng/scripts/*aspire-skills-bundle*.ps1
+    targets: [test:Infrastructure.Tests]
+    reason: agent-skills-bundle packaging/validation scripts (update-/verify-/common); Infrastructure.Tests/PowerShellScripts is the unit home for eng/scripts PowerShell validation, and verify-aspire-skills-bundle.ps1 is additionally exercised by the standalone verify-aspire-skills-bundle.yml PR workflow (self-triggers on these paths) -> route to the unit suite, not run-all
+  - paths:
+      - eng/scripts/verify-cli-npm-package.ps1
+      - eng/scripts/verify-cli-tool-nupkg.ps1
+    targets: [test:Aspire.Cli.EndToEnd.Tests]
+    reason: structural verifiers run inside build-cli-native-archives.yml (called by tests.yml) against the packaged CLI archive; no unit test parses them, and the CLI-archive build self-gates on tests_matrix_requires_cli_archive (Aspire.Cli.EndToEnd.Tests, the sole RequiresCliArchive=true project), so routing there builds+verifies the archive without forcing ALL -- mirrors the build-cli-e2e-image.yml route above
+  - paths:
       - eng/winget/**
     targets: [test:Aspire.Acquisition.Tests, job:winget-installer]
     reason: WinGet manifest generation; prepare_winget_installer_artifacts builds from eng/winget, Acquisition.Tests exercises installer-mode

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
@@ -156,6 +156,15 @@ public sealed class SelectTestsCliTests
                 var comment = File.ReadAllText(commentPath);
                 Assert.StartsWith("## Tests selector", comment);
                 Assert.DoesNotContain("audit mode", comment);
+                // The run-full-ci kill switch is surfaced near the top of every comment, before the
+                // selected-subset lists, as a GitHub [!TIP] callout so a reviewer who thinks the reduced
+                // selection is wrong sees the escape hatch first. Pin the alert, the label, and ordering.
+                Assert.Contains("> [!TIP]", comment);
+                Assert.Contains("Add the **`run-full-ci`** label", comment);
+                Assert.True(
+                    comment.IndexOf("run-full-ci", StringComparison.Ordinal)
+                        < comment.IndexOf("### Selected test projects", StringComparison.Ordinal),
+                    "The run-full-ci kill-switch note must appear before the selected test projects.");
                 Assert.Contains("### Selected test projects (1 / 2)", comment);
                 Assert.Contains("`Aspire.Hosting.Tests`", comment);
                 Assert.Contains("### Selected jobs (1)", comment);

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -645,6 +645,14 @@ internal static class Selection
             sb.AppendLine();
         }
 
+        // Surface the kill switch near the top of every comment: when the reduced selection looks wrong
+        // (a missing trigger-map rule, an unexpected skip), adding the `run-full-ci` label is the
+        // one-step escape hatch back to the full matrix. A GitHub `[!TIP]` alert renders as a colored,
+        // boxed callout so it can't be missed when skimming past the selected subset.
+        sb.AppendLine("> [!TIP]");
+        sb.AppendLine("> 🏃 **Want the full CI?** Add the **`run-full-ci`** label to this PR to unconditionally run the full test matrix and all jobs.");
+        sb.AppendLine();
+
         if (result.SelectsAll)
         {
             sb.AppendLine(CultureInfo.InvariantCulture, $"**Runs the full test matrix + all jobs (ALL)** — {result.EscalationReason}");


### PR DESCRIPTION
## Description

Flips the `select-tests` action in `tests.yml` from `enforce: 'false'`
(audit) to `'true'`, turning selective CI **on**.

### How this affects PRs

- PR CI will run a **reduced set of tests** relevant to the changed files,
  instead of the full matrix.
- Changes to files that aren't explicitly mapped, or that affect everything
  (e.g. `src/Directory.Build.props`), still run **everything** — same as
  today.
- The `run-full-ci` label remains the kill switch to force the full matrix.

The mapping lives in
[`eng/github-ci/test-trigger-map.yml`](https://github.com/microsoft/aspire/blob/main/eng/github-ci/test-trigger-map.yml)
(see [`docs/ci/test-trigger-map.md`](https://github.com/microsoft/aspire/blob/main/docs/ci/test-trigger-map.md)).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No _(CI workflow flag flip; both modes already covered by `Infrastructure.Tests`)_
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
