### PR TITLE
Use federated OIDC auth for Update Azure VM Sizes workflow

### DIFF
--- a/.github/workflows/update-azure-vm-sizes.yml
+++ b/.github/workflows/update-azure-vm-sizes.yml
@@ -8,18 +8,22 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write # For OIDC Azure login
 
 jobs:
   generate-and-pr:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'microsoft' }}
+    environment: deployment-testing
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Azure Login
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+      - name: Azure Login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
 
       - name: Generate updated Azure VM size descriptors
         working-directory: src/Aspire.Hosting.Azure.Kubernetes/tools

--- a/.github/workflows/update-azure-vm-sizes.yml
+++ b/.github/workflows/update-azure-vm-sizes.yml
@@ -6,7 +6,7 @@ name: Update Azure VM Sizes
 # an arbitrary ref, which keeps unreviewed branch code from ever wielding the bot token.
 on:
   schedule:
-    - cron: '0 6 1 * *' # Monthly on the 1st at 06:00 UTC
+    - cron: '0 6 * * *' # Daily at 06:00 UTC
 
 permissions:
   contents: write

--- a/.github/workflows/update-azure-vm-sizes.yml
+++ b/.github/workflows/update-azure-vm-sizes.yml
@@ -13,7 +13,10 @@ permissions:
 jobs:
   generate-and-pr:
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'microsoft' }}
+    # Only run on main. 'schedule' already runs only on the default branch, and
+    # 'workflow_dispatch' has no native branch filter, so guard the ref here to
+    # prevent the job (and its bot token / PR creation) from running off a branch.
+    if: ${{ github.repository_owner == 'microsoft' && github.ref == 'refs/heads/main' }}
     environment: deployment-testing
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-azure-vm-sizes.yml
+++ b/.github/workflows/update-azure-vm-sizes.yml
@@ -1,7 +1,10 @@
 name: Update Azure VM Sizes
 
+# No 'workflow_dispatch' trigger by design: this workflow mints the aspire-repo-bot
+# token and opens a PR, so it must only ever run as the reviewed copy on the default
+# branch. 'schedule' runs solely on the default branch and cannot be invoked against
+# an arbitrary ref, which keeps unreviewed branch code from ever wielding the bot token.
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 6 1 * *' # Monthly on the 1st at 06:00 UTC
 
@@ -13,10 +16,9 @@ permissions:
 jobs:
   generate-and-pr:
     runs-on: ubuntu-latest
-    # Only run on main. 'schedule' already runs only on the default branch, and
-    # 'workflow_dispatch' has no native branch filter, so guard the ref here to
-    # prevent the job (and its bot token / PR creation) from running off a branch.
-    if: ${{ github.repository_owner == 'microsoft' && github.ref == 'refs/heads/main' }}
+    # 'schedule' only ever runs on the default branch, so the owner guard is the
+    # only condition needed here.
+    if: ${{ github.repository_owner == 'microsoft' }}
     environment: deployment-testing
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Description

The `Update Azure VM Sizes` workflow (`update-azure-vm-sizes.yml`) has failed on **every** scheduled run since it was introduced in #16088. The `Azure Login` step errors with:

```
Login failed with Error: Using auth-type: SERVICE_PRINCIPAL. Not all values are present.
Ensure 'client-id' and 'tenant-id' are supplied.
```

The step used `azure/login` with `creds: ${{ secrets.AZURE_CREDENTIALS }}`, but that service-principal-JSON secret was never configured on the repo, so `creds` resolved empty and the action fell through to a broken auth path. The downstream generate/PR steps never ran.

## Fix

1. **Secretless federated (OIDC) auth.** Replace `azure/login@v2.3.0` (`creds`) with **`azure/login@v3.0.0`** (Node 24-compatible, clears the Node 20 deprecation warning) using native OIDC inputs (`client-id` / `tenant-id` / `subscription-id`). Add `id-token: write` permission and `environment: deployment-testing` so the OIDC token subject matches the existing Entra federated credential. This reuses the same identity/environment already used by the deployment E2E tests (`deployment-tests.yml`, `deployment-cleanup.yml`) and the `AZURE_DEPLOYMENT_TEST_*` secrets.

2. **Remove the `workflow_dispatch` trigger (security hardening).** This workflow mints the `aspire-repo-bot` token and opens a PR, so it must only ever run as the reviewed copy on the default branch. Because dispatchability is keyed off the default-branch workflow config, removing `workflow_dispatch` prevents an unreviewed feature branch from re-enabling it to run modified code with the bot token. `schedule` only ever runs on the default branch and cannot be pointed at an arbitrary ref, so the workflow can now only execute reviewed, merged code on `main`.

3. **Increase cadence from monthly to daily** (`'0 6 1 * *'` → `'0 6 * * *'`) so auth/generation breakage surfaces within a day instead of up to a month. The PR-creation step is idempotent (it updates the existing `update-azure-vm-sizes` branch/PR), so daily no-op runs are cheap.

## Prerequisite

The `deployment-testing` service principal needs at least **Reader** on the target subscription so the `Microsoft.Compute/skus` query in `GenVmSizes.cs` succeeds. Confirmed working by the validation run below.

## Testing

Validated end-to-end via a one-time manual `workflow_dispatch` run on this branch (run `28000938646`) **before** the `workflow_dispatch` trigger was removed. All steps passed — Azure Login (OIDC), VM-size generation, bot-token creation, and PR creation — and it produced the automated update PR #18422, proving the full pipeline now works.

Going forward, since there is no longer a manual trigger, validation happens on the **daily scheduled run on `main`**. To force an off-cycle run or post-merge validation, `workflow_dispatch` would be temporarily re-added via a reviewed PR.
