### PR TITLE
ci: temporarily disable flaky VS Code extension E2E tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -672,7 +672,12 @@ jobs:
 
   extension_e2e_tests:
     name: Run VS Code extension E2E tests
-    if: ${{ needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
+    # Temporarily disabled: the VS Code extension E2E shards are flaky and currently failing in CI
+    # (intermittent teardown AggregateError, see https://github.com/microsoft/aspire/issues/18098),
+    # so they block unrelated PRs. Keep the job defined (it stays in the aggregate gate's needs) but
+    # force it to skip until the flakiness is fixed. Re-enable by removing the `false &&` guard below.
+    # Tracked by https://github.com/microsoft/aspire/issues/18412.
+    if: ${{ false && needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
     uses: ./.github/workflows/extension-e2e-tests.yml
     needs: [setup_for_tests, build_packages, build_cli_archive_linux, build_cli_archive_windows, extension_tests_win, extension_bootstrap_linux]
 
@@ -789,8 +794,10 @@ jobs:
         #   bucket actually had work. Before selective CI these were always populated on a full run.
         # - cli_starter_validation_windows: this job only runs for pull requests and is expected to
         #   be skipped for other workflow events.
-        # - extension_e2e_tests: this job only runs when the PR/push changes the VS Code extension,
-        #   Aspire CLI, or the extension E2E workflow wiring.
+        # - extension_e2e_tests: temporarily disabled (always skipped) because the E2E shards are
+        #   flaky/failing; see https://github.com/microsoft/aspire/issues/18412. While
+        #   disabled, a 'skipped' result must NOT fail this gate, so the run_extension_e2e skip checks
+        #   were removed below. Restore them when re-enabling the job.
         # - polyglot_validation: this job runs for pull requests and main branch builds; it is
         #   expected to be skipped for other workflow events.
         # All other jobs in this gate are required, and a 'skipped' result is treated as a failure.
@@ -800,8 +807,6 @@ jobs:
                contains(needs.*.result, 'cancelled') ||
                (github.event_name == 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
-                 (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
-                  needs.extension_e2e_tests.result == 'skipped') ||
                  (needs.cli_starter_validation_windows.result == 'skipped' && (needs.setup_for_tests.outputs.run_cli_starter == 'true')) ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
@@ -825,8 +830,6 @@ jobs:
                  (needs.polyglot_validation.result == 'skipped' && (needs.setup_for_tests.outputs.run_polyglot == 'true')))) ||
                (github.event_name != 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
-                 (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
-                  needs.extension_e2e_tests.result == 'skipped') ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
                  needs.build_cli_archive_macos_x64.result == 'skipped' ||


### PR DESCRIPTION
**The VS Code extension E2E tests are flaky and currently failing in CI, blocking unrelated PRs.** The `zero-to-running` shard intermittently fails in its `after each` teardown:

```
1) Aspire zero-to-running E2E
     "after each" hook ...:
   AggregateError: Zero-to-running E2E teardown failed.
```

(tracked in #18098). Because the `extension_e2e_tests` job gates CI, this flakiness fails runs on PRs that don't touch the extension.

## The fix

Temporarily disable the `extension_e2e_tests` job in `tests.yml`:

- Force the job to always skip via `if: ${{ false && … }}` (keeping the `run_extension_e2e` reference so the trigger-map binding test stays valid).
- Remove the two aggregate-gate clauses (PR + non-PR) that treat a skipped e2e job as a failure, so the forced skip doesn't fail the overall gate.

Extension **unit** tests (`extension_tests_win`, `extension_bootstrap_linux`) are unaffected and still run.

## Re-enabling

Tracked by #18412. Revert: drop the `false &&` guard and restore the two gate clauses, after the flakiness in #18098 is fixed.

Refs #18098
