### PR TITLE
Fix SDK check failing after private SDK install by routing commands through IDotNetRuntimeSelector

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -24,9 +24,9 @@ internal sealed class AddCommand : BaseCommand
     private readonly IProjectLocator _projectLocator;
     private readonly IAddCommandPrompter _prompter;
     private readonly AspireCliTelemetry _telemetry;
-    private readonly IDotNetSdkInstaller _sdkInstaller;
+    private readonly IDotNetRuntimeSelector _runtimeSelector;
 
-    public AddCommand(IDotNetCliRunner runner, IPackagingService packagingService, IInteractionService interactionService, IProjectLocator projectLocator, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier)
+    public AddCommand(IDotNetCliRunner runner, IPackagingService packagingService, IInteractionService interactionService, IProjectLocator projectLocator, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetRuntimeSelector runtimeSelector, IFeatures features, ICliUpdateNotifier updateNotifier)
         : base("add", AddCommandStrings.Description, features, updateNotifier)
     {
         ArgumentNullException.ThrowIfNull(runner);
@@ -35,7 +35,7 @@ internal sealed class AddCommand : BaseCommand
         ArgumentNullException.ThrowIfNull(projectLocator);
         ArgumentNullException.ThrowIfNull(prompter);
         ArgumentNullException.ThrowIfNull(telemetry);
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
+        ArgumentNullException.ThrowIfNull(runtimeSelector);
 
         _runner = runner;
         _packagingService = packagingService;
@@ -43,7 +43,7 @@ internal sealed class AddCommand : BaseCommand
         _projectLocator = projectLocator;
         _prompter = prompter;
         _telemetry = telemetry;
-        _sdkInstaller = sdkInstaller;
+        _runtimeSelector = runtimeSelector;
 
         var integrationArgument = new Argument<string>("integration");
         integrationArgument.Description = AddCommandStrings.IntegrationArgumentDescription;
@@ -66,7 +66,7 @@ internal sealed class AddCommand : BaseCommand
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Check if the .NET SDK is available
-        if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_sdkInstaller, _interactionService, cancellationToken))
+        if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_interactionService, _runtimeSelector, cancellationToken))
         {
             return ExitCodeConstants.SdkNotInstalled;
         }

--- a/src/Aspire.Cli/Commands/DeployCommand.cs
+++ b/src/Aspire.Cli/Commands/DeployCommand.cs
@@ -14,8 +14,8 @@ namespace Aspire.Cli.Commands;
 
 internal sealed class DeployCommand : PublishCommandBase
 {
-    public DeployCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier)
-        : base("deploy", DeployCommandStrings.Description, runner, interactionService, projectLocator, telemetry, sdkInstaller, features, updateNotifier)
+    public DeployCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IDotNetRuntimeSelector runtimeSelector, IFeatures features, ICliUpdateNotifier updateNotifier)
+        : base("deploy", DeployCommandStrings.Description, runner, interactionService, projectLocator, telemetry, runtimeSelector, features, updateNotifier)
     {
     }
 

--- a/src/Aspire.Cli/Commands/ExecCommand.cs
+++ b/src/Aspire.Cli/Commands/ExecCommand.cs
@@ -25,7 +25,7 @@ internal class ExecCommand : BaseCommand
     private readonly IProjectLocator _projectLocator;
     private readonly IAnsiConsole _ansiConsole;
     private readonly AspireCliTelemetry _telemetry;
-    private readonly IDotNetSdkInstaller _sdkInstaller;
+    private readonly IDotNetRuntimeSelector _runtimeSelector;
 
     public ExecCommand(
         IDotNetCliRunner runner,
@@ -34,7 +34,7 @@ internal class ExecCommand : BaseCommand
         IProjectLocator projectLocator,
         IAnsiConsole ansiConsole,
         AspireCliTelemetry telemetry,
-        IDotNetSdkInstaller sdkInstaller,
+        IDotNetRuntimeSelector runtimeSelector,
         IFeatures features,
         ICliUpdateNotifier updateNotifier)
         : base("exec", ExecCommandStrings.Description, features, updateNotifier)
@@ -45,7 +45,7 @@ internal class ExecCommand : BaseCommand
         ArgumentNullException.ThrowIfNull(projectLocator);
         ArgumentNullException.ThrowIfNull(ansiConsole);
         ArgumentNullException.ThrowIfNull(telemetry);
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
+        ArgumentNullException.ThrowIfNull(runtimeSelector);
 
         _runner = runner;
         _interactionService = interactionService;
@@ -53,7 +53,7 @@ internal class ExecCommand : BaseCommand
         _projectLocator = projectLocator;
         _ansiConsole = ansiConsole;
         _telemetry = telemetry;
-        _sdkInstaller = sdkInstaller;
+        _runtimeSelector = runtimeSelector;
 
         var projectOption = new Option<FileInfo?>("--project");
         projectOption.Description = ExecCommandStrings.ProjectArgumentDescription;
@@ -82,7 +82,7 @@ internal class ExecCommand : BaseCommand
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Check if the .NET SDK is available
-        if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_sdkInstaller, _interactionService, cancellationToken))
+        if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_interactionService, _runtimeSelector, cancellationToken))
         {
             return ExitCodeConstants.SdkNotInstalled;
         }

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -27,7 +27,7 @@ internal sealed class NewCommand : BaseCommand
     private readonly IInteractionService _interactionService;
     private readonly IEnumerable<ITemplate> _templates;
     private readonly AspireCliTelemetry _telemetry;
-    private readonly IDotNetSdkInstaller _sdkInstaller;
+    private readonly IDotNetRuntimeSelector _runtimeSelector;
 
     public NewCommand(
         IDotNetCliRunner runner,
@@ -37,7 +37,7 @@ internal sealed class NewCommand : BaseCommand
         ICertificateService certificateService,
         ITemplateProvider templateProvider,
         AspireCliTelemetry telemetry,
-        IDotNetSdkInstaller sdkInstaller,
+        IDotNetRuntimeSelector runtimeSelector,
         IFeatures features,
         ICliUpdateNotifier updateNotifier)
         : base("new", NewCommandStrings.Description, features, updateNotifier)
@@ -49,7 +49,7 @@ internal sealed class NewCommand : BaseCommand
         ArgumentNullException.ThrowIfNull(interactionService);
         ArgumentNullException.ThrowIfNull(templateProvider);
         ArgumentNullException.ThrowIfNull(telemetry);
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
+        ArgumentNullException.ThrowIfNull(runtimeSelector);
 
         _runner = runner;
         _nuGetPackageCache = nuGetPackageCache;
@@ -57,7 +57,7 @@ internal sealed class NewCommand : BaseCommand
         _prompter = prompter;
         _interactionService = interactionService;
         _telemetry = telemetry;
-        _sdkInstaller = sdkInstaller;
+        _runtimeSelector = runtimeSelector;
 
         var nameOption = new Option<string>("--name", "-n");
         nameOption.Description = NewCommandStrings.NameArgumentDescription;
@@ -107,7 +107,7 @@ internal sealed class NewCommand : BaseCommand
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Check if the .NET SDK is available
-        if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_sdkInstaller, _interactionService, cancellationToken))
+        if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_interactionService, _runtimeSelector, cancellationToken))
         {
             return ExitCodeConstants.SdkNotInstalled;
         }

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -34,8 +34,8 @@ internal sealed class PublishCommand : PublishCommandBase
 {
     private readonly IPublishCommandPrompter _prompter;
 
-    public PublishCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, IPublishCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier)
-        : base("publish", PublishCommandStrings.Description, runner, interactionService, projectLocator, telemetry, sdkInstaller, features, updateNotifier)
+    public PublishCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, IPublishCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetRuntimeSelector runtimeSelector, IFeatures features, ICliUpdateNotifier updateNotifier)
+        : base("publish", PublishCommandStrings.Description, runner, interactionService, projectLocator, telemetry, runtimeSelector, features, updateNotifier)
     {
         ArgumentNullException.ThrowIfNull(prompter);
         _prompter = prompter;

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -26,7 +26,7 @@ internal abstract class PublishCommandBase : BaseCommand
     protected readonly IInteractionService _interactionService;
     protected readonly IProjectLocator _projectLocator;
     protected readonly AspireCliTelemetry _telemetry;
-    protected readonly IDotNetSdkInstaller _sdkInstaller;
+    protected readonly IDotNetRuntimeSelector _runtimeSelector;
 
     protected abstract string OperationCompletedPrefix { get; }
     protected abstract string OperationFailedPrefix { get; }
@@ -40,20 +40,20 @@ internal abstract class PublishCommandBase : BaseCommand
     private static bool IsCompletionStateWarning(string completionState) =>
         completionState == CompletionStates.CompletedWithWarning;
 
-    protected PublishCommandBase(string name, string description, IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier)
+    protected PublishCommandBase(string name, string description, IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IDotNetRuntimeSelector runtimeSelector, IFeatures features, ICliUpdateNotifier updateNotifier)
         : base(name, description, features, updateNotifier)
     {
         ArgumentNullException.ThrowIfNull(runner);
         ArgumentNullException.ThrowIfNull(interactionService);
         ArgumentNullException.ThrowIfNull(projectLocator);
         ArgumentNullException.ThrowIfNull(telemetry);
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
+        ArgumentNullException.ThrowIfNull(runtimeSelector);
 
         _runner = runner;
         _interactionService = interactionService;
         _projectLocator = projectLocator;
         _telemetry = telemetry;
-        _sdkInstaller = sdkInstaller;
+        _runtimeSelector = runtimeSelector;
 
         var projectOption = new Option<FileInfo?>("--project")
         {
@@ -82,7 +82,7 @@ internal abstract class PublishCommandBase : BaseCommand
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Check if the .NET SDK is available
-        if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_sdkInstaller, _interactionService, cancellationToken))
+        if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_interactionService, _runtimeSelector, cancellationToken))
         {
             return ExitCodeConstants.SdkNotInstalled;
         }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -28,7 +28,7 @@ internal sealed class RunCommand : BaseCommand
     private readonly IAnsiConsole _ansiConsole;
     private readonly AspireCliTelemetry _telemetry;
     private readonly IConfiguration _configuration;
-    private readonly IDotNetSdkInstaller _sdkInstaller;
+    private readonly IDotNetRuntimeSelector _runtimeSelector;
     private readonly IServiceProvider _serviceProvider;
 
     public RunCommand(
@@ -39,7 +39,7 @@ internal sealed class RunCommand : BaseCommand
         IAnsiConsole ansiConsole,
         AspireCliTelemetry telemetry,
         IConfiguration configuration,
-        IDotNetSdkInstaller sdkInstaller,
+        IDotNetRuntimeSelector runtimeSelector,
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         IServiceProvider serviceProvider)
@@ -52,7 +52,7 @@ internal sealed class RunCommand : BaseCommand
         ArgumentNullException.ThrowIfNull(ansiConsole);
         ArgumentNullException.ThrowIfNull(telemetry);
         ArgumentNullException.ThrowIfNull(configuration);
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
+        ArgumentNullException.ThrowIfNull(runtimeSelector);
 
         _runner = runner;
         _interactionService = interactionService;
@@ -62,7 +62,7 @@ internal sealed class RunCommand : BaseCommand
         _telemetry = telemetry;
         _configuration = configuration;
         _serviceProvider = serviceProvider;
-        _sdkInstaller = sdkInstaller;
+        _runtimeSelector = runtimeSelector;
 
         var projectOption = new Option<FileInfo?>("--project");
         projectOption.Description = RunCommandStrings.ProjectArgumentDescription;
@@ -78,7 +78,7 @@ internal sealed class RunCommand : BaseCommand
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Check if the .NET SDK is available
-        if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_sdkInstaller, _interactionService, cancellationToken))
+        if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_interactionService, _runtimeSelector, cancellationToken))
         {
             return ExitCodeConstants.SdkNotInstalled;
         }

--- a/src/Aspire.Cli/Configuration/AspireSettings.cs
+++ b/src/Aspire.Cli/Configuration/AspireSettings.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Aspire.Cli.Configuration;
+
+/// <summary>
+/// Configuration settings for Aspire CLI stored in settings.json.
+/// </summary>
+internal sealed class AspireSettings
+{
+    /// <summary>
+    /// .NET SDK configuration.
+    /// </summary>
+    [JsonPropertyName("dotnet")]
+    public DotNetSettings? DotNet { get; set; }
+}
+
+/// <summary>
+/// .NET SDK configuration settings.
+/// </summary>
+internal sealed class DotNetSettings
+{
+    /// <summary>
+    /// The mode to use for .NET SDK selection.
+    /// Valid values: "private", "system", "custom"
+    /// </summary>
+    [JsonPropertyName("mode")]
+    public string? Mode { get; set; }
+
+    /// <summary>
+    /// The specific SDK version to use.
+    /// </summary>
+    [JsonPropertyName("sdkVersion")]
+    public string? SdkVersion { get; set; }
+
+    /// <summary>
+    /// Custom path to dotnet executable (when mode is "custom").
+    /// </summary>
+    [JsonPropertyName("customPath")]
+    public string? CustomPath { get; set; }
+
+    /// <summary>
+    /// Legacy alias for preferring private SDK installation.
+    /// </summary>
+    [JsonPropertyName("preferPrivate")]
+    public bool? PreferPrivate { get; set; }
+}

--- a/src/Aspire.Cli/DotNet/DotNetRuntimeSelector.cs
+++ b/src/Aspire.Cli/DotNet/DotNetRuntimeSelector.cs
@@ -1,0 +1,313 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace Aspire.Cli.DotNet;
+
+/// <summary>
+/// Default implementation of <see cref="IDotNetRuntimeSelector"/>.
+/// </summary>
+internal sealed class DotNetRuntimeSelector(
+    ILogger<DotNetRuntimeSelector> logger,
+    IConfiguration configuration,
+    IDotNetSdkInstaller sdkInstaller,
+    IInteractionService interactionService,
+    IAnsiConsole console) : IDotNetRuntimeSelector
+{
+    private string? _dotNetExecutablePath;
+    private DotNetRuntimeMode _mode = DotNetRuntimeMode.System;
+    private readonly Dictionary<string, string> _environmentVariables = new();
+
+    /// <inheritdoc />
+    public string DotNetExecutablePath => _dotNetExecutablePath ?? "dotnet";
+
+    /// <inheritdoc />
+    public DotNetRuntimeMode Mode => _mode;
+
+    /// <inheritdoc />
+    public async Task<bool> InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        // Check environment variables first
+        var disablePrivateSdk = Environment.GetEnvironmentVariable("ASPIRE_DISABLE_PRIVATE_SDK") == "1";
+        var overrideVersion = Environment.GetEnvironmentVariable("ASPIRE_DOTNET_SDK_VERSION") 
+            ?? configuration["overrideMinimumSdkVersion"];
+        
+        // Load settings from ~/.aspire/settings.json
+        var settings = await LoadSettingsAsync();
+        
+        // Determine the required SDK version
+        var requiredVersion = overrideVersion 
+            ?? settings?.DotNet?.SdkVersion 
+            ?? DotNetSdkInstaller.MinimumSdkVersion;
+
+        // Determine the preferred mode
+        var preferredMode = DetermineModeFromSettings(settings, disablePrivateSdk);
+
+        // Check if system SDK meets requirements
+        var systemSdkAvailable = await sdkInstaller.CheckAsync(requiredVersion, cancellationToken);
+
+        switch (preferredMode)
+        {
+            case DotNetRuntimeMode.System:
+                if (systemSdkAvailable)
+                {
+                    _mode = DotNetRuntimeMode.System;
+                    _dotNetExecutablePath = "dotnet";
+                    return true;
+                }
+                else if (!disablePrivateSdk)
+                {
+                    // Fall back to private if system doesn't work
+                    return await TryInitializePrivateAsync(requiredVersion, cancellationToken);
+                }
+                else
+                {
+                    logger.LogError("System .NET SDK {Version} not available and private SDK disabled", requiredVersion);
+                    return false;
+                }
+
+            case DotNetRuntimeMode.Private:
+                if (!disablePrivateSdk)
+                {
+                    return await TryInitializePrivateAsync(requiredVersion, cancellationToken);
+                }
+                else
+                {
+                    logger.LogWarning("Private SDK requested but disabled by environment variable");
+                    if (systemSdkAvailable)
+                    {
+                        _mode = DotNetRuntimeMode.System;
+                        _dotNetExecutablePath = "dotnet";
+                        return true;
+                    }
+                    return false;
+                }
+
+            case DotNetRuntimeMode.Custom:
+                var customPath = settings?.DotNet?.CustomPath;
+                if (!string.IsNullOrEmpty(customPath) && File.Exists(customPath))
+                {
+                    _mode = DotNetRuntimeMode.Custom;
+                    _dotNetExecutablePath = customPath;
+                    return true;
+                }
+                logger.LogError("Custom dotnet path not found: {Path}", customPath);
+                return false;
+
+            default:
+                return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public IDictionary<string, string> GetEnvironmentVariables()
+    {
+        return new Dictionary<string, string>(_environmentVariables);
+    }
+
+    private async Task<AspireSettings?> LoadSettingsAsync()
+    {
+        try
+        {
+            var aspireHome = Environment.GetEnvironmentVariable("ASPIRE_HOME") 
+                ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire");
+            
+            var settingsPath = Path.Combine(aspireHome, "settings.json");
+            
+            if (!File.Exists(settingsPath))
+            {
+                return null;
+            }
+
+            var json = await File.ReadAllTextAsync(settingsPath);
+            return JsonSerializer.Deserialize(json, JsonSourceGenerationContext.Default.AspireSettings);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to load settings.json");
+            return null;
+        }
+    }
+
+    private static DotNetRuntimeMode DetermineModeFromSettings(AspireSettings? settings, bool disablePrivateSdk)
+    {
+        if (settings?.DotNet == null)
+        {
+            return DotNetRuntimeMode.System;
+        }
+
+        // Check for legacy preferPrivate setting
+        if (settings.DotNet.PreferPrivate == true && !disablePrivateSdk)
+        {
+            return DotNetRuntimeMode.Private;
+        }
+
+        return settings.DotNet.Mode?.ToLowerInvariant() switch
+        {
+            "private" when !disablePrivateSdk => DotNetRuntimeMode.Private,
+            "system" => DotNetRuntimeMode.System,
+            "custom" => DotNetRuntimeMode.Custom,
+            _ => DotNetRuntimeMode.System
+        };
+    }
+
+    private async Task<bool> TryInitializePrivateAsync(string requiredVersion, CancellationToken cancellationToken)
+    {
+        var aspireHome = Environment.GetEnvironmentVariable("ASPIRE_HOME") 
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire");
+        
+        var privateSdkPath = Path.Combine(aspireHome, "sdk", requiredVersion);
+        var privateDotNetPath = Path.Combine(privateSdkPath, "dotnet");
+        
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            privateDotNetPath += ".exe";
+        }
+
+        // Check if private SDK already exists and works
+        if (File.Exists(privateDotNetPath))
+        {
+            _mode = DotNetRuntimeMode.Private;
+            _dotNetExecutablePath = privateDotNetPath;
+            
+            // Set environment variables to isolate the private SDK
+            _environmentVariables["DOTNET_ROOT"] = privateSdkPath;
+            _environmentVariables["DOTNET_HOST_PATH"] = privateDotNetPath;
+            
+            return true;
+        }
+
+        // Private SDK doesn't exist, offer to install it
+        return await OfferToInstallPrivateSdkAsync(requiredVersion, privateSdkPath, privateDotNetPath, cancellationToken);
+    }
+
+    private async Task<bool> OfferToInstallPrivateSdkAsync(string requiredVersion, string privateSdkPath, string privateDotNetPath, CancellationToken cancellationToken)
+    {
+        var autoInstall = Environment.GetEnvironmentVariable("ASPIRE_AUTO_INSTALL") == "1";
+        
+        if (!autoInstall)
+        {
+            console.MarkupLine($"[yellow]Required .NET SDK version {requiredVersion} is not available on the system PATH.[/]");
+            console.MarkupLine($"[green]Would you like to install a private copy under ~/.aspire/sdk?[/]");
+            
+            if (!await interactionService.ConfirmAsync("Install private .NET SDK?", defaultValue: false, cancellationToken))
+            {
+                return false;
+            }
+        }
+
+        try
+        {
+            await console.Status()
+                .Spinner(Spinner.Known.Dots)
+                .StartAsync($"Installing .NET SDK {requiredVersion}...", async ctx =>
+                {
+                    ctx.Status($"Creating directory {privateSdkPath}...");
+                    Directory.CreateDirectory(privateSdkPath);
+
+                    ctx.Status($"Downloading and installing .NET SDK {requiredVersion}...");
+                    await InstallPrivateSdkAsync(requiredVersion, privateSdkPath, cancellationToken);
+                });
+
+            if (File.Exists(privateDotNetPath))
+            {
+                console.MarkupLine($"[green]Successfully installed private .NET SDK to {privateSdkPath}[/]");
+                
+                _mode = DotNetRuntimeMode.Private;
+                _dotNetExecutablePath = privateDotNetPath;
+                
+                // Set environment variables to isolate the private SDK
+                _environmentVariables["DOTNET_ROOT"] = privateSdkPath;
+                _environmentVariables["DOTNET_HOST_PATH"] = privateDotNetPath;
+                
+                return true;
+            }
+            else
+            {
+                console.MarkupLine("[red]Failed to install private .NET SDK[/]");
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to install private .NET SDK");
+            console.MarkupLine($"[red]Installation failed: {ex.Message}[/]");
+            return false;
+        }
+    }
+
+    private static async Task InstallPrivateSdkAsync(string requiredVersion, string installPath, CancellationToken cancellationToken)
+    {
+        // Use dotnet-install script to install the SDK
+        var scriptUrl = Environment.GetEnvironmentVariable("ASPIRE_DOTNET_INSTALL_SCRIPT_URL");
+        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        
+        if (string.IsNullOrEmpty(scriptUrl))
+        {
+            scriptUrl = isWindows 
+                ? "https://dot.net/v1/dotnet-install.ps1"
+                : "https://dot.net/v1/dotnet-install.sh";
+        }
+
+        var tempDir = Path.GetTempPath();
+        var scriptName = isWindows ? "dotnet-install.ps1" : "dotnet-install.sh";
+        var scriptPath = Path.Combine(tempDir, scriptName);
+
+        // Download the install script
+        using var httpClient = new HttpClient();
+        var scriptContent = await httpClient.GetStringAsync(scriptUrl, cancellationToken);
+        await File.WriteAllTextAsync(scriptPath, scriptContent, cancellationToken);
+
+        if (!isWindows)
+        {
+            // Make script executable on Unix
+            File.SetUnixFileMode(scriptPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        // Run the install script
+        var arguments = isWindows
+            ? $"-ExecutionPolicy Bypass -File \"{scriptPath}\" -Version {requiredVersion} -InstallDir \"{installPath}\" -NoPath"
+            : $"\"{scriptPath}\" --version {requiredVersion} --install-dir \"{installPath}\" --no-path";
+
+        var executable = isWindows ? "powershell" : "bash";
+        
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+        
+        await process.WaitForExitAsync(cancellationToken);
+        
+        if (process.ExitCode != 0)
+        {
+            var error = await process.StandardError.ReadToEndAsync(cancellationToken);
+            throw new InvalidOperationException($"dotnet-install script failed with exit code {process.ExitCode}: {error}");
+        }
+
+        // Clean up the script
+        try
+        {
+            File.Delete(scriptPath);
+        }
+        catch
+        {
+            // Ignore cleanup errors
+        }
+    }
+}

--- a/src/Aspire.Cli/DotNet/DotNetRuntimeSelector.cs
+++ b/src/Aspire.Cli/DotNet/DotNetRuntimeSelector.cs
@@ -26,6 +26,7 @@ internal sealed class DotNetRuntimeSelector(
     private string? _dotNetExecutablePath;
     private DotNetRuntimeMode _mode = DotNetRuntimeMode.System;
     private readonly Dictionary<string, string> _environmentVariables = new();
+    private bool? _initializeResult;
 
     /// <inheritdoc />
     public string DotNetExecutablePath => _dotNetExecutablePath ?? "dotnet";
@@ -36,19 +37,31 @@ internal sealed class DotNetRuntimeSelector(
     /// <inheritdoc />
     public async Task<bool> InitializeAsync(CancellationToken cancellationToken = default)
     {
+        // Return cached result if already initialized.
+        if (_initializeResult.HasValue)
+        {
+            return _initializeResult.Value;
+        }
+
+        _initializeResult = await InitializeCoreAsync(cancellationToken);
+        return _initializeResult.Value;
+    }
+
+    private async Task<bool> InitializeCoreAsync(CancellationToken cancellationToken)
+    {
         // Check configuration first, then environment variables
-        var disablePrivateSdk = configuration["ASPIRE_DISABLE_PRIVATE_SDK"] == "1" 
+        var disablePrivateSdk = configuration["ASPIRE_DISABLE_PRIVATE_SDK"] == "1"
             || Environment.GetEnvironmentVariable("ASPIRE_DISABLE_PRIVATE_SDK") == "1";
         var overrideVersion = configuration["ASPIRE_DOTNET_SDK_VERSION"]
-            ?? Environment.GetEnvironmentVariable("ASPIRE_DOTNET_SDK_VERSION") 
+            ?? Environment.GetEnvironmentVariable("ASPIRE_DOTNET_SDK_VERSION")
             ?? configuration["overrideMinimumSdkVersion"];
-        
+
         // Load settings from ~/.aspire/settings.json
         var settings = await LoadSettingsAsync();
-        
+
         // Determine the required SDK version
-        var requiredVersion = overrideVersion 
-            ?? settings?.DotNet?.SdkVersion 
+        var requiredVersion = overrideVersion
+            ?? settings?.DotNet?.SdkVersion
             ?? DotNetSdkInstaller.MinimumSdkVersion;
 
         // Determine the preferred mode

--- a/src/Aspire.Cli/DotNet/IDotNetRuntimeSelector.cs
+++ b/src/Aspire.Cli/DotNet/IDotNetRuntimeSelector.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.DotNet;
+
+/// <summary>
+/// Service responsible for selecting and managing the .NET runtime to use.
+/// </summary>
+internal interface IDotNetRuntimeSelector
+{
+    /// <summary>
+    /// Gets the path to the dotnet executable to use.
+    /// </summary>
+    string DotNetExecutablePath { get; }
+
+    /// <summary>
+    /// Gets the mode being used (private, system, or custom).
+    /// </summary>
+    DotNetRuntimeMode Mode { get; }
+
+    /// <summary>
+    /// Initializes the runtime selector, potentially installing a private SDK if needed.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if initialization succeeded, false otherwise.</returns>
+    Task<bool> InitializeAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets environment variables that should be set when launching processes.
+    /// </summary>
+    /// <returns>Dictionary of environment variables.</returns>
+    IDictionary<string, string> GetEnvironmentVariables();
+}
+
+/// <summary>
+/// Represents the mode of .NET runtime selection.
+/// </summary>
+internal enum DotNetRuntimeMode
+{
+    /// <summary>
+    /// Use the system-installed .NET SDK.
+    /// </summary>
+    System,
+
+    /// <summary>
+    /// Use a private .NET SDK installed under ~/.aspire/sdk.
+    /// </summary>
+    Private,
+
+    /// <summary>
+    /// Use a custom path specified by the user.
+    /// </summary>
+    Custom
+}

--- a/src/Aspire.Cli/JsonSourceGenerationContext.cs
+++ b/src/Aspire.Cli/JsonSourceGenerationContext.cs
@@ -3,12 +3,14 @@
 
 using System.Text.Json.Serialization;
 using System.Text.Json.Nodes;
+using Aspire.Cli.Configuration;
 
 namespace Aspire.Cli;
 
 [JsonSourceGenerationOptions(WriteIndented = true)]
 [JsonSerializable(typeof(CliSettings))]
 [JsonSerializable(typeof(JsonObject))]
+[JsonSerializable(typeof(AspireSettings))]
 internal partial class JsonSourceGenerationContext : JsonSerializerContext
 {
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -117,6 +117,11 @@ public class Program
         builder.Services.AddSingleton<AspireCliTelemetry>();
         builder.Services.AddTransient<IDotNetCliRunner, DotNetCliRunner>();
         builder.Services.AddSingleton<IDotNetSdkInstaller, DotNetSdkInstaller>();
+        
+        // .NET Runtime Selection and Process Launching
+        builder.Services.AddSingleton<IDotNetRuntimeSelector, DotNetRuntimeSelector>();
+        builder.Services.AddSingleton<IProcessLauncher, ProcessLauncher>();
+        
         builder.Services.AddTransient<IAppHostBackchannel, AppHostBackchannel>();
         builder.Services.AddSingleton<INuGetPackageCache, NuGetPackageCache>();
         builder.Services.AddHostedService<NuGetPackagePrefetcher>();
@@ -207,6 +212,10 @@ public class Program
         Console.OutputEncoding = Encoding.UTF8;
 
         using var app = await BuildApplicationAsync(args);
+
+        // Initialize the .NET runtime selector 
+        var runtimeSelector = app.Services.GetRequiredService<IDotNetRuntimeSelector>();
+        await runtimeSelector.InitializeAsync();
 
         await app.StartAsync().ConfigureAwait(false);
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -213,10 +213,6 @@ public class Program
 
         using var app = await BuildApplicationAsync(args);
 
-        // Initialize the .NET runtime selector 
-        var runtimeSelector = app.Services.GetRequiredService<IDotNetRuntimeSelector>();
-        await runtimeSelector.InitializeAsync();
-
         await app.StartAsync().ConfigureAwait(false);
 
         var rootCommand = app.Services.GetRequiredService<RootCommand>();

--- a/src/Aspire.Cli/Utils/IProcessLauncher.cs
+++ b/src/Aspire.Cli/Utils/IProcessLauncher.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Service responsible for launching processes with the correct .NET runtime.
+/// </summary>
+internal interface IProcessLauncher
+{
+    /// <summary>
+    /// Launches a dotnet process with the specified arguments.
+    /// </summary>
+    /// <param name="arguments">Arguments to pass to dotnet.</param>
+    /// <param name="workingDirectory">Working directory for the process.</param>
+    /// <param name="environmentVariables">Additional environment variables.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The exit code of the process.</returns>
+    Task<int> LaunchDotNetAsync(
+        string arguments,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Launches a generic process with the specified executable and arguments.
+    /// </summary>
+    /// <param name="executablePath">Path to the executable.</param>
+    /// <param name="arguments">Arguments to pass to the executable.</param>
+    /// <param name="workingDirectory">Working directory for the process.</param>
+    /// <param name="environmentVariables">Additional environment variables.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The exit code of the process.</returns>
+    Task<int> LaunchAsync(
+        string executablePath,
+        string? arguments = null,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Aspire.Cli/Utils/ProcessLauncher.cs
+++ b/src/Aspire.Cli/Utils/ProcessLauncher.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Cli.DotNet;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Default implementation of <see cref="IProcessLauncher"/> that uses the configured .NET runtime.
+/// </summary>
+internal class ProcessLauncher(
+    ILogger<ProcessLauncher> logger,
+    IDotNetRuntimeSelector runtimeSelector) : IProcessLauncher
+{
+    /// <inheritdoc />
+    public async Task<int> LaunchDotNetAsync(
+        string arguments,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await LaunchAsync(
+            runtimeSelector.DotNetExecutablePath,
+            arguments,
+            workingDirectory,
+            environmentVariables,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<int> LaunchAsync(
+        string executablePath,
+        string? arguments = null,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        CancellationToken cancellationToken = default)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executablePath,
+            Arguments = arguments ?? string.Empty,
+            UseShellExecute = false,
+            CreateNoWindow = false
+        };
+
+        if (!string.IsNullOrEmpty(workingDirectory))
+        {
+            startInfo.WorkingDirectory = workingDirectory;
+        }
+
+        // Apply environment variables from runtime selector
+        var runtimeEnvVars = runtimeSelector.GetEnvironmentVariables();
+        foreach (var kvp in runtimeEnvVars)
+        {
+            startInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
+        }
+
+        // Apply additional environment variables
+        if (environmentVariables != null)
+        {
+            foreach (var kvp in environmentVariables)
+            {
+                startInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
+            }
+        }
+
+        logger.LogDebug("Launching process: {Executable} {Arguments}", executablePath, arguments);
+
+        using var process = new Process { StartInfo = startInfo };
+        
+        process.Start();
+        await process.WaitForExitAsync(cancellationToken);
+
+        logger.LogDebug("Process exited with code: {ExitCode}", process.ExitCode);
+        
+        return process.ExitCode;
+    }
+}

--- a/src/Aspire.Cli/Utils/SdkInstallHelper.cs
+++ b/src/Aspire.Cli/Utils/SdkInstallHelper.cs
@@ -14,7 +14,49 @@ namespace Aspire.Cli.Utils;
 internal static class SdkInstallHelper
 {
     /// <summary>
+    /// Ensures that the .NET SDK is installed and available, attempting installation if needed.
+    /// </summary>
+    /// <param name="sdkInstaller">The SDK installer service.</param>
+    /// <param name="interactionService">The interaction service for user communication.</param>
+    /// <param name="runtimeSelector">The runtime selector for managing private SDK installation.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the SDK is available or was successfully installed, false otherwise.</returns>
+    public static async Task<bool> EnsureSdkInstalledAsync(
+        IDotNetSdkInstaller sdkInstaller,
+        IInteractionService interactionService,
+        IDotNetRuntimeSelector runtimeSelector,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sdkInstaller);
+        ArgumentNullException.ThrowIfNull(interactionService);
+        ArgumentNullException.ThrowIfNull(runtimeSelector);
+
+        // First, try to initialize the runtime selector (which may install a private SDK)
+        var isInitialized = await runtimeSelector.InitializeAsync(cancellationToken);
+        
+        if (!isInitialized)
+        {
+            var sdkErrorMessage = string.Format(CultureInfo.InvariantCulture, ErrorStrings.MininumSdkVersionMissing, DotNetSdkInstaller.MinimumSdkVersion);
+            interactionService.DisplayError(sdkErrorMessage);
+            return false;
+        }
+
+        // Re-check the SDK after initialization
+        var isSdkAvailable = await sdkInstaller.CheckAsync(cancellationToken);
+
+        if (!isSdkAvailable)
+        {
+            var sdkErrorMessage = string.Format(CultureInfo.InvariantCulture, ErrorStrings.MininumSdkVersionMissing, DotNetSdkInstaller.MinimumSdkVersion);
+            interactionService.DisplayError(sdkErrorMessage);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Ensures that the .NET SDK is installed and available, displaying an error message if it's not.
+    /// This is the legacy method signature for backwards compatibility.
     /// </summary>
     /// <param name="sdkInstaller">The SDK installer service.</param>
     /// <param name="interactionService">The interaction service for user communication.</param>

--- a/src/Aspire.Cli/Utils/SdkInstallHelper.cs
+++ b/src/Aspire.Cli/Utils/SdkInstallHelper.cs
@@ -14,37 +14,25 @@ namespace Aspire.Cli.Utils;
 internal static class SdkInstallHelper
 {
     /// <summary>
-    /// Ensures that the .NET SDK is installed and available, attempting installation if needed.
+    /// Ensures that the .NET SDK is installed and available, attempting private SDK installation if needed.
     /// </summary>
-    /// <param name="sdkInstaller">The SDK installer service.</param>
     /// <param name="interactionService">The interaction service for user communication.</param>
-    /// <param name="runtimeSelector">The runtime selector for managing private SDK installation.</param>
+    /// <param name="runtimeSelector">The runtime selector for managing SDK discovery and private SDK installation.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>True if the SDK is available or was successfully installed, false otherwise.</returns>
     public static async Task<bool> EnsureSdkInstalledAsync(
-        IDotNetSdkInstaller sdkInstaller,
         IInteractionService interactionService,
         IDotNetRuntimeSelector runtimeSelector,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
         ArgumentNullException.ThrowIfNull(interactionService);
         ArgumentNullException.ThrowIfNull(runtimeSelector);
 
-        // First, try to initialize the runtime selector (which may install a private SDK)
+        // Initialize the runtime selector (which checks for the SDK and may install a private copy).
+        // If initialization succeeds, the SDK is available (system or private), no further check needed.
         var isInitialized = await runtimeSelector.InitializeAsync(cancellationToken);
-        
+
         if (!isInitialized)
-        {
-            var sdkErrorMessage = string.Format(CultureInfo.InvariantCulture, ErrorStrings.MininumSdkVersionMissing, DotNetSdkInstaller.MinimumSdkVersion);
-            interactionService.DisplayError(sdkErrorMessage);
-            return false;
-        }
-
-        // Re-check the SDK after initialization
-        var isSdkAvailable = await sdkInstaller.CheckAsync(cancellationToken);
-
-        if (!isSdkAvailable)
         {
             var sdkErrorMessage = string.Format(CultureInfo.InvariantCulture, ErrorStrings.MininumSdkVersionMissing, DotNetSdkInstaller.MinimumSdkVersion);
             interactionService.DisplayError(sdkErrorMessage);

--- a/src/Aspire.Cli/Utils/SdkLockHelper.cs
+++ b/src/Aspire.Cli/Utils/SdkLockHelper.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Helper class for managing concurrent SDK installations with file locking.
+/// </summary>
+internal static class SdkLockHelper
+{
+    /// <summary>
+    /// Acquires a lock for SDK installation to prevent concurrent installations.
+    /// </summary>
+    /// <param name="sdkVersion">The SDK version being installed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A disposable lock that should be disposed when installation is complete.</returns>
+    public static async Task<IDisposable> AcquireSdkLockAsync(string sdkVersion, CancellationToken cancellationToken = default)
+    {
+        var aspireHome = Environment.GetEnvironmentVariable("ASPIRE_HOME") 
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire");
+        
+        var stateDir = Path.Combine(aspireHome, "state");
+        Directory.CreateDirectory(stateDir);
+        
+        var lockFileName = $"sdk-lock-{sdkVersion}.lock";
+        var lockFilePath = Path.Combine(stateDir, lockFileName);
+        
+        // Wait for any existing lock to be released
+        var maxWaitTime = TimeSpan.FromMinutes(10); // Maximum wait time
+        var startTime = DateTime.UtcNow;
+        
+        while (File.Exists(lockFilePath))
+        {
+            if (DateTime.UtcNow - startTime > maxWaitTime)
+            {
+                // Remove stale lock file if it's too old (more than 30 minutes)
+                var lockFileInfo = new FileInfo(lockFilePath);
+                if (DateTime.UtcNow - lockFileInfo.CreationTimeUtc > TimeSpan.FromMinutes(30))
+                {
+                    try
+                    {
+                        File.Delete(lockFilePath);
+                        break;
+                    }
+                    catch
+                    {
+                        // If we can't delete it, another process might be using it
+                    }
+                }
+                
+                throw new TimeoutException($"Timeout waiting for SDK installation lock for version {sdkVersion}");
+            }
+            
+            await Task.Delay(1000, cancellationToken);
+        }
+        
+        // Create lock file
+        await File.WriteAllTextAsync(lockFilePath, 
+            $"Locked by process {Environment.ProcessId} at {DateTime.UtcNow:O}", 
+            cancellationToken);
+        
+        return new SdkLock(lockFilePath);
+    }
+
+    private sealed class SdkLock : IDisposable
+    {
+        private readonly string _lockFilePath;
+        private bool _disposed;
+
+        public SdkLock(string lockFilePath)
+        {
+            _lockFilePath = lockFilePath;
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                try
+                {
+                    if (File.Exists(_lockFilePath))
+                    {
+                        File.Delete(_lockFilePath);
+                    }
+                }
+                catch
+                {
+                    // Ignore errors when cleaning up lock file
+                }
+                
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/SdkInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkInstallerTests.cs
@@ -16,9 +16,9 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.DotNetSdkInstallerFactory = _ => new TestDotNetSdkInstaller
+            options.DotNetRuntimeSelectorFactory = _ => new TestDotNetRuntimeSelector
             {
-                CheckAsyncCallback = _ => false // SDK not installed
+                InitializeAsyncCallback = _ => false // SDK not installed
             };
         });
         var provider = services.BuildServiceProvider();
@@ -36,9 +36,9 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.DotNetSdkInstallerFactory = _ => new TestDotNetSdkInstaller
+            options.DotNetRuntimeSelectorFactory = _ => new TestDotNetRuntimeSelector
             {
-                CheckAsyncCallback = _ => false // SDK not installed
+                InitializeAsyncCallback = _ => false // SDK not installed
             };
         });
         var provider = services.BuildServiceProvider();
@@ -56,9 +56,9 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.DotNetSdkInstallerFactory = _ => new TestDotNetSdkInstaller
+            options.DotNetRuntimeSelectorFactory = _ => new TestDotNetRuntimeSelector
             {
-                CheckAsyncCallback = _ => false // SDK not installed
+                InitializeAsyncCallback = _ => false // SDK not installed
             };
         });
         var provider = services.BuildServiceProvider();
@@ -76,9 +76,9 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.DotNetSdkInstallerFactory = _ => new TestDotNetSdkInstaller
+            options.DotNetRuntimeSelectorFactory = _ => new TestDotNetRuntimeSelector
             {
-                CheckAsyncCallback = _ => false // SDK not installed
+                InitializeAsyncCallback = _ => false // SDK not installed
             };
         });
         var provider = services.BuildServiceProvider();
@@ -96,9 +96,9 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.DotNetSdkInstallerFactory = _ => new TestDotNetSdkInstaller
+            options.DotNetRuntimeSelectorFactory = _ => new TestDotNetRuntimeSelector
             {
-                CheckAsyncCallback = _ => false // SDK not installed
+                InitializeAsyncCallback = _ => false // SDK not installed
             };
         });
         var provider = services.BuildServiceProvider();
@@ -117,9 +117,9 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.EnabledFeatures = [KnownFeatures.ExecCommandEnabled];
-            options.DotNetSdkInstallerFactory = _ => new TestDotNetSdkInstaller
+            options.DotNetRuntimeSelectorFactory = _ => new TestDotNetRuntimeSelector
             {
-                CheckAsyncCallback = _ => false // SDK not installed
+                InitializeAsyncCallback = _ => false // SDK not installed
             };
         });
         var provider = services.BuildServiceProvider();
@@ -137,9 +137,9 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.DotNetSdkInstallerFactory = _ => new TestDotNetSdkInstaller
+            options.DotNetRuntimeSelectorFactory = _ => new TestDotNetRuntimeSelector
             {
-                CheckAsyncCallback = _ => true // SDK installed
+                InitializeAsyncCallback = _ => true // SDK installed
             };
             // Make sure project locator doesn't find projects so it fails at the expected point
             options.ProjectLocatorFactory = _ => new NoProjectFileProjectLocator();

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetRuntimeSelectorTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetRuntimeSelectorTests.cs
@@ -1,0 +1,179 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Aspire.Cli.DotNet;
+using Aspire.Cli.Interaction;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Aspire.Cli.Tests.DotNet;
+
+public class DotNetRuntimeSelectorTests
+{
+    [Fact]
+    public void Constructor_SetsDefaultValues()
+    {
+        var logger = NullLogger<DotNetRuntimeSelector>.Instance;
+        var configuration = new ConfigurationBuilder().Build();
+        var sdkInstaller = new TestSdkInstaller();
+        var interactionService = new TestInteractionService();
+        var console = new TestAnsiConsole();
+
+        var selector = new DotNetRuntimeSelector(logger, configuration, sdkInstaller, interactionService, console);
+
+        Assert.Equal(DotNetRuntimeMode.System, selector.Mode);
+        Assert.Equal("dotnet", selector.DotNetExecutablePath);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithAvailableSystemSdk_ReturnsTrue()
+    {
+        var logger = NullLogger<DotNetRuntimeSelector>.Instance;
+        var configuration = new ConfigurationBuilder().Build();
+        var sdkInstaller = new TestSdkInstaller { CheckResult = true };
+        var interactionService = new TestInteractionService();
+        var console = new TestAnsiConsole();
+
+        var selector = new DotNetRuntimeSelector(logger, configuration, sdkInstaller, interactionService, console);
+
+        var result = await selector.InitializeAsync();
+
+        Assert.True(result);
+        Assert.Equal(DotNetRuntimeMode.System, selector.Mode);
+        Assert.Equal("dotnet", selector.DotNetExecutablePath);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithDisablePrivateSdkEnvVar_StopsAtSystemCheck()
+    {
+        var logger = NullLogger<DotNetRuntimeSelector>.Instance;
+        var configuration = new ConfigurationBuilder().Build();
+        var sdkInstaller = new TestSdkInstaller { CheckResult = false };
+        var interactionService = new TestInteractionService();
+        var console = new TestAnsiConsole();
+
+        // Set environment variable
+        Environment.SetEnvironmentVariable("ASPIRE_DISABLE_PRIVATE_SDK", "1");
+
+        try
+        {
+            var selector = new DotNetRuntimeSelector(logger, configuration, sdkInstaller, interactionService, console);
+
+            var result = await selector.InitializeAsync();
+
+            Assert.False(result);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPIRE_DISABLE_PRIVATE_SDK", null);
+        }
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithVersionOverride_UsesOverrideVersion()
+    {
+        var logger = NullLogger<DotNetRuntimeSelector>.Instance;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new[]
+            {
+                new KeyValuePair<string, string?>("overrideMinimumSdkVersion", "8.0.100")
+            })
+            .Build();
+        
+        var sdkInstaller = new TestSdkInstaller { CheckResult = true };
+        var interactionService = new TestInteractionService();
+        var console = new TestAnsiConsole();
+
+        var selector = new DotNetRuntimeSelector(logger, configuration, sdkInstaller, interactionService, console);
+
+        var result = await selector.InitializeAsync();
+
+        Assert.True(result);
+        Assert.Equal("8.0.100", sdkInstaller.LastCheckedVersion);
+    }
+
+    [Fact]
+    public void GetEnvironmentVariables_ReturnsEmptyDictionary_WhenNotInitialized()
+    {
+        var logger = NullLogger<DotNetRuntimeSelector>.Instance;
+        var configuration = new ConfigurationBuilder().Build();
+        var sdkInstaller = new TestSdkInstaller();
+        var interactionService = new TestInteractionService();
+        var console = new TestAnsiConsole();
+
+        var selector = new DotNetRuntimeSelector(logger, configuration, sdkInstaller, interactionService, console);
+
+        var envVars = selector.GetEnvironmentVariables();
+
+        Assert.Empty(envVars);
+    }
+
+    private sealed class TestSdkInstaller : IDotNetSdkInstaller
+    {
+        public bool CheckResult { get; set; } = true;
+        public string? LastCheckedVersion { get; private set; }
+
+        public Task<bool> CheckAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(CheckResult);
+        }
+
+        public Task<bool> CheckAsync(string minimumVersion, CancellationToken cancellationToken = default)
+        {
+            LastCheckedVersion = minimumVersion;
+            return Task.FromResult(CheckResult);
+        }
+
+        public Task InstallAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    private sealed class TestInteractionService : IInteractionService
+    {
+        public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action) => action();
+        public void ShowStatus(string statusText, Action action) => action();
+        public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, Spectre.Console.ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default) => Task.FromResult(defaultValue ?? string.Empty);
+        public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default) => Task.FromResult(defaultValue);
+        public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull => Task.FromResult(choices.First());
+        public int DisplayIncompatibleVersionError(Aspire.Cli.Backchannel.AppHostIncompatibleException ex, string appHostHostingVersion) => 1;
+        public void DisplayError(string errorMessage) { }
+        public void DisplayMessage(string emoji, string message) { }
+        public void DisplayPlainText(string text) { }
+        public void DisplayMarkdown(string markdown) { }
+        public void DisplaySuccess(string message) { }
+        public void DisplaySubtleMessage(string message) { }
+        public void DisplayDashboardUrls((string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken) dashboardUrls) { }
+        public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
+        public void DisplayCancellationMessage() { }
+        public void DisplayEmptyLine() { }
+        public void DisplayVersionUpdateNotification(string newerVersion) { }
+        public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) { }
+    }
+
+    private sealed class TestAnsiConsole : IAnsiConsole
+    {
+        public Profile Profile => new Profile(new TestConsoleOutput(), Encoding.UTF8);
+        public IAnsiConsoleCursor Cursor => throw new NotImplementedException();
+        public IAnsiConsoleInput Input => throw new NotImplementedException();
+        public IExclusivityMode ExclusivityMode => throw new NotImplementedException();
+        public RenderPipeline Pipeline => throw new NotImplementedException();
+
+        public void Clear(bool home) { }
+        public void Write(IRenderable renderable) { }
+    }
+
+    private sealed class TestConsoleOutput : IAnsiConsoleOutput
+    {
+        public TextWriter Writer => Console.Out;
+        public bool IsTerminal => false;
+        public int Width => 80;
+        public int Height => 25;
+
+        public void SetEncoding(Encoding encoding) { }
+    }
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetRuntimeSelector.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetRuntimeSelector.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.DotNet;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestDotNetRuntimeSelector : IDotNetRuntimeSelector
+{
+    public Func<CancellationToken, bool>? InitializeAsyncCallback { get; set; }
+
+    public string DotNetExecutablePath => "dotnet";
+
+    public DotNetRuntimeMode Mode => DotNetRuntimeMode.System;
+
+    public Task<bool> InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        return InitializeAsyncCallback != null
+            ? Task.FromResult(InitializeAsyncCallback(cancellationToken))
+            : Task.FromResult(true); // Default to SDK available
+    }
+
+    public IDictionary<string, string> GetEnvironmentVariables()
+    {
+        return new Dictionary<string, string>();
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -82,6 +82,7 @@ internal static class CliTestHelper
         services.AddSingleton(options.FeatureFlagsFactory);
         services.AddSingleton(options.CliUpdateNotifierFactory);
         services.AddSingleton(options.DotNetSdkInstallerFactory);
+        services.AddSingleton(options.DotNetRuntimeSelectorFactory);
         services.AddSingleton(options.PackagingServiceFactory);
         services.AddSingleton(options.CliExecutionContextFactory);
         services.AddTransient<RootCommand>();
@@ -228,6 +229,11 @@ internal sealed class CliServiceCollectionTestOptions
     public Func<IServiceProvider, IDotNetSdkInstaller> DotNetSdkInstallerFactory { get; set; } = (IServiceProvider serviceProvider) =>
     {
         return new TestDotNetSdkInstaller();
+    };
+
+    public Func<IServiceProvider, IDotNetRuntimeSelector> DotNetRuntimeSelectorFactory { get; set; } = (IServiceProvider serviceProvider) =>
+    {
+        return new TestDotNetRuntimeSelector();
     };
 
     public Func<IServiceProvider, INuGetPackageCache> NuGetPackageCacheFactory { get; set; } = (IServiceProvider serviceProvider) =>

--- a/tests/Aspire.Cli.Tests/Utils/ProcessLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ProcessLauncherTests.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.DotNet;
+using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class ProcessLauncherTests
+{
+    [Fact]
+    public async Task LaunchDotNetAsync_CallsLaunchAsync_WithRuntimeSelectorPath()
+    {
+        var logger = NullLogger<ProcessLauncher>.Instance;
+        var runtimeSelector = new TestRuntimeSelector
+        {
+            DotNetExecutablePath = "/custom/path/dotnet",
+            EnvironmentVariables = new Dictionary<string, string>()
+        };
+
+        var launcher = new TestProcessLauncher(logger, runtimeSelector);
+
+        await launcher.LaunchDotNetAsync("--version", "/working/dir");
+
+        Assert.Equal("/custom/path/dotnet", launcher.LastExecutablePath);
+        Assert.Equal("--version", launcher.LastArguments);
+        Assert.Equal("/working/dir", launcher.LastWorkingDirectory);
+    }
+
+    [Fact]
+    public async Task LaunchDotNetAsync_AppliesRuntimeEnvironmentVariables()
+    {
+        var logger = NullLogger<ProcessLauncher>.Instance;
+        var runtimeSelector = new TestRuntimeSelector
+        {
+            DotNetExecutablePath = "dotnet",
+            EnvironmentVariables = new Dictionary<string, string>
+            {
+                ["DOTNET_ROOT"] = "/custom/dotnet",
+                ["DOTNET_HOST_PATH"] = "/custom/dotnet/dotnet"
+            }
+        };
+
+        var launcher = new TestProcessLauncher(logger, runtimeSelector);
+
+        await launcher.LaunchDotNetAsync("--version");
+
+        Assert.True(launcher.LastEnvironmentVariables.ContainsKey("DOTNET_ROOT"));
+        Assert.Equal("/custom/dotnet", launcher.LastEnvironmentVariables["DOTNET_ROOT"]);
+        Assert.True(launcher.LastEnvironmentVariables.ContainsKey("DOTNET_HOST_PATH"));
+        Assert.Equal("/custom/dotnet/dotnet", launcher.LastEnvironmentVariables["DOTNET_HOST_PATH"]);
+    }
+
+    private sealed class TestRuntimeSelector : IDotNetRuntimeSelector
+    {
+        public string DotNetExecutablePath { get; set; } = "dotnet";
+        public DotNetRuntimeMode Mode { get; set; } = DotNetRuntimeMode.System;
+        public IDictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
+
+        public Task<bool> InitializeAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(true);
+        }
+
+        public IDictionary<string, string> GetEnvironmentVariables()
+        {
+            return EnvironmentVariables;
+        }
+    }
+
+    private sealed class TestProcessLauncher : ProcessLauncher
+    {
+        public string? LastExecutablePath { get; private set; }
+        public string? LastArguments { get; private set; }
+        public string? LastWorkingDirectory { get; private set; }
+        public IDictionary<string, string> LastEnvironmentVariables { get; private set; } = new Dictionary<string, string>();
+
+        private readonly IDotNetRuntimeSelector _runtimeSelector;
+
+        public TestProcessLauncher(ILogger<ProcessLauncher> logger, IDotNetRuntimeSelector runtimeSelector) 
+            : base(logger, runtimeSelector)
+        {
+            _runtimeSelector = runtimeSelector;
+        }
+
+        public override async Task<int> LaunchAsync(
+            string executablePath,
+            string? arguments = null,
+            string? workingDirectory = null,
+            IDictionary<string, string>? environmentVariables = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastExecutablePath = executablePath;
+            LastArguments = arguments;
+            LastWorkingDirectory = workingDirectory;
+            
+            // Combine runtime env vars and additional ones just like the base class
+            var runtimeEnvVars = _runtimeSelector.GetEnvironmentVariables();
+            var combined = new Dictionary<string, string>(runtimeEnvVars);
+            
+            if (environmentVariables != null)
+            {
+                foreach (var kvp in environmentVariables)
+                {
+                    combined[kvp.Key] = kvp.Value;
+                }
+            }
+            
+            LastEnvironmentVariables = combined;
+            
+            return await Task.FromResult(0);
+        }
+    }
+}


### PR DESCRIPTION
## Fixed: SDK check fails after private SDK installation

### Problem
After installing the private .NET SDK, `aspire new` (and other commands) showed:
> The minimum .NET SDK version (9.0.302) is not installed.

The per-command SDK check was calling `dotnet --list-sdks` using the system PATH `dotnet` executable, which doesn't know about the private SDK installed under `~/.aspire/sdk/`.

### Fix
- Commands now route through `IDotNetRuntimeSelector` instead of `IDotNetSdkInstaller` directly
- `DotNetRuntimeSelector.InitializeAsync` is now idempotent
- `SdkInstallHelper` no longer double-checks with system dotnet after private SDK install
- All tests pass

### Progress Update
- Fixed the issue where SDK check fails after private SDK installation
- Commands now route through IDotNetRuntimeSelector instead of IDotNetSdkInstaller directly
- DotNetRuntimeSelector.InitializeAsync is now idempotent
- SdkInstallHelper no longer double-checks with system dotnet after private SDK install