### PR TITLE
Add e2e test for resource command JSON result output separation

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -315,4 +315,88 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
         await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
     }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task ResourceCommand_JsonResult_WritesOnlyJsonToStdoutAndStatusToStderr()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var projectSuffix = Guid.NewGuid().ToString("N")[..6];
+        var projectName = $"ResourceCmdJsonApp_{projectSuffix}";
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+        await auto.AspireNewAsync(projectName, counter, template: AspireTemplate.EmptyAppHost);
+
+        await auto.TypeAsync($"cd {projectName}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Replace the generated apphost.cs with a minimal AppHost that has a
+        // command returning a JSON result.
+        var appHostFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, projectName, "apphost.cs");
+        var content = File.ReadAllText(appHostFilePath);
+        var sdkLine = content.Split('\n', 2)[0].TrimEnd('\r');
+
+        var newContent = $$"""
+            {{sdkLine}}
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            var resource = builder.AddParameter("test-resource");
+
+            resource.WithCommand(
+                name: "get-info",
+                displayName: "Get info",
+                executeCommand: context =>
+                {
+                    var json = "{\"status\":\"healthy\",\"version\":\"1.0.0\",\"items\":[1,2,3]}";
+                    return Task.FromResult(CommandResults.Success("Info retrieved", json, CommandResultFormat.Json));
+                });
+
+            builder.Build().Run();
+            """;
+
+        File.WriteAllText(appHostFilePath, newContent);
+
+        await auto.TypeAsync("aspire start");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync(RunCommandStrings.AppHostStartedSuccessfully, timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Run the resource command, separating stdout and stderr into distinct files.
+        await auto.TypeAsync("aspire resource test-resource get-info > /tmp/cmd-stdout.txt 2> /tmp/cmd-stderr.txt");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+        // Assert that stdout contains only valid JSON parsable by jq.
+        await auto.TypeAsync("jq . /tmp/cmd-stdout.txt > /dev/null && echo JSON_VALID || echo JSON_INVALID");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("JSON_VALID", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Assert that the JSON content matches what the command returned.
+        await auto.TypeAsync("jq -r '.status' /tmp/cmd-stdout.txt");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("healthy", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Assert that stderr has content (status/progress messages from the CLI).
+        await auto.TypeAsync("test -s /tmp/cmd-stderr.txt && echo STDERR_HAS_CONTENT || echo STDERR_EMPTY");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("STDERR_HAS_CONTENT", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire stop");
+        await auto.EnterAsync();
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitForSuccessPromptAsync(counter);
+    }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -377,9 +377,8 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
         // Assert that stdout contains only valid JSON parsable by jq.
-        await auto.TypeAsync("jq . /tmp/cmd-stdout.txt > /dev/null && echo JSON_VALID || echo JSON_INVALID");
+        await auto.TypeAsync("jq . /tmp/cmd-stdout.txt > /dev/null");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("JSON_VALID", timeout: TimeSpan.FromSeconds(10));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Assert that the JSON content matches what the command returned.
@@ -389,9 +388,8 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Assert that stderr has content (status/progress messages from the CLI).
-        await auto.TypeAsync("test -s /tmp/cmd-stderr.txt && echo STDERR_HAS_CONTENT || echo STDERR_EMPTY");
+        await auto.TypeAsync("test -s /tmp/cmd-stderr.txt");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("STDERR_HAS_CONTENT", timeout: TimeSpan.FromSeconds(10));
         await auto.WaitForSuccessPromptAsync(counter);
 
         await auto.TypeAsync("aspire stop");


### PR DESCRIPTION
## Description

Adds an end-to-end test that verifies resource commands returning JSON results write only valid JSON to stdout and route all human-readable status/progress messages to stderr. This ensures the output is pipeable to tools like `jq` without pollution from CLI status messages.

The test:
- Creates a minimal AppHost with a parameter resource that has a custom command returning `CommandResults.Success(...)` with `CommandResultFormat.Json`
- Runs `aspire resource test-resource get-info` with stdout/stderr separated into distinct files
- Asserts stdout is valid JSON parsable by `jq`
- Extracts a field from the JSON to confirm correctness
- Asserts stderr is non-empty (contains CLI status/progress output)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
