### PR TITLE
[automated] Re-enable VS Code extension E2E tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -702,12 +702,7 @@ jobs:
 
   extension_e2e_tests:
     name: Run VS Code extension E2E tests
-    # Temporarily disabled: the VS Code extension E2E shards are flaky and currently failing in CI
-    # (intermittent teardown AggregateError, see https://github.com/microsoft/aspire/issues/18098),
-    # so they block unrelated PRs. Keep the job defined (it stays in the aggregate gate's needs) but
-    # force it to skip until the flakiness is fixed. Re-enable by removing the `false &&` guard below.
-    # Tracked by https://github.com/microsoft/aspire/issues/18412.
-    if: ${{ false && needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
+    if: ${{ needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
     uses: ./.github/workflows/extension-e2e-tests.yml
     needs: [setup_for_tests, build_packages, build_cli_archive_linux, build_cli_archive_windows, extension_tests_win, extension_bootstrap_linux]
 
@@ -825,10 +820,8 @@ jobs:
         #   bucket actually had work. Before selective CI these were always populated on a full run.
         # - cli_starter_validation_windows: this job only runs for pull requests and is expected to
         #   be skipped for other workflow events.
-        # - extension_e2e_tests: temporarily disabled (always skipped) because the E2E shards are
-        #   flaky/failing; see https://github.com/microsoft/aspire/issues/18412. While
-        #   disabled, a 'skipped' result must NOT fail this gate, so the run_extension_e2e skip checks
-        #   were removed below. Restore them when re-enabling the job.
+        # - extension_e2e_tests: this job only runs when the PR/push changes the VS Code extension,
+        #   Aspire CLI, or the extension E2E workflow wiring.
         # - polyglot_validation: this job runs for pull requests and main branch builds; it is
         #   expected to be skipped for other workflow events.
         # All other jobs in this gate are required, and a 'skipped' result is treated as a failure.
@@ -838,6 +831,8 @@ jobs:
                contains(needs.*.result, 'cancelled') ||
                (github.event_name == 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
+                 (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
+                  needs.extension_e2e_tests.result == 'skipped') ||
                  (needs.cli_starter_validation_windows.result == 'skipped' && (needs.setup_for_tests.outputs.run_cli_starter == 'true')) ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
@@ -862,6 +857,8 @@ jobs:
                  (needs.polyglot_validation.result == 'skipped' && (needs.setup_for_tests.outputs.run_polyglot == 'true')))) ||
                (github.event_name != 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
+                 (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
+                  needs.extension_e2e_tests.result == 'skipped') ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
                  needs.build_cli_archive_macos_x64.result == 'skipped' ||

--- a/extension/src/test-e2e/debugDashboard.e2e.test.ts
+++ b/extension/src/test-e2e/debugDashboard.e2e.test.ts
@@ -75,7 +75,10 @@ suite('Aspire debug dashboard E2E', function () {
 
         await setShowStatusDelayForE2E(2500);
         try {
-            await executeE2eControlCommand({ name: 'stopDebugging' });
+            // Only wait for the E2E bridge to start the command. On Windows, waiting
+            // for stopDebugging to fully apply can let the transient stopping state
+            // appear and clear before the assertion starts polling for it.
+            await executeE2eControlCommand({ name: 'stopDebugging' }, { waitFor: 'started' });
             await waitForExtensionState(
                 file => file.state.stoppingPaths.some(stoppingPath => isSamePath(stoppingPath, appHostPath)),
                 `AppHost '${appHostPath}' to enter stopping state`,
@@ -107,7 +110,10 @@ suite('Aspire debug dashboard E2E', function () {
 
         await setShowStatusDelayForE2E(2500);
         try {
-            await executeE2eControlCommand({ name: 'stopDebugging' });
+            // Only wait for the E2E bridge to start the command. On Windows, waiting
+            // for stopDebugging to fully apply can let the transient stopping state
+            // appear and clear before the assertion starts polling for it.
+            await executeE2eControlCommand({ name: 'stopDebugging' }, { waitFor: 'started' });
             await waitForExtensionState(
                 file => file.state.stoppingPaths.some(stoppingPath => isSamePath(stoppingPath, appHostPath)),
                 `AppHost '${appHostPath}' to enter stopping state`,

--- a/extension/src/test-e2e/debugDashboard.e2e.test.ts
+++ b/extension/src/test-e2e/debugDashboard.e2e.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
-import { getCommandInvocationCount, getDebugLaunchCount, getTreeAppHostLabel, isSamePath, waitForAppHostLaunching, waitForCommandOutcome, waitForDebugConsoleOutput, waitForDebugDashboardUrl, waitForDebugLaunch, waitForDebugSessionStartup, waitForExtensionState, waitForHttpText, waitForNoDebugSessions, waitForNoRunningAppHost, waitForRepositoryIdle, waitForRunningAppHost, waitForWorkspaceAppHost } from './helpers/assertions';
+import { getCommandInvocationCount, getDebugLaunchCount, getStoppingPathEventCount, getTreeAppHostLabel, isSamePath, waitForAppHostLaunching, waitForCommandOutcome, waitForDebugConsoleOutput, waitForDebugDashboardUrl, waitForDebugLaunch, waitForDebugSessionStartup, waitForExtensionState, waitForHttpText, waitForNoDebugSessions, waitForNoRunningAppHost, waitForRepositoryIdle, waitForRunningAppHost, waitForStoppingPathEvent, waitForWorkspaceAppHost } from './helpers/assertions';
 import { executeE2eControlCommand, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setShowStatusDelayForE2E, stopPrimaryAppHostIfRunning, writeFileWithRetry } from './helpers/fixtures';
 import { getPrimaryAppHostProjectPath } from './helpers/paths';
 import { openAspireView, waitForEditorTitle, waitForTreeItem, waitForWorkbenchTextAfterIntegratedBrowserNavigation } from './helpers/vscode';
@@ -75,14 +75,9 @@ suite('Aspire debug dashboard E2E', function () {
 
         await setShowStatusDelayForE2E(2500);
         try {
-            // Only wait for the E2E bridge to start the command. On Windows, waiting
-            // for stopDebugging to fully apply can let the transient stopping state
-            // appear and clear before the assertion starts polling for it.
+            const beforeStoppingPathEvent = getStoppingPathEventCount();
             await executeE2eControlCommand({ name: 'stopDebugging' }, { waitFor: 'started' });
-            await waitForExtensionState(
-                file => file.state.stoppingPaths.some(stoppingPath => isSamePath(stoppingPath, appHostPath)),
-                `AppHost '${appHostPath}' to enter stopping state`,
-                120000);
+            await waitForStoppingPathEvent(appHostPath, 'entered', beforeStoppingPathEvent, 120000);
             await waitForNoDebugSessions();
             await waitForNoRunningAppHost(120000, appHostPath);
             await waitForExtensionState(
@@ -110,14 +105,9 @@ suite('Aspire debug dashboard E2E', function () {
 
         await setShowStatusDelayForE2E(2500);
         try {
-            // Only wait for the E2E bridge to start the command. On Windows, waiting
-            // for stopDebugging to fully apply can let the transient stopping state
-            // appear and clear before the assertion starts polling for it.
+            const beforeStoppingPathEvent = getStoppingPathEventCount();
             await executeE2eControlCommand({ name: 'stopDebugging' }, { waitFor: 'started' });
-            await waitForExtensionState(
-                file => file.state.stoppingPaths.some(stoppingPath => isSamePath(stoppingPath, appHostPath)),
-                `AppHost '${appHostPath}' to enter stopping state`,
-                120000);
+            await waitForStoppingPathEvent(appHostPath, 'entered', beforeStoppingPathEvent, 120000);
             await waitForNoDebugSessions();
             await waitForNoRunningAppHost(120000, appHostPath);
             await waitForExtensionState(

--- a/extension/src/test-e2e/helpers/assertions.ts
+++ b/extension/src/test-e2e/helpers/assertions.ts
@@ -124,6 +124,23 @@ export function getCommandInvocationCount(command?: string): number {
     return Math.max(0, ...matchingEvents.map(event => event.sequence));
 }
 
+export function getStoppingPathEventCount(): number {
+    return Math.max(0, ...readStateFile().stoppingPathEvents.map(event => event.sequence));
+}
+
+export async function waitForStoppingPathEvent(appHostPath: string, state: 'entered' | 'left', afterSequence: number, timeoutMs = 60000): Promise<ExtensionE2EStateFile['stoppingPathEvents'][number]> {
+    const file = await waitForExtensionState(
+        stateFile => stateFile.stoppingPathEvents.some(event => event.sequence > afterSequence && event.state === state && isSamePath(event.appHostPath, appHostPath)),
+        `AppHost '${appHostPath}' stopping path ${state} event`,
+        timeoutMs);
+    const event = file.stoppingPathEvents.find(candidate => candidate.sequence > afterSequence && candidate.state === state && isSamePath(candidate.appHostPath, appHostPath));
+    if (!event) {
+        throw new Error(`Stopping path '${state}' event for '${appHostPath}' was not found even though the state predicate matched.`);
+    }
+
+    return event;
+}
+
 export async function waitForTerminalCommand(
     predicate: (event: ExtensionE2EStateFile['terminalCommands'][number]) => boolean,
     description: string,

--- a/extension/src/test-e2e/helpers/assertions.ts
+++ b/extension/src/test-e2e/helpers/assertions.ts
@@ -310,7 +310,7 @@ export async function applyE2eControl(payload: Record<string, unknown>, waitFor:
     const revision = ++controlRevision;
     writeJsonFileAtomic(controlFilePath, { revision, ...payload });
     const stateFile = await waitForExtensionState(
-        file => file.control?.revision === revision && (file.control.status === 'error' || file.control.status === 'applied' || (waitFor === 'started' && file.control.status === 'started')),
+        file => file.control?.revision === revision && (file.control.status === 'error' || (waitFor === 'applied' ? file.control.status === 'applied' : file.control.startedObserved === true)),
         `E2E control revision ${revision}`,
         timeoutMs);
 

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import type { AspireExtensionE2EControlCommand, AspireExtensionE2EControlStatus } from '../../types/extensionApi';
 import { applyE2eControl, isSamePath, readStateFile, sleepSynchronously, waitForExtensionState } from './assertions';
 import { getCliPath, getPrimaryAppHostProjectPath, getRepoRoot, getWorkspaceRoot } from './paths';
-import { runProcess } from './process';
+import { ProcessError, runProcess } from './process';
 
 const csharpFileHeader = `// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
@@ -310,6 +310,11 @@ export async function stopAppHostIfRunning(appHostPath: string): Promise<void> {
     }
 
     if (/timed out|Failed to stop/i.test(stopError.message)) {
+        if (runningAppHostBeforeStop?.appHostPid !== undefined) {
+            await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop.appHostPid, 'after stopping');
+            return;
+        }
+
         const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);
         if (!runningAppHost) {
             await waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop?.appHostPid, 'after stopping');
@@ -423,7 +428,25 @@ async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string
         await waitForNoRunningAppHostPath(appHostPath, timeoutMs, knownAppHostPid, actionDescription);
     }
     catch (error) {
-        const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);
+        let runningAppHost: PsAppHost | undefined;
+        try {
+            runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);
+        }
+        catch (cliError) {
+            if (!isProcessTimeoutError(cliError) || knownAppHostPid === undefined) {
+                throw cliError;
+            }
+
+            const runningAppHostFromState = getRunningAppHostFromState(appHostPath);
+            if (runningAppHostFromState?.appHostPid !== knownAppHostPid) {
+                throw error;
+            }
+
+            await stopProcess(knownAppHostPid, 30000);
+            await waitForNoRunningAppHostPath(appHostPath, 5000, knownAppHostPid, actionDescription);
+            return;
+        }
+
         // The extension state file can lag behind the CLI registry after stopDebugging:
         // it may still contain an AppHost PID even though aspire ps has already dropped
         // the AppHost. At that point the PID may be stale/reused, so don't SIGTERM it.
@@ -438,6 +461,10 @@ async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string
         await stopProcess(runningAppHost.appHostPid, 30000);
         await waitForNoRunningAppHostPath(appHostPath, 5000, runningAppHost.appHostPid, actionDescription);
     }
+}
+
+function isProcessTimeoutError(error: unknown): boolean {
+    return error instanceof ProcessError && /\btimed out after \d+ms\b/i.test(error.message);
 }
 
 function getRunningAppHostFromState(appHostPath: string) {

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { spawnSync } from 'child_process';
 import type { AspireExtensionE2EControlCommand, AspireExtensionE2EControlStatus } from '../../types/extensionApi';
 import { applyE2eControl, isSamePath, readStateFile, sleepSynchronously, waitForExtensionState } from './assertions';
 import { getCliPath, getPrimaryAppHostProjectPath, getRepoRoot, getWorkspaceRoot } from './paths';
@@ -442,6 +443,10 @@ async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string
                 throw error;
             }
 
+            if (!isKnownAppHostProcess(knownAppHostPid, appHostPath)) {
+                throw error;
+            }
+
             await stopProcess(knownAppHostPid, 30000);
             await waitForNoRunningAppHostPath(appHostPath, 5000, knownAppHostPid, actionDescription);
             return;
@@ -465,6 +470,57 @@ async function waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath: string
 
 function isProcessTimeoutError(error: unknown): boolean {
     return error instanceof ProcessError && /\btimed out after \d+ms\b/i.test(error.message);
+}
+
+function isKnownAppHostProcess(pid: number, appHostPath: string): boolean {
+    const commandLine = getProcessCommandLine(pid);
+    if (commandLine === undefined) {
+        return false;
+    }
+
+    return normalizePathForCommandLineSearch(commandLine).includes(normalizePathForCommandLineSearch(appHostPath));
+}
+
+function getProcessCommandLine(pid: number): string | undefined {
+    if (!Number.isInteger(pid) || pid <= 0) {
+        return undefined;
+    }
+
+    if (process.platform === 'linux') {
+        try {
+            const commandLine = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8').replace(/\0/g, ' ').trim();
+            return commandLine.length > 0 ? commandLine : undefined;
+        }
+        catch (error) {
+            if (isProcessLookupError(error)) {
+                return undefined;
+            }
+
+            throw error;
+        }
+    }
+
+    if (process.platform === 'win32') {
+        const result = spawnSync('powershell.exe', [
+            '-NoProfile',
+            '-NonInteractive',
+            '-Command',
+            `$process = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; if ($process) { $process.CommandLine }`,
+        ], { encoding: 'utf8', timeout: 5000 });
+
+        return result.status === 0 && result.stdout.trim().length > 0 ? result.stdout.trim() : undefined;
+    }
+
+    const result = spawnSync('ps', ['-p', String(pid), '-o', 'command='], { encoding: 'utf8', timeout: 5000 });
+    return result.status === 0 && result.stdout.trim().length > 0 ? result.stdout.trim() : undefined;
+}
+
+function normalizePathForCommandLineSearch(value: string): string {
+    return value.replace(/\\/g, '/').toLowerCase();
+}
+
+function isProcessLookupError(error: unknown): boolean {
+    return error instanceof Error && 'code' in error && (error.code === 'ENOENT' || error.code === 'ESRCH' || error.code === 'EACCES' || error.code === 'EPERM');
 }
 
 function getRunningAppHostFromState(appHostPath: string) {

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -247,6 +247,23 @@ suite('E2E launch profile', () => {
         assert.ok(assertions.includes("waitFor === 'applied' ? file.control.status === 'applied' : file.control.startedObserved === true"));
     });
 
+    test('latches E2E AppHost stopping path transitions before snapshots can clear', () => {
+        const extensionRoot = path.resolve(__dirname, '..', '..');
+        const apiTypes = fs.readFileSync(path.join(extensionRoot, 'src', 'types', 'extensionApi.ts'), 'utf8');
+        const e2eStateFileBridge = fs.readFileSync(path.join(extensionRoot, 'src', 'testing', 'e2eStateFileBridge.ts'), 'utf8');
+        const assertions = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'helpers', 'assertions.ts'), 'utf8');
+        const debugDashboard = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'debugDashboard.e2e.test.ts'), 'utf8');
+
+        assert.ok(apiTypes.includes('stoppingPathEvents: readonly AspireExtensionE2EStoppingPathEvent[];'));
+        assert.ok(apiTypes.includes("state: 'entered' | 'left';"));
+        assert.ok(e2eStateFileBridge.includes('recordStoppingPathEvents(state.stoppingPaths);'));
+        assert.ok(e2eStateFileBridge.includes("stoppingPathEvents.push({ sequence: ++stoppingPathSequence, appHostPath, state: 'entered' });"));
+        assert.ok(assertions.includes('waitForStoppingPathEvent'));
+        assert.ok(debugDashboard.includes('const beforeStoppingPathEvent = getStoppingPathEventCount();'));
+        assert.ok(debugDashboard.includes("await waitForStoppingPathEvent(appHostPath, 'entered', beforeStoppingPathEvent, 120000);"));
+        assert.ok(!debugDashboard.includes("file => file.state.stoppingPaths.some(stoppingPath => isSamePath(stoppingPath, appHostPath))"));
+    });
+
     test('patches ExTester launch arguments without replacement-token expansion', () => {
         const extensionRoot = path.resolve(__dirname, '..', '..');
         const runner = fs.readFileSync(path.join(extensionRoot, 'scripts', 'run-e2e.js'), 'utf8');

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -218,6 +218,34 @@ suite('E2E launch profile', () => {
         assert.ok(runner.includes("'--disable-telemetry'"));
     });
 
+    test('uses known AppHost PID when E2E teardown CLI status probes time out', () => {
+        const extensionRoot = path.resolve(__dirname, '..', '..');
+        const fixtures = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'helpers', 'fixtures.ts'), 'utf8');
+        const stopTimeoutCase = fixtures.slice(fixtures.indexOf("if (/timed out|Failed to stop/i.test(stopError.message))"), fixtures.indexOf('const runningAppHost = await getRunningAppHostAccordingToCli(appHostPath);'));
+        const waitFallbackStart = fixtures.indexOf('catch (cliError)');
+        const waitFallback = fixtures.slice(waitFallbackStart, fixtures.indexOf('if (!runningAppHost)', waitFallbackStart));
+
+        assert.ok(fixtures.includes("import { ProcessError, runProcess } from './process';"));
+        assert.ok(stopTimeoutCase.includes('runningAppHostBeforeStop?.appHostPid !== undefined'));
+        assert.ok(stopTimeoutCase.includes('waitForNoRunningAppHostPathOrStopKnownProcess(appHostPath, 30000, runningAppHostBeforeStop.appHostPid'));
+        assert.ok(waitFallback.includes('isProcessTimeoutError(cliError)'));
+        assert.ok(waitFallback.includes('knownAppHostPid === undefined'));
+        assert.ok(waitFallback.includes('runningAppHostFromState?.appHostPid !== knownAppHostPid'));
+        assert.ok(waitFallback.includes('await stopProcess(knownAppHostPid, 30000);'));
+    });
+
+    test('latches E2E control command start before command completion can overwrite the state file', () => {
+        const extensionRoot = path.resolve(__dirname, '..', '..');
+        const apiTypes = fs.readFileSync(path.join(extensionRoot, 'src', 'types', 'extensionApi.ts'), 'utf8');
+        const e2eStateFileBridge = fs.readFileSync(path.join(extensionRoot, 'src', 'testing', 'e2eStateFileBridge.ts'), 'utf8');
+        const assertions = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'helpers', 'assertions.ts'), 'utf8');
+
+        assert.ok(apiTypes.includes('startedObserved?: boolean;'));
+        assert.ok(e2eStateFileBridge.includes("controlStatus = { revision, status: 'started', startedObserved: true };"));
+        assert.ok(e2eStateFileBridge.includes("controlStatus = { revision, status: 'applied', startedObserved: commandStarted, result };"));
+        assert.ok(assertions.includes("waitFor === 'applied' ? file.control.status === 'applied' : file.control.startedObserved === true"));
+    });
+
     test('patches ExTester launch arguments without replacement-token expansion', () => {
         const extensionRoot = path.resolve(__dirname, '..', '..');
         const runner = fs.readFileSync(path.join(extensionRoot, 'scripts', 'run-e2e.js'), 'utf8');

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -231,6 +231,7 @@ suite('E2E launch profile', () => {
         assert.ok(waitFallback.includes('isProcessTimeoutError(cliError)'));
         assert.ok(waitFallback.includes('knownAppHostPid === undefined'));
         assert.ok(waitFallback.includes('runningAppHostFromState?.appHostPid !== knownAppHostPid'));
+        assert.ok(waitFallback.includes('isKnownAppHostProcess(knownAppHostPid, appHostPath)'));
         assert.ok(waitFallback.includes('await stopProcess(knownAppHostPid, 30000);'));
     });
 

--- a/extension/src/testing/e2eStateFileBridge.ts
+++ b/extension/src/testing/e2eStateFileBridge.ts
@@ -136,13 +136,13 @@ export function createE2eStateFileBridge(
             const markCommandStarted = () => {
               if (!commandStarted) {
                 commandStarted = true;
-                controlStatus = { revision, status: 'started' };
+                controlStatus = { revision, status: 'started', startedObserved: true };
                 writeStateFile();
               }
             };
 
             const result = await executeE2eControlCommand(context, aspireContext, appHostLaunchService, appHostTreeProvider, terminalProvider, payload.command, markCommandStarted);
-            controlStatus = { revision, status: 'applied', result };
+            controlStatus = { revision, status: 'applied', startedObserved: commandStarted, result };
           }
           else {
             controlStatus = { revision, status: 'applied' };

--- a/extension/src/testing/e2eStateFileBridge.ts
+++ b/extension/src/testing/e2eStateFileBridge.ts
@@ -10,7 +10,7 @@ import { cleanupRun } from '../debugger/runCleanupRegistry';
 import type { AspireResourceExtendedDebugConfiguration, EnvVar, ExecutableLaunchConfiguration } from '../dcp/types';
 import { createStateSnapshot, getSensitiveDashboardUrl, isSamePath } from '../extensionState';
 import { AppHostLaunchRequestedEvent, AppHostLaunchService } from '../services/AppHostLaunchService';
-import type { AspireDebugConsoleOutputEvent, AspireExtensionE2ECommandInvocation, AspireExtensionE2EControlCommand, AspireExtensionE2EControlPayload, AspireExtensionE2EControlStatus, AspireExtensionE2EDebugConsoleOutput, AspireExtensionE2EDebugLaunch, AspireExtensionE2ETerminalCommand, AspireExtensionStateSnapshot } from '../types/extensionApi';
+import type { AspireDebugConsoleOutputEvent, AspireExtensionE2ECommandInvocation, AspireExtensionE2EControlCommand, AspireExtensionE2EControlPayload, AspireExtensionE2EControlStatus, AspireExtensionE2EDebugConsoleOutput, AspireExtensionE2EDebugLaunch, AspireExtensionE2EStoppingPathEvent, AspireExtensionE2ETerminalCommand, AspireExtensionStateSnapshot } from '../types/extensionApi';
 import { AspireTerminalCommandEvent, AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 import { extensionLogOutputChannel } from '../utils/logging';
 import { onDidInvokeCommand } from '../utils/telemetry';
@@ -38,23 +38,55 @@ export function createE2eStateFileBridge(
   const terminalCommands: AspireExtensionE2ETerminalCommand[] = [];
   const debugLaunches: AspireExtensionE2EDebugLaunch[] = [];
   const debugConsoleOutputs: AspireExtensionE2EDebugConsoleOutput[] = [];
+  const stoppingPathEvents: AspireExtensionE2EStoppingPathEvent[] = [];
   let commandInvocationSequence = 0;
   let terminalCommandSequence = 0;
   let debugLaunchSequence = 0;
   let debugConsoleOutputSequence = 0;
+  let stoppingPathSequence = 0;
+  let previousStoppingPaths: readonly string[] | undefined;
   let controlStatus: AspireExtensionE2EControlStatus | undefined;
   let lastControlRevision = -1;
   const writeStateFile = () => {
+    const state = createStateSnapshot(dataRepository, appHostLaunchService, appHostTreeProvider, aspireContext, true);
+    recordStoppingPathEvents(state.stoppingPaths);
+
     writeJsonFileAtomic(stateFile, {
       updatedAt: new Date().toISOString(),
-      state: createStateSnapshot(dataRepository, appHostLaunchService, appHostTreeProvider, aspireContext, true),
+      state,
       dashboardUrl: getSensitiveDashboardUrl(dataRepository),
       commandInvocations,
       terminalCommands,
       debugLaunches,
       debugConsoleOutputs,
+      stoppingPathEvents,
       control: controlStatus,
     });
+  };
+
+  const recordStoppingPathEvents = (currentStoppingPaths: readonly string[]) => {
+    if (previousStoppingPaths === undefined) {
+      previousStoppingPaths = [...currentStoppingPaths];
+      return;
+    }
+
+    for (const appHostPath of currentStoppingPaths) {
+      if (!previousStoppingPaths.some(previousPath => isSamePath(previousPath, appHostPath))) {
+        stoppingPathEvents.push({ sequence: ++stoppingPathSequence, appHostPath, state: 'entered' });
+      }
+    }
+
+    for (const appHostPath of previousStoppingPaths) {
+      if (!currentStoppingPaths.some(currentPath => isSamePath(currentPath, appHostPath))) {
+        stoppingPathEvents.push({ sequence: ++stoppingPathSequence, appHostPath, state: 'left' });
+      }
+    }
+
+    if (stoppingPathEvents.length > 100) {
+      stoppingPathEvents.splice(0, stoppingPathEvents.length - 100);
+    }
+
+    previousStoppingPaths = [...currentStoppingPaths];
   };
 
   fs.mkdirSync(path.dirname(stateFile), { recursive: true });

--- a/extension/src/types/extensionApi.ts
+++ b/extension/src/types/extensionApi.ts
@@ -129,6 +129,7 @@ export interface AspireDebugConsoleOutputEvent {
 export interface AspireExtensionE2EControlStatus {
     revision: number;
     status: 'started' | 'applied' | 'error';
+    startedObserved?: boolean;
     errorMessage?: string;
     result?: unknown;
 }

--- a/extension/src/types/extensionApi.ts
+++ b/extension/src/types/extensionApi.ts
@@ -104,6 +104,7 @@ export interface AspireExtensionE2EStateFile {
     terminalCommands: readonly AspireExtensionE2ETerminalCommand[];
     debugLaunches: readonly AspireExtensionE2EDebugLaunch[];
     debugConsoleOutputs: readonly AspireExtensionE2EDebugConsoleOutput[];
+    stoppingPathEvents: readonly AspireExtensionE2EStoppingPathEvent[];
     control?: AspireExtensionE2EControlStatus;
 }
 
@@ -118,6 +119,11 @@ export type AspireExtensionE2ETerminalCommand = AspireTerminalCommandEvent & Asp
 export type AspireExtensionE2EDebugLaunch = AppHostLaunchRequestedEvent & AspireExtensionE2ESequence;
 
 export type AspireExtensionE2EDebugConsoleOutput = AspireDebugConsoleOutputEvent & AspireExtensionE2ESequence;
+
+export interface AspireExtensionE2EStoppingPathEvent extends AspireExtensionE2ESequence {
+    appHostPath: string;
+    state: 'entered' | 'left';
+}
 
 export interface AspireDebugConsoleOutputEvent {
     debugSessionId: string;


### PR DESCRIPTION
## Description

This re-enables the VS Code extension E2E job for #18412 after fixing the races that made the re-enable unsafe.

The debug-dashboard failures were a test observability race, not the AppHost failing to stop. The failing Windows logs showed `global debug stop removes running apphost` timing out while waiting for `stoppingPaths`, but the last exported state already had no `debugSessions`, no `appHosts`, and no `stoppingPaths`. So the stop had completed before the test caught the transient stopping snapshot.

The fix is to record E2E `stoppingPathEvents` when an AppHost enters or leaves `stoppingPaths`. The debug-dashboard tests now assert that the AppHost entered stopping after the stop command was issued, so they no longer depend on polling a short-lived snapshot at exactly the right time. `startedObserved` remains as a durable command-start signal, but the stop-state assertion is guarded by the stopping-path transition event.

The zero-to-running teardown failures were a cleanup race. The failing logs showed teardown calling `aspire ps --format json` while Aspire was already stopping, and that status probe timed out twice. Cleanup now prefers the AppHost PID captured before stop, and only terminates it if the current process command line still belongs to the same AppHost. If the PID cannot be validated, teardown fails instead of risking a stale/reused PID.

Refs #18412
Refs #18098

### Verification

| Run | Config | Result |
|-----|--------|--------|
| Existing failure | Windows debug-dashboard in runs 27859653067 / 27880096863 | timed out waiting for transient stopping snapshot ❌ |
| Existing failure | Linux zero-to-running in run 27880096863 | teardown `aspire ps --format json` timed out while Aspire was stopping ❌ |
| Local | `corepack yarn run compile-e2e` | passed ✅ |
| Local | `corepack yarn run compile-tests` | passed ✅ |
| Local | `./node_modules/.bin/mocha out/test/e2eLaunchProfile.test.js --ui tdd --reporter dot` | 29 passing ✅ |
| Local | `corepack yarn run lint` | passed ✅ |
| Local | `dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- --filter-class "*.TestTriggerMapTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` | 15 passing ✅ |
| Local repeat | `run-test-repeatedly.sh -n 20 --run-all -- bash -lc 'cd extension && ./node_modules/.bin/mocha out/test/e2eLaunchProfile.test.js --ui tdd --reporter dot && echo "Total: 29"'` | 20/20 passed ✅ |
| PR CI before follow-up hardening | run 28080234419, full VS Code extension E2E matrix | all Linux/Windows extension E2E shards passed ✅ |
| PR CI final SHA | run 28111555341, full VS Code extension E2E matrix | all Linux/Windows extension E2E shards passed, including Windows `debug-dashboard` and Windows/Linux `zero-to-running` ✅ |

### Verification rationale

The standard `reproduce-flaky-tests.yml` workflow is for dotnet test projects, so it is not the right runner for these VS Code extension E2E shards. For this PR, the fix-flaky-test local repeat harness was used for the focused source-level E2E regression guards, and the real cross-OS validation is the GitHub-hosted extension E2E matrix from the regular CI workflow.

### Notes

- This intentionally keeps #18412 open until the restored E2E job has follow-up signal on the updated branch.
- Local repro of the Windows-only debug-dashboard failure was skipped because this machine is macOS; the real Windows proof comes from GitHub-hosted Windows E2E shards.
- This fix was investigated with the `fix-flaky-test`, `vscode-extension`, `ci-test-failures`, `pr-testing`, and review orchestration skills.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
