### PR TITLE
Document PostgreSQL 18 data volume upgrade in integration README

### DIFF
--- a/src/Aspire.Hosting.PostgreSQL/README.md
+++ b/src/Aspire.Hosting.PostgreSQL/README.md
@@ -125,6 +125,14 @@ removing the old volume and letting Aspire create a new PostgreSQL 18 volume:
 ```bash
 # Find the volume (Aspire names it "{appname}-{hash}-{resourceName}-data")
 docker volume ls
+
+# Stop your app first, then list any containers still referencing the volume
+# (docker volume rm fails while the volume is in use).
+docker ps -a --filter volume=<old-volume-name>
+
+# Remove each referencing container, then remove the volume so Aspire creates
+# a fresh PostgreSQL 18 volume on the next run.
+docker rm -f <container-id>
 docker volume rm <old-volume-name>
 ```
 

--- a/src/Aspire.Hosting.PostgreSQL/README.md
+++ b/src/Aspire.Hosting.PostgreSQL/README.md
@@ -63,6 +63,74 @@ The PostgreSQL database resource inherits all properties from its parent `Postgr
 
 Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `db1` becomes `DB1_URI`.
 
+## Data volumes and bind mounts
+
+Use `WithDataVolume` (or `WithDataBindMount`) to persist database data across restarts:
+
+```csharp
+var db = builder.AddPostgres("pgsql")
+                .WithDataVolume();
+```
+
+The data directory mounted into the container depends on the PostgreSQL version of the configured
+container image, which Aspire selects automatically:
+
+| PostgreSQL version | Container data directory |
+|--------------------|--------------------------|
+| 17 and earlier     | `/var/lib/postgresql/data` |
+| 18 and later       | `/var/lib/postgresql` |
+
+### Keeping an existing data volume working (PostgreSQL 18 upgrade)
+
+PostgreSQL 18 changed the on-disk data layout: the official image now expects the data directory at
+`/var/lib/postgresql` and stores cluster files in a major-version-specific subdirectory (see
+[docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259) and
+[docker-library/postgres#37](https://github.com/docker-library/postgres/issues/37)). Because Aspire 13.4
+upgraded the default PostgreSQL image to 18, a data volume that was created by an earlier Aspire version
+(PostgreSQL 17) is not compatible and the container fails to start with an error such as:
+
+```text
+Error: in 18+, these Docker images are configured to store database data in a
+       format which is compatible with "pg_ctlcluster" ...
+       Counter to that, there appears to be PostgreSQL data in:
+         /var/lib/postgresql
+```
+
+PostgreSQL does not upgrade data files between major versions automatically. Choose one of the following.
+
+#### Option 1 — Stay on PostgreSQL 17 (no migration, recommended)
+
+Pin the container image back to a PostgreSQL 17 tag. Your existing data volume keeps working unchanged,
+and Aspire automatically selects the matching data directory (`/var/lib/postgresql/data`) for version 17.
+
+```csharp
+var db = builder.AddPostgres("pgsql")
+                .WithImageTag("17.6")
+                .WithDataVolume();
+```
+
+> [!IMPORTANT]
+> Call `WithImageTag` (or `WithImage`) **before** `WithDataVolume`. Aspire picks the data directory from
+> the configured image tag at the time `WithDataVolume` is called, so the tag must be set first.
+
+#### Option 2 — Upgrade the data volume to PostgreSQL 18
+
+To move to PostgreSQL 18, upgrade your existing cluster by following the official PostgreSQL
+[upgrading documentation](https://www.postgresql.org/docs/current/upgrading.html) (for example, using
+`pg_dumpall`/restore or `pg_upgrade`), then run with the default (18+) image.
+
+If the data is disposable (for example, it is re-seeded on startup), you can instead start fresh by
+removing the old volume and letting Aspire create a new PostgreSQL 18 volume:
+
+```bash
+# Find the volume (Aspire names it "{appname}-{hash}-{resourceName}-data")
+docker volume ls
+docker volume rm <old-volume-name>
+```
+
+> [!IMPORTANT]
+> Back up your data volume before performing any migration.
+
 ## MCP (Model Context Protocol) Support
 
 The PostgreSQL hosting integration provides support for adding an MCP sidecar container that enables AI agents to interact with PostgreSQL databases. This is enabled by calling `WithPostgresMcp()` on a PostgreSQL database resource.


### PR DESCRIPTION
## Description

Aspire 13.4 bumped the default PostgreSQL container image from `17.6` to `18.3` (#17065). PostgreSQL 18 changed the on-disk data layout (the official image now expects the data directory at `/var/lib/postgresql` with cluster files in a major-version subdirectory). As a result, an existing `AddPostgres(...).WithDataVolume()` volume created on PostgreSQL 17 (Aspire <= 13.3) is incompatible and the container fails to start with a cryptic `pg_ctlcluster` error. This was a regression with no documented recovery path.

This is a documentation-only change. It adds a "Data volumes and bind mounts" section to the PostgreSQL hosting integration README that:

- Documents the version-dependent container data directory that Aspire selects automatically (`/var/lib/postgresql/data` for 17 and earlier, `/var/lib/postgresql` for 18+).
- Shows the startup error users hit after upgrading.
- Gives two recovery paths:
  - **Stay on PostgreSQL 17 (recommended, no migration):** pin the image with `WithImageTag("17.6")`. The existing volume keeps working unchanged because the version-aware path selection (added in #14202) automatically mounts the compatible `/var/lib/postgresql/data` directory for version 17. Includes an important note that `WithImageTag`/`WithImage` must be called **before** `WithDataVolume`, since the data directory is chosen from the configured tag at the time `WithDataVolume` runs.
  - **Upgrade the volume to PostgreSQL 18:** follow the official PostgreSQL upgrade documentation (`pg_dumpall`/restore or `pg_upgrade`), or start fresh by removing the volume if the data is disposable.

No code changes are required: the existing `GetPostgresDataDirectoryPath` logic already supports the pinning approach, which I verified against the existing path-selection tests and reproduced the underlying scenario directly with Docker.

Fixes: #17907

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No (documentation-only change; behavior is already covered by existing `WithDataVolume` path-selection tests)
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No