### PR TITLE
Replace Environment.GetEnvironmentVariable in CLI with IEnvironment abstraction

### DIFF
--- a/src/Aspire.Cli/Agents/CopilotCli/CopilotCliAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/CopilotCli/CopilotCliAgentEnvironmentScanner.cs
@@ -22,6 +22,7 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
     private readonly ICopilotCliRunner _copilotCliRunner;
     private readonly PlaywrightCliInstaller _playwrightCliInstaller;
     private readonly CliExecutionContext _executionContext;
+    private readonly IEnvironment _environment;
     private readonly ILogger<CopilotCliAgentEnvironmentScanner> _logger;
 
     /// <summary>
@@ -30,16 +31,19 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
     /// <param name="copilotCliRunner">The Copilot CLI runner for checking if Copilot CLI is installed.</param>
     /// <param name="playwrightCliInstaller">The Playwright CLI installer for secure installation.</param>
     /// <param name="executionContext">The CLI execution context for accessing environment variables and settings.</param>
+    /// <param name="environment">The environment abstraction for reading environment variables.</param>
     /// <param name="logger">The logger for diagnostic output.</param>
-    public CopilotCliAgentEnvironmentScanner(ICopilotCliRunner copilotCliRunner, PlaywrightCliInstaller playwrightCliInstaller, CliExecutionContext executionContext, ILogger<CopilotCliAgentEnvironmentScanner> logger)
+    public CopilotCliAgentEnvironmentScanner(ICopilotCliRunner copilotCliRunner, PlaywrightCliInstaller playwrightCliInstaller, CliExecutionContext executionContext, IEnvironment environment, ILogger<CopilotCliAgentEnvironmentScanner> logger)
     {
         ArgumentNullException.ThrowIfNull(copilotCliRunner);
         ArgumentNullException.ThrowIfNull(playwrightCliInstaller);
         ArgumentNullException.ThrowIfNull(executionContext);
+        ArgumentNullException.ThrowIfNull(environment);
         ArgumentNullException.ThrowIfNull(logger);
         _copilotCliRunner = copilotCliRunner;
         _playwrightCliInstaller = playwrightCliInstaller;
         _executionContext = executionContext;
+        _environment = environment;
         _logger = logger;
     }
 
@@ -51,7 +55,7 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
         var homeDirectory = _executionContext.HomeDirectory;
 
         // Check if we're running in a VSCode terminal
-        var isVSCode = _executionContext.GetEnvironmentVariable("TERM_PROGRAM") == "vscode";
+        var isVSCode = _environment.GetEnvironmentVariable("TERM_PROGRAM") == "vscode";
 
         if (isVSCode)
         {

--- a/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
@@ -22,6 +22,7 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
     private readonly IVsCodeCliRunner _vsCodeCliRunner;
     private readonly PlaywrightCliInstaller _playwrightCliInstaller;
     private readonly CliExecutionContext _executionContext;
+    private readonly IEnvironment _environment;
     private readonly ILogger<VsCodeAgentEnvironmentScanner> _logger;
 
     /// <summary>
@@ -30,16 +31,19 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
     /// <param name="vsCodeCliRunner">The VS Code CLI runner for checking if VS Code is installed.</param>
     /// <param name="playwrightCliInstaller">The Playwright CLI installer for secure installation.</param>
     /// <param name="executionContext">The CLI execution context for accessing environment variables and settings.</param>
+    /// <param name="environment">The environment abstraction for reading environment variables.</param>
     /// <param name="logger">The logger for diagnostic output.</param>
-    public VsCodeAgentEnvironmentScanner(IVsCodeCliRunner vsCodeCliRunner, PlaywrightCliInstaller playwrightCliInstaller, CliExecutionContext executionContext, ILogger<VsCodeAgentEnvironmentScanner> logger)
+    public VsCodeAgentEnvironmentScanner(IVsCodeCliRunner vsCodeCliRunner, PlaywrightCliInstaller playwrightCliInstaller, CliExecutionContext executionContext, IEnvironment environment, ILogger<VsCodeAgentEnvironmentScanner> logger)
     {
         ArgumentNullException.ThrowIfNull(vsCodeCliRunner);
         ArgumentNullException.ThrowIfNull(playwrightCliInstaller);
         ArgumentNullException.ThrowIfNull(executionContext);
+        ArgumentNullException.ThrowIfNull(environment);
         ArgumentNullException.ThrowIfNull(logger);
         _vsCodeCliRunner = vsCodeCliRunner;
         _playwrightCliInstaller = playwrightCliInstaller;
         _executionContext = executionContext;
+        _environment = environment;
         _logger = logger;
     }
 
@@ -168,7 +172,7 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
     /// </summary>
     private bool HasVsCodeEnvironmentVariables()
     {
-        if (_executionContext.GetEnvironmentVariable("TERM_PROGRAM") == "vscode")
+        if (_environment.GetEnvironmentVariable("TERM_PROGRAM") == "vscode")
         {
             return true;
         }

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/CertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/CertificateManager.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using Aspire.Cli;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -51,13 +52,13 @@ internal abstract class CertificateManager
 
     public const int RSAMinimumKeySizeInBits = 2048;
 
-    public static CertificateManager Create(ILogger logger) => OperatingSystem.IsWindows() ?
+    public static CertificateManager Create(ILogger logger, IEnvironment environment) => OperatingSystem.IsWindows() ?
 #pragma warning disable CA1416 // Validate platform compatibility
             new WindowsCertificateManager(logger) :
 #pragma warning restore CA1416 // Validate platform compatibility
             OperatingSystem.IsMacOS() ?
             new MacOSCertificateManager(logger) as CertificateManager :
-            new UnixCertificateManager(logger);
+            new UnixCertificateManager(logger, environment);
 
     protected CertificateManagerLogger Log { get; }
 

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
+using Aspire.Cli;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Certificates.Generation;
@@ -43,14 +44,17 @@ internal sealed partial class UnixCertificateManager : CertificateManager
     private const int MaxHashCollisions = 10; // Something is going badly wrong if we have this many dev certs with the same hash
 
     private HashSet<string>? _availableCommands;
+    private readonly IEnvironment _environment;
 
-    public UnixCertificateManager(ILogger logger) : base(logger)
+    public UnixCertificateManager(ILogger logger, IEnvironment environment) : base(logger)
     {
+        _environment = environment;
     }
 
     internal UnixCertificateManager(string subject, int version)
         : base(subject, version)
     {
+        _environment = new Aspire.Cli.HostEnvironment();
     }
 
     public override TrustLevel GetTrustLevel(X509Certificate2 certificate)
@@ -58,7 +62,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         var sawTrustSuccess = false;
         var sawTrustFailure = false;
 
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(OpenSslCertDirectoryOverrideVariableName)))
+        if (!string.IsNullOrEmpty(_environment.GetEnvironmentVariable(OpenSslCertDirectoryOverrideVariableName)))
         {
             // Warn but don't bail.
             Log.UnixOpenSslCertificateDirectoryOverrideIgnored(OpenSslCertDirectoryOverrideVariableName);
@@ -98,7 +102,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         // Will become the name of the file on disk and the nickname in the NSS DBs
         var certificateNickname = GetCertificateNickname(certificate);
 
-        var sslCertDirString = Environment.GetEnvironmentVariable(OpenSslCertificateDirectoryVariableName);
+        var sslCertDirString = _environment.GetEnvironmentVariable(OpenSslCertificateDirectoryVariableName);
         if (string.IsNullOrEmpty(sslCertDirString))
         {
             sawTrustFailure = true;
@@ -364,7 +368,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             var hasValidSslCertDir = false;
 
             // Check if SSL_CERT_DIR is already set and if certDir is already included
-            var existingSslCertDir = Environment.GetEnvironmentVariable(OpenSslCertificateDirectoryVariableName);
+            var existingSslCertDir = _environment.GetEnvironmentVariable(OpenSslCertificateDirectoryVariableName);
             if (!string.IsNullOrEmpty(existingSslCertDir))
             {
                 var existingDirs = existingSslCertDir.Split(Path.PathSeparator);
@@ -582,7 +586,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         return _availableCommands.Contains(command);
     }
 
-    private static HashSet<string> FindAvailableCommands()
+    private HashSet<string> FindAvailableCommands()
     {
         var availableCommands = new HashSet<string>();
 
@@ -590,7 +594,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         // but, given that all of v1 is EOL, it doesn't seem worthwhile to check the version.
         var commands = new[] { OpenSslCommand, CertUtilCommand };
 
-        var searchPath = Environment.GetEnvironmentVariable("PATH");
+        var searchPath = _environment.GetEnvironmentVariable("PATH");
 
         if (searchPath is null)
         {
@@ -639,7 +643,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
     /// Detects if the current environment is Windows Subsystem for Linux (WSL) with interop enabled.
     /// </summary>
     /// <returns>True if running on WSL with interop; otherwise, false.</returns>
-    private static bool IsRunningOnWslWithInterop()
+    private bool IsRunningOnWslWithInterop()
     {
         // WSL exposes special files that indicate WSL interop is enabled.
         // Either WSLInterop or WSLInterop-late may be present depending on the WSL version and configuration.
@@ -650,7 +654,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
 
         // Additionally check for standard WSL environment variables as a fallback.
         // WSL_INTEROP is set to the path of the interop socket.
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WSL_INTEROP")))
+        if (!string.IsNullOrEmpty(_environment.GetEnvironmentVariable("WSL_INTEROP")))
         {
             return true;
         }
@@ -807,7 +811,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
 
     private string GetOpenSslCertificateDirectory(string homeDirectory)
     {
-        var @override = Environment.GetEnvironmentVariable(OpenSslCertDirectoryOverrideVariableName);
+        var @override = _environment.GetEnvironmentVariable(OpenSslCertDirectoryOverrideVariableName);
         if (!string.IsNullOrEmpty(@override))
         {
             Log.UnixOpenSslCertificateDirectoryOverridePresent(OpenSslCertDirectoryOverrideVariableName);
@@ -833,7 +837,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
 
     private bool TryGetNssDbOverrides(out IReadOnlyList<string> overrides)
     {
-        var nssDbOverride = Environment.GetEnvironmentVariable(NssDbOverrideVariableName);
+        var nssDbOverride = _environment.GetEnvironmentVariable(NssDbOverrideVariableName);
         if (string.IsNullOrEmpty(nssDbOverride))
         {
             overrides = [];

--- a/src/Aspire.Cli/Certificates/CertificateHelpers.cs
+++ b/src/Aspire.Cli/Certificates/CertificateHelpers.cs
@@ -39,9 +39,9 @@ internal static partial class CertificateHelpers
     /// <summary>
     /// Gets the dev-certs trust path, respecting the <c>DOTNET_DEV_CERTS_OPENSSL_CERTIFICATE_DIRECTORY</c> override.
     /// </summary>
-    internal static string GetDevCertsTrustPath()
+    internal static string GetDevCertsTrustPath(IEnvironment environment)
     {
-        var overridePath = Environment.GetEnvironmentVariable(DevCertsOpenSslCertDirEnvVar);
+        var overridePath = environment.GetEnvironmentVariable(DevCertsOpenSslCertDirEnvVar);
         return !string.IsNullOrEmpty(overridePath) ? overridePath : s_defaultDevCertsTrustPath;
     }
 

--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -49,7 +49,6 @@ internal sealed class CertificateService(
     IInteractionService interactionService,
     AspireCliTelemetry telemetry,
     ICliHostEnvironment hostEnvironment,
-    CliExecutionContext executionContext,
     IEnvironment environment) : ICertificateService
 {
     private const string SslCertDirEnvVar = "SSL_CERT_DIR";
@@ -164,17 +163,17 @@ internal sealed class CertificateService(
     /// </summary>
     private bool ShouldGenerateHttpsCertificate()
     {
-        var value = executionContext.GetEnvironmentVariable(KnownConfigNames.CliGenerateHttpsCertificate);
+        var value = environment.GetEnvironmentVariable(KnownConfigNames.CliGenerateHttpsCertificate);
         return !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static void ConfigureSslCertDir(Dictionary<string, string> environmentVariables)
+    private void ConfigureSslCertDir(Dictionary<string, string> environmentVariables)
     {
         // Get the dev-certs trust path (respects DOTNET_DEV_CERTS_OPENSSL_CERTIFICATE_DIRECTORY override)
-        var devCertsTrustPath = CertificateHelpers.GetDevCertsTrustPath();
+        var devCertsTrustPath = CertificateHelpers.GetDevCertsTrustPath(environment);
 
         // Get the current SSL_CERT_DIR value (if any)
-        var currentSslCertDir = Environment.GetEnvironmentVariable(SslCertDirEnvVar);
+        var currentSslCertDir = environment.GetEnvironmentVariable(SslCertDirEnvVar);
 
         // Check if the dev-certs trust path is already included
         if (!string.IsNullOrEmpty(currentSslCertDir))

--- a/src/Aspire.Cli/CliExecutionContext.cs
+++ b/src/Aspire.Cli/CliExecutionContext.cs
@@ -7,7 +7,7 @@ using Aspire.Shared;
 
 namespace Aspire.Cli;
 
-internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory, DirectoryInfo cacheDirectory, DirectoryInfo sdksDirectory, DirectoryInfo logsDirectory, string logFilePath, string identityChannel, bool debugMode = false, IReadOnlyDictionary<string, string?>? environmentVariables = null, DirectoryInfo? homeDirectory = null, DirectoryInfo? packagesDirectory = null, DirectoryInfo? aspireHomeDirectory = null, string? identityVersion = null, string? identityCommit = null, string? nugetServiceIndexOverride = null, bool identityOverridden = false, DirectoryInfo? identityPackagesDirectory = null)
+internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory, DirectoryInfo cacheDirectory, DirectoryInfo sdksDirectory, DirectoryInfo logsDirectory, string logFilePath, string identityChannel, bool debugMode = false, DirectoryInfo? homeDirectory = null, DirectoryInfo? packagesDirectory = null, DirectoryInfo? aspireHomeDirectory = null, string? identityVersion = null, string? identityCommit = null, string? nugetServiceIndexOverride = null, bool identityOverridden = false, DirectoryInfo? identityPackagesDirectory = null)
 {
     public DirectoryInfo WorkingDirectory { get; } = workingDirectory;
     public DirectoryInfo HivesDirectory { get; } = hivesDirectory;
@@ -179,31 +179,6 @@ internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, Direct
             : Utils.CliPathHelper.GetAspireHomeDirectory());
 
     public bool DebugMode { get; } = debugMode;
-
-    /// <summary>
-    /// Gets the environment variables for the CLI execution context.
-    /// If null, the process environment variables should be used.
-    /// </summary>
-    public IReadOnlyDictionary<string, string?>? EnvironmentVariables { get; } = environmentVariables;
-
-    /// <summary>
-    /// Gets an environment variable value. Checks the context's environment variables first,
-    /// then falls back to the process environment if no custom environment was provided.
-    /// When a custom environment dictionary is provided (even if empty), only that dictionary is used
-    /// and no fallback to the process environment occurs.
-    /// </summary>
-    /// <param name="variable">The environment variable name.</param>
-    /// <returns>The value of the environment variable, or null if not found.</returns>
-    public string? GetEnvironmentVariable(string variable)
-    {
-        if (EnvironmentVariables is not null)
-        {
-            // If a custom environment dictionary was provided, only use it (don't fall back)
-            return EnvironmentVariables.TryGetValue(variable, out var value) ? value : null;
-        }
-
-        return Environment.GetEnvironmentVariable(variable);
-    }
 
     private Command? _command;
 

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -28,6 +28,7 @@ internal sealed class DashboardRunCommand : BaseCommand
     private readonly IBundleService _bundleService;
     private readonly LayoutProcessRunner _layoutProcessRunner;
     private readonly FileLoggerProvider _fileLoggerProvider;
+    private readonly IEnvironment _environment;
     private readonly ILogger<DashboardRunCommand> _logger;
 
     private static readonly Option<string?> s_frontendUrlOption = new("--frontend-url")
@@ -59,6 +60,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         IBundleService bundleService,
         LayoutProcessRunner layoutProcessRunner,
         FileLoggerProvider fileLoggerProvider,
+        IEnvironment environment,
         ILogger<DashboardRunCommand> logger,
         CommonCommandServices services)
         : base("run", DashboardCommandStrings.RunDescription, services)
@@ -66,6 +68,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         _bundleService = bundleService;
         _layoutProcessRunner = layoutProcessRunner;
         _fileLoggerProvider = fileLoggerProvider;
+        _environment = environment;
         _logger = logger;
 
         Options.Add(s_frontendUrlOption);
@@ -97,7 +100,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         // so that raw pass-through arguments (unmatched tokens) take precedence.
         var unmatchedTokens = parseResult.UnmatchedTokens;
         var allowAnonymous = parseResult.GetValue(s_allowAnonymousOption);
-        AddOptionArgs(parseResult, dashboardArgs, unmatchedTokens, ExecutionContext);
+        AddOptionArgs(parseResult, dashboardArgs, unmatchedTokens, _environment);
 
         // Set a browser token for frontend auth unless anonymous access is enabled.
         // Tokens and keys are passed via environment variables (not command-line args)
@@ -105,9 +108,9 @@ internal sealed class DashboardRunCommand : BaseCommand
         string? browserToken = null;
         var environmentVariables = new Dictionary<string, string>();
         layoutLease?.AddEnvironment(environmentVariables);
-        if (!allowAnonymous && !ConfigSettingHasValue(unmatchedTokens, ExecutionContext, KnownConfigNames.DashboardUnsecuredAllowAnonymous))
+        if (!allowAnonymous && !ConfigSettingHasValue(unmatchedTokens, _environment, KnownConfigNames.DashboardUnsecuredAllowAnonymous))
         {
-            if (!ConfigSettingHasValue(unmatchedTokens, ExecutionContext, DashboardConfigNames.DashboardFrontendBrowserTokenName.EnvVarName))
+            if (!ConfigSettingHasValue(unmatchedTokens, _environment, DashboardConfigNames.DashboardFrontendBrowserTokenName.EnvVarName))
             {
                 browserToken = TokenGenerator.GenerateToken();
                 environmentVariables[DashboardConfigNames.DashboardFrontendBrowserTokenName.EnvVarName] = browserToken;
@@ -115,12 +118,12 @@ internal sealed class DashboardRunCommand : BaseCommand
 
             // Enable API key authentication for the telemetry API so that only
             // callers who possess the key (or the browser token) can query it.
-            if (!ConfigSettingHasValue(unmatchedTokens, ExecutionContext, DashboardConfigNames.DashboardApiPrimaryApiKeyName.EnvVarName))
+            if (!ConfigSettingHasValue(unmatchedTokens, _environment, DashboardConfigNames.DashboardApiPrimaryApiKeyName.EnvVarName))
             {
                 var apiKey = TokenGenerator.GenerateToken();
                 environmentVariables[DashboardConfigNames.DashboardApiPrimaryApiKeyName.EnvVarName] = apiKey;
 
-                if (!ConfigSettingHasValue(unmatchedTokens, ExecutionContext, DashboardConfigNames.DashboardApiAuthModeName.EnvVarName))
+                if (!ConfigSettingHasValue(unmatchedTokens, _environment, DashboardConfigNames.DashboardApiAuthModeName.EnvVarName))
                 {
                     environmentVariables[DashboardConfigNames.DashboardApiAuthModeName.EnvVarName] = "ApiKey";
                 }
@@ -130,33 +133,33 @@ internal sealed class DashboardRunCommand : BaseCommand
         dashboardArgs.AddRange(unmatchedTokens);
 
         // Resolve URLs for the summary display.
-        var dashboardInfo = ResolveDashboardInfo(dashboardArgs, unmatchedTokens, ExecutionContext, browserToken);
+        var dashboardInfo = ResolveDashboardInfo(dashboardArgs, unmatchedTokens, _environment, browserToken);
 
         return await ExecuteForegroundAsync(managedPath, dashboardArgs, dashboardInfo, environmentVariables, cancellationToken).ConfigureAwait(false);
     }
 
-    private static void AddOptionArgs(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens, CliExecutionContext executionContext)
+    private static void AddOptionArgs(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens, IEnvironment environment)
     {
-        AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_frontendUrlOption, KnownConfigNames.AspNetCoreUrls, defaultValue: "http://localhost:18888");
-        AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_otlpGrpcUrlOption, KnownConfigNames.DashboardOtlpGrpcEndpointUrl, defaultValue: "http://localhost:4317");
-        AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_otlpHttpUrlOption, KnownConfigNames.DashboardOtlpHttpEndpointUrl, defaultValue: "http://localhost:4318");
-        AddBoolOptionArg(parseResult, args, unmatchedTokens, executionContext, s_allowAnonymousOption, KnownConfigNames.DashboardUnsecuredAllowAnonymous);
+        AddStringOptionArg(parseResult, args, unmatchedTokens, environment, s_frontendUrlOption, KnownConfigNames.AspNetCoreUrls, defaultValue: "http://localhost:18888");
+        AddStringOptionArg(parseResult, args, unmatchedTokens, environment, s_otlpGrpcUrlOption, KnownConfigNames.DashboardOtlpGrpcEndpointUrl, defaultValue: "http://localhost:4317");
+        AddStringOptionArg(parseResult, args, unmatchedTokens, environment, s_otlpHttpUrlOption, KnownConfigNames.DashboardOtlpHttpEndpointUrl, defaultValue: "http://localhost:4318");
+        AddBoolOptionArg(parseResult, args, unmatchedTokens, environment, s_allowAnonymousOption, KnownConfigNames.DashboardUnsecuredAllowAnonymous);
 
         // Always enable the telemetry API so CLI commands (e.g. aspire otel) can query the dashboard,
         // unless the user has explicitly configured either the enabled or disabled setting.
-        if (!ConfigSettingHasValue(unmatchedTokens, executionContext, KnownConfigNames.DashboardApiEnabled) &&
-            !ConfigSettingHasValue(unmatchedTokens, executionContext, KnownConfigNames.DashboardApiDisabled))
+        if (!ConfigSettingHasValue(unmatchedTokens, environment, KnownConfigNames.DashboardApiEnabled) &&
+            !ConfigSettingHasValue(unmatchedTokens, environment, KnownConfigNames.DashboardApiDisabled))
         {
             args.Add($"--{KnownConfigNames.DashboardApiEnabled}=true");
         }
 
-        AddStringOptionArg(parseResult, args, unmatchedTokens, executionContext, s_configFilePathOption, KnownConfigNames.DashboardConfigFilePath, defaultValue: null);
+        AddStringOptionArg(parseResult, args, unmatchedTokens, environment, s_configFilePathOption, KnownConfigNames.DashboardConfigFilePath, defaultValue: null);
     }
 
     private static void AddStringOptionArg(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens,
-        CliExecutionContext executionContext, Option<string?> option, string envVarName, string? defaultValue)
+        IEnvironment environment, Option<string?> option, string envVarName, string? defaultValue)
     {
-        if (ConfigSettingHasValue(unmatchedTokens, executionContext, envVarName))
+        if (ConfigSettingHasValue(unmatchedTokens, environment, envVarName))
         {
             return;
         }
@@ -172,9 +175,9 @@ internal sealed class DashboardRunCommand : BaseCommand
     }
 
     private static void AddBoolOptionArg(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens,
-        CliExecutionContext executionContext, Option<bool> option, string envVarName, bool? defaultValue = null)
+        IEnvironment environment, Option<bool> option, string envVarName, bool? defaultValue = null)
     {
-        if (ConfigSettingHasValue(unmatchedTokens, executionContext, envVarName))
+        if (ConfigSettingHasValue(unmatchedTokens, environment, envVarName))
         {
             return;
         }
@@ -196,7 +199,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         }
     }
 
-    internal static bool ConfigSettingHasValue(IReadOnlyList<string> unmatchedTokens, CliExecutionContext executionContext, string envVarName)
+    internal static bool ConfigSettingHasValue(IReadOnlyList<string> unmatchedTokens, IEnvironment environment, string envVarName)
     {
         // Check if already provided via unmatched tokens.
         var prefix = $"--{envVarName}=";
@@ -219,7 +222,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         }
 
         // Check if already set as an environment variable.
-        if (executionContext.GetEnvironmentVariable(envVarName) is not null)
+        if (environment.GetEnvironmentVariable(envVarName) is not null)
         {
             return true;
         }
@@ -227,11 +230,11 @@ internal sealed class DashboardRunCommand : BaseCommand
         return false;
     }
 
-    internal static DashboardInfo ResolveDashboardInfo(List<string> dashboardArgs, IReadOnlyList<string> unmatchedTokens, CliExecutionContext executionContext, string? browserToken)
+    internal static DashboardInfo ResolveDashboardInfo(List<string> dashboardArgs, IReadOnlyList<string> unmatchedTokens, IEnvironment environment, string? browserToken)
     {
-        var frontendUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, executionContext, KnownConfigNames.AspNetCoreUrls) ?? "http://localhost:18888";
-        var otlpGrpcUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, executionContext, KnownConfigNames.DashboardOtlpGrpcEndpointUrl) ?? "http://localhost:4317";
-        var otlpHttpUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, executionContext, KnownConfigNames.DashboardOtlpHttpEndpointUrl) ?? "http://localhost:4318";
+        var frontendUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, environment, KnownConfigNames.AspNetCoreUrls) ?? "http://localhost:18888";
+        var otlpGrpcUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, environment, KnownConfigNames.DashboardOtlpGrpcEndpointUrl) ?? "http://localhost:4317";
+        var otlpHttpUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, environment, KnownConfigNames.DashboardOtlpHttpEndpointUrl) ?? "http://localhost:4318";
 
         // Take the first URL if multiple are specified (semicolon-separated).
         var parts = frontendUrl.Split(';', StringSplitOptions.RemoveEmptyEntries);
@@ -248,7 +251,7 @@ internal sealed class DashboardRunCommand : BaseCommand
     /// Resolves a setting value by checking, in order: args (--KEY=value), unmatched tokens
     /// (--KEY value with space separator), and environment variables.
     /// </summary>
-    internal static string? ResolveSettingValue(List<string> args, IReadOnlyList<string> unmatchedTokens, CliExecutionContext executionContext, string key)
+    internal static string? ResolveSettingValue(List<string> args, IReadOnlyList<string> unmatchedTokens, IEnvironment environment, string key)
     {
         // First check --KEY=value in args (last-wins).
         var result = ResolveArgValue(args, key);
@@ -268,7 +271,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         }
 
         // Fall back to environment variable.
-        return executionContext.GetEnvironmentVariable(key);
+        return environment.GetEnvironmentVariable(key);
     }
 
     internal static string? ResolveArgValue(List<string> args, string key)

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -109,7 +109,8 @@ internal sealed class DotNetCliRunner(
     IFeatures features,
     IInteractionService interactionService,
     CliExecutionContext executionContext,
-    IProcessExecutionFactory executionFactory) : IDotNetCliRunner
+    IProcessExecutionFactory executionFactory,
+    IEnvironment environment) : IDotNetCliRunner
 {
     private readonly IDiskCache _diskCache = diskCache;
 
@@ -414,7 +415,7 @@ internal sealed class DotNetCliRunner(
             // Prepend the private SDK path to PATH. Check if the caller already provided a PATH override.
             var currentPath = env.TryGetValue("PATH", out var userPath)
                 ? userPath
-                : Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+                : environment.GetEnvironmentVariable("PATH") ?? string.Empty;
             env["PATH"] = $"{sdkInstallPath}{Path.PathSeparator}{currentPath}";
 
             logger.LogDebug("Using private SDK installation at {SdkPath}", sdkInstallPath);

--- a/src/Aspire.Cli/HostEnvironment.cs
+++ b/src/Aspire.Cli/HostEnvironment.cs
@@ -7,7 +7,7 @@ namespace Aspire.Cli;
 /// Default <see cref="IEnvironment"/> that delegates to the process
 /// environment and <see cref="OperatingSystem"/> runtime checks.
 /// </summary>
-internal sealed class HostEnvironment : IEnvironment
+public sealed class HostEnvironment : IEnvironment
 {
     public string? GetEnvironmentVariable(string variable) => Environment.GetEnvironmentVariable(variable);
 

--- a/src/Aspire.Cli/IEnvironment.cs
+++ b/src/Aspire.Cli/IEnvironment.cs
@@ -8,7 +8,7 @@ namespace Aspire.Cli;
 /// <see cref="Acquisition.IdentityResolver"/> can read environment variables
 /// and detect the host OS without a circular dependency between them.
 /// </summary>
-internal interface IEnvironment
+public interface IEnvironment
 {
     /// <summary>
     /// Gets the value of an environment variable.

--- a/src/Aspire.Cli/Layout/LayoutDiscovery.cs
+++ b/src/Aspire.Cli/Layout/LayoutDiscovery.cs
@@ -37,10 +37,12 @@ public interface ILayoutDiscovery
 public sealed class LayoutDiscovery : ILayoutDiscovery
 {
     private readonly ILogger<LayoutDiscovery> _logger;
+    private readonly IEnvironment _environment;
 
-    public LayoutDiscovery(ILogger<LayoutDiscovery> logger)
+    public LayoutDiscovery(ILogger<LayoutDiscovery> logger, IEnvironment environment)
     {
         _logger = logger;
+        _environment = environment;
     }
 
     /// <summary>
@@ -52,7 +54,7 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
     public LayoutConfiguration? DiscoverLayout(string? projectDirectory = null)
     {
         // 1. Try environment variable for layout path
-        var envLayoutPath = Environment.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
+        var envLayoutPath = _environment.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
         if (!string.IsNullOrEmpty(envLayoutPath))
         {
             _logger.LogDebug("Found ASPIRE_LAYOUT_PATH: {Path}", envLayoutPath);
@@ -117,8 +119,8 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
         // Check environment variable overrides first
         var envPath = component switch
         {
-            LayoutComponent.Dcp => Environment.GetEnvironmentVariable(BundleDiscovery.DcpPathEnvVar),
-            LayoutComponent.Managed => Environment.GetEnvironmentVariable(BundleDiscovery.ManagedPathEnvVar),
+            LayoutComponent.Dcp => _environment.GetEnvironmentVariable(BundleDiscovery.DcpPathEnvVar),
+            LayoutComponent.Managed => _environment.GetEnvironmentVariable(BundleDiscovery.ManagedPathEnvVar),
             _ => null
         };
 
@@ -135,7 +137,7 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
     public bool IsBundleModeAvailable(string? projectDirectory = null)
     {
         // Check if user explicitly wants SDK mode
-        var useSdk = Environment.GetEnvironmentVariable(BundleDiscovery.UseGlobalDotNetEnvVar);
+        var useSdk = _environment.GetEnvironmentVariable(BundleDiscovery.UseGlobalDotNetEnvVar);
         if (string.Equals(useSdk, "true", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(useSdk, "1", StringComparison.OrdinalIgnoreCase))
         {
@@ -312,11 +314,11 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
         // Environment variables for specific components take precedence
         // These will be checked at GetComponentPath time, but we note them here for logging
 
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(BundleDiscovery.DcpPathEnvVar)))
+        if (!string.IsNullOrEmpty(_environment.GetEnvironmentVariable(BundleDiscovery.DcpPathEnvVar)))
         {
             _logger.LogDebug("DCP path override from {EnvVar}", BundleDiscovery.DcpPathEnvVar);
         }
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(BundleDiscovery.ManagedPathEnvVar)))
+        if (!string.IsNullOrEmpty(_environment.GetEnvironmentVariable(BundleDiscovery.ManagedPathEnvVar)))
         {
             _logger.LogDebug("Managed path override from {EnvVar}", BundleDiscovery.ManagedPathEnvVar);
         }

--- a/src/Aspire.Cli/NuGet/BundleNuGetService.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetService.cs
@@ -46,7 +46,7 @@ internal sealed class BundleNuGetService : INuGetService
     private readonly ILayoutDiscovery _layoutDiscovery;
     private readonly LayoutProcessRunner _layoutProcessRunner;
     private readonly IFeatures _features;
-    private readonly CliExecutionContext _executionContext;
+    private readonly IEnvironment _environment;
     private readonly ILogger<BundleNuGetService> _logger;
     private readonly IBundleService? _bundleService;
 
@@ -54,14 +54,14 @@ internal sealed class BundleNuGetService : INuGetService
         ILayoutDiscovery layoutDiscovery,
         LayoutProcessRunner layoutProcessRunner,
         IFeatures features,
-        CliExecutionContext executionContext,
+        IEnvironment environment,
         ILogger<BundleNuGetService> logger,
         IBundleService? bundleService = null)
     {
         _layoutDiscovery = layoutDiscovery;
         _layoutProcessRunner = layoutProcessRunner;
         _features = features;
-        _executionContext = executionContext;
+        _environment = environment;
         _logger = logger;
         _bundleService = bundleService;
     }
@@ -181,7 +181,7 @@ internal sealed class BundleNuGetService : INuGetService
         }
 
         var environmentVariables = new Dictionary<string, string>();
-        NuGetSignatureVerificationEnabler.Apply(environmentVariables, _features, _executionContext);
+        NuGetSignatureVerificationEnabler.Apply(environmentVariables, _features, _environment);
         layoutLease?.AddEnvironment(environmentVariables);
 
         var (exitCode, output, error) = await _layoutProcessRunner.RunAsync(

--- a/src/Aspire.Cli/NuGet/NuGetSignatureVerificationEnabler.cs
+++ b/src/Aspire.Cli/NuGet/NuGetSignatureVerificationEnabler.cs
@@ -19,7 +19,7 @@ internal static class NuGetSignatureVerificationEnabler
     /// has explicitly set it to "false". The behavior can be disabled via the
     /// <see cref="KnownFeatures.NuGetSignatureVerificationEnabled"/> feature flag.
     /// </summary>
-    public static void Apply(Dictionary<string, string> environmentVariables, IFeatures features, CliExecutionContext executionContext)
+    public static void Apply(Dictionary<string, string> environmentVariables, IFeatures features, IEnvironment environment)
     {
         if (!OperatingSystem.IsLinux() ||
             !features.IsFeatureEnabled(
@@ -29,7 +29,7 @@ internal static class NuGetSignatureVerificationEnabler
             return;
         }
 
-        var value = executionContext.GetEnvironmentVariable(DotNetNuGetSignatureVerification);
+        var value = environment.GetEnvironmentVariable(DotNetNuGetSignatureVerification);
 
         // If the user explicitly set it to "false", respect that
         var effectiveValue = bool.TryParse(value, out var boolValue) && !boolValue

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -458,7 +458,7 @@ public class Program
         builder.Services.AddTransient<IProcessTreeGracefulShutdownSignaler>(sp => sp.GetRequiredService<ProcessTreeGracefulShutdownService>());
 
         // Register certificate tool runner - uses native CertificateManager directly (no subprocess needed)
-        builder.Services.AddSingleton(sp => CertificateManager.Create(sp.GetRequiredService<ILogger<NativeCertificateToolRunner>>()));
+        builder.Services.AddSingleton(sp => CertificateManager.Create(sp.GetRequiredService<ILogger<NativeCertificateToolRunner>>(), sp.GetRequiredService<IEnvironment>()));
         builder.Services.AddSingleton<ICertificateToolRunner, NativeCertificateToolRunner>();
 
         builder.Services.AddTransient<IDotNetCliRunner, DotNetCliRunner>();

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -130,6 +130,7 @@ internal enum AppHostProjectCandidateStatus
 internal sealed class ProjectLocator(
     ILogger<ProjectLocator> logger,
     CliExecutionContext executionContext,
+    IEnvironment environment,
     IInteractionService interactionService,
     IConfigurationService configurationService,
     IAppHostProjectFactory projectFactory,
@@ -1180,7 +1181,7 @@ internal sealed class ProjectLocator(
 
     private string? GetNuGetPackagesCachePath()
     {
-        var envPath = executionContext.GetEnvironmentVariable("NUGET_PACKAGES");
+        var envPath = environment.GetEnvironmentVariable("NUGET_PACKAGES");
         if (!string.IsNullOrEmpty(envPath))
         {
             return Path.GetFullPath(envPath);

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -27,7 +27,8 @@ internal class DotNetTemplateFactory(
     IFeatures features,
     AspireCliTelemetry telemetry,
     ICliHostEnvironment hostEnvironment,
-    TemplateNuGetConfigService templateNuGetConfigService)
+    TemplateNuGetConfigService templateNuGetConfigService,
+    IEnvironment environment)
     : ITemplateFactory
 {
     // Template-specific options
@@ -106,7 +107,7 @@ internal class DotNetTemplateFactory(
 
         // Fall back to checking for dotnet on the system PATH.
         var dotnetFileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
-        var pathVariable = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var pathVariable = environment.GetEnvironmentVariable("PATH") ?? string.Empty;
 
         foreach (var directory in pathVariable.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
         {

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/ContainerRuntimeCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/ContainerRuntimeCheck.cs
@@ -9,7 +9,7 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// <summary>
 /// Checks if a container runtime (Docker or Podman) is available and running.
 /// </summary>
-internal sealed class ContainerRuntimeCheck(ILogger<ContainerRuntimeCheck> logger) : IEnvironmentCheck
+internal sealed class ContainerRuntimeCheck(ILogger<ContainerRuntimeCheck> logger, IEnvironment environment) : IEnvironmentCheck
 {
     internal const string CheckName = "container-runtime";
 
@@ -34,8 +34,8 @@ internal sealed class ContainerRuntimeCheck(ILogger<ContainerRuntimeCheck> logge
             var podmanTask = ContainerRuntimeDetector.CheckRuntimeAsync(KnownContainerRuntimes.Podman, "Podman", isDefault: false, logger, cancellationToken);
             var runtimes = await Task.WhenAll(dockerTask, podmanTask);
 
-            var configuredRuntime = Environment.GetEnvironmentVariable("ASPIRE_CONTAINER_RUNTIME")
-                ?? Environment.GetEnvironmentVariable("DOTNET_ASPIRE_CONTAINER_RUNTIME");
+            var configuredRuntime = environment.GetEnvironmentVariable("ASPIRE_CONTAINER_RUNTIME")
+                ?? environment.GetEnvironmentVariable("DOTNET_ASPIRE_CONTAINER_RUNTIME");
 
             // Select best from already-probed results (no re-probing)
             ContainerRuntimeInfo? selected;

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -164,7 +164,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
                 Status = EnvironmentCheckStatus.Warning,
                 Message = DoctorCommandStrings.DevCertsPartiallyTrustedMessage,
                 Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsPartiallyTrustedDetailsFormat, devCertsTrustPath),
-                Fix = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsPartiallyTrustedFixFormat, BuildSslCertDirFixCommand(devCertsTrustPath)),
+                Fix = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsPartiallyTrustedFixFormat, BuildSslCertDirFixCommand(devCertsTrustPath, environment)),
                 Link = "https://aka.ms/aspire-prerequisites#dev-certs",
                 Metadata = metadata
             });
@@ -240,9 +240,9 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
     /// locations, matching the behavior of <see cref="Aspire.Cli.Certificates.CertificateService"/>.
     /// </para>
     /// </remarks>
-    private static string BuildSslCertDirFixCommand(string devCertsTrustPath)
+    private static string BuildSslCertDirFixCommand(string devCertsTrustPath, IEnvironment environment)
     {
-        var currentSslCertDir = Environment.GetEnvironmentVariable("SSL_CERT_DIR");
+        var currentSslCertDir = environment.GetEnvironmentVariable("SSL_CERT_DIR");
 
         if (!string.IsNullOrEmpty(currentSslCertDir))
         {

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -13,7 +13,7 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// <summary>
 /// Checks if the HTTPS development certificate is trusted and detects multiple certificates.
 /// </summary>
-internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateToolRunner certificateToolRunner) : IEnvironmentCheck
+internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateToolRunner certificateToolRunner, IEnvironment environment) : IEnvironmentCheck
 {
     internal const string CheckName = "dev-certs";
     internal const string VersionCheckName = "dev-certs-version";
@@ -28,7 +28,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         try
         {
             var trustResult = certificateToolRunner.CheckHttpCertificate();
-            var results = EvaluateCertificateResults(trustResult.Certificates);
+            var results = EvaluateCertificateResults(trustResult.Certificates, environment);
 
             return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>(results);
         }
@@ -50,9 +50,10 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
     /// Evaluates certificate information and produces the appropriate check results.
     /// </summary>
     /// <param name="certInfos">Certificate information from <see cref="ICertificateToolRunner.CheckHttpCertificate"/>.</param>
+    /// <param name="environment">The environment abstraction for reading environment variables.</param>
     /// <returns>The list of environment check results.</returns>
     internal static List<EnvironmentCheckResult> EvaluateCertificateResults(
-        IReadOnlyList<DevCertInfo> certInfos)
+        IReadOnlyList<DevCertInfo> certInfos, IEnvironment environment)
     {
         if (certInfos.Count == 0)
         {
@@ -155,7 +156,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         else if (partiallyTrustedCount > 0 && fullyTrustedCount == 0)
         {
             // Certificate is partially trusted (Linux with SSL_CERT_DIR not configured)
-            var devCertsTrustPath = CertificateHelpers.GetDevCertsTrustPath();
+            var devCertsTrustPath = CertificateHelpers.GetDevCertsTrustPath(environment);
             results.Add(new EnvironmentCheckResult
             {
                 Category = EnvironmentCheckCategories.Environment,

--- a/tests/Aspire.Cli.Tests/Agents/ClaudeCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/ClaudeCodeAgentEnvironmentScannerTests.cs
@@ -112,7 +112,6 @@ public class ClaudeCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
         return TestExecutionContextHelper.CreateExecutionContext(
             workingDirectory,
             debugMode: false,
-            environment: new TestEnvironment(),
             homeDirectory: workingDirectory);
     }
 

--- a/tests/Aspire.Cli.Tests/Agents/CopilotCliAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/CopilotCliAgentEnvironmentScannerTests.cs
@@ -22,7 +22,7 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -43,7 +43,7 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
         // Create a scanner that writes to a known test location
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -112,7 +112,7 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
 
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -152,7 +152,7 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
 
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -167,8 +167,9 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var copilotCliRunner = new FakeCopilotCliRunner(null); // Return null to verify it's not called
-        var executionContext = CreateExecutionContextWithVSCode(workspace.WorkspaceRoot);
-        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var vsCodeEnvironment = new TestEnvironment(new Dictionary<string, string?> { ["TERM_PROGRAM"] = "vscode" });
+        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, vsCodeEnvironment, NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -194,21 +195,6 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
         return TestExecutionContextHelper.CreateExecutionContext(
             workingDirectory,
             debugMode: false,
-            environment: new TestEnvironment(),
-            homeDirectory: workingDirectory);
-    }
-
-    private static CliExecutionContext CreateExecutionContextWithVSCode(DirectoryInfo workingDirectory)
-    {
-        var environmentVariables = new Dictionary<string, string?>
-        {
-            ["TERM_PROGRAM"] = "vscode"
-        };
-
-        return TestExecutionContextHelper.CreateExecutionContext(
-            workingDirectory,
-            debugMode: false,
-            environment: new TestEnvironment(environmentVariables),
             homeDirectory: workingDirectory);
     }
 
@@ -224,7 +210,7 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
 
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -252,7 +238,7 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
 
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -278,7 +264,7 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
 
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotCliAgentEnvironmentScanner(copilotCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotCliAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();

--- a/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
@@ -23,7 +23,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         var vsCodeFolder = workspace.CreateDirectory(".vscode");
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -41,7 +41,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         var childDir = workspace.CreateDirectory("subdir");
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(childDir);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(childDir, workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -59,7 +59,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         // Repository root is the workspace root, so search should stop there
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(childDir);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(childDir, workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -73,7 +73,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var vsCodeCliRunner = new FakeVsCodeCliRunner(new SemVersion(1, 85, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -89,7 +89,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         // This test assumes no VSCODE_* environment variables are set
@@ -107,7 +107,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         var vsCodePath = Path.Combine(workspace.WorkspaceRoot.FullName, ".vscode");
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         
         // First, make the scanner find a parent .vscode folder to get an applicator
         var parentVsCode = workspace.CreateDirectory(".vscode");
@@ -134,7 +134,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         var vsCodeFolder = workspace.CreateDirectory(".vscode");
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -190,7 +190,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -231,7 +231,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -262,7 +262,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         var vsCodeFolder = workspace.CreateDirectory(".vscode");
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -283,7 +283,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -311,7 +311,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -337,7 +337,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -384,12 +384,8 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         };
     }
 
-    private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo? homeDirectory = null, Dictionary<string, string?>? environmentVariables = null)
+    private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo? homeDirectory = null)
     {
-        // Default to an empty dictionary to prevent fallback to real system environment variables
-        // This ensures tests are isolated and don't fail based on the test environment (e.g., running from VS Code)
-        environmentVariables ??= [];
-
         // Use a separate directory for home to avoid conflicts with .vscode folder detection
         // (the scanner ignores .vscode in the home directory as that's for user settings, not workspace config)
         homeDirectory ??= new DirectoryInfo(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
@@ -397,7 +393,6 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         return TestExecutionContextHelper.CreateExecutionContext(
             workingDirectory,
             debugMode: false,
-            environment: new TestEnvironment(environmentVariables),
             homeDirectory: homeDirectory);
     }
 }

--- a/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
@@ -372,7 +372,7 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
         // probe must actually find the freshly extracted bundle via the Aspire-home
         // fallback. Relative-to-CLI discovery must fail (binary lives outside any
         // layout) for the home probe to be exercised.
-        var layoutDiscovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance)
+        var layoutDiscovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance, new HostEnvironment())
         {
             ProcessPathOverride = processPath
         };

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -323,8 +323,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var interactiveService = sp.GetRequiredService<IInteractionService>();
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
-                var executionContext = sp.GetRequiredService<CliExecutionContext>();
-                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, executionContext, new TestEnvironment { IsLinux = true });
+                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, new TestEnvironment { IsLinux = true });
             };
         });
 
@@ -450,9 +449,12 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 return new CliHostEnvironment(configuration, nonInteractive: true);
             };
             options.CliExecutionContextFactory = _ => TestExecutionContextHelper.CreateExecutionContext(
-                workspace.WorkspaceRoot, environment: new TestEnvironment(envVars));
+                workspace.WorkspaceRoot);
             options.InteractionServiceFactory = _ => new TestInteractionService();
         });
+
+        // Override the IEnvironment registration to include the env vars for this test
+        services.AddSingleton<IEnvironment>(new TestEnvironment(envVars));
 
         using var sp = services.BuildServiceProvider();
         var cs = sp.GetRequiredService<ICertificateService>();
@@ -513,8 +515,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var interactiveService = sp.GetRequiredService<IInteractionService>();
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
-                var executionContext = sp.GetRequiredService<CliExecutionContext>();
-                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, executionContext, environment ?? sp.GetRequiredService<IEnvironment>());
+                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, environment ?? sp.GetRequiredService<IEnvironment>());
             };
         });
 
@@ -559,6 +560,6 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
     private static void AssertSslCertDirContainsDevCertsTrustPath(IDictionary<string, string> environmentVariables)
     {
         Assert.True(environmentVariables.ContainsKey("SSL_CERT_DIR"));
-        Assert.Contains(CertificateHelpers.GetDevCertsTrustPath(), environmentVariables["SSL_CERT_DIR"].Split(Path.PathSeparator));
+        Assert.Contains(CertificateHelpers.GetDevCertsTrustPath(new HostEnvironment()), environmentVariables["SSL_CERT_DIR"].Split(Path.PathSeparator));
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
@@ -99,8 +99,7 @@ public class CertificatesCommandTests(ITestOutputHelper outputHelper)
             {
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
-                var executionContext = sp.GetRequiredService<CliExecutionContext>();
-                return new CertificateService(toolRunner, interactionService, telemetry, hostEnvironment, executionContext, new TestEnvironment { IsLinux = true });
+                return new CertificateService(toolRunner, interactionService, telemetry, hostEnvironment, new TestEnvironment { IsLinux = true });
             };
         });
         using var provider = services.BuildServiceProvider();

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -94,43 +94,36 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void DashboardRunCommand_SkipsDefaultWhenEnvVarIsSet()
     {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-
-        var envVars = new Dictionary<string, string?>
+        var environment = CreateEnvironment(new Dictionary<string, string?>
         {
             ["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"] = "http://custom:9999"
-        };
-        var executionContext = CreateExecutionContext(workspace, envVars);
+        });
 
         var unmatchedTokens = Array.Empty<string>();
 
-        Assert.True(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, executionContext, "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"));
-        Assert.False(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, executionContext, "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL"));
+        Assert.True(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, environment, "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"));
+        Assert.False(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, environment, "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL"));
     }
 
     [Fact]
     public void DashboardRunCommand_SkipsDefaultWhenUnmatchedTokenHasValue()
     {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-
-        var executionContext = CreateExecutionContext(workspace, new Dictionary<string, string?>());
+        var environment = CreateEnvironment(new Dictionary<string, string?>());
 
         var unmatchedTokens = new[] { "--ASPNETCORE_URLS=http://localhost:9999" };
 
-        Assert.True(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, executionContext, "ASPNETCORE_URLS"));
-        Assert.False(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, executionContext, "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"));
+        Assert.True(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, environment, "ASPNETCORE_URLS"));
+        Assert.False(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, environment, "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"));
     }
 
     [Fact]
     public void DashboardRunCommand_SkipsDefaultWhenUnmatchedTokenHasSpaceSeparatedValue()
     {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-
-        var executionContext = CreateExecutionContext(workspace, new Dictionary<string, string?>());
+        var environment = CreateEnvironment(new Dictionary<string, string?>());
 
         var unmatchedTokens = new[] { "--ASPNETCORE_URLS", "http://localhost:9999" };
 
-        Assert.True(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, executionContext, "ASPNETCORE_URLS"));
+        Assert.True(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, environment, "ASPNETCORE_URLS"));
     }
 
     [Fact]
@@ -376,13 +369,12 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     [InlineData("http://trailing:8080/", "http://trailing:8080")]
     public void ResolveDashboardInfo_FrontendUrlVariants_ResolvesExpectedUrl(string urlValue, string expectedDashboardUrl)
     {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var executionContext = CreateExecutionContext(workspace, new Dictionary<string, string?>());
+        var environment = CreateEnvironment(new Dictionary<string, string?>());
 
         var args = new List<string> { "dashboard", $"--ASPNETCORE_URLS={urlValue}" };
         var unmatchedTokens = Array.Empty<string>();
 
-        var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, executionContext, browserToken: null);
+        var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, environment, browserToken: null);
 
         Assert.Equal(expectedDashboardUrl, info.DashboardUrl);
     }
@@ -390,8 +382,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void ResolveDashboardInfo_EnvVarFrontendUrl_UsedInSummary()
     {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var executionContext = CreateExecutionContext(workspace, new Dictionary<string, string?>
+        var environment = CreateEnvironment(new Dictionary<string, string?>
         {
             ["ASPNETCORE_URLS"] = "http://envhost:9999"
         });
@@ -400,7 +391,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var args = new List<string> { "dashboard" };
         var unmatchedTokens = Array.Empty<string>();
 
-        var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, executionContext, browserToken: null);
+        var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, environment, browserToken: null);
 
         Assert.Equal("http://envhost:9999", info.DashboardUrl);
     }
@@ -408,14 +399,13 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void ResolveDashboardInfo_SpaceSeparatedUnmatchedToken_UsedInSummary()
     {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var executionContext = CreateExecutionContext(workspace, new Dictionary<string, string?>());
+        var environment = CreateEnvironment(new Dictionary<string, string?>());
 
         // No --ASPNETCORE_URLS= in the args list; the value comes through space-separated unmatched tokens.
         var args = new List<string> { "dashboard" };
         var unmatchedTokens = new[] { "--ASPNETCORE_URLS", "http://space:7777" };
 
-        var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, executionContext, browserToken: null);
+        var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, environment, browserToken: null);
 
         Assert.Equal("http://space:7777", info.DashboardUrl);
     }
@@ -423,8 +413,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void ResolveDashboardInfo_EnvVarOtlpUrls_UsedInSummary()
     {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var executionContext = CreateExecutionContext(workspace, new Dictionary<string, string?>
+        var environment = CreateEnvironment(new Dictionary<string, string?>
         {
             ["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"] = "http://grpc:1111",
             ["ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL"] = "http://http:2222"
@@ -433,7 +422,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var args = new List<string> { "dashboard" };
         var unmatchedTokens = Array.Empty<string>();
 
-        var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, executionContext, browserToken: null);
+        var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, environment, browserToken: null);
 
         Assert.Equal("http://grpc:1111", info.OtlpGrpcUrl);
         Assert.Equal("http://http:2222", info.OtlpHttpUrl);
@@ -442,8 +431,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void ResolveDashboardInfo_ArgTakesPrecedenceOverEnvVar()
     {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var executionContext = CreateExecutionContext(workspace, new Dictionary<string, string?>
+        var environment = CreateEnvironment(new Dictionary<string, string?>
         {
             ["ASPNETCORE_URLS"] = "http://envhost:9999"
         });
@@ -451,7 +439,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var args = new List<string> { "dashboard", "--ASPNETCORE_URLS=http://arghost:5555" };
         var unmatchedTokens = Array.Empty<string>();
 
-        var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, executionContext, browserToken: null);
+        var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, environment, browserToken: null);
 
         Assert.Equal("http://arghost:5555", info.DashboardUrl);
     }
@@ -459,13 +447,12 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void ResolveDashboardInfo_WithBrowserToken_AppendsLoginPath()
     {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var executionContext = CreateExecutionContext(workspace, new Dictionary<string, string?>());
+        var environment = CreateEnvironment(new Dictionary<string, string?>());
 
         var args = new List<string> { "dashboard", "--ASPNETCORE_URLS=http://localhost:18888" };
         var unmatchedTokens = Array.Empty<string>();
 
-        var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, executionContext, browserToken: "abc123");
+        var info = DashboardRunCommand.ResolveDashboardInfo(args, unmatchedTokens, environment, browserToken: "abc123");
 
         Assert.Equal("http://localhost:18888/login?t=abc123", info.DashboardUrl);
     }
@@ -544,9 +531,9 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         return (services, managedPath, executionFactory);
     }
 
-    private static CliExecutionContext CreateExecutionContext(TemporaryWorkspace workspace, Dictionary<string, string?> envVars)
+    private static IEnvironment CreateEnvironment(Dictionary<string, string?> envVars)
     {
-        return workspace.CreateExecutionContext(environmentVariables: envVars);
+        return new TestEnvironment(envVars);
     }
 
     private sealed class FakeLayoutDiscovery(LayoutConfiguration layout) : ILayoutDiscovery

--- a/tests/Aspire.Cli.Tests/Configuration/PrebuiltAppHostServerChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/PrebuiltAppHostServerChannelResolutionTests.cs
@@ -95,7 +95,7 @@ public class PrebuiltAppHostServerChannelResolutionTests(ITestOutputHelper outpu
             new NullLayoutDiscovery(),
             new LayoutProcessRunner(new TestProcessExecutionFactory()),
             new TestFeatures(),
-            TestExecutionContextFactory.CreateTestContext(),
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         return new PrebuiltAppHostServer(

--- a/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
@@ -48,7 +48,7 @@ public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
         var linkPath = Path.Combine(linksDir, "aspire");
         File.CreateSymbolicLink(linkPath, realBinary);
 
-        var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance)
+        var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance, new HostEnvironment())
         {
             ProcessPathOverride = linkPath
         };
@@ -77,7 +77,7 @@ public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
         var linkPath = Path.Combine(rawLayoutRoot, "aspire");
         File.CreateSymbolicLink(linkPath, realBinary);
 
-        var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance)
+        var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance, new HostEnvironment())
         {
             ProcessPathOverride = linkPath
         };
@@ -113,7 +113,7 @@ public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
         try
         {
             Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, layoutRoot);
-            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance);
+            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance, new HostEnvironment());
             var layout = discovery.DiscoverLayout();
 
             Assert.NotNull(layout);
@@ -148,7 +148,7 @@ public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
         {
             Environment.SetEnvironmentVariable(CliPathHelper.AspireHomeEnvironmentVariable, aspireHome);
 
-            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance)
+            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance, new HostEnvironment())
             {
                 ProcessPathOverride = binaryPath
             };
@@ -194,7 +194,7 @@ public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
         {
             Environment.SetEnvironmentVariable(CliPathHelper.AspireHomeEnvironmentVariable, aspireHome);
 
-            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance)
+            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance, new HostEnvironment())
             {
                 ProcessPathOverride = binaryPath
             };

--- a/tests/Aspire.Cli.Tests/NuGet/BundleNuGetServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/BundleNuGetServiceTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Concurrent;
 using Aspire.Cli.Layout;
 using Aspire.Cli.NuGet;
-using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Shared;
@@ -37,7 +36,7 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
             new TestFeatures(),
-            TestExecutionContextFactory.CreateTestContext(),
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         var manifestPath = await service.RestorePackagesAsync(
@@ -73,7 +72,7 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
             new TestFeatures(),
-            TestExecutionContextFactory.CreateTestContext(),
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         var resultA = await service.RestorePackagesAsync(
@@ -115,7 +114,7 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
             new TestFeatures(),
-            TestExecutionContextFactory.CreateTestContext(),
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         await service.RestorePackagesAsync(
@@ -161,7 +160,7 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
             new TestFeatures(),
-            TestExecutionContextFactory.CreateTestContext(),
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         var result = await service.RestorePackagesAsync(packageList, workingDirectory: appHostDirectory.FullName);
@@ -212,7 +211,7 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
             new TestFeatures(),
-            TestExecutionContextFactory.CreateTestContext(),
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         var result = await service.RestorePackagesAsync(packageList, workingDirectory: appHostDirectory.FullName);
@@ -241,7 +240,7 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
             new TestFeatures(),
-            TestExecutionContextFactory.CreateTestContext(),
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         var resultA = await service.RestorePackagesAsync(
@@ -276,7 +275,7 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
             new TestFeatures(),
-            TestExecutionContextFactory.CreateTestContext(),
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         var restoreRoot = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "integrations", "package-restore");
@@ -355,7 +354,7 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
             new TestFeatures(),
-            TestExecutionContextFactory.CreateTestContext(),
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         var packageList = new List<(string Id, string Version)> { ("Aspire.Hosting.JavaScript", "9.4.0") };
@@ -404,7 +403,7 @@ public class BundleNuGetServiceTests(ITestOutputHelper outputHelper)
             new FixedLayoutDiscovery(new LayoutConfiguration { LayoutPath = layoutRoot.FullName }),
             new LayoutProcessRunner(executionFactory),
             new TestFeatures(),
-            TestExecutionContextFactory.CreateTestContext(),
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         using var lockedFile = new FileStream(lockedFilePath, FileMode.Open, FileAccess.Read, FileShare.None);

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetSignatureVerificationEnablerTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetSignatureVerificationEnablerTests.cs
@@ -9,10 +9,9 @@ namespace Aspire.Cli.Tests.NuGet;
 
 public class NuGetSignatureVerificationEnablerTests
 {
-    private static CliExecutionContext CreateContext(Dictionary<string, string?>? envVars = null)
+    private static IEnvironment CreateEnvironment(Dictionary<string, string?>? envVars = null)
     {
-        var dir = new DirectoryInfo(Path.GetTempPath());
-        return TestExecutionContextHelper.CreateExecutionContext(dir, environment: new TestEnvironment(envVars));
+        return new TestEnvironment(envVars);
     }
 
     [Fact]
@@ -20,9 +19,9 @@ public class NuGetSignatureVerificationEnablerTests
     {
         var envVars = new Dictionary<string, string>();
         var features = new TestFeatures().SetFeature(KnownFeatures.NuGetSignatureVerificationEnabled, false);
-        var context = CreateContext();
+        var environment = CreateEnvironment();
 
-        NuGetSignatureVerificationEnabler.Apply(envVars, features, context);
+        NuGetSignatureVerificationEnabler.Apply(envVars, features, environment);
 
         Assert.Empty(envVars);
     }
@@ -37,9 +36,9 @@ public class NuGetSignatureVerificationEnablerTests
 
         var envVars = new Dictionary<string, string>();
         var features = new TestFeatures(); // default is true for this feature
-        var context = CreateContext(new Dictionary<string, string?>()); // empty env — no user override
+        var environment = CreateEnvironment(new Dictionary<string, string?>()); // empty env — no user override
 
-        NuGetSignatureVerificationEnabler.Apply(envVars, features, context);
+        NuGetSignatureVerificationEnabler.Apply(envVars, features, environment);
 
         Assert.True(envVars.ContainsKey(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification));
         Assert.Equal("True", envVars[NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification]);
@@ -55,12 +54,12 @@ public class NuGetSignatureVerificationEnablerTests
 
         var envVars = new Dictionary<string, string>();
         var features = new TestFeatures();
-        var context = CreateContext(new Dictionary<string, string?>
+        var environment = CreateEnvironment(new Dictionary<string, string?>
         {
             [NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification] = "false"
         });
 
-        NuGetSignatureVerificationEnabler.Apply(envVars, features, context);
+        NuGetSignatureVerificationEnabler.Apply(envVars, features, environment);
 
         Assert.True(envVars.ContainsKey(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification));
         Assert.Equal("False", envVars[NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification]);
@@ -76,12 +75,12 @@ public class NuGetSignatureVerificationEnablerTests
 
         var envVars = new Dictionary<string, string>();
         var features = new TestFeatures();
-        var context = CreateContext(new Dictionary<string, string?>
+        var environment = CreateEnvironment(new Dictionary<string, string?>
         {
             [NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification] = "true"
         });
 
-        NuGetSignatureVerificationEnabler.Apply(envVars, features, context);
+        NuGetSignatureVerificationEnabler.Apply(envVars, features, environment);
 
         Assert.True(envVars.ContainsKey(NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification));
         Assert.Equal("True", envVars[NuGetSignatureVerificationEnabler.DotNetNuGetSignatureVerification]);
@@ -97,9 +96,9 @@ public class NuGetSignatureVerificationEnablerTests
 
         var envVars = new Dictionary<string, string>();
         var features = new TestFeatures(); // default is true
-        var context = CreateContext();
+        var environment = CreateEnvironment();
 
-        NuGetSignatureVerificationEnabler.Apply(envVars, features, context);
+        NuGetSignatureVerificationEnabler.Apply(envVars, features, environment);
 
         Assert.Empty(envVars);
     }

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
@@ -565,7 +565,7 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
             new NullLayoutDiscovery(),
             new LayoutProcessRunner(new TestProcessExecutionFactory()),
             new TestFeatures(),
-            executionContext,
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         return new AppHostServerProjectFactory(

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -946,7 +946,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             new NullLayoutDiscovery(),
             new LayoutProcessRunner(new TestProcessExecutionFactory()),
             new TestFeatures(),
-            executionContext,
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         return new PrebuiltAppHostServer(
@@ -1902,7 +1902,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             new FixedLayoutDiscovery(layout),
             new LayoutProcessRunner(executionFactory),
             new TestFeatures(),
-            executionContext,
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         var stagingChannel = PackageChannel.CreateExplicitChannel(
@@ -2416,7 +2416,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             new FixedLayoutDiscovery(layout),
             new LayoutProcessRunner(executionFactory),
             new TestFeatures(),
-            TestExecutionContextFactory.CreateTestContext(),
+            new TestEnvironment(),
             Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
 
         var server = CreatePrebuiltAppHostServer(
@@ -2557,7 +2557,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             new FixedLayoutDiscovery(layout),
             new LayoutProcessRunner(new TestProcessExecutionFactory()),
             new TestFeatures(),
-            executionContext,
+            new TestEnvironment(),
             NullLogger<BundleNuGetService>.Instance);
 
         var server = CreatePrebuiltAppHostServer(

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -23,11 +23,10 @@ namespace Aspire.Cli.Tests.Projects;
 
 public class ProjectLocatorTests(ITestOutputHelper outputHelper)
 {
-    private static Aspire.Cli.CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory, IReadOnlyDictionary<string, string?>? environmentVariables = null)
+    private static Aspire.Cli.CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)
     {
         return TestExecutionContextHelper.CreateExecutionContext(
-            workingDirectory,
-            environment: new TestEnvironment(environmentVariables));
+            workingDirectory);
     }
 
     [Fact]
@@ -1821,8 +1820,8 @@ builder.Build().Run();");
         {
             ["NUGET_PACKAGES"] = Path.Combine(workspace.WorkspaceRoot.FullName, ".nuget", "packages")
         };
-        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot, environmentVariables: envVars);
-        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory, environment: new TestEnvironment(envVars));
 
         var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(
             workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
@@ -1889,8 +1888,8 @@ builder.Build().Run();");
         {
             ["NUGET_PACKAGES"] = customCacheDir
         };
-        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot, environmentVariables: envVars);
-        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory, environment: new TestEnvironment(envVars));
 
         var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(
             workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
@@ -1929,8 +1928,8 @@ builder.Build().Run();");
         {
             ["NUGET_PACKAGES"] = customCacheDir
         };
-        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot, environmentVariables: envVars);
-        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory, environment: new TestEnvironment(envVars));
 
         var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(
             workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
@@ -2978,7 +2977,8 @@ builder.Build().Run();");
         IDotNetSdkInstaller? sdkInstaller = null,
         IGitRepository? gitRepository = null,
         AspireCliTelemetry? telemetry = null,
-        ILogger<ProjectLocator>? logger = null)
+        ILogger<ProjectLocator>? logger = null,
+        IEnvironment? environment = null)
     {
         var appHostCandidateFinder = new AppHostCandidateFinder(
             gitRepository ?? new TestGitRepository(),
@@ -2988,6 +2988,7 @@ builder.Build().Run();");
         return new ProjectLocator(
             logger ?? NullLogger<ProjectLocator>.Instance,
             executionContext,
+            environment ?? new TestEnvironment(),
             interactionService ?? new TestInteractionService(),
             configurationService ?? new TestConfigurationService(executionContext),
             projectFactory ?? new TestAppHostProjectFactory(),

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -364,7 +364,8 @@ public class DotNetTemplateFactoryTests
             features,
             telemetry,
             hostEnvironment,
-            templateNuGetConfigService);
+            templateNuGetConfigService,
+            new HostEnvironment());
     }
 
     private sealed class TestInteractionService : IInteractionService

--- a/tests/Aspire.Cli.Tests/TestServices/TestProcessExecutionFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestProcessExecutionFactory.cs
@@ -277,7 +277,8 @@ internal static class DotNetCliRunnerTestHelper
             serviceProvider.GetRequiredService<IFeatures>(),
             serviceProvider.GetRequiredService<IInteractionService>(),
             executionContext,
-            executionFactory);
+            executionFactory,
+            new HostEnvironment());
     }
 
     public static DotNetCliRunner Create(
@@ -307,7 +308,8 @@ internal static class DotNetCliRunnerTestHelper
             serviceProvider.GetRequiredService<IFeatures>(),
             serviceProvider.GetRequiredService<IInteractionService>(),
             executionContext,
-            executionFactory);
+            executionFactory,
+            new HostEnvironment());
     }
 
     /// <summary>
@@ -339,7 +341,8 @@ internal static class DotNetCliRunnerTestHelper
             serviceProvider.GetRequiredService<IFeatures>(),
             serviceProvider.GetRequiredService<IInteractionService>(),
             executionContext,
-            executionFactory);
+            executionFactory,
+            new HostEnvironment());
 
         return (runner, executionFactory);
     }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -444,7 +444,8 @@ internal sealed class CliServiceCollectionTestOptions
         var appHostCandidateFinder = serviceProvider.GetService<IAppHostCandidateFinder>()
             ?? new AppHostCandidateFinder(gitRepository, profilingTelemetry, NullLogger<AppHostCandidateFinder>.Instance);
         var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
-        return new ProjectLocator(logger, executionContext, interactionService, configurationService, projectFactory, languageDiscovery, sdkInstaller, appHostCandidateFinder, telemetry);
+        var environment = serviceProvider.GetRequiredService<IEnvironment>();
+        return new ProjectLocator(logger, executionContext, environment, interactionService, configurationService, projectFactory, languageDiscovery, sdkInstaller, appHostCandidateFinder, telemetry);
     }
 
     public ISolutionLocator CreateDefaultSolutionLocatorFactory(IServiceProvider serviceProvider)
@@ -500,8 +501,7 @@ internal sealed class CliServiceCollectionTestOptions
         var interactiveService = serviceProvider.GetRequiredService<IInteractionService>();
         var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
         var hostEnvironment = serviceProvider.GetRequiredService<ICliHostEnvironment>();
-        var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
-        return new CertificateService(certificateToolRunner, interactiveService, telemetry, hostEnvironment, executionContext, serviceProvider.GetRequiredService<IEnvironment>());
+        return new CertificateService(certificateToolRunner, interactiveService, telemetry, hostEnvironment, serviceProvider.GetRequiredService<IEnvironment>());
     };
 
     public Func<IServiceProvider, IScaffoldingService> ScaffoldingServiceFactory { get; set; } = (IServiceProvider serviceProvider) =>
@@ -532,7 +532,7 @@ internal sealed class CliServiceCollectionTestOptions
         var executionFactory = serviceProvider.GetRequiredService<IProcessExecutionFactory>();
         var interactionService = serviceProvider.GetRequiredService<IInteractionService>();
 
-        return new DotNetCliRunner(logger, serviceProvider, telemetry, profilingTelemetry, configuration, diskCache, features, interactionService, executionContext, executionFactory);
+        return new DotNetCliRunner(logger, serviceProvider, telemetry, profilingTelemetry, configuration, diskCache, features, interactionService, executionContext, executionFactory, new HostEnvironment());
     };
 
     public Func<IServiceProvider, IDotNetSdkInstaller> DotNetSdkInstallerFactory { get; set; } = (IServiceProvider serviceProvider) =>
@@ -597,7 +597,7 @@ internal sealed class CliServiceCollectionTestOptions
         var scaffoldingService = serviceProvider.GetRequiredService<IScaffoldingService>();
         var cliTemplateLogger = serviceProvider.GetRequiredService<ILogger<CliTemplateFactory>>();
         var templateNuGetConfigService = serviceProvider.GetRequiredService<TemplateNuGetConfigService>();
-        var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, prompter, executionContext, sdkInstaller, features, telemetry, hostEnvironment, templateNuGetConfigService);
+        var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, prompter, executionContext, sdkInstaller, features, telemetry, hostEnvironment, templateNuGetConfigService, new HostEnvironment());
         var projectFactory = serviceProvider.GetRequiredService<IAppHostProjectFactory>();
         var cliFactory = new CliTemplateFactory(languageDiscovery, projectFactory, scaffoldingService, prompter, executionContext, interactionService, hostEnvironment, templateNuGetConfigService, cliTemplateLogger);
         return new TemplateProvider([dotNetFactory, cliFactory]);

--- a/tests/Aspire.Cli.Tests/Utils/DcpConnectionHealthCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DcpConnectionHealthCheckTests.cs
@@ -180,7 +180,7 @@ public class DcpConnectionHealthCheckTests(ITestOutputHelper outputHelper)
 
         RemoteExecutor.Invoke(static homePath =>
         {
-            var certificateManager = CertificateManager.Create(NullLogger.Instance);
+            var certificateManager = CertificateManager.Create(NullLogger.Instance, new HostEnvironment());
             using var certificate = certificateManager.CreateAspNetCoreHttpsDevelopmentCertificate(
                 DateTimeOffset.UtcNow.AddDays(-1),
                 DateTimeOffset.UtcNow.AddDays(30));

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckFixRecommendationTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckFixRecommendationTests.cs
@@ -14,7 +14,7 @@ public class DevCertsCheckFixRecommendationTests
     [Fact]
     public void EvaluateCertificateResults_NoCertificates_RecommendsTrust()
     {
-        var results = DevCertsCheck.EvaluateCertificateResults([]);
+        var results = DevCertsCheck.EvaluateCertificateResults([], new HostEnvironment());
 
         var result = Assert.Single(results);
         Assert.Equal(EnvironmentCheckStatus.Warning, result.Status);
@@ -31,7 +31,7 @@ public class DevCertsCheckFixRecommendationTests
             CreateDevCertInfo(CertificateManager.TrustLevel.None, "AABB1234", MinVersion)
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
+        var results = DevCertsCheck.EvaluateCertificateResults(certInfos, new HostEnvironment());
 
         var result = Assert.Single(results);
         Assert.Equal(EnvironmentCheckStatus.Warning, result.Status);
@@ -48,7 +48,7 @@ public class DevCertsCheckFixRecommendationTests
             CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AABB1234", MinVersion)
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
+        var results = DevCertsCheck.EvaluateCertificateResults(certInfos, new HostEnvironment());
 
         var result = Assert.Single(results);
         Assert.Equal(EnvironmentCheckStatus.Pass, result.Status);
@@ -64,7 +64,7 @@ public class DevCertsCheckFixRecommendationTests
             CreateDevCertInfo(CertificateManager.TrustLevel.None, "CCDD5678", MinVersion)
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
+        var results = DevCertsCheck.EvaluateCertificateResults(certInfos, new HostEnvironment());
 
         var result = Assert.Single(results);
         Assert.Equal(EnvironmentCheckStatus.Warning, result.Status);
@@ -82,7 +82,7 @@ public class DevCertsCheckFixRecommendationTests
             CreateDevCertInfo(CertificateManager.TrustLevel.None, "CCDD5678", MinVersion)
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
+        var results = DevCertsCheck.EvaluateCertificateResults(certInfos, new HostEnvironment());
 
         var result = Assert.Single(results);
         Assert.Equal(EnvironmentCheckStatus.Warning, result.Status);
@@ -99,7 +99,7 @@ public class DevCertsCheckFixRecommendationTests
             CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AABB1234", 1)
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
+        var results = DevCertsCheck.EvaluateCertificateResults(certInfos, new HostEnvironment());
 
         // Should have two results: pass for trust status, warning for old version
         Assert.Equal(2, results.Count);
@@ -118,7 +118,7 @@ public class DevCertsCheckFixRecommendationTests
             CreateDevCertInfo(CertificateManager.TrustLevel.Partial, "AABB1234", MinVersion)
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
+        var results = DevCertsCheck.EvaluateCertificateResults(certInfos, new HostEnvironment());
 
         var result = Assert.Single(results);
         Assert.Equal(EnvironmentCheckStatus.Warning, result.Status);
@@ -136,7 +136,7 @@ public class DevCertsCheckFixRecommendationTests
             CreateDevCertInfo(CertificateManager.TrustLevel.Full, "CCDD5678", MinVersion)
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
+        var results = DevCertsCheck.EvaluateCertificateResults(certInfos, new HostEnvironment());
 
         var result = Assert.Single(results);
         Assert.Equal(EnvironmentCheckStatus.Pass, result.Status);

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -30,7 +30,7 @@ public class DevCertsCheckTests
     [Fact]
     public void EvaluateCertificateResults_NoCertificates_ReturnsWarning()
     {
-        var results = DevCertsCheck.EvaluateCertificateResults([]);
+        var results = DevCertsCheck.EvaluateCertificateResults([], new HostEnvironment());
 
         var devCertsResult = Assert.Single(results);
         Assert.Equal(DevCertsCheck.CheckName, devCertsResult.Name);
@@ -47,7 +47,7 @@ public class DevCertsCheckTests
             CreateDevCertInfo(CertificateManager.TrustLevel.Full, "CCCC3333DDDD4444", MinVersion),
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+        var results = DevCertsCheck.EvaluateCertificateResults(certs, new HostEnvironment());
 
         var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Pass, devCertsResult.Status);
@@ -63,7 +63,7 @@ public class DevCertsCheckTests
             CreateDevCertInfo(CertificateManager.TrustLevel.None, "CCCC3333DDDD4444", MinVersion),
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+        var results = DevCertsCheck.EvaluateCertificateResults(certs, new HostEnvironment());
 
         var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
@@ -79,7 +79,7 @@ public class DevCertsCheckTests
             CreateDevCertInfo(CertificateManager.TrustLevel.None, "CCCC3333DDDD4444", MinVersion),
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+        var results = DevCertsCheck.EvaluateCertificateResults(certs, new HostEnvironment());
 
         var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
@@ -94,7 +94,7 @@ public class DevCertsCheckTests
             CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+        var results = DevCertsCheck.EvaluateCertificateResults(certs, new HostEnvironment());
 
         var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Pass, devCertsResult.Status);
@@ -109,7 +109,7 @@ public class DevCertsCheckTests
             CreateDevCertInfo(CertificateManager.TrustLevel.None, "AAAA1111BBBB2222", MinVersion),
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+        var results = DevCertsCheck.EvaluateCertificateResults(certs, new HostEnvironment());
 
         var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
@@ -124,7 +124,7 @@ public class DevCertsCheckTests
             CreateDevCertInfo(CertificateManager.TrustLevel.Partial, "AAAA1111BBBB2222", MinVersion),
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+        var results = DevCertsCheck.EvaluateCertificateResults(certs, new HostEnvironment());
 
         var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
@@ -139,7 +139,7 @@ public class DevCertsCheckTests
             CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion - 1),
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+        var results = DevCertsCheck.EvaluateCertificateResults(certs, new HostEnvironment());
 
         Assert.Equal(2, results.Count);
         var versionResult = Assert.Single(results, r => r.Name == DevCertsCheck.VersionCheckName);
@@ -156,7 +156,7 @@ public class DevCertsCheckTests
             CreateDevCertInfo(CertificateManager.TrustLevel.Full, "CCCC3333DDDD4444", MinVersion + 1),
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+        var results = DevCertsCheck.EvaluateCertificateResults(certs, new HostEnvironment());
 
         // Should only have the pass result, no version warning
         var devCertsResult = Assert.Single(results);
@@ -174,7 +174,7 @@ public class DevCertsCheckTests
             CreateDevCertInfo(CertificateManager.TrustLevel.Partial, "CCCC3333DDDD4444", MinVersion),
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+        var results = DevCertsCheck.EvaluateCertificateResults(certs, new HostEnvironment());
 
         // Should not have a "Multiple certs" warning since all are trusted
         var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
@@ -191,7 +191,7 @@ public class DevCertsCheckTests
             CreateDevCertInfo(CertificateManager.TrustLevel.None, "EEEE5555FFFF6666", MinVersion),
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+        var results = DevCertsCheck.EvaluateCertificateResults(certs, new HostEnvironment());
 
         var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
@@ -206,7 +206,7 @@ public class DevCertsCheckTests
             CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
         };
 
-        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+        var results = DevCertsCheck.EvaluateCertificateResults(certs, new HostEnvironment());
 
         var devCertsResult = Assert.Single(results, r => r.Name == DevCertsCheck.CheckName);
         Assert.NotNull(devCertsResult.Metadata);
@@ -226,7 +226,7 @@ public class DevCertsCheckTests
     [Fact]
     public void EvaluateCertificateResults_NoCertificates_DoesNotIncludeMetadata()
     {
-        var results = DevCertsCheck.EvaluateCertificateResults([]);
+        var results = DevCertsCheck.EvaluateCertificateResults([], new HostEnvironment());
 
         var devCertsResult = Assert.Single(results);
         Assert.Null(devCertsResult.Metadata);

--- a/tests/Aspire.Cli.Tests/Utils/TestExecutionContextHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/TestExecutionContextHelper.cs
@@ -19,7 +19,6 @@ internal static class TestExecutionContextHelper
     public static CliExecutionContext CreateExecutionContext(
         this TemporaryWorkspace workspace,
         string identityChannel = "local",
-        IReadOnlyDictionary<string, string?>? environmentVariables = null,
         string? logFilePath = null,
         string? identityVersion = null,
         string? identityCommit = null,
@@ -28,7 +27,6 @@ internal static class TestExecutionContextHelper
         return CreateExecutionContext(
             workspace.WorkspaceRoot,
             identityChannel: identityChannel,
-            environment: new TestEnvironment(environmentVariables),
             logFilePath: logFilePath,
             identityVersion: identityVersion,
             identityCommit: identityCommit,
@@ -45,7 +43,6 @@ internal static class TestExecutionContextHelper
         string identityChannel = "local",
         DirectoryInfo? homeDirectory = null,
         DirectoryInfo? hivesDirectory = null,
-        IEnvironment? environment = null,
         DirectoryInfo? packagesDirectory = null,
         bool debugMode = false,
         string? logFilePath = null,
@@ -76,7 +73,6 @@ internal static class TestExecutionContextHelper
             identityOverridden: identityOverridden,
             identityPackagesDirectory: identityPackagesDirectory,
             debugMode: debugMode,
-            environmentVariables: (environment as TestEnvironment)?.Variables,
             homeDirectory: homeDirectory,
             packagesDirectory: packagesDirectory);
     }


### PR DESCRIPTION
## Description

Replaces all direct `Environment.GetEnvironmentVariable` calls in the CLI with the `IEnvironment` abstraction, and removes the redundant `EnvironmentVariables` property from `CliExecutionContext`.

### Motivation

The CLI had a dual-path pattern for reading environment variables:
1. `CliExecutionContext.GetEnvironmentVariable()` / `CliExecutionContext.EnvironmentVariables` — populated at startup
2. `IEnvironment.GetEnvironmentVariable()` — the proper DI-friendly abstraction with `TestEnvironment` for test isolation

This PR consolidates on `IEnvironment` everywhere, making the code more testable and consistent.

### Changes

**`CliExecutionContext` cleanup:**
- Removed `environmentVariables` constructor parameter, `EnvironmentVariables` property, and `GetEnvironmentVariable()` method

**`IEnvironment` / `HostEnvironment` made public:**
- Changed from `internal` to `public` so classes like `LayoutDiscovery` (which is public) can take `IEnvironment` as a constructor parameter for standard DI resolution

**Callers updated to inject `IEnvironment` directly:**
- `DashboardRunCommand` — env var reads for dashboard configuration
- `CertificateService` — `SSL_CERT_DIR` lookup
- `CertificateHelpers` — dev certs trust path
- `UnixCertificateManager` — `HOME` env var
- `DotNetCliRunner` — `DOTNET_ROOT` and path resolution
- `LayoutDiscovery` — 6 env var reads for layout/bundle paths
- `DotNetTemplateFactory` — `DOTNET_CLI_HOME`
- `ContainerRuntimeCheck` — container runtime path detection
- `DevCertsCheck` — certificate evaluation
- `BundleNuGetService` — removed `CliExecutionContext` dependency
- `NuGetSignatureVerificationEnabler` — env var for signature verification
- `ProjectLocator` — `ASPIRE_ALLOW_UNSUPPORTED_APPHOST_TFM`
- `VsCodeAgentEnvironmentScanner` — `VSCODE_*` env vars
- `CopilotCliAgentEnvironmentScanner` — `COPILOT_CLI_*` env vars

**DI registration simplified:**
- `LayoutDiscovery` now uses plain `AddSingleton<ILayoutDiscovery, LayoutDiscovery>()` instead of a factory lambda

**Tests updated:**
- All affected test files use `TestEnvironment` for env var injection instead of `TestExecutionContextHelper` dictionaries

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes — `IEnvironment` and `HostEnvironment` changed from `internal` to `public`
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
