### PR TITLE
Improve npm CLI package README and install diagnostics

### DIFF
--- a/docs/specs/npm-cli-package.md
+++ b/docs/specs/npm-cli-package.md
@@ -106,7 +106,7 @@ The launcher:
 5. Copies the native binary to an Aspire-owned writable cache.
 6. Spawns the cached binary with inherited stdio and forwards all command-line arguments.
 
-During npm `postinstall`, the same launcher runs in `--npm-postinstall-check` mode. That mode stops after RID detection and native package resolution, so `npm install -g @microsoft/aspire-cli --omit=optional` fails immediately on supported platforms instead of leaving an installed `aspire` shim that can only fail later at first launch. Package managers can still skip lifecycle scripts with `--ignore-scripts`, so the normal runtime launcher keeps the same missing-native-package diagnostic.
+During npm `postinstall`, the same launcher runs in `--npm-postinstall-check` mode. That mode stops after RID detection and native package resolution, so `npm install -g @microsoft/aspire-cli --omit=optional` fails immediately on supported platforms instead of leaving an installed `aspire` shim that can only fail later at first launch. Unsupported platforms continue to install the shim successfully and report the unsupported-platform diagnostic at first `aspire` launch, preserving the optional-dependency package behavior for transitive and exploratory installs. Package managers can still skip lifecycle scripts with `--ignore-scripts`, so the normal runtime launcher keeps the same missing-native-package diagnostic.
 
 The default cache path is:
 

--- a/docs/specs/npm-cli-package.md
+++ b/docs/specs/npm-cli-package.md
@@ -54,6 +54,7 @@ bin/aspire-package-map.json
 The top-level `package.json` declares:
 
 - `bin.aspire = "bin/aspire.js"`
+- `scripts.postinstall = "node bin/aspire.js --npm-postinstall-check"`
 - `optionalDependencies` for every supported RID package at the same version
 - `files = ["bin", "README.md"]`
 
@@ -104,6 +105,8 @@ The launcher:
 4. Finds `bin/aspire` or `bin/aspire.exe` inside that package.
 5. Copies the native binary to an Aspire-owned writable cache.
 6. Spawns the cached binary with inherited stdio and forwards all command-line arguments.
+
+During npm `postinstall`, the same launcher runs in `--npm-postinstall-check` mode. That mode stops after RID detection and native package resolution, so `npm install -g @microsoft/aspire-cli --omit=optional` fails immediately on supported platforms instead of leaving an installed `aspire` shim that can only fail later at first launch. Package managers can still skip lifecycle scripts with `--ignore-scripts`, so the normal runtime launcher keeps the same missing-native-package diagnostic.
 
 The default cache path is:
 
@@ -208,5 +211,4 @@ MicroBuild's npm publish template documentation does not currently expose an npm
 ## Open follow-ups
 
 - Add Sigstore provenance once ESRP/MicroBuild's npm publish path supports it.
-- Add `npm install --no-optional` guidance and a clearer error message in the launcher when no RID package is installed.
 - Extract the large release-job PowerShell validation scripts once `releaseJob` can safely consume repository scripts. They remain inline today because `eng/pipelines/release-publish-nuget.yml` runs the ESRP-backed release job with `checkout: none`; extracting them now would require adding a trusted script artifact or changing release-job checkout behavior.

--- a/eng/clipack/npm/aspire.js
+++ b/eng/clipack/npm/aspire.js
@@ -130,6 +130,27 @@ function optionalDependenciesInstallMessage(pointerPackageName) {
     '(do not use --omit=optional, --no-optional, or npm_config_optional=false).';
 }
 
+function isUnsupportedPlatformError(error) {
+  return error && typeof error.message === 'string' && error.message.startsWith('Unsupported platform: ');
+}
+
+function runNpmPostinstallCheck(packageJson, ridDetector = detectRid) {
+  let rid;
+  try {
+    rid = ridDetector();
+  } catch (error) {
+    if (isUnsupportedPlatformError(error)) {
+      // Unsupported platforms intentionally keep the shim-install behavior so
+      // users get the friendly launcher diagnostic only when they try to run it.
+      return;
+    }
+
+    throw error;
+  }
+
+  resolveNativeBinary(rid, packageJson.version, packageJson.name);
+}
+
 function resolveNativeBinary(rid, expectedVersion, pointerPackageName) {
   const packageName = getRidPackageNames().get(rid);
   if (!packageName) {
@@ -294,8 +315,7 @@ function main() {
     // npm does not warn when users explicitly omit optional dependencies. Fail
     // the top-level package install on supported platforms so the missing native
     // RID package is reported during install instead of at first `aspire` launch.
-    const rid = detectRid();
-    resolveNativeBinary(rid, packageJson.version, packageJson.name);
+    runNpmPostinstallCheck(packageJson);
     return;
   }
 
@@ -386,6 +406,7 @@ if (require.main === module) {
 
 module.exports = {
   __testing: {
-    detectRid
+    detectRid,
+    runNpmPostinstallCheck
   }
 };

--- a/eng/clipack/npm/aspire.js
+++ b/eng/clipack/npm/aspire.js
@@ -12,6 +12,14 @@ const path = require('path');
 // friendly error path used by the rest of the launcher (try/catch around main).
 let ridPackageNames = null;
 
+function getRidPackageNames() {
+  if (ridPackageNames === null) {
+    ridPackageNames = loadRidPackageNames();
+  }
+
+  return ridPackageNames;
+}
+
 function loadRidPackageNames() {
   const packageMapPath = path.join(__dirname, 'aspire-package-map.json');
   let raw;
@@ -117,8 +125,13 @@ function isMusl() {
   return false;
 }
 
-function resolveNativeBinary(rid, expectedVersion) {
-  const packageName = ridPackageNames.get(rid);
+function optionalDependenciesInstallMessage(pointerPackageName) {
+  return `Reinstall ${pointerPackageName} without disabling npm optional dependencies ` +
+    '(do not use --omit=optional, --no-optional, or npm_config_optional=false).';
+}
+
+function resolveNativeBinary(rid, expectedVersion, pointerPackageName) {
+  const packageName = getRidPackageNames().get(rid);
   if (!packageName) {
     throw new Error(`No Aspire CLI npm package is available for RID '${rid}'.`);
   }
@@ -136,7 +149,7 @@ function resolveNativeBinary(rid, expectedVersion) {
 
     throw new Error(
       `The Aspire CLI native package '${packageName}' was not installed. ` +
-      'Reinstall @microsoft/aspire-cli with optional dependencies enabled.',
+      optionalDependenciesInstallMessage(pointerPackageName),
       { cause: error });
   }
 
@@ -275,14 +288,19 @@ function needsCopy(sourcePath, targetPath) {
 }
 
 function main() {
-  // Lazy-initialize so a missing/corrupt aspire-package-map.json reaches the
-  // top-level try/catch and produces a friendly error instead of a Node stack.
-  if (ridPackageNames === null) {
-    ridPackageNames = loadRidPackageNames();
-  }
   const packageJson = require(path.join(__dirname, '..', 'package.json'));
+
+  if (process.argv[2] === '--npm-postinstall-check') {
+    // npm does not warn when users explicitly omit optional dependencies. Fail
+    // the top-level package install on supported platforms so the missing native
+    // RID package is reported during install instead of at first `aspire` launch.
+    const rid = detectRid();
+    resolveNativeBinary(rid, packageJson.version, packageJson.name);
+    return;
+  }
+
   const rid = detectRid();
-  const nativeBinary = resolveNativeBinary(rid, packageJson.version);
+  const nativeBinary = resolveNativeBinary(rid, packageJson.version, packageJson.name);
   const executablePath = ensureCachedBinary(nativeBinary.binaryPath, nativeBinary.binaryName, packageJson.version, rid);
 
   // Forward terminating signals to the child so programmatic `kill <wrapper>`

--- a/eng/scripts/pack-cli-npm-package.pointer.README.md
+++ b/eng/scripts/pack-cli-npm-package.pointer.README.md
@@ -27,7 +27,11 @@ The npm package installs a small JavaScript `aspire` launcher. The native platfo
 
 ## Quick start
 
-Start from a repo with one or more app projects:
+- New app: run `aspire new` to create an Aspire app from a template.
+- Existing repo: run `aspire init`, then `aspire run`.
+- Dashboard only: run `aspire dashboard run` to start the standalone dashboard.
+
+For an existing repo with one or more app projects:
 
 ```bash
 aspire init
@@ -162,6 +166,7 @@ npm install -g __PACKAGE_NAME__
 - [Aspire documentation](https://aspire.dev/docs/)
 - [Aspire CLI command reference](https://aspire.dev/reference/cli/commands/aspire/)
 - [Build your first app](https://aspire.dev/get-started/first-app/)
+- [Browse Aspire samples](https://aspire.dev/reference/samples/)
 - [Standalone dashboard](https://aspire.dev/dashboard/standalone/)
 - [Aspire repository](https://github.com/microsoft/aspire)
 - [Aspire samples repository](https://github.com/microsoft/aspire-samples)

--- a/eng/scripts/pack-cli-npm-package.pointer.README.md
+++ b/eng/scripts/pack-cli-npm-package.pointer.README.md
@@ -23,7 +23,7 @@ aspire --version
 aspire --help
 ```
 
-The npm package installs a small JavaScript `aspire` launcher. The native platform packages are installed through npm optional dependencies. The launcher selects the package that matches your OS, CPU, and Linux libc. Do not install this package with optional dependencies disabled, or the launcher will not be able to find the native CLI binary.
+The npm package installs a small JavaScript `aspire` launcher. The native platform packages are installed through npm optional dependencies. The launcher selects the package that matches your OS, CPU, and Linux libc. Do not install this package with optional dependencies disabled, or installation fails because the launcher cannot find the native CLI binary.
 
 ## Quick start
 
@@ -134,7 +134,7 @@ npm uninstall -g __PACKAGE_NAME__
 
 ### Optional dependencies disabled
 
-If the launcher says the native package was not installed, reinstall without `--omit=optional`, `--no-optional`, or the `npm_config_optional=false` environment variable:
+If installation fails or the launcher says the native package was not installed, reinstall without `--omit=optional`, `--no-optional`, or the `npm_config_optional=false` environment variable:
 
 ```bash
 npm install -g __PACKAGE_NAME__

--- a/eng/scripts/pack-cli-npm-package.pointer.README.md
+++ b/eng/scripts/pack-cli-npm-package.pointer.README.md
@@ -1,12 +1,51 @@
 # __PACKAGE_NAME__
 
-The Aspire CLI, published for npm-based installs.
+The Aspire CLI for npm-based installs. Use it to create, run, publish, and deploy Aspire AppHosts from a terminal.
 
 ## What is Aspire?
 
-Your stack, streamlined. Aspire is a multi-language, code-first orchestration and observability layer for building, running, and deploying distributed applications.
+Aspire is a code-first app model for distributed applications. Your AppHost describes projects, containers, databases, caches, and their connections in code. `aspire run` starts the app locally and opens the Aspire dashboard with logs, traces, metrics, resources, and health checks.
 
-Use an AppHost to describe how services, frontends, containers, databases, caches, and connections fit together in code. The Aspire CLI runs the whole app locally, opens the OpenTelemetry dashboard for logs, traces, metrics, and health checks, and carries the same app model into deployment.
+## Install
+
+This package requires Node.js 20 or later.
+
+Supported platforms: Windows x64/Arm64, macOS x64/Arm64, Linux x64/Arm64 with glibc, and Linux x64 with musl/Alpine.
+
+```bash
+npm install -g __PACKAGE_NAME__
+```
+
+Then verify the install:
+
+```bash
+aspire --version
+aspire --help
+```
+
+The npm package installs a small JavaScript `aspire` launcher. The native platform packages are installed through npm optional dependencies. The launcher selects the package that matches your OS, CPU, and Linux libc. Do not install this package with optional dependencies disabled, or the launcher will not be able to find the native CLI binary.
+
+## Quick start
+
+Start from a repo with one or more app projects:
+
+```bash
+aspire init
+aspire run
+```
+
+Starting from scratch? See [Build your first app](https://aspire.dev/get-started/first-app/).
+
+## Useful commands
+
+- `aspire new` creates a new Aspire app from a template.
+- `aspire init` adds an AppHost to an existing repo.
+- `aspire add <integration>` installs integrations such as PostgreSQL or Redis.
+- `aspire run` starts the AppHost and opens the dashboard.
+- `aspire publish` prepares deployment artifacts from the AppHost model.
+- `aspire deploy` deploys an AppHost to its supported deployment targets.
+- `aspire dashboard run` starts only the dashboard for apps that already export OpenTelemetry.
+- `aspire --help` and `aspire <command> --help` show the current command options.
 
 ## Standalone dashboard
 
@@ -75,31 +114,9 @@ await builder.build().run();
 
 `addPostgres` and `addRedis` become available once the matching integrations are installed with `aspire add postgresql` and `aspire add redis`.
 
-## Install
+## Update or uninstall
 
-This package requires Node.js 20 or later.
-
-```bash
-npm install -g __PACKAGE_NAME__
-```
-
-Then verify the install:
-
-```bash
-aspire --version
-aspire --help
-```
-
-Start from a repo with one or more app projects:
-
-```bash
-aspire init
-aspire run
-```
-
-The native platform packages are installed through npm optional dependencies. Do not install this package with optional dependencies disabled, or the `aspire` launcher will not be able to find the native CLI binary.
-
-## Update
+Update to the latest npm release:
 
 ```bash
 npm install -g __PACKAGE_NAME__@latest
@@ -107,9 +124,46 @@ npm install -g __PACKAGE_NAME__@latest
 
 If you run `aspire update --self` from an npm install, the CLI points you back to this npm update command.
 
+Uninstall the npm package:
+
+```bash
+npm uninstall -g __PACKAGE_NAME__
+```
+
+## Troubleshooting
+
+### Optional dependencies disabled
+
+If the launcher says the native package was not installed, reinstall without `--omit=optional`, `--no-optional`, or the `npm_config_optional=false` environment variable:
+
+```bash
+npm install -g __PACKAGE_NAME__
+```
+
+### PATH cannot find `aspire`
+
+Make sure your shell can see npm's global executable directory. `npm prefix -g` shows the global prefix; on macOS and Linux the `aspire` shim is usually under the prefix's `bin` directory. On Windows it is usually under the npm directory in your user profile.
+
+### Supported platforms and architectures
+
+The npm package currently ships native binaries for Windows x64/Arm64, macOS x64/Arm64, Linux x64/Arm64 with glibc, and Linux x64 with musl/Alpine. Other platforms are not supported by this package.
+
+### Corrupted or mismatched install
+
+If the launcher reports a corrupted package, mismatched native package version, or missing native binary, reinstall the package:
+
+```bash
+npm uninstall -g __PACKAGE_NAME__
+npm install -g __PACKAGE_NAME__
+```
+
 ## Learn more
 
-- [Documentation](https://aspire.dev/docs/)
+- [Aspire documentation](https://aspire.dev/docs/)
+- [Aspire CLI command reference](https://aspire.dev/reference/cli/commands/aspire/)
 - [Build your first app](https://aspire.dev/get-started/first-app/)
+- [Standalone dashboard](https://aspire.dev/dashboard/standalone/)
 - [Aspire repository](https://github.com/microsoft/aspire)
 - [Aspire samples repository](https://github.com/microsoft/aspire-samples)
+- [Release notes](https://github.com/microsoft/aspire/releases)
+- [Report an issue](https://github.com/microsoft/aspire/issues)

--- a/eng/scripts/pack-cli-npm-package.ps1
+++ b/eng/scripts/pack-cli-npm-package.ps1
@@ -221,6 +221,9 @@ $pointerPackageJson = [ordered]@{
   bin = [ordered]@{
     aspire = 'bin/aspire.js'
   }
+  scripts = [ordered]@{
+    postinstall = 'node bin/aspire.js --npm-postinstall-check'
+  }
   # Minimum Node 20: the launcher (`bin/aspire.js`) uses Error options-bag
   # `new Error(msg, { cause: err })` which was added in Node 16.9.0. The
   # `libc` selector in the per-RID optionalDependencies relies on

--- a/eng/scripts/verify-cli-npm-package.ps1
+++ b/eng/scripts/verify-cli-npm-package.ps1
@@ -178,6 +178,10 @@ try {
     throw "Pointer package must expose the aspire bin at bin/aspire.js."
   }
 
+  if (-not $pointerPackageJson.scripts -or $pointerPackageJson.scripts.postinstall -ne 'node bin/aspire.js --npm-postinstall-check') {
+    throw "Pointer package must verify the native RID package during postinstall."
+  }
+
   if (-not (Test-Path -LiteralPath (Join-Path $pointerExtract 'package/bin/aspire.js'))) {
     throw "Pointer package is missing bin/aspire.js."
   }

--- a/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
@@ -182,10 +182,22 @@ public sealed class NpmCliPackageTests : IDisposable
 
         var readme = await File.ReadAllTextAsync(Path.Combine(package.PointerPackageRoot, "README.md"));
         Assert.Equal(await RenderTemplateAsync("eng/scripts/pack-cli-npm-package.pointer.README.md", ("PACKAGE_NAME", PackageName)), readme);
+        Assert.Contains("Use it to create, run, publish, and deploy Aspire AppHosts from a terminal.", readme);
         Assert.Contains("This package requires Node.js 20 or later.", readme);
+        Assert.Contains("Supported platforms:", readme);
         Assert.Contains($"npm install -g {PackageName}", readme);
+        Assert.Contains($"npm install -g {PackageName}@latest", readme);
         Assert.Contains("The native platform packages are installed through npm optional dependencies.", readme);
         Assert.Contains("If you run `aspire update --self` from an npm install, the CLI points you back to this npm update command.", readme);
+        Assert.Contains($"npm uninstall -g {PackageName}", readme);
+        Assert.Contains("## Troubleshooting", readme);
+        Assert.Contains("Optional dependencies disabled", readme);
+        Assert.Contains("the `npm_config_optional=false` environment variable", readme);
+        Assert.Contains("PATH cannot find `aspire`", readme);
+        Assert.Contains("Supported platforms and architectures", readme);
+        Assert.Contains("## Useful commands", readme);
+        Assert.Contains("`aspire deploy` deploys an AppHost to its supported deployment targets.", readme);
+        Assert.Contains("Aspire CLI command reference", readme);
         Assert.Contains("TypeScript AppHost (`apphost.mts`)", readme);
         Assert.Contains("import { createBuilder } from './.aspire/modules/aspire.mjs';", readme);
         Assert.Contains("aspire dashboard run", readme);

--- a/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
@@ -209,6 +209,16 @@ public sealed class NpmCliPackageTests : IDisposable
         Assert.DoesNotContain("```csharp", readme);
     }
 
+    [Fact]
+    public async Task PointerPackageReadmeSupportedPlatformTextMatchesSupportedRidMatrix()
+    {
+        var readme = await RenderTemplateAsync("eng/scripts/pack-cli-npm-package.pointer.README.md", ("PACKAGE_NAME", PackageName));
+        var supportedPlatformText = GetExpectedSupportedPlatformText();
+
+        Assert.Contains($"Supported platforms: {supportedPlatformText}.", readme);
+        Assert.Contains($"The npm package currently ships native binaries for {supportedPlatformText}. Other platforms are not supported by this package.", readme);
+    }
+
     [Theory]
     [MemberData(nameof(GetSupportedRidData))]
     [RequiresTools(["pwsh", "npm"])]
@@ -414,6 +424,89 @@ public sealed class NpmCliPackageTests : IDisposable
         return template;
     }
 
+    private static string GetExpectedSupportedPlatformText()
+    {
+        var platformGroups = new[]
+        {
+            new PlatformDescription("win32", null, "Windows", null),
+            new PlatformDescription("darwin", null, "macOS", null),
+            new PlatformDescription("linux", "glibc", "Linux", "with glibc"),
+            new PlatformDescription("linux", "musl", "Linux", "with musl/Alpine")
+        };
+
+        var describedRids = new HashSet<string>(StringComparer.Ordinal);
+        var descriptions = new List<string>();
+
+        foreach (var group in platformGroups)
+        {
+            var matchingRids = s_supportedRids
+                .Where(rid => rid.Os.Contains(group.Os, StringComparer.Ordinal) && HasLibc(rid, group.Libc))
+                .ToArray();
+
+            if (matchingRids.Length == 0)
+            {
+                continue;
+            }
+
+            foreach (var rid in matchingRids)
+            {
+                describedRids.Add(rid.Rid);
+            }
+
+            var cpuText = string.Join(
+                '/',
+                matchingRids
+                    .SelectMany(rid => rid.Cpu)
+                    .Distinct(StringComparer.Ordinal)
+                    .OrderBy(GetCpuDisplayOrder)
+                    .Select(FormatCpuName));
+            descriptions.Add(group.LibcDescription is null ? $"{group.Name} {cpuText}" : $"{group.Name} {cpuText} {group.LibcDescription}");
+        }
+
+        Assert.Equal(
+            s_supportedRids.Select(rid => rid.Rid).Order(StringComparer.Ordinal),
+            describedRids.Order(StringComparer.Ordinal));
+
+        return JoinDescriptions(descriptions);
+    }
+
+    private static bool HasLibc(RidPackageExpectation rid, string? libc)
+    {
+        return libc is null
+            ? rid.Libc is null
+            : rid.Libc?.Contains(libc, StringComparer.Ordinal) == true;
+    }
+
+    private static string FormatCpuName(string cpu)
+    {
+        return cpu switch
+        {
+            "arm64" => "Arm64",
+            _ => cpu
+        };
+    }
+
+    private static int GetCpuDisplayOrder(string cpu)
+    {
+        return cpu switch
+        {
+            "x64" => 0,
+            "arm64" => 1,
+            _ => 2
+        };
+    }
+
+    private static string JoinDescriptions(IReadOnlyList<string> descriptions)
+    {
+        return descriptions.Count switch
+        {
+            0 => throw new InvalidOperationException("Expected at least one supported npm CLI platform."),
+            1 => descriptions[0],
+            2 => $"{descriptions[0]} and {descriptions[1]}",
+            _ => $"{string.Join(", ", descriptions.Take(descriptions.Count - 1))}, and {descriptions[^1]}"
+        };
+    }
+
     private static JsonObject ReadJsonObject(string path)
     {
         var json = File.ReadAllText(path);
@@ -477,6 +570,8 @@ public sealed class NpmCliPackageTests : IDisposable
     }
 
     public sealed record RidPackageExpectation(string Rid, string BinaryName, string[] Os, string[] Cpu, string[]? Libc);
+
+    private sealed record PlatformDescription(string Os, string? Libc, string Name, string? LibcDescription);
 
     private sealed record PackedNpmPackage(string RidPackageRoot, string PointerPackageRoot);
 }

--- a/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
@@ -156,6 +156,42 @@ public sealed class NpmCliPackageTests : IDisposable
     }
 
     [Fact]
+    [RequiresTools(["node"])]
+    public async Task LauncherPostinstallCheckSucceedsWhenNativePackageIsInstalled()
+    {
+        var pointerPackageRoot = await CreateFakeNpmInstallAsync(includeRidPackages: true);
+
+        using var cmd = new NodeCommand(_output)
+            .WithTimeout(TimeSpan.FromSeconds(30));
+
+        var result = await cmd.ExecuteScriptAsync(
+            Path.Combine(pointerPackageRoot, "bin", "aspire.js"),
+            "--npm-postinstall-check");
+
+        result.EnsureSuccessful();
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task LauncherPostinstallCheckExplainsDisabledOptionalDependencies()
+    {
+        var pointerPackageRoot = await CreateFakeNpmInstallAsync(includeRidPackages: false);
+
+        using var cmd = new NodeCommand(_output)
+            .WithTimeout(TimeSpan.FromSeconds(30));
+
+        var result = await cmd.ExecuteScriptAsync(
+            Path.Combine(pointerPackageRoot, "bin", "aspire.js"),
+            "--npm-postinstall-check");
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("without disabling npm optional dependencies", result.Output);
+        Assert.Contains("--omit=optional", result.Output);
+        Assert.Contains("--no-optional", result.Output);
+        Assert.Contains("npm_config_optional=false", result.Output);
+    }
+
+    [Fact]
     [RequiresTools(["pwsh", "npm"])]
     public async Task PackScriptGeneratesPointerPackageMetadataMapAndReadme()
     {
@@ -171,6 +207,7 @@ public sealed class NpmCliPackageTests : IDisposable
             ["aspire", "typescript", "dotnet", "apphost", "polyglot", "distributed-applications", "code-first", "orchestration", "observability", "opentelemetry", "local-development"],
             GetStringArray(packageJson["keywords"]));
         Assert.Equal(">=20", GetString(GetObject(packageJson, "engines"), "node"));
+        Assert.Equal("node bin/aspire.js --npm-postinstall-check", GetString(GetObject(packageJson, "scripts"), "postinstall"));
         Assert.Equal(
             s_supportedRids.ToDictionary(rid => $"{PackageName}-{rid.Rid}", _ => PackageVersion, StringComparer.Ordinal),
             GetStringMap(GetObject(packageJson, "optionalDependencies")));
@@ -188,10 +225,12 @@ public sealed class NpmCliPackageTests : IDisposable
         Assert.Contains($"npm install -g {PackageName}", readme);
         Assert.Contains($"npm install -g {PackageName}@latest", readme);
         Assert.Contains("The native platform packages are installed through npm optional dependencies.", readme);
+        Assert.Contains("installation fails because the launcher cannot find the native CLI binary", readme);
         Assert.Contains("If you run `aspire update --self` from an npm install, the CLI points you back to this npm update command.", readme);
         Assert.Contains($"npm uninstall -g {PackageName}", readme);
         Assert.Contains("## Troubleshooting", readme);
         Assert.Contains("Optional dependencies disabled", readme);
+        Assert.Contains("If installation fails or the launcher says the native package was not installed", readme);
         Assert.Contains("the `npm_config_optional=false` environment variable", readme);
         Assert.Contains("PATH cannot find `aspire`", readme);
         Assert.Contains("Supported platforms and architectures", readme);
@@ -370,6 +409,60 @@ public sealed class NpmCliPackageTests : IDisposable
 
     private Task<string> ReadRepoFileAsync(string relativePath)
         => File.ReadAllTextAsync(Path.Combine(_repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+
+    private async Task<string> CreateFakeNpmInstallAsync(bool includeRidPackages)
+    {
+        var testRoot = Path.Combine(_tempDirectory.Path, Path.GetRandomFileName());
+        var nodeModulesRoot = Path.Combine(testRoot, "node_modules");
+        var pointerPackageRoot = Path.Combine(nodeModulesRoot, "@microsoft", "aspire-cli");
+        var pointerBinRoot = Path.Combine(pointerPackageRoot, "bin");
+        Directory.CreateDirectory(pointerBinRoot);
+
+        File.Copy(
+            Path.Combine(_repoRoot, "eng", "clipack", "npm", "aspire.js"),
+            Path.Combine(pointerBinRoot, "aspire.js"));
+
+        await File.WriteAllTextAsync(
+            Path.Combine(pointerPackageRoot, "package.json"),
+            $$"""
+            {
+              "name": "{{PackageName}}",
+              "version": "{{PackageVersion}}"
+            }
+            """);
+
+        var packageMap = new JsonObject();
+        foreach (var rid in s_supportedRids)
+        {
+            packageMap[rid.Rid] = $"{PackageName}-{rid.Rid}";
+        }
+
+        await File.WriteAllTextAsync(Path.Combine(pointerBinRoot, "aspire-package-map.json"), packageMap.ToJsonString());
+
+        if (includeRidPackages)
+        {
+            foreach (var rid in s_supportedRids)
+            {
+                var ridPackageRoot = Path.Combine(nodeModulesRoot, "@microsoft", $"aspire-cli-{rid.Rid}");
+                var ridBinRoot = Path.Combine(ridPackageRoot, "bin");
+                Directory.CreateDirectory(ridBinRoot);
+
+                await File.WriteAllTextAsync(
+                    Path.Combine(ridPackageRoot, "package.json"),
+                    $$"""
+                    {
+                      "name": "{{PackageName}}-{{rid.Rid}}",
+                      "version": "{{PackageVersion}}"
+                    }
+                    """);
+
+                await File.WriteAllTextAsync(Path.Combine(ridBinRoot, "aspire"), "native binary stub");
+                await File.WriteAllTextAsync(Path.Combine(ridBinRoot, "aspire.exe"), "native binary stub");
+            }
+        }
+
+        return pointerPackageRoot;
+    }
 
     public static TheoryData<RidPackageExpectation> GetSupportedRidData()
     {

--- a/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
@@ -173,22 +173,70 @@ public sealed class NpmCliPackageTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
-    public async Task LauncherPostinstallCheckExplainsDisabledOptionalDependencies()
+    public async Task LauncherPostinstallCheckExplainsDisabledOptionalDependenciesOnSupportedPlatform()
     {
         var pointerPackageRoot = await CreateFakeNpmInstallAsync(includeRidPackages: false);
+        var testScriptPath = Path.Combine(_tempDirectory.Path, $"{Path.GetRandomFileName()}.js");
+        await File.WriteAllTextAsync(
+            testScriptPath,
+            """
+            const launcher = require(process.argv[2]);
+
+            try {
+              launcher.__testing.runNpmPostinstallCheck(
+                { name: process.argv[3], version: process.argv[4] },
+                () => process.argv[5]);
+              console.error('Expected postinstall check to fail.');
+              process.exit(1);
+            } catch (error) {
+              console.log(error.message);
+            }
+            """);
 
         using var cmd = new NodeCommand(_output)
             .WithTimeout(TimeSpan.FromSeconds(30));
 
         var result = await cmd.ExecuteScriptAsync(
+            testScriptPath,
             Path.Combine(pointerPackageRoot, "bin", "aspire.js"),
-            "--npm-postinstall-check");
+            PackageName,
+            PackageVersion,
+            "linux-x64");
 
-        Assert.Equal(1, result.ExitCode);
+        result.EnsureSuccessful();
+
         Assert.Contains("without disabling npm optional dependencies", result.Output);
         Assert.Contains("--omit=optional", result.Output);
         Assert.Contains("--no-optional", result.Output);
         Assert.Contains("npm_config_optional=false", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task LauncherPostinstallCheckSkipsUnsupportedPlatform()
+    {
+        var pointerPackageRoot = await CreateFakeNpmInstallAsync(includeRidPackages: false);
+        var testScriptPath = Path.Combine(_tempDirectory.Path, $"{Path.GetRandomFileName()}.js");
+        await File.WriteAllTextAsync(
+            testScriptPath,
+            """
+            const launcher = require(process.argv[2]);
+
+            launcher.__testing.runNpmPostinstallCheck(
+              { name: process.argv[3], version: process.argv[4] },
+              () => launcher.__testing.detectRid('linux', 'arm64', true));
+            """);
+
+        using var cmd = new NodeCommand(_output)
+            .WithTimeout(TimeSpan.FromSeconds(30));
+
+        var result = await cmd.ExecuteScriptAsync(
+            testScriptPath,
+            Path.Combine(pointerPackageRoot, "bin", "aspire.js"),
+            PackageName,
+            PackageVersion);
+
+        result.EnsureSuccessful();
     }
 
     [Fact]
@@ -232,6 +280,9 @@ public sealed class NpmCliPackageTests : IDisposable
         Assert.Contains("Optional dependencies disabled", readme);
         Assert.Contains("If installation fails or the launcher says the native package was not installed", readme);
         Assert.Contains("the `npm_config_optional=false` environment variable", readme);
+        Assert.Contains("New app:", readme);
+        Assert.Contains("Existing repo:", readme);
+        Assert.Contains("Dashboard only:", readme);
         Assert.Contains("PATH cannot find `aspire`", readme);
         Assert.Contains("Supported platforms and architectures", readme);
         Assert.Contains("## Useful commands", readme);
@@ -240,6 +291,7 @@ public sealed class NpmCliPackageTests : IDisposable
         Assert.Contains("TypeScript AppHost (`apphost.mts`)", readme);
         Assert.Contains("import { createBuilder } from './.aspire/modules/aspire.mjs';", readme);
         Assert.Contains("aspire dashboard run", readme);
+        Assert.Contains("Browse Aspire samples", readme);
         Assert.DoesNotContain("apphost.ts", readme);
         Assert.DoesNotContain("./.aspire/modules/aspire.js", readme);
         Assert.DoesNotContain("__PACKAGE_NAME__", readme);


### PR DESCRIPTION
## Description

The npm package README is the first thing users see if they find `@microsoft/aspire-cli` on npm, so this makes it stand on its own a bit better. It now explains what Aspire is, how the npm launcher/native package split works, and what to do after install.

This also adds a top-level npm `postinstall` verification path. npm does not warn when optional dependencies are explicitly omitted, so the generated pointer package now runs `node bin/aspire.js --npm-postinstall-check` during install. On supported platforms, that fails immediately with the optional-dependencies guidance if the matching native RID package is missing. Unsupported platforms still install the shim successfully and report the unsupported-platform diagnostic only when `aspire` is launched, preserving the optional-dependency package behavior.

Fixes #18013

### User-facing usage

The generated npm README now includes install, verify, quick-start, update, uninstall, troubleshooting, and link sections. For example:

```bash
npm install -g @microsoft/aspire-cli
aspire --version
aspire init
aspire run
```

It also calls out Node.js 20+, supported OS/architecture combinations, optional dependency requirements, PATH guidance, and reinstall guidance for corrupted or mismatched native packages.

Implementation-wise, the generated README source remains `eng/scripts/pack-cli-npm-package.pointer.README.md`. The generated pointer package metadata declares the postinstall script, and the launcher owns the `--npm-postinstall-check` behavior.

Validation:

```bash
./restore.sh
MSBUILDTERMINALLOGGER=false dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- --filter-class "*.NpmCliPackageTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
