### PR TITLE
Fix user secrets escaping & and + as unicode sequences

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -172,6 +172,7 @@
     <Compile Include="$(SharedDir)UserSecrets\UserSecretsPathHelper.cs" Link="Utils\UserSecretsPathHelper.cs" />
     <Compile Include="$(SharedDir)UserSecrets\IsolatedUserSecretsHelper.cs" Link="Utils\IsolatedUserSecretsHelper.cs" />
     <Compile Include="$(SharedDir)UserSecrets\SecretsStore.cs" Link="Secrets\SecretsStore.cs" />
+    <Compile Include="$(SharedDir)UserSecrets\UserSecretsJsonOptions.cs" Link="Secrets\UserSecretsJsonOptions.cs" />
     <Compile Include="$(SharedDir)Json\AtsJsonCodeWriter.cs" Link="Utils\AtsJsonCodeWriter.cs" />
     <Compile Include="$(SharedDir)Json\JsonFlattener.cs" Link="Utils\JsonFlattener.cs" />
     <Compile Include="$(SharedDir)Otlp\OtlpHelpers.cs" Link="Otlp\OtlpHelpers.cs" />

--- a/src/Aspire.Cli/Commands/SecretListCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretListCommand.cs
@@ -58,7 +58,7 @@ internal sealed class SecretListCommand : BaseCommand
                 obj[key] = value;
             }
 
-            var json = obj.ToJsonString(SecretsStore.s_jsonOptions);
+            var json = obj.ToJsonString(UserSecretsJsonOptions.s_instance);
             InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
         }
         else

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -57,6 +57,7 @@
     <Compile Include="$(SharedDir)BackchannelConstants.cs" Link="Backchannel\BackchannelConstants.cs" />
     <Compile Include="$(SharedDir)TerminalHost\*.cs" Link="Backchannel\TerminalHost\%(Filename)%(Extension)" />
     <Compile Include="$(SharedDir)UserSecrets\UserSecretsPathHelper.cs" Link="UserSecrets\UserSecretsPathHelper.cs" />
+    <Compile Include="$(SharedDir)UserSecrets\UserSecretsJsonOptions.cs" Link="UserSecrets\UserSecretsJsonOptions.cs" />
     <Compile Include="$(SharedDir)X509Certificate2Extensions.cs" Link="Utils\X509Certificate2Extensions.cs" />
     <Compile Include="$(SharedDir)PasswordGenerator.cs" Link="Utils\PasswordGenerator.cs" />
     <Compile Include="$(SharedDir)ProcessSignaler.cs" Link="Utils\ProcessSignaler.cs" />

--- a/src/Aspire.Hosting/Pipelines/Internal/DeploymentStateManagerBase.cs
+++ b/src/Aspire.Hosting/Pipelines/Internal/DeploymentStateManagerBase.cs
@@ -30,14 +30,6 @@ internal abstract class DeploymentStateManagerBase<T>(ILogger<T> logger) : IDepl
     }
 
     /// <summary>
-    /// JSON serializer options used for writing deployment state files.
-    /// </summary>
-    protected static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
-    {
-        WriteIndented = true
-    };
-
-    /// <summary>
     /// Logger instance for the derived class.
     /// </summary>
     protected readonly ILogger<T> logger = logger;

--- a/src/Aspire.Hosting/Pipelines/Internal/FileDeploymentStateManager.cs
+++ b/src/Aspire.Hosting/Pipelines/Internal/FileDeploymentStateManager.cs
@@ -6,6 +6,7 @@
 
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
+using Aspire.Shared.UserSecrets;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -127,7 +128,7 @@ internal sealed partial class FileDeploymentStateManager(
             }
             await File.WriteAllTextAsync(
                 deploymentStatePath,
-                flattenedSecrets.ToJsonString(s_jsonSerializerOptions),
+                flattenedSecrets.ToJsonString(UserSecretsJsonOptions.s_instance),
                 cancellationToken).ConfigureAwait(false);
 
             logger.LogDebug("Deployment state saved to {Path}", deploymentStatePath);

--- a/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
+++ b/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
@@ -7,7 +7,6 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.Pipelines.Internal;
 using Aspire.Shared.UserSecrets;
@@ -79,8 +78,6 @@ internal sealed class UserSecretsManagerFactory
 
     private sealed class UserSecretsManager : IUserSecretsManager
     {
-        private static readonly JsonSerializerOptions s_jsonSerializerOptions = new() { WriteIndented = true };
-
         private readonly SemaphoreSlim _semaphore = new(1, 1);
         private readonly IFileSystemService _fileSystemService;
 
@@ -167,7 +164,7 @@ internal sealed class UserSecretsManagerFactory
                 var flattenedState = JsonFlattener.FlattenJsonObject(state);
                 EnsureUserSecretsDirectory();
 
-                var json = flattenedState.ToJsonString(s_jsonSerializerOptions);
+                var json = flattenedState.ToJsonString(UserSecretsJsonOptions.s_instance);
                 await File.WriteAllTextAsync(FilePath, json, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
             }
             finally
@@ -214,7 +211,7 @@ internal sealed class UserSecretsManagerFactory
                 contents[secret.Key] = secret.Value;
             }
 
-            var json = contents.ToJsonString(s_jsonSerializerOptions);
+            var json = contents.ToJsonString(UserSecretsJsonOptions.s_instance);
 
             // Create a temp file with the correct Unix file mode before moving it to the expected path.
             if (!OperatingSystem.IsWindows())

--- a/src/Shared/UserSecrets/SecretsStore.cs
+++ b/src/Shared/UserSecrets/SecretsStore.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Encodings.Web;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Shared.Json;
 
@@ -13,12 +11,6 @@ namespace Aspire.Shared.UserSecrets;
 /// </summary>
 internal sealed class SecretsStore
 {
-    internal static readonly JsonSerializerOptions s_jsonOptions = new()
-    {
-        WriteIndented = true,
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-    };
-
     private readonly string _secretsFilePath;
     private readonly Dictionary<string, string> _secrets;
 
@@ -90,7 +82,7 @@ internal sealed class SecretsStore
             obj[key] = value;
         }
 
-        var json = obj.ToJsonString(s_jsonOptions);
+        var json = obj.ToJsonString(UserSecretsJsonOptions.s_instance);
 
         // Unix: write to temp file then move for atomicity (matches aspnetcore pattern)
         if (!OperatingSystem.IsWindows())

--- a/src/Shared/UserSecrets/UserSecretsJsonOptions.cs
+++ b/src/Shared/UserSecrets/UserSecretsJsonOptions.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace Aspire.Shared.UserSecrets;
+
+/// <summary>
+/// Shared <see cref="JsonSerializerOptions"/> for reading and writing user secrets JSON files.
+/// Uses <see cref="JavaScriptEncoder.UnsafeRelaxedJsonEscaping"/> so characters like &amp; and +
+/// are preserved verbatim rather than being escaped as \u0026 and \u002B.
+/// </summary>
+internal static class UserSecretsJsonOptions
+{
+    internal static readonly JsonSerializerOptions s_instance = new()
+    {
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+}

--- a/tests/Aspire.Cli.Tests/Secrets/SecretsStoreTests.cs
+++ b/tests/Aspire.Cli.Tests/Secrets/SecretsStoreTests.cs
@@ -187,11 +187,12 @@ public class SecretsStoreTests : IDisposable
         store.Save();
 
         var json = File.ReadAllText(path);
-        // Should NOT contain \u0027 or \u003C escaping
-        Assert.DoesNotContain("\\u0027", json);
-        Assert.DoesNotContain("\\u003C", json);
-        Assert.Contains("'quotes'", json);
-        Assert.Contains("<angle>", json);
+        var expectedJson = """
+            {
+              "key": "value with 'quotes' and <angle> brackets"
+            }
+            """;
+        Assert.Equal(expectedJson, json, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -214,6 +215,28 @@ public class SecretsStoreTests : IDisposable
 
         Assert.True(store.ContainsKey("exists"));
         Assert.False(store.ContainsKey("missing"));
+    }
+
+    [Fact]
+    public void Save_PreservesAmpersandAndPlusCharacters()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/5537
+        // Characters like & and + were being escaped as \u0026 and \u002B
+        var path = GetSecretsPath();
+        var store = new SecretsStore(path);
+
+        store.Set("Parameters:token", "some=thing&looking=url&like=true");
+        store.Set("Parameters:password", "P+qMWNzkn*xm1rhXNF5st0");
+        store.Save();
+
+        var json = File.ReadAllText(path);
+        var expectedJson = """
+            {
+              "Parameters:token": "some=thing&looking=url&like=true",
+              "Parameters:password": "P+qMWNzkn*xm1rhXNF5st0"
+            }
+            """;
+        Assert.Equal(expectedJson, json, ignoreLineEndingDifferences: true);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/UserSecretsParameterDefaultTests.cs
+++ b/tests/Aspire.Hosting.Tests/UserSecretsParameterDefaultTests.cs
@@ -343,6 +343,35 @@ public class UserSecretsParameterDefaultTests
         DeleteUserSecretsFile(userSecretsId);
     }
 
+    [Fact]
+    public void TrySetSecret_PreservesSpecialCharactersVerbatim()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/5537
+        // Characters like & and + were being escaped as \u0026 and \u002B
+        var userSecretsId = Guid.NewGuid().ToString("N");
+        ClearUsersSecrets(userSecretsId);
+
+        var testAssembly = AssemblyBuilder.DefineDynamicAssembly(
+            new("TestAssembly"), AssemblyBuilderAccess.RunAndCollect, [new CustomAttributeBuilder(s_userSecretsIdAttrCtor, [userSecretsId])]);
+        var factory = CreateFactory();
+        var manager = factory.GetOrCreate(testAssembly);
+
+        Assert.True(manager.TrySetSecret("Parameters:token", "some=thing&looking=url&like=true"));
+        Assert.True(manager.TrySetSecret("Parameters:password", "P+qMWNzkn*xm1rhXNF5st0"));
+
+        // Verify the raw file preserves special characters verbatim
+        var json = File.ReadAllText(manager.FilePath);
+        var expectedJson = """
+            {
+              "Parameters:token": "some=thing&looking=url&like=true",
+              "Parameters:password": "P+qMWNzkn*xm1rhXNF5st0"
+            }
+            """;
+        Assert.Equal(expectedJson, json, ignoreLineEndingDifferences: true);
+
+        DeleteUserSecretsFile(userSecretsId);
+    }
+
     private static void EnsureUserSecretsDirectory(string secretsFilePath)
     {
         var directoryName = Path.GetDirectoryName(secretsFilePath);


### PR DESCRIPTION
## Description

When Aspire writes user secrets (e.g., generated passwords for SQL Server, RabbitMQ, etc.), characters like `&` and `+` were being escaped as `\u0026` and `\u002B` in the JSON file. This caused values to change from what the user originally set, breaking passwords and tokens that contain these characters.

The root cause is that `System.Text.Json`'s default encoder aggressively escapes characters that are safe in JSON but potentially unsafe in HTML/JavaScript contexts. Since user secrets files are never rendered in a browser, this escaping is unnecessary and harmful.

This PR uses `JavaScriptEncoder.UnsafeRelaxedJsonEscaping` when serializing user secrets JSON, and centralizes the `JsonSerializerOptions` into a single shared `UserSecretsJsonOptions` class to avoid future divergence. The three previous definitions in `SecretsStore`, `UserSecretsManager`, and `DeploymentStateManagerBase` now all reference this shared instance.

### User-facing usage

Parameters containing special characters are now preserved verbatim in user secrets:

```json
{
  "Parameters:token": "some=thing&looking=url&like=true",
  "Parameters:password": "P+qMWNzkn*xm1rhXNF5st0"
}
```

Previously these would have been written as:

```json
{
  "Parameters:token": "some=thing\u0026looking=url\u0026like=true",
  "Parameters:password": "P\u002BqMWNzkn*xm1rhXNF5st0"
}
```

Fixes #5537

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
