### PR TITLE
ci: auto-rerun failed scheduled Outerloop Tests runs (up to 3×)

### DIFF
--- a/.github/workflows/auto-rerun-outerloop-failures.yml
+++ b/.github/workflows/auto-rerun-outerloop-failures.yml
@@ -1,0 +1,52 @@
+# Unconditionally reruns failed "Outerloop Tests" runs (up to 3 reruns / 4 total
+# attempts), mirroring the PR force-rerun cadence. The scheduled outerloop runs this
+# targets have no associated PR, so there is no failure analysis, pattern matching, or
+# PR comment — a failed run is simply rerun until the attempt cap is reached.
+# See docs/ci/auto-rerun-outerloop-failures.md.
+name: Auto rerun outerloop failures
+
+on:
+  workflow_run:
+    workflows: ["Outerloop Tests"]
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  rerun-outerloop-failures:
+    name: Rerun outerloop failures
+    # The `if` carries every safety rail: only failed runs, only within the attempt cap
+    # (attempts 1–3 → up to 3 reruns / 4 total attempts), and only on microsoft/aspire.
+    # A cancelled run (conclusion 'cancelled') never matches, so cancellations are
+    # excluded for free.
+    #
+    # `event != 'pull_request'` restricts auto-rerun to the unattended scheduled (and
+    # manual workflow_dispatch) outerloop runs. tests-outerloop.yml also triggers on a
+    # narrow pull_request paths filter (CI-orchestration files); those PR runs have a
+    # human watching, who can use GitHub's "Re-run failed jobs" button. Auto-rerunning
+    # them would mask genuine breakage in exactly the PRs that change outerloop CI.
+    if: >-
+      ${{
+          github.repository_owner == 'microsoft' &&
+          github.event.workflow_run.event != 'pull_request' &&
+          github.event.workflow_run.conclusion == 'failure' &&
+          github.event.workflow_run.run_attempt <= 3
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Rerun failed outerloop jobs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // Unconditional: GitHub's rerun-failed-jobs API reruns every failed job for
+            // the attempt. No analysis or PR association — outerloop has no PR.
+            await github.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });

--- a/docs/ci/auto-rerun-outerloop-failures.md
+++ b/docs/ci/auto-rerun-outerloop-failures.md
@@ -1,0 +1,72 @@
+# Auto-rerun outerloop failures
+
+This document describes the workflow that automatically reruns failed
+[Outerloop Tests](../../.github/workflows/tests-outerloop.yml) runs.
+
+## How it works
+
+When an `Outerloop Tests` run finishes with a failure, the
+[`auto-rerun-outerloop-failures.yml`](../../.github/workflows/auto-rerun-outerloop-failures.yml)
+workflow asks GitHub to rerun the failed jobs. It keeps doing this for up to 3
+reruns (4 total attempts), then stops.
+
+The rerun is **unconditional**: there is no failure analysis, no log/test
+pattern matching, and no pull-request comment. The scheduled outerloop runs this
+targets have no associated PR, so a failed run is simply rerun as-is until the
+attempt cap is reached.
+
+`tests-outerloop.yml` also has a narrow `pull_request` paths trigger (for changes
+to a few CI-orchestration workflow files). Those PR-triggered runs are
+**excluded** from auto-rerun (`workflow_run.event != 'pull_request'`): a human is
+watching the PR and can use GitHub's **Re-run failed jobs** button, and
+auto-rerunning would mask genuine breakage in exactly the PRs that change
+outerloop CI.
+
+The whole workflow is the eligibility `if` plus a single `rerun-failed-jobs` API
+call — there is no script logic to maintain. This is deliberately separate from
+the PR-facing
+[auto-rerun-transient-ci-failures](auto-rerun-transient-ci-failures.md) workflow,
+which classifies failures and posts PR comments: that one's unconditional
+behavior is a temporary `FORCE_RERUN_ALL` measure and its normal path is
+PR-shaped, whereas outerloop's unconditional rerun is the permanent intent.
+
+```text
+Outerloop Tests run fails
+        │
+        ▼
+┌────────────────────────────────────────┐
+│  Eligible? (all in the job `if`)       │
+│  • conclusion == 'failure'            │
+│  • run_attempt <= 3                   │
+│  • event != 'pull_request'            │
+│  • repository_owner == 'microsoft'    │
+└──────────────┬─────────────────────────┘
+               │ yes
+               ▼
+   POST rerun-failed-jobs for the run
+```
+
+There is intentionally no `workflow_dispatch` path: GitHub's UI already provides
+a **Re-run failed jobs** button on any run for manual reruns.
+
+## Safety rails
+
+All rails live in the job-level `if`, so the rerun step only runs when every
+condition holds:
+
+| Rail | Detail |
+|------|--------|
+| **Attempt limit** | The run must be on attempt ≤ 3. Reruns fire from attempts 1, 2, and 3, so a run gets up to 3 automatic reruns (4 total attempts). |
+| **Failure-only triggering** | Only fires on `workflow_run.conclusion == 'failure'`. A `cancelled` run never triggers a rerun. |
+| **Scheduled/manual only** | Only fires when the outerloop run's trigger was not `pull_request` (`workflow_run.event != 'pull_request'`). PR-triggered outerloop runs (narrow paths filter) are left for the PR author to rerun manually. |
+| **Repository guard** | Only runs on `microsoft/aspire` (`github.repository_owner == 'microsoft'`). |
+
+GitHub's `rerun-failed-jobs` API reruns **all** failed jobs for the attempt
+(there is no API to rerun a subset), which is exactly the desired behavior here.
+
+## Files
+
+| File | Role |
+|------|------|
+| [`.github/workflows/auto-rerun-outerloop-failures.yml`](../../.github/workflows/auto-rerun-outerloop-failures.yml) | The workflow: trigger, eligibility gate, and the single rerun API call. |
+| [`.github/workflows/tests-outerloop.yml`](../../.github/workflows/tests-outerloop.yml) | The `Outerloop Tests` workflow that this one watches. |

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -6,6 +6,8 @@ This document explains how the automatic CI rerun system works and how to config
 
 When a `CI` pull request run fails on GitHub Actions, a companion workflow automatically analyzes the failure, determines whether it was caused by transient infrastructure or test issues, and — if safe — requests GitHub to rerun the failed jobs. It also posts a comment on the PR explaining what it did and why.
 
+> **Scheduled `Outerloop Tests` runs use a separate, simpler workflow.** Outerloop runs have no associated PR, so they are rerun unconditionally (no analysis, no PR comment) with the same attempt cadence. See [Auto-rerun outerloop failures](auto-rerun-outerloop-failures.md).
+
 > **Currently in force mode.** The workflow is temporarily configured to skip the analysis below and rerun the failed jobs on **any** failed run with an open PR. See [Force-rerun all failures](#force-rerun-all-failures-force_rerun_all). The rest of this section describes the normal (analysis) behavior that force mode bypasses.
 
 ```text

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -6,7 +6,7 @@ This document explains how the automatic CI rerun system works and how to config
 
 When a `CI` pull request run fails on GitHub Actions, a companion workflow automatically analyzes the failure, determines whether it was caused by transient infrastructure or test issues, and — if safe — requests GitHub to rerun the failed jobs. It also posts a comment on the PR explaining what it did and why.
 
-> **Scheduled `Outerloop Tests` runs use a separate, simpler workflow.** Outerloop runs have no associated PR, so they are rerun unconditionally (no analysis, no PR comment) with the same attempt cadence. See [Auto-rerun outerloop failures](auto-rerun-outerloop-failures.md).
+**Scheduled `Outerloop Tests` runs use a separate, simpler workflow.** Outerloop runs have no associated PR, so they are rerun unconditionally (no analysis, no PR comment) with the same attempt cadence. See [Auto-rerun outerloop failures](auto-rerun-outerloop-failures.md).
 
 > **Currently in force mode.** The workflow is temporarily configured to skip the analysis below and rerun the failed jobs on **any** failed run with an open PR. See [Force-rerun all failures](#force-rerun-all-failures-force_rerun_all). The rest of this section describes the normal (analysis) behavior that force mode bypasses.
 


### PR DESCRIPTION
## What was missing

Scheduled **Outerloop Tests** runs (daily 02:00 UTC) get no automatic retry. A
single transient or flaky failure leaves the run red until a human manually
clicks **Re-run failed jobs**. PR CI already gets unconditional auto-reruns (up
to 3) through the force-mode path in the transient-rerun workflow — outerloop
had no equivalent.

## The change

A small standalone workflow, `auto-rerun-outerloop-failures.yml`, watches
`Outerloop Tests` run completions and, on failure, reruns the failed jobs up to
3 times (4 total attempts) — the same cadence PRs get.

The entire workflow is an eligibility `if` plus a single `rerun-failed-jobs` API
call. No failure analysis, no log/test pattern matching, no PR comment — the
scheduled runs it targets have no associated PR.

Eligibility (all in the job `if`):

- `conclusion == 'failure'`
- `run_attempt <= 3` — reruns fire from attempts 1/2/3 → up to 3 reruns
- `event != 'pull_request'`
- `repository_owner == 'microsoft'`

## Why separate from the transient-rerun workflow

`auto-rerun-transient-ci-failures.yml` is PR-shaped: it downloads CI artifacts,
classifies failures, and posts PR comments, and its unconditional behavior is a
**temporary** `FORCE_RERUN_ALL` measure. Outerloop's unconditional rerun is the
*permanent* intent and has no PR to comment on, so folding it in would couple a
permanent behavior to a temporary hack and inject PR-vs-no-PR branching into the
most safety-critical rerun path. A standalone workflow is simpler and can't
break when force mode is reverted.

## Call-outs

- **PR-triggered outerloop runs are deliberately excluded.** `tests-outerloop.yml`
  also triggers on a narrow `pull_request` paths filter (CI-orchestration files).
  Those runs have a human watching and are left to manual rerun, so auto-rerun
  can't mask a genuine break in exactly the PRs that change outerloop CI.
- **Cannot be validated before merge.** `workflow_run` only fires once the
  workflow is on the default branch, so the first real exercise is the next
  scheduled outerloop failure after this merges — there's no green check on this
  PR proving it runs. The design mirrors the already-shipped transient workflow's
  `workflow_run` + `run_attempt <= 3` pattern.
- **No automated test.** A YAML-content assertion would just restate the file;
  the behavior lives entirely in GitHub's trigger evaluation, which a unit test
  can't exercise.

Docs: `docs/ci/auto-rerun-outerloop-failures.md` (new) + a cross-link from the
transient-rerun doc.
