### PR TITLE
Fix flaky ResourceCommandServiceTests by disabling version check

### DIFF
--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Channels;
+using Aspire.Hosting.Testing;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,11 +12,22 @@ namespace Aspire.Hosting.Tests;
 [Trait("Partition", "2")]
 public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
 {
+    /// <summary>
+    /// Creates a test builder with version checking disabled to prevent the VersionCheckService
+    /// from racing with tests that use IInteractionService.
+    /// </summary>
+    private IDistributedApplicationTestingBuilder CreateBuilder()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
+        return builder;
+    }
+
     [Fact]
     public async Task ExecuteCommandAsync_NoMatchingResource_Failure()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
 
@@ -34,7 +46,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     public async Task ExecuteCommandAsync_ResourceNameMultipleMatches_Failure()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithAnnotation(new DcpInstancesAnnotation([
@@ -57,7 +69,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     public async Task ExecuteCommandAsync_NoMatchingCommand_Failure()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
 
@@ -75,7 +87,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_NoMatchingCommand_SingleInstance_MessageUsesDisplayName()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithAnnotation(new DcpInstancesAnnotation([
@@ -94,7 +106,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_NoMatchingCommand_HasReplicas_MessageUsesResourceId()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithAnnotation(new DcpInstancesAnnotation([
@@ -117,7 +129,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     public async Task ExecuteCommandAsync_ResourceNameMultipleMatches_Success()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var commandResourcesChannel = Channel.CreateUnbounded<string>();
 
@@ -154,7 +166,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     public async Task ExecuteCommandAsync_HasReplicas_Success_CalledPerReplica()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var commandResourcesChannel = Channel.CreateUnbounded<string>();
 
@@ -196,7 +208,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     public async Task ExecuteCommandAsync_HasReplicas_Failure_CalledPerReplica()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithAnnotation(new DcpInstancesAnnotation([
@@ -235,7 +247,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     public async Task ExecuteCommandAsync_Canceled_Success()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: "mycommand",
@@ -261,7 +273,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     public async Task ExecuteCommandAsync_HasReplicas_Canceled_CalledPerReplica()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithAnnotation(new DcpInstancesAnnotation([
@@ -291,7 +303,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     public async Task ExecuteCommandAsync_HasReplicas_MixedFailureAndCanceled_OnlyFailuresInErrorMessage()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var callCount = 0;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -346,7 +358,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     public async Task ExecuteCommandAsync_OperationCanceledException_Canceled()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: "mycommand",
@@ -372,7 +384,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     public async Task ExecuteCommandAsync_LegacyCommandName_FallsBackToCurrentName()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: KnownResourceCommands.StartCommand,
@@ -393,7 +405,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     public async Task ExecuteCommandAsync_LegacyCommandName_ById_FallsBackToCurrentName()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: KnownResourceCommands.StopCommand,
@@ -415,7 +427,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [InlineData("delete-parameter", "parameter-delete")]
     public async Task ExecuteCommandAsync_LegacyParameterCommandName_FallsBackToCurrentName(string currentCommandName, string legacyCommandName)
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: currentCommandName,
@@ -433,7 +445,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_SuccessWithResult_ReturnsResultData()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: "generate-token",
@@ -454,7 +466,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_SuccessWithoutResult_ReturnsNoResultData()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: "mycommand",
@@ -473,7 +485,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_WithArgumentCollection_PassesArgumentsToCommand()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         InteractionInputCollection? capturedArguments = null;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -531,7 +543,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_WithArgumentValuesAndResource_PassesArgumentsToCommand()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         InteractionInputCollection? capturedArguments = null;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -572,7 +584,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_WithArgumentValuesAndResource_DoesNotRequirePublishedResourceState()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         InteractionInputCollection? capturedArguments = null;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -612,7 +624,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_SecretTextArgument_PreservesWhitespace()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         InteractionInputCollection? capturedArguments = null;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -659,7 +671,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task CreateCommandArguments_WithOrderedArgumentValues_MapsArgumentsByOrder()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: "mycommand",
@@ -704,7 +716,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task CreateCommandArguments_TooManyOrderedArgumentValues_ReturnsError()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: "mycommand",
@@ -735,7 +747,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task CreateCommandArguments_UnknownNamedArgumentValues_ReturnsError()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: "mycommand",
@@ -766,7 +778,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task CreateCommandArguments_DisabledNamedArgumentValues_ReturnsError()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: "mycommand",
@@ -798,7 +810,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task CreateCommandArguments_DynamicDisabledNamedArgumentValues_DoesNotReturnError()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: "mycommand",
@@ -839,7 +851,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task CreateCommandArguments_DisabledOrderedArgumentValues_ReturnsError()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithCommand(name: "mycommand",
@@ -871,7 +883,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_NoArguments_PassesEmptyArgumentsToCommand()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         InteractionInputCollection? capturedArguments = null;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -896,7 +908,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_InvalidBuiltInArgumentValidation_DoesNotExecuteCommand()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var executed = false;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -938,7 +950,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_LoadsDependentChoiceOptionsBeforeBuiltInValidation()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var executed = false;
         var loadCount = 0;
@@ -1012,7 +1024,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_SubmittedDynamicArgumentStillDisabledAfterLoading_ReturnsDisabledValidationError()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var executed = false;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -1104,7 +1116,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_LoadedDynamicArgumentStillDisabledWithDefaultValue_DoesNotReturnDisabledValidationError()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         InteractionInputCollection? capturedArguments = null;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -1174,7 +1186,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_UnknownNamedArgumentValues_DoesNotExecuteCommand()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var executed = false;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -1221,7 +1233,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_InteractiveWithoutArguments_PromptsForArguments()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var testInteractionService = new TestInteractionService();
         builder.Services.AddSingleton<IInteractionService>(testInteractionService);
@@ -1277,7 +1289,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_NonInteractiveWithoutArguments_DoesNotPrompt()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var testInteractionService = new TestInteractionService();
         builder.Services.AddSingleton<IInteractionService>(testInteractionService);
@@ -1326,7 +1338,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_NonInteractive_IsAvailableReturnsFalse()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         bool? isAvailableDuringExecution = null;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -1356,7 +1368,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_Interactive_IsAvailableNotAffectedByScope()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         bool? isAvailableDuringExecution = null;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -1392,7 +1404,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_PartialArgumentCollection_ValidatesMissingDeclaredArguments()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var executed = false;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -1448,7 +1460,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_InvalidCustomArgumentValidation_DoesNotExecuteCommand()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var executed = false;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -1496,7 +1508,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ExecuteCommandAsync_HasReplicas_SuccessWithResult_ReturnsFirstResultData()
     {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
 
         var callCount = 0;
         var custom = builder.AddResource(new CustomResource("myResource"));
@@ -1531,7 +1543,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
         using var tempDirectory = new TestTempDirectory();
         var projectPath = CreateBuildOutputTestProject(tempDirectory.Path, rebuildOutputMarker);
 
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateBuilder();
         var project = builder.AddProject("myProject", projectPath, options => options.ExcludeLaunchProfile = true);
         using var app = builder.Build();
 


### PR DESCRIPTION
## Description

Fixes a flaky test failure in `ExecuteCommandAsync_InteractiveWithoutArguments_PromptsForArguments` where the `VersionCheckService` background service races with the test's interaction channel.

**Root cause**: Tests that register a `TestInteractionService` with `IsAvailable = true` allow the `VersionCheckService` to push an "Update now" notification into the interaction channel before the test's expected "My command" interaction arrives. The test's `ReadAsync()` then picks up the wrong interaction, causing an intermittent `Assert.Equal` failure:

```
Expected: "My command"
Actual:   "Update now"
```

**Fix**: Add a `CreateBuilder()` helper method in `ResourceCommandServiceTests` that always sets `ASPIRE_VERSION_CHECK_DISABLED = true` via `KnownConfigNames.VersionCheckDisabled`, and use it consistently across all 41 tests in the class. This follows the same pattern used in `BrowserLogsBuilderExtensionsTests`.

CI failure: https://github.com/microsoft/aspire/actions/runs/27994875612

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
