### PR TITLE
Fix flaky WaitForLegacyDetachedStartupStabilityAsync_RetriesV2ProbeUntilChildExits test

### DIFF
--- a/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
@@ -19,6 +19,7 @@ using Aspire.Hosting;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -303,22 +304,28 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
     public async Task WaitForLegacyDetachedStartupStabilityAsync_RetriesV2ProbeUntilChildExits()
     {
         var probeCount = 0;
-        using var childProcess = Process.Start(CreateQuickFailProcessStartInfo()) ?? throw new InvalidOperationException("Failed to start test child process.");
+        var childExitTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var connection = new TestAppHostAuxiliaryBackchannel
         {
             SupportsV2 = true,
             GetResourceSnapshotsHandler = _ =>
             {
                 probeCount++;
+                // Signal child exit after the first probe so the method observes the exit
+                // during the retry delay, making the test deterministic.
+                childExitTcs.TrySetResult();
                 throw new IOException("model unavailable");
             }
         };
 
+        // Use FakeTimeProvider so the test never waits for real time and is fully deterministic.
+        var timeProvider = new FakeTimeProvider();
+
         var stable = await AppHostLauncher.WaitForLegacyDetachedStartupStabilityAsync(
             connection,
-            childProcess.WaitForExitAsync(),
+            childExitTcs.Task,
             TimeSpan.FromSeconds(120),
-            TimeProvider.System,
+            timeProvider,
             CancellationToken.None);
 
         Assert.False(stable);
@@ -641,22 +648,6 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
         return new ConfigurationBuilder()
             .AddInMemoryCollection(values.Select(value => new KeyValuePair<string, string?>(value.Key, value.Value)))
             .Build();
-    }
-
-    private static ProcessStartInfo CreateQuickFailProcessStartInfo()
-    {
-        var (fileName, arguments) = OperatingSystem.IsWindows()
-            ? ("cmd.exe", "/c ping -n 2 127.0.0.1 >NUL & exit /b 6")
-            : ("/bin/sh", "-c \"sleep 0.1; exit 6\"");
-
-        return new ProcessStartInfo(fileName)
-        {
-            Arguments = arguments,
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true
-        };
     }
 
     private sealed class AppHostLauncherHarness : IDisposable


### PR DESCRIPTION
## Description

Fixes flaky CI test `WaitForLegacyDetachedStartupStabilityAsync_RetriesV2ProbeUntilChildExits`.

The test used a real child process (`ping -n 2 127.0.0.1` on Windows, ~1-2 seconds) racing against the 2-second `s_legacyDetachedStartupStabilityWindow` timeout. On loaded CI machines, the timeout could fire before the child process exited, causing `WaitForLegacyDetachedStartupStabilityAsync` to return `true` (stable) instead of the expected `false`.

The fix replaces the real child process with a `TaskCompletionSource` that signals completion deterministically on the first probe call. This ensures the child "exit" always happens after at least one probe attempt but well before the stability window, eliminating the timing race. The now-unused `CreateQuickFailProcessStartInfo` helper is also removed.

CI failure: https://github.com/microsoft/aspire/actions/runs/28066133637

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
