### PR TITLE
Fix flaky ProcessGuestLauncherTests by avoiding nested PowerShell startup

### DIFF
--- a/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
@@ -6,20 +6,23 @@ using Aspire.Cli.DotNet;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging;
 using static Aspire.Cli.Tests.TestServices.ProcessTestHelpers;
 
 namespace Aspire.Cli.Tests.Projects;
 
 public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper)
 {
-    private static ProcessGuestLauncher CreateLauncher()
+    private readonly ILoggerFactory _loggerFactory = LoggerFactory.Create(builder => builder.AddXunit(outputHelper));
+
+    private ProcessGuestLauncher CreateLauncher()
         => new(
             "test",
-            NullLogger<ProcessGuestLauncher>.Instance,
+            _loggerFactory.CreateLogger<ProcessGuestLauncher>(),
             fileLoggerProvider: null,
             commandResolver: PathLookupHelper.FindFullPathFromPath,
-            processExecutionFactory: new ProcessExecutionFactory(NullLogger<ProcessExecutionFactory>.Instance));
+            processExecutionFactory: new ProcessExecutionFactory(_loggerFactory.CreateLogger<ProcessExecutionFactory>()));
 
     [Fact]
     public async Task LaunchAsync_NoOptions_OnCancellation_ForceKillsProcessTreeAndReturns()
@@ -300,11 +303,18 @@ public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper)
     {
         if (OperatingSystem.IsWindows())
         {
+            // Use cmd.exe as the descendant instead of powershell.exe because PowerShell has
+            // a multi-second cold start on CI runners, and nesting two powershell.exe processes
+            // (root + child) frequently exceeds the pid-file wait timeout.
             var scriptFile = new FileInfo(Path.Combine(workspaceRoot.FullName, "spawn-descendant.ps1"));
             var content =
-                "$child = Start-Process -FilePath powershell.exe -ArgumentList '-NoProfile', '-Command', 'Start-Sleep -Seconds 60' -PassThru" + Environment.NewLine +
+                "$psi = [System.Diagnostics.ProcessStartInfo]::new()" + Environment.NewLine +
+                "$psi.FileName = 'cmd.exe'" + Environment.NewLine +
+                "$psi.Arguments = '/c ping -n 60 127.0.0.1 > nul'" + Environment.NewLine +
+                "$psi.UseShellExecute = $false" + Environment.NewLine +
+                "$child = [System.Diagnostics.Process]::Start($psi)" + Environment.NewLine +
                 $"Set-Content -Path '{descendantPidFile.FullName}' -Value $child.Id" + Environment.NewLine +
-                "Wait-Process -Id $child.Id" + Environment.NewLine;
+                "$child.WaitForExit()" + Environment.NewLine;
             await File.WriteAllTextAsync(scriptFile.FullName, content);
 
             return ("powershell.exe", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptFile.FullName]);
@@ -328,7 +338,7 @@ public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper)
 
     private static async Task<int> WaitForPidFileAsync(FileInfo pidFile)
     {
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        var deadline = DateTime.UtcNow + TestConstants.LongTimeoutTimeSpan;
         while (DateTime.UtcNow < deadline)
         {
             if (pidFile.Exists)

--- a/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
@@ -12,9 +12,11 @@ using static Aspire.Cli.Tests.TestServices.ProcessTestHelpers;
 
 namespace Aspire.Cli.Tests.Projects;
 
-public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper)
+public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper) : IDisposable
 {
     private readonly ILoggerFactory _loggerFactory = LoggerFactory.Create(builder => builder.AddXunit(outputHelper));
+
+    public void Dispose() => _loggerFactory.Dispose();
 
     private ProcessGuestLauncher CreateLauncher()
         => new(


### PR DESCRIPTION
## Description

Fixes flaky test `ProcessGuestLauncherTests.LaunchAsync_WithGracefulServices_ProcessIgnoresSignal_ExpireEscalatesToTreeKill` which was timing out on CI waiting for the descendant pid file.

**Root cause**: The test spawned `powershell.exe` as the root process, which in turn used `Start-Process` to spawn another `powershell.exe` as the child. Two nested PowerShell cold starts on Windows CI runners frequently exceeded the 10-second pid file wait timeout.

**Fix**:
- Replace the child `powershell.exe -Command Start-Sleep` with `cmd.exe /c ping` (instant startup) while keeping the root PowerShell for PID discovery via `[Process]::Start()`
- Use `TestConstants.LongTimeoutTimeSpan` (60s local / 180s CI) for the pid file wait instead of a hardcoded 10s
- Wire up `ITestOutputHelper`-backed loggers so launcher diagnostics appear in CI failure output

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
