### PR TITLE
[ignore][experiment] shepherd fixable-CI validation — do not merge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
         uses: ./.github/actions/select-tests
         with:
           checkout: 'false'
-          enforce: 'false'
+          enforce: 'true'
           commentFile: ${{ env.SELECT_TESTS_COMMENT_FILE }}
           # Kill switch: the 'run-full-ci' PR label forces the full matrix + all jobs. Read from the event
           # payload snapshot, so adding the label takes effect on the next push (or reopen), not on a

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -80,6 +80,9 @@ ignore:
   - eng/scripts/debug-*.ps1                             # debug-aspire-channel/stable/staging: local channel-switch helpers
   - eng/scripts/debug-*.sh
   - eng/scripts/validate-cli-symbols.ps1                # AzDO native-AOT symbol publish validation; no GH-CI consumer
+  # [ignore][experiment] throwaway validation: enforce-mode selection routes a tests.yml edit to ALL,
+  # so ignore it here for this branch so flipping `enforce` doesn't itself force the full matrix.
+  - .github/workflows/tests.yml
   # Schedule-only workflows that regenerate API/ATS surface baselines; no PR-CI path.
   - .github/workflows/generate-api-diffs.yml
   - .github/workflows/generate-ats-diffs.yml
@@ -143,7 +146,6 @@ path_rules:
       - eng/scripts/scan-test-partitions-from-source.ps1   # source partition discovery in the runsheet builder; a bug skews every split project's enumeration -> err toward ALL
       - eng/TestEnumerationRunsheetBuilder/**
       - eng/testing/CITestsProperties.props
-      - .github/workflows/tests.yml
       - .github/workflows/run-tests.yml
       - .github/workflows/specialized-test-runner.yml
       - .github/workflows/build-packages.yml
@@ -203,7 +205,6 @@ path_rules:
       - tests/Aspire.Cli.EndToEnd.Tests/**
       - tests/Aspire.Hosting.Tests/Cli/**
       - eng/scripts/get-aspire-cli*
-      - .github/workflows/tests.yml
       - .github/workflows/extension-e2e-tests.yml
       - .github/workflows/build-packages.yml
       - .github/workflows/build-cli-native-archives.yml

--- a/tests/Aspire.Managed.Tests/NuGet/RestoreCommandTests.cs
+++ b/tests/Aspire.Managed.Tests/NuGet/RestoreCommandTests.cs
@@ -117,5 +117,5 @@ public class RestoreCommandTests : IDisposable
     /// Converts a file path to its JSON-escaped representation (e.g. backslashes doubled).
     /// </summary>
     private static string JsonEncodedPath(string path) =>
-        path.Replace("/", "//");
+        path.Replace("\\", "\\\\");
 }

--- a/tests/Aspire.Managed.Tests/NuGet/RestoreCommandTests.cs
+++ b/tests/Aspire.Managed.Tests/NuGet/RestoreCommandTests.cs
@@ -117,5 +117,5 @@ public class RestoreCommandTests : IDisposable
     /// Converts a file path to its JSON-escaped representation (e.g. backslashes doubled).
     /// </summary>
     private static string JsonEncodedPath(string path) =>
-        path.Replace(@"\", @"\\");
+        path.Replace("/", "//");
 }


### PR DESCRIPTION
Throwaway PR to validate AspireAiMonitor driving a fixable CI failure to
green. Not for review or merge — will be closed once captured.

To keep CI fast, the test selector is flipped to enforce mode and tests.yml
is neutralized in the trigger map (so the enforce flip doesn't itself force
the full matrix). Net selection: only Aspire.Managed.Tests (which carries a
seeded one-line bug in a JSON-escaping test helper) + Infrastructure.Tests
(validates the map/tests.yml edits). All heavy jobs are skipped.

Expected: Aspire.Managed.Tests red, everything else green.
