### PR TITLE
Trigger polyglot validation on integration ATS baseline changes

### DIFF
--- a/docs/ci/test-trigger-map.md
+++ b/docs/ci/test-trigger-map.md
@@ -174,7 +174,10 @@ Highlights:
 - **non-.NET job loose triggers** — only the paths the project graph cannot
   attribute, such as `tests/PolyglotAppHosts/**`, checked-in `*.ats.txt` /
   `*.tscompat.suppression.txt` baselines, `tools/TypeScriptApiCompat/**`, and
-  `extension/**`.
+  `extension/**`. A `src/Aspire.Hosting*/api/*.ats.txt` baseline fans out to
+  **both** `job:typescript-api-compat` (baseline diff) and `job:polyglot`,
+  because the polyglot playground regenerates and compiles that exported surface
+  in every language.
 - **linked source with no owning project directory** — `src/Aspire/Cli/**`
   carries explicit targets because it is linked into another project but is not
   itself a project directory.

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -175,12 +175,21 @@ path_rules:
     targets: [job:typescript-sdk]
     reason: vitest over generated TS SDK; ts-starter is a narrow sub-path of Aspire.Cli, not the whole project
   - paths:
-      - src/Aspire.Hosting*/api/*.ats.txt
       - src/**/*.tscompat.suppression.txt
       - tools/TypeScriptApiCompat/**
       - .github/workflows/typescript-api-compat.yml
     targets: [job:typescript-api-compat]
-    reason: checked-in *.ats.txt/suppression baselines are not compiled items (Layer 1 blind); Hosting/Cli production projects are in affected_project_rules
+    reason: checked-in suppression baselines are not compiled items (Layer 1 blind); Hosting/Cli production projects are in affected_project_rules
+  # A checked-in *.ats.txt baseline changes EXACTLY when an integration's [AspireExport] surface
+  # changes -- the same surface the per-language polyglot playground scripts regenerate and compile
+  # (aspire restore --apphost over tests/PolyglotAppHosts/<integration>/<lang>). So an exported-surface
+  # change must run BOTH typescript-api-compat (baseline diff) AND polyglot (regenerate+compile in every
+  # language), even when the author has not also touched the tests/PolyglotAppHosts fixtures. The baseline
+  # is not a compiled item, so Layer 1 is blind to it and these targets must be enumerated here.
+  - paths:
+      - src/Aspire.Hosting*/api/*.ats.txt
+    targets: [job:typescript-api-compat, job:polyglot]
+    reason: an integration's *.ats.txt baseline tracks its exported ATS surface; the polyglot playground regenerates+compiles that surface per language, so a baseline change must run polyglot too
   - paths: [extension/**]
     targets: [job:extension-unit]
     reason: extension_tests_win + extension_bootstrap_linux run yarn build/test in extension/

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -876,6 +876,63 @@ public sealed class SelectTestsAcceptanceTests : IDisposable
         Assert.False(r.SelectsAll);
     }
 
+    // An integration's checked-in *.ats.txt baseline tracks its exported [AspireExport] surface -- the
+    // same surface the per-language polyglot playground scripts regenerate and compile
+    // (aspire restore --apphost over tests/PolyglotAppHosts/<integration>/<lang>). A change to that
+    // baseline must therefore run BOTH typescript-api-compat (baseline diff) AND polyglot (regenerate +
+    // compile in every language), so a breaking surface change is caught even if the author did not also
+    // touch the tests/PolyglotAppHosts fixtures. The baseline is not a compiled item, so Layer 1 is blind
+    // to it: routing here is the only thing that fires polyglot. Run with --skip-layer1 semantics (no
+    // Layer 1 affected set) to prove the curated layer alone carries both targets.
+    [Fact]
+    public void RealMapIntegrationAtsBaselineChangeRunsTypeScriptApiCompatAndPolyglot()
+    {
+        var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+
+        var atsBaseline = FirstIntegrationAtsBaselineWithPolyglotFixture();
+
+        var r = selector.Select([atsBaseline], [], new SelectorOptions());
+
+        Assert.False(r.SelectsAll);
+        Assert.Contains("job:typescript-api-compat", r.Jobs);
+        Assert.Contains("job:polyglot", r.Jobs);
+    }
+
+    // A real src/Aspire.Hosting*/api/<name>.ats.txt baseline for a genuine INTEGRATION (not the
+    // codegen engine itself) whose integration also has a tests/PolyglotAppHosts/<name> fixture, so the
+    // change exercises the polyglot playground for that integration's exported surface. Computed from the
+    // filesystem (never hardcoded names) so it survives integrations being added or removed. The engine
+    // projects below are excluded because they reach polyglot through affected_project_rules (their
+    // project NAME), not through the *.ats.txt path rule under test here -- so picking one would not prove
+    // the path rule fires polyglot.
+    private static string FirstIntegrationAtsBaselineWithPolyglotFixture()
+    {
+        var srcDir = Path.Combine(RepoRoot.Path, "src");
+        var polyglotRoot = Path.Combine(RepoRoot.Path, "tests", "PolyglotAppHosts");
+
+        static bool IsEngineProject(string name) =>
+            name is "Aspire.Hosting" or "Aspire.Hosting.RemoteHost"
+            || name.StartsWith("Aspire.Hosting.CodeGeneration.", StringComparison.Ordinal);
+
+        foreach (var projectDir in Directory.EnumerateDirectories(srcDir, "Aspire.Hosting*").Order(StringComparer.Ordinal))
+        {
+            var name = Path.GetFileName(projectDir);
+            if (IsEngineProject(name))
+            {
+                continue;
+            }
+
+            var baseline = Path.Combine(projectDir, "api", $"{name}.ats.txt");
+            if (File.Exists(baseline) && Directory.Exists(Path.Combine(polyglotRoot, name)))
+            {
+                return $"src/{name}/api/{name}.ats.txt";
+            }
+        }
+
+        throw new InvalidOperationException("No integration src/Aspire.Hosting*/api/<name>.ats.txt with a matching tests/PolyglotAppHosts/<name> fixture was found.");
+    }
+
     private static (string Dir, string Test) FirstComponentWithSameNamedTest(IReadOnlyCollection<string> matrix)
     {
         var componentsRoot = Path.Combine(RepoRoot.Path, "src", "Components");


### PR DESCRIPTION
## Description

The selective-CI test trigger map routed checked-in `src/Aspire.Hosting*/api/*.ats.txt` baselines only to `job:typescript-api-compat`. But an integration's `*.ats.txt` baseline tracks the exact same `[AspireExport]` surface that the polyglot playground regenerates and compiles in every language (`aspire restore --apphost` over `tests/PolyglotAppHosts/<integration>/<lang>`). So when an author changed an integration's exported surface without also touching the `tests/PolyglotAppHosts` fixtures, polyglot validation was skipped even though the generated SDK shape for that integration had changed.

These baselines are checked-in reference files, not compiled MSBuild items, so Layer 1 (the project-graph closure) is blind to them. That means the routing has to be enumerated explicitly in the Layer 2 map.

### Approach

- Split the `*.ats.txt` glob out of the combined `typescript-api-compat` rule into its own path rule targeting **both** `job:typescript-api-compat` and `job:polyglot`, with a comment explaining why an exported-surface change must run both jobs.
- The remaining `*.tscompat.suppression.txt` / `tools/TypeScriptApiCompat/**` / workflow paths stay on `job:typescript-api-compat` only.
- Updated `docs/ci/test-trigger-map.md` to document the fan-out.
- Added a regression test (`RealMapIntegrationAtsBaselineChangeRunsTypeScriptApiCompatAndPolyglot`) that runs against the real map and confirms a genuine integration baseline selects both jobs. The test helper is filesystem-computed and skips the codegen engine projects (which reach polyglot via `affected_project_rules` by project name rather than via this path rule), so it proves the `*.ats.txt` path rule itself fires polyglot.

This was validated empirically by running the `SelectTests` tool against the real map both before and after the change. All 124 `TestTriggerMap` tests pass.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No