### PR TITLE
[ignore][experiment] settle-window validation — do not merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,21 +67,17 @@ jobs:
           "EXTENSION_VERSION_OVERRIDE=$EXTENSION_VERSION" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
 
   tests:
-    uses: ./.github/workflows/tests.yml
     name: Tests
+    runs-on: ubuntu-latest
     needs: [prepare_for_ci]
-    # issues:write + pull-requests:write are used only by tests.yml's isolated comment_selection job
-    # (which runs no PR code) to post the "selected tests" issue comment; every job that runs PR code
-    # stays at contents:read. Reusable-workflow tokens are capped by the caller, so this is where the
-    # elevated scope must be granted.
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
     if: ${{ github.repository_owner == 'microsoft' && needs.prepare_for_ci.outputs.skip_workflow != 'true' }}
-    with:
-      versionOverrideArg: ${{ needs.prepare_for_ci.outputs.VERSION_SUFFIX_OVERRIDE }}
-      extensionVersionOverride: ${{ needs.prepare_for_ci.outputs.EXTENSION_VERSION_OVERRIDE }}
+    steps:
+      # [ignore][experiment] settle-window validation — intentional fast failure to produce a red
+      # CI signal in ~1 min instead of the full multi-OS test matrix. This branch is throwaway.
+      - name: Intentional red for settle-window validation
+        run: |
+          echo "[ignore][experiment] settle-window validation — intentional failure"
+          exit 1
 
   # Stabilization gate.
   #
@@ -105,81 +101,14 @@ jobs:
   # build shape already.
   stabilization_check:
     name: Stabilization Check
-    runs-on: 8-core-ubuntu-latest
+    runs-on: ubuntu-latest
     needs: [prepare_for_ci]
     if: ${{ github.repository_owner == 'microsoft' && needs.prepare_for_ci.outputs.skip_workflow != 'true' }}
     steps:
-      # The actual stabilization work only makes sense for pull_request events. On push
-      # (including push to release branches with StabilizePackageVersion=true) the build is
-      # already running in the shape this job is meant to validate, so there's nothing to
-      # add. We still let the job *run* on push so the GitHub Actions result is 'success'
-      # rather than 'skipped' — otherwise the `results:` job's `contains(needs.*.result,
-      # 'skipped')` check would fail every push to main / release/**.
-      - name: Skip on push events
-        if: ${{ github.event_name != 'pull_request' }}
-        run: echo "Stabilization Check only runs on pull_request events. Skipping (job remains success)."
-
-      - name: Checkout code
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Build + pack with StabilizePackageVersion=true
-        if: ${{ github.event_name == 'pull_request' }}
-        # SkipNativeBuild=true keeps this job fast (~5min): pack-time NU5104 detection
-        # doesn't need NativeAOT CLI binaries, and the moderate smoke below invokes the
-        # CLI via `dotnet run --project src/Aspire.Cli/Aspire.Cli.csproj`.
-        run: |
-          ./build.sh -restore -build -ci -pack \
-            -p:StabilizePackageVersion=true \
-            -p:SkipTestProjects=false \
-            -p:SkipPlaygroundProjects=true \
-            -p:SkipNativeBuild=true \
-            -p:InstallBrowsersForPlaywright=false
-
-      - name: Run version-sensitive Aspire.Cli.Tests classes under stabilization
-        if: ${{ github.event_name == 'pull_request' }}
-        # Classes that touch IsPrerelease / channel detection / template version pinning /
-        # update-notification logic. These are the code paths most likely to behave
-        # differently when the CLI's own assembly version label is stable.
-        # NOTE: we intentionally do NOT pass --no-build / --no-restore here. SDK 10's
-        # `dotnet test` driver needs to perform its own MSBuild evaluation pass to detect
-        # the Microsoft.Testing.Platform runner (which Aspire.Cli.Tests uses), and without
-        # restore that evaluation reports "All projects must use that test runner ... using
-        # VSTest test runner" and exits non-zero. The previous pack step's restore is keyed
-        # by a different global-property fingerprint and can't be reused. The cost of
-        # letting `dotnet test` re-restore here is small because nothing on disk actually
-        # changes — it's just an in-memory evaluation pass.
-        run: |
-          ./dotnet.sh test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj \
-            --no-launch-profile \
-            -p:StabilizePackageVersion=true \
-            -- \
-            --filter-class "*.AssemblyMetadataChannelTests" \
-            --filter-class "*.IdentityChannelReaderTests" \
-            --filter-class "*.PackageChannelTests" \
-            --filter-class "*.PrebuiltAppHostServerChannelResolutionTests" \
-            --filter-class "*.DotNetBasedAppHostServerChannelResolutionTests" \
-            --filter-class "*.NewCommandChannelResolutionTests" \
-            --filter-class "*.ChannelReseedTests" \
-            --filter-class "*.VersionHelperTests" \
-            --filter-class "*.CliUpdateNotificationServiceTests" \
-            --filter-class "*.UpdateCommandTests" \
-            --filter-class "*.DotNetTemplateFactoryTests" \
-            --filter-not-trait "quarantined=true" \
-            --filter-not-trait "outerloop=true"
-
-      - name: aspire init + restore smoke against stable local feed
-        if: ${{ github.event_name == 'pull_request' }}
-        run: ./eng/scripts/stabilization-smoke-init-restore.sh
-
-      # Always upload logs, even if the build fails, to enable debugging
-      - name: Upload logs
-        if: ${{ always() && github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: stabilization_check_logs
-          path: artifacts/log
-          retention-days: 5
+      # [ignore][experiment] settle-window validation — the real stabilization build (~5 min) is
+      # neutralized to a no-op so the CI suite settles fast. This branch is throwaway.
+      - name: No-op for settle-window validation
+        run: echo "stabilization check skipped for [ignore][experiment] validation"
 
   # This job is used for branch protection. It fails if any of the dependent jobs failed
   results:


### PR DESCRIPTION
Throwaway PR to validate AspireAiMonitor's CI-settle-window drive gating
against real PR CI. Not for review or merge — will be closed once the
validation run is captured.

CI is intentionally reduced to a single fast `exit 1` (the heavy test
matrix and stabilization build are stubbed out in this branch) so the
suite goes red in ~1 minute.
