### PR TITLE
Fix Key Vault soft-delete reprovision recovery

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Channels;
+using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.Provisioning;
 using Aspire.Hosting.Azure.Provisioning.Internal;
@@ -652,7 +653,7 @@ internal sealed class AzureProvisioningController(
             throw new MissingConfigurationException("Azure resource location can't be changed because the interaction service is unavailable.");
         }
 
-        var targetResources = GetTargetAzureResources(model, resourceName);
+        var targetResources = GetTargetAzureResources(model, resourceName, includeAnnotationParentRelationships: false);
         var currentLocation = await GetEffectiveResourceLocationAsync(GetDeploymentStateResourceName(targetResources[0]), cancellationToken).ConfigureAwait(false);
         var locationOptions = await GetLocationOptionsAsync(cancellationToken).ConfigureAwait(false);
         var useChoiceInput = locationOptions.Count > 0;
@@ -1192,7 +1193,10 @@ internal sealed class AzureProvisioningController(
             !bicepResource.IsEmulator())];
     }
 
-    private static List<(IResource Resource, IAzureResource AzureResource)> GetTargetAzureResources(DistributedApplicationModel model, string resourceName)
+    private static List<(IResource Resource, IAzureResource AzureResource)> GetTargetAzureResources(
+        DistributedApplicationModel model,
+        string resourceName,
+        bool includeAnnotationParentRelationships = true)
     {
         var azureResources = GetProvisionableAzureResources(model);
         var targetResource = azureResources.SingleOrDefault(resource =>
@@ -1204,7 +1208,7 @@ internal sealed class AzureProvisioningController(
             throw new InvalidOperationException($"Azure resource '{resourceName}' was not found or cannot be reprovisioned.");
         }
 
-        var parentChildLookup = model.Resources.OfType<IResourceWithParent>().ToLookup(r => r.Parent);
+        var parentChildLookup = GetTargetParentChildLookup(model, includeAnnotationParentRelationships);
         var visitedResources = new HashSet<string>(StringComparers.ResourceName);
         var queue = new Queue<(IResource Resource, IAzureResource AzureResource)>();
         var targetResources = new List<(IResource Resource, IAzureResource AzureResource)>();
@@ -1261,14 +1265,41 @@ internal sealed class AzureProvisioningController(
         }
     }
 
+    private static ILookup<IResource, IResource> GetTargetParentChildLookup(DistributedApplicationModel model, bool includeAnnotationParentRelationships)
+    {
+        // WithParentRelationship stores visual parentage as ResourceRelationshipAnnotation instead of
+        // IResourceWithParent. Reprovision target discovery needs both forms so parent commands include
+        // generated Azure children such as implicit Key Vaults.
+        return model.Resources
+            .SelectMany(resource => GetResourceParents(resource, includeAnnotationParentRelationships).Select(parent => (Parent: parent, Child: resource)))
+            .ToLookup(static relationship => relationship.Parent, static relationship => relationship.Child);
+    }
+
+    private static IEnumerable<IResource> GetResourceParents(IResource resource, bool includeAnnotationParentRelationships)
+    {
+        if (resource is IResourceWithParent resourceWithParent)
+        {
+            yield return resourceWithParent.Parent;
+        }
+
+        // Change-location opts out of annotation-based parents so a parent resource with an
+        // implicit Key Vault child is not treated as a Key Vault location-change target.
+        if (includeAnnotationParentRelationships &&
+            resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships) &&
+            relationships.LastOrDefault(static relationship => relationship.Type == KnownRelationshipTypes.Parent) is { } parentRelationship)
+        {
+            yield return parentRelationship.Resource;
+        }
+    }
+
     private static bool IsKeyVaultTarget(DistributedApplicationModel model, string resourceName)
     {
-        return GetTargetAzureResources(model, resourceName)
+        return GetTargetAzureResources(model, resourceName, includeAnnotationParentRelationships: false)
             .Any(static resource => resource.AzureResource is IAzureKeyVaultResource);
     }
 
     private static void ThrowIfKeyVaultLocationChangeTarget(DistributedApplicationModel model, string resourceName)
-        => ThrowIfKeyVaultLocationChangeTarget(GetTargetAzureResources(model, resourceName));
+        => ThrowIfKeyVaultLocationChangeTarget(GetTargetAzureResources(model, resourceName, includeAnnotationParentRelationships: false));
 
     private static void ThrowIfKeyVaultLocationChangeTarget(IReadOnlyList<(IResource Resource, IAzureResource AzureResource)> targetResources)
     {
@@ -1818,7 +1849,7 @@ internal sealed class AzureProvisioningController(
 
     private async Task<bool> ExecuteChangeResourceLocationAsync(DistributedApplicationModel model, ChangeResourceLocationIntent intent, CancellationToken cancellationToken)
     {
-        var targetResources = GetTargetAzureResources(model, intent.ResourceName);
+        var targetResources = GetTargetAzureResources(model, intent.ResourceName, includeAnnotationParentRelationships: false);
         ThrowIfKeyVaultLocationChangeTarget(targetResources);
 
         var parentChildLookup = model.Resources.OfType<IResourceWithParent>().ToLookup(r => r.Parent);
@@ -1872,12 +1903,36 @@ internal sealed class AzureProvisioningController(
         {
             // If a delete command is canceled after the live vault is deleted but before purge finishes,
             // the next reprovision sees ARM's soft-delete conflict. At that point the user explicitly
-            // asked to recreate this resource, so purge the tombstone for the same target ID and retry once.
+            // asked to recreate this resource, so purge the tombstone for the same target ID when Azure
+            // can still find it.
+            var keyVaultResourceIdentifier = new ResourceIdentifier(keyVaultResourceId);
             UpdateActiveOperationPhase(
                 intent,
                 AzureProvisioningStrings.OperationPhasePurgingDeletedKeyVault,
-                FormatUserString(AzureProvisioningStrings.OperationPhasePurgingRecoverableKeyVaultFormat, new ResourceIdentifier(keyVaultResourceId).Name));
-            await DeleteAzureResourceIdsAsync([keyVaultResourceId], intent.ResourceName, effectiveLocation, currentContext.Location, allowKeyVaultPurgeTimeout: false, cancellationToken).ConfigureAwait(false);
+                FormatUserString(AzureProvisioningStrings.OperationPhasePurgingRecoverableKeyVaultFormat, keyVaultResourceIdentifier.Name));
+            var armClient = await GetArmClientForResourceIdAsync(keyVaultResourceId, cancellationToken).ConfigureAwait(false);
+            // Key Vault names are reserved by a location-scoped soft-delete tombstone after the live
+            // vault is gone. Reprovision has to purge that tombstone before ARM can create a new vault
+            // with the same generated name; if Azure reports the conflict but the tombstone cannot be
+            // found, retrying would just hide the actionable diagnostic.
+            var purged = await DeleteAzureResourceIdAndPurgeDeletedKeyVaultAsync(
+                armClient,
+                keyVaultResourceId,
+                intent.ResourceName,
+                effectiveLocation,
+                currentContext.Location,
+                allowKeyVaultPurgeTimeout: false,
+                cancellationToken).ConfigureAwait(false);
+            if (!purged)
+            {
+                var failureDetails = AzureProvisioningFailureDetails.CreateKeyVaultDeletedStateTombstoneNotFound(
+                    keyVaultResourceIdentifier.Name,
+                    keyVaultResourceId,
+                    GetKeyVaultPurgeLocations(effectiveLocation, currentContext.Location));
+                await PublishProvisioningFailureAsync(model, targetResources, failureDetails).ConfigureAwait(false);
+                throw new AzureProvisioningFailureException(failureDetails, ex);
+            }
+
             await ResetResourcesAsync(model, targetResources, preserveOverrides: true, cancellationToken).ConfigureAwait(false);
             return await EnsureProvisionedOrThrowAsync(model, targetResources, cancellationToken).ConfigureAwait(false);
         }
@@ -2178,7 +2233,10 @@ internal sealed class AzureProvisioningController(
             return intent.Operation;
         }
 
-        var resourceNames = GetTargetAzureResources(model, intent.Operation.ResourceNames.Single())
+        var resourceNames = GetTargetAzureResources(
+            model,
+            intent.Operation.ResourceNames.Single(),
+            includeAnnotationParentRelationships: intent is not ChangeResourceLocationIntent)
             .SelectMany(static resource => resource.Resource == resource.AzureResource
                 ? [resource.Resource.Name]
                 : new[] { resource.Resource.Name, resource.AzureResource.Name })
@@ -2355,7 +2413,10 @@ internal sealed class AzureProvisioningController(
     private async Task<JsonObject> CreateResourceCommandResultJsonAsync(string commandName, DistributedApplicationModel model, string resourceName, CancellationToken cancellationToken)
     {
         var json = await CreateCommandResultJsonAsync(commandName, resourceName, cancellationToken).ConfigureAwait(false);
-        var targetResources = GetTargetAzureResources(model, resourceName);
+        var targetResources = GetTargetAzureResources(
+            model,
+            resourceName,
+            includeAnnotationParentRelationships: commandName != ChangeResourceLocationCommandName);
         var effectiveLocation = await GetEffectiveResourceLocationAsync(GetDeploymentStateResourceName(targetResources[0]), cancellationToken).ConfigureAwait(false);
         json["resourceCount"] = targetResources.Count;
         json["location"] = effectiveLocation;
@@ -2841,31 +2902,62 @@ internal sealed class AzureProvisioningController(
             // from deployment state that point at a different subscription than the current context.
             var armClient = await GetArmClientForResourceIdAsync(resourceId, cancellationToken).ConfigureAwait(false);
 
-            _logger.LogInformation("Deleting Azure resource {ResourceId} for {ResourceName}.", resourceId, resourceName);
-
-            try
-            {
-                await armClient.DeleteResourceAsync(resourceId, cancellationToken).ConfigureAwait(false);
-            }
-            catch (RequestFailedException ex) when (ex.Status == 404)
-            {
-                _logger.LogInformation(ex, "Azure resource {ResourceId} was already absent while deleting resources for {ResourceName}.", resourceId, resourceName);
-            }
-
-            await PurgeDeletedKeyVaultAsync(armClient, resourceId, resourceName, resourceLocation, fallbackResourceLocation, allowKeyVaultPurgeTimeout, cancellationToken).ConfigureAwait(false);
+            await DeleteAzureResourceIdAndPurgeDeletedKeyVaultAsync(
+                armClient,
+                resourceId,
+                resourceName,
+                resourceLocation,
+                fallbackResourceLocation,
+                allowKeyVaultPurgeTimeout,
+                cancellationToken).ConfigureAwait(false);
         }
     }
 
-    private async Task PurgeDeletedKeyVaultAsync(IArmClient armClient, string resourceId, string resourceName, string? resourceLocation, string? fallbackResourceLocation, bool allowTimeout, CancellationToken cancellationToken)
+    private async Task<bool> DeleteAzureResourceIdAndPurgeDeletedKeyVaultAsync(
+        IArmClient armClient,
+        string resourceId,
+        string resourceName,
+        string? resourceLocation,
+        string? fallbackResourceLocation,
+        bool allowKeyVaultPurgeTimeout,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Deleting Azure resource {ResourceId} for {ResourceName}.", resourceId, resourceName);
+
+        try
+        {
+            await armClient.DeleteResourceAsync(resourceId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            _logger.LogInformation(ex, "Azure resource {ResourceId} was already absent while deleting resources for {ResourceName}.", resourceId, resourceName);
+        }
+
+        return await PurgeDeletedKeyVaultAsync(
+            armClient,
+            resourceId,
+            resourceName,
+            resourceLocation,
+            fallbackResourceLocation,
+            allowKeyVaultPurgeTimeout,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> PurgeDeletedKeyVaultAsync(
+        IArmClient armClient,
+        string resourceId,
+        string resourceName,
+        string? resourceLocation,
+        string? fallbackResourceLocation,
+        bool allowTimeout,
+        CancellationToken cancellationToken)
     {
         if (!IsKeyVaultResourceId(resourceId))
         {
-            return;
+            return false;
         }
 
-        var keyVaultLocations = new List<string>();
-        AddLocationIfPresent(keyVaultLocations, resourceLocation);
-        AddLocationIfPresent(keyVaultLocations, fallbackResourceLocation);
+        var keyVaultLocations = GetKeyVaultPurgeLocations(resourceLocation, fallbackResourceLocation);
 
         foreach (var keyVaultLocation in keyVaultLocations)
         {
@@ -2874,15 +2966,19 @@ internal sealed class AzureProvisioningController(
                 if (await armClient.PurgeDeletedKeyVaultAsync(resourceId, keyVaultLocation, cancellationToken).ConfigureAwait(false))
                 {
                     _logger.LogInformation("Purged deleted Azure Key Vault {ResourceId} in {Location} for {ResourceName}.", resourceId, keyVaultLocation, resourceName);
-                    return;
+                    return true;
                 }
+
+                _logger.LogInformation("Deleted Azure Key Vault {ResourceId} was not found in {Location} while purging for {ResourceName}.", resourceId, keyVaultLocation, resourceName);
             }
             catch (TimeoutException ex) when (allowTimeout)
             {
                 _logger.LogWarning(ex, "Timed out waiting for deleted Azure Key Vault {ResourceId} in {Location} to be purged for {ResourceName}. The live vault was deleted and purge was requested; a later reprovision can retry if Azure is still finalizing the tombstone.", resourceId, keyVaultLocation, resourceName);
-                return;
+                return true;
             }
         }
+
+        return false;
     }
 
     private static bool IsKeyVaultResourceId(string resourceId)
@@ -2890,6 +2986,17 @@ internal sealed class AzureProvisioningController(
         return ResourceIdentifier.TryParse(resourceId, out var parsedResourceId) &&
             parsedResourceId is not null &&
             string.Equals(parsedResourceId.ResourceType.ToString(), KeyVaultVaultResourceType, StringComparisons.AzureResourceType);
+    }
+
+    private static IReadOnlyList<string> GetKeyVaultPurgeLocations(string? resourceLocation, string? fallbackResourceLocation)
+    {
+        // Deleted Key Vault lookups are location-scoped. Try the resource's effective location first,
+        // then the current Azure context location as a fallback for older cached state or partial
+        // failures where the resource-specific location was not persisted.
+        var keyVaultLocations = new List<string>();
+        AddLocationIfPresent(keyVaultLocations, resourceLocation);
+        AddLocationIfPresent(keyVaultLocations, fallbackResourceLocation);
+        return keyVaultLocations;
     }
 
     private static void AddLocationIfPresent(List<string> locations, string? location)
@@ -3563,6 +3670,22 @@ internal sealed class AzureProvisioningController(
                 Properties = failureDetails is null
                     ? state.Properties
                     : failureDetails.SetResourceProperties(state.Properties, AzureProvisioningFailureDetails.ProvisionOperation)
+            }).ConfigureAwait(false);
+        }
+    }
+
+    private async Task PublishProvisioningFailureAsync(
+        DistributedApplicationModel model,
+        IReadOnlyList<(IResource Resource, IAzureResource AzureResource)> targetResources,
+        AzureProvisioningFailureDetails failureDetails)
+    {
+        var parentChildLookup = model.Resources.OfType<IResourceWithParent>().ToLookup(r => r.Parent);
+        foreach (var targetResource in targetResources)
+        {
+            await PublishUpdateToResourceTreeAsync(targetResource, parentChildLookup, state => state with
+            {
+                State = new(AzureProvisioningStrings.ResourceStateFailedToProvision, KnownResourceStateStyles.Error),
+                Properties = failureDetails.SetResourceProperties(state.Properties, AzureProvisioningFailureDetails.ProvisionOperation)
             }).ConfigureAwait(false);
         }
     }

--- a/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
@@ -1913,15 +1913,16 @@ internal sealed class AzureProvisioningController(
             var armClient = await GetArmClientForResourceIdAsync(keyVaultResourceId, cancellationToken).ConfigureAwait(false);
             // Key Vault names are reserved by a location-scoped soft-delete tombstone after the live
             // vault is gone. Reprovision has to purge that tombstone before ARM can create a new vault
-            // with the same generated name; if Azure reports the conflict but the tombstone cannot be
-            // found, retrying would just hide the actionable diagnostic.
-            var purged = await DeleteAzureResourceIdAndPurgeDeletedKeyVaultAsync(
+            // with the same generated name. ARM only reports this conflict once the live vault is already
+            // absent, so issue the purge directly rather than starting another delete that can wait on
+            // the same tombstone and delay the retry.
+            var purged = await PurgeDeletedKeyVaultAsync(
                 armClient,
                 keyVaultResourceId,
                 intent.ResourceName,
                 effectiveLocation,
                 currentContext.Location,
-                allowKeyVaultPurgeTimeout: false,
+                allowTimeout: false,
                 cancellationToken).ConfigureAwait(false);
             if (!purged)
             {

--- a/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
@@ -1196,7 +1196,7 @@ internal sealed class AzureProvisioningController(
     private static List<(IResource Resource, IAzureResource AzureResource)> GetTargetAzureResources(
         DistributedApplicationModel model,
         string resourceName,
-        bool includeAnnotationParentRelationships = true)
+        bool includeAnnotationParentRelationships)
     {
         var azureResources = GetProvisionableAzureResources(model);
         var targetResource = azureResources.SingleOrDefault(resource =>
@@ -1709,7 +1709,7 @@ internal sealed class AzureProvisioningController(
 
     private async Task<object?> ExecuteForgetResourceStateAsync(DistributedApplicationModel model, ForgetResourceStateIntent intent, CancellationToken cancellationToken)
     {
-        var targetResources = GetTargetAzureResources(model, intent.ResourceName);
+        var targetResources = GetTargetAzureResources(model, intent.ResourceName, includeAnnotationParentRelationships: true);
         // Forgetting state is local-only. It deliberately does not call ARM delete; users choose the
         // Delete command when they want Aspire to remove live Azure resources.
         await ResetResourcesAsync(model, targetResources, preserveOverrides: false, cancellationToken).ConfigureAwait(false);
@@ -1889,7 +1889,7 @@ internal sealed class AzureProvisioningController(
     private async Task<bool> ExecuteReprovisionResourceAsync(DistributedApplicationModel model, ReprovisionResourceIntent intent, CancellationToken cancellationToken)
     {
         UpdateActiveOperationPhase(intent, AzureProvisioningStrings.OperationPhaseReprovisioning);
-        var targetResources = GetTargetAzureResources(model, intent.ResourceName);
+        var targetResources = GetTargetAzureResources(model, intent.ResourceName, includeAnnotationParentRelationships: true);
         var effectiveLocation = await GetEffectiveResourceLocationAsync(GetDeploymentStateResourceName(targetResources[0]), cancellationToken).ConfigureAwait(false);
         var currentContext = await GetCurrentAzureContextAsync(cancellationToken).ConfigureAwait(false);
         await ResetResourcesAsync(model, targetResources, preserveOverrides: true, cancellationToken).ConfigureAwait(false);
@@ -1930,7 +1930,7 @@ internal sealed class AzureProvisioningController(
                     keyVaultResourceIdentifier.Name,
                     keyVaultResourceId,
                     GetKeyVaultPurgeLocations(effectiveLocation, currentContext.Location));
-                await PublishProvisioningFailureAsync(model, targetResources, failureDetails).ConfigureAwait(false);
+                await PublishSyntheticProvisioningFailureAsync(model, targetResources, failureDetails).ConfigureAwait(false);
                 throw new AzureProvisioningFailureException(failureDetails, ex);
             }
 
@@ -1974,7 +1974,7 @@ internal sealed class AzureProvisioningController(
 
     private async Task CancelResourceCoreAsync(DistributedApplicationModel model, string resourceName, CancellationToken cancellationToken)
     {
-        var targetResources = GetTargetAzureResources(model, resourceName);
+        var targetResources = GetTargetAzureResources(model, resourceName, includeAnnotationParentRelationships: true);
         var parentChildLookup = model.Resources.OfType<IResourceWithParent>().ToLookup(r => r.Parent);
 
         ActiveAzureOperation? activeOperation = null;
@@ -2040,7 +2040,7 @@ internal sealed class AzureProvisioningController(
     private async Task<DeleteAzureResourceResult> ExecuteDeleteAzureResourceAsync(DistributedApplicationModel model, DeleteAzureResourceIntent intent, CancellationToken cancellationToken)
     {
         UpdateActiveOperationPhase(intent, AzureProvisioningStrings.OperationPhaseDeletingAzureResource);
-        var targetResources = GetTargetAzureResources(model, intent.ResourceName);
+        var targetResources = GetTargetAzureResources(model, intent.ResourceName, includeAnnotationParentRelationships: true);
         var parentChildLookup = model.Resources.OfType<IResourceWithParent>().ToLookup(r => r.Parent);
 
         foreach (var resource in targetResources)
@@ -2427,7 +2427,7 @@ internal sealed class AzureProvisioningController(
 
     private async Task<CommandResultData> CreateAzureResourceInfoCommandResultDataAsync(DistributedApplicationModel model, string resourceName, CancellationToken cancellationToken)
     {
-        var targetResources = GetTargetAzureResources(model, resourceName);
+        var targetResources = GetTargetAzureResources(model, resourceName, includeAnnotationParentRelationships: true);
 
         // Targeting a parent Azure resource can include children and role assignments that must
         // be reprovisioned together. The info command, however, reports the resource the user
@@ -2967,6 +2967,9 @@ internal sealed class AzureProvisioningController(
                 if (await armClient.PurgeDeletedKeyVaultAsync(resourceId, keyVaultLocation, cancellationToken).ConfigureAwait(false))
                 {
                     _logger.LogInformation("Purged deleted Azure Key Vault {ResourceId} in {Location} for {ResourceName}.", resourceId, keyVaultLocation, resourceName);
+                    // The locations are candidates for the same recoverable vault tombstone. Once
+                    // Azure finds and accepts the purge in one location, there is no second
+                    // tombstone to purge.
                     return true;
                 }
 
@@ -3675,11 +3678,14 @@ internal sealed class AzureProvisioningController(
         }
     }
 
-    private async Task PublishProvisioningFailureAsync(
+    private async Task PublishSyntheticProvisioningFailureAsync(
         DistributedApplicationModel model,
         IReadOnlyList<(IResource Resource, IAzureResource AzureResource)> targetResources,
         AzureProvisioningFailureDetails failureDetails)
     {
+        // This is only for synthetic reprovision failures raised outside the normal per-resource
+        // provisioning task. Exceptions observed by AfterProvisionAsync keep their existing path so
+        // ARM-specific terminal states are not replaced with a generic provisioning failure.
         var parentChildLookup = model.Resources.OfType<IResourceWithParent>().ToLookup(r => r.Parent);
         foreach (var targetResource in targetResources)
         {

--- a/src/Aspire.Hosting.Azure/AzureProvisioningFailureDetails.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningFailureDetails.cs
@@ -50,6 +50,7 @@ internal sealed record AzureProvisioningFailureDetails(
     internal const string LiveResourceCheckOperation = "live-resource-check";
     internal const string MissingResourceIdReason = "missing-resource-id";
     internal const string MissingLiveResourceReason = "missing-live-resource";
+    internal const string KeyVaultDeletedStateTombstoneNotFoundReason = "key-vault-deleted-state-tombstone-not-found";
     internal const string ResourceGroupBeingDeletedErrorCode = "ResourceGroupBeingDeleted";
     internal const string LocationNotAvailableForResourceTypeErrorCode = "LocationNotAvailableForResourceType";
     internal const string SubscriptionNotFoundErrorCode = "SubscriptionNotFound";
@@ -113,6 +114,34 @@ internal sealed record AzureProvisioningFailureDetails(
         }
 
         return null;
+    }
+
+    internal static AzureProvisioningFailureDetails CreateKeyVaultDeletedStateTombstoneNotFound(
+        string resourceName,
+        string targetResourceId,
+        IReadOnlyList<string> attemptedLocations)
+    {
+        // ARM only reports the create conflict. Once our purge lookup cannot find the deleted vault,
+        // use an Aspire-local failure shape so command JSON, resource properties, and recommended
+        // actions describe the real blocker instead of repeating the generic provider error.
+        var locationMessage = attemptedLocations.Count == 0
+            ? "because no Azure location was available for the deleted-vault lookup"
+            : $"in the attempted location(s): {string.Join(", ", attemptedLocations)}";
+
+        return new(
+            Provider: "Microsoft.KeyVault",
+            ResourceType: "Microsoft.KeyVault/vaults",
+            ResourceName: resourceName,
+            TargetResourceId: targetResourceId,
+            CurrentLocation: null,
+            SupportedLocations: [],
+            HttpStatus: 409,
+            ErrorCode: KeyVaultDeletedStateTombstoneNotFoundReason,
+            ErrorMessage: $"Azure reported that Key Vault '{resourceName}' is in a deleted state, but the deleted vault was not found {locationMessage}. Aspire cannot purge or recover a tombstone that Azure does not return.",
+            Operation: ProvisionOperation,
+            RequestId: null,
+            CorrelationId: null,
+            RecommendedActions: GetRecommendedActions(KeyVaultDeletedStateTombstoneNotFoundReason));
     }
 
     internal static AzureProvisioningFailureDetails? FromResponseError(
@@ -231,6 +260,15 @@ internal sealed record AzureProvisioningFailureDetails(
             [
                 Action("reprovision-or-forget-state", $"Run '{AzureProvisioningController.ReprovisionResourceCommandName}' to recreate the missing Azure resource, or '{AzureProvisioningController.ForgetStateCommandName}' if it was intentionally deleted."),
                 Action("change-resource-group", $"Run '{AzureProvisioningController.ChangeAzureContextCommandName}' if the cached Azure context points at the wrong resource group.")
+            ];
+        }
+
+        if (string.Equals(errorCodeOrReason, KeyVaultDeletedStateTombstoneNotFoundReason, StringComparisons.AzureProvisioningErrorCode))
+        {
+            return
+            [
+                Action("retry-reprovision", $"Run '{AzureProvisioningController.ReprovisionResourceCommandName}' again after Azure finishes publishing the deleted Key Vault tombstone."),
+                Action("change-context-or-name", $"If Azure continues to report the conflict, run '{AzureProvisioningController.ChangeAzureContextCommandName}' with a different resource group or change the AppHost resource name so Azure generates a different Key Vault name.")
             ];
         }
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceExtensionsTests.cs
@@ -703,6 +703,54 @@ public class AzureEnvironmentResourceExtensionsTests
     }
 
     [Fact]
+    public async Task ChangeLocationCommand_IsEnabledForResourcesWithImplicitKeyVaultChildren()
+    {
+        var builder = CreateBuilder(isRunMode: true);
+        var deploymentStateManager = new TestDeploymentStateManager();
+        var testBicepProvisioner = new TestBicepProvisioner();
+
+        builder.Configuration["Azure:SubscriptionId"] = "12345678-1234-1234-1234-123456789012";
+        builder.Configuration["Azure:Location"] = "eastus";
+        builder.Configuration["Azure:ResourceGroup"] = "test-rg";
+        AddTestAzureProvisioning(builder, bicepProvisioner: testBicepProvisioner, deploymentStateManager: deploymentStateManager);
+
+        var postgres = builder.AddAzurePostgresFlexibleServer("pg")
+            .WithPasswordAuthentication();
+
+        using var app = builder.Build();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var notifications = app.Services.GetRequiredService<ResourceNotificationService>();
+        var preparer = new AzureResourcePreparer(
+            app.Services.GetRequiredService<IOptions<AzureProvisioningOptions>>(),
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>());
+
+        await preparer.OnBeforeStartAsync(new BeforeStartEvent(app.Services, model), CancellationToken.None);
+        await notifications.PublishUpdateAsync(postgres.Resource, state => state with { State = KnownResourceStates.Running });
+
+        Assert.True(notifications.TryGetCurrentState(postgres.Resource.Name, out var postgresEvent));
+        AssertCommandState(postgresEvent.Snapshot, AzureProvisioningController.ChangeResourceLocationCommandName, ResourceCommandState.Enabled);
+
+        var changeLocationCommand = Assert.Single(postgres.Resource.Annotations.OfType<ResourceCommandAnnotation>(), c => c.Name == AzureProvisioningController.ChangeResourceLocationCommandName);
+
+        var result = await changeLocationCommand.ExecuteCommand(new ExecuteCommandContext
+        {
+            Services = app.Services,
+            ResourceName = postgres.Resource.Name,
+            CancellationToken = CancellationToken.None,
+            Logger = NullLogger.Instance,
+            Arguments = CreateArguments((AzureBicepResource.KnownParameters.Location, "West US 3"))
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal("westus3", testBicepProvisioner.ProvisionedLocations["pg"]);
+        Assert.DoesNotContain("pg-kv", testBicepProvisioner.ProvisionedLocations.Keys);
+
+        var data = AssertCommandJsonData(result);
+        Assert.Equal(1, data["resourceCount"]?.GetValue<int>());
+    }
+
+    [Fact]
     public async Task GetAzureResourceCommand_ReturnsCachedDeploymentStateAndLiveStatus()
     {
         var builder = CreateBuilder(isRunMode: true);
@@ -875,6 +923,7 @@ public class AzureEnvironmentResourceExtensionsTests
 
     [Theory]
     [InlineData(AzureProvisioningFailureDetails.MissingLiveResourceReason, "reprovision-or-forget-state")]
+    [InlineData(AzureProvisioningFailureDetails.KeyVaultDeletedStateTombstoneNotFoundReason, "retry-reprovision")]
     [InlineData(AzureProvisioningFailureDetails.ResourceGroupBeingDeletedErrorCode, "change-resource-group")]
     [InlineData(AzureProvisioningFailureDetails.SubscriptionNotFoundErrorCode, "change-subscription")]
     [InlineData(AzureProvisioningFailureDetails.ServiceModelDeprecatedErrorCode, "choose-supported-model-version")]
@@ -3739,6 +3788,163 @@ public class AzureEnvironmentResourceExtensionsTests
     }
 
     [Fact]
+    public async Task ReprovisionResourceCommand_FailsWithDiagnosticWhenSoftDeleteConflictTombstoneIsNotDiscoverable()
+    {
+        var builder = CreateBuilder(isRunMode: true);
+        var deploymentStateManager = new TestDeploymentStateManager();
+        var testProvisioningContextProvider = new TestProvisioningContextProvider();
+        const string subscriptionId = "12345678-1234-1234-1234-123456789012";
+        const string resourceGroup = "test-rg";
+        const string keyVaultResourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.KeyVault/vaults/kv-test";
+        var purgedDeletedKeyVaults = new List<(string ResourceId, string Location)>();
+        var testBicepProvisioner = new KeyVaultSoftDeleteConflictThenSuccessProvisioner(keyVaultResourceId);
+
+        builder.Configuration["Azure:SubscriptionId"] = subscriptionId;
+        builder.Configuration["Azure:Location"] = "westus2";
+        builder.Configuration["Azure:ResourceGroup"] = resourceGroup;
+        builder.Services.AddSingleton<IDeploymentStateManager>(deploymentStateManager);
+        builder.AddAzureProvisioning();
+        builder.Services.RemoveAll<IArmClientProvider>();
+        builder.Services.AddSingleton<IArmClientProvider>(ProvisioningTestHelpers.CreateArmClientProvider(
+            existingResourceIds: [],
+            deletedResourceIds: null,
+            deploymentTargetResourceIds: null,
+            canceledDeploymentIds: null,
+            purgedDeletedKeyVaults: purgedDeletedKeyVaults,
+            purgeDeletedKeyVaultResult: false));
+        builder.Services.RemoveAll<AzureProvisioningController>();
+        builder.Services.AddSingleton(sp => new AzureProvisioningController(
+            sp.GetRequiredService<IConfiguration>(),
+            sp.GetRequiredService<IOptions<AzureProvisionerOptions>>(),
+            sp,
+            testBicepProvisioner,
+            deploymentStateManager,
+            sp.GetRequiredService<IDistributedApplicationEventing>(),
+            testProvisioningContextProvider,
+            sp.GetRequiredService<IAzureProvisioningOptionsManager>(),
+            sp.GetRequiredService<ResourceNotificationService>(),
+            sp.GetRequiredService<ResourceLoggerService>(),
+            sp.GetRequiredService<ILogger<AzureProvisioningController>>()));
+
+        var keyVault = builder.AddBicepTemplateString("kv3", "resource kv 'Microsoft.KeyVault/vaults@2024-11-01' = {}");
+
+        using var app = builder.Build();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var notifications = app.Services.GetRequiredService<ResourceNotificationService>();
+        var preparer = new AzureResourcePreparer(
+            app.Services.GetRequiredService<IOptions<AzureProvisioningOptions>>(),
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>());
+
+        await preparer.OnBeforeStartAsync(new BeforeStartEvent(app.Services, model), CancellationToken.None);
+
+        var keyVaultSection = await deploymentStateManager.AcquireSectionAsync("Azure:Deployments:kv3");
+        keyVaultSection.Data[AzureProvisioningController.LocationOverrideKey] = "ukwest";
+        await deploymentStateManager.SaveSectionAsync(keyVaultSection);
+
+        await notifications.PublishUpdateAsync(keyVault.Resource, state => state with { State = new("Canceled", KnownResourceStateStyles.Info) });
+
+        var reprovisionCommand = Assert.Single(keyVault.Resource.Annotations.OfType<ResourceCommandAnnotation>(), c => c.Name == AzureProvisioningController.ReprovisionResourceCommandName);
+
+        var result = await reprovisionCommand.ExecuteCommand(new ExecuteCommandContext
+        {
+            Services = app.Services,
+            ResourceName = keyVault.Resource.Name,
+            CancellationToken = CancellationToken.None,
+            Logger = NullLogger.Instance,
+            Arguments = new InteractionInputCollection([])
+        });
+
+        Assert.False(result.Success);
+        Assert.False(result.Canceled);
+        Assert.Equal(1, testBicepProvisioner.GetOrCreateResourceCallCount);
+        Assert.Collection(
+            purgedDeletedKeyVaults,
+            purgedDeletedKeyVault =>
+            {
+                Assert.Equal(keyVaultResourceId, purgedDeletedKeyVault.ResourceId);
+                Assert.Equal("ukwest", purgedDeletedKeyVault.Location);
+            },
+            purgedDeletedKeyVault =>
+            {
+                Assert.Equal(keyVaultResourceId, purgedDeletedKeyVault.ResourceId);
+                Assert.Equal("westus2", purgedDeletedKeyVault.Location);
+            });
+
+        var data = AssertCommandJsonData(result);
+        Assert.False(data["success"]?.GetValue<bool>());
+        var diagnostics = Assert.IsType<JsonArray>(data["diagnostics"]);
+        var diagnostic = Assert.IsType<JsonObject>(Assert.Single(diagnostics));
+        Assert.Equal("Microsoft.KeyVault", diagnostic["provider"]?.GetValue<string>());
+        Assert.Equal("Microsoft.KeyVault/vaults", diagnostic["resourceType"]?.GetValue<string>());
+        Assert.Equal("kv-test", diagnostic["resourceName"]?.GetValue<string>());
+        Assert.Equal(keyVaultResourceId, diagnostic["targetResourceId"]?.GetValue<string>());
+        Assert.Equal(AzureProvisioningFailureDetails.KeyVaultDeletedStateTombstoneNotFoundReason, diagnostic["errorCode"]?.GetValue<string>());
+        Assert.Equal(409, diagnostic["httpStatus"]?.GetValue<int>());
+        Assert.Contains("deleted vault was not found", diagnostic["errorMessage"]?.GetValue<string>(), StringComparison.Ordinal);
+        var recommendedActions = Assert.IsType<JsonArray>(diagnostic["recommendedActions"]);
+        Assert.Contains(recommendedActions, action => action?["code"]?.GetValue<string>() == "retry-reprovision");
+
+        Assert.True(notifications.TryGetCurrentState(keyVault.Resource.Name, out var keyVaultEvent));
+        Assert.Equal("Failed to Provision", keyVaultEvent.Snapshot.State?.Text);
+        Assert.Equal(AzureProvisioningFailureDetails.KeyVaultDeletedStateTombstoneNotFoundReason, keyVaultEvent.Snapshot.Properties.Single(p => p.Name == "azure.provisioning.error.code").Value?.ToString());
+        var snapshotRecommendedActions = Assert.IsType<string[]>(keyVaultEvent.Snapshot.Properties.Single(p => p.Name == "azure.provisioning.error.recommendedActions").Value);
+        Assert.Contains(snapshotRecommendedActions, action => action.Contains("deleted Key Vault tombstone", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ReprovisionResourceCommand_ProvisionsImplicitKeyVaultBeforePasswordAuthenticatedPostgres()
+    {
+        var builder = CreateBuilder(isRunMode: true);
+        var testBicepProvisioner = new ParentChildOrderingBicepProvisioner("pg-kv", "pg");
+
+        builder.Configuration["Azure:SubscriptionId"] = "12345678-1234-1234-1234-123456789012";
+        builder.Configuration["Azure:Location"] = "westus2";
+        builder.Configuration["Azure:ResourceGroup"] = "test-rg";
+        AddTestAzureProvisioning(builder, bicepProvisioner: testBicepProvisioner);
+
+        var postgres = builder.AddAzurePostgresFlexibleServer("pg")
+            .WithPasswordAuthentication();
+
+        using var app = builder.Build();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var notifications = app.Services.GetRequiredService<ResourceNotificationService>();
+        var preparer = new AzureResourcePreparer(
+            app.Services.GetRequiredService<IOptions<AzureProvisioningOptions>>(),
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>());
+
+        await preparer.OnBeforeStartAsync(new BeforeStartEvent(app.Services, model), CancellationToken.None);
+        await notifications.PublishUpdateAsync(postgres.Resource, state => state with { State = KnownResourceStates.Running });
+
+        var reprovisionCommand = Assert.Single(postgres.Resource.Annotations.OfType<ResourceCommandAnnotation>(), c => c.Name == AzureProvisioningController.ReprovisionResourceCommandName);
+
+        var commandTask = reprovisionCommand.ExecuteCommand(new ExecuteCommandContext
+        {
+            Services = app.Services,
+            ResourceName = postgres.Resource.Name,
+            CancellationToken = CancellationToken.None,
+            Logger = NullLogger.Instance,
+            Arguments = new InteractionInputCollection([])
+        });
+
+        await testBicepProvisioner.ChildProvisionStarted.Task.WaitAsync(s_testSynchronizationTimeout);
+        Assert.DoesNotContain("pg", testBicepProvisioner.ProvisionedResources);
+
+        testBicepProvisioner.AllowChildProvisionToComplete.TrySetResult();
+        var result = await commandTask.WaitAsync(s_testSynchronizationTimeout);
+
+        Assert.True(result.Success);
+        Assert.False(testBicepProvisioner.ParentStartedBeforeChildCompleted);
+        var provisionedResources = testBicepProvisioner.ProvisionedResources.ToArray();
+        var childIndex = Array.IndexOf(provisionedResources, "pg-kv");
+        var parentIndex = Array.IndexOf(provisionedResources, "pg");
+        Assert.Equal(0, childIndex);
+        Assert.NotEqual(-1, parentIndex);
+        Assert.True(childIndex < parentIndex);
+    }
+
+    [Fact]
     public async Task ChangeLocationCommand_FailsWhenProvisioningFails()
     {
         var builder = CreateBuilder(isRunMode: true);
@@ -5378,6 +5584,71 @@ public class AzureEnvironmentResourceExtensionsTests
 
             resource.Outputs["id"] = keyVaultResourceId;
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ParentChildOrderingBicepProvisioner(string childResourceName, string parentResourceName) : IBicepProvisioner
+    {
+        private readonly object _lock = new();
+        private readonly List<string> _provisionedResources = [];
+        private int _childCompleted;
+        private int _parentStartedBeforeChildCompleted;
+
+        public TaskCompletionSource ChildProvisionStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowChildProvisionToComplete { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool ParentStartedBeforeChildCompleted => Volatile.Read(ref _parentStartedBeforeChildCompleted) == 1;
+
+        public IReadOnlyList<string> ProvisionedResources
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return [.. _provisionedResources];
+                }
+            }
+        }
+
+        public Task<bool> ConfigureResourceAsync(AzureBicepResource resource, CancellationToken cancellationToken)
+            => Task.FromResult(false);
+
+        public Task<bool> ReconcileDeploymentStateAsync(AzureBicepResource resource, ProvisioningContext context, CancellationToken cancellationToken)
+            => Task.FromResult(false);
+
+        public async Task GetOrCreateResourceAsync(AzureBicepResource resource, ProvisioningContext context, CancellationToken cancellationToken)
+        {
+            if (string.Equals(resource.Name, childResourceName, StringComparison.Ordinal))
+            {
+                AddProvisionedResource(resource);
+                ChildProvisionStarted.TrySetResult();
+                await AllowChildProvisionToComplete.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                Volatile.Write(ref _childCompleted, 1);
+                return;
+            }
+
+            if (string.Equals(resource.Name, parentResourceName, StringComparison.Ordinal) &&
+                Volatile.Read(ref _childCompleted) == 0)
+            {
+                Volatile.Write(ref _parentStartedBeforeChildCompleted, 1);
+            }
+
+            AddProvisionedResource(resource);
+        }
+
+        private void AddProvisionedResource(AzureBicepResource resource)
+        {
+            lock (_lock)
+            {
+                _provisionedResources.Add(resource.Name);
+            }
+
+            resource.Outputs["id"] = $"/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.Test/resources/{resource.Name}";
+            resource.Outputs["name"] = resource.Name;
+            resource.Outputs["vaultUri"] = $"https://{resource.Name}.vault.azure.net/";
+            resource.Outputs["connectionString"] = $"Host={resource.Name}.postgres.database.azure.com";
+            resource.Outputs["hostName"] = $"{resource.Name}.postgres.database.azure.com";
         }
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceExtensionsTests.cs
@@ -3719,6 +3719,7 @@ public class AzureEnvironmentResourceExtensionsTests
         const string subscriptionId = "12345678-1234-1234-1234-123456789012";
         const string resourceGroup = "test-rg";
         const string keyVaultResourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.KeyVault/vaults/kv-test";
+        var deletedResourceIds = new List<string>();
         var purgedDeletedKeyVaults = new List<(string ResourceId, string Location)>();
         var testBicepProvisioner = new KeyVaultSoftDeleteConflictThenSuccessProvisioner(keyVaultResourceId);
 
@@ -3730,7 +3731,7 @@ public class AzureEnvironmentResourceExtensionsTests
         builder.Services.RemoveAll<IArmClientProvider>();
         builder.Services.AddSingleton<IArmClientProvider>(ProvisioningTestHelpers.CreateArmClientProvider(
             existingResourceIds: [],
-            deletedResourceIds: null,
+            deletedResourceIds: deletedResourceIds,
             deploymentTargetResourceIds: null,
             canceledDeploymentIds: null,
             purgedDeletedKeyVaults: purgedDeletedKeyVaults));
@@ -3779,6 +3780,7 @@ public class AzureEnvironmentResourceExtensionsTests
 
         Assert.True(result.Success);
         Assert.Equal(2, testBicepProvisioner.GetOrCreateResourceCallCount);
+        Assert.Empty(deletedResourceIds);
         var purgedDeletedKeyVault = Assert.Single(purgedDeletedKeyVaults);
         Assert.Equal(keyVaultResourceId, purgedDeletedKeyVault.ResourceId);
         Assert.Equal("ukwest", purgedDeletedKeyVault.Location);
@@ -3796,6 +3798,7 @@ public class AzureEnvironmentResourceExtensionsTests
         const string subscriptionId = "12345678-1234-1234-1234-123456789012";
         const string resourceGroup = "test-rg";
         const string keyVaultResourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.KeyVault/vaults/kv-test";
+        var deletedResourceIds = new List<string>();
         var purgedDeletedKeyVaults = new List<(string ResourceId, string Location)>();
         var testBicepProvisioner = new KeyVaultSoftDeleteConflictThenSuccessProvisioner(keyVaultResourceId);
 
@@ -3807,7 +3810,7 @@ public class AzureEnvironmentResourceExtensionsTests
         builder.Services.RemoveAll<IArmClientProvider>();
         builder.Services.AddSingleton<IArmClientProvider>(ProvisioningTestHelpers.CreateArmClientProvider(
             existingResourceIds: [],
-            deletedResourceIds: null,
+            deletedResourceIds: deletedResourceIds,
             deploymentTargetResourceIds: null,
             canceledDeploymentIds: null,
             purgedDeletedKeyVaults: purgedDeletedKeyVaults,
@@ -3858,6 +3861,7 @@ public class AzureEnvironmentResourceExtensionsTests
         Assert.False(result.Success);
         Assert.False(result.Canceled);
         Assert.Equal(1, testBicepProvisioner.GetOrCreateResourceCallCount);
+        Assert.Empty(deletedResourceIds);
         Assert.Collection(
             purgedDeletedKeyVaults,
             purgedDeletedKeyVault =>

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
@@ -65,7 +65,21 @@ internal static class ProvisioningTestHelpers
     public static IArmClientProvider CreateArmClientProvider(Func<string, Dictionary<string, object>> deploymentOutputsProvider) => new TestArmClientProvider(deploymentOutputsProvider);
     public static IArmClientProvider CreateArmClientProvider(IEnumerable<string> existingResourceIds) => new TestArmClientProvider(existingResourceIds: existingResourceIds);
     public static IArmClientProvider CreateArmClientProvider(IEnumerable<string> existingResourceIds, List<string> deletedResourceIds) => new TestArmClientProvider(existingResourceIds: existingResourceIds, deletedResourceIds: deletedResourceIds);
-    public static IArmClientProvider CreateArmClientProvider(IEnumerable<string> existingResourceIds, List<string>? deletedResourceIds, IEnumerable<string>? deploymentTargetResourceIds, List<string>? canceledDeploymentIds, List<(string ResourceId, string Location)>? purgedDeletedKeyVaults = null, Exception? purgeDeletedKeyVaultException = null) => new TestArmClientProvider(existingResourceIds: existingResourceIds, deletedResourceIds: deletedResourceIds, deploymentTargetResourceIds: deploymentTargetResourceIds, canceledDeploymentIds: canceledDeploymentIds, purgedDeletedKeyVaults: purgedDeletedKeyVaults, purgeDeletedKeyVaultException: purgeDeletedKeyVaultException);
+    public static IArmClientProvider CreateArmClientProvider(
+        IEnumerable<string> existingResourceIds,
+        List<string>? deletedResourceIds,
+        IEnumerable<string>? deploymentTargetResourceIds,
+        List<string>? canceledDeploymentIds,
+        List<(string ResourceId, string Location)>? purgedDeletedKeyVaults = null,
+        Exception? purgeDeletedKeyVaultException = null,
+        bool purgeDeletedKeyVaultResult = true) => new TestArmClientProvider(
+            existingResourceIds: existingResourceIds,
+            deletedResourceIds: deletedResourceIds,
+            deploymentTargetResourceIds: deploymentTargetResourceIds,
+            canceledDeploymentIds: canceledDeploymentIds,
+            purgedDeletedKeyVaults: purgedDeletedKeyVaults,
+            purgeDeletedKeyVaultException: purgeDeletedKeyVaultException,
+            purgeDeletedKeyVaultResult: purgeDeletedKeyVaultResult);
     public static IArmClientProvider CreateArmClientProviderForMissingResourceGroup() => new TestArmClientProvider(resourceGroupLookupReturnsNotFound: true);
     public static ITokenCredentialProvider CreateTokenCredentialProvider() => new TestTokenCredentialProvider();
     public static ISecretClientProvider CreateSecretClientProvider() => new TestSecretClientProvider(CreateTokenCredentialProvider());
@@ -199,6 +213,7 @@ internal sealed class TestArmClient : IArmClient
     private readonly Func<string, string, CancellationToken, Task<IEnumerable<string>>>? _supportedLocationsProvider;
     private readonly List<string>? _canceledDeploymentIds;
     private readonly Exception? _purgeDeletedKeyVaultException;
+    private readonly bool _purgeDeletedKeyVaultResult = true;
     private readonly bool _resourceGroupLookupReturnsNotFound;
 
     public TestRoleAssignmentCollection RoleAssignments { get; } = new();
@@ -245,7 +260,8 @@ internal sealed class TestArmClient : IArmClient
         IEnumerable<string>? deploymentTargetResourceIds = null,
         List<string>? canceledDeploymentIds = null,
         List<(string ResourceId, string Location)>? purgedDeletedKeyVaults = null,
-        Exception? purgeDeletedKeyVaultException = null)
+        Exception? purgeDeletedKeyVaultException = null,
+        bool purgeDeletedKeyVaultResult = true)
     {
         _existingResourceIds = new HashSet<string>(existingResourceIds, StringComparer.OrdinalIgnoreCase);
         _deletedResourceIds = deletedResourceIds;
@@ -253,6 +269,7 @@ internal sealed class TestArmClient : IArmClient
         _deploymentTargetResourceIds = deploymentTargetResourceIds;
         _canceledDeploymentIds = canceledDeploymentIds;
         _purgeDeletedKeyVaultException = purgeDeletedKeyVaultException;
+        _purgeDeletedKeyVaultResult = purgeDeletedKeyVaultResult;
     }
 
     public TestArmClient() : this(new Dictionary<string, object>())
@@ -390,7 +407,7 @@ internal sealed class TestArmClient : IArmClient
             return Task.FromException<bool>(_purgeDeletedKeyVaultException);
         }
 
-        return Task.FromResult(true);
+        return Task.FromResult(_purgeDeletedKeyVaultResult);
     }
 
     public Task CancelDeploymentAsync(string deploymentId, CancellationToken cancellationToken = default)
@@ -913,6 +930,7 @@ internal sealed class TestArmClientProvider : IArmClientProvider
     private readonly IEnumerable<string>? _deploymentTargetResourceIds;
     private readonly List<string>? _canceledDeploymentIds;
     private readonly Exception? _purgeDeletedKeyVaultException;
+    private readonly bool _purgeDeletedKeyVaultResult = true;
     private readonly bool _resourceGroupLookupReturnsNotFound;
 
     public TestArmClientProvider(Dictionary<string, object> deploymentOutputs)
@@ -943,7 +961,8 @@ internal sealed class TestArmClientProvider : IArmClientProvider
         IEnumerable<string>? deploymentTargetResourceIds = null,
         List<string>? canceledDeploymentIds = null,
         List<(string ResourceId, string Location)>? purgedDeletedKeyVaults = null,
-        Exception? purgeDeletedKeyVaultException = null)
+        Exception? purgeDeletedKeyVaultException = null,
+        bool purgeDeletedKeyVaultResult = true)
     {
         _existingResourceIds = existingResourceIds;
         _deletedResourceIds = deletedResourceIds;
@@ -951,6 +970,7 @@ internal sealed class TestArmClientProvider : IArmClientProvider
         _deploymentTargetResourceIds = deploymentTargetResourceIds;
         _canceledDeploymentIds = canceledDeploymentIds;
         _purgeDeletedKeyVaultException = purgeDeletedKeyVaultException;
+        _purgeDeletedKeyVaultResult = purgeDeletedKeyVaultResult;
     }
 
     public TestArmClientProvider() : this(new Dictionary<string, object>())
@@ -965,7 +985,7 @@ internal sealed class TestArmClientProvider : IArmClientProvider
         }
         if (_existingResourceIds is not null)
         {
-            return new TestArmClient(_existingResourceIds, _deletedResourceIds, _deploymentTargetResourceIds, _canceledDeploymentIds, _purgedDeletedKeyVaults, _purgeDeletedKeyVaultException);
+            return new TestArmClient(_existingResourceIds, _deletedResourceIds, _deploymentTargetResourceIds, _canceledDeploymentIds, _purgedDeletedKeyVaults, _purgeDeletedKeyVaultException, _purgeDeletedKeyVaultResult);
         }
         return new TestArmClient(_deploymentOutputs!, _resourceGroup, _resourceGroupLookupReturnsNotFound);
     }


### PR DESCRIPTION
## Description

Azure Key Vault names remain reserved by location-scoped soft-delete tombstones after the live vault is deleted. When an implicit Key Vault child is created for PostgreSQL password authentication, parent reprovision needs to include that child; otherwise users can hit an ARM deleted-state conflict that requires changing the AppHost model even though the conflict is recoverable or diagnosable.

This change expands per-resource Azure target discovery to include annotation-based parent relationships so reprovision/delete/get-resource include implicit Azure children, while keeping change-location scoped to the selected resource so a parent with an implicit Key Vault child is not blocked as a Key Vault target. It also distinguishes successful Key Vault tombstone purge-and-retry from the case where Azure reports a deleted-state conflict but the deleted vault cannot be found in any attempted location, surfacing a structured diagnostic and recommended actions instead of retrying into the same provider error.

Validation:

- `dotnet test --project tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj --no-launch-profile -- --filter-class "*.AzureEnvironmentResourceExtensionsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj /p:SkipNativeBuild=true`
- Manual Bicep playground validation for `postgres2` implicit Key Vault reprovision and `storage` role-assignment child reprovision, including dashboard checks with `playwright-cli`.

Fixes: #18403

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No