### PR TITLE
Introduce `NatsClusterResource`

### DIFF
--- a/src/Aspire.Hosting.Nats/Cluster/NatsClusterBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/Cluster/NatsClusterBuilderExtensions.cs
@@ -91,6 +91,10 @@ public static class NatsClusterBuilderExtensions
             clusterName: builder.Resource.Name,
             routes: [.. builder.Resource.Members.Select(m => m.ClusterEndpoint)]
         );
+        if (member.Resource.TryGetAnnotationsOfType<NatsJetStreamAnnotation>(out _))
+        {
+            member.WithServerName();
+        }
 
         return builder
             .WithAnnotation(new NatsClusterMemberAnnotation(member.Resource))

--- a/src/Aspire.Hosting.Nats/Cluster/NatsClusterBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/Cluster/NatsClusterBuilderExtensions.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.NATS.Net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NATS.Client.Core;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides extension methods for adding NATS cluster resources to the application model.
+/// </summary>
+public static class NatsClusterBuilderExtensions
+{
+    /// <summary>
+    /// Adds a NATS cluster resource to the application model.
+    /// </summary>
+    [AspireExport]
+    public static IResourceBuilder<NatsClusterResource> AddNatsCluster(
+        this IDistributedApplicationBuilder builder,
+        [ResourceName] string name
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var natsCluster = new NatsClusterResource(name);
+
+        var connectionString = null as string;
+
+        var healthCheckKey = $"{name}_check";
+        builder.Services.AddHealthChecks()
+            .Add(new HealthCheckRegistration(
+                healthCheckKey,
+                sp => new NatsHealthCheck(new NatsConnection(new()
+                {
+                    Url = connectionString!,
+                })),
+                failureStatus: default,
+                tags: default,
+                timeout: default
+            ));
+
+        return builder.AddResource(natsCluster)
+            .WithHealthCheck(healthCheckKey)
+            .WithInitialState(new()
+            {
+                ResourceType = "NATS Cluster",
+                CreationTimeStamp = DateTime.UtcNow,
+                State = KnownResourceStates.Waiting,
+                Properties = [],
+            })
+            .OnInitializeResource(async (resource, @event, ct) =>
+            {
+                await @event.Notifications.PublishUpdateAsync(resource, s => s with
+                {
+                    State = KnownResourceStates.Starting,
+                }).ConfigureAwait(false);
+
+                connectionString = await resource.ConnectionStringExpression.GetValueAsync(ct).ConfigureAwait(false)
+                    ?? throw new DistributedApplicationException($"ConnectionStringAvailableEvent was published for the '{resource.Name}' resource but the connection string was null.");
+
+                await @event.Eventing.PublishAsync(new ConnectionStringAvailableEvent(resource, @event.Services), ct)
+                    .ConfigureAwait(false);
+
+                await @event.Notifications.PublishUpdateAsync(resource, s => s with
+                {
+                    State = KnownResourceStates.Running,
+                }).ConfigureAwait(false);
+            });
+    }
+
+    /// <summary>
+    /// Adds a NATS server resource as a member of NATS cluster.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="member"></param>
+    /// <returns></returns>
+    [AspireExport]
+    public static IResourceBuilder<NatsClusterResource> WithMember(
+        this IResourceBuilder<NatsClusterResource> builder,
+        IResourceBuilder<NatsServerResource> member
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(member);
+
+        member.WithCluster(
+            clusterName: builder.Resource.Name,
+            routes: [.. builder.Resource.Members.Select(m => m.ClusterEndpoint)]
+        );
+
+        return builder
+            .WithAnnotation(new NatsClusterMemberAnnotation(member.Resource))
+            .WaitFor(member)
+            .WithRelationship(member, "cluster member");
+    }
+}
+
+internal sealed record NatsClusterMemberAnnotation(
+    NatsServerResource Member
+) : IResourceAnnotation;

--- a/src/Aspire.Hosting.Nats/Cluster/NatsClusterBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/Cluster/NatsClusterBuilderExtensions.cs
@@ -89,7 +89,7 @@ public static class NatsClusterBuilderExtensions
 
         member.WithCluster(
             clusterName: builder.Resource.Name,
-            routes: [.. builder.Resource.Members.Select(m => m.ClusterEndpoint)]
+            otherRoutesLocator: () => [.. builder.Resource.Members.Except([member.Resource]).Select(m => m.ClusterEndpoint)]
         );
         if (member.Resource.TryGetAnnotationsOfType<NatsJetStreamAnnotation>(out _))
         {

--- a/src/Aspire.Hosting.Nats/Cluster/NatsClusterBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/Cluster/NatsClusterBuilderExtensions.cs
@@ -60,7 +60,7 @@ public static class NatsClusterBuilderExtensions
                 }).ConfigureAwait(false);
 
                 connectionString = await resource.ConnectionStringExpression.GetValueAsync(ct).ConfigureAwait(false)
-                    ?? throw new DistributedApplicationException($"ConnectionStringAvailableEvent was published for the '{resource.Name}' resource but the connection string was null.");
+                    ?? throw new DistributedApplicationException($"{nameof(ConnectionStringAvailableEvent)} was published for the '{resource.Name}' resource but the connection string was null.");
 
                 await @event.Eventing.PublishAsync(new ConnectionStringAvailableEvent(resource, @event.Services), ct)
                     .ConfigureAwait(false);

--- a/src/Aspire.Hosting.Nats/Cluster/NatsClusterBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/Cluster/NatsClusterBuilderExtensions.cs
@@ -89,7 +89,7 @@ public static class NatsClusterBuilderExtensions
 
         member.WithCluster(
             clusterName: builder.Resource.Name,
-            otherRoutesLocator: () => [.. builder.Resource.Members.Except([member.Resource]).Select(m => m.ClusterEndpoint)]
+            routesLocator: () => [.. builder.Resource.Members.Except([member.Resource]).Select(m => m.ClusterEndpoint)]
         );
         if (member.Resource.TryGetAnnotationsOfType<NatsJetStreamAnnotation>(out _))
         {

--- a/src/Aspire.Hosting.Nats/Cluster/NatsClusterResource.cs
+++ b/src/Aspire.Hosting.Nats/Cluster/NatsClusterResource.cs
@@ -4,7 +4,7 @@
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// A resource that represents a NATS server container.
+/// A resource that represents a NATS cluster.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 [AspireExport(ExposeProperties = true)]

--- a/src/Aspire.Hosting.Nats/Cluster/NatsClusterResource.cs
+++ b/src/Aspire.Hosting.Nats/Cluster/NatsClusterResource.cs
@@ -28,10 +28,9 @@ public class NatsClusterResource(string name) : Resource(name), IResourceWithCon
         for (var i = 0; i < membersList.Count; i++)
         {
             var member = membersList[i];
-            var memberEndpoint = member.ClusterEndpoint;
 
             // NOTE: See https://docs.nats.io/using-nats/developer/connecting#connecting-to-clusters
-            builder.Append($"{memberEndpoint}");
+            builder.Append($"{member.ConnectionStringExpression}");
 
             if (i < membersList.Count - 1)
             {

--- a/src/Aspire.Hosting.Nats/Cluster/NatsClusterResource.cs
+++ b/src/Aspire.Hosting.Nats/Cluster/NatsClusterResource.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// A resource that represents a NATS server container.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
+[AspireExport(ExposeProperties = true)]
+public class NatsClusterResource(string name) : Resource(name), IResourceWithConnectionString, IResourceWithWaitSupport
+{
+    /// <summary>
+    /// Gets the connection string expression for the NATS cluster.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => BuildConnectionString();
+
+    /// <summary>
+    /// Gets the <see cref="NatsServerResource"/> instances that have been set up as members of this NATS cluster.
+    /// </summary>
+    public IEnumerable<NatsServerResource> Members => Annotations.OfType<NatsClusterMemberAnnotation>().Select(a => a.Member);
+
+    internal ReferenceExpression BuildConnectionString()
+    {
+        var builder = new ReferenceExpressionBuilder();
+
+        var membersList = Members.ToList();
+        for (var i = 0; i < membersList.Count; i++)
+        {
+            var member = membersList[i];
+            var memberEndpoint = member.ClusterEndpoint;
+
+            // NOTE: See https://docs.nats.io/using-nats/developer/connecting#connecting-to-clusters
+            builder.Append($"{memberEndpoint}");
+
+            if (i < membersList.Count - 1)
+            {
+                builder.AppendLiteral(",");
+            }
+        }
+
+        return builder.Build();
+    }
+}

--- a/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
@@ -208,6 +208,7 @@ public static class NatsBuilderExtensions
     )
     {
         ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(routesLocator);
 
         builder = builder
             .WithEndpoint(

--- a/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
@@ -211,7 +211,7 @@ public static class NatsBuilderExtensions
                 port: clusterPort,
                 name: NatsServerResource.ClusterEndpointName
             )
-            .WithArgs("--cluster", $"nats://localhost:{NatsServerResource.ConventionalClusterPort}");
+            .WithArgs("--cluster", $"nats://0.0.0.0:{NatsServerResource.ConventionalClusterPort}");
 
         if (clusterName is not (null or ""))
         {
@@ -223,20 +223,10 @@ public static class NatsBuilderExtensions
             builder = builder.WithArgs(context =>
             {
                 var otherRoutes = otherRoutesLocator();
-
-                var routesValueBuilder = new ReferenceExpressionBuilder();
-                for (var i = 0; i < otherRoutes.Count; i++)
-                {
-                    var route = otherRoutes[i];
-                    routesValueBuilder.Append($"{NatsServerResource.PrimaryNatsSchemeName}://{route.Property(EndpointProperty.HostAndPort)}");
-                    if (i < otherRoutes.Count - 1)
-                    {
-                        routesValueBuilder.AppendLiteral(",");
-                    }
-                }
+                var routeUrls = otherRoutes.Select(r => $"{NatsServerResource.PrimaryNatsSchemeName}://{r.Resource.Name}:{r.TargetPort}");
 
                 context.Args.Add("--routes");
-                context.Args.Add(routesValueBuilder.Build());
+                context.Args.Add(string.Join(',', routeUrls));
             });
         }
 

--- a/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
@@ -200,7 +200,7 @@ public static class NatsBuilderExtensions
         this IResourceBuilder<NatsServerResource> builder,
         string? clusterName = null,
         int? clusterPort = null,
-        IReadOnlyList<EndpointReference>? routes = null
+        Func<IReadOnlyList<EndpointReference>>? otherRoutesLocator = null
     )
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -215,23 +215,29 @@ public static class NatsBuilderExtensions
 
         if (clusterName is not (null or ""))
         {
-            builder = builder.WithArgs("--cluster_name", clusterName); // NOTE: If unset, NATS will create one automatically.
+            builder = builder.WithArgs("--cluster_name", clusterName); // NOTE: If unset, NATS will create one automatically, but only when JetStream isn't enabled.
         }
 
-        if (routes is not (null or []))
+        if (otherRoutesLocator is not null)
         {
-            var routesValueBuilder = new ReferenceExpressionBuilder();
-            for (var i = 0; i < routes.Count; i++)
+            builder = builder.WithArgs(context =>
             {
-                var route = routes[i];
-                routesValueBuilder.Append($"{NatsServerResource.PrimaryNatsSchemeName}://{route.Property(EndpointProperty.HostAndPort)}");
-                if (i < routes.Count - 1)
-                {
-                    routesValueBuilder.AppendLiteral(",");
-                }
-            }
+                var otherRoutes = otherRoutesLocator();
 
-            builder = builder.WithArgs("--routes", routesValueBuilder.Build());
+                var routesValueBuilder = new ReferenceExpressionBuilder();
+                for (var i = 0; i < otherRoutes.Count; i++)
+                {
+                    var route = otherRoutes[i];
+                    routesValueBuilder.Append($"{NatsServerResource.PrimaryNatsSchemeName}://{route.Property(EndpointProperty.HostAndPort)}");
+                    if (i < otherRoutes.Count - 1)
+                    {
+                        routesValueBuilder.AppendLiteral(",");
+                    }
+                }
+
+                context.Args.Add("--routes");
+                context.Args.Add(routesValueBuilder.Build());
+            });
         }
 
         return builder;

--- a/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
@@ -152,7 +152,8 @@ public static class NatsBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        return builder.WithArgs("-js");
+        return builder.WithAnnotation(new NatsJetStreamAnnotation())
+            .WithArgs("-js");
     }
 
     /// <summary>
@@ -235,4 +236,25 @@ public static class NatsBuilderExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Adds a server name to a NATS server instance.
+    /// </summary>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="serverName">The server name to set. Defaults to the resource name if not provided.</param>
+    /// <remarks>s
+    /// This is useful when configuring a NATS cluster with JetStream enabled, where each member of the cluster must have a unique server name.
+    /// </remarks>
+    [AspireExport]
+    public static IResourceBuilder<NatsServerResource> WithServerName(
+        this IResourceBuilder<NatsServerResource> builder,
+        string? serverName = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithArgs("--server_name", serverName ?? builder.Resource.Name);
+    }
 }
+
+internal sealed record NatsJetStreamAnnotation : IResourceAnnotation;

--- a/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
@@ -195,12 +195,16 @@ public static class NatsBuilderExtensions
     /// <summary>
     /// Adds cluster configurations to a NATS container resource.
     /// </summary>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="routesLocator">A function that returns a list of endpoint references for other cluster members.</param>
+    /// <param name="clusterName">The name of the cluster. Required if JetStream has been enabled on this NATS resource.</param>
+    /// <param name="clusterPort">The port for the cluster. If not provided, the conventional NATS cluster port will be used: <c>4248</c>. This port isn't exposed on the host.</param>
     [AspireExport]
     public static IResourceBuilder<NatsServerResource> WithCluster(
         this IResourceBuilder<NatsServerResource> builder,
+        Func<IReadOnlyList<EndpointReference>> routesLocator,
         string? clusterName = null,
-        int? clusterPort = null,
-        Func<IReadOnlyList<EndpointReference>>? otherRoutesLocator = null
+        int? clusterPort = null
     )
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -211,24 +215,33 @@ public static class NatsBuilderExtensions
                 port: clusterPort,
                 name: NatsServerResource.ClusterEndpointName
             )
-            .WithArgs("--cluster", $"nats://0.0.0.0:{NatsServerResource.ConventionalClusterPort}");
-
-        if (clusterName is not (null or ""))
-        {
-            builder = builder.WithArgs("--cluster_name", clusterName); // NOTE: If unset, NATS will create one automatically, but only when JetStream isn't enabled.
-        }
-
-        if (otherRoutesLocator is not null)
-        {
-            builder = builder.WithArgs(context =>
+            .WithArgs(context =>
             {
-                var otherRoutes = otherRoutesLocator();
-                var routeUrls = otherRoutes.Select(r => $"{NatsServerResource.PrimaryNatsSchemeName}://{r.Resource.Name}:{r.TargetPort}");
+                var otherRoutes = routesLocator();
+                if (otherRoutes is [])
+                {
+                    return;
+                }
 
+                context.Args.Add("--cluster");
+                context.Args.Add($"nats://0.0.0.0:{NatsServerResource.ConventionalClusterPort}");
+
+                if (clusterName is not (null or ""))
+                {
+                    // NOTE: If unset, NATS will create one automatically, but only when JetStream isn't enabled.
+                    context.Args.Add("--cluster_name");
+                    context.Args.Add(clusterName);
+                }
+                else if (builder.Resource.Annotations.OfType<NatsJetStreamAnnotation>().Any())
+                {
+                    throw new ArgumentException($"The '{nameof(clusterName)}' parameter must be provided when enabling JetStream support.");
+                }
+
+                var routeUrls = otherRoutes.Select(r => $"{NatsServerResource.PrimaryNatsSchemeName}://{r.Resource.Name}:{r.TargetPort}");
                 context.Args.Add("--routes");
                 context.Args.Add(string.Join(',', routeUrls));
-            });
-        }
+            })
+            .WithArgs();
 
         return builder;
     }

--- a/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
@@ -190,4 +190,49 @@ public static class NatsBuilderExtensions
         return builder.WithBindMount(source, "/var/lib/nats", isReadOnly)
             .WithArgs("-sd", "/var/lib/nats");
     }
+
+    /// <summary>
+    /// Adds cluster configurations to a NATS container resource.
+    /// </summary>
+    [AspireExport]
+    public static IResourceBuilder<NatsServerResource> WithCluster(
+        this IResourceBuilder<NatsServerResource> builder,
+        string? clusterName = null,
+        int? clusterPort = null,
+        IReadOnlyList<EndpointReference>? routes = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder = builder
+            .WithEndpoint(
+                targetPort: NatsServerResource.ConventionalClusterPort,
+                port: clusterPort,
+                name: NatsServerResource.ClusterEndpointName
+            )
+            .WithArgs("--cluster", $"nats://localhost:{NatsServerResource.ConventionalClusterPort}");
+
+        if (clusterName is not (null or ""))
+        {
+            builder = builder.WithArgs("--cluster_name", clusterName); // NOTE: If unset, NATS will create one automatically.
+        }
+
+        if (routes is not (null or []))
+        {
+            var routesValueBuilder = new ReferenceExpressionBuilder();
+            for (var i = 0; i < routes.Count; i++)
+            {
+                var route = routes[i];
+                routesValueBuilder.Append($"{NatsServerResource.PrimaryNatsSchemeName}://{route.Property(EndpointProperty.HostAndPort)}");
+                if (i < routes.Count - 1)
+                {
+                    routesValueBuilder.AppendLiteral(",");
+                }
+            }
+
+            builder = builder.WithArgs("--routes", routesValueBuilder.Build());
+        }
+
+        return builder;
+    }
 }

--- a/src/Aspire.Hosting.Nats/NatsServerResource.cs
+++ b/src/Aspire.Hosting.Nats/NatsServerResource.cs
@@ -11,10 +11,13 @@ namespace Aspire.Hosting.ApplicationModel;
 public class NatsServerResource(string name) : ContainerResource(name), IResourceWithConnectionString
 {
     internal const string PrimaryEndpointName = "tcp";
+    internal const string ClusterEndpointName = "cluster";
     internal const string PrimaryNatsSchemeName = "nats";
+    internal const int ConventionalClusterPort = 4248;
     private const string DefaultUserName = "nats";
 
     private EndpointReference? _primaryEndpoint;
+    private EndpointReference? _clusterEndpoint;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NatsServerResource"/> class.
@@ -32,6 +35,11 @@ public class NatsServerResource(string name) : ContainerResource(name), IResourc
     /// Gets the primary endpoint for the NATS server.
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
+
+    /// <summary>
+    /// Gets the cluster endpoint for the NATS server.
+    /// </summary>
+    public EndpointReference ClusterEndpoint => _clusterEndpoint ??= new(this, ClusterEndpointName);
 
     /// <summary>
     /// Gets the host endpoint reference for this resource.

--- a/tests/Aspire.Hosting.Nats.Tests/AddNatsTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/AddNatsTests.cs
@@ -307,4 +307,51 @@ public class AddNatsTests(ITestOutputHelper testOutputHelper)
             """;
         Assert.Equal(expectedManifest, manifest.ToString());
     }
+
+    [Fact]
+    public async Task WithServerNameWithNameOmittedAddsResourceNameAsServerName()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(testOutputHelper)
+            .AddNats("nats")
+            .WithServerName();
+
+        var singleNodeArgs = await ArgumentEvaluator.GetArgumentListAsync(builder.Resource);
+        Assert.Contains("--server_name", singleNodeArgs);
+        Assert.Contains("nats", singleNodeArgs);
+    }
+
+    [Fact]
+    public async Task WithServerNameWithNameSpecifiedAddsCustomNameAsServerName()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(testOutputHelper)
+            .AddNats("nats")
+            .WithServerName("custom_name");
+
+        var singleNodeArgs = await ArgumentEvaluator.GetArgumentListAsync(builder.Resource);
+        Assert.Contains("--server_name", singleNodeArgs);
+        Assert.Contains("custom_name", singleNodeArgs);
+    }
+
+    // [Fact]
+    // public async Task WithClusterAddsCorrectAnnotation()
+    // {
+    //     IResourceBuilder<NatsServerResource> builder = null!;
+
+    //     var action = () => builder.WithCluster(() => []);
+
+    //     var exception = Assert.Throws<ArgumentNullException>(action);
+    //     Assert.Equal(nameof(builder), exception.ParamName);
+    // }
+
+    // [Fact]
+    // public async Task WithClusterShouldThrowWhenRoutesLocatorIsNull()
+    // {
+    //     var builder = TestDistributedApplicationBuilder.Create(testOutputHelper)
+    //         .AddNats("nats");
+
+    //     var action = () => builder.WithCluster(null!);
+
+    //     var exception = Assert.Throws<ArgumentNullException>(action);
+    //     Assert.Equal(nameof(builder), exception.ParamName);
+    // }
 }

--- a/tests/Aspire.Hosting.Nats.Tests/Cluster/AddNatsClusterTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/Cluster/AddNatsClusterTests.cs
@@ -44,14 +44,31 @@ public class AddNatsClusterTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task WithMemberConfiguresServerWithClusterArg()
+    public async Task WithMemberMoreThanOnceConfiguresServersWithClusterArg()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
-        var natsNode = builder.AddNats("nats-1");
+        var natsNode1 = builder.AddNats("nats-1");
+        var natsNode2 = builder.AddNats("nats-2");
         builder.AddNatsCluster("rs0")
-            .WithMember(natsNode);
+            .WithMember(natsNode1)
+            .WithMember(natsNode2);
 
-        var args = await ArgumentEvaluator.GetArgumentListAsync(natsNode.Resource);
-        Assert.Contains("--cluster", args);
+        var natsNode1Args = await ArgumentEvaluator.GetArgumentListAsync(natsNode1.Resource);
+        Assert.Contains("--cluster", natsNode1Args);
+
+        var natsNode2Args = await ArgumentEvaluator.GetArgumentListAsync(natsNode2.Resource);
+        Assert.Contains("--cluster", natsNode2Args);
+    }
+
+    [Fact]
+    public async Task WithMemberOnlyOnceDoesNotAddClusterArgs()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var singleNode = builder.AddNats("nats-1");
+        builder.AddNatsCluster("rs0")
+            .WithMember(singleNode);
+
+        var singleNodeArgs = await ArgumentEvaluator.GetArgumentListAsync(singleNode.Resource);
+        Assert.DoesNotContain("--cluster", singleNodeArgs);
     }
 }

--- a/tests/Aspire.Hosting.Nats.Tests/Cluster/AddNatsClusterTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/Cluster/AddNatsClusterTests.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Nats.Tests;
+
+public class AddNatsClusterTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void AddNatsClusterAddsResourceToModel()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        builder.AddNatsCluster("nats-cluster");
+
+        using var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var resource = Assert.Single(appModel.Resources.OfType<NatsClusterResource>());
+        Assert.Equal("nats-cluster", resource.Name);
+    }
+
+    [Fact]
+    public void AddNatsClusterAddsHealthCheckAnnotationToResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var cluster = builder.AddNatsCluster("cluster");
+        Assert.Single(cluster.Resource.Annotations, a => a is HealthCheckAnnotation hca);
+    }
+
+    [Fact]
+    public void WithMemberAddsWaitAnnotationForMember()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var natsNode = builder.AddNats("nats-1");
+        var cluster = builder.AddNatsCluster("cluster")
+            .WithMember(natsNode);
+
+        Assert.Single(cluster.Resource.Annotations.OfType<WaitAnnotation>(),
+            a => a.Resource == natsNode.Resource);
+    }
+
+    [Fact]
+    public async Task WithMemberConfiguresServerWithClusterArg()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var natsNode = builder.AddNats("nats-1");
+        builder.AddNatsCluster("rs0")
+            .WithMember(natsNode);
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(natsNode.Resource);
+        Assert.Contains("--cluster", args);
+    }
+}

--- a/tests/Aspire.Hosting.Nats.Tests/Cluster/NatsClusterFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/Cluster/NatsClusterFunctionalTests.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREPERSISTENCE001 // Resource lifetime APIs are experimental.
+
+using Aspire.TestUtilities;
+using Aspire.Hosting.Utils;
+using NATS.Client.Core;
+using Polly;
+
+namespace Aspire.Hosting.Nats.Tests;
+
+public class NatsClusterFunctionalTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    [RequiresFeature(TestFeature.Docker)]
+    public async Task VerifyNatsClusterResource()
+    {
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new() { MaxRetryAttempts = 10, Delay = TimeSpan.FromSeconds(1) })
+            .Build();
+
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+
+        var node = builder.AddNats("nats-1");
+        var cluster = builder.AddNatsCluster("cluster").WithMember(node);
+
+        using var app = builder.Build();
+        await app.StartAsync(cts.Token);
+
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(cluster.Resource.Name, cts.Token);
+
+        var connectionString = await cluster.Resource.ConnectionStringExpression.GetValueAsync(cts.Token);
+
+        await pipeline.ExecuteAsync(async token =>
+        {
+            var client = new NatsConnection(new()
+            {
+                Url = connectionString!,
+            });
+            await client.ConnectAsync();
+        }, cts.Token);
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    [RequiresFeature(TestFeature.Docker)]
+    public async Task VerifyMultiNodeNatsClusterResource()
+    {
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new() { MaxRetryAttempts = 10, Delay = TimeSpan.FromSeconds(1) })
+            .Build();
+
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+
+        var node1 = builder.AddNats("nats-1");
+        var node2 = builder.AddNats("nats-2");
+        var node3 = builder.AddNats("nats-3");
+        var cluster = builder.AddNatsCluster("cluster")
+            .WithMember(node1)
+            .WithMember(node2)
+            .WithMember(node3);
+
+        using var app = builder.Build();
+        await app.StartAsync(cts.Token);
+
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(cluster.Resource.Name, cts.Token);
+
+        var connectionString = await cluster.Resource.ConnectionStringExpression.GetValueAsync(cts.Token);
+
+        await pipeline.ExecuteAsync(async token =>
+        {
+            var client = new NatsConnection(new()
+            {
+                Url = connectionString!,
+            });
+            await client.ConnectAsync();
+        }, cts.Token);
+
+        await app.StopAsync();
+    }
+}

--- a/tests/Aspire.Hosting.Nats.Tests/Cluster/NatsClusterFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/Cluster/NatsClusterFunctionalTests.cs
@@ -84,13 +84,13 @@ public class NatsClusterFunctionalTests(ITestOutputHelper testOutputHelper)
             await node2Connection.ConnectAsync();
 
             var subscribedSignal = new TaskCompletionSource();
-            var sub = Task.Run(async () =>
+            var subscriptionTask = Task.Run(async () =>
             {
-                var sub = await node2Connection.SubscribeCoreAsync<string>("test.subject", cancellationToken: cts.Token);
+                var subscription = await node2Connection.SubscribeCoreAsync<string>("test.subject", cancellationToken: cts.Token);
                 await node2Connection.PingAsync(cts.Token); // NOTE: See https://docs.nats.io/using-nats/developer/sending/caches
                 subscribedSignal.SetResult();
 
-                await foreach (var msg in sub.Msgs.ReadAllAsync(cts.Token))
+                await foreach (var msg in subscription.Msgs.ReadAllAsync(cts.Token))
                 {
                     break;
                 }
@@ -99,7 +99,7 @@ public class NatsClusterFunctionalTests(ITestOutputHelper testOutputHelper)
             await subscribedSignal.Task;
             await node1Connection.PublishAsync("test.subject", "hello from node 1", cancellationToken: cts.Token);
 
-            await sub;
+            await subscriptionTask;
         }, cts.Token);
 
         await app.StopAsync();

--- a/tests/Aspire.Hosting.Nats.Tests/Cluster/NatsClusterFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/Cluster/NatsClusterFunctionalTests.cs
@@ -71,13 +71,9 @@ public class NatsClusterFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var connectionString = await cluster.Resource.ConnectionStringExpression.GetValueAsync(cts.Token);
 
+        // NOTE: This the most reliable way to verify that the cluster is functional. We publish a message through one node and subscribe on a different node, proving the message crosses the cluster boundary
         await pipeline.ExecuteAsync(async token =>
         {
-            var client = new NatsConnection(new()
-            {
-                Url = connectionString!,
-            });
-
             var node1ConnectionString = await node1.Resource.ConnectionStringExpression.GetValueAsync(cts.Token);
             var node2ConnectionString = await node2.Resource.ConnectionStringExpression.GetValueAsync(cts.Token);
 
@@ -87,14 +83,20 @@ public class NatsClusterFunctionalTests(ITestOutputHelper testOutputHelper)
             await node1Connection.ConnectAsync();
             await node2Connection.ConnectAsync();
 
+            var subscribedSignal = new TaskCompletionSource();
             var sub = Task.Run(async () =>
             {
-                await foreach (var msg in node2Connection.SubscribeAsync<string>("test.subject", cancellationToken: cts.Token))
+                var sub = await node2Connection.SubscribeCoreAsync<string>("test.subject", cancellationToken: cts.Token);
+                await node2Connection.PingAsync(cts.Token); // NOTE: See https://docs.nats.io/using-nats/developer/sending/caches
+                subscribedSignal.SetResult();
+
+                await foreach (var msg in sub.Msgs.ReadAllAsync(cts.Token))
                 {
                     break;
                 }
             }, cts.Token);
 
+            await subscribedSignal.Task;
             await node1Connection.PublishAsync("test.subject", "hello from node 1", cancellationToken: cts.Token);
 
             await sub;

--- a/tests/Aspire.Hosting.Nats.Tests/Cluster/NatsClusterFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/Cluster/NatsClusterFunctionalTests.cs
@@ -23,7 +23,7 @@ public class NatsClusterFunctionalTests(ITestOutputHelper testOutputHelper)
 
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
 
-        var node = builder.AddNats("nats-1");
+        var node = builder.AddNats("nats-1").WithJetStream(); // NOTE: JetStream is needed in order to verify the cluster's mechanisms in the assert phase of the tests.
         var cluster = builder.AddNatsCluster("cluster").WithMember(node);
 
         using var app = builder.Build();
@@ -56,9 +56,9 @@ public class NatsClusterFunctionalTests(ITestOutputHelper testOutputHelper)
 
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
 
-        var node1 = builder.AddNats("nats-1");
-        var node2 = builder.AddNats("nats-2");
-        var node3 = builder.AddNats("nats-3");
+        var node1 = builder.AddNats("nats-1").WithJetStream(); // NOTE: JetStream is needed in order to verify the cluster's mechanisms in the assert phase of the tests.
+        var node2 = builder.AddNats("nats-2").WithJetStream();
+        var node3 = builder.AddNats("nats-3").WithJetStream();
         var cluster = builder.AddNatsCluster("cluster")
             .WithMember(node1)
             .WithMember(node2)
@@ -77,7 +77,27 @@ public class NatsClusterFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 Url = connectionString!,
             });
-            await client.ConnectAsync();
+
+            var node1ConnectionString = await node1.Resource.ConnectionStringExpression.GetValueAsync(cts.Token);
+            var node2ConnectionString = await node2.Resource.ConnectionStringExpression.GetValueAsync(cts.Token);
+
+            await using var node1Connection = new NatsConnection(new() { Url = node1ConnectionString! });
+            await using var node2Connection = new NatsConnection(new() { Url = node2ConnectionString! });
+
+            await node1Connection.ConnectAsync();
+            await node2Connection.ConnectAsync();
+
+            var sub = Task.Run(async () =>
+            {
+                await foreach (var msg in node2Connection.SubscribeAsync<string>("test.subject", cancellationToken: cts.Token))
+                {
+                    break;
+                }
+            }, cts.Token);
+
+            await node1Connection.PublishAsync("test.subject", "hello from node 1", cancellationToken: cts.Token);
+
+            await sub;
         }, cts.Token);
 
         await app.StopAsync();

--- a/tests/Aspire.Hosting.Nats.Tests/Cluster/NatsClusterPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/Cluster/NatsClusterPublicApiTests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Nats.Tests;
+
+public class NatsClusterPublicApiTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void WithMemberThrowsWhenBuilderIsNull()
+    {
+        using var appBuilder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var member = appBuilder.AddNats("mongo1");
+
+        IResourceBuilder<NatsClusterResource> builder = null!;
+        var action = () => builder.WithMember(member);
+
+        Assert.Throws<ArgumentNullException>(action);
+    }
+
+    [Fact]
+    public void WithMemberThrowsWhenMemberIsNull()
+    {
+        using var appBuilder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var cluster = appBuilder.AddNatsCluster("mongo1");
+
+        var action = () => cluster.WithMember(null!);
+
+        Assert.Throws<ArgumentNullException>(action);
+    }
+}

--- a/tests/Aspire.Hosting.Nats.Tests/NatsPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/NatsPublicApiTests.cs
@@ -182,4 +182,38 @@ public class NatsPublicApiTests(ITestOutputHelper testOutputHelper)
             : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(name), exception.ParamName);
     }
+
+    [Fact]
+    public void WithClusterShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<NatsServerResource> builder = null!;
+
+        var action = () => builder.WithCluster(() => []);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithClusterShouldThrowWhenRoutesLocatorIsNull()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(testOutputHelper)
+            .AddNats("nats");
+
+        var action = () => builder.WithCluster(null!);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal("routesLocator", exception.ParamName);
+    }
+
+    [Fact]
+    public void WithServerNameShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<NatsServerResource> builder = null!;
+
+        var action = () => builder.WithServerName();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
 }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Nats/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Nats/Go/apphost.go
@@ -62,6 +62,22 @@ func main() {
 	_ = nats.UserNameReference()
 	_ = nats.ConnectionStringExpression()
 
+	cluster := builder.AddNatsCluster("nats-cluster")
+	if err = cluster.Err(); err != nil {
+		log.Fatalf(aspire.FormatError(err))
+	}
+
+	clusterMember1 := builder.AddNats("cluster-member-1").WithJetStream()
+	clusterMember2 := builder.AddNats("cluster-member-2").WithJetStream()
+	clusterMember3 := builder.AddNats("cluster-member-3").WithJetStream()
+
+	cluster.WithMember(clusterMember1).WithMember(clusterMember2).WithMember(clusterMember3)
+	if err = cluster.Err(); err != nil {
+		log.Fatalf(aspire.FormatError(err))
+	}
+
+	_ = cluster.ConnectionStringExpression()
+
 	app, err := builder.Build()
 	if err != nil {
 		log.Fatalf(aspire.FormatError(err))

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Nats/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Nats/Java/AppHost.java
@@ -34,5 +34,19 @@ void main() throws Exception {
         var _uri = nats.uriExpression();
         var _userName = nats.userNameReference();
         var _cstr = nats.connectionStringExpression();
+        
+        var clusterMember1 = builder.addNats("cluster-member-1")
+            .withJetStream();
+        var clusterMember2 = builder.addNats("cluster-member-2")
+            .withJetStream();
+        var clusterMember3 = builder.addNats("cluster-member-3")
+            .withJetStream();
+
+        var cluster =  builder.addNatsCluster("nats-cluster")
+            .withMember(clusterMember1)
+            .withMember(clusterMember2)
+            .withMember(clusterMember3);
+
+        var _clusterCstr = cluster.connectionStringExpression();
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Nats/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Nats/Python/apphost.py
@@ -32,4 +32,10 @@ with create_builder() as builder:
     _uri = nats.uri_expression
     _user_name = nats.user_name_reference
     _cstr = nats.connection_string_expression
+    cluster_member_1 = builder.add_nats("cluster-member-1").with_jet_stream()
+    cluster_member_2 = builder.add_nats("cluster-member-2").with_jet_stream()
+    cluster_member_3 = builder.add_nats("cluster-member-3").with_jet_stream()
+    cluster = builder.add_nats_cluster("nats-cluster")
+    cluster.with_member(cluster_member_1).with_member(cluster_member_2).with_member(cluster_member_3)
+    _cluster_cstr = cluster.connection_string_expression
     builder.run()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Nats/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Nats/TypeScript/apphost.mts
@@ -47,4 +47,19 @@ const _uri = await nats.uriExpression();
 const _userName = await nats.userNameReference();
 
 const _cstr = await nats.connectionStringExpression();
+
+const clusterMember1 = await builder.addNats("cluster-member-1")
+    .withJetStream();
+const clusterMember2 = await builder.addNats("cluster-member-2")
+    .withJetStream();
+const clusterMember3 = await builder.addNats("cluster-member-3")
+    .withJetStream();
+
+const cluster = await builder.addNatsCluster("nats-cluster")
+    .withMember(clusterMember1)
+    .withMember(clusterMember2)
+    .withMember(clusterMember3);
+
+const _clusterCstr = await cluster.connectionStringExpression();
+
 await builder.build().run();


### PR DESCRIPTION
## Description

Introduces a new meta resource type `NatsClusterResource` that can be used to establish a full-mesh NATS cluster; a la `MongoDBReplicaSet` in #18196

Fixes #7563

A few things worth noting:
- Follows a similar design & set of conventions as #18196
- Unlike MongoDB, NATS doesn't allow a cluster to consist of a single node. So, in order to establish consistent semantics with #18196, single-node `NatsClusterResource`s are specially-handled. (Added a functional test for this scenario too, of course).
- Added a robust functional test for the multi-node scenario that proves the individual nodes have indeed formed a cluster. It works by connecting to two distinct nodes, subscribing to a subject on one node, and then publishing a matching message on the other node, if the subscription receives said message through the connection to the first node, that demonstrates that inter-node communication indeed works properly.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
