### PR TITLE
Enable CA1310 and CA1311 globally and fix warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -117,6 +117,12 @@ dotnet_diagnostic.CA1047.severity = warning
 # CA1305: Specify IFormatProvider
 dotnet_diagnostic.CA1305.severity = warning
 
+# CA1310: Specify StringComparison for correctness
+dotnet_diagnostic.CA1310.severity = warning
+
+# CA1311: Specify a culture or use an invariant version
+dotnet_diagnostic.CA1311.severity = warning
+
 # CA1507: Use nameof to express symbol names
 dotnet_diagnostic.CA1507.severity = warning
 

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/MyAzureBlobTrigger.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/MyAzureBlobTrigger.cs
@@ -14,6 +14,6 @@ public class MyAzureBlobTrigger(BlobContainerClient containerClient, ILogger<MyA
         await containerClient.UploadBlobAsync(blobName, new BinaryData(triggerString));
 
         logger.LogInformation("C# blob trigger function invoked for 'myblobcontainer/{source}' with {message}...", blobName, triggerString);
-        return triggerString.ToUpper();
+        return triggerString.ToUpperInvariant();
     }
 }

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -1027,7 +1027,7 @@ internal sealed class DotNetCliRunner(
     internal static bool TryParsePackageVersionFromStdout(string stdout, [NotNullWhen(true)] out string? version)
     {
         var lines = stdout.Split(Environment.NewLine);
-        var successLine = lines.SingleOrDefault(x => x.StartsWith("Success: Aspire.ProjectTemplates"));
+        var successLine = lines.SingleOrDefault(x => x.StartsWith("Success: Aspire.ProjectTemplates", StringComparison.Ordinal));
 
         if (successLine is null)
         {

--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -290,11 +290,11 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
                packageName.Equals("Aspire.ProjectTemplates", StringComparison.Ordinal) ||
                packageName.Equals("Aspire.Cli", StringComparison.Ordinal);
 
-        var isExcluded = packageName.StartsWith("Aspire.Hosting.AppHost") ||
-                         packageName.StartsWith("Aspire.Hosting.Sdk") ||
-                         packageName.StartsWith("Aspire.Hosting.Orchestration") ||
-                         packageName.StartsWith("Aspire.Hosting.Testing") ||
-                         packageName.StartsWith("Aspire.Hosting.Msi");
+        var isExcluded = packageName.StartsWith("Aspire.Hosting.AppHost", StringComparison.Ordinal) ||
+                         packageName.StartsWith("Aspire.Hosting.Sdk", StringComparison.Ordinal) ||
+                         packageName.StartsWith("Aspire.Hosting.Orchestration", StringComparison.Ordinal) ||
+                         packageName.StartsWith("Aspire.Hosting.Testing", StringComparison.Ordinal) ||
+                         packageName.StartsWith("Aspire.Hosting.Msi", StringComparison.Ordinal);
 
         return isHostingOrCommunityToolkitNamespaced && !isExcluded;
     }

--- a/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
@@ -161,11 +161,11 @@ internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache
                    packageName.Equals("Aspire.ProjectTemplates", StringComparison.Ordinal) ||
                    packageName.Equals("Aspire.Cli", StringComparison.Ordinal);
 
-            var isExcluded = packageName.StartsWith("Aspire.Hosting.AppHost") ||
-                             packageName.StartsWith("Aspire.Hosting.Sdk") ||
-                             packageName.StartsWith("Aspire.Hosting.Orchestration") ||
-                             packageName.StartsWith("Aspire.Hosting.Testing") ||
-                             packageName.StartsWith("Aspire.Hosting.Msi");
+            var isExcluded = packageName.StartsWith("Aspire.Hosting.AppHost", StringComparison.Ordinal) ||
+                             packageName.StartsWith("Aspire.Hosting.Sdk", StringComparison.Ordinal) ||
+                             packageName.StartsWith("Aspire.Hosting.Orchestration", StringComparison.Ordinal) ||
+                             packageName.StartsWith("Aspire.Hosting.Testing", StringComparison.Ordinal) ||
+                             packageName.StartsWith("Aspire.Hosting.Msi", StringComparison.Ordinal);
 
             return isHostingOrCommunityToolkitNamespaced && !isExcluded;
         }

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -208,12 +208,12 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
     {
         if (Environment.OSVersion.Platform == PlatformID.Win32NT)
         {
-            return path.StartsWith(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+            return path.StartsWith(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), StringComparison.Ordinal);
         }
         else
         {
             var globalNuGetFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget");
-            return path.StartsWith(globalNuGetFolder);
+            return path.StartsWith(globalNuGetFolder, StringComparison.Ordinal);
         }
     }
 
@@ -1141,7 +1141,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
 
     private static bool IsMSBuildPropertyExpression(string value)
     {
-        return value.StartsWith("$(") && value.EndsWith(")") && value.Length > 3;
+        return value.StartsWith("$(", StringComparison.Ordinal) && value.EndsWith(")", StringComparison.Ordinal) && value.Length > 3;
     }
 
     private static string? ExtractPropertyNameFromExpression(string expression)

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DeprecatedWorkloadCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DeprecatedWorkloadCheck.cs
@@ -116,7 +116,7 @@ internal sealed class DeprecatedWorkloadCheck(ILogger<DeprecatedWorkloadCheck> l
             // Skip header lines, separator lines, and informational lines
             if (trimmedLine.StartsWith("Installed", StringComparison.OrdinalIgnoreCase) ||
                 trimmedLine.StartsWith("Workload version:", StringComparison.OrdinalIgnoreCase) ||
-                trimmedLine.StartsWith("---") ||
+                trimmedLine.StartsWith("---", StringComparison.Ordinal) ||
                 trimmedLine.StartsWith("Use", StringComparison.OrdinalIgnoreCase) ||
                 string.IsNullOrWhiteSpace(trimmedLine))
             {

--- a/src/Aspire.Cli/Utils/StringUtils.cs
+++ b/src/Aspire.Cli/Utils/StringUtils.cs
@@ -62,7 +62,7 @@ internal static class StringUtils
         }
 
         // Starts with (high priority)
-        if (targetLower.StartsWith(searchLower))
+        if (targetLower.StartsWith(searchLower, StringComparison.Ordinal))
         {
             return 0.95;
         }

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
@@ -303,8 +303,8 @@ public partial class SummaryDetailsView<T> : IGlobalKeydownListener, IDisposable
             out float? panel2Size,
             out float? panel1Fraction)
         {
-            if (panel1SizeString is null || !panel1SizeString.EndsWith("fr")
-                || panel2SizeString is null || !panel2SizeString.EndsWith("fr"))
+            if (panel1SizeString is null || !panel1SizeString.EndsWith("fr", StringComparison.Ordinal)
+                || panel2SizeString is null || !panel2SizeString.EndsWith("fr", StringComparison.Ordinal))
             {
                 panel1Size = null;
                 panel2Size = null;

--- a/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
@@ -110,7 +110,7 @@ public partial class TextVisualizer : ComponentBase, IAsyncDisposable
     {
         // we support light (a11y-light-min) and dark (a11y-dark-min) themes.
         // syntax to force a theme for highlight.js is "theme-{themeName}"
-        return $"log-content highlight-line language-{ViewModel.FormatKind} theme-a11y-{ThemeManager.EffectiveTheme.ToLower()}-min";
+        return $"log-content highlight-line language-{ViewModel.FormatKind} theme-a11y-{ThemeManager.EffectiveTheme.ToLowerInvariant()}-min";
     }
 
     private static MarkupString GetFormattedPlaintext(StringLogLine line)

--- a/src/Aspire.Dashboard/Model/Assistant/FollowUpPromptViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/FollowUpPromptViewModel.cs
@@ -74,7 +74,7 @@ public sealed class FollowUpPromptViewModel
         text = writer.ToString();
 
         // Trim bold stars if the question was surrounded with them.
-        if (text.Length >= 4 && text.StartsWith("**") && text.EndsWith("**"))
+        if (text.Length >= 4 && text.StartsWith("**", StringComparison.Ordinal) && text.EndsWith("**", StringComparison.Ordinal))
         {
             text = text[2..^2];
         }

--- a/src/Aspire.Dashboard/Model/ConnectionStringParser.cs
+++ b/src/Aspire.Dashboard/Model/ConnectionStringParser.cs
@@ -484,7 +484,7 @@ internal static partial class ConnectionStringParser
 
         // Reject obvious file path indicators
         if (connectionString.StartsWith('/') || connectionString.StartsWith('\\') ||
-            connectionString.StartsWith("./") || connectionString.StartsWith("../") ||
+            connectionString.StartsWith("./", StringComparison.Ordinal) || connectionString.StartsWith("../", StringComparison.Ordinal) ||
             (connectionString.Length > 2 && connectionString[1] == ':' && char.IsLetter(connectionString[0])))
         {
             return false;

--- a/src/Aspire.Dashboard/Model/DefaultInstrumentUnitResolver.cs
+++ b/src/Aspire.Dashboard/Model/DefaultInstrumentUnitResolver.cs
@@ -33,11 +33,11 @@ public sealed class DefaultInstrumentUnitResolver(IStringLocalizer<ControlsStrin
 
         // Hard code for instrument names that don't have units
         // but have a descriptive name that lets us infer the unit.
-        if (instrument.Name.EndsWith(".count"))
+        if (instrument.Name.EndsWith(".count", StringComparison.Ordinal))
         {
             return UntitleCase(loc[nameof(ControlsStrings.PlotlyChartCount)], titleCase);
         }
-        else if (instrument.Name.EndsWith(".length"))
+        else if (instrument.Name.EndsWith(".length", StringComparison.Ordinal))
         {
             return UntitleCase(loc[nameof(ControlsStrings.PlotlyChartLength)], titleCase);
         }

--- a/src/Aspire.Dashboard/Model/Markdown/HighlightedCodeBlockRenderer.cs
+++ b/src/Aspire.Dashboard/Model/Markdown/HighlightedCodeBlockRenderer.cs
@@ -59,11 +59,11 @@ public class HighlightedCodeBlockRenderer : HtmlObjectRenderer<CodeBlock>
         {
             // Language is added to a CSS class name for highlightjs.
             // Fix known languages that contain invalid CSS class name characters.
-            title = info.ToLower() switch
+            title = info.ToLowerInvariant() switch
             {
                 "c#" => "csharp",
                 "c++" => "cpp",
-                _ => info.ToLower()
+                _ => info.ToLowerInvariant()
             };
 
             codeAttributes.AddClass($"language-{title}");

--- a/src/Aspire.Dashboard/Model/ResourceUrlHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceUrlHelpers.cs
@@ -52,7 +52,7 @@ internal static class ResourceUrlHelpers
         // - endpoint name
         var orderedUrls = urls
             .OrderByDescending(e => e.SortOrder)
-            .ThenByDescending(e => e.Url?.StartsWith("https") == true)
+            .ThenByDescending(e => e.Url?.StartsWith("https", StringComparison.Ordinal) == true)
             .ThenByDescending(e => e.Url is not null)
             .ThenBy(e => e.Name, StringComparers.EndpointAnnotationName)
             .ToList();

--- a/src/Aspire.Hosting.CodeGeneration.Python/AtsPythonCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Python/AtsPythonCodeGenerator.cs
@@ -665,7 +665,7 @@ internal sealed class AtsPythonCodeGenerator : ICodeGenerator
 
         // Convert camelCase to snake_case
         var snakeName = ToSnakeCase(methodName);
-        if (snakeName.EndsWith("_async"))
+        if (snakeName.EndsWith("_async", StringComparison.Ordinal))
         {
             snakeName = snakeName[..^6];
         }
@@ -674,7 +674,7 @@ internal sealed class AtsPythonCodeGenerator : ICodeGenerator
 
     private static string GetMethodAsOptionName(string methodName)
     {
-        if (methodName.StartsWith("with_"))
+        if (methodName.StartsWith("with_", StringComparison.Ordinal))
         {
             return methodName[5..];
         }
@@ -684,7 +684,7 @@ internal sealed class AtsPythonCodeGenerator : ICodeGenerator
     private static string GetMethodParametersName(string methodName)
     {
         methodName = char.ToUpper(methodName[0]) + methodName.Substring(1);
-        if (methodName.StartsWith("With"))
+        if (methodName.StartsWith("With", StringComparison.Ordinal))
         {
             methodName = methodName[4..];
         }
@@ -2470,14 +2470,14 @@ internal sealed class AtsPythonCodeGenerator : ICodeGenerator
         }
 
         // Dict/Parameters format includes all params (required + optional)
-        if (optionType.EndsWith("Parameters"))
+        if (optionType.EndsWith("Parameters", StringComparison.Ordinal))
         {
             return optionalParams.Any(p => string.Equals(p.Name, paramName, StringComparison.Ordinal));
         }
 
         // Tuple format includes optional params only when there's exactly 1 optional
         // and the tuple has an extra slot for it
-        if (optionType.StartsWith("("))
+        if (optionType.StartsWith("(", StringComparison.Ordinal))
         {
             var tupleSlots = SplitTupleTypes(optionType.Trim('(', ')'));
             if (tupleSlots.Count == requiredParams.Count + 1 && optionalParams.Count == 1)
@@ -2533,7 +2533,7 @@ internal sealed class AtsPythonCodeGenerator : ICodeGenerator
             builder.AppendLine(CultureInfo.InvariantCulture, $"                rpc_args: dict[str, typing.Any] = {{\"{targetParamName}\": handle}}");
             builder.AppendLine(CultureInfo.InvariantCulture, $"                handle = self._wrap_builder(client.invoke_capability('{variationCapabilityId}', rpc_args))");
         }
-        else if (currentOption.EndsWith("Parameters"))
+        else if (currentOption.EndsWith("Parameters", StringComparison.Ordinal))
         {
             builder.AppendLine(CultureInfo.InvariantCulture, $"            {clause} _validate_dict_types(_{optionName}, {currentOption}):");
             builder.AppendLine(CultureInfo.InvariantCulture, $"                rpc_args: dict[str, typing.Any] = {{\"{targetParamName}\": handle}}");
@@ -2560,7 +2560,7 @@ internal sealed class AtsPythonCodeGenerator : ICodeGenerator
                 builder.AppendLine(CultureInfo.InvariantCulture, $"                handle = self._wrap_builder(client.invoke_capability('{variationCapabilityId}', rpc_args))");
             }
         }
-        else if (currentOption.StartsWith("(")) // Tuple of parameters
+        else if (currentOption.StartsWith("(", StringComparison.Ordinal)) // Tuple of parameters
         {
             var paramTypes = SplitTupleTypes(currentOption.Trim('(', ')'));
             builder.AppendLine(CultureInfo.InvariantCulture, $"            {clause} _validate_tuple_types(_{optionName}, {currentOption}):");

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentContext.cs
@@ -154,7 +154,7 @@ internal sealed class DockerComposeEnvironmentContext(DockerComposeEnvironmentRe
     private static void RemoveHttpsServiceDiscoveryVariables(Dictionary<string, object> environmentVariables)
     {
         var keysToRemove = environmentVariables
-            .Where(kvp => kvp.Value is EndpointReference epRef && epRef.Scheme == "https" && kvp.Key.StartsWith("services__"))
+            .Where(kvp => kvp.Value is EndpointReference epRef && epRef.Scheme == "https" && kvp.Key.StartsWith("services__", StringComparison.Ordinal))
             .Select(kvp => kvp.Key)
             .ToList();
 

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -1411,7 +1411,7 @@ public static class JavaScriptHostingExtensions
                 {
                     configTarget = ctx.Arguments[cfgIndex + 1] switch
                     {
-                        string s when !string.IsNullOrEmpty(s) && !s.StartsWith("--") => s,
+                        string s when !string.IsNullOrEmpty(s) && !s.StartsWith("--", StringComparison.Ordinal) => s,
                         ReferenceExpression re => await re.GetValueAsync(ctx.CancellationToken).ConfigureAwait(false),
                         _ => null,
                     };

--- a/src/Aspire.Hosting.Kubernetes/Extensions/HelmExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/Extensions/HelmExtensions.cs
@@ -45,7 +45,7 @@ internal static partial class HelmExtensions
         => $"{ValuesSegment}.{ConfigKey}.{resourceName}.{parameterName}".ToHelmValuesSectionName().ToHelmExpression();
 
     public static string ToHelmChartName(this string applicationName)
-        => applicationName.ToLower().Replace("_", "-").Replace(".", "-");
+        => applicationName.ToLowerInvariant().Replace("_", "-").Replace(".", "-");
 
     /// <summary>
     /// Converts the specified resource name into a Kubernetes resource name.

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
@@ -314,7 +314,7 @@ internal sealed class KubernetesPublishingContext(
         }
 
         var resourceName = templatedItem.Metadata.Name;
-        if (resourceName.StartsWith($"{baseName.ToLowerInvariant()}-"))
+        if (resourceName.StartsWith($"{baseName.ToLowerInvariant()}-", StringComparison.Ordinal))
         {
             resourceName = resourceName.Substring(baseName.Length + 1); // +1 for the hyphen
         }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -453,7 +453,7 @@ public partial class KubernetesResource(string name, IResource resource, Kuberne
     private static void RemoveHttpsServiceDiscoveryVariables(Dictionary<string, object> environmentVariables)
     {
         var keysToRemove = environmentVariables
-            .Where(kvp => kvp.Value is EndpointReference epRef && epRef.Scheme == "https" && kvp.Key.StartsWith("services__"))
+            .Where(kvp => kvp.Value is EndpointReference epRef && epRef.Scheme == "https" && kvp.Key.StartsWith("services__", StringComparison.Ordinal))
             .Select(kvp => kvp.Key)
             .ToList();
 

--- a/src/Aspire.Hosting.Orleans/ProviderConfiguration.cs
+++ b/src/Aspire.Hosting.Orleans/ProviderConfiguration.cs
@@ -22,7 +22,7 @@ internal sealed class ProviderConfiguration(string providerType, string? service
         var resourceType = resourceBuilder.Resource.GetType().Name;
 
         // Use a simple transformation to get the provider type: remove the "Resource" suffix if it exists.
-        var providerType = resourceType.EndsWith(resource) ? resourceType[..^resource.Length] : resourceType;
+        var providerType = resourceType.EndsWith(resource, StringComparison.Ordinal) ? resourceType[..^resource.Length] : resourceType;
 
         return new(providerType, serviceKey, resourceBuilder);
     }

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -205,7 +205,7 @@ public static class RabbitMQBuilderExtensions
                 if (existingTag.Length > alpine.Length)
                 {
                     // Transform tag like "3.12-alpine" to "3.12-management-alpine"
-                    var tagPrefix = existingTag[..existingTag.IndexOf($"-{alpine}")];
+                    var tagPrefix = existingTag[..existingTag.IndexOf($"-{alpine}", StringComparison.Ordinal)];
                     annotation.Tag = $"{tagPrefix}-{management}-{alpine}";
                 }
                 else

--- a/src/Aspire.Hosting.RemoteHost/Ats/ReferenceExpressionRef.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/ReferenceExpressionRef.cs
@@ -243,7 +243,7 @@ internal sealed class ReferenceExpressionRef
             var parts = SplitFormatString(Format!);
             foreach (var part in parts)
             {
-                if (part.StartsWith("{") && part.EndsWith("}") &&
+                if (part.StartsWith("{", StringComparison.Ordinal) && part.EndsWith("}", StringComparison.Ordinal) &&
                     int.TryParse(part[1..^1], out var index) &&
                     index >= 0 && index < valueProviders.Length)
                 {

--- a/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
+++ b/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
@@ -2253,7 +2253,7 @@ public static class AtsCapabilityScanner
         var voidTypeRef = new AtsTypeRef { TypeId = AtsConstants.Void, Category = AtsTypeCategory.Primitive };
 
         // Action<T>, Action<T1, T2>, etc. - all params are inputs, void return
-        if (genericDefFullName.StartsWith("System.Action`"))
+        if (genericDefFullName.StartsWith("System.Action`", StringComparison.Ordinal))
         {
             var parameters = new List<AtsCallbackParameterInfo>();
             for (var i = 0; i < genericArgs.Count; i++)
@@ -2274,7 +2274,7 @@ public static class AtsCapabilityScanner
 
         // Func<TResult>, Func<T, TResult>, Func<T1, T2, TResult>, etc.
         // Last generic arg is return type, rest are parameters
-        if (genericDefFullName.StartsWith("System.Func`"))
+        if (genericDefFullName.StartsWith("System.Func`", StringComparison.Ordinal))
         {
             var parameters = new List<AtsCallbackParameterInfo>();
             for (var i = 0; i < genericArgs.Count - 1; i++)

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -446,7 +446,7 @@ public static class ContainerResourceBuilderExtensions
         if (parsedReference.Digest is { })
         {
             const string prefix = "sha256:";
-            if (!parsedReference.Digest.StartsWith(prefix))
+            if (!parsedReference.Digest.StartsWith(prefix, StringComparison.Ordinal))
             {
                 throw new ArgumentOutOfRangeException(nameof(image), parsedReference.Digest, "invalid digest format");
             }

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -952,7 +952,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
             // (e.g. Aspire.Hosting.Dashboard.Model.IconResolver). Third-party categories (e.g.
             // Microsoft.AspNetCore.Server.Kestrel) get a "ThirdParty" segment so they can be filtered
             // with a single rule on "Aspire.Hosting.Dashboard.ThirdParty".
-            if (category.StartsWith("Aspire.Dashboard."))
+            if (category.StartsWith("Aspire.Dashboard.", StringComparison.Ordinal))
             {
                 var categoryTrimmed = category["Aspire.Dashboard.".Length..];
                 return loggerFactory.CreateLogger($"Aspire.Hosting.Dashboard.{categoryTrimmed}");

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -35,7 +35,7 @@ internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
                 );
         }
 
-        if (!_options.Value.OutputPath.EndsWith(".json"))
+        if (!_options.Value.OutputPath.EndsWith(".json", StringComparison.Ordinal))
         {
             // If the manifest path ends with .json we assume that the output path was specified
             // as a filename. If not, we assume that the output path was specified as a directory

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingExtensions.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingExtensions.cs
@@ -44,7 +44,7 @@ internal static class ManifestPublishingExtensions
 
                 var outputPath = pipelineOptions.Value.OutputPath;
 
-                if (!outputPath.EndsWith(".json"))
+                if (!outputPath.EndsWith(".json", StringComparison.Ordinal))
                 {
                     // If the manifest path ends with .json we assume that the output path was specified
                     // as a filename. If not, we assume that the output path was specified as a directory

--- a/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
+++ b/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
@@ -88,7 +88,7 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
                 var path = spec.ConfigurationPaths[i];
 
                 var pathSegments = new Queue<string>();
-                foreach (var segment in path.Split(':').Where(segment => !segment.StartsWith(RootPathPrefix)))
+                foreach (var segment in path.Split(':').Where(segment => !segment.StartsWith(RootPathPrefix, StringComparison.Ordinal)))
                 {
                     pathSegments.Enqueue(segment);
                 }
@@ -686,7 +686,7 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
 
             foreach (var excludedPath in _exclusionPaths)
             {
-                if (excludedPath.StartsWith(currentPath) && excludedPath.EndsWith(property.ConfigurationKeyName))
+                if (excludedPath.StartsWith(currentPath, StringComparison.Ordinal) && excludedPath.EndsWith(property.ConfigurationKeyName, StringComparison.Ordinal))
                 {
                     var fullPath = $"{currentPath}.{property.ConfigurationKeyName}";
                     if (excludedPath == fullPath)

--- a/src/Tools/ConfigurationSchemaGenerator/RuntimeSource/.editorconfig
+++ b/src/Tools/ConfigurationSchemaGenerator/RuntimeSource/.editorconfig
@@ -6,6 +6,12 @@ dotnet_diagnostic.IDE0161.severity = none
 # CA1305: Specify IFormatProvider
 dotnet_diagnostic.CA1305.severity = none
 
+# CA1310: Specify StringComparison for correctness
+dotnet_diagnostic.CA1310.severity = none
+
+# CA1311: Specify a culture or use an invariant version
+dotnet_diagnostic.CA1311.severity = none
+
 # IDE0005: Remove unnecessary usings
 dotnet_diagnostic.IDE0005.severity = none
 

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -5,3 +5,9 @@ dotnet_diagnostic.CA2007.severity = silent
 
 # CA1305: Specify IFormatProvider
 dotnet_diagnostic.CA1305.severity = none
+
+# CA1310: Specify StringComparison for correctness
+dotnet_diagnostic.CA1310.severity = none
+
+# CA1311: Specify a culture or use an invariant version
+dotnet_diagnostic.CA1311.severity = none

--- a/tools/CreateLayout/Program.cs
+++ b/tools/CreateLayout/Program.cs
@@ -386,7 +386,7 @@ internal sealed class LayoutBuilder : IDisposable
 
     private void Log(string message)
     {
-        if (_verbose || !message.StartsWith("  "))
+        if (_verbose || !message.StartsWith("  ", StringComparison.Ordinal))
         {
             Console.WriteLine(message);
         }

--- a/tools/ExtractTestPartitions/Program.cs
+++ b/tools/ExtractTestPartitions/Program.cs
@@ -75,7 +75,7 @@ static void ExtractPartitions(string assemblyPath, string outputFile)
                 var attrTypeName = attr.AttributeType.FullName ?? attr.AttributeType.Name;
 
                 // Check for Trait attribute with Partition key
-                if (!attrTypeName.EndsWith(".TraitAttribute") && attrTypeName != "TraitAttribute")
+                if (!attrTypeName.EndsWith(".TraitAttribute", StringComparison.Ordinal) && attrTypeName != "TraitAttribute")
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary

Enable CA1310 (Specify StringComparison for correctness) and CA1311 (Specify a culture or use an invariant version) as warnings globally in `.editorconfig`, alongside the already-enabled CA1305.

## Changes

- Added `CA1310` and `CA1311` as warnings in the root `.editorconfig`
- Suppressed both rules in `tests/.editorconfig` and `src/Tools/ConfigurationSchemaGenerator/RuntimeSource/.editorconfig` (matching how CA1305 is already handled)
- Fixed all existing violations:
  - **CA1310**: Added `StringComparison.Ordinal` to `StartsWith`, `EndsWith`, and `IndexOf` calls operating on machine-readable strings
  - **CA1311**: Changed `ToLower()` → `ToLowerInvariant()` and `ToUpper()` → `ToUpperInvariant()` for CSS class names, Helm chart names, and other non-user-facing strings