### PR TITLE
Add 'Connection reset by peer' to transient CI failure retry patterns

### DIFF
--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -115,6 +115,7 @@ const infrastructureNetworkFailureLogOverridePatterns = [
     /expected 'packfile'/i,
     /\bRPC failed\b/i,
     /\bRecv failure\b/i,
+    /Unable to read data from the transport connection: Connection reset by peer/i,
 ];
 
 function matchesAny(value, patterns) {

--- a/eng/test-retry-patterns.json
+++ b/eng/test-retry-patterns.json
@@ -53,6 +53,10 @@
       "reason": "Transient DNS resolution failure in job log"
     },
     {
+      "output": "Connection reset by peer",
+      "reason": "Transient network connection reset by peer"
+    },
+    {
       "output": { "regex": "mcr\\.microsoft\\.com[\\s\\S]{0,500}403 Forbidden" },
       "reason": "MCR registry rate limiting (HTTP 403)"
     },

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -237,6 +237,23 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task AllowsLogBasedOverrideForConnectionResetByPeerInBuildSteps()
+    {
+        WorkflowJob job = CreateJob(failedSteps: ["Build RID-specific packages"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(
+            job,
+            "Process completed with exit code 1.",
+            "Unhandled exception: Unable to read data from the transport connection: Connection reset by peer.");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Equal(
+            "Failed step 'Build RID-specific packages' will be retried because the job log shows a likely transient infrastructure network failure. Matched pattern: `/Unable to read data from the transport connection: Connection reset by peer/i`.",
+            result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task UsesLongerMarkdownFenceWhenMatchedPatternContainsBackticks()
     {
         string result = await InvokeHarnessAsync<string>(


### PR DESCRIPTION
## Summary

The "Build native CLI archive (Linux) / Build CLI (linux-x64)" job failed with a transient network error during `dotnet tool restore`:

```
Unhandled exception: Unable to read data from the transport connection: Connection reset by peer.
```

This is a transient network failure that should be automatically retried.

## Changes

- **`auto-rerun-transient-ci-failures.js`**: Added `/Unable to read data from the transport connection: Connection reset by peer/i` to `infrastructureNetworkFailureLogOverridePatterns` so the auto-rerun workflow detects this transient error in non-test build steps and marks the job for retry.
- **`eng/test-retry-patterns.json`**: Added `"Connection reset by peer"` to `jobFailurePatterns` for coverage when the same error occurs during test execution steps.
- **`AutoRerunTransientCiFailuresTests.cs`**: Added `AllowsLogBasedOverrideForConnectionResetByPeerInBuildSteps` test verifying the pattern correctly triggers a retry for the "Build RID-specific packages" step.

## Validation

All 99 `AutoRerunTransientCiFailuresTests` pass locally.