### PR TITLE
Fix Playwright download transient errors failing the build

### DIFF
--- a/tests/Shared/Playwright/Playwright.targets
+++ b/tests/Shared/Playwright/Playwright.targets
@@ -31,15 +31,23 @@
       <_PlaywrightInstallCommand>dotnet exec --runtimeconfig $(MSBuildThisFileDirectory)Microsoft.Playwright.runtimeconfig.json $(_MicrosoftPlaywrightDllPath) install @(BrowsersForPlaywrightToInstall, ' ')</_PlaywrightInstallCommand>
     </PropertyGroup>
 
+    <!-- Playwright's install command tries multiple CDN mirrors internally and writes error
+         messages to stderr for mirrors that fail, even when it ultimately succeeds via a
+         fallback mirror. IgnoreStandardErrorWarningFormat prevents MSBuild from promoting
+         those transient error messages into build errors while the exit code still drives
+         overall success/failure. -->
+
     <!-- First attempt ignores the exit code; if it fails, retry once and fail the build on the second failure -->
     <Exec Command="$(_PlaywrightInstallCommand)"
           EnvironmentVariables="@(_EnvVarsForPlaywrightInstall)"
-          IgnoreExitCode="true">
+          IgnoreExitCode="true"
+          IgnoreStandardErrorWarningFormat="true">
       <Output TaskParameter="ExitCode" PropertyName="_PlaywrightInstallExitCode1" />
     </Exec>
 
     <Exec Condition="'$(_PlaywrightInstallExitCode1)' != '0'"
           Command="$(_PlaywrightInstallCommand)"
-          EnvironmentVariables="@(_EnvVarsForPlaywrightInstall)" />
+          EnvironmentVariables="@(_EnvVarsForPlaywrightInstall)"
+          IgnoreStandardErrorWarningFormat="true" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary

Fixes a flaky build failure in `Aspire.Templates.Tests` caused by Playwright's browser download emitting transient error messages that MSBuild promotes to build errors.

## Problem

Playwright's `install` command tries multiple CDN mirrors internally when downloading browsers. When earlier mirrors fail (e.g., "server closed connection"), it writes error-formatted messages to stderr before succeeding via a fallback mirror. MSBuild's `Exec` task parses those lines (matching the `EXEC : error :` pattern) and promotes them to structured build errors — causing the overall build to report "Build FAILED" despite the command exiting with code 0.

Example CI failure:
```
EXEC : error : Download failed: server closed connection. URL: https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1187/chromium-headless-shell-mac-arm64.zip
EXEC : error : Download failed: server closed connection. URL: https://playwright.download.prss.microsoft.com/dbazure/download/playwright/builds/chromium/1187/chromium-headless-shell-mac-arm64.zip
```
The download ultimately succeeded via a third CDN URL, but the build still failed due to the logged errors.

## Fix

Add `IgnoreStandardErrorWarningFormat="true"` to both `Exec` invocations in `tests/Shared/Playwright/Playwright.targets`. This tells MSBuild not to parse Playwright's output for error/warning patterns — only the exit code determines success/failure. The output still appears in the build log for debugging.

The existing retry logic (first attempt ignores exit code, second attempt fails the build on non-zero exit) remains unchanged.