### PR TITLE
Speed up AppHost candidate discovery

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -648,10 +648,18 @@ internal sealed class ProjectLocator(
     }
 
     private static bool HasAppHostMarkerInBuildFile(string buildFilePath, Dictionary<string, bool> dotNetBuildFileMarkerCache)
+        => HasAppHostMarkerInBuildFile(buildFilePath, dotNetBuildFileMarkerCache, new HashSet<string>(StringComparer.Ordinal));
+
+    private static bool HasAppHostMarkerInBuildFile(string buildFilePath, Dictionary<string, bool> dotNetBuildFileMarkerCache, HashSet<string> visitedBuildFiles)
     {
         if (dotNetBuildFileMarkerCache.TryGetValue(buildFilePath, out var hasAppHostMarker))
         {
             return hasAppHostMarker;
+        }
+
+        if (!visitedBuildFiles.Add(buildFilePath))
+        {
+            return false;
         }
 
         if (!File.Exists(buildFilePath))
@@ -662,9 +670,18 @@ internal sealed class ProjectLocator(
 
         try
         {
+            var buildFileDirectory = Path.GetDirectoryName(buildFilePath);
             foreach (var line in File.ReadLines(buildFilePath))
             {
                 if (ContainsDotNetAppHostProjectContentMarker(line))
+                {
+                    dotNetBuildFileMarkerCache[buildFilePath] = true;
+                    return true;
+                }
+
+                if (buildFileDirectory is not null &&
+                    TryGetResolvableImportPath(line, buildFileDirectory) is { } importedBuildFilePath &&
+                    HasAppHostMarkerInBuildFile(importedBuildFilePath, dotNetBuildFileMarkerCache, visitedBuildFiles))
                 {
                     dotNetBuildFileMarkerCache[buildFilePath] = true;
                     return true;
@@ -683,6 +700,43 @@ internal sealed class ProjectLocator(
 
     private static bool ContainsDotNetAppHostProjectContentMarker(string line)
         => s_dotNetAppHostProjectContentMarkers.Any(marker => line.Contains(marker, StringComparison.OrdinalIgnoreCase));
+
+    private static string? TryGetResolvableImportPath(string line, string importingDirectory)
+    {
+        if (!line.Contains("<Import", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var projectAttributeIndex = line.IndexOf("Project=", StringComparison.OrdinalIgnoreCase);
+        if (projectAttributeIndex < 0)
+        {
+            return null;
+        }
+
+        var quoteIndex = projectAttributeIndex + "Project=".Length;
+        if (quoteIndex >= line.Length || line[quoteIndex] is not ('"' or '\''))
+        {
+            return null;
+        }
+
+        var quote = line[quoteIndex];
+        var endQuoteIndex = line.IndexOf(quote, quoteIndex + 1);
+        if (endQuoteIndex < 0)
+        {
+            return null;
+        }
+
+        var importPath = line[(quoteIndex + 1)..endQuoteIndex];
+        if (importPath.IndexOfAny(['$', '*', '?']) >= 0)
+        {
+            return null;
+        }
+
+        return Path.GetFullPath(Path.IsPathRooted(importPath)
+            ? importPath
+            : Path.Combine(importingDirectory, importPath));
+    }
 
     /// <inheritdoc />
     public async Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default)

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -141,6 +141,13 @@ internal sealed class ProjectLocator(
 {
     private const string AspireConfigAppHostPathKey = "appHost.path";
     private const string LegacySettingsAppHostPathKey = "appHostPath";
+    private static readonly string[] s_dotNetProjectExtensions = [".csproj", ".fsproj", ".vbproj"];
+    private static readonly string[] s_dotNetAppHostProjectContentMarkers =
+    [
+        "<IsAspireHost>",
+        "Aspire.AppHost.Sdk",
+        "Aspire.Hosting"
+    ];
 
     /// <summary>
     /// Finds all candidate AppHost projects in the specified search directory with language metadata.
@@ -348,6 +355,13 @@ internal sealed class ProjectLocator(
                     continue;
                 }
 
+                if (scope is not AppHostDiscoveryScope.ExplicitDirectory &&
+                    IsOrdinaryDotNetProjectCandidate(candidateFile, handler))
+                {
+                    logger.LogTrace("Skipping ordinary .NET project candidate {CandidateFile}", candidateFile.FullName);
+                    continue;
+                }
+
                 candidatesWithHandlers.Add((candidateFile, handler));
             }
 
@@ -548,6 +562,48 @@ internal sealed class ProjectLocator(
         }
 
         return await FindAppHostsAsync();
+    }
+
+    private static bool IsOrdinaryDotNetProjectCandidate(FileInfo candidateFile, IAppHostProject handler)
+    {
+        if (!handler.LanguageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase) ||
+            !s_dotNetProjectExtensions.Contains(candidateFile.Extension, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (Path.GetFileNameWithoutExtension(candidateFile.Name).Contains("AppHost", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (candidateFile.DirectoryName is { } directoryName &&
+            (File.Exists(Path.Combine(directoryName, "AppHost.cs")) ||
+             File.Exists(Path.Combine(directoryName, "apphost.cs"))))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var reader = candidateFile.OpenText();
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                if (s_dotNetAppHostProjectContentMarkers.Any(marker => line.Contains(marker, StringComparison.Ordinal)))
+                {
+                    return false;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // If the cheap prefilter cannot read a project file that discovery found, keep the
+            // previous behavior and let the full project validation path report the real failure.
+            return false;
+        }
+
+        return true;
     }
 
     /// <inheritdoc />

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -146,7 +146,10 @@ internal sealed class ProjectLocator(
     [
         "<IsAspireHost",
         "Aspire.AppHost.Sdk",
-        "Aspire.Hosting"
+        "Include=\"Aspire.Hosting\"",
+        "Include='Aspire.Hosting'",
+        "Include=\"Aspire.Hosting.AppHost\"",
+        "Include='Aspire.Hosting.AppHost'"
     ];
 
     /// <summary>
@@ -344,6 +347,7 @@ internal sealed class ProjectLocator(
 
             logger.LogDebug("Found {CandidateCount} unique candidate files matching AppHost detection patterns", candidateFiles.Length);
 
+            var dotNetBuildFileMarkerCache = new Dictionary<string, bool>(StringComparer.Ordinal);
             foreach (var candidateFile in candidateFiles)
             {
                 logger.LogDebug("Checking candidate file {CandidateFile}", candidateFile.FullName);
@@ -356,7 +360,7 @@ internal sealed class ProjectLocator(
                 }
 
                 if (scope is not AppHostDiscoveryScope.ExplicitDirectory &&
-                    IsOrdinaryDotNetProjectCandidate(candidateFile, handler))
+                    IsOrdinaryDotNetProjectCandidate(candidateFile, handler, dotNetBuildFileMarkerCache))
                 {
                     logger.LogTrace("Skipping ordinary .NET project candidate {CandidateFile}", candidateFile.FullName);
                     continue;
@@ -564,7 +568,7 @@ internal sealed class ProjectLocator(
         return await FindAppHostsAsync();
     }
 
-    private static bool IsOrdinaryDotNetProjectCandidate(FileInfo candidateFile, IAppHostProject handler)
+    private static bool IsOrdinaryDotNetProjectCandidate(FileInfo candidateFile, IAppHostProject handler, Dictionary<string, bool> dotNetBuildFileMarkerCache)
     {
         if (!handler.LanguageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase) ||
             !s_dotNetProjectExtensions.Contains(candidateFile.Extension, StringComparer.OrdinalIgnoreCase))
@@ -584,27 +588,101 @@ internal sealed class ProjectLocator(
             return false;
         }
 
-        try
+        var (hasAppHostMarker, hasImport) = ScanDotNetProjectFile(candidateFile);
+        if (hasAppHostMarker || hasImport)
         {
-            using var reader = candidateFile.OpenText();
-            string? line;
-            while ((line = reader.ReadLine()) is not null)
-            {
-                if (s_dotNetAppHostProjectContentMarkers.Any(marker => line.Contains(marker, StringComparison.Ordinal)))
-                {
-                    return false;
-                }
-            }
+            // Explicit imports can hide the Aspire.Hosting/AppHost markers in a separate props/targets
+            // file. Keep those projects on the existing MSBuild validation path instead of trying to
+            // emulate import resolution here.
+            return false;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+
+        if (HasAppHostMarkerInImplicitBuildFiles(candidateFile.Directory, dotNetBuildFileMarkerCache))
         {
-            // If the cheap prefilter cannot read a project file that discovery found, keep the
-            // previous behavior and let the full project validation path report the real failure.
             return false;
         }
 
         return true;
     }
+
+    private static (bool HasAppHostMarker, bool HasImport) ScanDotNetProjectFile(FileInfo candidateFile)
+    {
+        try
+        {
+            using var reader = candidateFile.OpenText();
+            string? line;
+            var hasImport = false;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                hasImport |= line.Contains("<Import", StringComparison.Ordinal);
+                if (ContainsDotNetAppHostProjectContentMarker(line))
+                {
+                    return (true, hasImport);
+                }
+            }
+
+            return (false, hasImport);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // If the cheap prefilter cannot read a project file that discovery found, keep the
+            // previous behavior and let the full project validation path report the real failure.
+            return (true, true);
+        }
+    }
+
+    private static bool HasAppHostMarkerInImplicitBuildFiles(DirectoryInfo? directory, Dictionary<string, bool> dotNetBuildFileMarkerCache)
+    {
+        while (directory is not null)
+        {
+            if (HasAppHostMarkerInBuildFile(Path.Combine(directory.FullName, "Directory.Build.props"), dotNetBuildFileMarkerCache) ||
+                HasAppHostMarkerInBuildFile(Path.Combine(directory.FullName, "Directory.Build.targets"), dotNetBuildFileMarkerCache))
+            {
+                return true;
+            }
+
+            directory = directory.Parent;
+        }
+
+        return false;
+    }
+
+    private static bool HasAppHostMarkerInBuildFile(string buildFilePath, Dictionary<string, bool> dotNetBuildFileMarkerCache)
+    {
+        if (dotNetBuildFileMarkerCache.TryGetValue(buildFilePath, out var hasAppHostMarker))
+        {
+            return hasAppHostMarker;
+        }
+
+        if (!File.Exists(buildFilePath))
+        {
+            dotNetBuildFileMarkerCache[buildFilePath] = false;
+            return false;
+        }
+
+        try
+        {
+            foreach (var line in File.ReadLines(buildFilePath))
+            {
+                if (ContainsDotNetAppHostProjectContentMarker(line))
+                {
+                    dotNetBuildFileMarkerCache[buildFilePath] = true;
+                    return true;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            dotNetBuildFileMarkerCache[buildFilePath] = true;
+            return true;
+        }
+
+        dotNetBuildFileMarkerCache[buildFilePath] = false;
+        return false;
+    }
+
+    private static bool ContainsDotNetAppHostProjectContentMarker(string line)
+        => s_dotNetAppHostProjectContentMarkers.Any(marker => line.Contains(marker, StringComparison.Ordinal));
 
     /// <inheritdoc />
     public async Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default)

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -144,7 +144,7 @@ internal sealed class ProjectLocator(
     private static readonly string[] s_dotNetProjectExtensions = [".csproj", ".fsproj", ".vbproj"];
     private static readonly string[] s_dotNetAppHostProjectContentMarkers =
     [
-        "<IsAspireHost>",
+        "<IsAspireHost",
         "Aspire.AppHost.Sdk",
         "Aspire.Hosting"
     ];

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -682,7 +682,7 @@ internal sealed class ProjectLocator(
     }
 
     private static bool ContainsDotNetAppHostProjectContentMarker(string line)
-        => s_dotNetAppHostProjectContentMarkers.Any(marker => line.Contains(marker, StringComparison.Ordinal));
+        => s_dotNetAppHostProjectContentMarkers.Any(marker => line.Contains(marker, StringComparison.OrdinalIgnoreCase));
 
     /// <inheritdoc />
     public async Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default)

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -2362,6 +2362,89 @@ builder.Build().Run();");
     }
 
     [Fact]
+    public async Task FindAppHostProjectsAsync_ValidatesDotNetProjectCandidatesWithImportedAppHostMarkers()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostProjectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "CustomHost.csproj"));
+        await File.WriteAllTextAsync(appHostProjectFile.FullName, """
+            <Project>
+              <Import Project="hosting.props" />
+            </Project>
+            """);
+        await File.WriteAllTextAsync(Path.Combine(workspace.WorkspaceRoot.FullName, "hosting.props"), """
+            <Project>
+              <ItemGroup>
+                <PackageReference Include="Aspire.Hosting" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        var validatedProjectNames = new List<string>();
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            ValidateAppHostCallback = projectFile =>
+            {
+                lock (validatedProjectNames)
+                {
+                    validatedProjectNames.Add(projectFile.Name);
+                }
+
+                return new AppHostValidationResult(IsValid: true);
+            }
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+
+        var found = await projectLocator.FindAppHostProjectsAsync(workspace.WorkspaceRoot, AppHostDiscoveryScope.AllFiles, CancellationToken.None).DefaultTimeout();
+
+        var appHostCandidate = Assert.Single(found);
+        Assert.Equal(appHostProjectFile.FullName, appHostCandidate.AppHostFile.FullName);
+        Assert.Equal([appHostProjectFile.Name], validatedProjectNames);
+    }
+
+    [Fact]
+    public async Task FindAppHostProjectsAsync_ValidatesDotNetProjectCandidatesWithImplicitDirectoryBuildAppHostMarkers()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        await File.WriteAllTextAsync(Path.Combine(workspace.WorkspaceRoot.FullName, "Directory.Build.props"), """
+            <Project>
+              <PropertyGroup>
+                <IsAspireHost>true</IsAspireHost>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var appHostProjectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "CustomHost.csproj"));
+        await File.WriteAllTextAsync(appHostProjectFile.FullName, "<Project />");
+
+        var validatedProjectNames = new List<string>();
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            ValidateAppHostCallback = projectFile =>
+            {
+                lock (validatedProjectNames)
+                {
+                    validatedProjectNames.Add(projectFile.Name);
+                }
+
+                return new AppHostValidationResult(IsValid: true);
+            }
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+
+        var found = await projectLocator.FindAppHostProjectsAsync(workspace.WorkspaceRoot, AppHostDiscoveryScope.AllFiles, CancellationToken.None).DefaultTimeout();
+
+        var appHostCandidate = Assert.Single(found);
+        Assert.Equal(appHostProjectFile.FullName, appHostCandidate.AppHostFile.FullName);
+        Assert.Equal([appHostProjectFile.Name], validatedProjectNames);
+    }
+
+    [Fact]
     public async Task FindAppHostProjectsAsync_ExplicitDirectoryScope_AppliesSkipListButNotGit()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -2050,7 +2050,7 @@ builder.Build().Run();");
         var appHost2File = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost2.csproj"));
         await File.WriteAllTextAsync(appHost2File.FullName, "Not a real apphost");
 
-        var slowValidationFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "SlowValidation.csproj"));
+        var slowValidationFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "SlowValidationAppHost.csproj"));
         await File.WriteAllTextAsync(slowValidationFile.FullName, "Not a real apphost");
 
         var slowValidationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -2287,6 +2287,78 @@ builder.Build().Run();");
                 Assert.Equal(unbuildableAppHost.FullName, candidate.AppHostFile.FullName);
                 Assert.Equal(AppHostProjectCandidateStatus.PossiblyUnbuildable, candidate.Status);
             });
+    }
+
+    [Fact]
+    public async Task FindAppHostProjectsAsync_SkipsOrdinaryDotNetProjectCandidatesBeforeValidation()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostProjectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost", "AppHost.csproj"));
+        Directory.CreateDirectory(appHostProjectFile.DirectoryName!);
+        await File.WriteAllTextAsync(appHostProjectFile.FullName, "Not a real project file.");
+
+        var libraryProjectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Library", "Library.csproj"));
+        Directory.CreateDirectory(libraryProjectFile.DirectoryName!);
+        await File.WriteAllTextAsync(libraryProjectFile.FullName, "Not a real project file.");
+
+        var validatedProjectNames = new List<string>();
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            ValidateAppHostCallback = projectFile =>
+            {
+                lock (validatedProjectNames)
+                {
+                    validatedProjectNames.Add(projectFile.Name);
+                }
+
+                return new AppHostValidationResult(IsValid: projectFile.FullName == appHostProjectFile.FullName);
+            }
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+
+        var found = await projectLocator.FindAppHostProjectsAsync(workspace.WorkspaceRoot, AppHostDiscoveryScope.AllFiles, CancellationToken.None).DefaultTimeout();
+
+        var appHostCandidate = Assert.Single(found);
+        Assert.Equal(appHostProjectFile.FullName, appHostCandidate.AppHostFile.FullName);
+        Assert.Equal([appHostProjectFile.Name], validatedProjectNames.Order(StringComparer.Ordinal).ToArray());
+    }
+
+    [Theory]
+    [InlineData("<Project><PropertyGroup><IsAspireHost>true</IsAspireHost></PropertyGroup></Project>")]
+    [InlineData("<Project Sdk=\"Aspire.AppHost.Sdk/13.0.0\" />")]
+    [InlineData("<Project><ItemGroup><PackageReference Include=\"Aspire.Hosting\" /></ItemGroup></Project>")]
+    public async Task FindAppHostProjectsAsync_ValidatesDotNetProjectCandidatesWithAppHostMarkers(string projectContent)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostProjectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "CustomHost.csproj"));
+        await File.WriteAllTextAsync(appHostProjectFile.FullName, projectContent);
+
+        var validatedProjectNames = new List<string>();
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            ValidateAppHostCallback = projectFile =>
+            {
+                lock (validatedProjectNames)
+                {
+                    validatedProjectNames.Add(projectFile.Name);
+                }
+
+                return new AppHostValidationResult(IsValid: true);
+            }
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+
+        var found = await projectLocator.FindAppHostProjectsAsync(workspace.WorkspaceRoot, AppHostDiscoveryScope.AllFiles, CancellationToken.None).DefaultTimeout();
+
+        var appHostCandidate = Assert.Single(found);
+        Assert.Equal(appHostProjectFile.FullName, appHostCandidate.AppHostFile.FullName);
+        Assert.Equal([appHostProjectFile.Name], validatedProjectNames);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -2446,6 +2446,51 @@ builder.Build().Run();");
     }
 
     [Fact]
+    public async Task FindAppHostProjectsAsync_ValidatesDotNetProjectCandidatesWithImplicitDirectoryBuildImportedAppHostMarkers()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        await File.WriteAllTextAsync(Path.Combine(workspace.WorkspaceRoot.FullName, "Directory.Build.props"), """
+            <Project>
+              <Import Project="hosting.props" />
+            </Project>
+            """);
+        await File.WriteAllTextAsync(Path.Combine(workspace.WorkspaceRoot.FullName, "hosting.props"), """
+            <Project>
+              <PropertyGroup>
+                <IsAspireHost>true</IsAspireHost>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var appHostProjectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "CustomHost.csproj"));
+        await File.WriteAllTextAsync(appHostProjectFile.FullName, "<Project />");
+
+        var validatedProjectNames = new List<string>();
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            ValidateAppHostCallback = projectFile =>
+            {
+                lock (validatedProjectNames)
+                {
+                    validatedProjectNames.Add(projectFile.Name);
+                }
+
+                return new AppHostValidationResult(IsValid: true);
+            }
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+
+        var found = await projectLocator.FindAppHostProjectsAsync(workspace.WorkspaceRoot, AppHostDiscoveryScope.AllFiles, CancellationToken.None).DefaultTimeout();
+
+        var appHostCandidate = Assert.Single(found);
+        Assert.Equal(appHostProjectFile.FullName, appHostCandidate.AppHostFile.FullName);
+        Assert.Equal([appHostProjectFile.Name], validatedProjectNames);
+    }
+
+    [Fact]
     public async Task FindAppHostProjectsAsync_ExplicitDirectoryScope_AppliesSkipListButNotGit()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -2330,6 +2330,7 @@ builder.Build().Run();");
     [InlineData("<Project><PropertyGroup><IsAspireHost>true</IsAspireHost></PropertyGroup></Project>")]
     [InlineData("<Project Sdk=\"Aspire.AppHost.Sdk/13.0.0\" />")]
     [InlineData("<Project><ItemGroup><PackageReference Include=\"Aspire.Hosting\" /></ItemGroup></Project>")]
+    [InlineData("<Project><ItemGroup><PackageReference Include=\"aspire.hosting\" /></ItemGroup></Project>")]
     public async Task FindAppHostProjectsAsync_ValidatesDotNetProjectCandidatesWithAppHostMarkers(string projectContent)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Description

This speeds up AppHost discovery in large repos where `aspire ls` has to enumerate a lot of ordinary .NET projects from the repo root.

The expensive part was not the file walk. In the Aspire repo root, candidate file discovery was ~400-455ms, but the CLI then sent hundreds of `.csproj` candidates through MSBuild validation. Most of those were obviously not AppHosts and failed later with `MSB4057` because `ComputeRunArguments` is not defined.

This keeps explicit directory/project behavior alone, but adds a cheap pre-validation filter for ambient discovery: ordinary `.csproj`/`.fsproj`/`.vbproj` files that do not look AppHost-related are skipped before MSBuild. AppHost-looking project names, sibling `AppHost.cs`, direct AppHost markers, explicit project imports, implicit `Directory.Build.props`/`Directory.Build.targets` AppHost markers, and resolvable imports from those implicit build files still go through normal validation. The import handling is intentionally conservative so projects that inherit `Aspire.Hosting` or `<IsAspireHost>` from props/targets do not get hidden by the filter, and marker matching is case-insensitive.

> Draft while CI finishes after the latest edge-case fix.

### User-facing usage

No command shape changes. The scenario improved here is running candidate discovery from a large repo root:

```bash
aspire ls --format json --non-interactive --nologo
```

### Benchmark notes

Benchmarked from `/Volumes/DevDrive/source/repos/aspire-adamint` with isolated `ASPIRE_HOME` directories and locally built baseline/fixed CLIs.

| Scenario | Baseline | Fixed | Candidate output |
| --- | ---: | ---: | --- |
| Repo-root `aspire ls`, cold | 44.52s | 10.00s | identical, 144 candidates |
| Repo-root `aspire ls`, fixed warm | n/a | 1.62s | identical, 144 candidates |
| `playground/TestShop/TestShop.AppHost` `aspire ls` | 1.34s / 0.45s / 0.37s | 0.79s / 0.38s / 0.41s | identical, 1 candidate |
| Repo-root `aspire run --no-build` multiple-AppHost error path | 3.16s / 1.82s / 1.57s | 2.38s / 1.00s / 1.27s | same exit behavior |

Fixes #18439

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
