### PR TITLE
fix(skills): match MTP lowercase "total:" in run-test-repeatedly zero-test guard

### DIFF
--- a/.agents/skills/fix-flaky-test/run-test-repeatedly.sh
+++ b/.agents/skills/fix-flaky-test/run-test-repeatedly.sh
@@ -237,8 +237,11 @@ for i in $(seq 1 "$ITERATIONS"); do
     EXIT_CODE=$?
 
     # Detect zero-test runs (exit code 8 is masked by --ignore-exit-code 8 in Testing.props)
+    # Match case-insensitively: MTP's native runner emits a lowercase "total: N" summary,
+    # while VSTest emits "Total: N". A case-sensitive match misses MTP and mis-flags every
+    # passing MTP run as a zero-test failure.
     if [[ $EXIT_CODE -eq 0 ]]; then
-        if ! grep -qE "Total:\s*[1-9]" "$ITER_LOG" 2>/dev/null; then
+        if ! grep -qiE "Total:\s*[1-9]" "$ITER_LOG" 2>/dev/null; then
             EXIT_CODE=8
         fi
     fi


### PR DESCRIPTION
The `fix-flaky-test` skill's local hammer script (`run-test-repeatedly.sh`) classifies a **passing** run as a "zero tests executed" failure whenever the test runner is MTP (Microsoft.Testing.Platform).

### Symptom

Every iteration of an all-passing run is reported as a zero-test failure, so the script's final pass/fail tally is wrong even though the tests actually passed.

### Root cause

The zero-test guard greps the iteration log case-sensitively for `Total:`:

```sh
if ! grep -qE "Total:\s*[1-9]" "$ITER_LOG" 2>/dev/null; then
    EXIT_CODE=8   # treat as zero-test run
fi
```

MTP's native runner emits a **lowercase** summary — `total: N` / `failed: N` / `succeeded: N` — whereas VSTest emits `Total: N`. The case-sensitive match never sees MTP's `total:`, so the guard fires on every passing MTP run and forces `EXIT_CODE=8`.

### Fix

Make the grep case-insensitive (`grep -qiE`), matching both `Total:` and `total:`.

The PowerShell sibling `run-test-repeatedly.ps1` already uses `-match`, which is case-insensitive by default, so it needs no change. The `reproduce-flaky-tests.yml` workflow already uses `grep -qiE` and is unaffected.
