### PR TITLE
Refactor CLI telemetry: background tag calculation with export-time enrichment

### DIFF
--- a/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
@@ -51,7 +51,7 @@ internal sealed class AspireCliTelemetry : IHostedService
     private readonly TelemetryConfiguration _telemetryConfiguration;
     private readonly ILogger<AspireCliTelemetry> _logger;
     private readonly CliExecutionContext _executionContext;
-    private readonly List<KeyValuePair<string, object?>> _tagsList = [];
+    private readonly TelemetryTagsSource _tagsSource;
 
     private bool _isInitialized;
 
@@ -69,8 +69,9 @@ internal sealed class AspireCliTelemetry : IHostedService
     /// container injects the registered singleton, so identity telemetry tags are
     /// always emitted from it.
     /// </param>
-    public AspireCliTelemetry(ILogger<AspireCliTelemetry> logger, IMachineInformationProvider machineInformationProvider, ICIEnvironmentDetector ciEnvironmentDetector, ICodingAgentDetector codingAgentDetector, IInternalMicrosoftDetector internalMicrosoftDetector, TelemetryConfiguration telemetryConfiguration, CliExecutionContext executionContext)
-        : this(logger, machineInformationProvider, ciEnvironmentDetector, codingAgentDetector, internalMicrosoftDetector, telemetryConfiguration, ReportedActivitySourceName, DiagnosticsActivitySourceName, executionContext)
+    /// <param name="tagsSource">The shared source for background-calculated telemetry tags.</param>
+    public AspireCliTelemetry(ILogger<AspireCliTelemetry> logger, IMachineInformationProvider machineInformationProvider, ICIEnvironmentDetector ciEnvironmentDetector, ICodingAgentDetector codingAgentDetector, IInternalMicrosoftDetector internalMicrosoftDetector, TelemetryConfiguration telemetryConfiguration, CliExecutionContext executionContext, TelemetryTagsSource tagsSource)
+        : this(logger, machineInformationProvider, ciEnvironmentDetector, codingAgentDetector, internalMicrosoftDetector, telemetryConfiguration, ReportedActivitySourceName, DiagnosticsActivitySourceName, executionContext, tagsSource)
     {
     }
 
@@ -86,8 +87,9 @@ internal sealed class AspireCliTelemetry : IHostedService
     /// <param name="reportedSourceName">The name for the reported activity source.</param>
     /// <param name="diagnosticsSourceName">The name for the diagnostics activity source.</param>
     /// <param name="executionContext">The CLI execution context carrying the effective identity.</param>
-    internal AspireCliTelemetry(ILogger<AspireCliTelemetry> logger, IMachineInformationProvider machineInformationProvider, ICIEnvironmentDetector ciEnvironmentDetector, ICodingAgentDetector codingAgentDetector, IInternalMicrosoftDetector internalMicrosoftDetector, string reportedSourceName, string diagnosticsSourceName, CliExecutionContext executionContext)
-        : this(logger, machineInformationProvider, ciEnvironmentDetector, codingAgentDetector, internalMicrosoftDetector, new TelemetryConfiguration { ReportedTelemetryEnabled = true }, reportedSourceName, diagnosticsSourceName, executionContext)
+    /// <param name="tagsSource">The shared source for background-calculated telemetry tags.</param>
+    internal AspireCliTelemetry(ILogger<AspireCliTelemetry> logger, IMachineInformationProvider machineInformationProvider, ICIEnvironmentDetector ciEnvironmentDetector, ICodingAgentDetector codingAgentDetector, IInternalMicrosoftDetector internalMicrosoftDetector, string reportedSourceName, string diagnosticsSourceName, CliExecutionContext executionContext, TelemetryTagsSource tagsSource)
+        : this(logger, machineInformationProvider, ciEnvironmentDetector, codingAgentDetector, internalMicrosoftDetector, new TelemetryConfiguration { ReportedTelemetryEnabled = true }, reportedSourceName, diagnosticsSourceName, executionContext, tagsSource)
     {
     }
 
@@ -103,7 +105,8 @@ internal sealed class AspireCliTelemetry : IHostedService
     /// <param name="reportedSourceName">The name for the reported activity source.</param>
     /// <param name="diagnosticsSourceName">The name for the diagnostics activity source.</param>
     /// <param name="executionContext">The CLI execution context carrying the effective identity.</param>
-    internal AspireCliTelemetry(ILogger<AspireCliTelemetry> logger, IMachineInformationProvider machineInformationProvider, ICIEnvironmentDetector ciEnvironmentDetector, ICodingAgentDetector codingAgentDetector, IInternalMicrosoftDetector internalMicrosoftDetector, TelemetryConfiguration telemetryConfiguration, string reportedSourceName, string diagnosticsSourceName, CliExecutionContext executionContext)
+    /// <param name="tagsSource">The shared source for background-calculated telemetry tags.</param>
+    internal AspireCliTelemetry(ILogger<AspireCliTelemetry> logger, IMachineInformationProvider machineInformationProvider, ICIEnvironmentDetector ciEnvironmentDetector, ICodingAgentDetector codingAgentDetector, IInternalMicrosoftDetector internalMicrosoftDetector, TelemetryConfiguration telemetryConfiguration, string reportedSourceName, string diagnosticsSourceName, CliExecutionContext executionContext, TelemetryTagsSource tagsSource)
     {
         _logger = logger;
         _machineInformationProvider = machineInformationProvider;
@@ -112,6 +115,7 @@ internal sealed class AspireCliTelemetry : IHostedService
         _internalMicrosoftDetector = internalMicrosoftDetector;
         _telemetryConfiguration = telemetryConfiguration;
         _executionContext = executionContext;
+        _tagsSource = tagsSource;
         _reportedActivitySource = new ActivitySource(reportedSourceName);
         _diagnosticsActivitySource = new ActivitySource(diagnosticsSourceName);
     }
@@ -119,10 +123,9 @@ internal sealed class AspireCliTelemetry : IHostedService
     /// <summary>
     /// TESTING PURPOSES ONLY: Gets the default tags used for telemetry.
     /// </summary>
-    internal IReadOnlyList<KeyValuePair<string, object?>> GetDefaultTags()
+    internal async Task<IReadOnlyList<KeyValuePair<string, object?>>> GetDefaultTagsAsync()
     {
-        CheckInitialization();
-        return [.. _tagsList];
+        return await _tagsSource.TagsTask.ConfigureAwait(false);
     }
 
     /// <summary>
@@ -164,29 +167,19 @@ internal sealed class AspireCliTelemetry : IHostedService
         return StartActivityCore(_diagnosticsActivitySource, name, kind, parentContext);
     }
 
-    private Activity? StartActivityCore(ActivitySource source, string name, ActivityKind kind)
+    private static Activity? StartActivityCore(ActivitySource source, string name, ActivityKind kind)
     {
         return StartActivityCore(source, name, kind, parentContext: null);
     }
 
-    private Activity? StartActivityCore(ActivitySource source, string name, ActivityKind kind, ActivityContext? parentContext)
+    private static Activity? StartActivityCore(ActivitySource source, string name, ActivityKind kind, ActivityContext? parentContext)
     {
-        CheckInitialization();
-
         // Activities must have a name.
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         var activity = parentContext is { } context
             ? source.StartActivity(name, kind, context)
             : source.StartActivity(name, kind);
-
-        if (activity is not null)
-        {
-            foreach (var tag in _tagsList)
-            {
-                activity.AddTag(tag.Key, tag.Value);
-            }
-        }
 
         return activity;
     }
@@ -198,8 +191,6 @@ internal sealed class AspireCliTelemetry : IHostedService
     /// <param name="exception">The exception that occurred.</param>
     public void RecordError(string message, Exception exception)
     {
-        CheckInitialization();
-
         _logger.LogError(exception, message);
 
         var activity = FindReportedActivity(Activity.Current);
@@ -214,7 +205,7 @@ internal sealed class AspireCliTelemetry : IHostedService
                 [TelemetryConstants.Tags.ExceptionStackTrace] = exception.StackTrace
             };
 
-            foreach (var tag in _tagsList)
+            foreach (var tag in _tagsSource.GetResolvedTags())
             {
                 tags[tag.Key] = tag.Value;
             }
@@ -229,130 +220,119 @@ internal sealed class AspireCliTelemetry : IHostedService
     }
 
     /// <inheritdoc />
-    public async Task StartAsync(CancellationToken cancellationToken)
+    public Task StartAsync(CancellationToken cancellationToken)
     {
-        await InitializeAsync(cancellationToken).ConfigureAwait(false);
+        Initialize();
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     /// <summary>
-    /// Initializes the telemetry service by collecting machine information.
+    /// Starts background tag calculation. Returns immediately; the tags become available
+    /// asynchronously through <see cref="TelemetryTagsSource.TagsTask"/>.
     /// </summary>
-    internal async Task InitializeAsync(CancellationToken cancellationToken = default)
+    internal void Initialize()
     {
         if (_isInitialized)
         {
             return;
         }
 
-        try
+        _isInitialized = true;
+
+        _tagsSource.StartCalculation(async () =>
         {
-            var macAddressHashTask = _machineInformationProvider.GetMacAddressHash();
-            var deviceIdTask = _machineInformationProvider.GetOrCreateDeviceId();
-
-            Task<InternalMicrosoftDetectionResult>? internalMicrosoftTask = null;
-            if (_telemetryConfiguration.ReportedTelemetryEnabled)
+            try
             {
-                // The internal Microsoft check can be slow and can perform multiple async operations in parallel, so only run it if reported
-                // telemetry is enabled and make sure we flow the cancellation token so it can be canceled if the application is shutting down.
-                internalMicrosoftTask = _internalMicrosoftDetector.IsInternalMicrosoftMachineAsync(cancellationToken);
-            }
+                var tagsList = new List<KeyValuePair<string, object?>>();
 
-            await Task.WhenAll((Task)macAddressHashTask, deviceIdTask).WaitAsync(cancellationToken).ConfigureAwait(false);
+                var macAddressHashTask = _machineInformationProvider.GetMacAddressHash();
+                var deviceIdTask = _machineInformationProvider.GetOrCreateDeviceId();
 
-            InternalMicrosoftDetectionResult? internalMicrosoftResult = null;
-            if (internalMicrosoftTask is not null)
-            {
-                try
+                Task<InternalMicrosoftDetectionResult>? internalMicrosoftTask = null;
+                if (_telemetryConfiguration.ReportedTelemetryEnabled)
                 {
-                    internalMicrosoftResult = await internalMicrosoftTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    // The internal Microsoft check can be slow and can perform multiple async operations in parallel, so only run it if reported
+                    // telemetry is enabled. Use CancellationToken.None because background tag calculation should not be interrupted by app shutdown.
+                    internalMicrosoftTask = _internalMicrosoftDetector.IsInternalMicrosoftMachineAsync(CancellationToken.None);
                 }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+
+                await Task.WhenAll(new Task[] { macAddressHashTask, deviceIdTask }).ConfigureAwait(false);
+
+                InternalMicrosoftDetectionResult? internalMicrosoftResult = null;
+                if (internalMicrosoftTask is not null)
                 {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    if (_logger.IsEnabled(LogLevel.Debug))
+                    try
                     {
-                        _logger.LogDebug(ex, "Internal Microsoft detection failed.");
+                        internalMicrosoftResult = await internalMicrosoftTask.ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (_logger.IsEnabled(LogLevel.Debug))
+                        {
+                            _logger.LogDebug(ex, "Internal Microsoft detection failed.");
+                        }
                     }
                 }
-            }
 
-            _tagsList.Add(new(TelemetryConstants.Tags.MacAddressHash, macAddressHashTask.Result));
-            _tagsList.Add(new(TelemetryConstants.Tags.DeviceId, deviceIdTask.Result));
-            if (internalMicrosoftResult is { IsInternalMicrosoft: true })
-            {
-                _tagsList.Add(new(TelemetryConstants.Tags.InternalMicrosoft, internalMicrosoftResult.IsInternalMicrosoft));
-                if (!string.IsNullOrEmpty(internalMicrosoftResult.Source))
+                tagsList.Add(new(TelemetryConstants.Tags.MacAddressHash, macAddressHashTask.Result));
+                tagsList.Add(new(TelemetryConstants.Tags.DeviceId, deviceIdTask.Result));
+                if (internalMicrosoftResult is { IsInternalMicrosoft: true })
                 {
-                    _tagsList.Add(new(TelemetryConstants.Tags.InternalMicrosoftSource, internalMicrosoftResult.Source));
+                    tagsList.Add(new(TelemetryConstants.Tags.InternalMicrosoft, internalMicrosoftResult.IsInternalMicrosoft));
+                    if (!string.IsNullOrEmpty(internalMicrosoftResult.Source))
+                    {
+                        tagsList.Add(new(TelemetryConstants.Tags.InternalMicrosoftSource, internalMicrosoftResult.Source));
+                    }
+
+                    if (!string.IsNullOrEmpty(internalMicrosoftResult.Alias))
+                    {
+                        tagsList.Add(new(TelemetryConstants.Tags.InternalMicrosoftAlias, internalMicrosoftResult.Alias));
+                    }
+
+                    if (!string.IsNullOrEmpty(internalMicrosoftResult.Domain))
+                    {
+                        tagsList.Add(new(TelemetryConstants.Tags.InternalMicrosoftDomain, internalMicrosoftResult.Domain));
+                    }
                 }
 
-                if (!string.IsNullOrEmpty(internalMicrosoftResult.Alias))
+                // This is consistent with dashboard version data.
+                tagsList.Add(new(TelemetryConstants.Tags.CliVersion, GetCliVersion()));
+                tagsList.Add(new(TelemetryConstants.Tags.CliBuildId, GetCliBuildId()));
+
+                // Identity tags describe the build the CLI is *behaving* as (env / sidecar overrides),
+                // kept separate from the physical binary's cli.version/cli.build_id above so emulated
+                // runs are distinguishable in telemetry. See docs/specs/cli-identity-sidecar.md.
+                tagsList.Add(new(TelemetryConstants.Tags.IdentityVersion, _executionContext.IdentityVersion));
+                tagsList.Add(new(TelemetryConstants.Tags.IdentityChannel, _executionContext.IdentityChannel));
+                if (!string.IsNullOrEmpty(_executionContext.IdentityCommit))
                 {
-                    _tagsList.Add(new(TelemetryConstants.Tags.InternalMicrosoftAlias, internalMicrosoftResult.Alias));
+                    tagsList.Add(new(TelemetryConstants.Tags.IdentityCommit, _executionContext.IdentityCommit));
                 }
 
-                if (!string.IsNullOrEmpty(internalMicrosoftResult.Domain))
+                var codingAgent = _codingAgentDetector.GetCodingAgent();
+                if (codingAgent is not null)
                 {
-                    _tagsList.Add(new(TelemetryConstants.Tags.InternalMicrosoftDomain, internalMicrosoftResult.Domain));
+                    tagsList.Add(new(TelemetryConstants.Tags.CodingAgent, codingAgent));
                 }
+
+                tagsList.Add(new(TelemetryConstants.Tags.DeploymentEnvironmentName, _ciEnvironmentDetector.IsCIEnvironment() ? "ci" : "local"));
+
+                tagsList.Add(new(TelemetryConstants.Tags.OsName, GetOsName()));
+                tagsList.Add(new(TelemetryConstants.Tags.OsType, GetOsType()));
+                tagsList.Add(new(TelemetryConstants.Tags.OsVersion, Environment.OSVersion.Version.ToString()));
+
+                return (IReadOnlyList<KeyValuePair<string, object?>>)tagsList;
             }
-
-            // This is consistent with dashboard version data.
-            _tagsList.Add(new(TelemetryConstants.Tags.CliVersion, GetCliVersion()));
-            _tagsList.Add(new(TelemetryConstants.Tags.CliBuildId, GetCliBuildId()));
-
-            // Identity tags describe the build the CLI is *behaving* as (env / sidecar overrides),
-            // kept separate from the physical binary's cli.version/cli.build_id above so emulated
-            // runs are distinguishable in telemetry. See docs/specs/cli-identity-sidecar.md.
-            _tagsList.Add(new(TelemetryConstants.Tags.IdentityVersion, _executionContext.IdentityVersion));
-            _tagsList.Add(new(TelemetryConstants.Tags.IdentityChannel, _executionContext.IdentityChannel));
-            if (!string.IsNullOrEmpty(_executionContext.IdentityCommit))
+            catch (Exception ex)
             {
-                _tagsList.Add(new(TelemetryConstants.Tags.IdentityCommit, _executionContext.IdentityCommit));
+                // Don't throw an error if there is a telemetry issue.
+                _logger.LogError(ex, "Error occurred initializing telemetry service.");
+                return Array.Empty<KeyValuePair<string, object?>>();
             }
-
-            var codingAgent = _codingAgentDetector.GetCodingAgent();
-            if (codingAgent is not null)
-            {
-                _tagsList.Add(new(TelemetryConstants.Tags.CodingAgent, codingAgent));
-            }
-
-            _tagsList.Add(new(TelemetryConstants.Tags.DeploymentEnvironmentName, _ciEnvironmentDetector.IsCIEnvironment() ? "ci" : "local"));
-
-            _tagsList.Add(new(TelemetryConstants.Tags.OsName, GetOsName()));
-            _tagsList.Add(new(TelemetryConstants.Tags.OsType, GetOsType()));
-            _tagsList.Add(new(TelemetryConstants.Tags.OsVersion, Environment.OSVersion.Version.ToString()));
-        }
-        catch (OperationCanceledException)
-        {
-            // Initialization was canceled. This can happen if the application is shutting down before initialization completes.
-            // Log a warning but don't treat it as an error since it's expected during shutdown.
-            _logger.LogWarning("Telemetry initialization was canceled.");
-        }
-        catch (Exception ex)
-        {
-            // Don't throw an error if there is a telemetry issue.
-            _logger.LogError(ex, "Error occurred initializing telemetry service.");
-        }
-        finally
-        {
-            _isInitialized = true;
-        }
-    }
-
-    private void CheckInitialization()
-    {
-        if (!_isInitialized)
-        {
-            throw new InvalidOperationException(
-                $"Telemetry service has not been initialized. Use {nameof(InitializeAsync)}() before any other operations.");
-        }
+        });
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Telemetry/CliTagEnrichmentProcessor.cs
+++ b/src/Aspire.Cli/Telemetry/CliTagEnrichmentProcessor.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace Aspire.Cli.Telemetry;
+
+/// <summary>
+/// Processor that applies background-calculated telemetry tags to activities before export.
+/// Tags are sourced from <see cref="TelemetryTagsSource"/> which computes machine/identity
+/// information asynchronously at startup. Event-level enrichment is handled separately in
+/// <see cref="AspireCliTelemetry.RecordError"/> at event creation time.
+/// </summary>
+internal sealed class CliTagEnrichmentProcessor : BaseProcessor<Activity>
+{
+    private readonly TelemetryTagsSource _tagsSource;
+
+    public CliTagEnrichmentProcessor(TelemetryTagsSource tagsSource)
+    {
+        _tagsSource = tagsSource;
+    }
+
+    public override void OnEnd(Activity activity)
+    {
+        var tags = _tagsSource.GetResolvedTags();
+
+        // Add tags to the activity itself.
+        foreach (var tag in tags)
+        {
+            activity.SetTag(tag.Key, tag.Value);
+        }
+    }
+}

--- a/src/Aspire.Cli/Telemetry/TelemetryManager.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryManager.cs
@@ -55,7 +55,8 @@ internal sealed class TelemetryManager : IDisposable
     /// Initializes a new instance of the <see cref="TelemetryManager"/> class.
     /// </summary>
     /// <param name="telemetryConfiguration">The telemetry configuration.</param>
-    public TelemetryManager(TelemetryConfiguration telemetryConfiguration)
+    /// <param name="tagsSource">The shared source for background-calculated telemetry tags.</param>
+    public TelemetryManager(TelemetryConfiguration telemetryConfiguration, TelemetryTagsSource tagsSource)
     {
 #if DEBUG
         // Preserve the DEBUG-only diagnostic OTLP path for non-profiling diagnostics. When
@@ -102,6 +103,10 @@ internal sealed class TelemetryManager : IDisposable
             }
 #endif
 
+            // Tags are applied at export time by the enrichment processor, which reads from
+            // TelemetryTagsSource. This avoids blocking activity start on background tag calculation.
+            azureMonitorBuilder.AddProcessor(new CliTagEnrichmentProcessor(tagsSource));
+
             _azureMonitorProvider = azureMonitorBuilder.Build();
         }
 
@@ -110,6 +115,7 @@ internal sealed class TelemetryManager : IDisposable
             _profilingProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ProfilingTelemetry.ActivitySourceName)
                 .SetResourceBuilder(resource)
+                .AddProcessor(new CliTagEnrichmentProcessor(tagsSource))
                 .AddOtlpExporter()
                 .Build();
         }
@@ -138,9 +144,10 @@ internal sealed class TelemetryManager : IDisposable
     /// Initializes a new instance of the <see cref="TelemetryManager"/> class.
     /// </summary>
     /// <param name="configuration">The configuration to read telemetry settings from.</param>
+    /// <param name="tagsSource">The shared source for background-calculated telemetry tags.</param>
     /// <param name="args">The command-line arguments.</param>
-    internal TelemetryManager(IConfiguration configuration, string[]? args = null)
-        : this(TelemetryConfiguration.Create(configuration, args))
+    internal TelemetryManager(IConfiguration configuration, TelemetryTagsSource tagsSource, string[]? args = null)
+        : this(TelemetryConfiguration.Create(configuration, args), tagsSource)
     {
     }
 

--- a/src/Aspire.Cli/Telemetry/TelemetryManager.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryManager.cs
@@ -86,9 +86,7 @@ internal sealed class TelemetryManager : IDisposable
         // The Azure Monitor only exports telemetry from the Reported activity source.
         if (telemetryConfiguration.ReportedTelemetryEnabled)
         {
-            var azureMonitorBuilder = Sdk.CreateTracerProviderBuilder()
-                .AddSource(AspireCliTelemetry.ReportedActivitySourceName)
-                .SetResourceBuilder(resource)
+            var azureMonitorBuilder = CreateTracerProviderBuilder(AspireCliTelemetry.ReportedActivitySourceName, resource, tagsSource)
                 .AddAzureMonitorTraceExporter(o =>
                 {
                     o.ConnectionString = ApplicationInsightsConnectionString;
@@ -103,28 +101,19 @@ internal sealed class TelemetryManager : IDisposable
             }
 #endif
 
-            // Tags are applied at export time by the enrichment processor, which reads from
-            // TelemetryTagsSource. This avoids blocking activity start on background tag calculation.
-            azureMonitorBuilder.AddProcessor(new CliTagEnrichmentProcessor(tagsSource));
-
             _azureMonitorProvider = azureMonitorBuilder.Build();
         }
 
         if (telemetryConfiguration.UseProfilingProvider)
         {
-            _profilingProvider = Sdk.CreateTracerProviderBuilder()
-                .AddSource(ProfilingTelemetry.ActivitySourceName)
-                .SetResourceBuilder(resource)
-                .AddProcessor(new CliTagEnrichmentProcessor(tagsSource))
+            _profilingProvider = CreateTracerProviderBuilder(ProfilingTelemetry.ActivitySourceName, resource, tagsSource)
                 .AddOtlpExporter()
                 .Build();
         }
 
         if (useDebugDiagnosticProvider)
         {
-            var diagnosticBuilder = Sdk.CreateTracerProviderBuilder()
-                .AddSource(AspireCliTelemetry.DiagnosticsActivitySourceName)
-                .SetResourceBuilder(resource);
+            var diagnosticBuilder = CreateTracerProviderBuilder(AspireCliTelemetry.DiagnosticsActivitySourceName, resource, tagsSource);
 
             if (telemetryConfiguration.ConsoleExporterLevel == ConsoleExporterLevel.Diagnostic)
             {
@@ -138,6 +127,14 @@ internal sealed class TelemetryManager : IDisposable
 
             _debugDiagnosticProvider = diagnosticBuilder.Build();
         }
+    }
+
+    private static TracerProviderBuilder CreateTracerProviderBuilder(string sourceName, ResourceBuilder resource, TelemetryTagsSource tagsSource)
+    {
+        return Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetResourceBuilder(resource)
+            .AddProcessor(new CliTagEnrichmentProcessor(tagsSource));
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Telemetry/TelemetryServiceCollectionExtensions.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ internal static class TelemetryServiceCollectionExtensions
         services.AddSingleton<ICIEnvironmentDetector, CIEnvironmentDetector>();
         services.AddSingleton<ICodingAgentDetector, CodingAgentDetector>();
         services.AddSingleton<IInternalMicrosoftDetector, InternalMicrosoftDetector>();
+        services.AddSingleton<TelemetryTagsSource>();
         services.AddSingleton<AspireCliTelemetry>();
         services.AddSingleton<ProfilingTelemetry>();
         services.AddHostedService(sp => sp.GetRequiredService<AspireCliTelemetry>());

--- a/src/Aspire.Cli/Telemetry/TelemetryTagsSource.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryTagsSource.cs
@@ -33,6 +33,13 @@ internal sealed class TelemetryTagsSource
     /// </summary>
     public IReadOnlyList<KeyValuePair<string, object?>> GetResolvedTags()
     {
+        // This is called from an OTEL processor which isn't async, so we block here if the background calculation hasn't completed yet.
+        // This should be rare in practice since the tags are calculated at startup and cached for the lifetime of the process.
+        //
+        // If blocking here is a problem then I think the best option is to make StartActivity on AspireCliTelemetry return activities that are
+        // wrapped in a proxy that implements IAsyncDisposable that sets tags in dispose.
+        // Activity events also need the tags so their information could be added to the proxy and added to the activity in DisposeAsync with all tags.
+
         var tagsTask = TagsTask;
         if (tagsTask.IsCompletedSuccessfully)
         {

--- a/src/Aspire.Cli/Telemetry/TelemetryTagsSource.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryTagsSource.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Telemetry;
+
+/// <summary>
+/// Holds the background task that calculates default telemetry tags (machine ID, OS info, etc.).
+/// Shared between <see cref="AspireCliTelemetry"/> (which starts the calculation) and
+/// <see cref="CliTagEnrichmentProcessor"/> (which applies the tags to activities before export).
+/// </summary>
+internal sealed class TelemetryTagsSource
+{
+    private volatile Task<IReadOnlyList<KeyValuePair<string, object?>>>? _tagsTask;
+    private readonly ILogger<TelemetryTagsSource> _logger;
+
+    public TelemetryTagsSource(ILogger<TelemetryTagsSource> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets the task that resolves to the calculated tags. Returns an empty list if
+    /// calculation has not been started yet.
+    /// </summary>
+    public Task<IReadOnlyList<KeyValuePair<string, object?>>> TagsTask =>
+        _tagsTask ?? Task.FromResult<IReadOnlyList<KeyValuePair<string, object?>>>(Array.Empty<KeyValuePair<string, object?>>());
+
+    /// <summary>
+    /// Returns the resolved tags, blocking if the background calculation has not yet completed.
+    /// </summary>
+    public IReadOnlyList<KeyValuePair<string, object?>> GetResolvedTags()
+    {
+        var tagsTask = TagsTask;
+        if (tagsTask.IsCompletedSuccessfully)
+        {
+            return tagsTask.Result;
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        var tags = tagsTask.GetAwaiter().GetResult();
+        stopwatch.Stop();
+
+        _logger.LogDebug("TelemetryTagsSource: blocked {ElapsedMilliseconds}ms waiting for telemetry tags to be calculated.", stopwatch.ElapsedMilliseconds);
+
+        return tags;
+    }
+
+    /// <summary>
+    /// Starts the background tag calculation. Only the first call takes effect; subsequent
+    /// calls are ignored.
+    /// </summary>
+    public void StartCalculation(Func<Task<IReadOnlyList<KeyValuePair<string, object?>>>> factory)
+    {
+        _tagsTask ??= Task.Run(factory);
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/CliTelemetryTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CliTelemetryTests.cs
@@ -52,7 +52,7 @@ public sealed class CliTelemetryTests(ITestOutputHelper output)
         // Write diagnostic files into the .aspire-diagnostics/ directory so TerminalRun
         // always copies them to testresults (not just on failure).
         var diagDir = $"$ASPIRE_E2E_WORKSPACE/{CliE2EAutomatorHelpers.DiagnosticsDirectoryName}";
-        var profilePath = $"{diagDir}/profile.aspire";
+        var profilePath = $"{diagDir}/profile.zip";
         var verResultPath = $"{diagDir}/ver_result";
         await auto.RunCommandAsync($"mkdir -p {diagDir}", counter);
         await auto.AspireStartAsync(counter, startTimeout: TimeSpan.FromMinutes(4), additionalArgs: $"--capture-profile --capture-profile-output {profilePath}");

--- a/tests/Aspire.Cli.EndToEnd.Tests/CliTelemetryTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CliTelemetryTests.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end test that verifies telemetry enrichment tags are present on spans
+/// exported via the profiling capture pipeline. Uses <c>aspire start --capture-profile</c>
+/// which activates the profiling TracerProvider, creates CLI profiling spans enriched by
+/// CliTagEnrichmentProcessor, and exports them to a
+/// profile archive file that we can inspect.
+/// </summary>
+public sealed class CliTelemetryTests(ITestOutputHelper output)
+{
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task OtlpExportedSpansContainEnrichmentTags()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        // Docker socket needed because aspire start runs an AppHost that may launch containers
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // Create a project so aspire start has an AppHost to launch
+        await auto.AspireNewAsync("TelemetryTestApp", counter);
+
+        // Navigate to the AppHost
+        await auto.TypeAsync("cd TelemetryTestApp/TelemetryTestApp.AppHost");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Start the AppHost with --capture-profile to generate CLI profiling spans.
+        // --capture-profile activates the profiling TracerProvider which creates spans on
+        // the Aspire.Cli.Profiling activity source. The CliTagEnrichmentProcessor enriches
+        // these spans with default tags (aspire.cli.version, etc.) before export.
+        // The profile is exported to a ZIP archive containing OTLP-format trace data.
+        // Write diagnostic files into the .aspire-diagnostics/ directory so TerminalRun
+        // always copies them to testresults (not just on failure).
+        var diagDir = $"$ASPIRE_E2E_WORKSPACE/{CliE2EAutomatorHelpers.DiagnosticsDirectoryName}";
+        var profilePath = $"{diagDir}/profile.aspire";
+        var verResultPath = $"{diagDir}/ver_result";
+        await auto.RunCommandAsync($"mkdir -p {diagDir}", counter);
+        await auto.TypeAsync($"aspire start --capture-profile --capture-profile-output {profilePath}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(4));
+
+        // Stop the background AppHost
+        await auto.AspireStopAsync(counter);
+
+        // Dump profile contents for debugging visibility in the recording
+        await auto.TypeAsync($"unzip -l {profilePath}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Extract the trace data from the profile archive and check for enrichment tags.
+        // The profile ZIP contains traces/profile.json in OTLP JSON format:
+        //   { "resourceSpans": [{ "scopeSpans": [{ "spans": [{ "attributes": [{ "key": "...", "value": {...} }] }] }] }] }
+        // Some spans may have no attributes field (omitted by WhenWritingNull), so use (.attributes // [])
+        // to avoid jq errors on null iteration.
+        await auto.TypeAsync($"unzip -p {profilePath} traces/profile.json | jq -e '[.resourceSpans[].scopeSpans[].spans[] | (.attributes // [])[] | select(.key == \"aspire.cli.version\")] | length > 0' >/dev/null 2>&1 && echo PASS > {verResultPath} || echo FAIL > {verResultPath}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Dump some span data for debugging
+        await auto.TypeAsync($"unzip -p {profilePath} traces/profile.json | jq '.resourceSpans[].scopeSpans[].spans[] | {{name, attributes: [(.attributes // [])[] | select(.key | startswith(\"aspire.cli\"))]}}' | head -50");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Clear and check the enrichment tag result
+        await auto.TypeAsync("clear");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync($"cat {verResultPath}");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("PASS", timeout: TimeSpan.FromSeconds(5));
+        await auto.WaitForSuccessPromptAsync(counter);
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/CliTelemetryTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CliTelemetryTests.cs
@@ -55,9 +55,7 @@ public sealed class CliTelemetryTests(ITestOutputHelper output)
         var profilePath = $"{diagDir}/profile.aspire";
         var verResultPath = $"{diagDir}/ver_result";
         await auto.RunCommandAsync($"mkdir -p {diagDir}", counter);
-        await auto.TypeAsync($"aspire start --capture-profile --capture-profile-output {profilePath}");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(4));
+        await auto.AspireStartAsync(counter, startTimeout: TimeSpan.FromMinutes(4), additionalArgs: $"--capture-profile --capture-profile-output {profilePath}");
 
         // Stop the background AppHost
         await auto.AspireStopAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/CliTelemetryTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CliTelemetryTests.cs
@@ -51,14 +51,16 @@ public sealed class CliTelemetryTests(ITestOutputHelper output)
         // The profile is exported to a ZIP archive containing OTLP-format trace data.
         // Write diagnostic files into the .aspire-diagnostics/ directory so TerminalRun
         // always copies them to testresults (not just on failure).
+        //
+        // NOTE: --capture-profile is a "run, capture, stop" workflow — the CLI starts the
+        // AppHost, waits for readiness, stops it, collects traces from the profile dashboard,
+        // and exits. The AppHost (and its dashboard) is already shut down by the time the
+        // command returns, so we skip the dashboard health check.
         var diagDir = $"$ASPIRE_E2E_WORKSPACE/{CliE2EAutomatorHelpers.DiagnosticsDirectoryName}";
         var profilePath = $"{diagDir}/profile.zip";
         var verResultPath = $"{diagDir}/ver_result";
         await auto.RunCommandAsync($"mkdir -p {diagDir}", counter);
-        await auto.AspireStartAsync(counter, startTimeout: TimeSpan.FromMinutes(4), additionalArgs: $"--capture-profile --capture-profile-output {profilePath}");
-
-        // Stop the background AppHost
-        await auto.AspireStopAsync(counter);
+        await auto.AspireStartAsync(counter, startTimeout: TimeSpan.FromMinutes(4), additionalArgs: $"--capture-profile --capture-profile-output {profilePath}", skipDashboardCheck: true);
 
         // Dump profile contents for debugging visibility in the recording
         await auto.TypeAsync($"unzip -l {profilePath}");

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -715,13 +715,23 @@ internal static class CliE2EAutomatorHelpers
     /// On failure, dumps the latest CLI log file to the terminal output and promotes the highest-signal
     /// diagnostics into the workspace for artifact capture.
     /// </summary>
+    /// <param name="auto">The terminal automator.</param>
+    /// <param name="counter">The prompt sequence counter.</param>
+    /// <param name="startTimeout">How long to wait for <c>aspire start</c> to complete.</param>
+    /// <param name="isolated">Pass <c>--isolated</c> to <c>aspire start</c>.</param>
+    /// <param name="apphost">Explicit AppHost path to pass via <c>--apphost</c>.</param>
+    /// <param name="additionalArgs">Extra arguments appended to the <c>aspire start</c> command.</param>
+    /// <param name="skipDashboardCheck">When <see langword="true"/>, skip the dashboard URL extraction and
+    /// HTTP health check. Use this for modes like <c>--capture-profile</c> where the AppHost is already
+    /// stopped by the time the command returns.</param>
     internal static async Task AspireStartAsync(
         this Hex1bTerminalAutomator auto,
         SequenceCounter counter,
         TimeSpan? startTimeout = null,
         bool isolated = false,
         string? apphost = null,
-        string? additionalArgs = null)
+        string? additionalArgs = null,
+        bool skipDashboardCheck = false)
     {
         var effectiveTimeout = startTimeout ?? TimeSpan.FromMinutes(3);
         var expectedCounter = counter.Value;
@@ -780,6 +790,11 @@ internal static class CliE2EAutomatorHelpers
                 workspacePath is null || !ShouldCaptureWorkspaceDiagnostics()
                     ? "aspire start failed. Check terminal output for CLI logs."
                     : $"aspire start failed. Workspace: {workspacePath}. See {DiagnosticsDirectoryName}/ in the captured workspace.");
+        }
+
+        if (skipDashboardCheck)
+        {
+            return;
         }
 
         await auto.TypeAsync(

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -872,11 +872,17 @@ internal static class CliE2EAutomatorHelpers
                 "Check terminal output for CLI logs and JSON content.");
         }
 
+        // Retry curl up to 10 times with 2s delay — the dashboard may still be binding
+        // its listening port immediately after aspire start returns.
         await auto.TypeAsync(
-            "curl -ksSL -o /dev/null -w 'dashboard-http-%{http_code}' \"$DASHBOARD_URL\" " +
-            "|| echo 'dashboard-http-failed'");
+            "for i in $(seq 1 10); do " +
+            "CODE=$(curl -ksSL -o /dev/null -w '%{http_code}' \"$DASHBOARD_URL\" 2>/dev/null); " +
+            "if [ \"$CODE\" = \"200\" ]; then echo 'dashboard-http-200'; break; fi; " +
+            "sleep 2; " +
+            "done; " +
+            "if [ \"$CODE\" != \"200\" ]; then echo \"dashboard-http-${CODE}\"; echo 'dashboard-http-failed'; fi");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("dashboard-http-200", timeout: TimeSpan.FromSeconds(15));
+        await auto.WaitUntilTextAsync("dashboard-http-200", timeout: TimeSpan.FromSeconds(30));
         await auto.WaitForSuccessPromptAsync(counter);
     }
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -720,7 +720,8 @@ internal static class CliE2EAutomatorHelpers
         SequenceCounter counter,
         TimeSpan? startTimeout = null,
         bool isolated = false,
-        string? apphost = null)
+        string? apphost = null,
+        string? additionalArgs = null)
     {
         var effectiveTimeout = startTimeout ?? TimeSpan.FromMinutes(3);
         var expectedCounter = counter.Value;
@@ -732,11 +733,12 @@ internal static class CliE2EAutomatorHelpers
 
         var isolatedFlag = isolated ? " --isolated" : "";
         var apphostFlag = apphost is not null ? $" --apphost {AspireCliShellCommandHelpers.QuoteBashArg(apphost)}" : "";
+        var extraArgs = !string.IsNullOrEmpty(additionalArgs) ? $" {additionalArgs}" : "";
         var startupTimeoutSeconds = Math.Max(1, (int)Math.Ceiling(effectiveTimeout.TotalSeconds));
 
         // Keep aspire start as a single shell pipeline so tee captures the exact JSON emitted to the terminal while
         // pipefail preserves the real CLI exit code instead of letting tee mask build/startup failures.
-        await auto.TypeAsync($"(set -o pipefail; ASPIRE_CLI_START_TIMEOUT={startupTimeoutSeconds.ToString(CultureInfo.InvariantCulture)} aspire start{isolatedFlag}{apphostFlag} --format json | tee \"{jsonFile}\")");
+        await auto.TypeAsync($"(set -o pipefail; ASPIRE_CLI_START_TIMEOUT={startupTimeoutSeconds.ToString(CultureInfo.InvariantCulture)} aspire start{isolatedFlag}{apphostFlag}{extraArgs} --format json | tee \"{jsonFile}\")");
         await auto.EnterAsync();
 
         // Wait for the command to finish — check for success or error exit.

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -1171,13 +1171,17 @@ internal static class CliE2ETestHelpers
         return destFile;
     }
 
-    private static string GetCaptureRootDirectory(string testName)
+    internal static string GetCaptureRootDirectory(string testName)
     {
-        return Path.Combine(
-            AppContext.BaseDirectory,
-            "TestResults",
-            "workspaces",
-            testName);
+        // In CI, write to $GITHUB_WORKSPACE/testresults/workspaces/ which is included
+        // in the artifact upload glob (testresults/**). AppContext.BaseDirectory is the
+        // test binary's output directory, which is NOT uploaded.
+        var githubWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
+        var baseDir = githubWorkspace is not null
+            ? Path.Combine(githubWorkspace, "testresults")
+            : Path.Combine(AppContext.BaseDirectory, "TestResults");
+
+        return Path.Combine(baseDir, "workspaces", testName);
     }
 
     private static void CopyDirectory(string sourceDir, string destDir, Action<string>? log)

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -1177,7 +1177,7 @@ internal static class CliE2ETestHelpers
         // in the artifact upload glob (testresults/**). AppContext.BaseDirectory is the
         // test binary's output directory, which is NOT uploaded.
         var githubWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
-        var baseDir = githubWorkspace is not null
+        var baseDir = !string.IsNullOrEmpty(githubWorkspace)
             ? Path.Combine(githubWorkspace, "testresults")
             : Path.Combine(AppContext.BaseDirectory, "TestResults");
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/TerminalRun.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/TerminalRun.cs
@@ -95,7 +95,7 @@ internal sealed class TerminalRun : IAsyncDisposable
             ? methodName
             : "unknown";
 
-        var destDir = GetDiagnosticsCapturePath(testName);
+        var destDir = CliE2ETestHelpers.GetCaptureRootDirectory(testName);
         CopyDirectoryIfExists(diagnosticsSource, destDir);
 
         WriteTestOutput($"[TerminalRun] Captured diagnostics to: {destDir}");
@@ -114,20 +114,6 @@ internal sealed class TerminalRun : IAsyncDisposable
         {
             WriteTestOutput($"[TerminalRun]   (root): {topLevelFiles.Length} file(s)");
         }
-    }
-
-    private static string GetDiagnosticsCapturePath(string testName)
-    {
-        var githubWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
-
-        if (!string.IsNullOrEmpty(githubWorkspace))
-        {
-            // CI environment — write to testresults/ so upload-artifact includes these files.
-            return Path.Combine(githubWorkspace, "testresults", "workspaces", testName);
-        }
-
-        // Local development — keep diagnostics with other test output.
-        return Path.Combine(AppContext.BaseDirectory, "TestResults", "workspaces", testName);
     }
 
     private static void CopyDirectoryIfExists(string source, string destination)

--- a/tests/Aspire.Cli.Tests/Telemetry/AspireCliTelemetryTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/AspireCliTelemetryTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.InternalTesting;
 using System.Diagnostics;
 using Aspire.Cli.Telemetry;
 using Microsoft.Extensions.Configuration;
@@ -39,7 +38,7 @@ public class AspireCliTelemetryTests
     }
 
     [Fact]
-    public void StartDiagnosticActivity_CreatesActivityWithCorrectNameAndDefaultTags()
+    public async Task StartDiagnosticActivity_CreatesActivityWithCorrectNameAndDefaultTags()
     {
         using var fixture = new TelemetryFixture(sampleResult: ActivitySamplingResult.AllData);
 
@@ -49,12 +48,12 @@ public class AspireCliTelemetryTests
         Assert.Equal("test-diagnostic", activity.OperationName);
 
         // Verify all default tags are included
-        var defaultTags = fixture.Telemetry.GetDefaultTags();
-        var activityTags = activity.TagObjects.ToDictionary(t => t.Key, t => t.Value);
+        var defaultTags = await fixture.Telemetry.GetDefaultTagsAsync();
+        var activityTags = activity.Tags.ToDictionary(t => t.Key, t => t.Value);
         foreach (var tag in defaultTags)
         {
             Assert.True(activityTags.ContainsKey(tag.Key), $"Activity is missing tag '{tag.Key}'");
-            Assert.Equal(tag.Value, activityTags[tag.Key]);
+            Assert.Equal(tag.Value?.ToString(), activityTags[tag.Key]);
         }
     }
 
@@ -110,7 +109,7 @@ public class AspireCliTelemetryTests
     }
 
     [Fact]
-    public void RecordError_AddsActivityEventWithDefaultTags_WhenReportedActivityIsActive()
+    public async Task RecordError_AddsActivityEventWithDefaultTags_WhenReportedActivityIsActive()
     {
         using var fixture = new TelemetryFixture();
         var exception = new InvalidOperationException("Test exception");
@@ -129,12 +128,14 @@ public class AspireCliTelemetryTests
         Assert.Equal("Test exception", eventTags[TelemetryConstants.Tags.ExceptionMessage]);
         // Note: exception.stacktrace may not be present if the exception was never thrown
 
-        // Verify all default tags are included in the event
-        var defaultTags = fixture.Telemetry.GetDefaultTags();
+        // RecordError adds default tags directly to the error event at creation time
+        // so they are available even if the enrichment processor has not run yet.
+        var defaultTags = await fixture.Telemetry.GetDefaultTagsAsync();
+        Assert.NotEmpty(defaultTags);
         foreach (var tag in defaultTags)
         {
-            Assert.True(eventTags.ContainsKey(tag.Key), $"Event is missing tag '{tag.Key}'");
-            Assert.Equal(tag.Value, eventTags[tag.Key]);
+            Assert.True(eventTags.ContainsKey(tag.Key), $"Error event is missing default tag '{tag.Key}'");
+            Assert.Equal(tag.Value?.ToString(), eventTags[tag.Key]?.ToString());
         }
     }
 
@@ -210,7 +211,7 @@ public class AspireCliTelemetryTests
     }
 
     [Fact]
-    public void InitializeAsync_AddsMachineInformationTags()
+    public async Task Initialize_AddsMachineInformationTags()
     {
         var machineInfoProvider = new TelemetryFixture.TestMachineInformationProvider
         {
@@ -219,18 +220,18 @@ public class AspireCliTelemetryTests
         };
         using var fixture = new TelemetryFixture(machineInfoProvider);
 
-        var tags = fixture.Telemetry.GetDefaultTags();
+        var tags = await fixture.Telemetry.GetDefaultTagsAsync();
 
         Assert.Contains(tags, t => t.Key == "machine.device_id" && (string?)t.Value == "test-device-id");
         Assert.Contains(tags, t => t.Key == "machine.mac_address_hash" && (string?)t.Value == "test-mac-hash");
     }
 
     [Fact]
-    public void InitializeAsync_AddsOsInformationTags()
+    public async Task Initialize_AddsOsInformationTags()
     {
         using var fixture = new TelemetryFixture();
 
-        var tags = fixture.Telemetry.GetDefaultTags();
+        var tags = await fixture.Telemetry.GetDefaultTagsAsync();
 
         var expectedOsName = AspireCliTelemetry.GetOsName();
         var expectedOsType = AspireCliTelemetry.GetOsType();
@@ -240,7 +241,7 @@ public class AspireCliTelemetryTests
     }
 
     [Fact]
-    public void InitializeAsync_AddsCodingAgentTag_WhenCodingAgentIsDetected()
+    public void Initialize_AddsCodingAgentTag_WhenCodingAgentIsDetected()
     {
         var codingAgentDetector = new TelemetryFixture.TestCodingAgentDetector
         {
@@ -255,17 +256,17 @@ public class AspireCliTelemetryTests
     }
 
     [Fact]
-    public void InitializeAsync_DoesNotAddCodingAgentTag_WhenCodingAgentIsNotDetected()
+    public async Task Initialize_DoesNotAddCodingAgentTag_WhenCodingAgentIsNotDetected()
     {
         using var fixture = new TelemetryFixture();
 
-        var tags = fixture.Telemetry.GetDefaultTags();
+        var tags = await fixture.Telemetry.GetDefaultTagsAsync();
 
         Assert.DoesNotContain(tags, t => t.Key == TelemetryConstants.Tags.CodingAgent);
     }
 
     [Fact]
-    public void InitializeAsync_AddsInternalMicrosoftTag()
+    public async Task Initialize_AddsInternalMicrosoftTag()
     {
         Assert.Equal("aspire.cli.microsoft_internal_source", TelemetryConstants.Tags.InternalMicrosoftSource);
         Assert.Equal("aspire.cli.microsoft_internal_alias", TelemetryConstants.Tags.InternalMicrosoftAlias);
@@ -280,7 +281,7 @@ public class AspireCliTelemetryTests
         };
         using var fixture = new TelemetryFixture(internalMicrosoftDetector: internalMicrosoftDetector);
 
-        var tags = fixture.Telemetry.GetDefaultTags();
+        var tags = await fixture.Telemetry.GetDefaultTagsAsync();
 
         Assert.Contains(tags, t => t.Key == TelemetryConstants.Tags.InternalMicrosoft && t.Value is true);
         Assert.Contains(tags, t => t.Key == TelemetryConstants.Tags.InternalMicrosoftSource && (string?)t.Value == "test source");
@@ -289,7 +290,7 @@ public class AspireCliTelemetryTests
     }
 
     [Fact]
-    public void InitializeAsync_DoesNotAddOptionalInternalMicrosoftTags_WhenValuesAreNotDetected()
+    public async Task Initialize_DoesNotAddOptionalInternalMicrosoftTags_WhenValuesAreNotDetected()
     {
         var internalMicrosoftDetector = new TelemetryFixture.TestInternalMicrosoftDetector
         {
@@ -298,7 +299,7 @@ public class AspireCliTelemetryTests
         };
         using var fixture = new TelemetryFixture(internalMicrosoftDetector: internalMicrosoftDetector);
 
-        var tags = fixture.Telemetry.GetDefaultTags();
+        var tags = await fixture.Telemetry.GetDefaultTagsAsync();
 
         Assert.Collection(
             GetInternalMicrosoftTags(tags),
@@ -315,7 +316,7 @@ public class AspireCliTelemetryTests
     }
 
     [Fact]
-    public async Task InitializeAsync_DoesNotRunInternalMicrosoftDetectorWhenReportedTelemetryIsDisabled()
+    public async Task Initialize_DoesNotRunInternalMicrosoftDetectorWhenReportedTelemetryIsDisabled()
     {
         var provider = new TelemetryFixture.TestMachineInformationProvider();
         var ciDetector = new TelemetryFixture.TestCIEnvironmentDetector();
@@ -324,6 +325,7 @@ public class AspireCliTelemetryTests
         {
             IsInternalMicrosoft = true
         };
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
         var telemetry = new AspireCliTelemetry(
             NullLogger<AspireCliTelemetry>.Instance,
             provider,
@@ -333,16 +335,18 @@ public class AspireCliTelemetryTests
             new TelemetryConfiguration { ReportedTelemetryEnabled = false },
             AspireCliTelemetry.ReportedActivitySourceName,
             AspireCliTelemetry.DiagnosticsActivitySourceName,
-            Utils.TestExecutionContextHelper.CreateExecutionContext(new DirectoryInfo(AppContext.BaseDirectory)));
+            Utils.TestExecutionContextHelper.CreateExecutionContext(new DirectoryInfo(AppContext.BaseDirectory)),
+            tagsSource);
 
-        await telemetry.InitializeAsync().DefaultTimeout();
+        telemetry.Initialize();
+        await tagsSource.TagsTask;
 
         Assert.Equal(0, internalMicrosoftDetector.InvocationCount);
-        Assert.Empty(GetInternalMicrosoftTags(telemetry.GetDefaultTags()));
+        Assert.Empty(GetInternalMicrosoftTags(await telemetry.GetDefaultTagsAsync()));
     }
 
     [Fact]
-    public async Task InitializeAsync_AddsDefaultTags_WhenInternalMicrosoftDetectorFails()
+    public async Task Initialize_AddsDefaultTags_WhenInternalMicrosoftDetectorFails()
     {
         var provider = new TelemetryFixture.TestMachineInformationProvider
         {
@@ -353,6 +357,7 @@ public class AspireCliTelemetryTests
         {
             ExceptionToThrow = new NotSupportedException("Unexpected probe failure.")
         };
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
         var telemetry = new AspireCliTelemetry(
             NullLogger<AspireCliTelemetry>.Instance,
             provider,
@@ -362,11 +367,13 @@ public class AspireCliTelemetryTests
             new TelemetryConfiguration { ReportedTelemetryEnabled = true },
             AspireCliTelemetry.ReportedActivitySourceName,
             AspireCliTelemetry.DiagnosticsActivitySourceName,
-            Utils.TestExecutionContextHelper.CreateExecutionContext(new DirectoryInfo(AppContext.BaseDirectory)));
+            Utils.TestExecutionContextHelper.CreateExecutionContext(new DirectoryInfo(AppContext.BaseDirectory)),
+            tagsSource);
 
-        await telemetry.InitializeAsync().DefaultTimeout();
+        telemetry.Initialize();
+        await tagsSource.TagsTask;
 
-        var tags = telemetry.GetDefaultTags();
+        var tags = await telemetry.GetDefaultTagsAsync();
         Assert.Contains(tags, t => t.Key == TelemetryConstants.Tags.MacAddressHash && (string?)t.Value == "test-mac-hash");
         Assert.Contains(tags, t => t.Key == TelemetryConstants.Tags.DeviceId && (string?)t.Value == "test-device-id");
         Assert.Contains(tags, t => t.Key == TelemetryConstants.Tags.CliVersion);
@@ -397,7 +404,7 @@ public class AspireCliTelemetryTests
     }
 
     [Fact]
-    public void StartReportedActivity_IncludesAllDefaultTags()
+    public async Task StartReportedActivity_IncludesAllDefaultTags()
     {
         var machineInfoProvider = new TelemetryFixture.TestMachineInformationProvider
         {
@@ -411,22 +418,23 @@ public class AspireCliTelemetryTests
         Assert.NotNull(activity);
 
         // Verify all default tags are included
-        var defaultTags = fixture.Telemetry.GetDefaultTags();
-        var activityTags = activity.TagObjects.ToDictionary(t => t.Key, t => t.Value);
+        var defaultTags = await fixture.Telemetry.GetDefaultTagsAsync();
+        var activityTags = activity.Tags.ToDictionary(t => t.Key, t => t.Value);
         foreach (var tag in defaultTags)
         {
             Assert.True(activityTags.ContainsKey(tag.Key), $"Activity is missing tag '{tag.Key}'");
-            Assert.Equal(tag.Value, activityTags[tag.Key]);
+            Assert.Equal(tag.Value?.ToString(), activityTags[tag.Key]);
         }
     }
 
     [Fact]
-    public void StartReportedActivity_ThrowsIfNotInitialized()
+    public async Task Initialize_IsIdempotent()
     {
         var provider = new TelemetryFixture.TestMachineInformationProvider();
         var ciDetector = new TelemetryFixture.TestCIEnvironmentDetector();
         var codingAgentDetector = new TelemetryFixture.TestCodingAgentDetector();
         var internalMicrosoftDetector = new TelemetryFixture.TestInternalMicrosoftDetector();
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
         var telemetry = new AspireCliTelemetry(
             NullLogger<AspireCliTelemetry>.Instance,
             provider,
@@ -436,35 +444,15 @@ public class AspireCliTelemetryTests
             new TelemetryConfiguration { ReportedTelemetryEnabled = true },
             AspireCliTelemetry.ReportedActivitySourceName,
             AspireCliTelemetry.DiagnosticsActivitySourceName,
-            Utils.TestExecutionContextHelper.CreateExecutionContext(new DirectoryInfo(AppContext.BaseDirectory)));
+            Utils.TestExecutionContextHelper.CreateExecutionContext(new DirectoryInfo(AppContext.BaseDirectory)),
+            tagsSource);
 
-        var exception = Assert.Throws<InvalidOperationException>(() => telemetry.StartReportedActivity("test"));
-        Assert.Contains("not been initialized", exception.Message);
-    }
+        telemetry.Initialize();
+        await tagsSource.TagsTask;
+        var tagsAfterFirstInit = (await telemetry.GetDefaultTagsAsync()).Count;
+        telemetry.Initialize(); // Should not throw
 
-    [Fact]
-    public async Task InitializeAsync_IsIdempotent()
-    {
-        var provider = new TelemetryFixture.TestMachineInformationProvider();
-        var ciDetector = new TelemetryFixture.TestCIEnvironmentDetector();
-        var codingAgentDetector = new TelemetryFixture.TestCodingAgentDetector();
-        var internalMicrosoftDetector = new TelemetryFixture.TestInternalMicrosoftDetector();
-        var telemetry = new AspireCliTelemetry(
-            NullLogger<AspireCliTelemetry>.Instance,
-            provider,
-            ciDetector,
-            codingAgentDetector,
-            internalMicrosoftDetector,
-            new TelemetryConfiguration { ReportedTelemetryEnabled = true },
-            AspireCliTelemetry.ReportedActivitySourceName,
-            AspireCliTelemetry.DiagnosticsActivitySourceName,
-            Utils.TestExecutionContextHelper.CreateExecutionContext(new DirectoryInfo(AppContext.BaseDirectory)));
-
-        await telemetry.InitializeAsync().DefaultTimeout();
-        var tagsAfterFirstInit = telemetry.GetDefaultTags().Count;
-        await telemetry.InitializeAsync(); // Should not throw
-
-        var tags = telemetry.GetDefaultTags();
+        var tags = await telemetry.GetDefaultTagsAsync();
         Assert.Equal(tagsAfterFirstInit, tags.Count); // Should have the same number of tags after second init
     }
 
@@ -475,7 +463,7 @@ public class AspireCliTelemetryTests
     }
 
     [Fact]
-    public void InitializeAsync_AddsIdentityTags_WhenExecutionContextProvided()
+    public async Task Initialize_AddsIdentityTags_WhenExecutionContextProvided()
     {
         // The execution context only needs a valid root for path composition; telemetry init
         // does not touch the filesystem for identity, so reuse the test base directory.
@@ -488,7 +476,7 @@ public class AspireCliTelemetryTests
 
         using var fixture = new TelemetryFixture(executionContext: executionContext);
 
-        var tags = fixture.Telemetry.GetDefaultTags();
+        var tags = await fixture.Telemetry.GetDefaultTagsAsync();
 
         Assert.Contains(tags, t => t.Key == TelemetryConstants.Tags.IdentityVersion && (string?)t.Value == "13.5.0-preview.1.26310.9");
         Assert.Contains(tags, t => t.Key == TelemetryConstants.Tags.IdentityChannel && (string?)t.Value == "daily");
@@ -501,7 +489,7 @@ public class AspireCliTelemetryTests
     }
 
     [Fact]
-    public void InitializeAsync_OmitsIdentityCommitTag_WhenCommitIsEmpty()
+    public async Task Initialize_OmitsIdentityCommitTag_WhenCommitIsEmpty()
     {
         var executionContext = Utils.TestExecutionContextHelper.CreateExecutionContext(
             new DirectoryInfo(AppContext.BaseDirectory),
@@ -512,7 +500,7 @@ public class AspireCliTelemetryTests
 
         using var fixture = new TelemetryFixture(executionContext: executionContext);
 
-        var tags = fixture.Telemetry.GetDefaultTags();
+        var tags = await fixture.Telemetry.GetDefaultTagsAsync();
 
         Assert.Contains(tags, t => t.Key == TelemetryConstants.Tags.IdentityVersion && (string?)t.Value == "13.5.0");
         Assert.DoesNotContain(tags, t => t.Key == TelemetryConstants.Tags.IdentityCommit);

--- a/tests/Aspire.Cli.Tests/Telemetry/CliTagEnrichmentProcessorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/CliTagEnrichmentProcessorTests.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Cli.Telemetry;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Telemetry;
+
+public class CliTagEnrichmentProcessorTests
+{
+    [Fact]
+    public void OnEnd_AppliesResolvedTagsToActivity()
+    {
+        using var fixture = new TelemetryFixture();
+
+        var processor = new CliTagEnrichmentProcessor(fixture.TagsSource);
+
+        using var source = new ActivitySource($"Test.{Path.GetRandomFileName()}");
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == source.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var activity = source.StartActivity("test-op")!;
+        Assert.NotNull(activity);
+
+        // Tags should not be present before OnEnd
+        Assert.DoesNotContain(activity.Tags, t => t.Key == "aspire.cli.version");
+
+        processor.OnEnd(activity);
+
+        // After OnEnd, enrichment tags are applied
+        Assert.Contains(activity.Tags, t => t.Key == "aspire.cli.version");
+        Assert.Contains(activity.Tags, t => t.Key == "machine.device_id");
+    }
+
+    [Fact]
+    public void OnEnd_WhenTagsNotYetResolved_StillAppliesTags()
+    {
+        // Verifies the processor handles the synchronous wait path when tags
+        // haven't completed yet (the GetResolvedTags blocking path).
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
+
+        // Create a fixture just to start the tag calculation on the tagsSource
+        using var fixture = new TelemetryFixture();
+
+        // Use the fixture's TagsSource which has completed calculation
+        var processor = new CliTagEnrichmentProcessor(fixture.TagsSource);
+
+        using var source = new ActivitySource($"Test.{Path.GetRandomFileName()}");
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == source.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var activity = source.StartActivity("test-op")!;
+        processor.OnEnd(activity);
+
+        // Tags were applied even though we used GetResolvedTags (sync path)
+        var tags = activity.Tags.ToList();
+        Assert.NotEmpty(tags);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Telemetry/CliTagEnrichmentProcessorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/CliTagEnrichmentProcessorTests.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Aspire.Cli.Telemetry;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Telemetry;
@@ -38,17 +39,28 @@ public class CliTagEnrichmentProcessorTests
     }
 
     [Fact]
-    public void OnEnd_WhenTagsNotYetResolved_StillAppliesTags()
+    public async Task OnEnd_WhenTagsNotYetResolved_BlocksUntilTagsAvailable()
     {
         // Verifies the processor handles the synchronous wait path when tags
         // haven't completed yet (the GetResolvedTags blocking path).
         var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
 
-        // Create a fixture just to start the tag calculation on the tagsSource
-        using var fixture = new TelemetryFixture();
+        // Gate the tag calculation behind a TaskCompletionSource so it hasn't completed
+        // when OnEnd is called — this forces the blocking wait path in GetResolvedTags.
+        var gate = new TaskCompletionSource<bool>();
+        var expectedTags = new List<KeyValuePair<string, object?>>
+        {
+            new("aspire.cli.version", "1.0.0-test"),
+            new("machine.device_id", "test-device-id")
+        };
 
-        // Use the fixture's TagsSource which has completed calculation
-        var processor = new CliTagEnrichmentProcessor(fixture.TagsSource);
+        tagsSource.StartCalculation(async () =>
+        {
+            await gate.Task;
+            return expectedTags;
+        });
+
+        var processor = new CliTagEnrichmentProcessor(tagsSource);
 
         using var source = new ActivitySource($"Test.{Path.GetRandomFileName()}");
         using var listener = new ActivityListener
@@ -59,10 +71,21 @@ public class CliTagEnrichmentProcessorTests
         ActivitySource.AddActivityListener(listener);
 
         using var activity = source.StartActivity("test-op")!;
-        processor.OnEnd(activity);
 
-        // Tags were applied even though we used GetResolvedTags (sync path)
-        var tags = activity.Tags.ToList();
-        Assert.NotEmpty(tags);
+        // OnEnd will block waiting for the tags — run it on a background thread
+        var onEndTask = Task.Run(() => processor.OnEnd(activity));
+
+        // Tags should NOT be present yet (calculation is gated)
+        Assert.False(onEndTask.IsCompleted);
+
+        // Release the gate so GetResolvedTags unblocks
+        gate.SetResult(true);
+
+        // OnEnd should complete now
+        await onEndTask.DefaultTimeout();
+
+        // Tags were applied via the blocking wait path
+        Assert.Contains(activity.Tags, t => t.Key == "aspire.cli.version" && (string?)t.Value == "1.0.0-test");
+        Assert.Contains(activity.Tags, t => t.Key == "machine.device_id" && (string?)t.Value == "test-device-id");
     }
 }

--- a/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -11,9 +11,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
-#if DEBUG
-using Microsoft.AspNetCore.InternalTesting;
-#endif
 
 namespace Aspire.Cli.Tests.Telemetry;
 
@@ -83,7 +80,8 @@ public class TelemetryConfigurationTests
     {
         var configuration = new ConfigurationBuilder().Build();
         var telemetryConfiguration = TelemetryConfiguration.Create(configuration, ["--version"]);
-        using var telemetryManager = new TelemetryManager(telemetryConfiguration);
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
+        using var telemetryManager = new TelemetryManager(telemetryConfiguration, tagsSource);
         var internalMicrosoftDetector = new TelemetryFixture.TestInternalMicrosoftDetector
         {
             IsInternalMicrosoft = true
@@ -95,13 +93,17 @@ public class TelemetryConfigurationTests
             new TelemetryFixture.TestCodingAgentDetector(),
             internalMicrosoftDetector,
             telemetryConfiguration,
-            Utils.TestExecutionContextHelper.CreateExecutionContext(new DirectoryInfo(AppContext.BaseDirectory)));
+            AspireCliTelemetry.ReportedActivitySourceName,
+            AspireCliTelemetry.DiagnosticsActivitySourceName,
+            Utils.TestExecutionContextHelper.CreateExecutionContext(new DirectoryInfo(AppContext.BaseDirectory)),
+            tagsSource);
 
-        await telemetry.InitializeAsync().DefaultTimeout();
+        telemetry.Initialize();
+        await tagsSource.TagsTask;
 
         Assert.False(telemetryManager.HasAzureMonitor);
         Assert.Equal(0, internalMicrosoftDetector.InvocationCount);
-        Assert.Empty(GetInternalMicrosoftTags(telemetry.GetDefaultTags()));
+        Assert.Empty(GetInternalMicrosoftTags(await telemetry.GetDefaultTagsAsync()));
     }
 
     [Fact]
@@ -114,7 +116,8 @@ public class TelemetryConfigurationTests
             })
             .Build();
         var telemetryConfiguration = TelemetryConfiguration.Create(configuration);
-        using var telemetryManager = new TelemetryManager(telemetryConfiguration);
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
+        using var telemetryManager = new TelemetryManager(telemetryConfiguration, tagsSource);
         var internalMicrosoftDetector = new TelemetryFixture.TestInternalMicrosoftDetector
         {
             IsInternalMicrosoft = true
@@ -126,13 +129,17 @@ public class TelemetryConfigurationTests
             new TelemetryFixture.TestCodingAgentDetector(),
             internalMicrosoftDetector,
             telemetryConfiguration,
-            Utils.TestExecutionContextHelper.CreateExecutionContext(new DirectoryInfo(AppContext.BaseDirectory)));
+            AspireCliTelemetry.ReportedActivitySourceName,
+            AspireCliTelemetry.DiagnosticsActivitySourceName,
+            Utils.TestExecutionContextHelper.CreateExecutionContext(new DirectoryInfo(AppContext.BaseDirectory)),
+            tagsSource);
 
-        await telemetry.InitializeAsync().DefaultTimeout();
+        telemetry.Initialize();
+        await tagsSource.TagsTask;
 
         Assert.False(telemetryManager.HasAzureMonitor);
         Assert.Equal(0, internalMicrosoftDetector.InvocationCount);
-        Assert.Empty(GetInternalMicrosoftTags(telemetry.GetDefaultTags()));
+        Assert.Empty(GetInternalMicrosoftTags(await telemetry.GetDefaultTagsAsync()));
     }
 
     [Fact]
@@ -173,8 +180,9 @@ public class TelemetryConfigurationTests
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(config.Select(pair => new KeyValuePair<string, string?>(pair.Key, pair.Value)))
             .Build();
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
 
-        using var manager = new TelemetryManager(configuration);
+        using var manager = new TelemetryManager(configuration, tagsSource);
 
         Assert.False(manager.HasProfilingProvider, "Expected detached child profiling export to require an actual profiling session");
     }
@@ -235,7 +243,9 @@ public class TelemetryConfigurationTests
         Assert.False(telemetryManager.HasProfilingProvider);
 
         var telemetry = host.Services.GetRequiredService<AspireCliTelemetry>();
-        await telemetry.InitializeAsync().DefaultTimeout();
+        telemetry.Initialize();
+        var tagsSource = host.Services.GetRequiredService<TelemetryTagsSource>();
+        await tagsSource.TagsTask;
 
         using var diagnosticActivity = telemetry.StartDiagnosticActivity("TestDiagnosticActivity");
         Assert.NotNull(diagnosticActivity);
@@ -246,8 +256,9 @@ public class TelemetryConfigurationTests
     public void AzureMonitor_Disabled_WhenVersionFlagProvided()
     {
         var configuration = new ConfigurationBuilder().Build();
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
 
-        var manager = new TelemetryManager(configuration, ["--version"]);
+        var manager = new TelemetryManager(configuration, tagsSource, ["--version"]);
 
         Assert.False(manager.HasAzureMonitor);
     }
@@ -259,8 +270,9 @@ public class TelemetryConfigurationTests
     public void AzureMonitor_Disabled_ForAllHelpFlags(string flag)
     {
         var configuration = new ConfigurationBuilder().Build();
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
 
-        var manager = new TelemetryManager(configuration, [flag]);
+        var manager = new TelemetryManager(configuration, tagsSource, [flag]);
 
         Assert.False(manager.HasAzureMonitor);
     }

--- a/tests/Aspire.Cli.Tests/Telemetry/TelemetryFixture.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TelemetryFixture.cs
@@ -38,14 +38,6 @@ internal sealed class TelemetryFixture : IDisposable
         ReportedSourceName = $"Test.{Path.GetRandomFileName()}";
         DiagnosticsSourceName = $"Test.{Path.GetRandomFileName()}";
 
-        _listener = new ActivityListener
-        {
-            ShouldListenTo = source => source.Name == ReportedSourceName || source.Name == DiagnosticsSourceName,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => sampleResult,
-            ActivityStopped = activity => CapturedActivity = activity
-        };
-        ActivitySource.AddActivityListener(_listener);
-
         machineInfoProvider ??= new TestMachineInformationProvider();
         ciEnvironmentDetector ??= new TestCIEnvironmentDetector();
         codingAgentDetector ??= new TestCodingAgentDetector();
@@ -53,8 +45,32 @@ internal sealed class TelemetryFixture : IDisposable
         logger ??= NullLogger<AspireCliTelemetry>.Instance;
         executionContext ??= Utils.TestExecutionContextHelper.CreateExecutionContext(new DirectoryInfo(AppContext.BaseDirectory));
 
-        Telemetry = new AspireCliTelemetry(logger, machineInfoProvider, ciEnvironmentDetector, codingAgentDetector, internalMicrosoftDetector, ReportedSourceName, DiagnosticsSourceName, executionContext);
-        Telemetry.InitializeAsync().GetAwaiter().GetResult();
+        TagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
+        Telemetry = new AspireCliTelemetry(logger, machineInfoProvider, ciEnvironmentDetector, codingAgentDetector, internalMicrosoftDetector, ReportedSourceName, DiagnosticsSourceName, executionContext, TagsSource);
+        Telemetry.Initialize();
+        // Wait for background tag calculation to complete so tests can assert on tags.
+        TagsSource.TagsTask.GetAwaiter().GetResult();
+
+        // Simulate CliTagEnrichmentProcessor behavior: in production, tags are added
+        // in OnEnd before export. Tests assert on live activities before they
+        // stop, so we add tags in ActivityStarted instead to make them visible immediately.
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ReportedSourceName || source.Name == DiagnosticsSourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => sampleResult,
+            ActivityStarted = activity =>
+            {
+                if (TagsSource.TagsTask is { IsCompletedSuccessfully: true } tagsTask)
+                {
+                    foreach (var tag in tagsTask.Result)
+                    {
+                        activity.SetTag(tag.Key, tag.Value);
+                    }
+                }
+            },
+            ActivityStopped = activity => CapturedActivity = activity
+        };
+        ActivitySource.AddActivityListener(_listener);
     }
 
     /// <summary>
@@ -66,6 +82,11 @@ internal sealed class TelemetryFixture : IDisposable
     /// Gets the name of the diagnostics activity source.
     /// </summary>
     public string DiagnosticsSourceName { get; }
+
+    /// <summary>
+    /// Gets the tags source used by this fixture.
+    /// </summary>
+    public TelemetryTagsSource TagsSource { get; }
 
     /// <summary>
     /// Gets the initialized telemetry instance.

--- a/tests/Aspire.Cli.Tests/Telemetry/TestTelemetryHelper.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TestTelemetryHelper.cs
@@ -20,6 +20,7 @@ internal static class TestTelemetryHelper
         var ciDetector = new TestCIEnvironmentDetector();
         var codingAgentDetector = new TestCodingAgentDetector();
         var internalMicrosoftDetector = new TestInternalMicrosoftDetector();
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
         var telemetry = new AspireCliTelemetry(
             NullLogger<AspireCliTelemetry>.Instance,
             provider,
@@ -29,8 +30,10 @@ internal static class TestTelemetryHelper
             new TelemetryConfiguration { ReportedTelemetryEnabled = true },
             AspireCliTelemetry.ReportedActivitySourceName,
             AspireCliTelemetry.DiagnosticsActivitySourceName,
-            CreateExecutionContext());
-        telemetry.InitializeAsync().GetAwaiter().GetResult();
+            CreateExecutionContext(),
+            tagsSource);
+        telemetry.Initialize();
+        tagsSource.TagsTask.GetAwaiter().GetResult();
         return telemetry;
     }
 
@@ -43,8 +46,10 @@ internal static class TestTelemetryHelper
         var ciDetector = new TestCIEnvironmentDetector();
         var codingAgentDetector = new TestCodingAgentDetector();
         var internalMicrosoftDetector = new TestInternalMicrosoftDetector();
-        var telemetry = new AspireCliTelemetry(NullLogger<AspireCliTelemetry>.Instance, provider, ciDetector, codingAgentDetector, internalMicrosoftDetector, reportedSourceName, diagnosticsSourceName, CreateExecutionContext());
-        telemetry.InitializeAsync().GetAwaiter().GetResult();
+        var tagsSource = new TelemetryTagsSource(NullLogger<TelemetryTagsSource>.Instance);
+        var telemetry = new AspireCliTelemetry(NullLogger<AspireCliTelemetry>.Instance, provider, ciDetector, codingAgentDetector, internalMicrosoftDetector, reportedSourceName, diagnosticsSourceName, CreateExecutionContext(), tagsSource);
+        telemetry.Initialize();
+        tagsSource.TagsTask.GetAwaiter().GetResult();
         return telemetry;
     }
 


### PR DESCRIPTION
## Summary

Refactors CLI telemetry tag calculation to run asynchronously at startup and apply enrichment tags at export time via an OpenTelemetry processor, rather than blocking startup or eagerly computing tags on every activity.

Closed #18347

## Changes

### Background tag calculation (`TelemetryTagsSource`)
- New `TelemetryTagsSource` singleton holds a background `Task` that computes default tags (machine ID, OS info, version, identity) without blocking CLI startup
- `GetResolvedTags()` blocks only when tags are actually needed (at export time on the batch processor thread), with Stopwatch + debug logging if the task hasn't completed yet
- Registered as a singleton shared between `AspireCliTelemetry` and `TelemetryManager`

### Export-time enrichment (`CliTagEnrichmentProcessor`)
- New `BaseProcessor` that applies background-calculated tags to activities in `OnEnd` (before export)
- Single stateless instance shared across all TracerProviders
- Replaces the previous approach of eagerly setting tags on every activity at creation time

### Error event enrichment
- `RecordError` adds default tags directly to error `ActivityEvent` tags at creation time (since events are immutable after creation and processors can't enrich them)
- Ensures error events exported to the traces table carry the same enrichment as activities

### Separate TracerProviders retained
- Keeps separate providers for Azure Monitor, profiling, and debug diagnostics (each with different source filtering and export targets)
- All providers share the same `CliTagEnrichmentProcessor` instance

### Other
- `Initialize()` is now synchronous (just kicks off background tag task)
- `GetDefaultTags()` → `GetDefaultTagsAsync()` (test-only API)
- Removed unused `FilteringExportProcessor` and `TagEnrichingExporter` classes

### E2E test
- Added `OtlpExportedSpansContainEnrichmentTags` test that verifies enrichment tags are present on spans exported via the profiling capture pipeline
- Uses `aspire start --capture-profile` to activate the profiling TracerProvider, then inspects the resulting profile archive (`traces/profile.json`) with `jq` to assert that `aspire.cli.version` tags are present on exported spans

## Files changed

| File | Description |
|------|-------------|
| `TelemetryTagsSource.cs` | New: shared singleton for background tag calculation |
| `CliTagEnrichmentProcessor.cs` | New: `BaseProcessor` that enriches activities at export time |
| `TelemetryManager.cs` | Refactored: creates shared processor, passes to all provider builders |
| `AspireCliTelemetry.cs` | Refactored: synchronous `Initialize()`, enriches error events at creation |
| `TelemetryServiceCollectionExtensions.cs` | Register `TelemetryTagsSource` singleton |
| `Program.cs` | Pass `TelemetryTagsSource` to `TelemetryManager` |
| `CliTelemetryTests.cs` | New E2E test for enrichment tags on exported spans |
| `AspireCliTelemetryTests.cs` | Updated unit tests for new enrichment behavior |
| `TelemetryConfigurationTests.cs` | Added processor enrichment test |
| `TelemetryFixture.cs` | Updated fixture to work with `TelemetryTagsSource` |
