### PR TITLE
Draft: Add AppHost target version telemetry (automated)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -36,6 +36,8 @@
     "onDebugInitialConfigurations:aspire",
     "onDebugDynamicConfigurations:aspire",
     "workspaceContains:**/*.csproj",
+    "workspaceContains:**/*.fsproj",
+    "workspaceContains:**/*.vbproj",
     "workspaceContains:**/aspire.config.json",
     "workspaceContains:**/.aspire/**",
     "onView:workbench.view.debug",

--- a/extension/src/debugger/AspireDebugConfigurationMetadata.ts
+++ b/extension/src/debugger/AspireDebugConfigurationMetadata.ts
@@ -1,0 +1,1 @@
+export const appHostTelemetryTargetPathConfigKey = '__aspireAppHostTelemetryTargetPath';

--- a/extension/src/debugger/AspireDebugConfigurationProvider.ts
+++ b/extension/src/debugger/AspireDebugConfigurationProvider.ts
@@ -4,6 +4,7 @@ import { AppHostDiscoveryService, getDebugTargetForCandidate } from '../utils/ap
 import type { CandidateAppHostDisplayInfo } from '../utils/appHostDiscovery';
 import { checkCliAvailableOrRedirect } from '../utils/workspace';
 import { extensionLogOutputChannel } from '../utils/logging';
+import { appHostTelemetryTargetPathConfigKey } from './AspireDebugConfigurationMetadata';
 
 export class AspireDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
     constructor(private readonly _appHostDiscoveryService: AppHostDiscoveryService) {
@@ -65,7 +66,16 @@ export class AspireDebugConfigurationProvider implements vscode.DebugConfigurati
 
     async resolveDebugConfigurationWithSubstitutedVariables(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | null | undefined> {
         if (typeof config.program === 'string') {
-            config.program = await this.resolveDebugTarget(config.program, folder);
+            const program = config.program;
+            config.program = await this.resolveDebugTarget(program, folder);
+
+            const telemetryTarget = await this.tryFindWorkspaceDefaultCandidate(program, folder);
+            if (telemetryTarget) {
+                config[appHostTelemetryTargetPathConfigKey] = telemetryTarget.path;
+            }
+            else {
+                delete config[appHostTelemetryTargetPathConfigKey];
+            }
         }
 
         return config;
@@ -88,6 +98,16 @@ export class AspireDebugConfigurationProvider implements vscode.DebugConfigurati
         catch (error) {
             extensionLogOutputChannel.warn(`Failed to resolve AppHost debug target ${filePath}: ${error}`);
             return filePath;
+        }
+    }
+
+    private async tryFindWorkspaceDefaultCandidate(filePath: string, folder: vscode.WorkspaceFolder | undefined): Promise<CandidateAppHostDisplayInfo | undefined> {
+        try {
+            return await this._appHostDiscoveryService.tryFindWorkspaceDefaultCandidate(filePath, folder);
+        }
+        catch (error) {
+            extensionLogOutputChannel.warn(`Failed to discover workspace AppHost telemetry target ${filePath}: ${error}`);
+            return undefined;
         }
     }
 

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -22,6 +22,7 @@ import os from "os";
 import { EnvironmentVariables } from "../utils/environment";
 import { sendTelemetryEvent } from "../utils/telemetry";
 import { classifyAppHostPath, classifyAppHostDirectory } from "../utils/appHostLanguage";
+import { getAppHostTargetVersion } from "../utils/appHostTargetVersion";
 import type { AspireDebugConsoleOutputEvent } from "../types/extensionApi";
 
 export type DashboardBrowserType = 'openExternalBrowser' | 'integratedBrowser' | 'debugChrome' | 'debugEdge' | 'debugFirefox';
@@ -76,6 +77,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
   // Tracks the AppHost-language classification of the launched program so it can
   // be repeated on the matching end event without re-deriving from `configuration`.
   private _appHostLanguageAtLaunch: 'csharp' | 'typescript' | 'unknown' = 'unknown';
+  private _appHostTargetVersionAtLaunch = 'unknown';
   // Mode the AppHost was launched with (`run` | `debug`) — captured for the
   // matching end event.
   private _appHostModeAtLaunch: 'run' | 'debug' = 'run';
@@ -153,6 +155,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       this._appHostLanguageAtLaunch = appHostIsDirectory
         ? classifyAppHostDirectory(appHostPath)
         : classifyAppHostPath(appHostPath);
+      this._appHostTargetVersionAtLaunch = getAppHostTargetVersion(appHostPath) ?? 'unknown';
       this._appHostModeAtLaunch = noDebug ? 'run' : 'debug';
       // `command` originates in the user's launch.json and is typed in the
       // contributing extension surface as AspireCommandType ('run'|'deploy'|
@@ -164,6 +167,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       sendTelemetryEvent('debug/apphost/start', {
         mode: this._appHostModeAtLaunch,
         apphost_language: this._appHostLanguageAtLaunch,
+        apphost_target_version: this._appHostTargetVersionAtLaunch,
         apphost_is_directory: appHostIsDirectory ? 'true' : 'false',
         command: commandForTelemetry,
       });
@@ -688,6 +692,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     const startMs = this._appHostStartTimeMs;
     const mode = this._appHostModeAtLaunch;
     const language = this._appHostLanguageAtLaunch;
+    const targetVersion = this._appHostTargetVersionAtLaunch;
     const debugSessionId = this.debugSessionId;
     const dcpServer = this._dcpServer;
 
@@ -716,6 +721,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
         sendTelemetryEvent('debug/apphost/end', {
           mode,
           apphost_language: language,
+          apphost_target_version: targetVersion,
           ended_with_error: aggregate?.anyNonZeroExit ? 'true' : 'false',
           distinct_resource_types: aggregate ? aggregate.distinctResourceTypes.join(',') : '',
         }, {

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -202,15 +202,20 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     // Append any additional command args forwarded from the CLI (e.g., step name for 'do', unmatched tokens)
     const commandArgs = this.configuration.args ?? [];
     const appHostPath = this._session.configuration.program as string;
-    // Telemetry: emit `debug/apphost/start` once per AppHost launch. We do it
-    // here (rather than in the constructor) because the constructor runs
-    // before VS Code's debug-launch UX completes; this branch is the single
-    // entry point that triggers an actual CLI spawn. The matching end event
-    // is emitted from dispose().
-    this._appHostModeAtLaunch = noDebug ? 'run' : 'debug';
-
-    const appHostIsDirectory = await this.isDirectory(appHostPath);
     const extensionArgs: string[] = [];
+    // Telemetry: emit `debug/apphost/start` once per AppHost launch. This must
+    // happen before any awaited filesystem metadata work because child
+    // `debug/runsession/start` events can arrive immediately after CLI spawn.
+    // Values that need async enrichment start as bounded sentinel values here
+    // and are resolved in the background for the matching end event.
+    this._appHostStartTimeMs = Date.now();
+    this._appHostModeAtLaunch = noDebug ? 'run' : 'debug';
+    // Before the filesystem probe below, the file extension is the only language
+    // signal available. Directory-launched AppHosts report `unknown` on start
+    // telemetry and are enriched on the matching end event.
+    this._appHostLanguageAtLaunch = classifyAppHostPath(appHostPath);
+    this._appHostTargetVersionAtLaunch = 'unknown';
+    this._appHostTargetVersionAtLaunchPromise = this.resolveAppHostTargetVersionAtLaunch(appHostPath);
     // `command` originates in the user's launch.json and is typed in the
     // contributing extension surface as AspireCommandType ('run'|'deploy'|
     // 'publish'|'do'), but launch.json is freeform JSON — a typo or custom
@@ -218,18 +223,18 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     // set so the dimension stays bounded.
     const knownCommands: ReadonlySet<string> = new Set(['run', 'deploy', 'publish', 'do']);
     const commandForTelemetry = knownCommands.has(command) ? command : 'other';
-    this._appHostLanguageAtLaunchPromise = this.resolveAppHostLanguageAtLaunch(appHostPath, appHostIsDirectory);
-    this._appHostTargetVersionAtLaunchPromise = this.resolveAppHostTargetVersionAtLaunch(appHostPath);
-    this._appHostStartTimeMs = Date.now();
-    void Promise.all([this._appHostLanguageAtLaunchPromise, this._appHostTargetVersionAtLaunchPromise]).then(([appHostLanguage, appHostTargetVersion]) => {
-      sendTelemetryEvent('debug/apphost/start', {
-        mode: this._appHostModeAtLaunch,
-        apphost_language: appHostLanguage,
-        apphost_target_version: appHostTargetVersion,
-        apphost_is_directory: appHostIsDirectory ? 'true' : 'false',
-        command: commandForTelemetry,
-      });
+    sendTelemetryEvent('debug/apphost/start', {
+      mode: this._appHostModeAtLaunch,
+      apphost_language: this._appHostLanguageAtLaunch,
+      apphost_target_version: this._appHostTargetVersionAtLaunch,
+      // The true directory/file answer requires fs.stat; keep start telemetry
+      // ahead of filesystem work so child debug telemetry cannot overtake it.
+      apphost_is_directory: 'unknown',
+      command: commandForTelemetry,
     });
+
+    const appHostIsDirectory = await this.isDirectory(appHostPath);
+    this._appHostLanguageAtLaunchPromise = this.resolveAppHostLanguageAtLaunch(appHostPath, appHostIsDirectory);
 
     // For 'do' with an explicit step (old CLI fallback), pass it as a positional argument
     const step = this.configuration.step;

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -773,6 +773,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     if (startMs !== undefined) {
       setTimeout(() => {
         void (async () => {
+          const durationMs = Date.now() - startMs;
           const resolvedLanguage = await languagePromise ?? language;
           const resolvedTargetVersion = await targetVersionPromise ?? targetVersion;
           const aggregate = dcpServer.takeDebugSessionAggregateStats(debugSessionId);
@@ -784,7 +785,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
             ended_with_error: aggregate?.anyNonZeroExit ? 'true' : 'false',
             distinct_resource_types: aggregate ? aggregate.distinctResourceTypes.join(',') : '',
           }, {
-            duration_ms: Date.now() - startMs,
+            duration_ms: durationMs,
             total_child_sessions: aggregate?.totalChildSessions ?? 0,
             distinct_resource_type_count: aggregate?.distinctResourceTypes.length ?? 0,
           });

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -211,8 +211,9 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     // Telemetry: emit `debug/apphost/start` once per AppHost launch. This must
     // happen before any awaited filesystem metadata work because child
     // `debug/runsession/start` events can arrive immediately after CLI spawn.
-    // Values that need async enrichment start as bounded sentinel values here
-    // and are resolved in the background for the matching end event.
+    // Values that need async enrichment are resolved in the background for the
+    // matching end event instead of being reported as permanently-unknown start
+    // dimensions.
     this._appHostStartTimeMs = Date.now();
     this._appHostModeAtLaunch = noDebug ? 'run' : 'debug';
     // Before the filesystem probe below, the file extension is the only language
@@ -232,10 +233,6 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     sendTelemetryEvent('debug/apphost/start', {
       mode: this._appHostModeAtLaunch,
       apphost_language: this._appHostLanguageAtLaunch,
-      apphost_target_version: this._appHostTargetVersionAtLaunch,
-      // The true directory/file answer requires fs.stat; keep start telemetry
-      // ahead of filesystem work so child debug telemetry cannot overtake it.
-      apphost_is_directory: 'unknown',
       command: commandForTelemetry,
     });
 

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -24,6 +24,7 @@ import { sendTelemetryEvent } from "../utils/telemetry";
 import { classifyAppHostPath, classifyAppHostDirectory } from "../utils/appHostLanguage";
 import { getAppHostTargetVersion } from "../utils/appHostTargetVersion";
 import type { AspireDebugConsoleOutputEvent } from "../types/extensionApi";
+import { appHostTelemetryTargetPathConfigKey } from "./AspireDebugConfigurationMetadata";
 
 export type DashboardBrowserType = 'openExternalBrowser' | 'integratedBrowser' | 'debugChrome' | 'debugEdge' | 'debugFirefox';
 
@@ -203,6 +204,9 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     // Append any additional command args forwarded from the CLI (e.g., step name for 'do', unmatched tokens)
     const commandArgs = this.configuration.args ?? [];
     const appHostPath = this._session.configuration.program as string;
+    const appHostTelemetryTargetPath = typeof this._session.configuration[appHostTelemetryTargetPathConfigKey] === 'string'
+      ? this._session.configuration[appHostTelemetryTargetPathConfigKey]
+      : undefined;
     const extensionArgs: string[] = [];
     // Telemetry: emit `debug/apphost/start` once per AppHost launch. This must
     // happen before any awaited filesystem metadata work because child
@@ -216,7 +220,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     // telemetry and are enriched on the matching end event.
     this._appHostLanguageAtLaunch = classifyAppHostPath(appHostPath);
     this._appHostTargetVersionAtLaunch = 'unknown';
-    this._appHostTargetVersionAtLaunchPromise = this.resolveAppHostTargetVersionAtLaunch(appHostPath);
+    this._appHostTargetVersionAtLaunchPromise = this.resolveAppHostTargetVersionAtLaunch(appHostTelemetryTargetPath ?? appHostPath);
     this._appHostIsDirectoryAtLaunch = 'unknown';
     // `command` originates in the user's launch.json and is typed in the
     // contributing extension surface as AspireCommandType ('run'|'deploy'|
@@ -241,7 +245,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     }
 
     this._appHostIsDirectoryAtLaunch = appHostIsDirectory ? 'true' : 'false';
-    this._appHostLanguageAtLaunchPromise = this.resolveAppHostLanguageAtLaunch(appHostPath, appHostIsDirectory);
+    this._appHostLanguageAtLaunchPromise = this.resolveAppHostLanguageAtLaunch(appHostPath, appHostIsDirectory, appHostTelemetryTargetPath);
 
     // For 'do' with an explicit step (old CLI fallback), pass it as a positional argument
     const step = this.configuration.step;
@@ -299,11 +303,14 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     }
   }
 
-  private async resolveAppHostLanguageAtLaunch(appHostPath: string | undefined, appHostIsDirectory: boolean): Promise<'csharp' | 'typescript' | 'unknown'> {
+  private async resolveAppHostLanguageAtLaunch(appHostPath: string | undefined, appHostIsDirectory: boolean, appHostTelemetryTargetPath: string | undefined): Promise<'csharp' | 'typescript' | 'unknown'> {
     try {
-      this._appHostLanguageAtLaunch = appHostIsDirectory
-        ? await classifyAppHostDirectory(appHostPath)
-        : classifyAppHostPath(appHostPath);
+      const telemetryTargetLanguage = classifyAppHostPath(appHostTelemetryTargetPath);
+      this._appHostLanguageAtLaunch = telemetryTargetLanguage !== 'unknown'
+        ? telemetryTargetLanguage
+        : (appHostIsDirectory
+          ? await classifyAppHostDirectory(appHostPath)
+          : classifyAppHostPath(appHostPath));
     }
     catch {
       // Telemetry enrichment must never break or delay the debug launch path.

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { EventEmitter } from "vscode";
-import * as fs from "fs";
+import { promises as fs } from "fs";
 import { createDebugAdapterTracker, AppHostOutputHandler, AppHostRestartHandler } from "./adapterTracker";
 import { AspireResourceExtendedDebugConfiguration, AspireResourceDebugSession, EnvVar, AspireExtendedDebugConfiguration, NodeLaunchConfiguration, ProjectLaunchConfiguration, StartAppHostOptions } from "../dcp/types";
 import { extensionLogOutputChannel } from "../utils/logging";
@@ -77,7 +77,11 @@ export class AspireDebugSession implements vscode.DebugAdapter {
   // Tracks the AppHost-language classification of the launched program so it can
   // be repeated on the matching end event without re-deriving from `configuration`.
   private _appHostLanguageAtLaunch: 'csharp' | 'typescript' | 'unknown' = 'unknown';
+  private _appHostLanguageAtLaunchPromise: Promise<'csharp' | 'typescript' | 'unknown'> | undefined = undefined;
+  // Resolving telemetry metadata can require project/config reads, so the launch
+  // path starts the work in the background and reuses the same result for start/end telemetry.
   private _appHostTargetVersionAtLaunch = 'unknown';
+  private _appHostTargetVersionAtLaunchPromise: Promise<string> | undefined = undefined;
   // Mode the AppHost was launched with (`run` | `debug`) — captured for the
   // matching end event.
   private _appHostModeAtLaunch: 'run' | 'debug' = 'run';
@@ -137,86 +141,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
         body: {}
       });
 
-      const command = this.configuration.command ?? 'run';
-      const noDebug = !!message.arguments?.noDebug && command === 'run';
-
-      // Append any additional command args forwarded from the CLI (e.g., step name for 'do', unmatched tokens)
-      const commandArgs = this.configuration.args ?? [];
-      const appHostPath = this._session.configuration.program as string;
-      const appHostIsDirectory = isDirectory(appHostPath);
-      const extensionArgs: string[] = [];
-
-      // Telemetry: emit `debug/apphost/start` once per AppHost launch. We do it
-      // here (rather than in the constructor) because the constructor runs
-      // before VS Code's debug-launch UX completes; this branch is the single
-      // entry point that triggers an actual CLI spawn. The matching end event
-      // is emitted from dispose().
-      this._appHostStartTimeMs = Date.now();
-      this._appHostLanguageAtLaunch = appHostIsDirectory
-        ? classifyAppHostDirectory(appHostPath)
-        : classifyAppHostPath(appHostPath);
-      this._appHostTargetVersionAtLaunch = getAppHostTargetVersion(appHostPath) ?? 'unknown';
-      this._appHostModeAtLaunch = noDebug ? 'run' : 'debug';
-      // `command` originates in the user's launch.json and is typed in the
-      // contributing extension surface as AspireCommandType ('run'|'deploy'|
-      // 'publish'|'do'), but launch.json is freeform JSON — a typo or custom
-      // value would otherwise leak verbatim into telemetry. Clamp to the known
-      // set so the dimension stays bounded.
-      const knownCommands: ReadonlySet<string> = new Set(['run', 'deploy', 'publish', 'do']);
-      const commandForTelemetry = knownCommands.has(command) ? command : 'other';
-      sendTelemetryEvent('debug/apphost/start', {
-        mode: this._appHostModeAtLaunch,
-        apphost_language: this._appHostLanguageAtLaunch,
-        apphost_target_version: this._appHostTargetVersionAtLaunch,
-        apphost_is_directory: appHostIsDirectory ? 'true' : 'false',
-        command: commandForTelemetry,
-      });
-
-      // For 'do' with an explicit step (old CLI fallback), pass it as a positional argument
-      const step = this.configuration.step;
-      if (command === 'do' && step && commandArgs.length === 0) {
-        extensionArgs.push(step);
-      }
-
-      // --start-debug-session tells the CLI to launch the AppHost via the extension with debugger attached
-      if (!noDebug) {
-        extensionArgs.push('--start-debug-session');
-      }
-
-      if (!commandArgs.includes('--nologo')) {
-        extensionArgs.push('--nologo');
-      }
-
-      if (process.env[EnvironmentVariables.ASPIRE_CLI_STOP_ON_ENTRY] === 'true') {
-        extensionArgs.push('--cli-wait-for-debugger');
-      }
-
-      if (process.env[EnvironmentVariables.ASPIRE_APPHOST_STOP_ON_ENTRY] === 'true') {
-        extensionArgs.push('--wait-for-debugger');
-      }
-
-      if (this._terminalProvider.isCliDebugLoggingEnabled()) {
-        extensionArgs.push('--debug');
-      }
-
-      if (!appHostIsDirectory) {
-        extensionArgs.push('--apphost', appHostPath);
-      }
-
-      const args = buildAspireCommandArgs(command, commandArgs, extensionArgs);
-      const commandLabel = `aspire ${command}`;
-
-      if (appHostIsDirectory) {
-        this.sendMessageWithEmoji("📁", launchingWithDirectory(appHostPath));
-
-        void this.spawnAspireCommand(args, appHostPath, noDebug, commandLabel);
-      }
-      else {
-        this.sendMessageWithEmoji("📂", launchingWithAppHost(appHostPath));
-
-        const workspaceFolder = path.dirname(appHostPath);
-        void this.spawnAspireCommand(args, workspaceFolder, noDebug, commandLabel);
-      }
+      void this.handleLaunchMessage(message);
     }
     else if (message.command === 'disconnect' || message.command === 'terminate') {
       this.sendMessageWithEmoji("🔌", disconnectingFromSession);
@@ -268,9 +193,124 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       });
     }
 
-    function isDirectory(pathToCheck: string): boolean {
-      return fs.existsSync(pathToCheck) && fs.statSync(pathToCheck).isDirectory();
+  }
+
+  private async handleLaunchMessage(message: any): Promise<void> {
+    const command = this.configuration.command ?? 'run';
+    const noDebug = !!message.arguments?.noDebug && command === 'run';
+
+    // Append any additional command args forwarded from the CLI (e.g., step name for 'do', unmatched tokens)
+    const commandArgs = this.configuration.args ?? [];
+    const appHostPath = this._session.configuration.program as string;
+    // Telemetry: emit `debug/apphost/start` once per AppHost launch. We do it
+    // here (rather than in the constructor) because the constructor runs
+    // before VS Code's debug-launch UX completes; this branch is the single
+    // entry point that triggers an actual CLI spawn. The matching end event
+    // is emitted from dispose().
+    this._appHostModeAtLaunch = noDebug ? 'run' : 'debug';
+
+    const appHostIsDirectory = await this.isDirectory(appHostPath);
+    const extensionArgs: string[] = [];
+    // `command` originates in the user's launch.json and is typed in the
+    // contributing extension surface as AspireCommandType ('run'|'deploy'|
+    // 'publish'|'do'), but launch.json is freeform JSON — a typo or custom
+    // value would otherwise leak verbatim into telemetry. Clamp to the known
+    // set so the dimension stays bounded.
+    const knownCommands: ReadonlySet<string> = new Set(['run', 'deploy', 'publish', 'do']);
+    const commandForTelemetry = knownCommands.has(command) ? command : 'other';
+    this._appHostLanguageAtLaunchPromise = this.resolveAppHostLanguageAtLaunch(appHostPath, appHostIsDirectory);
+    this._appHostTargetVersionAtLaunchPromise = this.resolveAppHostTargetVersionAtLaunch(appHostPath);
+    this._appHostStartTimeMs = Date.now();
+    void Promise.all([this._appHostLanguageAtLaunchPromise, this._appHostTargetVersionAtLaunchPromise]).then(([appHostLanguage, appHostTargetVersion]) => {
+      sendTelemetryEvent('debug/apphost/start', {
+        mode: this._appHostModeAtLaunch,
+        apphost_language: appHostLanguage,
+        apphost_target_version: appHostTargetVersion,
+        apphost_is_directory: appHostIsDirectory ? 'true' : 'false',
+        command: commandForTelemetry,
+      });
+    });
+
+    // For 'do' with an explicit step (old CLI fallback), pass it as a positional argument
+    const step = this.configuration.step;
+    if (command === 'do' && step && commandArgs.length === 0) {
+      extensionArgs.push(step);
     }
+
+    // --start-debug-session tells the CLI to launch the AppHost via the extension with debugger attached
+    if (!noDebug) {
+      extensionArgs.push('--start-debug-session');
+    }
+
+    if (!commandArgs.includes('--nologo')) {
+      extensionArgs.push('--nologo');
+    }
+
+    if (process.env[EnvironmentVariables.ASPIRE_CLI_STOP_ON_ENTRY] === 'true') {
+      extensionArgs.push('--cli-wait-for-debugger');
+    }
+
+    if (process.env[EnvironmentVariables.ASPIRE_APPHOST_STOP_ON_ENTRY] === 'true') {
+      extensionArgs.push('--wait-for-debugger');
+    }
+
+    if (this._terminalProvider.isCliDebugLoggingEnabled()) {
+      extensionArgs.push('--debug');
+    }
+
+    if (!appHostIsDirectory) {
+      extensionArgs.push('--apphost', appHostPath);
+    }
+
+    const args = buildAspireCommandArgs(command, commandArgs, extensionArgs);
+    const commandLabel = `aspire ${command}`;
+
+    if (appHostIsDirectory) {
+      this.sendMessageWithEmoji("📁", launchingWithDirectory(appHostPath));
+
+      void this.spawnAspireCommand(args, appHostPath, noDebug, commandLabel);
+    }
+    else {
+      this.sendMessageWithEmoji("📂", launchingWithAppHost(appHostPath));
+
+      const workspaceFolder = path.dirname(appHostPath);
+      void this.spawnAspireCommand(args, workspaceFolder, noDebug, commandLabel);
+    }
+  }
+
+  private async isDirectory(pathToCheck: string): Promise<boolean> {
+    try {
+      return (await fs.stat(pathToCheck)).isDirectory();
+    }
+    catch {
+      return false;
+    }
+  }
+
+  private async resolveAppHostLanguageAtLaunch(appHostPath: string | undefined, appHostIsDirectory: boolean): Promise<'csharp' | 'typescript' | 'unknown'> {
+    try {
+      this._appHostLanguageAtLaunch = appHostIsDirectory
+        ? await classifyAppHostDirectory(appHostPath)
+        : classifyAppHostPath(appHostPath);
+    }
+    catch {
+      // Telemetry enrichment must never break or delay the debug launch path.
+      this._appHostLanguageAtLaunch = 'unknown';
+    }
+
+    return this._appHostLanguageAtLaunch;
+  }
+
+  private async resolveAppHostTargetVersionAtLaunch(appHostPath: string | undefined): Promise<string> {
+    try {
+      this._appHostTargetVersionAtLaunch = await getAppHostTargetVersion(appHostPath) ?? 'unknown';
+    }
+    catch {
+      // Telemetry enrichment must never break or delay the debug launch path.
+      this._appHostTargetVersionAtLaunch = 'unknown';
+    }
+
+    return this._appHostTargetVersionAtLaunch;
   }
 
   async spawnAspireCommand(args: string[], workingDirectory: string | undefined, noDebug: boolean, commandLabel: string = 'aspire run') {
@@ -692,7 +732,9 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     const startMs = this._appHostStartTimeMs;
     const mode = this._appHostModeAtLaunch;
     const language = this._appHostLanguageAtLaunch;
+    const languagePromise = this._appHostLanguageAtLaunchPromise;
     const targetVersion = this._appHostTargetVersionAtLaunch;
+    const targetVersionPromise = this._appHostTargetVersionAtLaunchPromise;
     const debugSessionId = this.debugSessionId;
     const dcpServer = this._dcpServer;
 
@@ -717,18 +759,22 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     // AppHosts that aborted before reaching the CLI spawn.
     if (startMs !== undefined) {
       setTimeout(() => {
-        const aggregate = dcpServer.takeDebugSessionAggregateStats(debugSessionId);
-        sendTelemetryEvent('debug/apphost/end', {
-          mode,
-          apphost_language: language,
-          apphost_target_version: targetVersion,
-          ended_with_error: aggregate?.anyNonZeroExit ? 'true' : 'false',
-          distinct_resource_types: aggregate ? aggregate.distinctResourceTypes.join(',') : '',
-        }, {
-          duration_ms: Date.now() - startMs,
-          total_child_sessions: aggregate?.totalChildSessions ?? 0,
-          distinct_resource_type_count: aggregate?.distinctResourceTypes.length ?? 0,
-        });
+        void (async () => {
+          const resolvedLanguage = await languagePromise ?? language;
+          const resolvedTargetVersion = await targetVersionPromise ?? targetVersion;
+          const aggregate = dcpServer.takeDebugSessionAggregateStats(debugSessionId);
+          sendTelemetryEvent('debug/apphost/end', {
+            mode,
+            apphost_language: resolvedLanguage,
+            apphost_target_version: resolvedTargetVersion,
+            ended_with_error: aggregate?.anyNonZeroExit ? 'true' : 'false',
+            distinct_resource_types: aggregate ? aggregate.distinctResourceTypes.join(',') : '',
+          }, {
+            duration_ms: Date.now() - startMs,
+            total_child_sessions: aggregate?.totalChildSessions ?? 0,
+            distinct_resource_type_count: aggregate?.distinctResourceTypes.length ?? 0,
+          });
+        })();
       }, 500);
     }
   }

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -217,9 +217,12 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     this._appHostStartTimeMs = Date.now();
     this._appHostModeAtLaunch = noDebug ? 'run' : 'debug';
     // Before the filesystem probe below, the file extension is the only language
-    // signal available. Directory-launched AppHosts report `unknown` on start
-    // telemetry and are enriched on the matching end event.
-    this._appHostLanguageAtLaunch = classifyAppHostPath(appHostPath);
+    // signal available. Prefer the resolved telemetry target when a default
+    // workspace launch already selected a concrete AppHost.
+    const appHostTelemetryTargetLanguage = classifyAppHostPath(appHostTelemetryTargetPath);
+    this._appHostLanguageAtLaunch = appHostTelemetryTargetLanguage !== 'unknown'
+      ? appHostTelemetryTargetLanguage
+      : classifyAppHostPath(appHostPath);
     this._appHostTargetVersionAtLaunch = 'unknown';
     this._appHostTargetVersionAtLaunchPromise = this.resolveAppHostTargetVersionAtLaunch(appHostTelemetryTargetPath ?? appHostPath);
     this._appHostIsDirectoryAtLaunch = 'unknown';

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -82,6 +82,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
   // path starts the work in the background and reuses the same result for start/end telemetry.
   private _appHostTargetVersionAtLaunch = 'unknown';
   private _appHostTargetVersionAtLaunchPromise: Promise<string> | undefined = undefined;
+  private _appHostIsDirectoryAtLaunch: 'true' | 'false' | 'unknown' = 'unknown';
   // Mode the AppHost was launched with (`run` | `debug`) — captured for the
   // matching end event.
   private _appHostModeAtLaunch: 'run' | 'debug' = 'run';
@@ -216,6 +217,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     this._appHostLanguageAtLaunch = classifyAppHostPath(appHostPath);
     this._appHostTargetVersionAtLaunch = 'unknown';
     this._appHostTargetVersionAtLaunchPromise = this.resolveAppHostTargetVersionAtLaunch(appHostPath);
+    this._appHostIsDirectoryAtLaunch = 'unknown';
     // `command` originates in the user's launch.json and is typed in the
     // contributing extension surface as AspireCommandType ('run'|'deploy'|
     // 'publish'|'do'), but launch.json is freeform JSON — a typo or custom
@@ -234,6 +236,11 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     });
 
     const appHostIsDirectory = await this.isDirectory(appHostPath);
+    if (this._disposed) {
+      return;
+    }
+
+    this._appHostIsDirectoryAtLaunch = appHostIsDirectory ? 'true' : 'false';
     this._appHostLanguageAtLaunchPromise = this.resolveAppHostLanguageAtLaunch(appHostPath, appHostIsDirectory);
 
     // For 'do' with an explicit step (old CLI fallback), pass it as a positional argument
@@ -740,6 +747,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     const languagePromise = this._appHostLanguageAtLaunchPromise;
     const targetVersion = this._appHostTargetVersionAtLaunch;
     const targetVersionPromise = this._appHostTargetVersionAtLaunchPromise;
+    const appHostIsDirectory = this._appHostIsDirectoryAtLaunch;
     const debugSessionId = this.debugSessionId;
     const dcpServer = this._dcpServer;
 
@@ -772,6 +780,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
             mode,
             apphost_language: resolvedLanguage,
             apphost_target_version: resolvedTargetVersion,
+            apphost_is_directory: appHostIsDirectory,
             ended_with_error: aggregate?.anyNonZeroExit ? 'true' : 'false',
             distinct_resource_types: aggregate ? aggregate.distinctResourceTypes.join(',') : '',
           }, {

--- a/extension/src/test-e2e/packageSurface.e2e.test.ts
+++ b/extension/src/test-e2e/packageSurface.e2e.test.ts
@@ -428,6 +428,8 @@ const expectedActivationEvents = [
     'onDebugInitialConfigurations:aspire',
     'onDebugDynamicConfigurations:aspire',
     'workspaceContains:**/*.csproj',
+    'workspaceContains:**/*.fsproj',
+    'workspaceContains:**/*.vbproj',
     'workspaceContains:**/aspire.config.json',
     'workspaceContains:**/.aspire/**',
     'onView:workbench.view.debug',

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -140,6 +140,31 @@ suite('AppHost discovery', () => {
             }
         });
 
+        test('resolves workspace folder debug target to the single discovered AppHost candidate', async () => {
+            stubFileSystemWatchers(sandbox);
+            sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
+                options?.stdoutCallback?.(JSON.stringify([{
+                    path: buildPath('workspace', 'NestedAppHost', 'apphost.ts'),
+                    language: 'typescript/nodejs',
+                    status: 'buildable',
+                    aspireHostingVersion: '13.5.0',
+                }]));
+                options?.exitCallback?.(0);
+                return { kill: () => { } } as any;
+            });
+            const service = new AppHostDiscoveryService(makeTerminalProvider());
+            const workspaceFolder = makeWorkspaceFolder(buildPath('workspace'));
+
+            try {
+                const result = await service.resolveDebugTarget(workspaceFolder.uri.fsPath, workspaceFolder);
+
+                assert.strictEqual(result, buildPath('workspace', 'NestedAppHost', 'apphost.ts'));
+            }
+            finally {
+                service.dispose();
+            }
+        });
+
         test('fires change event and invalidates cache when watched files change', async () => {
             const watcherCallbacks = stubFileSystemWatchers(sandbox);
             const clock = sandbox.useFakeTimers();

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -665,6 +665,70 @@ suite('AppHost discovery', () => {
             }
         });
 
+        test('falls back to FSharp and Visual Basic project files when CLI discovery fails', async () => {
+            const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-apphost-discovery-'));
+            try {
+                stubFileSystemWatchers(sandbox);
+                const fsharpAppHostProjectPath = path.join(tempDir, 'FSharpAppHost', 'FSharpAppHost.fsproj');
+                const visualBasicAppHostProjectPath = path.join(tempDir, 'VisualBasicAppHost', 'VisualBasicAppHost.vbproj');
+                fs.mkdirSync(path.dirname(fsharpAppHostProjectPath), { recursive: true });
+                fs.mkdirSync(path.dirname(visualBasicAppHostProjectPath), { recursive: true });
+                fs.writeFileSync(fsharpAppHostProjectPath, `<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+`);
+                fs.writeFileSync(visualBasicAppHostProjectPath, `<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+`);
+                findFilesStub.callsFake(async (include: vscode.GlobPattern) => {
+                    const pattern = typeof include === 'string' ? include : include.pattern;
+                    if (pattern.endsWith('*.fsproj')) {
+                        return [vscode.Uri.file(fsharpAppHostProjectPath)];
+                    }
+
+                    if (pattern.endsWith('*.vbproj')) {
+                        return [vscode.Uri.file(visualBasicAppHostProjectPath)];
+                    }
+
+                    return [];
+                });
+                sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, args = [], options) => {
+                    options?.stderrCallback?.(`${args.join(' ')} failed`);
+                    options?.exitCallback?.(1);
+                    return { kill: () => { } } as any;
+                });
+                const service = new AppHostDiscoveryService(makeTerminalProvider());
+
+                try {
+                    const result = await service.discover(makeWorkspaceFolder(tempDir));
+
+                    assert.deepStrictEqual(result, [
+                        {
+                            path: vscode.Uri.file(fsharpAppHostProjectPath).fsPath,
+                            language: 'fsharp',
+                            status: 'buildable',
+                        },
+                        {
+                            path: vscode.Uri.file(visualBasicAppHostProjectPath).fsPath,
+                            language: 'visualbasic',
+                            status: 'buildable',
+                        },
+                    ]);
+                }
+                finally {
+                    service.dispose();
+                }
+            }
+            finally {
+                fs.rmSync(tempDir, { recursive: true, force: true });
+            }
+        });
+
         test('uses VS Code file system when falling back to project files', async () => {
             const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-apphost-discovery-'));
             try {

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -140,7 +140,7 @@ suite('AppHost discovery', () => {
             }
         });
 
-        test('resolves workspace folder debug target to the single discovered AppHost candidate', async () => {
+        test('keeps workspace folder debug target unchanged and returns default candidate separately', async () => {
             stubFileSystemWatchers(sandbox);
             sandbox.stub(cliModule, 'spawnCliProcess').callsFake((_terminalProvider, _command, _args, options) => {
                 options?.stdoutCallback?.(JSON.stringify([{
@@ -157,8 +157,10 @@ suite('AppHost discovery', () => {
 
             try {
                 const result = await service.resolveDebugTarget(workspaceFolder.uri.fsPath, workspaceFolder);
+                const candidate = await service.tryFindWorkspaceDefaultCandidate(workspaceFolder.uri.fsPath, workspaceFolder);
 
-                assert.strictEqual(result, buildPath('workspace', 'NestedAppHost', 'apphost.ts'));
+                assert.strictEqual(result, workspaceFolder.uri.fsPath);
+                assert.strictEqual(candidate?.path, buildPath('workspace', 'NestedAppHost', 'apphost.ts'));
             }
             finally {
                 service.dispose();

--- a/extension/src/test/appHostDiscovery.test.ts
+++ b/extension/src/test/appHostDiscovery.test.ts
@@ -147,7 +147,6 @@ suite('AppHost discovery', () => {
                     path: buildPath('workspace', 'NestedAppHost', 'apphost.ts'),
                     language: 'typescript/nodejs',
                     status: 'buildable',
-                    aspireHostingVersion: '13.5.0',
                 }]));
                 options?.exitCallback?.(0);
                 return { kill: () => { } } as any;

--- a/extension/src/test/appHostLanguage.test.ts
+++ b/extension/src/test/appHostLanguage.test.ts
@@ -53,6 +53,8 @@ suite('appHostLanguage.classifyAppHostPath', () => {
 
     test('classifies .csproj and .cs as csharp', () => {
         assert.strictEqual(classifyAppHostPath('/abs/path/AppHost.csproj'), 'csharp');
+        assert.strictEqual(classifyAppHostPath('/abs/path/AppHost.fsproj'), 'csharp');
+        assert.strictEqual(classifyAppHostPath('/abs/path/AppHost.vbproj'), 'csharp');
         assert.strictEqual(classifyAppHostPath('AppHost.cs'), 'csharp');
         assert.strictEqual(classifyAppHostPath('C:\\repos\\My.AppHost.csproj'), 'csharp');
     });

--- a/extension/src/test/appHostLanguage.test.ts
+++ b/extension/src/test/appHostLanguage.test.ts
@@ -145,6 +145,13 @@ suite('appHostLanguage.classifyAppHostDirectory', () => {
         assert.strictEqual(await classifyAppHostDirectory(dir), 'unknown');
     });
 
+    test('ignores non-AppHost C# files when classifying a TypeScript AppHost directory', async () => {
+        const dir = makeTempDir();
+        writeFileSync(join(dir, 'apphost.ts'), '');
+        writeFileSync(join(dir, 'helper.cs'), '');
+        assert.strictEqual(await classifyAppHostDirectory(dir), 'typescript');
+    });
+
     test('returns csharp when both csharp and typescript markers exist (deterministic fallback)', async () => {
         // Highly unusual but plausible during polyglot migration. The
         // classifier prefers csharp so the dimension stays deterministic

--- a/extension/src/test/appHostLanguage.test.ts
+++ b/extension/src/test/appHostLanguage.test.ts
@@ -30,6 +30,11 @@ suite('appHostLanguage.summarizeAppHostLanguages', () => {
         assert.strictEqual(summarizeAppHostLanguages([c('csharp'), c('python')]), 'polyglot');
     });
 
+    test('returns polyglot when a missing language is mixed with a known one', () => {
+        assert.strictEqual(summarizeAppHostLanguages([c('csharp'), c(null)]), 'polyglot');
+        assert.strictEqual(summarizeAppHostLanguages([c('typescript'), c(null)]), 'polyglot');
+    });
+
     test('returns unknown when no candidate has a recognizable language', () => {
         assert.strictEqual(summarizeAppHostLanguages([c(null), c(null)]), 'unknown');
     });
@@ -158,6 +163,13 @@ suite('appHostLanguage.classifyAppHostDirectory', () => {
         const dir = makeTempDir();
         writeFileSync(join(dir, 'apphost.ts'), '');
         writeFileSync(join(dir, 'Helper.csproj'), '<Project Sdk="Microsoft.NET.Sdk" />');
+        assert.strictEqual(await classifyAppHostDirectory(dir), 'typescript');
+    });
+
+    test('ignores AppHost-named non-Aspire C# projects when classifying a TypeScript AppHost directory', async () => {
+        const dir = makeTempDir();
+        writeFileSync(join(dir, 'apphost.ts'), '');
+        writeFileSync(join(dir, 'AppHost.Helper.csproj'), '<Project Sdk="Microsoft.NET.Sdk" />');
         assert.strictEqual(await classifyAppHostDirectory(dir), 'typescript');
     });
 

--- a/extension/src/test/appHostLanguage.test.ts
+++ b/extension/src/test/appHostLanguage.test.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { summarizeAppHostLanguages, classifyAppHostPath, classifyAppHostDirectory } from '../utils/appHostLanguage';
 import type { CandidateAppHostDisplayInfo } from '../utils/appHostDiscovery';
@@ -79,15 +78,19 @@ suite('appHostLanguage.classifyAppHostPath', () => {
 });
 
 suite('appHostLanguage.classifyAppHostDirectory', () => {
-    // Each test creates a unique temp directory under the OS temp root and
+    // Each test creates a unique temp directory under the extension workspace and
     // tears it down after. We rely on real fs because classifyAppHostDirectory
-    // uses readdirSync; mocking would defeat the purpose.
+    // needs to inspect actual directory entries; mocking would defeat the purpose.
     const tempDirs: string[] = [];
+    const tempParent = join(process.cwd(), '.test-tmp');
+
     function makeTempDir(): string {
-        const dir = mkdtempSync(join(tmpdir(), 'aspire-classify-'));
+        mkdirSync(tempParent, { recursive: true });
+        const dir = mkdtempSync(join(tempParent, 'aspire-classify-'));
         tempDirs.push(dir);
         return dir;
     }
+
     teardown(() => {
         for (const dir of tempDirs) {
             if (existsSync(dir)) {
@@ -97,52 +100,58 @@ suite('appHostLanguage.classifyAppHostDirectory', () => {
         tempDirs.length = 0;
     });
 
-    test('returns unknown for undefined or missing directory', () => {
-        assert.strictEqual(classifyAppHostDirectory(undefined), 'unknown');
-        assert.strictEqual(classifyAppHostDirectory(''), 'unknown');
-        assert.strictEqual(classifyAppHostDirectory('/path/that/definitely/does/not/exist/aspire-test'), 'unknown');
+    suiteTeardown(() => {
+        if (existsSync(tempParent)) {
+            rmSync(tempParent, { recursive: true, force: true });
+        }
     });
 
-    test('classifies directory containing a .csproj as csharp', () => {
+    test('returns unknown for undefined or missing directory', async () => {
+        assert.strictEqual(await classifyAppHostDirectory(undefined), 'unknown');
+        assert.strictEqual(await classifyAppHostDirectory(''), 'unknown');
+        assert.strictEqual(await classifyAppHostDirectory('/path/that/definitely/does/not/exist/aspire-test'), 'unknown');
+    });
+
+    test('classifies directory containing a .csproj as csharp', async () => {
         const dir = makeTempDir();
         writeFileSync(join(dir, 'AppHost.csproj'), '');
-        assert.strictEqual(classifyAppHostDirectory(dir), 'csharp');
+        assert.strictEqual(await classifyAppHostDirectory(dir), 'csharp');
     });
 
-    test('classifies directory containing a .cs AppHost as csharp', () => {
+    test('classifies directory containing a .cs AppHost as csharp', async () => {
         const dir = makeTempDir();
         writeFileSync(join(dir, 'AppHost.cs'), '');
         writeFileSync(join(dir, 'README.md'), '');
-        assert.strictEqual(classifyAppHostDirectory(dir), 'csharp');
+        assert.strictEqual(await classifyAppHostDirectory(dir), 'csharp');
     });
 
-    test('classifies directory containing an apphost.ts as typescript', () => {
+    test('classifies directory containing an apphost.ts as typescript', async () => {
         const dir = makeTempDir();
         writeFileSync(join(dir, 'apphost.ts'), '');
         writeFileSync(join(dir, 'package.json'), '{}');
-        assert.strictEqual(classifyAppHostDirectory(dir), 'typescript');
+        assert.strictEqual(await classifyAppHostDirectory(dir), 'typescript');
     });
 
-    test('classifies directory containing an apphost.cjs as typescript', () => {
+    test('classifies directory containing an apphost.cjs as typescript', async () => {
         const dir = makeTempDir();
         writeFileSync(join(dir, 'apphost.cjs'), '');
-        assert.strictEqual(classifyAppHostDirectory(dir), 'typescript');
+        assert.strictEqual(await classifyAppHostDirectory(dir), 'typescript');
     });
 
-    test('returns unknown for a directory with no recognized AppHost markers', () => {
+    test('returns unknown for a directory with no recognized AppHost markers', async () => {
         const dir = makeTempDir();
         writeFileSync(join(dir, 'README.md'), '');
         writeFileSync(join(dir, 'main.py'), '');
-        assert.strictEqual(classifyAppHostDirectory(dir), 'unknown');
+        assert.strictEqual(await classifyAppHostDirectory(dir), 'unknown');
     });
 
-    test('returns csharp when both csharp and typescript markers exist (deterministic fallback)', () => {
+    test('returns csharp when both csharp and typescript markers exist (deterministic fallback)', async () => {
         // Highly unusual but plausible during polyglot migration. The
         // classifier prefers csharp so the dimension stays deterministic
         // rather than depending on directory-listing order.
         const dir = makeTempDir();
         writeFileSync(join(dir, 'AppHost.csproj'), '');
         writeFileSync(join(dir, 'apphost.ts'), '');
-        assert.strictEqual(classifyAppHostDirectory(dir), 'csharp');
+        assert.strictEqual(await classifyAppHostDirectory(dir), 'csharp');
     });
 });

--- a/extension/src/test/appHostLanguage.test.ts
+++ b/extension/src/test/appHostLanguage.test.ts
@@ -152,6 +152,24 @@ suite('appHostLanguage.classifyAppHostDirectory', () => {
         assert.strictEqual(await classifyAppHostDirectory(dir), 'typescript');
     });
 
+    test('ignores non-AppHost C# projects when classifying a TypeScript AppHost directory', async () => {
+        const dir = makeTempDir();
+        writeFileSync(join(dir, 'apphost.ts'), '');
+        writeFileSync(join(dir, 'Helper.csproj'), '<Project Sdk="Microsoft.NET.Sdk" />');
+        assert.strictEqual(await classifyAppHostDirectory(dir), 'typescript');
+    });
+
+    test('classifies non-standard C# project names that reference Aspire Hosting as csharp', async () => {
+        const dir = makeTempDir();
+        writeFileSync(join(dir, 'Orchestration.csproj'), `<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.1" />
+  </ItemGroup>
+</Project>
+`);
+        assert.strictEqual(await classifyAppHostDirectory(dir), 'csharp');
+    });
+
     test('returns csharp when both csharp and typescript markers exist (deterministic fallback)', async () => {
         // Highly unusual but plausible during polyglot migration. The
         // classifier prefers csharp so the dimension stays deterministic

--- a/extension/src/test/appHostTargetVersion.test.ts
+++ b/extension/src/test/appHostTargetVersion.test.ts
@@ -173,6 +173,19 @@ suite('appHostTargetVersion', () => {
         assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.5.2');
     });
 
+    test('summarizes a BOM-prefixed unversioned C# project SDK version from global.json msbuild-sdks', async () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'AppHost.csproj');
+        writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk" />');
+        writeFileSync(join(dir, 'global.json'), `\uFEFF${JSON.stringify({
+            'msbuild-sdks': {
+                'Aspire.AppHost.Sdk': '13.5.2',
+            },
+        })}`);
+
+        assert.strictEqual(await summarizeAppHostTargetVersions([candidate(appHostPath, 'csharp')]), '13.5.2');
+    });
+
     test('reads an unversioned C# project Sdk element version from global.json msbuild-sdks', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'AppHost.csproj');
@@ -226,6 +239,15 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
 
         assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.4.2');
         assert.strictEqual(await getAppHostTargetVersion(dir), '13.4.2');
+    });
+
+    test('summarizes a BOM-prefixed polyglot SDK version from aspire.config.json', async () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'apphost.ts');
+        writeFileSync(appHostPath, 'import { aspire } from "@microsoft/aspire";');
+        writeFileSync(join(dir, 'aspire.config.json'), `\uFEFF${JSON.stringify({ sdk: { version: '13.4.2' } })}`);
+
+        assert.strictEqual(await summarizeAppHostTargetVersions([candidate(appHostPath, 'typescript')]), '13.4.2');
     });
 
     test('reads the polyglot SDK version from a directory with non-AppHost C# files', async () => {

--- a/extension/src/test/appHostTargetVersion.test.ts
+++ b/extension/src/test/appHostTargetVersion.test.ts
@@ -10,11 +10,11 @@ function candidate(path: string, language: string | null, aspireHostingVersion?:
 
 suite('appHostTargetVersion', () => {
     const tempDirs: string[] = [];
+    const tempParent = join(process.cwd(), '.test-tmp');
 
     function makeTempDir(): string {
-        const parent = join(process.cwd(), '.test-tmp');
-        mkdirSync(parent, { recursive: true });
-        const dir = mkdtempSync(join(parent, 'apphost-target-version-'));
+        mkdirSync(tempParent, { recursive: true });
+        const dir = mkdtempSync(join(tempParent, 'apphost-target-version-'));
         tempDirs.push(dir);
         return dir;
     }
@@ -28,38 +28,43 @@ suite('appHostTargetVersion', () => {
         tempDirs.length = 0;
     });
 
-    test('summarizes no AppHost candidates as none', () => {
-        assert.strictEqual(summarizeAppHostTargetVersions([]), 'none');
+    suiteTeardown(() => {
+        if (existsSync(tempParent)) {
+            rmSync(tempParent, { recursive: true, force: true });
+        }
     });
 
-    test('summarizes candidate AspireHostingVersion values from aspire ls output', () => {
+    test('summarizes no AppHost candidates as none', async () => {
+        assert.strictEqual(await summarizeAppHostTargetVersions([]), 'none');
+    });
+
+    test('summarizes candidate AspireHostingVersion values from aspire ls output', async () => {
         const candidates = [
             candidate('/workspace/AppHost/AppHost.csproj', 'csharp', '13.5.0'),
             candidate('/workspace/Other/AppHost.csproj', 'csharp', '13.5.0'),
         ];
 
-        assert.strictEqual(summarizeAppHostTargetVersions(candidates), '13.5.0');
+        assert.strictEqual(await summarizeAppHostTargetVersions(candidates), '13.5.0');
     });
 
-    test('summarizes semver-like prerelease target versions from aspire ls output', () => {
+    test('buckets multiple distinct target versions from aspire ls output', async () => {
         const candidates = [
             candidate('/workspace/AppHost/AppHost.csproj', 'csharp', '13.5.0-preview.1'),
             candidate('/workspace/Other/AppHost.csproj', 'csharp', '13.5.0-pr.18457.gabcdef'),
         ];
 
-        assert.strictEqual(summarizeAppHostTargetVersions(candidates), '13.5.0-pr.18457.gabcdef,13.5.0-preview.1');
+        assert.strictEqual(await summarizeAppHostTargetVersions(candidates), 'multiple');
     });
 
-    test('accepts bounded prerelease target version segments', () => {
+    test('accepts bounded prerelease target version segments', async () => {
         const candidates = [
-            candidate('/workspace/AppHost/AppHost.csproj', 'csharp', '13.5.0-abcdefghijklmnopq'),
             candidate('/workspace/Other/AppHost.csproj', 'csharp', '13.5.0-abcdefghijklmnopqrst'),
         ];
 
-        assert.strictEqual(summarizeAppHostTargetVersions(candidates), '13.5.0-abcdefghijklmnopq,13.5.0-abcdefghijklmnopqrst');
+        assert.strictEqual(await summarizeAppHostTargetVersions(candidates), '13.5.0-abcdefghijklmnopqrst');
     });
 
-    test('maps arbitrary aspire ls target versions to unknown', () => {
+    test('maps arbitrary aspire ls target versions to unknown', async () => {
         const candidates = [
             candidate('/empty/does/not/exist/apphost.ts', 'typescript', ''),
             candidate('/long/does/not/exist/apphost.ts', 'typescript', `13.5.0-${'a'.repeat(80)}`),
@@ -69,35 +74,36 @@ suite('appHostTargetVersion', () => {
             candidate('/still/does/not/exist/apphost.ts', 'typescript', '13.5.0-preview.1 with arbitrary text'),
         ];
 
-        assert.strictEqual(summarizeAppHostTargetVersions(candidates), 'unknown');
+        assert.strictEqual(await summarizeAppHostTargetVersions(candidates), 'unknown');
     });
 
-    test('falls back to project parsing when aspire ls omits target versions', () => {
+    test('falls back to project parsing when aspire ls omits target versions', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'AppHost.csproj');
         writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk/13.5.1" />');
 
-        assert.strictEqual(summarizeAppHostTargetVersions([candidate(appHostPath, 'csharp')]), '13.5.1');
+        assert.strictEqual(await summarizeAppHostTargetVersions([candidate(appHostPath, 'csharp')]), '13.5.1');
     });
 
-    test('falls back to project parsing when aspire ls returns a null target version', () => {
+    test('falls back to project parsing when aspire ls returns a null target version', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'AppHost.csproj');
         writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk/13.5.1" />');
 
-        assert.strictEqual(summarizeAppHostTargetVersions([candidate(appHostPath, 'csharp', null)]), '13.5.1');
+        assert.strictEqual(await summarizeAppHostTargetVersions([candidate(appHostPath, 'csharp', null)]), '13.5.1');
     });
 
-    test('summarizes multiple distinct target versions deterministically', () => {
+    test('keeps the target version summary bounded for many distinct target versions', async () => {
         const candidates = [
-            candidate('/workspace/New/AppHost.csproj', 'csharp', '13.6.0'),
-            candidate('/workspace/Old/AppHost.csproj', 'csharp', '13.5.0'),
+            ...Array.from({ length: 100 }, (_, index) => candidate(`/workspace/AppHost${index}/AppHost.csproj`, 'csharp', `13.${index}.0`)),
         ];
+        const result = await summarizeAppHostTargetVersions(candidates);
 
-        assert.strictEqual(summarizeAppHostTargetVersions(candidates), '13.5.0,13.6.0');
+        assert.strictEqual(result, 'multiple');
+        assert.ok(result.length <= 16);
     });
 
-    test('reads the C# project SDK version', () => {
+    test('reads the C# project SDK version', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'AppHost.csproj');
         writeFileSync(appHostPath, `<Project Sdk="Microsoft.NET.Sdk; Aspire.AppHost.Sdk/13.5.1">
@@ -107,10 +113,10 @@ suite('appHostTargetVersion', () => {
 </Project>
 `);
 
-        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.5.1');
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.5.1');
     });
 
-    test('ignores commented C# project SDK versions', () => {
+    test('ignores commented C# project SDK versions', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'AppHost.csproj');
         writeFileSync(appHostPath, `<!-- <Project Sdk="Aspire.AppHost.Sdk/1.2.3"> -->
@@ -121,10 +127,10 @@ suite('appHostTargetVersion', () => {
 </Project>
 `);
 
-        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.5.1');
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.5.1');
     });
 
-    test('ignores commented C# SDK element and property versions', () => {
+    test('ignores commented C# SDK element and property versions', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'AppHost.csproj');
         writeFileSync(appHostPath, `<Project Sdk="Microsoft.NET.Sdk">
@@ -134,35 +140,69 @@ suite('appHostTargetVersion', () => {
 </Project>
 `);
 
-        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.5.1');
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.5.1');
     });
 
-    test('rejects malformed C# project SDK versions', () => {
+    test('rejects malformed C# project SDK versions', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'AppHost.csproj');
         writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk/C:\\Users\\me\\AppHost" />');
 
-        assert.strictEqual(getAppHostTargetVersion(appHostPath), undefined);
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), undefined);
     });
 
-    test('does not use polyglot config as the version for an unversioned C# project SDK', () => {
+    test('does not use polyglot config as the version for an unversioned C# project SDK', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'AppHost.csproj');
         writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk" />');
         writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({ sdk: { version: '13.4.2' } }));
 
-        assert.strictEqual(getAppHostTargetVersion(appHostPath), undefined);
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), undefined);
     });
 
-    test('does not use polyglot config as the version for an unversioned C# project directory', () => {
+    test('reads an unversioned C# project SDK version from global.json msbuild-sdks', async () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'AppHost.csproj');
+        writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk" />');
+        writeFileSync(join(dir, 'global.json'), JSON.stringify({
+            'msbuild-sdks': {
+                'Aspire.AppHost.Sdk': '13.5.2',
+            },
+        }));
+
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.5.2');
+    });
+
+    test('reads an unversioned C# project Sdk element version from global.json msbuild-sdks', async () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'AppHost.csproj');
+        writeFileSync(appHostPath, '<Project><Sdk Name="Aspire.AppHost.Sdk" /></Project>');
+        writeFileSync(join(dir, 'global.json'), JSON.stringify({
+            'msbuild-sdks': {
+                'Aspire.AppHost.Sdk': '13.5.3',
+            },
+        }));
+
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.5.3');
+    });
+
+    test('does not use polyglot config as the version for an unversioned C# project directory', async () => {
         const dir = makeTempDir();
         writeFileSync(join(dir, 'AppHost.csproj'), '<Project Sdk="Aspire.AppHost.Sdk" />');
         writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({ sdk: { version: '13.4.2' } }));
 
-        assert.strictEqual(getAppHostTargetVersion(dir), undefined);
+        assert.strictEqual(await getAppHostTargetVersion(dir), undefined);
     });
 
-    test('reads the C# single-file SDK directive version', () => {
+    test('buckets multiple project SDK versions from a directory', async () => {
+        const dir = makeTempDir();
+        writeFileSync(join(dir, 'New.AppHost.csproj'), '<Project Sdk="Aspire.AppHost.Sdk/13.6.0" />');
+        writeFileSync(join(dir, 'Old.AppHost.csproj'), '<Project Sdk="Aspire.AppHost.Sdk/13.5.0" />');
+
+        assert.strictEqual(await getAppHostTargetVersion(dir), 'multiple');
+    });
+
+    test('reads the C# single-file SDK directive version', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'apphost.cs');
         writeFileSync(appHostPath, `#:sdk Aspire.AppHost.Sdk@13.6.0-preview.1
@@ -170,10 +210,10 @@ suite('appHostTargetVersion', () => {
 var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
 `);
 
-        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.6.0-preview.1');
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.6.0-preview.1');
     });
 
-    test('reads the polyglot SDK version from aspire.config.json', () => {
+    test('reads the polyglot SDK version from aspire.config.json', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'apphost.ts');
         writeFileSync(appHostPath, 'import { aspire } from "@microsoft/aspire";');
@@ -184,11 +224,11 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
   }
 }`);
 
-        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.4.2');
-        assert.strictEqual(getAppHostTargetVersion(dir), '13.4.2');
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.4.2');
+        assert.strictEqual(await getAppHostTargetVersion(dir), '13.4.2');
     });
 
-    test('reads the polyglot SDK version from JSONC config with a trailing comma', () => {
+    test('reads the polyglot SDK version from JSONC config with a trailing comma', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'apphost.ts');
         writeFileSync(appHostPath, 'import { aspire } from "@microsoft/aspire";');
@@ -198,28 +238,28 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
   },
 }`);
 
-        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.4.2');
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.4.2');
     });
 
-    test('ignores malformed polyglot SDK versions from config', () => {
+    test('ignores malformed polyglot SDK versions from config', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'apphost.ts');
         writeFileSync(appHostPath, 'import { aspire } from "@microsoft/aspire";');
         writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({ sdk: { version: '../arbitrary/path' } }));
 
-        assert.strictEqual(getAppHostTargetVersion(appHostPath), undefined);
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), undefined);
     });
 
-    test('falls back to the legacy sdkVersion config key', () => {
+    test('falls back to the legacy sdkVersion config key', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'apphost.ts');
         writeFileSync(appHostPath, 'import { aspire } from "@microsoft/aspire";');
         writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({ sdkVersion: '13.3.1' }));
 
-        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.3.1');
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.3.1');
     });
 
-    test('returns unknown when candidates have no available target version', () => {
-        assert.strictEqual(summarizeAppHostTargetVersions([candidate('/does/not/exist/apphost.ts', 'typescript')]), 'unknown');
+    test('returns unknown when candidates have no available target version', async () => {
+        assert.strictEqual(await summarizeAppHostTargetVersions([candidate('/does/not/exist/apphost.ts', 'typescript')]), 'unknown');
     });
 });

--- a/extension/src/test/appHostTargetVersion.test.ts
+++ b/extension/src/test/appHostTargetVersion.test.ts
@@ -4,8 +4,8 @@ import { join } from 'node:path';
 import { getAppHostTargetVersion, summarizeAppHostTargetVersions } from '../utils/appHostTargetVersion';
 import type { CandidateAppHostDisplayInfo } from '../utils/appHostDiscovery';
 
-function candidate(path: string, language: string | null, aspireHostingVersion?: string | null): CandidateAppHostDisplayInfo {
-    return { path, language, status: 'buildable', aspireHostingVersion };
+function candidate(path: string, language: string | null): CandidateAppHostDisplayInfo {
+    return { path, language, status: 'buildable' };
 }
 
 suite('appHostTargetVersion', () => {
@@ -38,55 +38,61 @@ suite('appHostTargetVersion', () => {
         assert.strictEqual(await summarizeAppHostTargetVersions([]), 'none');
     });
 
-    test('summarizes candidate AspireHostingVersion values from aspire ls output', async () => {
+    function writeProjectWithSdkVersion(directory: string, fileName: string, version: string): string {
+        const appHostPath = join(directory, fileName);
+        writeFileSync(appHostPath, `<Project Sdk="Aspire.AppHost.Sdk/${version}" />`);
+        return appHostPath;
+    }
+
+    test('summarizes candidate target versions from project files', async () => {
+        const dir = makeTempDir();
         const candidates = [
-            candidate('/workspace/AppHost/AppHost.csproj', 'csharp', '13.5.0'),
-            candidate('/workspace/Other/AppHost.csproj', 'csharp', '13.5.0'),
+            candidate(writeProjectWithSdkVersion(dir, 'AppHost.csproj', '13.5.0'), 'csharp'),
+            candidate(writeProjectWithSdkVersion(dir, 'Other.AppHost.csproj', '13.5.0'), 'csharp'),
         ];
 
         assert.strictEqual(await summarizeAppHostTargetVersions(candidates), '13.5.0');
     });
 
-    test('buckets multiple distinct target versions from aspire ls output', async () => {
+    test('buckets multiple distinct target versions from project files', async () => {
+        const dir = makeTempDir();
         const candidates = [
-            candidate('/workspace/AppHost/AppHost.csproj', 'csharp', '13.5.0-preview.1'),
-            candidate('/workspace/Other/AppHost.csproj', 'csharp', '13.5.0-pr.18457.gabcdef'),
+            candidate(writeProjectWithSdkVersion(dir, 'AppHost.csproj', '13.5.0-preview.1'), 'csharp'),
+            candidate(writeProjectWithSdkVersion(dir, 'Other.AppHost.csproj', '13.5.0-pr.18457.gabcdef'), 'csharp'),
         ];
 
         assert.strictEqual(await summarizeAppHostTargetVersions(candidates), 'multiple');
     });
 
     test('accepts bounded prerelease target version segments', async () => {
+        const dir = makeTempDir();
         const candidates = [
-            candidate('/workspace/Other/AppHost.csproj', 'csharp', '13.5.0-abcdefghijklmnopqrst'),
+            candidate(writeProjectWithSdkVersion(dir, 'AppHost.csproj', '13.5.0-abcdefghijklmnopqrst'), 'csharp'),
         ];
 
         assert.strictEqual(await summarizeAppHostTargetVersions(candidates), '13.5.0-abcdefghijklmnopqrst');
     });
 
-    test('maps arbitrary aspire ls target versions to unknown', async () => {
+    test('maps missing target versions to unknown', async () => {
         const candidates = [
-            candidate('/empty/does/not/exist/apphost.ts', 'typescript', ''),
-            candidate('/long/does/not/exist/apphost.ts', 'typescript', `13.5.0-${'a'.repeat(80)}`),
-            candidate('/segment/does/not/exist/apphost.ts', 'typescript', '13.5.0-abcdefghijklmnopqrstu'),
-            candidate('/does/not/exist/apphost.ts', 'typescript', 'C:\\Users\\me\\workspace\\AppHost.csproj'),
-            candidate('/also/does/not/exist/apphost.ts', 'typescript', '<Project Sdk="Aspire.AppHost.Sdk/13.5.0">'),
-            candidate('/still/does/not/exist/apphost.ts', 'typescript', '13.5.0-preview.1 with arbitrary text'),
+            candidate('/does/not/exist/apphost.ts', 'typescript'),
+            candidate('/also/does/not/exist/AppHost.csproj', 'csharp'),
         ];
 
         assert.strictEqual(await summarizeAppHostTargetVersions(candidates), 'unknown');
     });
 
     test('buckets mixed known and unknown target versions as multiple', async () => {
+        const dir = makeTempDir();
         const candidates = [
-            candidate('/workspace/AppHost/AppHost.csproj', 'csharp', '13.5.0'),
+            candidate(writeProjectWithSdkVersion(dir, 'AppHost.csproj', '13.5.0'), 'csharp'),
             candidate('/does/not/exist/apphost.ts', 'typescript'),
         ];
 
         assert.strictEqual(await summarizeAppHostTargetVersions(candidates), 'multiple');
     });
 
-    test('falls back to project parsing when aspire ls omits target versions', async () => {
+    test('uses project parsing for candidate target versions', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'AppHost.csproj');
         writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk/13.5.1" />');
@@ -94,17 +100,10 @@ suite('appHostTargetVersion', () => {
         assert.strictEqual(await summarizeAppHostTargetVersions([candidate(appHostPath, 'csharp')]), '13.5.1');
     });
 
-    test('falls back to project parsing when aspire ls returns a null target version', async () => {
-        const dir = makeTempDir();
-        const appHostPath = join(dir, 'AppHost.csproj');
-        writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk/13.5.1" />');
-
-        assert.strictEqual(await summarizeAppHostTargetVersions([candidate(appHostPath, 'csharp', null)]), '13.5.1');
-    });
-
     test('keeps the target version summary bounded for many distinct target versions', async () => {
+        const dir = makeTempDir();
         const candidates = [
-            ...Array.from({ length: 100 }, (_, index) => candidate(`/workspace/AppHost${index}/AppHost.csproj`, 'csharp', `13.${index}.0`)),
+            ...Array.from({ length: 100 }, (_, index) => candidate(writeProjectWithSdkVersion(dir, `AppHost${index}.csproj`, `13.${index}.0`), 'csharp')),
         ];
         const result = await summarizeAppHostTargetVersions(candidates);
 

--- a/extension/src/test/appHostTargetVersion.test.ts
+++ b/extension/src/test/appHostTargetVersion.test.ts
@@ -41,6 +41,53 @@ suite('appHostTargetVersion', () => {
         assert.strictEqual(summarizeAppHostTargetVersions(candidates), '13.5.0');
     });
 
+    test('summarizes semver-like prerelease target versions from aspire ls output', () => {
+        const candidates = [
+            candidate('/workspace/AppHost/AppHost.csproj', 'csharp', '13.5.0-preview.1'),
+            candidate('/workspace/Other/AppHost.csproj', 'csharp', '13.5.0-pr.18457.gabcdef'),
+        ];
+
+        assert.strictEqual(summarizeAppHostTargetVersions(candidates), '13.5.0-pr.18457.gabcdef,13.5.0-preview.1');
+    });
+
+    test('accepts bounded prerelease target version segments', () => {
+        const candidates = [
+            candidate('/workspace/AppHost/AppHost.csproj', 'csharp', '13.5.0-abcdefghijklmnopq'),
+            candidate('/workspace/Other/AppHost.csproj', 'csharp', '13.5.0-abcdefghijklmnopqrst'),
+        ];
+
+        assert.strictEqual(summarizeAppHostTargetVersions(candidates), '13.5.0-abcdefghijklmnopq,13.5.0-abcdefghijklmnopqrst');
+    });
+
+    test('maps arbitrary aspire ls target versions to unknown', () => {
+        const candidates = [
+            candidate('/empty/does/not/exist/apphost.ts', 'typescript', ''),
+            candidate('/long/does/not/exist/apphost.ts', 'typescript', `13.5.0-${'a'.repeat(80)}`),
+            candidate('/segment/does/not/exist/apphost.ts', 'typescript', '13.5.0-abcdefghijklmnopqrstu'),
+            candidate('/does/not/exist/apphost.ts', 'typescript', 'C:\\Users\\me\\workspace\\AppHost.csproj'),
+            candidate('/also/does/not/exist/apphost.ts', 'typescript', '<Project Sdk="Aspire.AppHost.Sdk/13.5.0">'),
+            candidate('/still/does/not/exist/apphost.ts', 'typescript', '13.5.0-preview.1 with arbitrary text'),
+        ];
+
+        assert.strictEqual(summarizeAppHostTargetVersions(candidates), 'unknown');
+    });
+
+    test('falls back to project parsing when aspire ls omits target versions', () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'AppHost.csproj');
+        writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk/13.5.1" />');
+
+        assert.strictEqual(summarizeAppHostTargetVersions([candidate(appHostPath, 'csharp')]), '13.5.1');
+    });
+
+    test('falls back to project parsing when aspire ls returns a null target version', () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'AppHost.csproj');
+        writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk/13.5.1" />');
+
+        assert.strictEqual(summarizeAppHostTargetVersions([candidate(appHostPath, 'csharp', null)]), '13.5.1');
+    });
+
     test('summarizes multiple distinct target versions deterministically', () => {
         const candidates = [
             candidate('/workspace/New/AppHost.csproj', 'csharp', '13.6.0'),
@@ -61,6 +108,41 @@ suite('appHostTargetVersion', () => {
 `);
 
         assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.5.1');
+    });
+
+    test('ignores commented C# project SDK versions', () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'AppHost.csproj');
+        writeFileSync(appHostPath, `<!-- <Project Sdk="Aspire.AppHost.Sdk/1.2.3"> -->
+<Project Sdk="Microsoft.NET.Sdk; Aspire.AppHost.Sdk/13.5.1">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+`);
+
+        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.5.1');
+    });
+
+    test('ignores commented C# SDK element and property versions', () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'AppHost.csproj');
+        writeFileSync(appHostPath, `<Project Sdk="Microsoft.NET.Sdk">
+  <!-- <Sdk Name="Aspire.AppHost.Sdk" Version="1.2.3" /> -->
+  <!-- <AspireHostingSDKVersion>2.3.4</AspireHostingSDKVersion> -->
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.5.1" />
+</Project>
+`);
+
+        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.5.1');
+    });
+
+    test('rejects malformed C# project SDK versions', () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'AppHost.csproj');
+        writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk/C:\\Users\\me\\AppHost" />');
+
+        assert.strictEqual(getAppHostTargetVersion(appHostPath), undefined);
     });
 
     test('does not use polyglot config as the version for an unversioned C# project SDK', () => {
@@ -104,6 +186,28 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
 
         assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.4.2');
         assert.strictEqual(getAppHostTargetVersion(dir), '13.4.2');
+    });
+
+    test('reads the polyglot SDK version from JSONC config with a trailing comma', () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'apphost.ts');
+        writeFileSync(appHostPath, 'import { aspire } from "@microsoft/aspire";');
+        writeFileSync(join(dir, 'aspire.config.json'), `{
+  "sdk": {
+    "version": "13.4.2",
+  },
+}`);
+
+        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.4.2');
+    });
+
+    test('ignores malformed polyglot SDK versions from config', () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'apphost.ts');
+        writeFileSync(appHostPath, 'import { aspire } from "@microsoft/aspire";');
+        writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({ sdk: { version: '../arbitrary/path' } }));
+
+        assert.strictEqual(getAppHostTargetVersion(appHostPath), undefined);
     });
 
     test('falls back to the legacy sdkVersion config key', () => {

--- a/extension/src/test/appHostTargetVersion.test.ts
+++ b/extension/src/test/appHostTargetVersion.test.ts
@@ -77,6 +77,15 @@ suite('appHostTargetVersion', () => {
         assert.strictEqual(await summarizeAppHostTargetVersions(candidates), 'unknown');
     });
 
+    test('buckets mixed known and unknown target versions as multiple', async () => {
+        const candidates = [
+            candidate('/workspace/AppHost/AppHost.csproj', 'csharp', '13.5.0'),
+            candidate('/does/not/exist/apphost.ts', 'typescript'),
+        ];
+
+        assert.strictEqual(await summarizeAppHostTargetVersions(candidates), 'multiple');
+    });
+
     test('falls back to project parsing when aspire ls omits target versions', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'AppHost.csproj');

--- a/extension/src/test/appHostTargetVersion.test.ts
+++ b/extension/src/test/appHostTargetVersion.test.ts
@@ -228,6 +228,16 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         assert.strictEqual(await getAppHostTargetVersion(dir), '13.4.2');
     });
 
+    test('reads the polyglot SDK version from a directory with non-AppHost C# files', async () => {
+        const dir = makeTempDir();
+        writeFileSync(join(dir, 'apphost.ts'), 'import { aspire } from "@microsoft/aspire";');
+        writeFileSync(join(dir, 'helper.cs'), '#:sdk Aspire.AppHost.Sdk@13.5.0\npublic static class Helper { }');
+        writeFileSync(join(dir, 'Helper.csproj'), '<Project Sdk="Microsoft.NET.Sdk" />');
+        writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({ sdk: { version: '13.4.2' } }));
+
+        assert.strictEqual(await getAppHostTargetVersion(dir), '13.4.2');
+    });
+
     test('reads the polyglot SDK version from JSONC config with a trailing comma', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'apphost.ts');
@@ -239,6 +249,17 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
 }`);
 
         assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.4.2');
+    });
+
+    test('does not read ancestor polyglot config past a nearer aspire.config.json', async () => {
+        const dir = makeTempDir();
+        const appHostDir = join(dir, 'src', 'AppHost');
+        mkdirSync(appHostDir, { recursive: true });
+        writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({ sdk: { version: '13.4.2' } }));
+        writeFileSync(join(appHostDir, 'aspire.config.json'), JSON.stringify({}));
+        writeFileSync(join(appHostDir, 'apphost.ts'), 'import { aspire } from "@microsoft/aspire";');
+
+        assert.strictEqual(await getAppHostTargetVersion(appHostDir), undefined);
     });
 
     test('ignores malformed polyglot SDK versions from config', async () => {
@@ -257,6 +278,22 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({ sdkVersion: '13.3.1' }));
 
         assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.3.1');
+    });
+
+    test('does not read ancestor global.json past a nearer global.json', async () => {
+        const dir = makeTempDir();
+        const appHostDir = join(dir, 'src', 'AppHost');
+        mkdirSync(appHostDir, { recursive: true });
+        writeFileSync(join(dir, 'global.json'), JSON.stringify({
+            'msbuild-sdks': {
+                'Aspire.AppHost.Sdk': '13.5.2',
+            },
+        }));
+        writeFileSync(join(appHostDir, 'global.json'), JSON.stringify({}));
+        const appHostPath = join(appHostDir, 'AppHost.csproj');
+        writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk" />');
+
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), undefined);
     });
 
     test('returns unknown when candidates have no available target version', async () => {

--- a/extension/src/test/appHostTargetVersion.test.ts
+++ b/extension/src/test/appHostTargetVersion.test.ts
@@ -125,6 +125,17 @@ suite('appHostTargetVersion', () => {
         assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.5.1');
     });
 
+    test('reads F# and Visual Basic project SDK versions', async () => {
+        const dir = makeTempDir();
+        const fsharpAppHostPath = join(dir, 'AppHost.fsproj');
+        const visualBasicAppHostPath = join(dir, 'AppHost.vbproj');
+        writeFileSync(fsharpAppHostPath, '<Project Sdk="Aspire.AppHost.Sdk/13.5.1" />');
+        writeFileSync(visualBasicAppHostPath, '<Project Sdk="Aspire.AppHost.Sdk/13.5.2" />');
+
+        assert.strictEqual(await getAppHostTargetVersion(fsharpAppHostPath), '13.5.1');
+        assert.strictEqual(await getAppHostTargetVersion(visualBasicAppHostPath), '13.5.2');
+    });
+
     test('ignores commented C# project SDK versions', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'AppHost.csproj');

--- a/extension/src/test/appHostTargetVersion.test.ts
+++ b/extension/src/test/appHostTargetVersion.test.ts
@@ -1,0 +1,121 @@
+import * as assert from 'assert';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getAppHostTargetVersion, summarizeAppHostTargetVersions } from '../utils/appHostTargetVersion';
+import type { CandidateAppHostDisplayInfo } from '../utils/appHostDiscovery';
+
+function candidate(path: string, language: string | null, aspireHostingVersion?: string | null): CandidateAppHostDisplayInfo {
+    return { path, language, status: 'buildable', aspireHostingVersion };
+}
+
+suite('appHostTargetVersion', () => {
+    const tempDirs: string[] = [];
+
+    function makeTempDir(): string {
+        const parent = join(process.cwd(), '.test-tmp');
+        mkdirSync(parent, { recursive: true });
+        const dir = mkdtempSync(join(parent, 'apphost-target-version-'));
+        tempDirs.push(dir);
+        return dir;
+    }
+
+    teardown(() => {
+        for (const dir of tempDirs) {
+            if (existsSync(dir)) {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        }
+        tempDirs.length = 0;
+    });
+
+    test('summarizes no AppHost candidates as none', () => {
+        assert.strictEqual(summarizeAppHostTargetVersions([]), 'none');
+    });
+
+    test('summarizes candidate AspireHostingVersion values from aspire ls output', () => {
+        const candidates = [
+            candidate('/workspace/AppHost/AppHost.csproj', 'csharp', '13.5.0'),
+            candidate('/workspace/Other/AppHost.csproj', 'csharp', '13.5.0'),
+        ];
+
+        assert.strictEqual(summarizeAppHostTargetVersions(candidates), '13.5.0');
+    });
+
+    test('summarizes multiple distinct target versions deterministically', () => {
+        const candidates = [
+            candidate('/workspace/New/AppHost.csproj', 'csharp', '13.6.0'),
+            candidate('/workspace/Old/AppHost.csproj', 'csharp', '13.5.0'),
+        ];
+
+        assert.strictEqual(summarizeAppHostTargetVersions(candidates), '13.5.0,13.6.0');
+    });
+
+    test('reads the C# project SDK version', () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'AppHost.csproj');
+        writeFileSync(appHostPath, `<Project Sdk="Microsoft.NET.Sdk; Aspire.AppHost.Sdk/13.5.1">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+`);
+
+        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.5.1');
+    });
+
+    test('does not use polyglot config as the version for an unversioned C# project SDK', () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'AppHost.csproj');
+        writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk" />');
+        writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({ sdk: { version: '13.4.2' } }));
+
+        assert.strictEqual(getAppHostTargetVersion(appHostPath), undefined);
+    });
+
+    test('does not use polyglot config as the version for an unversioned C# project directory', () => {
+        const dir = makeTempDir();
+        writeFileSync(join(dir, 'AppHost.csproj'), '<Project Sdk="Aspire.AppHost.Sdk" />');
+        writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({ sdk: { version: '13.4.2' } }));
+
+        assert.strictEqual(getAppHostTargetVersion(dir), undefined);
+    });
+
+    test('reads the C# single-file SDK directive version', () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'apphost.cs');
+        writeFileSync(appHostPath, `#:sdk Aspire.AppHost.Sdk@13.6.0-preview.1
+
+var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
+`);
+
+        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.6.0-preview.1');
+    });
+
+    test('reads the polyglot SDK version from aspire.config.json', () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'apphost.ts');
+        writeFileSync(appHostPath, 'import { aspire } from "@microsoft/aspire";');
+        writeFileSync(join(dir, 'aspire.config.json'), `{
+  // JSONC comments are allowed in Aspire config files.
+  "sdk": {
+    "version": "13.4.2"
+  }
+}`);
+
+        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.4.2');
+        assert.strictEqual(getAppHostTargetVersion(dir), '13.4.2');
+    });
+
+    test('falls back to the legacy sdkVersion config key', () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'apphost.ts');
+        writeFileSync(appHostPath, 'import { aspire } from "@microsoft/aspire";');
+        writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({ sdkVersion: '13.3.1' }));
+
+        assert.strictEqual(getAppHostTargetVersion(appHostPath), '13.3.1');
+    });
+
+    test('returns unknown when candidates have no available target version', () => {
+        assert.strictEqual(summarizeAppHostTargetVersions([candidate('/does/not/exist/apphost.ts', 'typescript')]), 'unknown');
+    });
+});

--- a/extension/src/test/appHostTargetVersion.test.ts
+++ b/extension/src/test/appHostTargetVersion.test.ts
@@ -226,6 +226,28 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.6.0-preview.1');
     });
 
+    test('reads a BOM-prefixed C# single-file SDK directive version', async () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'apphost.cs');
+        writeFileSync(appHostPath, `\uFEFF#:sdk Aspire.AppHost.Sdk@13.6.0
+
+var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
+`);
+
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), '13.6.0');
+    });
+
+    test('does not use polyglot config for a BOM-prefixed C# single-file AppHost directory', async () => {
+        const dir = makeTempDir();
+        writeFileSync(join(dir, 'apphost.cs'), `\uFEFF#:sdk Aspire.AppHost.Sdk@13.6.0
+
+var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
+`);
+        writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({ sdk: { version: '13.4.2' } }));
+
+        assert.strictEqual(await getAppHostTargetVersion(dir), '13.6.0');
+    });
+
     test('reads the polyglot SDK version from aspire.config.json', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'apphost.ts');

--- a/extension/src/test/appHostTargetVersion.test.ts
+++ b/extension/src/test/appHostTargetVersion.test.ts
@@ -306,6 +306,16 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         assert.strictEqual(await getAppHostTargetVersion(appHostDir), undefined);
     });
 
+    test('does not read same-directory legacy settings when aspire.config.json has no SDK version', async () => {
+        const dir = makeTempDir();
+        mkdirSync(join(dir, '.aspire'), { recursive: true });
+        writeFileSync(join(dir, 'aspire.config.json'), JSON.stringify({}));
+        writeFileSync(join(dir, '.aspire', 'settings.json'), JSON.stringify({ sdk: { version: '13.3.0' } }));
+        writeFileSync(join(dir, 'apphost.ts'), 'import { aspire } from "@microsoft/aspire";');
+
+        assert.strictEqual(await getAppHostTargetVersion(dir), undefined);
+    });
+
     test('ignores malformed polyglot SDK versions from config', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'apphost.ts');

--- a/extension/src/test/appHostTargetVersion.test.ts
+++ b/extension/src/test/appHostTargetVersion.test.ts
@@ -169,6 +169,38 @@ suite('appHostTargetVersion', () => {
         assert.strictEqual(await getAppHostTargetVersion(appHostPath), undefined);
     });
 
+    test('reads the older C# AppHost package reference version', async () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'AppHost.csproj');
+        writeFileSync(appHostPath, `<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.1" />
+  </ItemGroup>
+</Project>
+`);
+
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), '8.2.1');
+    });
+
+    test('reads the centrally managed older C# AppHost package reference version', async () => {
+        const dir = makeTempDir();
+        const appHostPath = join(dir, 'AppHost.csproj');
+        writeFileSync(appHostPath, `<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" />
+  </ItemGroup>
+</Project>
+`);
+        writeFileSync(join(dir, 'Directory.Packages.props'), `<Project>
+  <ItemGroup>
+    <PackageVersion Include="Aspire.Hosting" Version="8.2.2" />
+  </ItemGroup>
+</Project>
+`);
+
+        assert.strictEqual(await getAppHostTargetVersion(appHostPath), '8.2.2');
+    });
+
     test('reads an unversioned C# project SDK version from global.json msbuild-sdks', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'AppHost.csproj');

--- a/extension/src/test/appHostTargetVersion.test.ts
+++ b/extension/src/test/appHostTargetVersion.test.ts
@@ -266,6 +266,14 @@ suite('appHostTargetVersion', () => {
         assert.strictEqual(await getAppHostTargetVersion(dir), 'multiple');
     });
 
+    test('buckets mixed known and unknown project SDK versions from a directory as multiple', async () => {
+        const dir = makeTempDir();
+        writeFileSync(join(dir, 'Versioned.AppHost.csproj'), '<Project Sdk="Aspire.AppHost.Sdk/13.6.0" />');
+        writeFileSync(join(dir, 'Unversioned.AppHost.csproj'), '<Project Sdk="Aspire.AppHost.Sdk" />');
+
+        assert.strictEqual(await getAppHostTargetVersion(dir), 'multiple');
+    });
+
     test('reads the C# single-file SDK directive version', async () => {
         const dir = makeTempDir();
         const appHostPath = join(dir, 'apphost.cs');

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -198,13 +198,23 @@ function getPowerShellForShellProof(): string | undefined {
 function makeProofTerminalProvider(sandbox: sinon.SinonSandbox, proof: ShellProof, commandLines: string[]): { terminalProvider: AspireTerminalProvider; dispose: () => void } {
     const subscriptions: vscode.Disposable[] = [];
     const terminalProvider = new AspireTerminalProvider(subscriptions);
+    terminalProvider.rpcServerConnectionInfo = {
+        address: 'http://localhost:1234',
+        token: 'rpc-token',
+        cert: 'rpc-cert',
+    };
+    terminalProvider.dcpServerConnectionInfo = {
+        address: 'http://localhost:5678',
+        token: 'dcp-token',
+        certificate: 'dcp-cert',
+    };
     sandbox.stub(cliPathModule, 'resolveCliPath').resolves({ cliPath: proof.cliPath, available: true, source: 'configured' });
     sandbox.stub(terminalProvider, 'isCliDebugLoggingEnabled').returns(false);
+    const commandSubscription = terminalProvider.onDidSendAspireCommand(event => commandLines.push(event.commandLine));
     sandbox.stub(terminalProvider, 'getAspireTerminal').returns({
         terminal: {
             shellIntegration: {
-                executeCommand: (commandLine: string) => {
-                    commandLines.push(commandLine);
+                executeCommand: (_commandLine: string) => {
                     return {} as vscode.TerminalShellExecution;
                 }
             },
@@ -217,6 +227,7 @@ function makeProofTerminalProvider(sandbox: sinon.SinonSandbox, proof: ShellProo
     return {
         terminalProvider,
         dispose: () => {
+            commandSubscription.dispose();
             terminalProvider.dispose();
             subscriptions.forEach(subscription => subscription.dispose());
         },

--- a/extension/src/test/aspireDebugConfigurationProvider.test.ts
+++ b/extension/src/test/aspireDebugConfigurationProvider.test.ts
@@ -92,6 +92,22 @@ suite('AspireDebugConfigurationProvider', () => {
         assert.strictEqual(config?.program, programPath);
     });
 
+    test('leaves workspace folder launch target unchanged and records AppHost telemetry target', async () => {
+        const folder = createWorkspaceFolder(tempDir);
+        const appHostPath = path.join(tempDir, 'NestedAppHost', 'apphost.ts');
+        const provider = new AspireDebugConfigurationProvider(createAppHostDiscoveryService(appHostPath));
+
+        const config = await provider.resolveDebugConfigurationWithSubstitutedVariables(folder, {
+            name: 'Debug AppHost',
+            type: 'aspire',
+            request: 'launch',
+            program: folder.uri.fsPath
+        });
+
+        assert.strictEqual(config?.program, folder.uri.fsPath);
+        assert.strictEqual(config?.__aspireAppHostTelemetryTargetPath, appHostPath);
+    });
+
     test('provides dynamic launch config when active file resolves to AppHost candidate', async () => {
         const folder = createWorkspaceFolder(tempDir);
         const programPath = path.join(tempDir, 'AppHost', 'Program.cs');
@@ -173,13 +189,16 @@ function createWorkspaceFolder(folderPath: string): vscode.WorkspaceFolder {
 }
 
 function createAppHostDiscoveryService(resolvedPath: string, candidatePath: string | null = resolvedPath, language = 'csharp'): AppHostDiscoveryService {
+    const createCandidate = () => candidatePath ? {
+        path: candidatePath,
+        language: language,
+        status: 'buildable',
+    } : undefined;
+
     return {
-        resolveDebugTarget: async () => resolvedPath,
-        tryFindCandidateForEditorFile: async () => candidatePath ? {
-            path: candidatePath,
-            language: language,
-            status: 'buildable',
-        } : undefined,
+        resolveDebugTarget: async (filePath: string, folder?: vscode.WorkspaceFolder) => folder && path.resolve(filePath) === path.resolve(folder.uri.fsPath) ? filePath : resolvedPath,
+        tryFindWorkspaceDefaultCandidate: async (filePath: string, folder?: vscode.WorkspaceFolder) => folder && path.resolve(filePath) === path.resolve(folder.uri.fsPath) ? createCandidate() : undefined,
+        tryFindCandidateForEditorFile: async () => createCandidate(),
     } as unknown as AppHostDiscoveryService;
 }
 

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -87,12 +87,6 @@ suite('AspireDebugSession tests', () => {
     });
 
     test('reports unknown AppHost target version in start telemetry before async enrichment', async () => {
-        const tempDir = makeTempDir();
-        const appHostPath = join(tempDir, 'apphost.cs');
-        writeFileSync(appHostPath, `#:sdk Aspire.AppHost.Sdk@13.6.0
-
-var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
-`);
         const fake = new FakeTelemetryReporter();
         const restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);
         const parentDebugSession = {
@@ -104,7 +98,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
                 type: 'aspire',
                 request: 'launch',
                 name: 'Aspire',
-                program: appHostPath,
+                program: '/workspace/apphost.cs',
                 command: 'run',
             },
             customRequest: sinon.stub(),
@@ -114,7 +108,12 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             isCliDebugLoggingEnabled: () => false,
         };
         const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, {} as any, terminalProvider as any, () => { });
-        sinon.stub(aspireDebugSession, 'spawnAspireCommand').resolves();
+        let resolveTargetVersion: ((value: string) => void) | undefined;
+        const targetVersionPromise = new Promise<string>(resolve => {
+            resolveTargetVersion = resolve;
+        });
+        sinon.stub(aspireDebugSession as any, 'resolveAppHostTargetVersionAtLaunch').returns(targetVersionPromise);
+        const spawnStub = sinon.stub(aspireDebugSession, 'spawnAspireCommand').resolves();
 
         try {
             aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
@@ -124,8 +123,10 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             assert.ok(event);
             assert.strictEqual(event.properties?.apphost_language, 'csharp');
             assert.strictEqual(event.properties?.apphost_target_version, 'unknown');
+            await waitFor(() => spawnStub.calledOnce);
         }
         finally {
+            resolveTargetVersion?.('13.6.0');
             restoreReporter();
         }
     });
@@ -215,6 +216,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         sinon.stub(vscode.debug, 'stopDebugging').resolves();
         const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
         const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, dcpServer as any, terminalProvider as any, () => { });
+        sinon.stub(aspireDebugSession as any, 'resolveAppHostTargetVersionAtLaunch').resolves('unknown');
         sinon.stub(aspireDebugSession as any, 'isDirectory').returns(new Promise<boolean>(() => { }));
 
         try {
@@ -278,12 +280,6 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
     });
 
     test('reports AppHost target version in end telemetry', async () => {
-        const tempDir = makeTempDir();
-        const appHostPath = join(tempDir, 'apphost.cs');
-        writeFileSync(appHostPath, `#:sdk Aspire.AppHost.Sdk@13.6.0
-
-var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
-`);
         const fake = new FakeTelemetryReporter();
         const restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);
         const parentDebugSession = {
@@ -295,7 +291,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
                 type: 'aspire',
                 request: 'launch',
                 name: 'Aspire',
-                program: appHostPath,
+                program: '/workspace/apphost.cs',
                 command: 'run',
             },
             customRequest: sinon.stub(),
@@ -313,11 +309,18 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         };
         sinon.stub(vscode.debug, 'stopDebugging').resolves();
         const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, dcpServer as any, terminalProvider as any, () => { });
-        sinon.stub(aspireDebugSession, 'spawnAspireCommand').resolves();
+        let resolveTargetVersion: ((value: string) => void) | undefined;
+        const targetVersionPromise = new Promise<string>(resolve => {
+            resolveTargetVersion = resolve;
+        });
+        sinon.stub(aspireDebugSession as any, 'resolveAppHostTargetVersionAtLaunch').returns(targetVersionPromise);
+        const spawnStub = sinon.stub(aspireDebugSession, 'spawnAspireCommand').resolves();
 
         try {
             aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
-            await waitFor(() => fake.events.some(event => event.name === 'debug/apphost/start'));
+            await waitFor(() => spawnStub.calledOnce);
+            resolveTargetVersion!('13.6.0');
+            await targetVersionPromise;
             const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
             aspireDebugSession.dispose();
             await waitForWithFakeClock(clock, () => fake.events.some(event => event.name === 'debug/apphost/end'));
@@ -328,13 +331,12 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             assert.strictEqual(event.properties?.apphost_target_version, '13.6.0');
         }
         finally {
+            resolveTargetVersion?.('13.6.0');
             restoreReporter();
         }
     });
 
     test('reports resolved AppHost directory classification in end telemetry', async () => {
-        const tempDir = makeTempDir();
-        writeFileSync(join(tempDir, 'apphost.ts'), 'import { aspire } from "@microsoft/aspire";');
         const fake = new FakeTelemetryReporter();
         const restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);
         const parentDebugSession = {
@@ -346,7 +348,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
                 type: 'aspire',
                 request: 'launch',
                 name: 'Aspire',
-                program: tempDir,
+                program: '/workspace/apphost',
                 command: 'run',
             },
             customRequest: sinon.stub(),
@@ -364,6 +366,13 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         };
         sinon.stub(vscode.debug, 'stopDebugging').resolves();
         const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, dcpServer as any, terminalProvider as any, () => { });
+        let resolveLanguage: ((value: 'csharp' | 'typescript' | 'unknown') => void) | undefined;
+        const languagePromise = new Promise<'csharp' | 'typescript' | 'unknown'>(resolve => {
+            resolveLanguage = resolve;
+        });
+        sinon.stub(aspireDebugSession as any, 'isDirectory').resolves(true);
+        sinon.stub(aspireDebugSession as any, 'resolveAppHostLanguageAtLaunch').returns(languagePromise);
+        sinon.stub(aspireDebugSession as any, 'resolveAppHostTargetVersionAtLaunch').resolves('unknown');
         const spawnStub = sinon.stub(aspireDebugSession, 'spawnAspireCommand').resolves();
 
         try {
@@ -373,15 +382,19 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             assert.ok(startEvent);
             assert.strictEqual(startEvent.properties?.apphost_is_directory, 'unknown');
 
+            resolveLanguage!('typescript');
+            await languagePromise;
             const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
             aspireDebugSession.dispose();
             await waitForWithFakeClock(clock, () => fake.events.some(event => event.name === 'debug/apphost/end'));
 
             const endEvent = fake.events.find(event => event.name === 'debug/apphost/end');
             assert.ok(endEvent);
+            assert.strictEqual(endEvent.properties?.apphost_language, 'typescript');
             assert.strictEqual(endEvent.properties?.apphost_is_directory, 'true');
         }
         finally {
+            resolveLanguage?.('typescript');
             restoreReporter();
         }
     });

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -86,7 +86,7 @@ suite('AspireDebugSession tests', () => {
         ]);
     });
 
-    test('reports AppHost target version in start telemetry', async () => {
+    test('reports unknown AppHost target version in start telemetry before async enrichment', async () => {
         const tempDir = makeTempDir();
         const appHostPath = join(tempDir, 'apphost.cs');
         writeFileSync(appHostPath, `#:sdk Aspire.AppHost.Sdk@13.6.0
@@ -123,7 +123,110 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             const event = fake.events.find(event => event.name === 'debug/apphost/start');
             assert.ok(event);
             assert.strictEqual(event.properties?.apphost_language, 'csharp');
-            assert.strictEqual(event.properties?.apphost_target_version, '13.6.0');
+            assert.strictEqual(event.properties?.apphost_target_version, 'unknown');
+        }
+        finally {
+            restoreReporter();
+        }
+    });
+
+    test('emits AppHost start telemetry before target version resolution completes', async () => {
+        const tempDir = makeTempDir();
+        const appHostPath = join(tempDir, 'apphost.cs');
+        writeFileSync(appHostPath, `#:sdk Aspire.AppHost.Sdk@13.6.0
+
+var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
+`);
+        const fake = new FakeTelemetryReporter();
+        const restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            workspaceFolder: undefined,
+            configuration: {
+                type: 'aspire',
+                request: 'launch',
+                name: 'Aspire',
+                program: appHostPath,
+                command: 'run',
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub(),
+        };
+        const terminalProvider = {
+            isCliDebugLoggingEnabled: () => false,
+        };
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, {} as any, terminalProvider as any, () => { });
+        let resolveTargetVersion: ((value: string) => void) | undefined;
+        const targetVersionPromise = new Promise<string>(resolve => {
+            resolveTargetVersion = resolve;
+        });
+        sinon.stub(aspireDebugSession as any, 'resolveAppHostTargetVersionAtLaunch').returns(targetVersionPromise);
+
+        let eventsAtSpawn: RecordedEvent[] = [];
+        const spawnStub = sinon.stub(aspireDebugSession, 'spawnAspireCommand').callsFake(async () => {
+            eventsAtSpawn = [...fake.events];
+        });
+
+        try {
+            aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
+
+            await waitFor(() => spawnStub.calledOnce);
+            const event = eventsAtSpawn.find(event => event.name === 'debug/apphost/start');
+            assert.ok(event, 'Expected debug/apphost/start to be emitted before spawnAspireCommand.');
+            assert.strictEqual(event.properties?.apphost_language, 'csharp');
+            assert.strictEqual(event.properties?.apphost_target_version, 'unknown');
+        }
+        finally {
+            resolveTargetVersion?.('13.6.0');
+            restoreReporter();
+        }
+    });
+
+    test('emits AppHost end telemetry when disposed before launch filesystem check completes', async () => {
+        const fake = new FakeTelemetryReporter();
+        const restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            workspaceFolder: undefined,
+            configuration: {
+                type: 'aspire',
+                request: 'launch',
+                name: 'Aspire',
+                program: '/workspace/apphost.cs',
+                command: 'run',
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub(),
+        };
+        const terminalProvider = {
+            isCliDebugLoggingEnabled: () => false,
+        };
+        const dcpServer = {
+            takeDebugSessionAggregateStats: sinon.stub().returns({
+                anyNonZeroExit: false,
+                distinctResourceTypes: [],
+                totalChildSessions: 0,
+            }),
+        };
+        sinon.stub(vscode.debug, 'stopDebugging').resolves();
+        const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, dcpServer as any, terminalProvider as any, () => { });
+        sinon.stub(aspireDebugSession as any, 'isDirectory').returns(new Promise<boolean>(() => { }));
+
+        try {
+            aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
+            aspireDebugSession.dispose();
+
+            await waitForWithFakeClock(clock, () => fake.events.some(event => event.name === 'debug/apphost/end'));
+
+            const event = fake.events.find(event => event.name === 'debug/apphost/end');
+            assert.ok(event, 'Expected debug/apphost/end when disposal races with launch startup.');
+            assert.strictEqual(event.properties?.apphost_language, 'csharp');
+            assert.strictEqual(event.properties?.apphost_target_version, 'unknown');
         }
         finally {
             restoreReporter();
@@ -173,8 +276,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             await waitFor(() => fake.events.some(event => event.name === 'debug/apphost/start'));
             const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
             aspireDebugSession.dispose();
-            await clock.tickAsync(500);
-            await clock.tickAsync(0);
+            await waitForWithFakeClock(clock, () => fake.events.some(event => event.name === 'debug/apphost/end'));
 
             const event = fake.events.find(event => event.name === 'debug/apphost/end');
             assert.ok(event);
@@ -529,6 +631,17 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             }
 
             await new Promise(resolve => setTimeout(resolve, 10));
+        }
+    }
+
+    async function waitForWithFakeClock(clock: sinon.SinonFakeTimers, predicate: () => boolean): Promise<void> {
+        const timeoutAt = clock.now + 5000;
+        while (!predicate()) {
+            if (clock.now > timeoutAt) {
+                throw new Error('Timed out waiting for condition.');
+            }
+
+            await clock.tickAsync(10);
         }
     }
 });

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -233,6 +233,50 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         }
     });
 
+    test('does not spawn Aspire when disposed before launch filesystem check resolves', async () => {
+        let resolveIsDirectory: ((value: boolean) => void) | undefined;
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            workspaceFolder: undefined,
+            configuration: {
+                type: 'aspire',
+                request: 'launch',
+                name: 'Aspire',
+                program: '/workspace/apphost.cs',
+                command: 'run',
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub(),
+        };
+        const terminalProvider = {
+            isCliDebugLoggingEnabled: () => false,
+        };
+        const dcpServer = {
+            takeDebugSessionAggregateStats: sinon.stub().returns({
+                anyNonZeroExit: false,
+                distinctResourceTypes: [],
+                totalChildSessions: 0,
+            }),
+        };
+        sinon.stub(vscode.debug, 'stopDebugging').resolves();
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, dcpServer as any, terminalProvider as any, () => { });
+        sinon.stub(aspireDebugSession as any, 'isDirectory').returns(new Promise<boolean>(resolve => {
+            resolveIsDirectory = resolve;
+        }));
+        const spawnStub = sinon.stub(aspireDebugSession, 'spawnAspireCommand').resolves();
+
+        aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
+        sinon.useFakeTimers({ shouldClearNativeTimers: true });
+        aspireDebugSession.dispose();
+        resolveIsDirectory!(false);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        assert.strictEqual(spawnStub.called, false);
+    });
+
     test('reports AppHost target version in end telemetry', async () => {
         const tempDir = makeTempDir();
         const appHostPath = join(tempDir, 'apphost.cs');
@@ -282,6 +326,60 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             assert.ok(event);
             assert.strictEqual(event.properties?.apphost_language, 'csharp');
             assert.strictEqual(event.properties?.apphost_target_version, '13.6.0');
+        }
+        finally {
+            restoreReporter();
+        }
+    });
+
+    test('reports resolved AppHost directory classification in end telemetry', async () => {
+        const tempDir = makeTempDir();
+        writeFileSync(join(tempDir, 'apphost.ts'), 'import { aspire } from "@microsoft/aspire";');
+        const fake = new FakeTelemetryReporter();
+        const restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            workspaceFolder: undefined,
+            configuration: {
+                type: 'aspire',
+                request: 'launch',
+                name: 'Aspire',
+                program: tempDir,
+                command: 'run',
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub(),
+        };
+        const terminalProvider = {
+            isCliDebugLoggingEnabled: () => false,
+        };
+        const dcpServer = {
+            takeDebugSessionAggregateStats: sinon.stub().returns({
+                anyNonZeroExit: false,
+                distinctResourceTypes: [],
+                totalChildSessions: 0,
+            }),
+        };
+        sinon.stub(vscode.debug, 'stopDebugging').resolves();
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, dcpServer as any, terminalProvider as any, () => { });
+        const spawnStub = sinon.stub(aspireDebugSession, 'spawnAspireCommand').resolves();
+
+        try {
+            aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
+            await waitFor(() => spawnStub.calledOnce);
+            const startEvent = fake.events.find(event => event.name === 'debug/apphost/start');
+            assert.ok(startEvent);
+            assert.strictEqual(startEvent.properties?.apphost_is_directory, 'unknown');
+
+            const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+            aspireDebugSession.dispose();
+            await waitForWithFakeClock(clock, () => fake.events.some(event => event.name === 'debug/apphost/end'));
+
+            const endEvent = fake.events.find(event => event.name === 'debug/apphost/end');
+            assert.ok(endEvent);
+            assert.strictEqual(endEvent.properties?.apphost_is_directory, 'true');
         }
         finally {
             restoreReporter();

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -336,6 +336,65 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         }
     });
 
+    test('reports AppHost end duration before async metadata enrichment completes', async () => {
+        const fake = new FakeTelemetryReporter();
+        const restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            workspaceFolder: undefined,
+            configuration: {
+                type: 'aspire',
+                request: 'launch',
+                name: 'Aspire',
+                program: '/workspace/apphost.cs',
+                command: 'run',
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub(),
+        };
+        const terminalProvider = {
+            isCliDebugLoggingEnabled: () => false,
+        };
+        const dcpServer = {
+            takeDebugSessionAggregateStats: sinon.stub().returns({
+                anyNonZeroExit: false,
+                distinctResourceTypes: [],
+                totalChildSessions: 0,
+            }),
+        };
+        sinon.stub(vscode.debug, 'stopDebugging').resolves();
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, dcpServer as any, terminalProvider as any, () => { });
+        let resolveTargetVersion: ((value: string) => void) | undefined;
+        const targetVersionPromise = new Promise<string>(resolve => {
+            resolveTargetVersion = resolve;
+        });
+        sinon.stub(aspireDebugSession as any, 'resolveAppHostTargetVersionAtLaunch').returns(targetVersionPromise);
+        sinon.stub(aspireDebugSession, 'spawnAspireCommand').resolves();
+        const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+
+        try {
+            aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
+            await clock.tickAsync(100);
+            aspireDebugSession.dispose();
+            await clock.tickAsync(500);
+            await clock.tickAsync(10_000);
+            resolveTargetVersion!('13.6.0');
+            await waitForWithFakeClock(clock, () => fake.events.some(event => event.name === 'debug/apphost/end'));
+
+            const event = fake.events.find(event => event.name === 'debug/apphost/end');
+            assert.ok(event);
+            assert.strictEqual(event.properties?.apphost_target_version, '13.6.0');
+            assert.ok(event.measurements?.duration_ms !== undefined);
+            assert.ok(event.measurements.duration_ms < 1_000, `Expected duration to exclude async metadata wait, got ${event.measurements.duration_ms}ms.`);
+        }
+        finally {
+            resolveTargetVersion?.('13.6.0');
+            restoreReporter();
+        }
+    });
+
     test('reports resolved AppHost directory classification in end telemetry', async () => {
         const fake = new FakeTelemetryReporter();
         const restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -1,11 +1,55 @@
 import * as assert from 'assert';
+import type { TelemetryReporter } from '@vscode/extension-telemetry';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { AspireDebugSession, buildAspireCommandArgs, getLoggableDebugConfiguration } from '../debugger/AspireDebugSession';
 import { AspireResourceExtendedDebugConfiguration } from '../dcp/types';
+import { __resetCommonPropertiesForTests, __setReporterForTests } from '../utils/telemetry';
+
+interface RecordedEvent {
+    name: string;
+    properties?: Record<string, string>;
+    measurements?: Record<string, number>;
+}
+
+class FakeTelemetryReporter {
+    public events: RecordedEvent[] = [];
+
+    sendTelemetryEvent(name: string, properties?: Record<string, string>, measurements?: Record<string, number>): void {
+        this.events.push({ name, properties, measurements });
+    }
+
+    sendTelemetryErrorEvent(): void { /* not used here */ }
+    sendDangerousTelemetryEvent(): void { /* not used here */ }
+    sendDangerousTelemetryErrorEvent(): void { /* not used here */ }
+    sendRawTelemetryEvent(): void { /* not used here */ }
+
+    dispose(): Promise<void> { return Promise.resolve(); }
+}
 
 suite('AspireDebugSession tests', () => {
-    teardown(() => sinon.restore());
+    const tempDirs: string[] = [];
+
+    function makeTempDir(): string {
+        const parent = join(process.cwd(), '.test-tmp');
+        mkdirSync(parent, { recursive: true });
+        const dir = mkdtempSync(join(parent, 'aspire-debug-session-'));
+        tempDirs.push(dir);
+        return dir;
+    }
+
+    teardown(() => {
+        sinon.restore();
+        __resetCommonPropertiesForTests();
+        for (const dir of tempDirs) {
+            if (existsSync(dir)) {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        }
+        tempDirs.length = 0;
+    });
 
     test('suppresses the Aspire CLI first-run banner for extension-managed launches', () => {
         const parentDebugSession = {
@@ -39,6 +83,103 @@ suite('AspireDebugSession tests', () => {
             '--apphost',
             '/workspace/apphost.cs',
         ]);
+    });
+
+    test('reports AppHost target version in start telemetry', () => {
+        const tempDir = makeTempDir();
+        const appHostPath = join(tempDir, 'apphost.cs');
+        writeFileSync(appHostPath, `#:sdk Aspire.AppHost.Sdk@13.6.0
+
+var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
+`);
+        const fake = new FakeTelemetryReporter();
+        const restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            workspaceFolder: undefined,
+            configuration: {
+                type: 'aspire',
+                request: 'launch',
+                name: 'Aspire',
+                program: appHostPath,
+                command: 'run',
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub(),
+        };
+        const terminalProvider = {
+            isCliDebugLoggingEnabled: () => false,
+        };
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, {} as any, terminalProvider as any, () => { });
+        sinon.stub(aspireDebugSession, 'spawnAspireCommand').resolves();
+
+        try {
+            aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
+
+            const event = fake.events.find(event => event.name === 'debug/apphost/start');
+            assert.ok(event);
+            assert.strictEqual(event.properties?.apphost_language, 'csharp');
+            assert.strictEqual(event.properties?.apphost_target_version, '13.6.0');
+        }
+        finally {
+            restoreReporter();
+        }
+    });
+
+    test('reports AppHost target version in end telemetry', async () => {
+        const tempDir = makeTempDir();
+        const appHostPath = join(tempDir, 'apphost.cs');
+        writeFileSync(appHostPath, `#:sdk Aspire.AppHost.Sdk@13.6.0
+
+var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
+`);
+        const fake = new FakeTelemetryReporter();
+        const restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            workspaceFolder: undefined,
+            configuration: {
+                type: 'aspire',
+                request: 'launch',
+                name: 'Aspire',
+                program: appHostPath,
+                command: 'run',
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub(),
+        };
+        const terminalProvider = {
+            isCliDebugLoggingEnabled: () => false,
+        };
+        const dcpServer = {
+            takeDebugSessionAggregateStats: sinon.stub().returns({
+                anyNonZeroExit: false,
+                distinctResourceTypes: ['project'],
+                totalChildSessions: 1,
+            }),
+        };
+        sinon.stub(vscode.debug, 'stopDebugging').resolves();
+        const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, dcpServer as any, terminalProvider as any, () => { });
+        sinon.stub(aspireDebugSession, 'spawnAspireCommand').resolves();
+
+        try {
+            aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
+            aspireDebugSession.dispose();
+            await clock.tickAsync(500);
+
+            const event = fake.events.find(event => event.name === 'debug/apphost/end');
+            assert.ok(event);
+            assert.strictEqual(event.properties?.apphost_language, 'csharp');
+            assert.strictEqual(event.properties?.apphost_target_version, '13.6.0');
+        }
+        finally {
+            restoreReporter();
+        }
     });
 
     test('redacts debug configuration environment fields from logs by default', () => {

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -51,7 +51,7 @@ suite('AspireDebugSession tests', () => {
         tempDirs.length = 0;
     });
 
-    test('suppresses the Aspire CLI first-run banner for extension-managed launches', () => {
+    test('suppresses the Aspire CLI first-run banner for extension-managed launches', async () => {
         const parentDebugSession = {
             id: 'aspire-session',
             type: 'aspire',
@@ -75,6 +75,7 @@ suite('AspireDebugSession tests', () => {
 
         aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
 
+        await waitFor(() => spawnStub.calledOnce);
         assert.strictEqual(spawnStub.calledOnce, true);
         assert.deepStrictEqual(spawnStub.firstCall.args[0], [
             'run',
@@ -85,7 +86,7 @@ suite('AspireDebugSession tests', () => {
         ]);
     });
 
-    test('reports AppHost target version in start telemetry', () => {
+    test('reports AppHost target version in start telemetry', async () => {
         const tempDir = makeTempDir();
         const appHostPath = join(tempDir, 'apphost.cs');
         writeFileSync(appHostPath, `#:sdk Aspire.AppHost.Sdk@13.6.0
@@ -118,6 +119,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         try {
             aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
 
+            await waitFor(() => fake.events.some(event => event.name === 'debug/apphost/start'));
             const event = fake.events.find(event => event.name === 'debug/apphost/start');
             assert.ok(event);
             assert.strictEqual(event.properties?.apphost_language, 'csharp');
@@ -163,14 +165,16 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             }),
         };
         sinon.stub(vscode.debug, 'stopDebugging').resolves();
-        const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
         const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, dcpServer as any, terminalProvider as any, () => { });
         sinon.stub(aspireDebugSession, 'spawnAspireCommand').resolves();
 
         try {
             aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
+            await waitFor(() => fake.events.some(event => event.name === 'debug/apphost/start'));
+            const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
             aspireDebugSession.dispose();
             await clock.tickAsync(500);
+            await clock.tickAsync(0);
 
             const event = fake.events.find(event => event.name === 'debug/apphost/end');
             assert.ok(event);
@@ -516,4 +520,15 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             assert.deepStrictEqual(args, ['run', '--isolated', '--apphost', '/workspace/AppHost.csproj', '--', '--custom-arg', 'value']);
         });
     });
+
+    async function waitFor(predicate: () => boolean): Promise<void> {
+        const start = Date.now();
+        while (!predicate()) {
+            if (Date.now() - start > 5000) {
+                throw new Error('Timed out waiting for condition.');
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 10));
+        }
+    }
 });

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -87,7 +87,7 @@ suite('AspireDebugSession tests', () => {
         ]);
     });
 
-    test('reports unknown AppHost target version in start telemetry before async enrichment', async () => {
+    test('omits AppHost target version in start telemetry before async enrichment', async () => {
         const fake = new FakeTelemetryReporter();
         const restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);
         const parentDebugSession = {
@@ -123,7 +123,7 @@ suite('AspireDebugSession tests', () => {
             const event = fake.events.find(event => event.name === 'debug/apphost/start');
             assert.ok(event);
             assert.strictEqual(event.properties?.apphost_language, 'csharp');
-            assert.strictEqual(event.properties?.apphost_target_version, 'unknown');
+            assert.strictEqual(Object.prototype.hasOwnProperty.call(event.properties ?? {}, 'apphost_target_version'), false);
             await waitFor(() => spawnStub.calledOnce);
         }
         finally {
@@ -178,7 +178,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             const event = eventsAtSpawn.find(event => event.name === 'debug/apphost/start');
             assert.ok(event, 'Expected debug/apphost/start to be emitted before spawnAspireCommand.');
             assert.strictEqual(event.properties?.apphost_language, 'csharp');
-            assert.strictEqual(event.properties?.apphost_target_version, 'unknown');
+            assert.strictEqual(Object.prototype.hasOwnProperty.call(event.properties ?? {}, 'apphost_target_version'), false);
         }
         finally {
             resolveTargetVersion?.('13.6.0');
@@ -440,7 +440,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             await waitFor(() => spawnStub.calledOnce);
             const startEvent = fake.events.find(event => event.name === 'debug/apphost/start');
             assert.ok(startEvent);
-            assert.strictEqual(startEvent.properties?.apphost_is_directory, 'unknown');
+            assert.strictEqual(Object.prototype.hasOwnProperty.call(startEvent.properties ?? {}, 'apphost_is_directory'), false);
 
             resolveLanguage!('typescript');
             await languagePromise;
@@ -512,7 +512,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             const startEvent = fake.events.find(event => event.name === 'debug/apphost/start');
             assert.ok(startEvent);
             assert.strictEqual(startEvent.properties?.apphost_language, 'unknown');
-            assert.strictEqual(startEvent.properties?.apphost_target_version, 'unknown');
+            assert.strictEqual(Object.prototype.hasOwnProperty.call(startEvent.properties ?? {}, 'apphost_target_version'), false);
 
             const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
             aspireDebugSession.dispose();

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { AspireDebugSession, buildAspireCommandArgs, getLoggableDebugConfiguration } from '../debugger/AspireDebugSession';
+import { appHostTelemetryTargetPathConfigKey } from '../debugger/AspireDebugConfigurationMetadata';
 import { AspireResourceExtendedDebugConfiguration } from '../dcp/types';
 import { __resetCommonPropertiesForTests, __setReporterForTests } from '../utils/telemetry';
 
@@ -454,6 +455,76 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         }
         finally {
             resolveLanguage?.('typescript');
+            restoreReporter();
+        }
+    });
+
+    test('uses workspace default candidate only for directory launch telemetry enrichment', async () => {
+        const workspaceDir = makeTempDir();
+        const appHostDir = join(workspaceDir, 'NestedAppHost');
+        mkdirSync(appHostDir);
+        const appHostPath = join(appHostDir, 'apphost.ts');
+        writeFileSync(appHostPath, 'import { createBuilder } from "./.aspire/modules/aspire";');
+        writeFileSync(join(appHostDir, 'aspire.config.json'), JSON.stringify({ sdk: { version: '13.6.0' } }));
+        const fake = new FakeTelemetryReporter();
+        const restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            workspaceFolder: undefined,
+            configuration: {
+                type: 'aspire',
+                request: 'launch',
+                name: 'Aspire',
+                program: workspaceDir,
+                command: 'run',
+                [appHostTelemetryTargetPathConfigKey]: appHostPath,
+            },
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub(),
+        };
+        const terminalProvider = {
+            isCliDebugLoggingEnabled: () => false,
+        };
+        const dcpServer = {
+            takeDebugSessionAggregateStats: sinon.stub().returns({
+                anyNonZeroExit: false,
+                distinctResourceTypes: [],
+                totalChildSessions: 0,
+            }),
+        };
+        sinon.stub(vscode.debug, 'stopDebugging').resolves();
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession as unknown as vscode.DebugSession, {} as any, dcpServer as any, terminalProvider as any, () => { });
+        const spawnStub = sinon.stub(aspireDebugSession, 'spawnAspireCommand').resolves();
+
+        try {
+            aspireDebugSession.handleMessage({ command: 'launch', seq: 1, arguments: { noDebug: false } });
+            await waitFor(() => spawnStub.calledOnce);
+            assert.deepStrictEqual(spawnStub.firstCall.args[0], [
+                'run',
+                '--start-debug-session',
+                '--nologo',
+            ]);
+            assert.strictEqual(spawnStub.firstCall.args[1], workspaceDir);
+
+            await waitFor(() => fake.events.some(event => event.name === 'debug/apphost/start'));
+            const startEvent = fake.events.find(event => event.name === 'debug/apphost/start');
+            assert.ok(startEvent);
+            assert.strictEqual(startEvent.properties?.apphost_language, 'unknown');
+            assert.strictEqual(startEvent.properties?.apphost_target_version, 'unknown');
+
+            const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+            aspireDebugSession.dispose();
+            await waitForWithFakeClock(clock, () => fake.events.some(event => event.name === 'debug/apphost/end'));
+
+            const endEvent = fake.events.find(event => event.name === 'debug/apphost/end');
+            assert.ok(endEvent);
+            assert.strictEqual(endEvent.properties?.apphost_language, 'typescript');
+            assert.strictEqual(endEvent.properties?.apphost_target_version, '13.6.0');
+            assert.strictEqual(endEvent.properties?.apphost_is_directory, 'true');
+        }
+        finally {
             restoreReporter();
         }
     });

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -511,7 +511,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             await waitFor(() => fake.events.some(event => event.name === 'debug/apphost/start'));
             const startEvent = fake.events.find(event => event.name === 'debug/apphost/start');
             assert.ok(startEvent);
-            assert.strictEqual(startEvent.properties?.apphost_language, 'unknown');
+            assert.strictEqual(startEvent.properties?.apphost_language, 'typescript');
             assert.strictEqual(Object.prototype.hasOwnProperty.call(startEvent.properties ?? {}, 'apphost_target_version'), false);
 
             const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });

--- a/extension/src/test/meaningfulEngagement.test.ts
+++ b/extension/src/test/meaningfulEngagement.test.ts
@@ -1,0 +1,89 @@
+import * as assert from 'assert';
+import type { TelemetryReporter } from '@vscode/extension-telemetry';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import type { CandidateAppHostDisplayInfo, AppHostDiscoveryService } from '../utils/appHostDiscovery';
+import { MeaningfulEngagementReporter } from '../utils/meaningfulEngagement';
+import { __resetCommonPropertiesForTests, __setReporterForTests, getCommonTelemetryProperties } from '../utils/telemetry';
+
+interface RecordedEvent {
+    name: string;
+    properties?: Record<string, string>;
+    measurements?: Record<string, number>;
+}
+
+class FakeTelemetryReporter {
+    public events: RecordedEvent[] = [];
+
+    sendTelemetryEvent(name: string, properties?: Record<string, string>, measurements?: Record<string, number>): void {
+        this.events.push({ name, properties, measurements });
+    }
+
+    sendTelemetryErrorEvent(): void { /* not used here */ }
+    sendDangerousTelemetryEvent(): void { /* not used here */ }
+    sendDangerousTelemetryErrorEvent(): void { /* not used here */ }
+    sendRawTelemetryEvent(): void { /* not used here */ }
+
+    dispose(): Promise<void> { return Promise.resolve(); }
+}
+
+suite('MeaningfulEngagementReporter', () => {
+    let fake: FakeTelemetryReporter;
+    let restoreReporter: () => void;
+
+    setup(() => {
+        fake = new FakeTelemetryReporter();
+        restoreReporter = __setReporterForTests(fake as unknown as TelemetryReporter);
+        __resetCommonPropertiesForTests();
+    });
+
+    teardown(() => {
+        sinon.restore();
+        restoreReporter();
+        __resetCommonPropertiesForTests();
+    });
+
+    test('includes AppHost target versions with AppHost language telemetry', async () => {
+        const workspaceFolder = {
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        } as vscode.WorkspaceFolder;
+        const candidates: CandidateAppHostDisplayInfo[] = [{
+            path: '/workspace/AppHost/AppHost.csproj',
+            language: 'csharp',
+            status: 'buildable',
+            aspireHostingVersion: '13.5.0',
+        }];
+        const discovery = {
+            onDidChangeCandidates: () => ({ dispose: () => { } }),
+            discover: async () => candidates,
+        } as unknown as AppHostDiscoveryService;
+        sinon.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder]);
+
+        const reporter = new MeaningfulEngagementReporter(discovery);
+        try {
+            reporter.recordCommandInvoked();
+            await waitFor(() => fake.events.length === 1);
+
+            assert.strictEqual(fake.events[0].name, 'engagement/active');
+            assert.strictEqual(fake.events[0].properties?.apphost_languages, 'csharp');
+            assert.strictEqual(fake.events[0].properties?.apphost_target_versions, '13.5.0');
+            assert.strictEqual(getCommonTelemetryProperties().apphost_target_versions, '13.5.0');
+        }
+        finally {
+            reporter.dispose();
+        }
+    });
+});
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+    const start = Date.now();
+    while (!predicate()) {
+        if (Date.now() - start > 1000) {
+            throw new Error('Timed out waiting for condition.');
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+    }
+}

--- a/extension/src/test/meaningfulEngagement.test.ts
+++ b/extension/src/test/meaningfulEngagement.test.ts
@@ -1,5 +1,7 @@
 import * as assert from 'assert';
 import type { TelemetryReporter } from '@vscode/extension-telemetry';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import type { CandidateAppHostDisplayInfo, AppHostDiscoveryService } from '../utils/appHostDiscovery';
@@ -30,6 +32,15 @@ class FakeTelemetryReporter {
 suite('MeaningfulEngagementReporter', () => {
     let fake: FakeTelemetryReporter;
     let restoreReporter: () => void;
+    const tempDirs: string[] = [];
+    const tempParent = join(process.cwd(), '.test-tmp');
+
+    function makeTempDir(): string {
+        mkdirSync(tempParent, { recursive: true });
+        const dir = mkdtempSync(join(tempParent, 'meaningful-engagement-'));
+        tempDirs.push(dir);
+        return dir;
+    }
 
     setup(() => {
         fake = new FakeTelemetryReporter();
@@ -39,21 +50,35 @@ suite('MeaningfulEngagementReporter', () => {
 
     teardown(() => {
         sinon.restore();
+        for (const dir of tempDirs) {
+            if (existsSync(dir)) {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        }
+        tempDirs.length = 0;
         restoreReporter();
         __resetCommonPropertiesForTests();
     });
 
+    suiteTeardown(() => {
+        if (existsSync(tempParent)) {
+            rmSync(tempParent, { recursive: true, force: true });
+        }
+    });
+
     test('includes AppHost target versions with AppHost language telemetry', async () => {
+        const workspacePath = makeTempDir();
+        const appHostPath = join(workspacePath, 'AppHost.csproj');
+        writeFileSync(appHostPath, '<Project Sdk="Aspire.AppHost.Sdk/13.5.0" />');
         const workspaceFolder = {
-            uri: vscode.Uri.file('/workspace'),
+            uri: vscode.Uri.file(workspacePath),
             name: 'workspace',
             index: 0,
         } as vscode.WorkspaceFolder;
         const candidates: CandidateAppHostDisplayInfo[] = [{
-            path: '/workspace/AppHost/AppHost.csproj',
+            path: appHostPath,
             language: 'csharp',
             status: 'buildable',
-            aspireHostingVersion: '13.5.0',
         }];
         const discovery = {
             onDidChangeCandidates: () => ({ dispose: () => { } }),

--- a/extension/src/test/packageManifest.test.ts
+++ b/extension/src/test/packageManifest.test.ts
@@ -164,6 +164,14 @@ suite('extension/package.json', () => {
         assert.ok(activationEvents.includes('workspaceContains:**/apphost.cjs'));
     });
 
+    test('FSharp and Visual Basic AppHost projects activate the extension', () => {
+        const manifest = readManifest();
+        const activationEvents = manifest.activationEvents ?? [];
+
+        assert.ok(activationEvents.includes('workspaceContains:**/*.fsproj'));
+        assert.ok(activationEvents.includes('workspaceContains:**/*.vbproj'));
+    });
+
     test('Explorer AppHost commands include Node module filenames', () => {
         const manifest = readManifest();
         const explorerMenus = manifest.contributes.menus?.['explorer/context'] ?? [];

--- a/extension/src/test/telemetryInventory.test.ts
+++ b/extension/src/test/telemetryInventory.test.ts
@@ -5,6 +5,7 @@ import * as ts from 'typescript';
 
 type TelemetryInventory = {
     events: Record<string, Record<string, unknown>>;
+    commonProperties: Record<string, unknown>;
 };
 
 type TelemetryRegistryEvent = {
@@ -41,6 +42,20 @@ function readTelemetryRegistryEvents(): TelemetryRegistryEvent[] {
     });
 
     return events;
+}
+
+function readCommonTelemetryProperties(): string[] {
+    const registryPath = path.resolve(__dirname, '../../src/utils/telemetryRegistry.ts');
+    const sourceText = fs.readFileSync(registryPath, 'utf8');
+    const sourceFile = ts.createSourceFile(registryPath, sourceText, ts.ScriptTarget.Latest, true);
+
+    for (const node of sourceFile.statements) {
+        if (ts.isTypeAliasDeclaration(node) && node.name.text === 'CommonTelemetryProperty') {
+            return getStringLiteralUnion(node.type).sort();
+        }
+    }
+
+    return [];
 }
 
 function getSchemaEntries(typeNode: ts.TypeNode): string[] {
@@ -107,5 +122,13 @@ suite('extension/telemetry.json', () => {
             });
 
         assert.deepStrictEqual(missingInventoryEntries, []);
+    });
+
+    test('declares every common property from telemetry registry', () => {
+        const inventory = readTelemetryInventory();
+        const missingCommonProperties = readCommonTelemetryProperties()
+            .filter(property => !Object.hasOwn(inventory.commonProperties, property));
+
+        assert.deepStrictEqual(missingCommonProperties, []);
     });
 });

--- a/extension/src/test/telemetryInventory.test.ts
+++ b/extension/src/test/telemetryInventory.test.ts
@@ -1,14 +1,90 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as ts from 'typescript';
 
 type TelemetryInventory = {
-    events: Record<string, unknown>;
+    events: Record<string, Record<string, unknown>>;
 };
+
+type TelemetryRegistryEvent = {
+    name: string;
+    entries: string[];
+};
+
+const telemetryEntityPrefix = 'microsoft-aspire.aspire-vscode/';
 
 function readTelemetryInventory(): TelemetryInventory {
     const inventoryPath = path.resolve(__dirname, '../../telemetry.json');
     return JSON.parse(fs.readFileSync(inventoryPath, 'utf8')) as TelemetryInventory;
+}
+
+function readTelemetryRegistryEvents(): TelemetryRegistryEvent[] {
+    const registryPath = path.resolve(__dirname, '../../src/utils/telemetryRegistry.ts');
+    const sourceText = fs.readFileSync(registryPath, 'utf8');
+    const sourceFile = ts.createSourceFile(registryPath, sourceText, ts.ScriptTarget.Latest, true);
+    const events: TelemetryRegistryEvent[] = [];
+
+    sourceFile.forEachChild(node => {
+        if (!ts.isInterfaceDeclaration(node) || node.name.text !== 'TelemetryEventSchema') {
+            return;
+        }
+
+        for (const member of node.members) {
+            if (!ts.isPropertySignature(member) || !member.type || !ts.isStringLiteral(member.name)) {
+                continue;
+            }
+
+            const entries = getSchemaEntries(member.type);
+            events.push({ name: member.name.text, entries });
+        }
+    });
+
+    return events;
+}
+
+function getSchemaEntries(typeNode: ts.TypeNode): string[] {
+    if (!ts.isTypeLiteralNode(typeNode)) {
+        return [];
+    }
+
+    const entries = new Set<string>();
+
+    for (const member of typeNode.members) {
+        if (!ts.isPropertySignature(member) || !member.type || !ts.isIdentifier(member.name)) {
+            continue;
+        }
+
+        if (member.name.text !== 'properties' && member.name.text !== 'measurements') {
+            continue;
+        }
+
+        for (const entry of getStringLiteralUnion(member.type)) {
+            entries.add(entry);
+        }
+    }
+
+    return [...entries].sort();
+}
+
+function getStringLiteralUnion(typeNode: ts.TypeNode): string[] {
+    if (typeNode.kind === ts.SyntaxKind.NeverKeyword) {
+        return [];
+    }
+
+    if (ts.isLiteralTypeNode(typeNode) && ts.isStringLiteral(typeNode.literal)) {
+        return [typeNode.literal.text];
+    }
+
+    if (ts.isUnionTypeNode(typeNode)) {
+        return typeNode.types.flatMap(getStringLiteralUnion);
+    }
+
+    if (ts.isParenthesizedTypeNode(typeNode)) {
+        return getStringLiteralUnion(typeNode.type);
+    }
+
+    return [];
 }
 
 suite('extension/telemetry.json', () => {
@@ -17,5 +93,19 @@ suite('extension/telemetry.json', () => {
         const mixedCaseEntityNames = Object.keys(inventory.events).filter(name => name !== name.toLowerCase());
 
         assert.deepStrictEqual(mixedCaseEntityNames, []);
+    });
+
+    test('declares every event property from telemetry registry', () => {
+        const inventory = readTelemetryInventory();
+        const missingInventoryEntries = readTelemetryRegistryEvents()
+            .flatMap(event => {
+                const inventoryEvent = inventory.events[`${telemetryEntityPrefix}${event.name}`];
+
+                return event.entries
+                    .filter(entry => !Object.hasOwn(inventoryEvent ?? {}, entry))
+                    .map(entry => `${event.name}.${entry}`);
+            });
+
+        assert.deepStrictEqual(missingInventoryEntries, []);
     });
 });

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -17,7 +17,6 @@ export interface CandidateAppHostDisplayInfo {
     path: string;
     language: string | null;
     status: string | null;
-    aspireHostingVersion?: string | null;
     selected?: boolean;
 }
 
@@ -26,7 +25,6 @@ export interface AppHostCandidate {
     path: string;
     language: string;
     status: string;
-    aspireHostingVersion?: string | null;
 }
 
 export interface AppHostProjectSearchResult {
@@ -632,10 +630,7 @@ function isLsCandidate(obj: unknown): obj is CandidateAppHostDisplayInfo {
         && typeof obj === 'object'
         && typeof (obj as CandidateAppHostDisplayInfo).path === 'string'
         && typeof (obj as CandidateAppHostDisplayInfo).language === 'string'
-        && typeof (obj as CandidateAppHostDisplayInfo).status === 'string'
-        && ((obj as CandidateAppHostDisplayInfo).aspireHostingVersion === undefined
-            || (obj as CandidateAppHostDisplayInfo).aspireHostingVersion === null
-            || typeof (obj as CandidateAppHostDisplayInfo).aspireHostingVersion === 'string');
+        && typeof (obj as CandidateAppHostDisplayInfo).status === 'string';
 }
 
 function toDisplayCandidate(candidate: CandidateAppHostDisplayInfo | AppHostCandidate): CandidateAppHostDisplayInfo {
@@ -644,10 +639,6 @@ function toDisplayCandidate(candidate: CandidateAppHostDisplayInfo | AppHostCand
         language: candidate.language,
         status: candidate.status,
     };
-
-    if (candidate.aspireHostingVersion !== undefined) {
-        displayCandidate.aspireHostingVersion = candidate.aspireHostingVersion;
-    }
 
     return displayCandidate;
 }
@@ -709,10 +700,7 @@ function isAppHostProjectSearchResult(obj: unknown): obj is AppHostProjectSearch
             && typeof candidate.relativePath === 'string'
             && typeof candidate.path === 'string'
             && typeof candidate.language === 'string'
-            && typeof candidate.status === 'string'
-            && (candidate.aspireHostingVersion === undefined
-                || candidate.aspireHostingVersion === null
-                || typeof candidate.aspireHostingVersion === 'string'));
+            && typeof candidate.status === 'string');
 }
 
 function toCandidatesFromLegacySearchResult(parsed: LegacyAppHostProjectSearchResult): CandidateAppHostDisplayInfo[] {

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -165,9 +165,9 @@ export class AppHostDiscoveryService implements vscode.Disposable {
                 this._throwIfDisposed();
                 let fileFallbackError: unknown;
                 try {
-                    const appHosts = await discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder);
+                    const appHosts = await discoverProjectAppHostsFromWorkspaceFiles(workspaceFolder);
                     if (appHosts.length > 0) {
-                        extensionLogOutputChannel.warn(`CLI AppHost discovery failed; using ${appHosts.length} C# AppHost project candidate(s) found in the workspace.`);
+                        extensionLogOutputChannel.warn(`CLI AppHost discovery failed; using ${appHosts.length} AppHost project candidate(s) found in the workspace.`);
                         return appHosts;
                     }
                 }
@@ -570,11 +570,15 @@ function parseCandidateOutput(output: string, commandName: string): CandidateApp
     throw new Error(`${commandName} returned an unexpected output shape.`);
 }
 
-async function discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
+async function discoverProjectAppHostsFromWorkspaceFiles(workspaceFolder: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo[]> {
     // This is the final fallback after both CLI discovery paths fail. Do not cap the
     // project scan here: VS Code returns only the first maxResults matches, which can
     // hide the only AppHost in a large workspace.
-    const projectUris = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, '**/*.csproj'), getAppHostDiscoveryExcludeGlob());
+    const projectUris = (await Promise.all([
+        vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, '**/*.csproj'), getAppHostDiscoveryExcludeGlob()),
+        vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, '**/*.fsproj'), getAppHostDiscoveryExcludeGlob()),
+        vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, '**/*.vbproj'), getAppHostDiscoveryExcludeGlob()),
+    ])).flat();
     const candidates: CandidateAppHostDisplayInfo[] = [];
     for (const uri of projectUris.sort((left, right) => left.fsPath.localeCompare(right.fsPath))) {
         let projectContents: string;
@@ -586,10 +590,10 @@ async function discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder: 
             continue;
         }
 
-        if (isCSharpAppHostProject(projectContents)) {
+        if (isAppHostProject(projectContents)) {
             candidates.push({
                 path: uri.fsPath,
-                language: 'csharp',
+                language: getProjectLanguage(uri.fsPath),
                 status: 'buildable',
             });
         }
@@ -598,8 +602,16 @@ async function discoverCSharpAppHostProjectsFromWorkspaceFiles(workspaceFolder: 
     return candidates;
 }
 
-function isCSharpAppHostProject(projectContents: string): boolean {
+function isAppHostProject(projectContents: string): boolean {
     return /<Project\b[^>]*\bSdk\s*=\s*["']Aspire\.AppHost\.Sdk(?:\/[^"']*)?["']/i.test(projectContents);
+}
+
+function getProjectLanguage(projectPath: string): string {
+    return path.extname(projectPath).toLowerCase() === '.fsproj'
+        ? 'fsharp'
+        : path.extname(projectPath).toLowerCase() === '.vbproj'
+            ? 'visualbasic'
+            : 'csharp';
 }
 
 function parseLegacyGetAppHostsOutput(output: string): LegacyAppHostProjectSearchResult {

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -97,11 +97,23 @@ export class AppHostDiscoveryService implements vscode.Disposable {
             return undefined;
         }
 
+        if (isSamePath(filePath, folder.uri.fsPath)) {
+            return undefined;
+        }
+
         const candidates = await this.discover(folder);
-        const candidate = isSamePath(filePath, folder.uri.fsPath)
-            ? findWorkspaceDefaultCandidate(candidates)
-            : findCandidateForEditorFile(filePath, candidates);
+        const candidate = findCandidateForEditorFile(filePath, candidates);
         return candidate ? getDebugTargetForCandidate(candidate) : undefined;
+    }
+
+    async tryFindWorkspaceDefaultCandidate(filePath: string, workspaceFolder?: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo | undefined> {
+        const folder = workspaceFolder ?? vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
+        if (!folder || !isSamePath(filePath, folder.uri.fsPath)) {
+            return undefined;
+        }
+
+        const candidates = await this.discover(folder);
+        return findWorkspaceDefaultCandidate(candidates);
     }
 
     async tryFindCandidateForEditorFile(filePath: string, workspaceFolder?: vscode.WorkspaceFolder): Promise<CandidateAppHostDisplayInfo | undefined> {

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -17,6 +17,7 @@ export interface CandidateAppHostDisplayInfo {
     path: string;
     language: string | null;
     status: string | null;
+    aspireHostingVersion?: string | null;
     selected?: boolean;
 }
 
@@ -25,6 +26,7 @@ export interface AppHostCandidate {
     path: string;
     language: string;
     status: string;
+    aspireHostingVersion?: string | null;
 }
 
 export interface AppHostProjectSearchResult {
@@ -524,6 +526,7 @@ function parseCandidateOutput(output: string, commandName: string): CandidateApp
                 path: candidate.path,
                 language: candidate.language,
                 status: candidate.status,
+                aspireHostingVersion: candidate.aspireHostingVersion,
             }));
 
         const unexpectedCandidateCount = parsed.length - appHosts.length;
@@ -539,6 +542,7 @@ function parseCandidateOutput(output: string, commandName: string): CandidateApp
             path: candidate.path,
             language: candidate.language,
             status: candidate.status,
+            aspireHostingVersion: candidate.aspireHostingVersion,
             selected: typeof parsed.selected_project_file === 'string' && isSamePath(parsed.selected_project_file, candidate.path),
         }));
     }
@@ -610,7 +614,10 @@ function isLsCandidate(obj: unknown): obj is CandidateAppHostDisplayInfo {
         && typeof obj === 'object'
         && typeof (obj as CandidateAppHostDisplayInfo).path === 'string'
         && typeof (obj as CandidateAppHostDisplayInfo).language === 'string'
-        && typeof (obj as CandidateAppHostDisplayInfo).status === 'string';
+        && typeof (obj as CandidateAppHostDisplayInfo).status === 'string'
+        && ((obj as CandidateAppHostDisplayInfo).aspireHostingVersion === undefined
+            || (obj as CandidateAppHostDisplayInfo).aspireHostingVersion === null
+            || typeof (obj as CandidateAppHostDisplayInfo).aspireHostingVersion === 'string');
 }
 
 function formatErrorMessage(error: unknown): string {
@@ -670,7 +677,10 @@ function isAppHostProjectSearchResult(obj: unknown): obj is AppHostProjectSearch
             && typeof candidate.relativePath === 'string'
             && typeof candidate.path === 'string'
             && typeof candidate.language === 'string'
-            && typeof candidate.status === 'string');
+            && typeof candidate.status === 'string'
+            && (candidate.aspireHostingVersion === undefined
+                || candidate.aspireHostingVersion === null
+                || typeof candidate.aspireHostingVersion === 'string'));
 }
 
 function toCandidatesFromLegacySearchResult(parsed: LegacyAppHostProjectSearchResult): CandidateAppHostDisplayInfo[] {

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -522,12 +522,7 @@ function parseCandidateOutput(output: string, commandName: string): CandidateApp
     if (Array.isArray(parsed)) {
         const appHosts = parsed
             .filter(isLsCandidate)
-            .map(candidate => ({
-                path: candidate.path,
-                language: candidate.language,
-                status: candidate.status,
-                aspireHostingVersion: candidate.aspireHostingVersion,
-            }));
+            .map(candidate => toDisplayCandidate(candidate));
 
         const unexpectedCandidateCount = parsed.length - appHosts.length;
         if (unexpectedCandidateCount > 0) {
@@ -539,10 +534,7 @@ function parseCandidateOutput(output: string, commandName: string): CandidateApp
 
     if (isAppHostProjectSearchResult(parsed)) {
         return parsed.app_host_candidates.map(candidate => ({
-            path: candidate.path,
-            language: candidate.language,
-            status: candidate.status,
-            aspireHostingVersion: candidate.aspireHostingVersion,
+            ...toDisplayCandidate(candidate),
             selected: typeof parsed.selected_project_file === 'string' && isSamePath(parsed.selected_project_file, candidate.path),
         }));
     }
@@ -618,6 +610,20 @@ function isLsCandidate(obj: unknown): obj is CandidateAppHostDisplayInfo {
         && ((obj as CandidateAppHostDisplayInfo).aspireHostingVersion === undefined
             || (obj as CandidateAppHostDisplayInfo).aspireHostingVersion === null
             || typeof (obj as CandidateAppHostDisplayInfo).aspireHostingVersion === 'string');
+}
+
+function toDisplayCandidate(candidate: CandidateAppHostDisplayInfo | AppHostCandidate): CandidateAppHostDisplayInfo {
+    const displayCandidate: CandidateAppHostDisplayInfo = {
+        path: candidate.path,
+        language: candidate.language,
+        status: candidate.status,
+    };
+
+    if (candidate.aspireHostingVersion !== undefined) {
+        displayCandidate.aspireHostingVersion = candidate.aspireHostingVersion;
+    }
+
+    return displayCandidate;
 }
 
 function formatErrorMessage(error: unknown): string {

--- a/extension/src/utils/appHostDiscovery.ts
+++ b/extension/src/utils/appHostDiscovery.ts
@@ -92,7 +92,15 @@ export class AppHostDiscoveryService implements vscode.Disposable {
     }
 
     async tryResolveDebugTarget(filePath: string, workspaceFolder?: vscode.WorkspaceFolder): Promise<string | undefined> {
-        const candidate = await this.tryFindCandidateForEditorFile(filePath, workspaceFolder);
+        const folder = workspaceFolder ?? vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
+        if (!folder) {
+            return undefined;
+        }
+
+        const candidates = await this.discover(folder);
+        const candidate = isSamePath(filePath, folder.uri.fsPath)
+            ? findWorkspaceDefaultCandidate(candidates)
+            : findCandidateForEditorFile(filePath, candidates);
         return candidate ? getDebugTargetForCandidate(candidate) : undefined;
     }
 
@@ -396,6 +404,12 @@ export function findCandidateForEditorFile(filePath: string, candidates: readonl
         .filter(candidate => isCSharpProjectCandidate(candidate) && isCSharpSourceFileForProjectCandidate(filePath, candidate.path))
         .sort((left, right) => path.dirname(right.path).length - path.dirname(left.path).length)[0];
     return projectCandidate;
+}
+
+function findWorkspaceDefaultCandidate(candidates: readonly CandidateAppHostDisplayInfo[]): CandidateAppHostDisplayInfo | undefined {
+    const buildableCandidates = candidates.filter(isBuildableCandidate);
+    return buildableCandidates.find(candidate => candidate.selected)
+        ?? (buildableCandidates.length === 1 ? buildableCandidates[0] : undefined);
 }
 
 export function getDebugTargetForCandidate(candidate: CandidateAppHostDisplayInfo): string {
@@ -707,6 +721,10 @@ function isCSharpProjectCandidate(candidate: CandidateAppHostDisplayInfo): boole
     // candidate adaptation/matching.
     return path.extname(candidate.path).toLowerCase() === '.csproj'
         && (candidate.language === null || candidate.language.toLowerCase() === 'csharp');
+}
+
+function isBuildableCandidate(candidate: CandidateAppHostDisplayInfo): boolean {
+    return candidate.status === null || candidate.status === 'buildable';
 }
 
 function isCSharpSourceFileForProjectCandidate(filePath: string, projectPath: string): boolean {

--- a/extension/src/utils/appHostLanguage.ts
+++ b/extension/src/utils/appHostLanguage.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
 import { CandidateAppHostDisplayInfo } from './appHostDiscovery';
 
 /**
@@ -112,22 +112,19 @@ export function classifyAppHostPath(appHostPath: string | undefined): 'csharp' |
  * launches AppHosts as a directory (e.g. `aspire run` without `--apphost`)
  * because the entry file lives next to `package.json` / `*.csproj` and is
  * discovered at runtime. Looking only at the directory name itself loses the
- * language signal entirely, so we synchronously enumerate the directory and
- * match well-known AppHost file names.
+ * language signal entirely, so we enumerate the directory and match well-known
+ * AppHost file names.
  *
- * Used at telemetry-emit time only — the function is intentionally synchronous
- * to keep the launch-telemetry call path simple and to avoid plumbing async
- * through {@link AspireDebugSession.handleMessage}. Directory reads are
- * O(entries), small for typical AppHost roots; any failure (permissions,
- * missing directory) returns `'unknown'` rather than throwing.
+ * Directory reads are O(entries), small for typical AppHost roots; any failure
+ * (permissions, missing directory) returns `'unknown'` rather than throwing.
  */
-export function classifyAppHostDirectory(directoryPath: string | undefined): 'csharp' | 'typescript' | 'unknown' {
+export async function classifyAppHostDirectory(directoryPath: string | undefined): Promise<'csharp' | 'typescript' | 'unknown'> {
     if (!directoryPath) {
         return 'unknown';
     }
     let entries: string[];
     try {
-        entries = readdirSync(directoryPath);
+        entries = await fs.readdir(directoryPath);
     }
     catch {
         return 'unknown';

--- a/extension/src/utils/appHostLanguage.ts
+++ b/extension/src/utils/appHostLanguage.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
 import { CandidateAppHostDisplayInfo } from './appHostDiscovery';
 
 /**
@@ -132,7 +133,7 @@ export async function classifyAppHostDirectory(directoryPath: string | undefined
     let sawCsharp = false;
     let sawTypescript = false;
     for (const entry of entries) {
-        if (isCsharpAppHostMarker(entry)) {
+        if (await isCsharpAppHostMarker(directoryPath, entry)) {
             sawCsharp = true;
         }
         else if (isTypescriptAppHostMarker(entry)) {
@@ -154,9 +155,60 @@ export async function classifyAppHostDirectory(directoryPath: string | undefined
     return 'unknown';
 }
 
-function isCsharpAppHostMarker(entry: string): boolean {
+async function isCsharpAppHostMarker(directoryPath: string, entry: string): Promise<boolean> {
     const lower = entry.toLowerCase();
-    return lower === 'apphost.cs' || lower.endsWith('.csproj') || lower.endsWith('.fsproj') || lower.endsWith('.vbproj');
+    if (lower === 'apphost.cs') {
+        return true;
+    }
+
+    if (!lower.endsWith('.csproj') && !lower.endsWith('.fsproj') && !lower.endsWith('.vbproj')) {
+        return false;
+    }
+
+    if (projectFileNameLooksLikeAppHost(lower)) {
+        return true;
+    }
+
+    return await projectFileReferencesAspireAppHost(directoryPath, entry);
+}
+
+function projectFileNameLooksLikeAppHost(fileName: string): boolean {
+    const nameWithoutExtension = fileName.replace(/\.[^.]+$/, '');
+    return nameWithoutExtension === 'apphost'
+        || nameWithoutExtension.startsWith('apphost')
+        || nameWithoutExtension.endsWith('.apphost')
+        || nameWithoutExtension.includes('.apphost.');
+}
+
+async function projectFileReferencesAspireAppHost(directoryPath: string, entry: string): Promise<boolean> {
+    let contents: string;
+    try {
+        contents = await fs.readFile(join(directoryPath, entry), 'utf8');
+    }
+    catch {
+        return false;
+    }
+
+    const uncommentedContents = contents.replace(/<!--[\s\S]*?-->/g, '');
+    // C# AppHost project files can advertise Aspire through SDK, package, or evaluated properties:
+    //   <Project Sdk="Aspire.AppHost.Sdk/13.5.0">
+    //   <Sdk Name="Aspire.AppHost.Sdk" Version="13.5.0" />
+    //   <PackageReference Include="Aspire.Hosting.AppHost" />
+    //   <IsAspireHost>true</IsAspireHost>
+    return projectSdkReferencesAspireAppHost(uncommentedContents)
+        || /<Sdk\b(?=[^>]*\bName\s*=\s*(["'])Aspire\.AppHost\.Sdk\1)[^>]*>/is.test(uncommentedContents)
+        || /<(?:PackageReference|AspireProjectOrPackageReference)\b(?=[^>]*\bInclude\s*=\s*["']Aspire\.Hosting(?:\.AppHost)?["'])[^>]*>/is.test(uncommentedContents)
+        || /<IsAspireHost>\s*true\s*<\/IsAspireHost>/i.test(uncommentedContents);
+}
+
+function projectSdkReferencesAspireAppHost(contents: string): boolean {
+    const projectSdkMatch = /<Project\b[^>]*\bSdk\s*=\s*(["'])(?<sdks>.*?)\1/is.exec(contents);
+    const sdkAttribute = projectSdkMatch?.groups?.sdks;
+    if (!sdkAttribute) {
+        return false;
+    }
+
+    return sdkAttribute.split(';').some(sdk => /^Aspire\.AppHost\.Sdk(?:\/|$)/i.test(sdk.trim()));
 }
 
 function isTypescriptAppHostMarker(entry: string): boolean {

--- a/extension/src/utils/appHostLanguage.ts
+++ b/extension/src/utils/appHostLanguage.ts
@@ -25,9 +25,9 @@ export type AppHostLanguageSummary = 'csharp' | 'typescript' | 'polyglot' | 'unk
  * the summary. Anything we don't recognize is grouped as `'other'` so that a
  * mixed workspace still reports `polyglot` rather than hiding the diversity.
  */
-function languageFamily(raw: string | null | undefined): 'csharp' | 'typescript' | 'other' | undefined {
+function languageFamily(raw: string | null | undefined): 'csharp' | 'typescript' | 'other' {
     if (!raw) {
-        return undefined;
+        return 'other';
     }
     const value = raw.toLowerCase();
     if (value === 'csharp' || value === 'c#') {
@@ -51,9 +51,6 @@ export function summarizeAppHostLanguages(candidates: readonly CandidateAppHostD
 
     for (const candidate of candidates) {
         const family = languageFamily(candidate.language);
-        if (family === undefined) {
-            continue;
-        }
         sawAny = true;
         if (family === 'csharp') {
             sawCsharp = true;
@@ -175,9 +172,7 @@ async function isCsharpAppHostMarker(directoryPath: string, entry: string): Prom
 function projectFileNameLooksLikeAppHost(fileName: string): boolean {
     const nameWithoutExtension = fileName.replace(/\.[^.]+$/, '');
     return nameWithoutExtension === 'apphost'
-        || nameWithoutExtension.startsWith('apphost')
-        || nameWithoutExtension.endsWith('.apphost')
-        || nameWithoutExtension.includes('.apphost.');
+        || nameWithoutExtension.endsWith('.apphost');
 }
 
 async function projectFileReferencesAspireAppHost(directoryPath: string, entry: string): Promise<boolean> {

--- a/extension/src/utils/appHostLanguage.ts
+++ b/extension/src/utils/appHostLanguage.ts
@@ -98,7 +98,7 @@ export function classifyAppHostPath(appHostPath: string | undefined): 'csharp' |
         return 'unknown';
     }
     const lower = appHostPath.toLowerCase();
-    if (lower.endsWith('.csproj') || lower.endsWith('.cs')) {
+    if (lower.endsWith('.csproj') || lower.endsWith('.fsproj') || lower.endsWith('.vbproj') || lower.endsWith('.cs')) {
         return 'csharp';
     }
     if (lower.endsWith('.ts') || lower.endsWith('.mts') || lower.endsWith('.cts') ||

--- a/extension/src/utils/appHostLanguage.ts
+++ b/extension/src/utils/appHostLanguage.ts
@@ -132,11 +132,10 @@ export async function classifyAppHostDirectory(directoryPath: string | undefined
     let sawCsharp = false;
     let sawTypescript = false;
     for (const entry of entries) {
-        const family = classifyAppHostPath(entry);
-        if (family === 'csharp') {
+        if (isCsharpAppHostMarker(entry)) {
             sawCsharp = true;
         }
-        else if (family === 'typescript') {
+        else if (isTypescriptAppHostMarker(entry)) {
             sawTypescript = true;
         }
     }
@@ -153,4 +152,15 @@ export async function classifyAppHostDirectory(directoryPath: string | undefined
         return 'typescript';
     }
     return 'unknown';
+}
+
+function isCsharpAppHostMarker(entry: string): boolean {
+    const lower = entry.toLowerCase();
+    return lower === 'apphost.cs' || lower.endsWith('.csproj') || lower.endsWith('.fsproj') || lower.endsWith('.vbproj');
+}
+
+function isTypescriptAppHostMarker(entry: string): boolean {
+    const lower = entry.toLowerCase();
+    return lower === 'apphost.ts' || lower === 'apphost.mts' || lower === 'apphost.cts' ||
+        lower === 'apphost.js' || lower === 'apphost.mjs' || lower === 'apphost.cjs';
 }

--- a/extension/src/utils/appHostTargetVersion.ts
+++ b/extension/src/utils/appHostTargetVersion.ts
@@ -101,9 +101,15 @@ async function getAppHostTargetVersionFromDirectory(directoryPath: string): Prom
 
     const versions = new Set<string>();
     let sawCSharpAppHostFile = false;
+    let sawUnversionedCSharpAppHostFile = false;
     for (const result of versionResults) {
         sawCSharpAppHostFile ||= result.isCSharpAppHostFile;
+        sawUnversionedCSharpAppHostFile ||= result.isCSharpAppHostFile && result.version === undefined;
         addVersion(versions, result.version);
+    }
+
+    if (versions.size > 0 && sawUnversionedCSharpAppHostFile) {
+        versions.add(unknownVersion);
     }
 
     const summary = summarizeVersions(versions);

--- a/extension/src/utils/appHostTargetVersion.ts
+++ b/extension/src/utils/appHostTargetVersion.ts
@@ -385,6 +385,13 @@ async function readJsoncFile(filePath: string): Promise<JsoncFileResult> {
         return { exists: false };
     }
 
+    if (contents.startsWith('\uFEFF')) {
+        // jsonc-parser reports a leading UTF-8 BOM as InvalidSymbol even though
+        // the rest of the JSONC object is parsed. Strip only that exact prefix so
+        // BOM-prefixed config files work without accepting any other invalid input.
+        contents = contents.slice(1);
+    }
+
     const errors: ParseError[] = [];
     const parsed = parse(contents, errors, { allowTrailingComma: true }) as unknown;
     return {

--- a/extension/src/utils/appHostTargetVersion.ts
+++ b/extension/src/utils/appHostTargetVersion.ts
@@ -92,11 +92,7 @@ async function getAppHostTargetVersionFromDirectory(directoryPath: string): Prom
     }
 
     const versionResults = await Promise.all(entries.map(async entry => {
-        const entryPath = join(directoryPath, entry);
-        return {
-            isCSharpAppHostFile: isCSharpAppHostFile(entryPath),
-            version: await getAppHostTargetVersionFromFile(entryPath),
-        };
+        return await getAppHostTargetVersionInfoFromDirectoryEntry(directoryPath, entry, entries);
     }));
 
     const versions = new Set<string>();
@@ -115,9 +111,33 @@ async function getAppHostTargetVersionFromDirectory(directoryPath: string): Prom
 }
 
 async function getAppHostTargetVersionFromFile(filePath: string): Promise<string | undefined> {
+    return (await getAppHostTargetVersionInfoFromFile(filePath)).version;
+}
+
+async function getAppHostTargetVersionInfoFromDirectoryEntry(directoryPath: string, entry: string, entries: readonly string[]): Promise<FileTargetVersionInfo> {
+    const entryPath = join(directoryPath, entry);
+    const versionInfo = await getAppHostTargetVersionInfoFromFile(entryPath);
+
+    if (extname(entry).toLowerCase() !== '.cs') {
+        return versionInfo;
+    }
+
+    // Match the CLI's single-file AppHost detection so unrelated helper.cs files
+    // cannot block a polyglot directory from using aspire.config.json.
+    return isSingleFileCSharpAppHostEntry(entry, entries)
+        ? versionInfo
+        : noFileTargetVersionInfo();
+}
+
+interface FileTargetVersionInfo {
+    version?: string;
+    isCSharpAppHostFile: boolean;
+}
+
+async function getAppHostTargetVersionInfoFromFile(filePath: string): Promise<FileTargetVersionInfo> {
     const extension = extname(filePath).toLowerCase();
     if (extension !== '.csproj' && extension !== '.cs') {
-        return undefined;
+        return noFileTargetVersionInfo();
     }
 
     let contents: string;
@@ -125,35 +145,53 @@ async function getAppHostTargetVersionFromFile(filePath: string): Promise<string
         contents = await fs.readFile(filePath, 'utf8');
     }
     catch {
-        return undefined;
+        return noFileTargetVersionInfo();
     }
 
     if (extension === '.cs') {
-        return getAspireAppHostSdkVersionFromSingleFile(contents);
+        const singleFileVersion = getAspireAppHostSdkVersionFromSingleFile(contents);
+        return {
+            version: singleFileVersion.version,
+            isCSharpAppHostFile: singleFileVersion.referencesAspireAppHostSdk,
+        };
     }
 
     const projectVersion = getAspireAppHostSdkVersionFromProject(contents);
     if (projectVersion.version) {
-        return projectVersion.version;
+        return {
+            version: projectVersion.version,
+            isCSharpAppHostFile: true,
+        };
     }
 
-    return projectVersion.referencesAspireAppHostSdk && !projectVersion.hasInlineVersion
+    const globalJsonVersion = projectVersion.referencesAspireAppHostSdk && !projectVersion.hasInlineVersion
         ? await getGlobalJsonMsBuildSdkVersion(dirname(filePath))
         : undefined;
+
+    return {
+        version: globalJsonVersion,
+        isCSharpAppHostFile: projectVersion.referencesAspireAppHostSdk,
+    };
 }
 
 function isPolyglotAppHostFile(filePath: string): boolean {
     return ['.ts', '.mts', '.cts', '.js', '.mjs', '.cjs'].includes(extname(filePath).toLowerCase());
 }
 
-function isCSharpAppHostFile(filePath: string): boolean {
-    return ['.csproj', '.cs'].includes(extname(filePath).toLowerCase());
+function isSingleFileCSharpAppHostEntry(entry: string, entries: readonly string[]): boolean {
+    return entry.toLowerCase() === 'apphost.cs'
+        && !entries.some(entry => extname(entry).toLowerCase() === '.csproj');
 }
 
 interface ProjectSdkVersionInfo {
     version?: string;
     referencesAspireAppHostSdk: boolean;
     hasInlineVersion: boolean;
+}
+
+interface SingleFileSdkVersionInfo {
+    version?: string;
+    referencesAspireAppHostSdk: boolean;
 }
 
 function getAspireAppHostSdkVersionFromProject(contents: string): ProjectSdkVersionInfo {
@@ -245,18 +283,21 @@ function getAspireHostingSdkVersionProperty(contents: string): string | undefine
     return normalizeVersion(propertyMatch?.groups?.version);
 }
 
-function getAspireAppHostSdkVersionFromSingleFile(contents: string): string | undefined {
+function getAspireAppHostSdkVersionFromSingleFile(contents: string): SingleFileSdkVersionInfo {
     // Single-file C# AppHosts target Aspire with a file directive:
     //   #:sdk Aspire.AppHost.Sdk@13.5.0
-    const directiveMatch = /^[ \t]*#:sdk[ \t]+Aspire\.AppHost\.Sdk@(?<version>\S+)/im.exec(contents);
-    return normalizeVersion(directiveMatch?.groups?.version);
+    const directiveMatch = /^[ \t]*#:sdk[ \t]+Aspire\.AppHost\.Sdk(?:@(?<version>\S+))?/im.exec(contents);
+    return {
+        version: normalizeVersion(directiveMatch?.groups?.version),
+        referencesAspireAppHostSdk: directiveMatch !== null,
+    };
 }
 
 async function getConfiguredSdkVersion(startDirectory: string): Promise<string | undefined> {
     for (let directory = resolve(startDirectory); ; directory = dirname(directory)) {
-        const version = await getConfiguredSdkVersionInDirectory(directory);
-        if (version) {
-            return version;
+        const result = await getConfiguredSdkVersionInDirectory(directory);
+        if (result.version || result.foundConfig) {
+            return result.version;
         }
 
         const parent = dirname(directory);
@@ -266,23 +307,44 @@ async function getConfiguredSdkVersion(startDirectory: string): Promise<string |
     }
 }
 
-async function getConfiguredSdkVersionInDirectory(directory: string): Promise<string | undefined> {
-    return await readSdkVersionFromConfigFile(join(directory, 'aspire.config.json'))
-        ?? await readSdkVersionFromConfigFile(join(directory, '.aspire', 'settings.json'));
+interface ConfiguredSdkVersionInfo {
+    version?: string;
+    foundConfig: boolean;
 }
 
-async function readSdkVersionFromConfigFile(configPath: string): Promise<string | undefined> {
-    const parsed = await readJsoncFile(configPath);
+async function getConfiguredSdkVersionInDirectory(directory: string): Promise<ConfiguredSdkVersionInfo> {
+    const configVersion = await readSdkVersionFromConfigFile(join(directory, 'aspire.config.json'));
+    if (configVersion.version || configVersion.foundConfig) {
+        const settingsVersion = await readSdkVersionFromConfigFile(join(directory, '.aspire', 'settings.json'));
+        return {
+            version: configVersion.version ?? settingsVersion.version,
+            foundConfig: true,
+        };
+    }
+
+    return await readSdkVersionFromConfigFile(join(directory, '.aspire', 'settings.json'));
+}
+
+async function readSdkVersionFromConfigFile(configPath: string): Promise<ConfiguredSdkVersionInfo> {
+    const file = await readJsoncFile(configPath);
+    if (!file.exists) {
+        return { foundConfig: false };
+    }
+
+    const parsed = file.value;
     const sdk = getJsonObjectProperty(parsed, 'sdk');
-    return normalizeVersion(sdk?.version)
-        ?? normalizeVersion(parsed?.sdkVersion);
+    return {
+        version: normalizeVersion(sdk?.version)
+            ?? normalizeVersion(parsed?.sdkVersion),
+        foundConfig: true,
+    };
 }
 
 async function getGlobalJsonMsBuildSdkVersion(startDirectory: string): Promise<string | undefined> {
     for (let directory = resolve(startDirectory); ; directory = dirname(directory)) {
-        const version = await readAspireAppHostSdkVersionFromGlobalJson(join(directory, 'global.json'));
-        if (version) {
-            return version;
+        const result = await readAspireAppHostSdkVersionFromGlobalJson(join(directory, 'global.json'));
+        if (result.version || result.foundConfig) {
+            return result.version;
         }
 
         const parent = dirname(directory);
@@ -292,27 +354,43 @@ async function getGlobalJsonMsBuildSdkVersion(startDirectory: string): Promise<s
     }
 }
 
-async function readAspireAppHostSdkVersionFromGlobalJson(globalJsonPath: string): Promise<string | undefined> {
-    const parsed = await readJsoncFile(globalJsonPath);
+async function readAspireAppHostSdkVersionFromGlobalJson(globalJsonPath: string): Promise<ConfiguredSdkVersionInfo> {
+    const file = await readJsoncFile(globalJsonPath);
+    if (!file.exists) {
+        return { foundConfig: false };
+    }
+
+    const parsed = file.value;
     const msBuildSdks = getJsonObjectProperty(parsed, 'msbuild-sdks');
     // MSBuild's SDK resolver reads this global.json shape:
     //   { "msbuild-sdks": { "Aspire.AppHost.Sdk": "13.5.0" } }
     // See https://learn.microsoft.com/visualstudio/msbuild/how-to-use-project-sdk#how-project-sdks-are-resolved.
-    return normalizeVersion(msBuildSdks?.['Aspire.AppHost.Sdk']);
+    return {
+        version: normalizeVersion(msBuildSdks?.['Aspire.AppHost.Sdk']),
+        foundConfig: true,
+    };
 }
 
-async function readJsoncFile(filePath: string): Promise<Record<string, unknown> | undefined> {
+interface JsoncFileResult {
+    exists: boolean;
+    value?: Record<string, unknown>;
+}
+
+async function readJsoncFile(filePath: string): Promise<JsoncFileResult> {
     let contents: string;
     try {
         contents = await fs.readFile(filePath, 'utf8');
     }
     catch {
-        return undefined;
+        return { exists: false };
     }
 
     const errors: ParseError[] = [];
     const parsed = parse(contents, errors, { allowTrailingComma: true }) as unknown;
-    return errors.length === 0 && isJsonObject(parsed) ? parsed : undefined;
+    return {
+        exists: true,
+        value: errors.length === 0 && isJsonObject(parsed) ? parsed : undefined,
+    };
 }
 
 function getJsonObjectProperty(obj: Record<string, unknown> | undefined, propertyName: string): Record<string, unknown> | undefined {
@@ -343,5 +421,11 @@ function noProjectSdkVersionInfo(): ProjectSdkVersionInfo {
     return {
         referencesAspireAppHostSdk: false,
         hasInlineVersion: false,
+    };
+}
+
+function noFileTargetVersionInfo(): FileTargetVersionInfo {
+    return {
+        isCSharpAppHostFile: false,
     };
 }

--- a/extension/src/utils/appHostTargetVersion.ts
+++ b/extension/src/utils/appHostTargetVersion.ts
@@ -142,7 +142,7 @@ async function getAppHostTargetVersionInfoFromFile(filePath: string): Promise<Fi
 
     let contents: string;
     try {
-        contents = await fs.readFile(filePath, 'utf8');
+        contents = stripLeadingByteOrderMark(await fs.readFile(filePath, 'utf8'));
     }
     catch {
         return noFileTargetVersionInfo();
@@ -379,17 +379,10 @@ interface JsoncFileResult {
 async function readJsoncFile(filePath: string): Promise<JsoncFileResult> {
     let contents: string;
     try {
-        contents = await fs.readFile(filePath, 'utf8');
+        contents = stripLeadingByteOrderMark(await fs.readFile(filePath, 'utf8'));
     }
     catch {
         return { exists: false };
-    }
-
-    if (contents.startsWith('\uFEFF')) {
-        // jsonc-parser reports a leading UTF-8 BOM as InvalidSymbol even though
-        // the rest of the JSONC object is parsed. Strip only that exact prefix so
-        // BOM-prefixed config files work without accepting any other invalid input.
-        contents = contents.slice(1);
     }
 
     const errors: ParseError[] = [];
@@ -398,6 +391,13 @@ async function readJsoncFile(filePath: string): Promise<JsoncFileResult> {
         exists: true,
         value: errors.length === 0 && isJsonObject(parsed) ? parsed : undefined,
     };
+}
+
+function stripLeadingByteOrderMark(contents: string): string {
+    // Node's UTF-8 text decoder exposes a file BOM as U+FEFF at offset 0. Strip
+    // only that exact prefix so anchored parsers, like "#:sdk" single-file AppHost
+    // detection and jsonc-parser, see the same first character users see.
+    return contents.startsWith('\uFEFF') ? contents.slice(1) : contents;
 }
 
 function getJsonObjectProperty(obj: Record<string, unknown> | undefined, propertyName: string): Record<string, unknown> | undefined {

--- a/extension/src/utils/appHostTargetVersion.ts
+++ b/extension/src/utils/appHostTargetVersion.ts
@@ -140,7 +140,7 @@ interface FileTargetVersionInfo {
 
 async function getAppHostTargetVersionInfoFromFile(filePath: string): Promise<FileTargetVersionInfo> {
     const extension = extname(filePath).toLowerCase();
-    if (extension !== '.csproj' && extension !== '.cs') {
+    if (!isDotNetProjectExtension(extension) && extension !== '.cs') {
         return noFileTargetVersionInfo();
     }
 
@@ -205,7 +205,11 @@ function isPolyglotAppHostFile(filePath: string): boolean {
 
 function isSingleFileCSharpAppHostEntry(entry: string, entries: readonly string[]): boolean {
     return entry.toLowerCase() === 'apphost.cs'
-        && !entries.some(entry => extname(entry).toLowerCase() === '.csproj');
+        && !entries.some(entry => isDotNetProjectExtension(extname(entry).toLowerCase()));
+}
+
+function isDotNetProjectExtension(extension: string): boolean {
+    return extension === '.csproj' || extension === '.fsproj' || extension === '.vbproj';
 }
 
 interface ProjectSdkVersionInfo {

--- a/extension/src/utils/appHostTargetVersion.ts
+++ b/extension/src/utils/appHostTargetVersion.ts
@@ -21,7 +21,7 @@ export async function summarizeAppHostTargetVersions(candidates: readonly Candid
 
     const versions = new Set<string>();
     const resolvedVersions = await Promise.all(candidates.map(async candidate =>
-        normalizeVersion(candidate.aspireHostingVersion) ?? await getAppHostTargetVersion(candidate.path)));
+        await getAppHostTargetVersion(candidate.path)));
 
     for (const version of resolvedVersions) {
         addCandidateVersion(versions, version);
@@ -262,8 +262,8 @@ function getAspireHostingPackageVersionFromItems(contents: string, itemNames: re
     //   <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.1" />
     //   <PackageReference Include="Aspire.Hosting"><Version>8.2.1</Version></PackageReference>
     //   <PackageVersion Include="Aspire.Hosting" Version="8.2.2" />
-    // The CLI prefers Aspire.Hosting before Aspire.Hosting.AppHost; keep the fallback aligned so
-    // old CLIs that omit aspireHostingVersion report the same version source as new CLIs.
+    // The CLI prefers Aspire.Hosting before Aspire.Hosting.AppHost; keep extension-side telemetry
+    // aligned with that precedence while parsing project files locally.
     const packageIds = ['Aspire.Hosting', 'Aspire.Hosting.AppHost'];
     let referencesAspireHostingPackage = false;
     let hasInlineVersion = false;

--- a/extension/src/utils/appHostTargetVersion.ts
+++ b/extension/src/utils/appHostTargetVersion.ts
@@ -1,94 +1,120 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
 import { dirname, extname, join, resolve } from 'node:path';
 import { parse, type ParseError } from 'jsonc-parser';
 import type { CandidateAppHostDisplayInfo } from './appHostDiscovery';
 
 const unknownVersion = 'unknown';
 const noAppHostsVersion = 'none';
+const multipleVersions = 'multiple';
 const maxVersionLength = 64;
 // apphost_target_version is SystemMetaData telemetry, so keep values bounded to
 // Aspire version shapes like "13.4.2", "13.5.0-preview.1", or
 // "13.5.0-pr.18457.gabcdef" instead of emitting arbitrary project/config text.
 const semverLikeVersionRegex = /^\d{1,3}\.\d{1,4}\.\d{1,4}(?:-[0-9A-Za-z][0-9A-Za-z-]{0,19}(?:\.[0-9A-Za-z][0-9A-Za-z-]{0,19}){0,5})?$/;
 
-export function summarizeAppHostTargetVersions(candidates: readonly CandidateAppHostDisplayInfo[]): string {
+export type AppHostTargetVersionSummary = typeof noAppHostsVersion | typeof unknownVersion | typeof multipleVersions | string;
+
+export async function summarizeAppHostTargetVersions(candidates: readonly CandidateAppHostDisplayInfo[]): Promise<AppHostTargetVersionSummary> {
     if (candidates.length === 0) {
         return noAppHostsVersion;
     }
 
     const versions = new Set<string>();
-    for (const candidate of candidates) {
-        const version = normalizeVersion(candidate.aspireHostingVersion) ?? getAppHostTargetVersion(candidate.path);
-        if (version) {
-            versions.add(version);
-        }
+    const resolvedVersions = await Promise.all(candidates.map(async candidate =>
+        normalizeVersion(candidate.aspireHostingVersion) ?? await getAppHostTargetVersion(candidate.path)));
+
+    for (const version of resolvedVersions) {
+        addVersion(versions, version);
     }
 
-    return versions.size === 0
-        ? unknownVersion
-        : [...versions].sort((left, right) => left.localeCompare(right)).join(',');
+    return summarizeVersions(versions) ?? unknownVersion;
 }
 
-export function getAppHostTargetVersion(appHostPath: string | undefined): string | undefined {
+export async function getAppHostTargetVersion(appHostPath: string | undefined): Promise<string | undefined> {
     if (!appHostPath) {
         return undefined;
     }
 
     const resolvedPath = resolve(appHostPath);
-    if (!existsSync(resolvedPath)) {
-        return undefined;
-    }
-
     let isDirectory: boolean;
     try {
-        isDirectory = statSync(resolvedPath).isDirectory();
+        isDirectory = (await fs.stat(resolvedPath)).isDirectory();
     }
     catch {
         return undefined;
     }
 
     if (isDirectory) {
-        return getAppHostTargetVersionFromDirectory(resolvedPath);
+        return await getAppHostTargetVersionFromDirectory(resolvedPath);
     }
 
-    const fileVersion = getAppHostTargetVersionFromFile(resolvedPath);
+    const fileVersion = await getAppHostTargetVersionFromFile(resolvedPath);
     if (fileVersion) {
         return fileVersion;
     }
 
     return isPolyglotAppHostFile(resolvedPath)
-        ? getConfiguredSdkVersion(dirname(resolvedPath))
+        ? await getConfiguredSdkVersion(dirname(resolvedPath))
         : undefined;
 }
 
-function getAppHostTargetVersionFromDirectory(directoryPath: string): string | undefined {
+function addVersion(versions: Set<string>, version: string | undefined): void {
+    if (!version) {
+        return;
+    }
+
+    versions.add(version);
+}
+
+function summarizeVersions(versions: ReadonlySet<string>): string | undefined {
+    if (versions.size === 0) {
+        return undefined;
+    }
+
+    // apphost_target_versions is a common SystemMetaData property copied onto
+    // many events. Preserve the exact version only when every AppHost agrees;
+    // mixed workspaces collapse to a fixed bucket so a large workspace cannot
+    // create a long or high-cardinality comma-delimited value.
+    if (versions.has(multipleVersions) || versions.size > 1) {
+        return multipleVersions;
+    }
+
+    return [...versions][0];
+}
+
+async function getAppHostTargetVersionFromDirectory(directoryPath: string): Promise<string | undefined> {
     let entries: string[];
     try {
-        entries = readdirSync(directoryPath);
+        entries = await fs.readdir(directoryPath);
     }
     catch {
         return undefined;
     }
 
+    const versionResults = await Promise.all(entries.map(async entry => {
+        const entryPath = join(directoryPath, entry);
+        return {
+            isCSharpAppHostFile: isCSharpAppHostFile(entryPath),
+            version: await getAppHostTargetVersionFromFile(entryPath),
+        };
+    }));
+
     const versions = new Set<string>();
     let sawCSharpAppHostFile = false;
-    for (const entry of entries) {
-        const entryPath = join(directoryPath, entry);
-        sawCSharpAppHostFile ||= isCSharpAppHostFile(entryPath);
-        const version = getAppHostTargetVersionFromFile(entryPath);
-        if (version) {
-            versions.add(version);
-        }
+    for (const result of versionResults) {
+        sawCSharpAppHostFile ||= result.isCSharpAppHostFile;
+        addVersion(versions, result.version);
     }
 
-    if (versions.size > 0) {
-        return [...versions].sort((left, right) => left.localeCompare(right)).join(',');
+    const summary = summarizeVersions(versions);
+    if (summary) {
+        return summary;
     }
 
-    return sawCSharpAppHostFile ? undefined : getConfiguredSdkVersion(directoryPath);
+    return sawCSharpAppHostFile ? undefined : await getConfiguredSdkVersion(directoryPath);
 }
 
-function getAppHostTargetVersionFromFile(filePath: string): string | undefined {
+async function getAppHostTargetVersionFromFile(filePath: string): Promise<string | undefined> {
     const extension = extname(filePath).toLowerCase();
     if (extension !== '.csproj' && extension !== '.cs') {
         return undefined;
@@ -96,15 +122,24 @@ function getAppHostTargetVersionFromFile(filePath: string): string | undefined {
 
     let contents: string;
     try {
-        contents = readFileSync(filePath, 'utf8');
+        contents = await fs.readFile(filePath, 'utf8');
     }
     catch {
         return undefined;
     }
 
-    return extension === '.csproj'
-        ? getAspireAppHostSdkVersionFromProject(contents)
-        : getAspireAppHostSdkVersionFromSingleFile(contents);
+    if (extension === '.cs') {
+        return getAspireAppHostSdkVersionFromSingleFile(contents);
+    }
+
+    const projectVersion = getAspireAppHostSdkVersionFromProject(contents);
+    if (projectVersion.version) {
+        return projectVersion.version;
+    }
+
+    return projectVersion.referencesAspireAppHostSdk && !projectVersion.hasInlineVersion
+        ? await getGlobalJsonMsBuildSdkVersion(dirname(filePath))
+        : undefined;
 }
 
 function isPolyglotAppHostFile(filePath: string): boolean {
@@ -115,11 +150,23 @@ function isCSharpAppHostFile(filePath: string): boolean {
     return ['.csproj', '.cs'].includes(extname(filePath).toLowerCase());
 }
 
-function getAspireAppHostSdkVersionFromProject(contents: string): string | undefined {
+interface ProjectSdkVersionInfo {
+    version?: string;
+    referencesAspireAppHostSdk: boolean;
+    hasInlineVersion: boolean;
+}
+
+function getAspireAppHostSdkVersionFromProject(contents: string): ProjectSdkVersionInfo {
     const uncommentedContents = stripXmlComments(contents);
-    return getAspireAppHostSdkVersionFromProjectSdkAttribute(uncommentedContents)
-        ?? getAspireAppHostSdkVersionFromSdkElement(uncommentedContents)
-        ?? getAspireHostingSdkVersionProperty(uncommentedContents);
+    const sdkAttribute = getAspireAppHostSdkVersionFromProjectSdkAttribute(uncommentedContents);
+    const sdkElement = getAspireAppHostSdkVersionFromSdkElement(uncommentedContents);
+    const propertyVersion = getAspireHostingSdkVersionProperty(uncommentedContents);
+
+    return {
+        version: sdkAttribute.version ?? sdkElement.version ?? propertyVersion,
+        referencesAspireAppHostSdk: sdkAttribute.referencesAspireAppHostSdk || sdkElement.referencesAspireAppHostSdk,
+        hasInlineVersion: sdkAttribute.hasInlineVersion || sdkElement.hasInlineVersion,
+    };
 }
 
 function stripXmlComments(contents: string): string {
@@ -130,41 +177,63 @@ function stripXmlComments(contents: string): string {
     return contents.replace(/<!--[\s\S]*?-->/g, '');
 }
 
-function getAspireAppHostSdkVersionFromProjectSdkAttribute(contents: string): string | undefined {
+function getAspireAppHostSdkVersionFromProjectSdkAttribute(contents: string): ProjectSdkVersionInfo {
     // SDK-style AppHosts usually target Aspire through the Project SDK:
     //   <Project Sdk="Aspire.AppHost.Sdk/13.5.0">
     // Multiple SDKs are semicolon-delimited:
     //   <Project Sdk="Microsoft.NET.Sdk; Aspire.AppHost.Sdk/13.5.0">
+    // Standard MSBuild SDK resolution also allows the version to be omitted here
+    // and supplied by global.json's "msbuild-sdks" object.
     const projectSdkMatch = /<Project\b[^>]*\bSdk\s*=\s*(["'])(?<sdks>.*?)\1/is.exec(contents);
     const sdkAttribute = projectSdkMatch?.groups?.sdks;
     if (!sdkAttribute) {
-        return undefined;
+        return noProjectSdkVersionInfo();
     }
 
+    let referencesAspireAppHostSdk = false;
+    let hasInlineVersion = false;
     for (const sdk of sdkAttribute.split(';')) {
         const trimmedSdk = sdk.trim();
-        const versionMatch = /^Aspire\.AppHost\.Sdk\/(?<version>[^;\s"']+)$/i.exec(trimmedSdk);
-        const version = normalizeVersion(versionMatch?.groups?.version);
+        const sdkMatch = /^Aspire\.AppHost\.Sdk(?:\/(?<version>[^;\s"']+))?$/i.exec(trimmedSdk);
+        if (!sdkMatch) {
+            continue;
+        }
+
+        referencesAspireAppHostSdk = true;
+        if (sdkMatch.groups?.version !== undefined) {
+            hasInlineVersion = true;
+        }
+
+        const version = normalizeVersion(sdkMatch.groups?.version);
         if (version) {
-            return version;
+            return { version, referencesAspireAppHostSdk, hasInlineVersion };
         }
     }
 
-    return undefined;
+    return { referencesAspireAppHostSdk, hasInlineVersion };
 }
 
-function getAspireAppHostSdkVersionFromSdkElement(contents: string): string | undefined {
+function getAspireAppHostSdkVersionFromSdkElement(contents: string): ProjectSdkVersionInfo {
     // Older projects can express the SDK as an element:
     //   <Sdk Name="Aspire.AppHost.Sdk" Version="13.5.0" />
-    const sdkElementRegex = /<Sdk\b(?=[^>]*\bName\s*=\s*(["'])Aspire\.AppHost\.Sdk\1)(?=[^>]*\bVersion\s*=\s*(["'])(?<version>.*?)\2)[^>]*>/gis;
+    // The Version attribute may be omitted when global.json supplies the SDK version.
+    const sdkElementRegex = /<Sdk\b(?=[^>]*\bName\s*=\s*(["'])Aspire\.AppHost\.Sdk\1)[^>]*>/gis;
+    let referencesAspireAppHostSdk = false;
+    let hasInlineVersion = false;
     for (const match of contents.matchAll(sdkElementRegex)) {
-        const version = normalizeVersion(match.groups?.version);
+        referencesAspireAppHostSdk = true;
+        const versionMatch = /\bVersion\s*=\s*(["'])(?<version>.*?)\1/is.exec(match[0]);
+        if (versionMatch) {
+            hasInlineVersion = true;
+        }
+
+        const version = normalizeVersion(versionMatch?.groups?.version);
         if (version) {
-            return version;
+            return { version, referencesAspireAppHostSdk, hasInlineVersion };
         }
     }
 
-    return undefined;
+    return { referencesAspireAppHostSdk, hasInlineVersion };
 }
 
 function getAspireHostingSdkVersionProperty(contents: string): string | undefined {
@@ -183,9 +252,9 @@ function getAspireAppHostSdkVersionFromSingleFile(contents: string): string | un
     return normalizeVersion(directiveMatch?.groups?.version);
 }
 
-function getConfiguredSdkVersion(startDirectory: string): string | undefined {
+async function getConfiguredSdkVersion(startDirectory: string): Promise<string | undefined> {
     for (let directory = resolve(startDirectory); ; directory = dirname(directory)) {
-        const version = getConfiguredSdkVersionInDirectory(directory);
+        const version = await getConfiguredSdkVersionInDirectory(directory);
         if (version) {
             return version;
         }
@@ -197,29 +266,62 @@ function getConfiguredSdkVersion(startDirectory: string): string | undefined {
     }
 }
 
-function getConfiguredSdkVersionInDirectory(directory: string): string | undefined {
-    return readSdkVersionFromConfigFile(join(directory, 'aspire.config.json'))
-        ?? readSdkVersionFromConfigFile(join(directory, '.aspire', 'settings.json'));
+async function getConfiguredSdkVersionInDirectory(directory: string): Promise<string | undefined> {
+    return await readSdkVersionFromConfigFile(join(directory, 'aspire.config.json'))
+        ?? await readSdkVersionFromConfigFile(join(directory, '.aspire', 'settings.json'));
 }
 
-function readSdkVersionFromConfigFile(configPath: string): string | undefined {
-    if (!existsSync(configPath)) {
-        return undefined;
-    }
+async function readSdkVersionFromConfigFile(configPath: string): Promise<string | undefined> {
+    const parsed = await readJsoncFile(configPath);
+    const sdk = getJsonObjectProperty(parsed, 'sdk');
+    return normalizeVersion(sdk?.version)
+        ?? normalizeVersion(parsed?.sdkVersion);
+}
 
-    try {
-        const errors: ParseError[] = [];
-        const parsed = parse(readFileSync(configPath, 'utf8'), errors, { allowTrailingComma: true });
-        if (errors.length > 0) {
-            return undefined;
+async function getGlobalJsonMsBuildSdkVersion(startDirectory: string): Promise<string | undefined> {
+    for (let directory = resolve(startDirectory); ; directory = dirname(directory)) {
+        const version = await readAspireAppHostSdkVersionFromGlobalJson(join(directory, 'global.json'));
+        if (version) {
+            return version;
         }
 
-        return normalizeVersion(parsed?.sdk?.version)
-            ?? normalizeVersion(parsed?.sdkVersion);
+        const parent = dirname(directory);
+        if (parent === directory) {
+            return undefined;
+        }
+    }
+}
+
+async function readAspireAppHostSdkVersionFromGlobalJson(globalJsonPath: string): Promise<string | undefined> {
+    const parsed = await readJsoncFile(globalJsonPath);
+    const msBuildSdks = getJsonObjectProperty(parsed, 'msbuild-sdks');
+    // MSBuild's SDK resolver reads this global.json shape:
+    //   { "msbuild-sdks": { "Aspire.AppHost.Sdk": "13.5.0" } }
+    // See https://learn.microsoft.com/visualstudio/msbuild/how-to-use-project-sdk#how-project-sdks-are-resolved.
+    return normalizeVersion(msBuildSdks?.['Aspire.AppHost.Sdk']);
+}
+
+async function readJsoncFile(filePath: string): Promise<Record<string, unknown> | undefined> {
+    let contents: string;
+    try {
+        contents = await fs.readFile(filePath, 'utf8');
     }
     catch {
         return undefined;
     }
+
+    const errors: ParseError[] = [];
+    const parsed = parse(contents, errors, { allowTrailingComma: true }) as unknown;
+    return errors.length === 0 && isJsonObject(parsed) ? parsed : undefined;
+}
+
+function getJsonObjectProperty(obj: Record<string, unknown> | undefined, propertyName: string): Record<string, unknown> | undefined {
+    const value = obj?.[propertyName];
+    return isJsonObject(value) ? value : undefined;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function normalizeVersion(version: unknown): string | undefined {
@@ -235,4 +337,11 @@ function normalizeVersion(version: unknown): string | undefined {
     return semverLikeVersionRegex.test(trimmedVersion)
         ? trimmedVersion
         : undefined;
+}
+
+function noProjectSdkVersionInfo(): ProjectSdkVersionInfo {
+    return {
+        referencesAspireAppHostSdk: false,
+        hasInlineVersion: false,
+    };
 }

--- a/extension/src/utils/appHostTargetVersion.ts
+++ b/extension/src/utils/appHostTargetVersion.ts
@@ -24,7 +24,7 @@ export async function summarizeAppHostTargetVersions(candidates: readonly Candid
         normalizeVersion(candidate.aspireHostingVersion) ?? await getAppHostTargetVersion(candidate.path)));
 
     for (const version of resolvedVersions) {
-        addVersion(versions, version);
+        addCandidateVersion(versions, version);
     }
 
     return summarizeVersions(versions) ?? unknownVersion;
@@ -56,6 +56,10 @@ export async function getAppHostTargetVersion(appHostPath: string | undefined): 
     return isPolyglotAppHostFile(resolvedPath)
         ? await getConfiguredSdkVersion(dirname(resolvedPath))
         : undefined;
+}
+
+function addCandidateVersion(versions: Set<string>, version: string | undefined): void {
+    addVersion(versions, version ?? unknownVersion);
 }
 
 function addVersion(versions: Set<string>, version: string | undefined): void {

--- a/extension/src/utils/appHostTargetVersion.ts
+++ b/extension/src/utils/appHostTargetVersion.ts
@@ -1,10 +1,15 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, extname, join, resolve } from 'node:path';
-import { stripComments } from 'jsonc-parser';
+import { parse, type ParseError } from 'jsonc-parser';
 import type { CandidateAppHostDisplayInfo } from './appHostDiscovery';
 
 const unknownVersion = 'unknown';
 const noAppHostsVersion = 'none';
+const maxVersionLength = 64;
+// apphost_target_version is SystemMetaData telemetry, so keep values bounded to
+// Aspire version shapes like "13.4.2", "13.5.0-preview.1", or
+// "13.5.0-pr.18457.gabcdef" instead of emitting arbitrary project/config text.
+const semverLikeVersionRegex = /^\d{1,3}\.\d{1,4}\.\d{1,4}(?:-[0-9A-Za-z][0-9A-Za-z-]{0,19}(?:\.[0-9A-Za-z][0-9A-Za-z-]{0,19}){0,5})?$/;
 
 export function summarizeAppHostTargetVersions(candidates: readonly CandidateAppHostDisplayInfo[]): string {
     if (candidates.length === 0) {
@@ -111,9 +116,18 @@ function isCSharpAppHostFile(filePath: string): boolean {
 }
 
 function getAspireAppHostSdkVersionFromProject(contents: string): string | undefined {
-    return getAspireAppHostSdkVersionFromProjectSdkAttribute(contents)
-        ?? getAspireAppHostSdkVersionFromSdkElement(contents)
-        ?? getAspireHostingSdkVersionProperty(contents);
+    const uncommentedContents = stripXmlComments(contents);
+    return getAspireAppHostSdkVersionFromProjectSdkAttribute(uncommentedContents)
+        ?? getAspireAppHostSdkVersionFromSdkElement(uncommentedContents)
+        ?? getAspireHostingSdkVersionProperty(uncommentedContents);
+}
+
+function stripXmlComments(contents: string): string {
+    // Project files can contain inactive SDK declarations in XML comments, for example:
+    //   <!-- <Project Sdk="Aspire.AppHost.Sdk/1.2.3"> -->
+    // Remove comments before applying the lightweight SDK regexes so telemetry cannot report
+    // a version from an inactive project fragment.
+    return contents.replace(/<!--[\s\S]*?-->/g, '');
 }
 
 function getAspireAppHostSdkVersionFromProjectSdkAttribute(contents: string): string | undefined {
@@ -194,7 +208,12 @@ function readSdkVersionFromConfigFile(configPath: string): string | undefined {
     }
 
     try {
-        const parsed = JSON.parse(stripComments(readFileSync(configPath, 'utf8')));
+        const errors: ParseError[] = [];
+        const parsed = parse(readFileSync(configPath, 'utf8'), errors, { allowTrailingComma: true });
+        if (errors.length > 0) {
+            return undefined;
+        }
+
         return normalizeVersion(parsed?.sdk?.version)
             ?? normalizeVersion(parsed?.sdkVersion);
     }
@@ -204,7 +223,16 @@ function readSdkVersionFromConfigFile(configPath: string): string | undefined {
 }
 
 function normalizeVersion(version: unknown): string | undefined {
-    return typeof version === 'string' && version.trim() !== ''
-        ? version.trim()
+    if (typeof version !== 'string') {
+        return undefined;
+    }
+
+    const trimmedVersion = version.trim();
+    if (trimmedVersion.length === 0 || trimmedVersion.length > maxVersionLength) {
+        return undefined;
+    }
+
+    return semverLikeVersionRegex.test(trimmedVersion)
+        ? trimmedVersion
         : undefined;
 }

--- a/extension/src/utils/appHostTargetVersion.ts
+++ b/extension/src/utils/appHostTargetVersion.ts
@@ -1,0 +1,210 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, extname, join, resolve } from 'node:path';
+import { stripComments } from 'jsonc-parser';
+import type { CandidateAppHostDisplayInfo } from './appHostDiscovery';
+
+const unknownVersion = 'unknown';
+const noAppHostsVersion = 'none';
+
+export function summarizeAppHostTargetVersions(candidates: readonly CandidateAppHostDisplayInfo[]): string {
+    if (candidates.length === 0) {
+        return noAppHostsVersion;
+    }
+
+    const versions = new Set<string>();
+    for (const candidate of candidates) {
+        const version = normalizeVersion(candidate.aspireHostingVersion) ?? getAppHostTargetVersion(candidate.path);
+        if (version) {
+            versions.add(version);
+        }
+    }
+
+    return versions.size === 0
+        ? unknownVersion
+        : [...versions].sort((left, right) => left.localeCompare(right)).join(',');
+}
+
+export function getAppHostTargetVersion(appHostPath: string | undefined): string | undefined {
+    if (!appHostPath) {
+        return undefined;
+    }
+
+    const resolvedPath = resolve(appHostPath);
+    if (!existsSync(resolvedPath)) {
+        return undefined;
+    }
+
+    let isDirectory: boolean;
+    try {
+        isDirectory = statSync(resolvedPath).isDirectory();
+    }
+    catch {
+        return undefined;
+    }
+
+    if (isDirectory) {
+        return getAppHostTargetVersionFromDirectory(resolvedPath);
+    }
+
+    const fileVersion = getAppHostTargetVersionFromFile(resolvedPath);
+    if (fileVersion) {
+        return fileVersion;
+    }
+
+    return isPolyglotAppHostFile(resolvedPath)
+        ? getConfiguredSdkVersion(dirname(resolvedPath))
+        : undefined;
+}
+
+function getAppHostTargetVersionFromDirectory(directoryPath: string): string | undefined {
+    let entries: string[];
+    try {
+        entries = readdirSync(directoryPath);
+    }
+    catch {
+        return undefined;
+    }
+
+    const versions = new Set<string>();
+    let sawCSharpAppHostFile = false;
+    for (const entry of entries) {
+        const entryPath = join(directoryPath, entry);
+        sawCSharpAppHostFile ||= isCSharpAppHostFile(entryPath);
+        const version = getAppHostTargetVersionFromFile(entryPath);
+        if (version) {
+            versions.add(version);
+        }
+    }
+
+    if (versions.size > 0) {
+        return [...versions].sort((left, right) => left.localeCompare(right)).join(',');
+    }
+
+    return sawCSharpAppHostFile ? undefined : getConfiguredSdkVersion(directoryPath);
+}
+
+function getAppHostTargetVersionFromFile(filePath: string): string | undefined {
+    const extension = extname(filePath).toLowerCase();
+    if (extension !== '.csproj' && extension !== '.cs') {
+        return undefined;
+    }
+
+    let contents: string;
+    try {
+        contents = readFileSync(filePath, 'utf8');
+    }
+    catch {
+        return undefined;
+    }
+
+    return extension === '.csproj'
+        ? getAspireAppHostSdkVersionFromProject(contents)
+        : getAspireAppHostSdkVersionFromSingleFile(contents);
+}
+
+function isPolyglotAppHostFile(filePath: string): boolean {
+    return ['.ts', '.mts', '.cts', '.js', '.mjs', '.cjs'].includes(extname(filePath).toLowerCase());
+}
+
+function isCSharpAppHostFile(filePath: string): boolean {
+    return ['.csproj', '.cs'].includes(extname(filePath).toLowerCase());
+}
+
+function getAspireAppHostSdkVersionFromProject(contents: string): string | undefined {
+    return getAspireAppHostSdkVersionFromProjectSdkAttribute(contents)
+        ?? getAspireAppHostSdkVersionFromSdkElement(contents)
+        ?? getAspireHostingSdkVersionProperty(contents);
+}
+
+function getAspireAppHostSdkVersionFromProjectSdkAttribute(contents: string): string | undefined {
+    // SDK-style AppHosts usually target Aspire through the Project SDK:
+    //   <Project Sdk="Aspire.AppHost.Sdk/13.5.0">
+    // Multiple SDKs are semicolon-delimited:
+    //   <Project Sdk="Microsoft.NET.Sdk; Aspire.AppHost.Sdk/13.5.0">
+    const projectSdkMatch = /<Project\b[^>]*\bSdk\s*=\s*(["'])(?<sdks>.*?)\1/is.exec(contents);
+    const sdkAttribute = projectSdkMatch?.groups?.sdks;
+    if (!sdkAttribute) {
+        return undefined;
+    }
+
+    for (const sdk of sdkAttribute.split(';')) {
+        const trimmedSdk = sdk.trim();
+        const versionMatch = /^Aspire\.AppHost\.Sdk\/(?<version>[^;\s"']+)$/i.exec(trimmedSdk);
+        const version = normalizeVersion(versionMatch?.groups?.version);
+        if (version) {
+            return version;
+        }
+    }
+
+    return undefined;
+}
+
+function getAspireAppHostSdkVersionFromSdkElement(contents: string): string | undefined {
+    // Older projects can express the SDK as an element:
+    //   <Sdk Name="Aspire.AppHost.Sdk" Version="13.5.0" />
+    const sdkElementRegex = /<Sdk\b(?=[^>]*\bName\s*=\s*(["'])Aspire\.AppHost\.Sdk\1)(?=[^>]*\bVersion\s*=\s*(["'])(?<version>.*?)\2)[^>]*>/gis;
+    for (const match of contents.matchAll(sdkElementRegex)) {
+        const version = normalizeVersion(match.groups?.version);
+        if (version) {
+            return version;
+        }
+    }
+
+    return undefined;
+}
+
+function getAspireHostingSdkVersionProperty(contents: string): string | undefined {
+    // Polyglot generated server projects carry the evaluated SDK version as:
+    //   <AspireHostingSDKVersion>13.5.0</AspireHostingSDKVersion>
+    // This can also appear in SDK-imported props for C# projects. Prefer the
+    // explicit AppHost SDK forms above when they are present.
+    const propertyMatch = /<AspireHostingSDKVersion>\s*(?<version>[^<\s]+)\s*<\/AspireHostingSDKVersion>/i.exec(contents);
+    return normalizeVersion(propertyMatch?.groups?.version);
+}
+
+function getAspireAppHostSdkVersionFromSingleFile(contents: string): string | undefined {
+    // Single-file C# AppHosts target Aspire with a file directive:
+    //   #:sdk Aspire.AppHost.Sdk@13.5.0
+    const directiveMatch = /^[ \t]*#:sdk[ \t]+Aspire\.AppHost\.Sdk@(?<version>\S+)/im.exec(contents);
+    return normalizeVersion(directiveMatch?.groups?.version);
+}
+
+function getConfiguredSdkVersion(startDirectory: string): string | undefined {
+    for (let directory = resolve(startDirectory); ; directory = dirname(directory)) {
+        const version = getConfiguredSdkVersionInDirectory(directory);
+        if (version) {
+            return version;
+        }
+
+        const parent = dirname(directory);
+        if (parent === directory) {
+            return undefined;
+        }
+    }
+}
+
+function getConfiguredSdkVersionInDirectory(directory: string): string | undefined {
+    return readSdkVersionFromConfigFile(join(directory, 'aspire.config.json'))
+        ?? readSdkVersionFromConfigFile(join(directory, '.aspire', 'settings.json'));
+}
+
+function readSdkVersionFromConfigFile(configPath: string): string | undefined {
+    if (!existsSync(configPath)) {
+        return undefined;
+    }
+
+    try {
+        const parsed = JSON.parse(stripComments(readFileSync(configPath, 'utf8')));
+        return normalizeVersion(parsed?.sdk?.version)
+            ?? normalizeVersion(parsed?.sdkVersion);
+    }
+    catch {
+        return undefined;
+    }
+}
+
+function normalizeVersion(version: unknown): string | undefined {
+    return typeof version === 'string' && version.trim() !== ''
+        ? version.trim()
+        : undefined;
+}

--- a/extension/src/utils/appHostTargetVersion.ts
+++ b/extension/src/utils/appHostTargetVersion.ts
@@ -315,11 +315,7 @@ interface ConfiguredSdkVersionInfo {
 async function getConfiguredSdkVersionInDirectory(directory: string): Promise<ConfiguredSdkVersionInfo> {
     const configVersion = await readSdkVersionFromConfigFile(join(directory, 'aspire.config.json'));
     if (configVersion.version || configVersion.foundConfig) {
-        const settingsVersion = await readSdkVersionFromConfigFile(join(directory, '.aspire', 'settings.json'));
-        return {
-            version: configVersion.version ?? settingsVersion.version,
-            foundConfig: true,
-        };
+        return configVersion;
     }
 
     return await readSdkVersionFromConfigFile(join(directory, '.aspire', 'settings.json'));

--- a/extension/src/utils/appHostTargetVersion.ts
+++ b/extension/src/utils/appHostTargetVersion.ts
@@ -152,6 +152,8 @@ async function getAppHostTargetVersionInfoFromFile(filePath: string): Promise<Fi
         return noFileTargetVersionInfo();
     }
 
+    const uncommentedContents = stripXmlComments(contents);
+
     if (extension === '.cs') {
         const singleFileVersion = getAspireAppHostSdkVersionFromSingleFile(contents);
         return {
@@ -160,7 +162,26 @@ async function getAppHostTargetVersionInfoFromFile(filePath: string): Promise<Fi
         };
     }
 
-    const projectVersion = getAspireAppHostSdkVersionFromProject(contents);
+    const packageVersion = getAspireHostingPackageVersionFromProject(uncommentedContents);
+    if (packageVersion.version) {
+        return {
+            version: packageVersion.version,
+            isCSharpAppHostFile: true,
+        };
+    }
+
+    const centralPackageVersion = packageVersion.referencesAspireHostingPackage && !packageVersion.hasInlineVersion
+        ? await getCentralAspireHostingPackageVersion(dirname(filePath))
+        : undefined;
+
+    if (centralPackageVersion) {
+        return {
+            version: centralPackageVersion,
+            isCSharpAppHostFile: true,
+        };
+    }
+
+    const projectVersion = getAspireAppHostSdkVersionFromProject(uncommentedContents);
     if (projectVersion.version) {
         return {
             version: projectVersion.version,
@@ -174,7 +195,7 @@ async function getAppHostTargetVersionInfoFromFile(filePath: string): Promise<Fi
 
     return {
         version: globalJsonVersion,
-        isCSharpAppHostFile: projectVersion.referencesAspireAppHostSdk,
+        isCSharpAppHostFile: packageVersion.referencesAspireHostingPackage || projectVersion.referencesAspireAppHostSdk,
     };
 }
 
@@ -193,16 +214,21 @@ interface ProjectSdkVersionInfo {
     hasInlineVersion: boolean;
 }
 
+interface PackageVersionInfo {
+    version?: string;
+    referencesAspireHostingPackage: boolean;
+    hasInlineVersion: boolean;
+}
+
 interface SingleFileSdkVersionInfo {
     version?: string;
     referencesAspireAppHostSdk: boolean;
 }
 
 function getAspireAppHostSdkVersionFromProject(contents: string): ProjectSdkVersionInfo {
-    const uncommentedContents = stripXmlComments(contents);
-    const sdkAttribute = getAspireAppHostSdkVersionFromProjectSdkAttribute(uncommentedContents);
-    const sdkElement = getAspireAppHostSdkVersionFromSdkElement(uncommentedContents);
-    const propertyVersion = getAspireHostingSdkVersionProperty(uncommentedContents);
+    const sdkAttribute = getAspireAppHostSdkVersionFromProjectSdkAttribute(contents);
+    const sdkElement = getAspireAppHostSdkVersionFromSdkElement(contents);
+    const propertyVersion = getAspireHostingSdkVersionProperty(contents);
 
     return {
         version: sdkAttribute.version ?? sdkElement.version ?? propertyVersion,
@@ -217,6 +243,79 @@ function stripXmlComments(contents: string): string {
     // Remove comments before applying the lightweight SDK regexes so telemetry cannot report
     // a version from an inactive project fragment.
     return contents.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+function getAspireHostingPackageVersionFromProject(contents: string): PackageVersionInfo {
+    return getAspireHostingPackageVersionFromItems(contents, ['PackageReference', 'AspireProjectOrPackageReference', 'PackageVersion']);
+}
+
+function getAspireHostingPackageVersionFromPackageVersionsFile(contents: string): PackageVersionInfo {
+    return getAspireHostingPackageVersionFromItems(contents, ['PackageVersion']);
+}
+
+function getAspireHostingPackageVersionFromItems(contents: string, itemNames: readonly string[]): PackageVersionInfo {
+    // Older C# AppHosts can target Aspire through package metadata instead of the AppHost SDK:
+    //   <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.1" />
+    //   <PackageReference Include="Aspire.Hosting"><Version>8.2.1</Version></PackageReference>
+    //   <PackageVersion Include="Aspire.Hosting" Version="8.2.2" />
+    // The CLI prefers Aspire.Hosting before Aspire.Hosting.AppHost; keep the fallback aligned so
+    // old CLIs that omit aspireHostingVersion report the same version source as new CLIs.
+    const packageIds = ['Aspire.Hosting', 'Aspire.Hosting.AppHost'];
+    let referencesAspireHostingPackage = false;
+    let hasInlineVersion = false;
+
+    for (const itemName of itemNames) {
+        const items = getMsBuildItems(contents, itemName);
+        for (const packageId of packageIds) {
+            for (const item of items) {
+                const identity = getMsBuildItemIdentity(item);
+                if (identity !== packageId) {
+                    continue;
+                }
+
+                referencesAspireHostingPackage = true;
+                const versionMetadata = getMsBuildVersionMetadata(item);
+                hasInlineVersion ||= versionMetadata.hasVersion;
+                if (versionMetadata.version) {
+                    return { version: versionMetadata.version, referencesAspireHostingPackage, hasInlineVersion };
+                }
+            }
+        }
+    }
+
+    return { referencesAspireHostingPackage, hasInlineVersion };
+}
+
+function getMsBuildItems(contents: string, itemName: string): string[] {
+    const itemRegex = new RegExp(`<${itemName}\\b[^>]*(?:/>|>[\\s\\S]*?</${itemName}>)`, 'gi');
+    return [...contents.matchAll(itemRegex)].map(match => match[0]);
+}
+
+function getMsBuildItemIdentity(item: string): string | undefined {
+    return getXmlAttribute(item, 'Include')
+        ?? getXmlAttribute(item, 'Update');
+}
+
+function getMsBuildVersionMetadata(item: string): { version?: string; hasVersion: boolean } {
+    const version = getXmlAttribute(item, 'VersionOverride')
+        ?? getXmlAttribute(item, 'Version')
+        ?? getXmlElementText(item, 'Version');
+
+    return {
+        version: normalizeVersion(version),
+        hasVersion: version !== undefined,
+    };
+}
+
+function getXmlAttribute(xml: string, attributeName: string): string | undefined {
+    const openingTag = /^<[^>]+>/s.exec(xml)?.[0];
+    const attributeMatch = new RegExp(`\\b${attributeName}\\s*=\\s*(["'])(?<value>.*?)\\1`, 'is').exec(openingTag ?? '');
+    return attributeMatch?.groups?.value;
+}
+
+function getXmlElementText(xml: string, elementName: string): string | undefined {
+    const elementMatch = new RegExp(`<${elementName}>\\s*(?<value>[^<\\s]+)\\s*</${elementName}>`, 'i').exec(xml);
+    return elementMatch?.groups?.value;
 }
 
 function getAspireAppHostSdkVersionFromProjectSdkAttribute(contents: string): ProjectSdkVersionInfo {
@@ -354,6 +453,20 @@ async function getGlobalJsonMsBuildSdkVersion(startDirectory: string): Promise<s
     }
 }
 
+async function getCentralAspireHostingPackageVersion(startDirectory: string): Promise<string | undefined> {
+    for (let directory = resolve(startDirectory); ; directory = dirname(directory)) {
+        const result = await readAspireHostingPackageVersionFromDirectoryPackages(join(directory, 'Directory.Packages.props'));
+        if (result.version || result.foundConfig) {
+            return result.version;
+        }
+
+        const parent = dirname(directory);
+        if (parent === directory) {
+            return undefined;
+        }
+    }
+}
+
 async function readAspireAppHostSdkVersionFromGlobalJson(globalJsonPath: string): Promise<ConfiguredSdkVersionInfo> {
     const file = await readJsoncFile(globalJsonPath);
     if (!file.exists) {
@@ -367,6 +480,22 @@ async function readAspireAppHostSdkVersionFromGlobalJson(globalJsonPath: string)
     // See https://learn.microsoft.com/visualstudio/msbuild/how-to-use-project-sdk#how-project-sdks-are-resolved.
     return {
         version: normalizeVersion(msBuildSdks?.['Aspire.AppHost.Sdk']),
+        foundConfig: true,
+    };
+}
+
+async function readAspireHostingPackageVersionFromDirectoryPackages(packagesPath: string): Promise<ConfiguredSdkVersionInfo> {
+    let contents: string;
+    try {
+        contents = stripXmlComments(stripLeadingByteOrderMark(await fs.readFile(packagesPath, 'utf8')));
+    }
+    catch {
+        return { foundConfig: false };
+    }
+
+    const packageVersion = getAspireHostingPackageVersionFromPackageVersionsFile(contents);
+    return {
+        version: packageVersion.version,
         foundConfig: true,
     };
 }

--- a/extension/src/utils/meaningfulEngagement.ts
+++ b/extension/src/utils/meaningfulEngagement.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { AppHostDiscoveryService } from './appHostDiscovery';
 import { summarizeAppHostLanguages } from './appHostLanguage';
+import { summarizeAppHostTargetVersions } from './appHostTargetVersion';
 import { sendTelemetryEvent, setCommandInvocationListener, setCommonTelemetryProperties } from './telemetry';
 
 /**
@@ -115,31 +116,39 @@ export class MeaningfulEngagementReporter implements vscode.Disposable {
         // Collect a coarse snapshot of the workspace state at fire time. We
         // intentionally only fetch from already-running discovery — never
         // forcing a new discovery — to keep the event side-effect-free.
-        const languageSummary = await this._safeLanguageSummary();
+        const appHostSummary = await this._safeAppHostSummary();
         const workspaceFolderCount = vscode.workspace.workspaceFolders?.length ?? 0;
         const hasCSharpDevKit = vscode.extensions.getExtension('ms-dotnettools.csdevkit') !== undefined;
 
         // Publish a small set of properties to be merged into every
         // subsequent event in this session.
         setCommonTelemetryProperties({
-            apphost_languages: languageSummary,
-            apphost_present: languageSummary === 'none' ? 'false' : 'true',
+            apphost_languages: appHostSummary.languages,
+            apphost_target_versions: appHostSummary.targetVersions,
+            apphost_present: appHostSummary.languages === 'none' ? 'false' : 'true',
         });
 
         sendTelemetryEvent('engagement/active', {
             trigger,
-            apphost_present: languageSummary === 'none' ? 'false' : 'true',
-            apphost_languages: languageSummary,
+            apphost_present: appHostSummary.languages === 'none' ? 'false' : 'true',
+            apphost_languages: appHostSummary.languages,
+            apphost_target_versions: appHostSummary.targetVersions,
             has_csharp_devkit: hasCSharpDevKit ? 'true' : 'false',
         }, {
             workspace_folders: workspaceFolderCount,
         });
     }
 
-    private async _safeLanguageSummary(): Promise<ReturnType<typeof summarizeAppHostLanguages>> {
+    private async _safeAppHostSummary(): Promise<{
+        languages: ReturnType<typeof summarizeAppHostLanguages>;
+        targetVersions: ReturnType<typeof summarizeAppHostTargetVersions>;
+    }> {
         const folders = vscode.workspace.workspaceFolders;
         if (!folders || folders.length === 0) {
-            return 'none';
+            return {
+                languages: 'none',
+                targetVersions: 'none',
+            };
         }
         const all: import('./appHostDiscovery').CandidateAppHostDisplayInfo[] = [];
         for (const folder of folders) {
@@ -151,6 +160,9 @@ export class MeaningfulEngagementReporter implements vscode.Disposable {
                 // ignored; see _checkAppHostsForFolder
             }
         }
-        return summarizeAppHostLanguages(all);
+        return {
+            languages: summarizeAppHostLanguages(all),
+            targetVersions: summarizeAppHostTargetVersions(all),
+        };
     }
 }

--- a/extension/src/utils/meaningfulEngagement.ts
+++ b/extension/src/utils/meaningfulEngagement.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { AppHostDiscoveryService } from './appHostDiscovery';
 import { summarizeAppHostLanguages } from './appHostLanguage';
-import { summarizeAppHostTargetVersions } from './appHostTargetVersion';
+import { type AppHostTargetVersionSummary, summarizeAppHostTargetVersions } from './appHostTargetVersion';
 import { sendTelemetryEvent, setCommandInvocationListener, setCommonTelemetryProperties } from './telemetry';
 
 /**
@@ -141,7 +141,7 @@ export class MeaningfulEngagementReporter implements vscode.Disposable {
 
     private async _safeAppHostSummary(): Promise<{
         languages: ReturnType<typeof summarizeAppHostLanguages>;
-        targetVersions: ReturnType<typeof summarizeAppHostTargetVersions>;
+        targetVersions: AppHostTargetVersionSummary;
     }> {
         const folders = vscode.workspace.workspaceFolders;
         if (!folders || folders.length === 0) {
@@ -162,7 +162,7 @@ export class MeaningfulEngagementReporter implements vscode.Disposable {
         }
         return {
             languages: summarizeAppHostLanguages(all),
-            targetVersions: summarizeAppHostTargetVersions(all),
+            targetVersions: await summarizeAppHostTargetVersions(all),
         };
     }
 }

--- a/extension/src/utils/telemetryRegistry.ts
+++ b/extension/src/utils/telemetryRegistry.ts
@@ -36,7 +36,7 @@
  * catalog tracks (event, property) pairs — every common property duplicates
  * into a row for every event. The set is deliberately tiny.
  */
-export type CommonTelemetryProperty = 'apphost_languages' | 'apphost_present';
+export type CommonTelemetryProperty = 'apphost_languages' | 'apphost_target_versions' | 'apphost_present';
 
 /**
  * Per-event schema. Each entry lists the event-specific properties and
@@ -62,11 +62,11 @@ export interface TelemetryEventSchema {
         measurements: 'running_apphosts' | 'total_resources';
     };
     'debug/apphost/start': {
-        properties: 'mode' | 'apphost_language' | 'apphost_is_directory' | 'command';
+        properties: 'mode' | 'apphost_language' | 'apphost_target_version' | 'apphost_is_directory' | 'command';
         measurements: never;
     };
     'debug/apphost/end': {
-        properties: 'mode' | 'apphost_language' | 'ended_with_error' | 'distinct_resource_types';
+        properties: 'mode' | 'apphost_language' | 'apphost_target_version' | 'ended_with_error' | 'distinct_resource_types';
         measurements: 'duration_ms' | 'total_child_sessions' | 'distinct_resource_type_count';
     };
     'debug/runsession/start': {

--- a/extension/src/utils/telemetryRegistry.ts
+++ b/extension/src/utils/telemetryRegistry.ts
@@ -62,7 +62,7 @@ export interface TelemetryEventSchema {
         measurements: 'running_apphosts' | 'total_resources';
     };
     'debug/apphost/start': {
-        properties: 'mode' | 'apphost_language' | 'apphost_target_version' | 'apphost_is_directory' | 'command';
+        properties: 'mode' | 'apphost_language' | 'command';
         measurements: never;
     };
     'debug/apphost/end': {

--- a/extension/src/utils/telemetryRegistry.ts
+++ b/extension/src/utils/telemetryRegistry.ts
@@ -66,7 +66,7 @@ export interface TelemetryEventSchema {
         measurements: never;
     };
     'debug/apphost/end': {
-        properties: 'mode' | 'apphost_language' | 'apphost_target_version' | 'ended_with_error' | 'distinct_resource_types';
+        properties: 'mode' | 'apphost_language' | 'apphost_target_version' | 'apphost_is_directory' | 'ended_with_error' | 'distinct_resource_types';
         measurements: 'duration_ms' | 'total_child_sessions' | 'distinct_resource_type_count';
     };
     'debug/runsession/start': {

--- a/extension/telemetry.json
+++ b/extension/telemetry.json
@@ -77,6 +77,11 @@
         "purpose": "FeatureInsight",
         "comment": "The AppHost project language detected by the extension."
       },
+      "apphost_target_version": {
+        "classification": "SystemMetaData",
+        "purpose": "FeatureInsight",
+        "comment": "The Aspire version targeted by the AppHost."
+      },
       "apphost_is_directory": {
         "classification": "SystemMetaData",
         "purpose": "FeatureInsight",
@@ -98,6 +103,11 @@
         "classification": "SystemMetaData",
         "purpose": "FeatureInsight",
         "comment": "The AppHost project language detected by the extension."
+      },
+      "apphost_target_version": {
+        "classification": "SystemMetaData",
+        "purpose": "FeatureInsight",
+        "comment": "The Aspire version targeted by the AppHost."
       },
       "ended_with_error": {
         "classification": "SystemMetaData",
@@ -418,6 +428,11 @@
       "classification": "SystemMetaData",
       "purpose": "FeatureInsight",
       "comment": "The AppHost languages detected in the current workspace."
+    },
+    "apphost_target_versions": {
+      "classification": "SystemMetaData",
+      "purpose": "FeatureInsight",
+      "comment": "The Aspire versions targeted by AppHosts in the current workspace."
     },
     "apphost_present": {
       "classification": "SystemMetaData",

--- a/extension/telemetry.json
+++ b/extension/telemetry.json
@@ -109,6 +109,11 @@
         "purpose": "FeatureInsight",
         "comment": "The Aspire version targeted by the AppHost."
       },
+      "apphost_is_directory": {
+        "classification": "SystemMetaData",
+        "purpose": "FeatureInsight",
+        "comment": "Whether the AppHost launch target was a directory."
+      },
       "ended_with_error": {
         "classification": "SystemMetaData",
         "purpose": "PerformanceAndHealth",

--- a/extension/telemetry.json
+++ b/extension/telemetry.json
@@ -77,16 +77,6 @@
         "purpose": "FeatureInsight",
         "comment": "The AppHost project language detected by the extension."
       },
-      "apphost_target_version": {
-        "classification": "SystemMetaData",
-        "purpose": "FeatureInsight",
-        "comment": "The Aspire version targeted by the AppHost."
-      },
-      "apphost_is_directory": {
-        "classification": "SystemMetaData",
-        "purpose": "FeatureInsight",
-        "comment": "Whether the AppHost launch target was a directory."
-      },
       "command": {
         "classification": "SystemMetaData",
         "purpose": "FeatureInsight",


### PR DESCRIPTION
## Description

The VS Code extension already reports AppHost language in telemetry, but it did not include the Aspire version targeted by the AppHost. This makes it harder to understand which Aspire SDK versions are being used across C# and polyglot AppHosts.

This adds AppHost target-version telemetry wherever the extension already reports AppHost language:

- `debug/apphost/start` and `debug/apphost/end` include `apphost_target_version`.
- common telemetry properties include `apphost_target_versions` next to `apphost_languages`.
- C# AppHosts are read from `Aspire.AppHost.Sdk` project SDK attributes, old `<Sdk />` elements, `AspireHostingSDKVersion`, and single-file `#:sdk Aspire.AppHost.Sdk@...` directives.
- polyglot AppHosts are read from `aspire.config.json` / legacy `.aspire/settings.json` SDK version settings.

Validation:

```text
corepack yarn install --immutable --mode=skip-builds
TMPDIR=$PWD/.test-tmp corepack yarn run compile-tests
Focused vscode-test run for appHostTargetVersion, MeaningfulEngagementReporter, and AspireDebugSession target-version telemetry: 13 passing
TMPDIR=$PWD/.test-tmp corepack yarn run lint
TMPDIR=$PWD/.test-tmp corepack yarn run compile
```

`yarn run compile` completed with the existing webpack warnings for optional `ws` dependencies and expression dependencies. Focused VS Code tests needed a short `--user-data-dir` because the default `.vscode-test/user-data/...sock` path exceeds the macOS Unix socket length from this worktree path.

Fixes #17921

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
