### PR TITLE
[ignore][experiment] shepherd NATS validation — do not merge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -247,7 +247,7 @@ jobs:
 
   build_packages:
     name: Build packages
-    if: false  # [ignore][experiment] disabled for fast validation CI
+    if: false  # [ignore][experiment] disabled foo
     uses: ./.github/workflows/build-packages.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
         uses: ./.github/actions/select-tests
         with:
           checkout: 'false'
-          enforce: 'false'
+          enforce: 'true'
           commentFile: ${{ env.SELECT_TESTS_COMMENT_FILE }}
           # Kill switch: the 'run-full-ci' PR label forces the full matrix + all jobs. Read from the event
           # payload snapshot, so adding the label takes effect on the next push (or reopen), not on a
@@ -246,12 +246,14 @@ jobs:
 
   build_packages:
     name: Build packages
+    if: false  # [ignore][experiment] disabled for fast validation CI
     uses: ./.github/workflows/build-packages.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
 
   build_cli_archive_linux:
     name: Build native CLI archive (Linux)
+    if: false  # [ignore][experiment] disabled for fast validation CI
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -259,6 +261,7 @@ jobs:
 
   build_cli_archive_linux_arm64:
     name: Build native CLI archive (Linux ARM64)
+    if: false  # [ignore][experiment] disabled for fast validation CI
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -270,6 +273,7 @@ jobs:
   # without waiting for the slower Windows/macOS builds.
   build_cli_archive_windows:
     name: Build native CLI archive (Windows)
+    if: false  # [ignore][experiment] disabled for fast validation CI
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -277,6 +281,7 @@ jobs:
 
   build_cli_archive_windows_arm64:
     name: Build native CLI archive (Windows ARM64)
+    if: false  # [ignore][experiment] disabled for fast validation CI
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -284,6 +289,7 @@ jobs:
 
   build_cli_archive_macos:
     name: Build native CLI archive (macOS)
+    if: false  # [ignore][experiment] disabled for fast validation CI
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -291,6 +297,7 @@ jobs:
 
   build_cli_archive_macos_x64:
     name: Build native CLI archive (macOS x64)
+    if: false  # [ignore][experiment] disabled for fast validation CI
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -359,6 +366,7 @@ jobs:
           ./result/bin/aspire --version
 
   build_cli_e2e_image:
+    if: false  # [ignore][experiment] disabled for fast validation CI
     name: Build CLI E2E Docker image
     uses: ./.github/workflows/build-cli-e2e-image.yml
     needs: setup_for_tests
@@ -843,7 +851,6 @@ jobs:
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
                  (needs.typescript_api_compat.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_api_compat == 'true')) ||
-                 needs.build_cli_archive_macos_x64.result == 'skipped' ||
                  (needs.prepare_winget_installer_artifacts.result == 'skipped' && (needs.setup_for_tests.outputs.run_winget_installer == 'true')) ||
                  (needs.prepare_homebrew_installer_artifacts.result == 'skipped' && (needs.setup_for_tests.outputs.run_homebrew_installer == 'true')) ||
                  (needs.nix_package.result == 'skipped' && (needs.setup_for_tests.outputs.run_nix_package == 'true')) ||
@@ -864,7 +871,6 @@ jobs:
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
-                 needs.build_cli_archive_macos_x64.result == 'skipped' ||
                  (needs.prepare_winget_installer_artifacts.result == 'skipped' && (needs.setup_for_tests.outputs.run_winget_installer == 'true')) ||
                  (needs.prepare_homebrew_installer_artifacts.result == 'skipped' && (needs.setup_for_tests.outputs.run_homebrew_installer == 'true')) ||
                  (needs.nix_package.result == 'skipped' && (needs.setup_for_tests.outputs.run_nix_package == 'true')) ||

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -366,7 +366,6 @@ jobs:
           ./result/bin/aspire --version
 
   build_cli_e2e_image:
-    if: false  # [ignore][experiment] disabled for fast validation CI
     name: Build CLI E2E Docker image
     uses: ./.github/workflows/build-cli-e2e-image.yml
     needs: setup_for_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,15 +58,16 @@ jobs:
 
       # Compute the selected test subset + non-.NET job booleans. The action reuses this job's checkout
       # (checkout=false) so the BeforeBuildProps.props it may write survives for enumerate-tests below,
-      # and does its own minimal SDK bootstrap (setupDotNet=true). enforce: 'false' keeps this audit-only
-      # (the knob is documented on the action's `enforce` input). No job-level actions/setup-dotnet on
+      # and does its own minimal SDK bootstrap (setupDotNet=true). enforce: 'true' makes the selector gate
+      # the matrix (instead of audit-only run-all); the knob is documented on the action's `enforce` input.
+      # No job-level actions/setup-dotnet on
       # purpose -- global.json declares tools.runtimes, so Arcade always uses repo-local .dotnet.
       - name: Select relevant tests
         id: select_tests
         uses: ./.github/actions/select-tests
         with:
           checkout: 'false'
-          enforce: 'true'
+          enforce: 'true'  # [ignore][experiment] flipped from 'false' for fast validation CI
           commentFile: ${{ env.SELECT_TESTS_COMMENT_FILE }}
           # Kill switch: the 'run-full-ci' PR label forces the full matrix + all jobs. Read from the event
           # payload snapshot, so adding the label takes effect on the next push (or reopen), not on a

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -247,14 +247,14 @@ jobs:
 
   build_packages:
     name: Build packages
-    if: false  # [ignore][experiment] disabled foo
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'experiment-fast-ci') }}  # [ignore][experiment] skipped only when the 'experiment-fast-ci' label is present (default: runs, merge-safe)
     uses: ./.github/workflows/build-packages.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
 
   build_cli_archive_linux:
     name: Build native CLI archive (Linux)
-    if: false  # [ignore][experiment] disabled for fast validation CI
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'experiment-fast-ci') }}  # [ignore][experiment] skipped only when the 'experiment-fast-ci' label is present (default: runs, merge-safe)
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -262,7 +262,7 @@ jobs:
 
   build_cli_archive_linux_arm64:
     name: Build native CLI archive (Linux ARM64)
-    if: false  # [ignore][experiment] disabled for fast validation CI
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'experiment-fast-ci') }}  # [ignore][experiment] skipped only when the 'experiment-fast-ci' label is present (default: runs, merge-safe)
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -274,7 +274,7 @@ jobs:
   # without waiting for the slower Windows/macOS builds.
   build_cli_archive_windows:
     name: Build native CLI archive (Windows)
-    if: false  # [ignore][experiment] disabled for fast validation CI
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'experiment-fast-ci') }}  # [ignore][experiment] skipped only when the 'experiment-fast-ci' label is present (default: runs, merge-safe)
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -282,7 +282,7 @@ jobs:
 
   build_cli_archive_windows_arm64:
     name: Build native CLI archive (Windows ARM64)
-    if: false  # [ignore][experiment] disabled for fast validation CI
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'experiment-fast-ci') }}  # [ignore][experiment] skipped only when the 'experiment-fast-ci' label is present (default: runs, merge-safe)
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -290,7 +290,7 @@ jobs:
 
   build_cli_archive_macos:
     name: Build native CLI archive (macOS)
-    if: false  # [ignore][experiment] disabled for fast validation CI
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'experiment-fast-ci') }}  # [ignore][experiment] skipped only when the 'experiment-fast-ci' label is present (default: runs, merge-safe)
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -298,7 +298,7 @@ jobs:
 
   build_cli_archive_macos_x64:
     name: Build native CLI archive (macOS x64)
-    if: false  # [ignore][experiment] disabled for fast validation CI
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'experiment-fast-ci') }}  # [ignore][experiment] skipped only when the 'experiment-fast-ci' label is present (default: runs, merge-safe)
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -839,6 +839,14 @@ jobs:
         #   were removed below. Restore them when re-enabling the job.
         # - polyglot_validation: this job runs for pull requests and main branch builds; it is
         #   expected to be skipped for other workflow events.
+        # - build_packages and the build_cli_archive_* jobs ([ignore][experiment]): these package and
+        #   native CLI archive jobs are gated on the ABSENCE of the 'experiment-fast-ci' PR label, so by
+        #   default (no label, and on non-PR events) they still run and a real failure is caught via the
+        #   contains(needs.*.result, 'failure') check above. When that label is present they are
+        #   intentionally skipped for fast validation CI; the build_cli_archive_macos_x64 skip-as-failure
+        #   check below is therefore suppressed under the same label (its only required-archive guard).
+        #   Remove this bullet, the job-level label gates, and the macos_x64 label guards when the
+        #   experiment ends.
         # All other jobs in this gate are required, and a 'skipped' result is treated as a failure.
         if: >-
           ${{ always() &&
@@ -851,6 +859,8 @@ jobs:
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
                  (needs.typescript_api_compat.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_api_compat == 'true')) ||
+                 (needs.build_cli_archive_macos_x64.result == 'skipped' &&
+                  !contains(github.event.pull_request.labels.*.name, 'experiment-fast-ci')) ||
                  (needs.prepare_winget_installer_artifacts.result == 'skipped' && (needs.setup_for_tests.outputs.run_winget_installer == 'true')) ||
                  (needs.prepare_homebrew_installer_artifacts.result == 'skipped' && (needs.setup_for_tests.outputs.run_homebrew_installer == 'true')) ||
                  (needs.nix_package.result == 'skipped' && (needs.setup_for_tests.outputs.run_nix_package == 'true')) ||
@@ -871,6 +881,8 @@ jobs:
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
+                 (needs.build_cli_archive_macos_x64.result == 'skipped' &&
+                  !contains(github.event.pull_request.labels.*.name, 'experiment-fast-ci')) ||
                  (needs.prepare_winget_installer_artifacts.result == 'skipped' && (needs.setup_for_tests.outputs.run_winget_installer == 'true')) ||
                  (needs.prepare_homebrew_installer_artifacts.result == 'skipped' && (needs.setup_for_tests.outputs.run_homebrew_installer == 'true')) ||
                  (needs.nix_package.result == 'skipped' && (needs.setup_for_tests.outputs.run_nix_package == 'true')) ||

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -80,8 +80,6 @@ ignore:
   - eng/scripts/debug-*.ps1                             # debug-aspire-channel/stable/staging: local channel-switch helpers
   - eng/scripts/debug-*.sh
   - eng/scripts/validate-cli-symbols.ps1                # AzDO native-AOT symbol publish validation; no GH-CI consumer
-  # [ignore][experiment] throwaway: ignore tests.yml so the enforce flip doesn't force the full matrix.
-  - .github/workflows/tests.yml
   # Schedule-only workflows that regenerate API/ATS surface baselines; no PR-CI path.
   - .github/workflows/generate-api-diffs.yml
   - .github/workflows/generate-ats-diffs.yml

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -80,6 +80,8 @@ ignore:
   - eng/scripts/debug-*.ps1                             # debug-aspire-channel/stable/staging: local channel-switch helpers
   - eng/scripts/debug-*.sh
   - eng/scripts/validate-cli-symbols.ps1                # AzDO native-AOT symbol publish validation; no GH-CI consumer
+  # [ignore][experiment] throwaway: ignore tests.yml so the enforce flip doesn't force the full matrix.
+  - .github/workflows/tests.yml
   # Schedule-only workflows that regenerate API/ATS surface baselines; no PR-CI path.
   - .github/workflows/generate-api-diffs.yml
   - .github/workflows/generate-ats-diffs.yml
@@ -143,7 +145,6 @@ path_rules:
       - eng/scripts/scan-test-partitions-from-source.ps1   # source partition discovery in the runsheet builder; a bug skews every split project's enumeration -> err toward ALL
       - eng/TestEnumerationRunsheetBuilder/**
       - eng/testing/CITestsProperties.props
-      - .github/workflows/tests.yml
       - .github/workflows/run-tests.yml
       - .github/workflows/specialized-test-runner.yml
       - .github/workflows/build-packages.yml
@@ -203,7 +204,6 @@ path_rules:
       - tests/Aspire.Cli.EndToEnd.Tests/**
       - tests/Aspire.Hosting.Tests/Cli/**
       - eng/scripts/get-aspire-cli*
-      - .github/workflows/tests.yml
       - .github/workflows/extension-e2e-tests.yml
       - .github/workflows/build-packages.yml
       - .github/workflows/build-cli-native-archives.yml

--- a/tests/Aspire.NATS.Net.Tests/ConfigurationTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/ConfigurationTests.cs
@@ -13,7 +13,7 @@ public class ConfigurationTests
 
     [Fact]
     public void HealthCheckIsEnabledByDefault()
-        => Assert.True(new NatsClientSettings().DisableHealthChecks);
+        => Assert.False(new NatsClientSettings().DisableHealthChecks);
 
     [Fact]
     public void TracingIsEnabledByDefault()

--- a/tests/Aspire.NATS.Net.Tests/ConfigurationTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/ConfigurationTests.cs
@@ -13,7 +13,7 @@ public class ConfigurationTests
 
     [Fact]
     public void HealthCheckIsEnabledByDefault()
-        => Assert.False(new NatsClientSettings().DisableHealthChecks);
+        => Assert.True(new NatsClientSettings().DisableHealthChecks);
 
     [Fact]
     public void TracingIsEnabledByDefault()


### PR DESCRIPTION
Throwaway PR to validate AspireAiMonitor driving a fixable CI failure to a
ready-for-merge state. Not for review or merge — will be closed once captured.

Fast CI: the test selector is in enforce mode, native CLI-archive/package
build jobs are disabled, and tests.yml is ignored in the trigger map. Net
selection: only Aspire.NATS.Net.Tests (seeded bug: ConfigurationTests
asserts the wrong default) + Infrastructure.Tests (validates the edits).

Expected: Aspire.NATS.Net.Tests red, everything else green; no native builds.
