### PR TITLE
Quarantine flaky LsCommand JSON-format test

### DIFF
--- a/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
@@ -10,6 +10,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.TestUtilities;
 using Aspire.Tests;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,7 +18,6 @@ using Microsoft.Extensions.Time.Testing;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 using InvocationConfiguration = System.CommandLine.InvocationConfiguration;
-using Aspire.TestUtilities;
 
 namespace Aspire.Cli.Tests.Commands;
 

--- a/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Time.Testing;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 using InvocationConfiguration = System.CommandLine.InvocationConfiguration;
+using Aspire.TestUtilities;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -206,6 +207,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/18476")]
     public async Task LsCommand_JsonFormat_OnlyJsonOnStdout_StatusMessagesOnStderr()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Summary

Quarantines `Aspire.Cli.Tests.Commands.LsCommandTests.LsCommand_JsonFormat_OnlyJsonOnStdout_StatusMessagesOnStderr`, which is failing the rolling `main` build.

It fails intermittently with a `NullReferenceException` thrown **inside `System.CommandLine`** while parsing `ls --format json`:

```
System.NullReferenceException : Object reference not set to an instance of an object.
   at System.CommandLine.Parsing.CommandResult.ValidateOptionsAndAddDefaultResults(Boolean completeValidation)
   at System.CommandLine.Parsing.ParseOperation.Parse()
   at Aspire.Cli.Tests.Commands.LsCommandTests.LsCommand_JsonFormat_OnlyJsonOnStdout_StatusMessagesOnStderr() in tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs:line 234
```

First seen in run [28116640870](https://github.com/microsoft/aspire/actions/runs/28116640870).

## Verification

- `dotnet build tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj` — succeeded.
- Ran the test with `--filter-not-trait "quarantined=true"` — **zero tests ran**, confirming it is now excluded from the normal lane.

Issue: #18476
