### PR TITLE
Make Playwright browser provisioning resilient to download timeouts

### DIFF
--- a/tests/Shared/Playwright/Playwright.targets
+++ b/tests/Shared/Playwright/Playwright.targets
@@ -22,9 +22,19 @@
     <ItemGroup>
       <_EnvVarsForPlaywrightInstall Include="PLAYWRIGHT_BROWSERS_PATH=$(PlaywrightDependenciesDirectory)" />
       <_EnvVarsForPlaywrightInstall Condition="'$(ContinuousIntegrationBuild)' == 'true'" Include="PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true" />
+      <!-- Increase the download timeout from the default 30s to 120s to avoid transient CI failures -->
+      <_EnvVarsForPlaywrightInstall Condition="'$(ContinuousIntegrationBuild)' == 'true'" Include="PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=120000" />
     </ItemGroup>
 
+    <!-- First attempt uses IgnoreExitCode; if it fails, retry once and fail the build on the second failure -->
     <Exec Command="dotnet exec --runtimeconfig $(MSBuildThisFileDirectory)Microsoft.Playwright.runtimeconfig.json $(_MicrosoftPlaywrightDllPath) install @(BrowsersForPlaywrightToInstall, ' ')"
+          EnvironmentVariables="@(_EnvVarsForPlaywrightInstall)"
+          IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="_PlaywrightInstallExitCode1" />
+    </Exec>
+
+    <Exec Condition="'$(_PlaywrightInstallExitCode1)' != '0'"
+          Command="dotnet exec --runtimeconfig $(MSBuildThisFileDirectory)Microsoft.Playwright.runtimeconfig.json $(_MicrosoftPlaywrightDllPath) install @(BrowsersForPlaywrightToInstall, ' ')"
           EnvironmentVariables="@(_EnvVarsForPlaywrightInstall)" />
   </Target>
 </Project>

--- a/tests/Shared/Playwright/Playwright.targets
+++ b/tests/Shared/Playwright/Playwright.targets
@@ -26,15 +26,20 @@
       <_EnvVarsForPlaywrightInstall Condition="'$(ContinuousIntegrationBuild)' == 'true'" Include="PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=120000" />
     </ItemGroup>
 
-    <!-- First attempt uses IgnoreExitCode; if it fails, retry once and fail the build on the second failure -->
-    <Exec Command="dotnet exec --runtimeconfig $(MSBuildThisFileDirectory)Microsoft.Playwright.runtimeconfig.json $(_MicrosoftPlaywrightDllPath) install @(BrowsersForPlaywrightToInstall, ' ')"
+    <!-- Build the install command once so the initial attempt and retry cannot drift apart -->
+    <PropertyGroup>
+      <_PlaywrightInstallCommand>dotnet exec --runtimeconfig $(MSBuildThisFileDirectory)Microsoft.Playwright.runtimeconfig.json $(_MicrosoftPlaywrightDllPath) install @(BrowsersForPlaywrightToInstall, ' ')</_PlaywrightInstallCommand>
+    </PropertyGroup>
+
+    <!-- First attempt ignores the exit code; if it fails, retry once and fail the build on the second failure -->
+    <Exec Command="$(_PlaywrightInstallCommand)"
           EnvironmentVariables="@(_EnvVarsForPlaywrightInstall)"
           IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="_PlaywrightInstallExitCode1" />
     </Exec>
 
     <Exec Condition="'$(_PlaywrightInstallExitCode1)' != '0'"
-          Command="dotnet exec --runtimeconfig $(MSBuildThisFileDirectory)Microsoft.Playwright.runtimeconfig.json $(_MicrosoftPlaywrightDllPath) install @(BrowsersForPlaywrightToInstall, ' ')"
+          Command="$(_PlaywrightInstallCommand)"
           EnvironmentVariables="@(_EnvVarsForPlaywrightInstall)" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary

Fixes transient CI failures where Playwright browser downloads time out during build (e.g., [this run](https://github.com/microsoft/aspire/actions/runs/28069512727/job/83101928418)).

The FFMPEG download from the Playwright CDN mirror timed out after the default 30s, causing the entire `ProvisionBrowsersForPlaywright` target to fail with exit code -1.

## Changes

Two improvements to `tests/Shared/Playwright/Playwright.targets`:

1. **Increased download timeout**: Sets `PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=120000` (120s) in CI environments, up from the default 30s. This is an [officially documented Playwright env var](https://playwright.dev/docs/browsers#install-behind-a-firewall-or-a-proxy).

2. **Automatic retry**: If the first `playwright install` attempt fails (transient network issue), automatically retries once. Uses the standard MSBuild pattern of `IgnoreExitCode=true` + `ExitCode` output on the first attempt, with a conditional second attempt that will fail the build if it also fails.

## Testing

- Verified the targets file builds successfully (`dotnet build` with `InstallBrowsersForPlaywright=false`)
- Verified MSBuild preprocessed output shows correct target expansion with both env var and retry logic
