### PR TITLE
Remove npm README workflow badges

### DIFF
--- a/eng/scripts/pack-cli-npm-package.pointer.README.md
+++ b/eng/scripts/pack-cli-npm-package.pointer.README.md
@@ -1,8 +1,5 @@
 # __PACKAGE_NAME__
 
-[![CI](https://github.com/microsoft/aspire/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/microsoft/aspire/actions/workflows/ci.yml)
-[![Tests](https://github.com/microsoft/aspire/actions/workflows/tests.yml/badge.svg?branch=main&event=push)](https://github.com/microsoft/aspire/actions/workflows/tests.yml)
-
 The Aspire CLI, published for npm-based installs.
 
 ## What is Aspire?


### PR DESCRIPTION
## Description

Removes the repo-level CI and Tests badges from the generated `@microsoft/aspire-cli` npm package README. The package README now starts with the package name and npm-specific description instead of showing GitHub Actions status badges for the source repository.

Validation:
- Ran `eng/scripts/pack-cli-npm-package.ps1` with a temporary native binary and inspected the generated `@microsoft/aspire-cli` README from the npm tarball.
- Ran `git diff --check`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
