### PR TITLE
Configure HTTPS certificates for project resources

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -135,6 +135,7 @@
     <Compile Include="$(SharedDir)ChannelExtensions.cs" Link="Utils\ChannelExtensions.cs" />
     <Compile Include="$(SharedDir)CommandLineArgsParser.cs" Link="Utils\CommandLineArgsParser.cs" />
     <Compile Include="$(SharedDir)EnumerableExtensions.cs" Link="Utils\EnumerableExtensions.cs" />
+    <Compile Include="$(SharedDir)KnownAspNetCoreConfigNames.cs" Link="Utils\KnownAspNetCoreConfigNames.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)LaunchProfiles\LaunchSettingsReader.cs" Link="LaunchProfiles\LaunchSettingsReader.cs" />
     <Compile Include="$(SharedDir)IntegrationPackageProbeManifest.cs" Link="Utils\IntegrationPackageProbeManifest.cs" />

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -140,7 +140,7 @@ internal sealed class DashboardRunCommand : BaseCommand
 
     private static void AddOptionArgs(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens, IEnvironment environment)
     {
-        AddStringOptionArg(parseResult, args, unmatchedTokens, environment, s_frontendUrlOption, KnownConfigNames.AspNetCoreUrls, defaultValue: "http://localhost:18888");
+        AddStringOptionArg(parseResult, args, unmatchedTokens, environment, s_frontendUrlOption, KnownAspNetCoreConfigNames.Urls, defaultValue: "http://localhost:18888");
         AddStringOptionArg(parseResult, args, unmatchedTokens, environment, s_otlpGrpcUrlOption, KnownConfigNames.DashboardOtlpGrpcEndpointUrl, defaultValue: "http://localhost:4317");
         AddStringOptionArg(parseResult, args, unmatchedTokens, environment, s_otlpHttpUrlOption, KnownConfigNames.DashboardOtlpHttpEndpointUrl, defaultValue: "http://localhost:4318");
         AddBoolOptionArg(parseResult, args, unmatchedTokens, environment, s_allowAnonymousOption, KnownConfigNames.DashboardUnsecuredAllowAnonymous);
@@ -232,7 +232,7 @@ internal sealed class DashboardRunCommand : BaseCommand
 
     internal static DashboardInfo ResolveDashboardInfo(List<string> dashboardArgs, IReadOnlyList<string> unmatchedTokens, IEnvironment environment, string? browserToken)
     {
-        var frontendUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, environment, KnownConfigNames.AspNetCoreUrls) ?? "http://localhost:18888";
+        var frontendUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, environment, KnownAspNetCoreConfigNames.Urls) ?? "http://localhost:18888";
         var otlpGrpcUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, environment, KnownConfigNames.DashboardOtlpGrpcEndpointUrl) ?? "http://localhost:4317";
         var otlpHttpUrl = ResolveSettingValue(dashboardArgs, unmatchedTokens, environment, KnownConfigNames.DashboardOtlpHttpEndpointUrl) ?? "http://localhost:4318";
 

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -810,8 +810,8 @@ internal sealed class InitCommand : BaseCommand
                     ["applicationUrl"] = $"https://localhost:{ports.DashboardHttpsPort};http://localhost:{ports.DashboardHttpPort}",
                     ["environmentVariables"] = new JsonObject
                     {
-                        ["ASPNETCORE_ENVIRONMENT"] = "Development",
-                        ["DOTNET_ENVIRONMENT"] = "Development",
+                        [KnownAspNetCoreConfigNames.Environment] = "Development",
+                        [KnownAspNetCoreConfigNames.DotNetEnvironment] = "Development",
                         [KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = $"https://localhost:{ports.OtlpHttpsPort}",
                         [KnownConfigNames.ResourceServiceEndpointUrl] = $"https://localhost:{ports.ResourceServiceHttpsPort}"
                     }
@@ -824,8 +824,8 @@ internal sealed class InitCommand : BaseCommand
                     ["applicationUrl"] = $"http://localhost:{ports.DashboardHttpPort}",
                     ["environmentVariables"] = new JsonObject
                     {
-                        ["ASPNETCORE_ENVIRONMENT"] = "Development",
-                        ["DOTNET_ENVIRONMENT"] = "Development",
+                        [KnownAspNetCoreConfigNames.Environment] = "Development",
+                        [KnownAspNetCoreConfigNames.DotNetEnvironment] = "Development",
                         [KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = $"http://localhost:{ports.OtlpHttpPort}",
                         [KnownConfigNames.ResourceServiceEndpointUrl] = $"http://localhost:{ports.ResourceServiceHttpPort}",
                         [KnownConfigNames.AllowUnsecuredTransport] = "true"

--- a/src/Aspire.Cli/Profiling/ProfileCaptureService.cs
+++ b/src/Aspire.Cli/Profiling/ProfileCaptureService.cs
@@ -83,7 +83,7 @@ internal sealed class ProfileCaptureService(
         var dashboardArgs = new[]
         {
             "dashboard",
-            $"--{KnownConfigNames.AspNetCoreUrls}={options.DashboardUrl}",
+            $"--{KnownAspNetCoreConfigNames.Urls}={options.DashboardUrl}",
             $"--{KnownConfigNames.DashboardOtlpGrpcEndpointUrl}={options.OtlpGrpcUrl}",
             $"--{KnownConfigNames.DashboardOtlpHttpEndpointUrl}={options.OtlpHttpUrl}",
             $"--{KnownConfigNames.DashboardUnsecuredAllowAnonymous}=true",

--- a/src/Aspire.Cli/Projects/AppHostEnvironmentDefaults.cs
+++ b/src/Aspire.Cli/Projects/AppHostEnvironmentDefaults.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting;
+
 namespace Aspire.Cli.Projects;
 
 /// <summary>
@@ -10,10 +12,8 @@ internal static class AppHostEnvironmentDefaults
 {
     private const string EnvironmentArgumentName = "--environment";
     private const string EnvironmentArgumentAlias = "-e";
-    private const string AspNetCoreEnvironmentVariableName = "ASPNETCORE_ENVIRONMENT";
 
     internal const string AspireEnvironmentVariableName = "ASPIRE_ENVIRONMENT";
-    internal const string DotNetEnvironmentVariableName = "DOTNET_ENVIRONMENT";
     internal const string DevelopmentEnvironmentName = "Development";
     internal const string ProductionEnvironmentName = "Production";
 
@@ -22,7 +22,7 @@ internal static class AppHostEnvironmentDefaults
     /// when filtering launch profile values.
     /// </summary>
     internal static bool IsEnvironmentVariableName(string variableName) =>
-        variableName is DotNetEnvironmentVariableName or AspNetCoreEnvironmentVariableName or AspireEnvironmentVariableName;
+        variableName is KnownAspNetCoreConfigNames.DotNetEnvironment or KnownAspNetCoreConfigNames.Environment or AspireEnvironmentVariableName;
 
     /// <summary>
     /// Applies the effective environment to the launch environment variables.
@@ -39,11 +39,11 @@ internal static class AppHostEnvironmentDefaults
     {
         if (TryResolveEnvironment(environmentVariables, inheritedEnvironmentVariables, args, out var environment))
         {
-            environmentVariables[DotNetEnvironmentVariableName] = environment;
+            environmentVariables[KnownAspNetCoreConfigNames.DotNetEnvironment] = environment;
         }
         else if (defaultEnvironment is not null)
         {
-            environmentVariables[DotNetEnvironmentVariableName] = defaultEnvironment;
+            environmentVariables[KnownAspNetCoreConfigNames.DotNetEnvironment] = defaultEnvironment;
         }
     }
 
@@ -56,8 +56,8 @@ internal static class AppHostEnvironmentDefaults
         // Match DistributedApplicationBuilder precedence:
         // explicit --environment, then DOTNET_ENVIRONMENT, then ASPIRE_ENVIRONMENT.
         if (TryGetRequestedEnvironment(args, out environment) ||
-            TryGetEnvironmentValue(environmentVariables, DotNetEnvironmentVariableName, out environment) ||
-            TryGetInheritedEnvironmentValue(inheritedEnvironmentVariables, DotNetEnvironmentVariableName, out environment) ||
+            TryGetEnvironmentValue(environmentVariables, KnownAspNetCoreConfigNames.DotNetEnvironment, out environment) ||
+            TryGetInheritedEnvironmentValue(inheritedEnvironmentVariables, KnownAspNetCoreConfigNames.DotNetEnvironment, out environment) ||
             TryGetEnvironmentValue(environmentVariables, AspireEnvironmentVariableName, out environment) ||
             TryGetInheritedEnvironmentValue(inheritedEnvironmentVariables, AspireEnvironmentVariableName, out environment))
         {

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -798,7 +798,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
             if (!string.IsNullOrWhiteSpace(profile.ApplicationUrl))
             {
-                env["ASPNETCORE_URLS"] = profile.ApplicationUrl;
+                env[KnownAspNetCoreConfigNames.Urls] = profile.ApplicationUrl;
             }
 
             if (profile.EnvironmentVariables is not null)
@@ -1053,7 +1053,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             return false;
         }
 
-        env["ASPNETCORE_URLS"] = profile.ApplicationUrl;
+        env[KnownAspNetCoreConfigNames.Urls] = profile.ApplicationUrl;
 
         if (profile.EnvironmentVariables is not null)
         {
@@ -1073,7 +1073,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
     private static void ApplyDefaultSingleFileEndpoints(IDictionary<string, string> env)
     {
-        env["ASPNETCORE_URLS"] = "https://localhost:17193;http://localhost:15069";
+        env[KnownAspNetCoreConfigNames.Urls] = "https://localhost:17193;http://localhost:15069";
         env["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"] = "https://localhost:21293";
         env["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"] = "https://localhost:22086";
     }

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -505,7 +505,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
 
         // Dev mode uses debug builds which require Development environment
         // for the dashboard to resolve static web assets correctly
-        startInfo.Environment["ASPNETCORE_ENVIRONMENT"] = "Development";
+        startInfo.Environment[KnownAspNetCoreConfigNames.Environment] = "Development";
 
         // Wire WithTerminal() for guest/polyglot AppHosts running from the repo. The
         // generated AppHostServer references Aspire.Hosting from the repo and DCP resolves

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -903,7 +903,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             if (profileElement.Value.TryGetProperty("applicationUrl", out var appUrl) &&
                 appUrl.ValueKind == JsonValueKind.String)
             {
-                result["ASPNETCORE_URLS"] = appUrl.GetString()!;
+                result[KnownAspNetCoreConfigNames.Urls] = appUrl.GetString()!;
             }
 
             // Read environment variables
@@ -956,7 +956,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
         if (!string.IsNullOrEmpty(profile.ApplicationUrl))
         {
-            result["ASPNETCORE_URLS"] = profile.ApplicationUrl;
+            result[KnownAspNetCoreConfigNames.Urls] = profile.ApplicationUrl;
         }
 
         if (profile.EnvironmentVariables is not null)

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -290,6 +290,7 @@
     <Compile Include="$(SharedDir)LocaleHelpers.cs" Link="Utils\LocaleHelpers.cs" />
     <Compile Include="$(SharedDir)CompareHelpers.cs" Link="Utils\CompareHelpers.cs" />
     <Compile Include="$(SharedDir)IConfigurationExtensions.cs" Link="Utils\IConfigurationExtensions.cs" />
+    <Compile Include="$(SharedDir)KnownAspNetCoreConfigNames.cs" Link="Utils\KnownAspNetCoreConfigNames.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)KnownResourceNames.cs" Link="Utils\KnownResourceNames.cs" />
     <Compile Include="$(SharedDir)KnownFormats.cs" Link="Utils\KnownFormats.cs" />

--- a/src/Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AppService.csproj
+++ b/src/Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AppService.csproj
@@ -16,6 +16,7 @@
     <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="Shared\ComputeEnvironmentEndpointResolver.cs" />
     <Compile Include="$(SharedDir)ContainerRegistryInfrastructure.cs" LinkBase="Shared\ContainerRegistryInfrastructure.cs" />
     <Compile Include="$(SharedDir)DashboardConfigNames.cs" LinkBase="Shared\DashboardConfigNames.cs" />
+    <Compile Include="$(SharedDir)KnownAspNetCoreConfigNames.cs" LinkBase="Shared\KnownAspNetCoreConfigNames.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" LinkBase="Shared\KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)KnownOtelConfigNames.cs" LinkBase="Shared\KnownOtelConfigNames.cs" />
     <Compile Include="$(SharedDir)ResourceNameComparer.cs" LinkBase="Shared\ResourceNameComparer.cs" />

--- a/src/Aspire.Hosting.Testing/Aspire.Hosting.Testing.csproj
+++ b/src/Aspire.Hosting.Testing/Aspire.Hosting.Testing.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <Compile Include="$(SharedDir)LaunchProfiles\LaunchSettingsReader.cs" Link="LaunchSettingsReader.cs" />
     <Compile Include="$(SharedDir)LaunchProfiles\LaunchSettingsSerializerContext.cs" Link="LaunchSettingsSerializerContext.cs" />
+    <Compile Include="$(SharedDir)\KnownAspNetCoreConfigNames.cs" Link="KnownAspNetCoreConfigNames.cs" />
     <Compile Include="$(SharedDir)\KnownConfigNames.cs" Link="KnownConfigNames.cs" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -203,7 +203,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
         SetDefault("DcpPublisher:WaitForResourceCleanup", "true");
 
         // Make sure we have a dashboard URL and OTLP endpoint URL.
-        SetDefault(KnownConfigNames.AspNetCoreUrls, "http://localhost:8080");
+        SetDefault(KnownAspNetCoreConfigNames.Urls, "http://localhost:8080");
         SetDefaultFallback(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, KnownConfigNames.Legacy.DashboardOtlpGrpcEndpointUrl, "http://localhost:4317");
 
         // Since the testing builder defaults all dashboard/OTLP URLs to HTTP, also allow

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -28,6 +28,7 @@
     <Compile Include="$(SharedDir)KnownResourceNames.cs" Link="Utils\KnownResourceNames.cs" />
     <Compile Include="$(SharedDir)KnownEndpointNames.cs" Link="Utils\KnownEndpointNames.cs" />
     <Compile Include="$(SharedDir)EnvironmentVariableNameEncoder.cs" Link="ApplicationModel\EnvironmentVariableNameEncoder.cs" />
+    <Compile Include="$(SharedDir)KnownAspNetCoreConfigNames.cs" Link="Utils\KnownAspNetCoreConfigNames.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)KnownContainerRuntimes.cs" Link="Utils\KnownContainerRuntimes.cs" />
     <Compile Include="$(SharedDir)ContainerRuntimeDetector.cs" Link="Publishing\ContainerRuntimeDetector.cs" />

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -438,10 +438,10 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
                 {
                     // Ensure we use a trusted developer certificate (Kestrel selects the latest certificate, which may not be trusted after an SDK update).
                     // There can be issues referencing an exported PEM key pair on MacOS, so we the PFX version of the certificate here.
-                    ctx.EnvironmentVariables["Kestrel__Certificates__Default__Path"] = ctx.PfxPath;
+                    ctx.EnvironmentVariables[KnownAspNetCoreConfigNames.KestrelCertificatesDefaultPath] = ctx.PfxPath;
                     if (ctx.Password is not null)
                     {
-                        ctx.EnvironmentVariables["Kestrel__Certificates__Default__Password"] = ctx.Password;
+                        ctx.EnvironmentVariables[KnownAspNetCoreConfigNames.KestrelCertificatesDefaultPassword] = ctx.Password;
                     }
 
                     return Task.CompletedTask;
@@ -597,7 +597,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
 
         var resourceServiceUrl = await dashboardEndpointProvider.GetResourceServiceUriAsync(context.CancellationToken).ConfigureAwait(false);
 
-        context.EnvironmentVariables["ASPNETCORE_ENVIRONMENT"] = environment;
+        context.EnvironmentVariables[KnownAspNetCoreConfigNames.Environment] = environment;
         context.EnvironmentVariables[DashboardConfigNames.ResourceServiceUrlName.EnvVarName] = resourceServiceUrl;
 
         PopulateDashboardUrls(context);

--- a/src/Aspire.Hosting/Dashboard/DashboardOptions.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardOptions.cs
@@ -25,7 +25,7 @@ internal class ConfigureDefaultDashboardOptions(IConfiguration configuration, IO
     public void Configure(DashboardOptions options)
     {
         options.DashboardPath = dcpOptions.Value.DashboardPath;
-        options.DashboardUrl = configuration[KnownConfigNames.AspNetCoreUrls];
+        options.DashboardUrl = configuration[KnownAspNetCoreConfigNames.Urls];
         options.DashboardToken = configuration["AppHost:BrowserToken"];
 
         options.OtlpGrpcEndpointUrl = NormalizeUrl(configuration.GetString(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, KnownConfigNames.Legacy.DashboardOtlpGrpcEndpointUrl));
@@ -34,7 +34,7 @@ internal class ConfigureDefaultDashboardOptions(IConfiguration configuration, IO
         options.OtlpApiKey = configuration["AppHost:OtlpApiKey"];
         options.ApiKey = configuration["AppHost:DashboardApiKey"];
 
-        options.AspNetCoreEnvironment = configuration["ASPNETCORE_ENVIRONMENT"] ?? "Production";
+        options.AspNetCoreEnvironment = configuration[KnownAspNetCoreConfigNames.Environment] ?? "Production";
 
         options.TelemetryOptOut = bool.TryParse(configuration["ASPIRE_DASHBOARD_TELEMETRY_OPTOUT"], out var telemetryOptOut)
             ? telemetryOptOut

--- a/src/Aspire.Hosting/Dashboard/TransportOptionsValidator.cs
+++ b/src/Aspire.Hosting/Dashboard/TransportOptionsValidator.cs
@@ -20,7 +20,7 @@ internal class TransportOptionsValidator(IConfiguration configuration, Distribut
         }
 
         // Validate ASPNETCORE_URLS
-        var applicationUrls = configuration[KnownConfigNames.AspNetCoreUrls];
+        var applicationUrls = configuration[KnownAspNetCoreConfigNames.Urls];
         if (!string.IsNullOrEmpty(applicationUrls))
         {
             var firstApplicationUrl = applicationUrls.Split(";").First();

--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -45,10 +45,10 @@ internal sealed class DcpHost
     // These environment variables should never be inherited by DCP from the app host.
     private static readonly string[] s_doNotInheritEnvironmentVars =
     [
-        "ASPNETCORE_URLS",
+        KnownAspNetCoreConfigNames.Urls,
         "DOTNET_LAUNCH_PROFILE",
-        "ASPNETCORE_ENVIRONMENT",
-        "DOTNET_ENVIRONMENT",
+        KnownAspNetCoreConfigNames.Environment,
+        KnownAspNetCoreConfigNames.DotNetEnvironment,
         KnownConfigNames.AspireLogLevel,
     ];
 
@@ -694,4 +694,3 @@ internal sealed class DcpHost
         return false;
     }
 }
-

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -23,10 +23,6 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class ProjectResourceBuilderExtensions
 {
-    private const string AspNetCoreForwardedHeadersEnabledVariableName = "ASPNETCORE_FORWARDEDHEADERS_ENABLED";
-    private const string KestrelCertificatesDefaultPathVariableName = "Kestrel__Certificates__Default__Path";
-    private const string KestrelCertificatesDefaultPasswordVariableName = "Kestrel__Certificates__Default__Password";
-
     /// <summary>
     /// Adds a .NET project to the application model.
     /// </summary>
@@ -514,14 +510,14 @@ public static class ProjectResourceBuilderExtensions
 
             // Kestrel's default certificate configuration accepts PFX paths directly. This avoids
             // PEM key-pair path handling differences in local development environments.
-            ctx.EnvironmentVariables[KestrelCertificatesDefaultPathVariableName] = ctx.PfxPath;
+            ctx.EnvironmentVariables[KnownAspNetCoreConfigNames.KestrelCertificatesDefaultPath] = ctx.PfxPath;
             if (ctx.Password is not null)
             {
-                ctx.EnvironmentVariables[KestrelCertificatesDefaultPasswordVariableName] = ctx.Password;
+                ctx.EnvironmentVariables[KnownAspNetCoreConfigNames.KestrelCertificatesDefaultPassword] = ctx.Password;
             }
             else
             {
-                ctx.EnvironmentVariables.Remove(KestrelCertificatesDefaultPasswordVariableName);
+                ctx.EnvironmentVariables.Remove(KnownAspNetCoreConfigNames.KestrelCertificatesDefaultPassword);
             }
 
             return Task.CompletedTask;
@@ -542,7 +538,7 @@ public static class ProjectResourceBuilderExtensions
                 // If we have any endpoints & the forwarded headers wasn't disabled then add it
                 if (projectResource.GetEndpoints().Any() && !projectResource.Annotations.OfType<DisableForwardedHeadersAnnotation>().Any())
                 {
-                    context.EnvironmentVariables[AspNetCoreForwardedHeadersEnabledVariableName] = "true";
+                    context.EnvironmentVariables[KnownAspNetCoreConfigNames.ForwardedHeadersEnabled] = "true";
                 }
             });
         }
@@ -970,7 +966,7 @@ public static class ProjectResourceBuilderExtensions
         }
 
         var projectDirectoryPath = Path.GetDirectoryName(projectMetadata.ProjectPath)!;
-        var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        var env = Environment.GetEnvironmentVariable(KnownAspNetCoreConfigNames.Environment) ?? Environment.GetEnvironmentVariable(KnownAspNetCoreConfigNames.DotNetEnvironment);
         var appSettingsPath = Path.Combine(projectDirectoryPath, "appsettings.json");
         var appSettingsEnvironmentPath = Path.Combine(projectDirectoryPath, $"appsettings.{env}.json");
         // .NET 10 introduced support for application-specific settings files: https://github.com/dotnet/runtime/pull/116987
@@ -1021,7 +1017,7 @@ public static class ProjectResourceBuilderExtensions
     {
         builder.WithEnvironment(context =>
         {
-            if (context.EnvironmentVariables.ContainsKey("ASPNETCORE_URLS"))
+            if (context.EnvironmentVariables.ContainsKey(KnownAspNetCoreConfigNames.Urls))
             {
                 // If the user has already set ASPNETCORE_URLS, we don't want to override it.
                 return;
@@ -1044,7 +1040,7 @@ public static class ProjectResourceBuilderExtensions
                 {
                     // Add the environment variable for the HTTPS port if we have an HTTPS service. This will make sure the
                     // HTTPS redirection middleware avoids redirecting to the internal port.
-                    context.EnvironmentVariables["ASPNETCORE_HTTPS_PORT"] = e.Property(EndpointProperty.Port);
+                    context.EnvironmentVariables[KnownAspNetCoreConfigNames.HttpsPort] = e.Property(EndpointProperty.Port);
 
                     processedHttpsPort = true;
                 }
@@ -1056,7 +1052,7 @@ public static class ProjectResourceBuilderExtensions
             if (!aspnetCoreUrls.IsEmpty)
             {
                 // Combine into a single expression
-                context.EnvironmentVariables["ASPNETCORE_URLS"] = aspnetCoreUrls.Build();
+                context.EnvironmentVariables[KnownAspNetCoreConfigNames.Urls] = aspnetCoreUrls.Build();
             }
         });
     }

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREEXTENSION001
+#pragma warning disable ASPIRECERTIFICATES001
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
@@ -23,6 +24,8 @@ namespace Aspire.Hosting;
 public static class ProjectResourceBuilderExtensions
 {
     private const string AspNetCoreForwardedHeadersEnabledVariableName = "ASPNETCORE_FORWARDEDHEADERS_ENABLED";
+    private const string KestrelCertificatesDefaultPathVariableName = "Kestrel__Certificates__Default__Path";
+    private const string KestrelCertificatesDefaultPasswordVariableName = "Kestrel__Certificates__Default__Password";
 
     /// <summary>
     /// Adds a .NET project to the application model.
@@ -497,6 +500,28 @@ public static class ProjectResourceBuilderExtensions
                 var logger = resourceLogger.GetLogger(builder.Resource);
                 logger.LogWarning("Certificate trust scope is set to '{Scope}', but the feature is not supported for .NET projects on Windows. No certificate trust customization will be applied. Set the certificate trust scope to 'None' to disable this warning.", Enum.GetName(ctx.Scope));
                 return Task.CompletedTask;
+            }
+
+            return Task.CompletedTask;
+        });
+
+        builder.WithHttpsCertificateConfiguration(ctx =>
+        {
+            if (!ctx.Resource.Annotations.OfType<EndpointAnnotation>().Any(e => e.TlsEnabled))
+            {
+                return Task.CompletedTask;
+            }
+
+            // Kestrel's default certificate configuration accepts PFX paths directly. This avoids
+            // PEM key-pair path handling differences in local development environments.
+            ctx.EnvironmentVariables[KestrelCertificatesDefaultPathVariableName] = ctx.PfxPath;
+            if (ctx.Password is not null)
+            {
+                ctx.EnvironmentVariables[KestrelCertificatesDefaultPasswordVariableName] = ctx.Password;
+            }
+            else
+            {
+                ctx.EnvironmentVariables.Remove(KestrelCertificatesDefaultPasswordVariableName);
             }
 
             return Task.CompletedTask;

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -5,7 +5,7 @@ namespace Aspire.Hosting;
 
 internal static class DashboardConfigNames
 {
-    public static readonly ConfigName DashboardFrontendUrlName = new(KnownConfigNames.AspNetCoreUrls);
+    public static readonly ConfigName DashboardFrontendUrlName = new(KnownAspNetCoreConfigNames.Urls);
 
     public static readonly ConfigName DashboardOtlpGrpcUrlName = new(KnownConfigNames.DashboardOtlpGrpcEndpointUrl);
     public static readonly ConfigName DashboardOtlpHttpUrlName = new(KnownConfigNames.DashboardOtlpHttpEndpointUrl);

--- a/src/Shared/KnownAspNetCoreConfigNames.cs
+++ b/src/Shared/KnownAspNetCoreConfigNames.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides constants for well-known ASP.NET Core configuration names.
+/// </summary>
+internal static class KnownAspNetCoreConfigNames
+{
+    public const string Environment = "ASPNETCORE_ENVIRONMENT";
+    public const string DotNetEnvironment = "DOTNET_ENVIRONMENT";
+    public const string ForwardedHeadersEnabled = "ASPNETCORE_FORWARDEDHEADERS_ENABLED";
+    public const string HttpsPort = "ASPNETCORE_HTTPS_PORT";
+    public const string Urls = "ASPNETCORE_URLS";
+    public const string KestrelCertificatesDefaultPath = "Kestrel__Certificates__Default__Path";
+    public const string KestrelCertificatesDefaultPassword = "Kestrel__Certificates__Default__Password";
+}

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -5,7 +5,6 @@ namespace Aspire.Hosting;
 
 internal static class KnownConfigNames
 {
-    public const string AspNetCoreUrls = "ASPNETCORE_URLS";
     public const string AllowUnsecuredTransport = "ASPIRE_ALLOW_UNSECURED_TRANSPORT";
     public const string VersionCheckDisabled = "ASPIRE_VERSION_CHECK_DISABLED";
     public const string DashboardOtlpGrpcEndpointUrl = "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL";

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Aspire.Hosting;
 using Aspire.Shared;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -112,7 +113,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var unmatchedTokens = new[] { "--ASPNETCORE_URLS=http://localhost:9999" };
 
-        Assert.True(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, environment, "ASPNETCORE_URLS"));
+        Assert.True(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, environment, KnownAspNetCoreConfigNames.Urls));
         Assert.False(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, environment, "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"));
     }
 
@@ -123,7 +124,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var unmatchedTokens = new[] { "--ASPNETCORE_URLS", "http://localhost:9999" };
 
-        Assert.True(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, environment, "ASPNETCORE_URLS"));
+        Assert.True(DashboardRunCommand.ConfigSettingHasValue(unmatchedTokens, environment, KnownAspNetCoreConfigNames.Urls));
     }
 
     [Fact]
@@ -384,7 +385,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     {
         var environment = CreateEnvironment(new Dictionary<string, string?>
         {
-            ["ASPNETCORE_URLS"] = "http://envhost:9999"
+            [KnownAspNetCoreConfigNames.Urls] = "http://envhost:9999"
         });
 
         // No arg in the list — should fall back to the environment variable.
@@ -433,7 +434,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     {
         var environment = CreateEnvironment(new Dictionary<string, string?>
         {
-            ["ASPNETCORE_URLS"] = "http://envhost:9999"
+            [KnownAspNetCoreConfigNames.Urls] = "http://envhost:9999"
         });
 
         var args = new List<string> { "dashboard", "--ASPNETCORE_URLS=http://arghost:5555" };

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -12,6 +12,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Scaffolding;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Hosting;
 using Aspire.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -201,15 +202,15 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var httpsUrls = https["applicationUrl"]!.GetValue<string>();
         Assert.StartsWith("https://localhost:", httpsUrls);
         var httpsEnv = https["environmentVariables"]!.AsObject();
-        Assert.Equal("Development", httpsEnv["ASPNETCORE_ENVIRONMENT"]!.GetValue<string>());
-        Assert.Equal("Development", httpsEnv["DOTNET_ENVIRONMENT"]!.GetValue<string>());
+        Assert.Equal("Development", httpsEnv[KnownAspNetCoreConfigNames.Environment]!.GetValue<string>());
+        Assert.Equal("Development", httpsEnv[KnownAspNetCoreConfigNames.DotNetEnvironment]!.GetValue<string>());
         Assert.StartsWith("https://localhost:", httpsEnv["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]!.GetValue<string>());
         Assert.StartsWith("https://localhost:", httpsEnv["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]!.GetValue<string>());
 
         var http = profiles["http"]!.AsObject();
         Assert.Equal("Project", http["commandName"]!.GetValue<string>());
         var httpEnv = http["environmentVariables"]!.AsObject();
-        Assert.Equal("Development", httpEnv["ASPNETCORE_ENVIRONMENT"]!.GetValue<string>());
+        Assert.Equal("Development", httpEnv[KnownAspNetCoreConfigNames.Environment]!.GetValue<string>());
         Assert.StartsWith("http://localhost:", httpEnv["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]!.GetValue<string>());
         Assert.StartsWith("http://localhost:", httpEnv["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]!.GetValue<string>());
         Assert.Equal("true", httpEnv["ASPIRE_ALLOW_UNSECURED_TRANSPORT"]!.GetValue<string>());

--- a/tests/Aspire.Cli.Tests/ProfileCaptureServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/ProfileCaptureServiceTests.cs
@@ -58,7 +58,7 @@ public class ProfileCaptureServiceTests(ITestOutputHelper outputHelper)
         Assert.Equal(
             [
                 "dashboard",
-                $"--{KnownConfigNames.AspNetCoreUrls}={options.DashboardUrl}",
+                $"--{KnownAspNetCoreConfigNames.Urls}={options.DashboardUrl}",
                 $"--{KnownConfigNames.DashboardOtlpGrpcEndpointUrl}={options.OtlpGrpcUrl}",
                 $"--{KnownConfigNames.DashboardOtlpHttpEndpointUrl}={options.OtlpHttpUrl}",
                 $"--{KnownConfigNames.DashboardUnsecuredAllowAnonymous}=true",

--- a/tests/Aspire.Cli.Tests/Projects/AppHostEnvironmentDefaultsTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostEnvironmentDefaultsTests.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Projects;
+using Aspire.Hosting;
 
 namespace Aspire.Cli.Tests.Projects;
 
 public class AppHostEnvironmentDefaultsTests
 {
-    private const string AspNetCoreEnvironmentVariableName = "ASPNETCORE_ENVIRONMENT";
-
     [Fact]
     public void ApplyEffectiveEnvironment_UsesDefaultWhenNoEnvironmentVariablesAreSet()
     {
@@ -16,8 +15,8 @@ public class AppHostEnvironmentDefaultsTests
 
         AppHostEnvironmentDefaults.ApplyEffectiveEnvironment(env, AppHostEnvironmentDefaults.ProductionEnvironmentName);
 
-        Assert.Equal("Production", env["DOTNET_ENVIRONMENT"]);
-        Assert.False(env.ContainsKey(AspNetCoreEnvironmentVariableName));
+        Assert.Equal("Production", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
     }
 
     [Fact]
@@ -25,14 +24,14 @@ public class AppHostEnvironmentDefaultsTests
     {
         var env = new Dictionary<string, string>
         {
-            [AppHostEnvironmentDefaults.DotNetEnvironmentVariableName] = "Production",
+            [KnownAspNetCoreConfigNames.DotNetEnvironment] = "Production",
             [AppHostEnvironmentDefaults.AspireEnvironmentVariableName] = "Staging"
         };
 
         AppHostEnvironmentDefaults.ApplyEffectiveEnvironment(env, AppHostEnvironmentDefaults.DevelopmentEnvironmentName);
 
-        Assert.Equal("Production", env["DOTNET_ENVIRONMENT"]);
-        Assert.False(env.ContainsKey(AspNetCoreEnvironmentVariableName));
+        Assert.Equal("Production", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
         Assert.Equal("Staging", env["ASPIRE_ENVIRONMENT"]);
     }
 
@@ -41,7 +40,7 @@ public class AppHostEnvironmentDefaultsTests
     {
         var env = new Dictionary<string, string>
         {
-            [AppHostEnvironmentDefaults.DotNetEnvironmentVariableName] = "Production",
+            [KnownAspNetCoreConfigNames.DotNetEnvironment] = "Production",
             [AppHostEnvironmentDefaults.AspireEnvironmentVariableName] = "Development"
         };
 
@@ -50,8 +49,8 @@ public class AppHostEnvironmentDefaultsTests
             AppHostEnvironmentDefaults.DevelopmentEnvironmentName,
             args: ["--environment", "Staging"]);
 
-        Assert.Equal("Staging", env["DOTNET_ENVIRONMENT"]);
-        Assert.False(env.ContainsKey(AspNetCoreEnvironmentVariableName));
+        Assert.Equal("Staging", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
         Assert.Equal("Development", env["ASPIRE_ENVIRONMENT"]);
     }
 
@@ -61,13 +60,13 @@ public class AppHostEnvironmentDefaultsTests
         var env = new Dictionary<string, string>
         {
             [AppHostEnvironmentDefaults.AspireEnvironmentVariableName] = "Testing",
-            [AspNetCoreEnvironmentVariableName] = "Staging"
+            [KnownAspNetCoreConfigNames.Environment] = "Staging"
         };
 
         AppHostEnvironmentDefaults.ApplyEffectiveEnvironment(env, AppHostEnvironmentDefaults.DevelopmentEnvironmentName);
 
-        Assert.Equal("Testing", env["DOTNET_ENVIRONMENT"]);
-        Assert.Equal("Staging", env["ASPNETCORE_ENVIRONMENT"]);
+        Assert.Equal("Testing", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.Equal("Staging", env[KnownAspNetCoreConfigNames.Environment]);
         Assert.Equal("Testing", env["ASPIRE_ENVIRONMENT"]);
     }
 
@@ -85,7 +84,7 @@ public class AppHostEnvironmentDefaultsTests
             AppHostEnvironmentDefaults.ProductionEnvironmentName,
             inherited);
 
-        Assert.Equal("Staging", env["DOTNET_ENVIRONMENT"]);
-        Assert.False(env.ContainsKey(AspNetCoreEnvironmentVariableName));
+        Assert.Equal("Staging", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
@@ -6,6 +6,7 @@ using Aspire.Cli.Layout;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Aspire.Hosting;
 using Aspire.Hosting.Utils;
 using Aspire.Shared;
 using Microsoft.Extensions.DependencyInjection;
@@ -61,9 +62,9 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             env,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("Development", env["DOTNET_ENVIRONMENT"]);
-        Assert.False(env.ContainsKey("ASPNETCORE_ENVIRONMENT"));
-        Assert.Equal("https://localhost:17193;http://localhost:15069", env["ASPNETCORE_URLS"]);
+        Assert.Equal("Development", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
+        Assert.Equal("https://localhost:17193;http://localhost:15069", env[KnownAspNetCoreConfigNames.Urls]);
     }
 
     [Fact]
@@ -77,9 +78,9 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             env,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("Production", env["DOTNET_ENVIRONMENT"]);
-        Assert.False(env.ContainsKey("ASPNETCORE_ENVIRONMENT"));
-        Assert.Equal("https://localhost:17193;http://localhost:15069", env["ASPNETCORE_URLS"]);
+        Assert.Equal("Production", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
+        Assert.Equal("https://localhost:17193;http://localhost:15069", env[KnownAspNetCoreConfigNames.Urls]);
     }
 
     [Fact]
@@ -94,9 +95,9 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             inheritedEnvironmentVariables: new Dictionary<string, string?>(),
             args: ["--environment", "Staging"]);
 
-        Assert.Equal("Staging", env["DOTNET_ENVIRONMENT"]);
-        Assert.False(env.ContainsKey("ASPNETCORE_ENVIRONMENT"));
-        Assert.Equal("https://localhost:17193;http://localhost:15069", env["ASPNETCORE_URLS"]);
+        Assert.Equal("Staging", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
+        Assert.Equal("https://localhost:17193;http://localhost:15069", env[KnownAspNetCoreConfigNames.Urls]);
     }
 
     [Fact]
@@ -126,9 +127,9 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             env,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("Production", env["DOTNET_ENVIRONMENT"]);
-        Assert.False(env.ContainsKey("ASPNETCORE_ENVIRONMENT"));
-        Assert.Equal("https://localhost:19000;http://localhost:15000", env["ASPNETCORE_URLS"]);
+        Assert.Equal("Production", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
+        Assert.Equal("https://localhost:19000;http://localhost:15000", env[KnownAspNetCoreConfigNames.Urls]);
         Assert.Equal("https://localhost:21000", env["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
         Assert.Equal("https://localhost:22000", env["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]);
     }
@@ -147,8 +148,8 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
                 [AppHostEnvironmentDefaults.AspireEnvironmentVariableName] = "Staging"
             });
 
-        Assert.Equal("Staging", env["DOTNET_ENVIRONMENT"]);
-        Assert.False(env.ContainsKey("ASPNETCORE_ENVIRONMENT"));
+        Assert.Equal("Staging", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
     }
 
     [Fact]
@@ -165,9 +166,9 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             Assert.True(noBuild);
             Assert.False(noRestore);
             Assert.False(options.NoLaunchProfile);
-            Assert.Equal("Development", env!["DOTNET_ENVIRONMENT"]);
-            Assert.False(env.ContainsKey("ASPNETCORE_ENVIRONMENT"));
-            Assert.Equal("https://localhost:17193;http://localhost:15069", env["ASPNETCORE_URLS"]);
+            Assert.Equal("Development", env![KnownAspNetCoreConfigNames.DotNetEnvironment]);
+            Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
+            Assert.Equal("https://localhost:17193;http://localhost:15069", env[KnownAspNetCoreConfigNames.Urls]);
             return Task.FromResult(0);
         };
 
@@ -198,8 +199,8 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             Assert.False(noRestore);
             Assert.False(options.NoLaunchProfile);
             Assert.Equal(["--environment", "Staging"], args);
-            Assert.Equal("Staging", env!["DOTNET_ENVIRONMENT"]);
-            Assert.False(env.ContainsKey("ASPNETCORE_ENVIRONMENT"));
+            Assert.Equal("Staging", env![KnownAspNetCoreConfigNames.DotNetEnvironment]);
+            Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
             return Task.FromResult(0);
         };
 
@@ -559,8 +560,8 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
                 args);
             Assert.NotNull(env);
             Assert.Equal("http", env["DOTNET_LAUNCH_PROFILE"]);
-            Assert.Equal("http://localhost:15000", env["ASPNETCORE_URLS"]);
-            Assert.Equal("Development", env["DOTNET_ENVIRONMENT"]);
+            Assert.Equal("http://localhost:15000", env[KnownAspNetCoreConfigNames.Urls]);
+            Assert.Equal("Development", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
             Assert.Equal("context-value", env["CUSTOM_ENV"]);
             return Task.FromResult(123);
         };
@@ -950,7 +951,7 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             Assert.Empty(args);
             Assert.NotNull(env);
             Assert.Equal("flat", env["DOTNET_LAUNCH_PROFILE"]);
-            Assert.Equal("http://localhost:16000", env["ASPNETCORE_URLS"]);
+            Assert.Equal("http://localhost:16000", env[KnownAspNetCoreConfigNames.Urls]);
             Assert.Equal("from-run-json", env["CUSTOM_ENV"]);
             return Task.FromResult(101);
         };
@@ -1012,7 +1013,7 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             Assert.Equal(appHostCommand.FullName, command);
             Assert.NotNull(env);
             Assert.Equal("vb", env["DOTNET_LAUNCH_PROFILE"]);
-            Assert.Equal("http://localhost:17000", env["ASPNETCORE_URLS"]);
+            Assert.Equal("http://localhost:17000", env[KnownAspNetCoreConfigNames.Urls]);
             return Task.FromResult(102);
         };
 
@@ -1307,9 +1308,9 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             Assert.False(noRestore);
             Assert.True(options.NoLaunchProfile);
             Assert.Equal(["--operation", "publish"], args);
-            Assert.Equal("Production", env!["DOTNET_ENVIRONMENT"]);
-            Assert.False(env.ContainsKey("ASPNETCORE_ENVIRONMENT"));
-            Assert.Equal("https://localhost:19000;http://localhost:15000", env["ASPNETCORE_URLS"]);
+            Assert.Equal("Production", env![KnownAspNetCoreConfigNames.DotNetEnvironment]);
+            Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
+            Assert.Equal("https://localhost:19000;http://localhost:15000", env[KnownAspNetCoreConfigNames.Urls]);
             Assert.Equal("https://localhost:21000", env["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
             Assert.Equal("https://localhost:22000", env["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]);
             Assert.False(env.ContainsKey("ASPIRE_ENVIRONMENT"));
@@ -1342,8 +1343,8 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             Assert.False(noRestore);
             Assert.True(options.NoLaunchProfile);
             Assert.Equal(["--operation", "publish", "--environment", "Staging"], args);
-            Assert.Equal("Staging", env!["DOTNET_ENVIRONMENT"]);
-            Assert.False(env.ContainsKey("ASPNETCORE_ENVIRONMENT"));
+            Assert.Equal("Staging", env![KnownAspNetCoreConfigNames.DotNetEnvironment]);
+            Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
             return Task.FromResult(0);
         };
 
@@ -1391,7 +1392,7 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             Assert.False(noRestore);
             Assert.True(options.NoLaunchProfile);
             Assert.Equal(["--operation", "publish"], args);
-            Assert.Equal("Production", env!["DOTNET_ENVIRONMENT"]);
+            Assert.Equal("Production", env![KnownAspNetCoreConfigNames.DotNetEnvironment]);
             Assert.Equal(Path.Combine(bundleRoot.FullName, BundleDiscovery.DcpDirectoryName), env[BundleDiscovery.DcpPathEnvVar]);
             Assert.Equal(
                 Path.Combine(bundleRoot.FullName, BundleDiscovery.ManagedDirectoryName, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
@@ -1437,12 +1438,12 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             env,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("https://myapp.dev.localhost:17050;http://myapp.dev.localhost:15050", env["ASPNETCORE_URLS"]);
+        Assert.Equal("https://myapp.dev.localhost:17050;http://myapp.dev.localhost:15050", env[KnownAspNetCoreConfigNames.Urls]);
         Assert.Equal("https://myapp.dev.localhost:21050", env["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
         Assert.Equal("https://myapp.dev.localhost:22050", env["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]);
         // Run path copies profile env vars verbatim (matches what dotnet does when reading apphost.run.json natively).
-        Assert.Equal("Development", env["DOTNET_ENVIRONMENT"]);
-        Assert.Equal("Development", env["ASPNETCORE_ENVIRONMENT"]);
+        Assert.Equal("Development", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.Equal("Development", env[KnownAspNetCoreConfigNames.Environment]);
     }
 
     [Fact]
@@ -1472,12 +1473,12 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             env,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("https://myapp.dev.localhost:17050;http://myapp.dev.localhost:15050", env["ASPNETCORE_URLS"]);
+        Assert.Equal("https://myapp.dev.localhost:17050;http://myapp.dev.localhost:15050", env[KnownAspNetCoreConfigNames.Urls]);
         Assert.Equal("https://myapp.dev.localhost:21050", env["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
         Assert.Equal("https://myapp.dev.localhost:22050", env["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]);
         // Publish path filters env-name vars from profile, then ApplyEffectiveEnvironment sets DOTNET_ENVIRONMENT=Production.
-        Assert.Equal("Production", env["DOTNET_ENVIRONMENT"]);
-        Assert.False(env.ContainsKey("ASPNETCORE_ENVIRONMENT"));
+        Assert.Equal("Production", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(env.ContainsKey(KnownAspNetCoreConfigNames.Environment));
     }
 
     [Fact]
@@ -1516,7 +1517,7 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             env,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("https://from-run-json:19000", env["ASPNETCORE_URLS"]);
+        Assert.Equal("https://from-run-json:19000", env[KnownAspNetCoreConfigNames.Urls]);
         Assert.Equal("https://from-run-json:21000", env["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
     }
 
@@ -1536,8 +1537,8 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             env,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("https://localhost:17193;http://localhost:15069", env["ASPNETCORE_URLS"]);
-        Assert.Equal("Development", env["DOTNET_ENVIRONMENT"]);
+        Assert.Equal("https://localhost:17193;http://localhost:15069", env[KnownAspNetCoreConfigNames.Urls]);
+        Assert.Equal("Development", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
     }
 
     [Fact]
@@ -1563,7 +1564,7 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             env,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("https://localhost:17193;http://localhost:15069", env["ASPNETCORE_URLS"]);
+        Assert.Equal("https://localhost:17193;http://localhost:15069", env[KnownAspNetCoreConfigNames.Urls]);
         Assert.Equal("https://localhost:21293", env["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
     }
 
@@ -1588,7 +1589,7 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             env,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("https://localhost:17193;http://localhost:15069", env["ASPNETCORE_URLS"]);
+        Assert.Equal("https://localhost:17193;http://localhost:15069", env[KnownAspNetCoreConfigNames.Urls]);
     }
 
     [Fact]
@@ -1603,8 +1604,8 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             env,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("https://localhost:17193;http://localhost:15069", env["ASPNETCORE_URLS"]);
-        Assert.Equal("Development", env["DOTNET_ENVIRONMENT"]);
+        Assert.Equal("https://localhost:17193;http://localhost:15069", env[KnownAspNetCoreConfigNames.Urls]);
+        Assert.Equal("Development", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
     }
 
     [Fact]
@@ -1632,8 +1633,8 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             inheritedEnvironmentVariables: new Dictionary<string, string?>(),
             args: ["--environment", "Staging"]);
 
-        Assert.Equal("Staging", env["DOTNET_ENVIRONMENT"]);
-        Assert.Equal("https://myapp.dev.localhost:17050", env["ASPNETCORE_URLS"]);
+        Assert.Equal("Staging", env[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.Equal("https://myapp.dev.localhost:17050", env[KnownAspNetCoreConfigNames.Urls]);
     }
 
     private FileInfo CreateSingleFileAppHost(bool useCliBundle = false)

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -12,6 +12,7 @@ using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Aspire.Hosting;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -21,8 +22,6 @@ namespace Aspire.Cli.Tests.Projects;
 
 public class GuestAppHostProjectTests : IDisposable
 {
-    private const string AspNetCoreEnvironmentVariableName = "ASPNETCORE_ENVIRONMENT";
-
     private readonly TemporaryWorkspace _workspace;
     private readonly IConfiguration _configuration;
     private readonly ProfilingTelemetry _profilingTelemetry;
@@ -346,8 +345,8 @@ public class GuestAppHostProjectTests : IDisposable
 
         var envVars = project.GetServerEnvironmentVariables(_workspace.WorkspaceRoot);
 
-        Assert.Equal("https://localhost:16319;http://localhost:16320", envVars["ASPNETCORE_URLS"]);
-        Assert.Equal("Development", envVars["ASPNETCORE_ENVIRONMENT"]);
+        Assert.Equal("https://localhost:16319;http://localhost:16320", envVars[KnownAspNetCoreConfigNames.Urls]);
+        Assert.Equal("Development", envVars[KnownAspNetCoreConfigNames.Environment]);
         Assert.Equal("https://localhost:17269", envVars["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
         Assert.Equal("https://localhost:17269", envVars["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]);
         Assert.False(envVars.ContainsKey("ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL"));
@@ -361,8 +360,8 @@ public class GuestAppHostProjectTests : IDisposable
             defaultEnvironment: AppHostEnvironmentDefaults.ProductionEnvironmentName,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("Production", envVars["DOTNET_ENVIRONMENT"]);
-        Assert.False(envVars.ContainsKey("ASPNETCORE_ENVIRONMENT"));
+        Assert.Equal("Production", envVars[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(envVars.ContainsKey(KnownAspNetCoreConfigNames.Environment));
     }
 
     [Fact]
@@ -371,9 +370,9 @@ public class GuestAppHostProjectTests : IDisposable
         var envVars = GuestAppHostProject.GetServerEnvironmentVariables(
             launchProfileEnvironmentVariables: new Dictionary<string, string>
             {
-                ["ASPNETCORE_URLS"] = "https://localhost:16319;http://localhost:16320",
-                ["ASPNETCORE_ENVIRONMENT"] = "Development",
-                ["DOTNET_ENVIRONMENT"] = "Development",
+                [KnownAspNetCoreConfigNames.Urls] = "https://localhost:16319;http://localhost:16320",
+                [KnownAspNetCoreConfigNames.Environment] = "Development",
+                [KnownAspNetCoreConfigNames.DotNetEnvironment] = "Development",
                 ["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"] = "https://localhost:17269",
                 ["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"] = "https://localhost:18269"
             },
@@ -381,9 +380,9 @@ public class GuestAppHostProjectTests : IDisposable
             includeLaunchProfileEnvironmentVariables: false,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("Production", envVars["DOTNET_ENVIRONMENT"]);
-        Assert.False(envVars.ContainsKey("ASPNETCORE_ENVIRONMENT"));
-        Assert.Equal("https://localhost:16319;http://localhost:16320", envVars["ASPNETCORE_URLS"]);
+        Assert.Equal("Production", envVars[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(envVars.ContainsKey(KnownAspNetCoreConfigNames.Environment));
+        Assert.Equal("https://localhost:16319;http://localhost:16320", envVars[KnownAspNetCoreConfigNames.Urls]);
         Assert.Equal("https://localhost:17269", envVars["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
         Assert.Equal("https://localhost:18269", envVars["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]);
         Assert.False(envVars.ContainsKey("ASPIRE_ENVIRONMENT"));
@@ -395,17 +394,17 @@ public class GuestAppHostProjectTests : IDisposable
         var envVars = GuestAppHostProject.GetServerEnvironmentVariables(
             launchProfileEnvironmentVariables: new Dictionary<string, string>
             {
-                ["ASPNETCORE_URLS"] = "https://localhost:16319;http://localhost:16320",
+                [KnownAspNetCoreConfigNames.Urls] = "https://localhost:16319;http://localhost:16320",
                 ["ASPIRE_ENVIRONMENT"] = "Development",
-                ["ASPNETCORE_ENVIRONMENT"] = "Development",
-                ["DOTNET_ENVIRONMENT"] = "Development",
+                [KnownAspNetCoreConfigNames.Environment] = "Development",
+                [KnownAspNetCoreConfigNames.DotNetEnvironment] = "Development",
             },
             defaultEnvironment: AppHostEnvironmentDefaults.ProductionEnvironmentName,
             inheritedEnvironmentVariables: new Dictionary<string, string?>(),
             args: ["--environment", "Staging"]);
 
-        Assert.Equal("Staging", envVars["DOTNET_ENVIRONMENT"]);
-        Assert.Equal("Development", envVars["ASPNETCORE_ENVIRONMENT"]);
+        Assert.Equal("Staging", envVars[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.Equal("Development", envVars[KnownAspNetCoreConfigNames.Environment]);
         Assert.Equal("Development", envVars["ASPIRE_ENVIRONMENT"]);
     }
 
@@ -435,7 +434,7 @@ public class GuestAppHostProjectTests : IDisposable
             new Dictionary<string, string>
             {
                 ["CUSTOM_CONTEXT_VARIABLE"] = "context",
-                ["ASPNETCORE_URLS"] = "http://context"
+                [KnownAspNetCoreConfigNames.Urls] = "http://context"
             },
             new Dictionary<string, string>
             {
@@ -443,10 +442,10 @@ public class GuestAppHostProjectTests : IDisposable
             });
 
         Assert.Equal("context", envVars["CUSTOM_CONTEXT_VARIABLE"]);
-        Assert.Equal("https://localhost:16319;http://localhost:16320", envVars["ASPNETCORE_URLS"]);
+        Assert.Equal("https://localhost:16319;http://localhost:16320", envVars[KnownAspNetCoreConfigNames.Urls]);
         Assert.Equal("Staging", envVars["ASPIRE_ENVIRONMENT"]);
-        Assert.Equal("Staging", envVars["DOTNET_ENVIRONMENT"]);
-        Assert.False(envVars.ContainsKey("ASPNETCORE_ENVIRONMENT"));
+        Assert.Equal("Staging", envVars[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(envVars.ContainsKey(KnownAspNetCoreConfigNames.Environment));
         Assert.Equal("https://localhost:17269", envVars["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
         Assert.Equal("https://localhost:18269", envVars["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]);
         Assert.Equal("/tmp/certs", envVars["SSL_CERT_DIR"]);
@@ -459,10 +458,10 @@ public class GuestAppHostProjectTests : IDisposable
             contextEnvironmentVariables: new Dictionary<string, string>(),
             launchProfileEnvironmentVariables: new Dictionary<string, string>
             {
-                ["ASPNETCORE_URLS"] = "https://localhost:16319;http://localhost:16320",
+                [KnownAspNetCoreConfigNames.Urls] = "https://localhost:16319;http://localhost:16320",
                 ["ASPIRE_ENVIRONMENT"] = "Development",
-                ["ASPNETCORE_ENVIRONMENT"] = "Development",
-                ["DOTNET_ENVIRONMENT"] = "Development",
+                [KnownAspNetCoreConfigNames.Environment] = "Development",
+                [KnownAspNetCoreConfigNames.DotNetEnvironment] = "Development",
                 ["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"] = "https://localhost:17269",
                 ["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"] = "https://localhost:18269"
             },
@@ -470,9 +469,9 @@ public class GuestAppHostProjectTests : IDisposable
             includeLaunchProfileEnvironmentVariables: false,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("Production", envVars["DOTNET_ENVIRONMENT"]);
-        Assert.False(envVars.ContainsKey("ASPNETCORE_ENVIRONMENT"));
-        Assert.Equal("https://localhost:16319;http://localhost:16320", envVars["ASPNETCORE_URLS"]);
+        Assert.Equal("Production", envVars[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(envVars.ContainsKey(KnownAspNetCoreConfigNames.Environment));
+        Assert.Equal("https://localhost:16319;http://localhost:16320", envVars[KnownAspNetCoreConfigNames.Urls]);
         Assert.Equal("https://localhost:17269", envVars["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
         Assert.Equal("https://localhost:18269", envVars["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]);
         Assert.False(envVars.ContainsKey("ASPIRE_ENVIRONMENT"));
@@ -486,15 +485,15 @@ public class GuestAppHostProjectTests : IDisposable
             launchProfileEnvironmentVariables: new Dictionary<string, string>
             {
                 ["ASPIRE_ENVIRONMENT"] = "Development",
-                ["ASPNETCORE_ENVIRONMENT"] = "Development",
-                ["DOTNET_ENVIRONMENT"] = "Development",
+                [KnownAspNetCoreConfigNames.Environment] = "Development",
+                [KnownAspNetCoreConfigNames.DotNetEnvironment] = "Development",
             },
             defaultEnvironment: AppHostEnvironmentDefaults.ProductionEnvironmentName,
             inheritedEnvironmentVariables: new Dictionary<string, string?>(),
             args: ["--environment", "Staging"]);
 
-        Assert.Equal("Staging", envVars["DOTNET_ENVIRONMENT"]);
-        Assert.Equal("Development", envVars["ASPNETCORE_ENVIRONMENT"]);
+        Assert.Equal("Staging", envVars[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.Equal("Development", envVars[KnownAspNetCoreConfigNames.Environment]);
         Assert.Equal("Development", envVars["ASPIRE_ENVIRONMENT"]);
     }
 
@@ -510,8 +509,8 @@ public class GuestAppHostProjectTests : IDisposable
                 [AppHostEnvironmentDefaults.AspireEnvironmentVariableName] = "Staging"
             });
 
-        Assert.Equal("Staging", envVars["DOTNET_ENVIRONMENT"]);
-        Assert.False(envVars.ContainsKey("ASPNETCORE_ENVIRONMENT"));
+        Assert.Equal("Staging", envVars[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(envVars.ContainsKey(KnownAspNetCoreConfigNames.Environment));
     }
 
     [Fact]
@@ -520,14 +519,14 @@ public class GuestAppHostProjectTests : IDisposable
         var envVars = GuestAppHostProject.CreateGuestEnvironmentVariables(
             contextEnvironmentVariables: new Dictionary<string, string>
             {
-                [AppHostEnvironmentDefaults.DotNetEnvironmentVariableName] = "Production",
+                [KnownAspNetCoreConfigNames.DotNetEnvironment] = "Production",
                 [AppHostEnvironmentDefaults.AspireEnvironmentVariableName] = "Staging"
             },
             launchProfileEnvironmentVariables: null,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("Production", envVars["DOTNET_ENVIRONMENT"]);
-        Assert.False(envVars.ContainsKey("ASPNETCORE_ENVIRONMENT"));
+        Assert.Equal("Production", envVars[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.False(envVars.ContainsKey(KnownAspNetCoreConfigNames.Environment));
         Assert.Equal("Staging", envVars["ASPIRE_ENVIRONMENT"]);
     }
 
@@ -538,13 +537,13 @@ public class GuestAppHostProjectTests : IDisposable
             contextEnvironmentVariables: new Dictionary<string, string>
             {
                 [AppHostEnvironmentDefaults.AspireEnvironmentVariableName] = "Testing",
-                [AspNetCoreEnvironmentVariableName] = "Staging"
+                [KnownAspNetCoreConfigNames.Environment] = "Staging"
             },
             launchProfileEnvironmentVariables: null,
             inheritedEnvironmentVariables: new Dictionary<string, string?>());
 
-        Assert.Equal("Testing", envVars["DOTNET_ENVIRONMENT"]);
-        Assert.Equal("Staging", envVars["ASPNETCORE_ENVIRONMENT"]);
+        Assert.Equal("Testing", envVars[KnownAspNetCoreConfigNames.DotNetEnvironment]);
+        Assert.Equal("Staging", envVars[KnownAspNetCoreConfigNames.Environment]);
         Assert.Equal("Testing", envVars["ASPIRE_ENVIRONMENT"]);
     }
 

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -115,7 +115,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         // Assert
         // OTLP endpoints are optional, so only frontend URL is required
         Assert.Collection(app.ValidationFailures,
-            s => Assert.Contains(KnownConfigNames.AspNetCoreUrls, s));
+            s => Assert.Contains(KnownAspNetCoreConfigNames.Urls, s));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/AspireEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/AspireEnvironmentTests.cs
@@ -130,20 +130,20 @@ public class AspireEnvironmentTests
 
         if (dotnetEnvironment is not null)
         {
-            options.StartInfo.Environment["DOTNET_ENVIRONMENT"] = dotnetEnvironment;
+            options.StartInfo.Environment[KnownAspNetCoreConfigNames.DotNetEnvironment] = dotnetEnvironment;
         }
         else
         {
-            options.StartInfo.Environment.Remove("DOTNET_ENVIRONMENT");
+            options.StartInfo.Environment.Remove(KnownAspNetCoreConfigNames.DotNetEnvironment);
         }
 
         if (aspNetCoreEnvironment is not null)
         {
-            options.StartInfo.Environment["ASPNETCORE_ENVIRONMENT"] = aspNetCoreEnvironment;
+            options.StartInfo.Environment[KnownAspNetCoreConfigNames.Environment] = aspNetCoreEnvironment;
         }
         else
         {
-            options.StartInfo.Environment.Remove("ASPNETCORE_ENVIRONMENT");
+            options.StartInfo.Environment.Remove(KnownAspNetCoreConfigNames.Environment);
         }
 
         return options;

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -1475,7 +1475,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create(
             options => options.DisableDashboard = false,
             outputHelper,
-            $"{KnownConfigNames.AspNetCoreUrls}=http://localhost",
+            $"{KnownAspNetCoreConfigNames.Urls}=http://localhost",
             $"{KnownConfigNames.DashboardOtlpGrpcEndpointUrl}=http://localhost",
             $"{KnownConfigNames.DashboardUnsecuredAllowAnonymous}=true",
             $"{KnownConfigNames.ProfilingEnabled}=true");

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardOptionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardOptionsTests.cs
@@ -20,8 +20,8 @@ public class DashboardOptionsTests
         var builder = DistributedApplication.CreateBuilder();
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            { "ASPNETCORE_ENVIRONMENT", "Development" },
-            { KnownConfigNames.AspNetCoreUrls, "https://localhost:8080" },
+            { KnownAspNetCoreConfigNames.Environment, "Development" },
+            { KnownAspNetCoreConfigNames.Urls, "https://localhost:8080" },
             { KnownConfigNames.DashboardOtlpGrpcEndpointUrl, otlpEndpoint },
             { KnownConfigNames.DashboardOtlpHttpEndpointUrl, null }
         });
@@ -38,7 +38,7 @@ public class DashboardOptionsTests
         var builder = DistributedApplication.CreateBuilder();
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            { KnownConfigNames.AspNetCoreUrls, "https://localhost:8080" },
+            { KnownAspNetCoreConfigNames.Urls, "https://localhost:8080" },
             { KnownConfigNames.DashboardOtlpGrpcEndpointUrl, null },
             { KnownConfigNames.DashboardOtlpHttpEndpointUrl, "https://localhost:4318" }
         });
@@ -62,8 +62,8 @@ public class DashboardOptionsTests
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             { "ASPIRE_DASHBOARD_TELEMETRY_OPTOUT", configurationValue },
-            { "ASPNETCORE_ENVIRONMENT", "Development" },
-            { KnownConfigNames.AspNetCoreUrls, "http://localhost:8080" },
+            { KnownAspNetCoreConfigNames.Environment, "Development" },
+            { KnownAspNetCoreConfigNames.Urls, "http://localhost:8080" },
             { KnownConfigNames.DashboardOtlpGrpcEndpointUrl, "http://localhost:4317" }
         });
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -98,7 +98,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            ["ASPNETCORE_URLS"] = "http://localhost",
+            [KnownAspNetCoreConfigNames.Urls] = "http://localhost",
             [dashboardOtlpGrpcEndpointUrlKey] = "http://localhost"
         });
 
@@ -138,12 +138,12 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
             },
             e =>
             {
-                Assert.Equal("ASPNETCORE_ENVIRONMENT", e.Key);
+                Assert.Equal(KnownAspNetCoreConfigNames.Environment, e.Key);
                 Assert.Equal("Production", e.Value);
             },
             e =>
             {
-                Assert.Equal(KnownConfigNames.AspNetCoreUrls, e.Key);
+                Assert.Equal(KnownAspNetCoreConfigNames.Urls, e.Key);
                 Assert.Equal("http://localhost:5003", e.Value);
             },
             e =>
@@ -192,7 +192,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [KnownConfigNames.AspNetCoreUrls] = "https://localhost:17131;http://localhost:15000",
+            [KnownAspNetCoreConfigNames.Urls] = "https://localhost:17131;http://localhost:15000",
             [dashboardOtlpGrpcEndpointUrlKey] = string.Empty
         });
 
@@ -263,7 +263,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         var config = new Dictionary<string, string?>
         {
-            [KnownConfigNames.AspNetCoreUrls] = dashboardUrls,
+            [KnownAspNetCoreConfigNames.Urls] = dashboardUrls,
         };
 
         if (allowUnsecuredTransport is not null)
@@ -363,7 +363,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [KnownConfigNames.AspNetCoreUrls] = "http://localhost",
+            [KnownAspNetCoreConfigNames.Urls] = "http://localhost",
             [dashboardOtlpGrpcEndpointUrlKey] = "http://localhost",
             ["AppHost:BrowserToken"] = "TestBrowserToken!",
             ["AppHost:OtlpApiKey"] = "TestOtlpApiKey!"
@@ -405,7 +405,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [KnownConfigNames.AspNetCoreUrls] = "http://localhost",
+            [KnownAspNetCoreConfigNames.Urls] = "http://localhost",
             [dashboardOtlpGrpcEndpointUrlKey] = "http://localhost"
         });
 
@@ -441,7 +441,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [KnownConfigNames.AspNetCoreUrls] = "http://localhost",
+            [KnownAspNetCoreConfigNames.Urls] = "http://localhost",
             [dashboardOtlpGrpcEndpointUrlKey] = "http://localhost"
         });
 
@@ -478,7 +478,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [KnownConfigNames.AspNetCoreUrls] = "http://localhost",
+            [KnownAspNetCoreConfigNames.Urls] = "http://localhost",
             [otlpHttpEndpointUrlKey] = "http://localhost",
             [corsAllowedOriginsKey] = explicitCorsAllowedOrigins
         });
@@ -573,7 +573,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [KnownConfigNames.AspNetCoreUrls] = "http://localhost",
+            [KnownAspNetCoreConfigNames.Urls] = "http://localhost",
             [otlpGrpcEndpointUrlKey] = "http://localhost",
             [corsAllowedOriginsKey] = explicitCorsAllowedOrigins
         });
@@ -607,7 +607,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [KnownConfigNames.AspNetCoreUrls] = "https://localhost",
+            [KnownAspNetCoreConfigNames.Urls] = "https://localhost",
             [KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "http://localhost"
         });
 
@@ -801,7 +801,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         var config = new Dictionary<string, string?>
         {
-            [KnownConfigNames.AspNetCoreUrls] = "http://localhost;https://localhost",
+            [KnownAspNetCoreConfigNames.Urls] = "http://localhost;https://localhost",
             [KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "http://localhost"
         };
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/TransportOptionsValidatorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/TransportOptionsValidatorTests.cs
@@ -18,7 +18,7 @@ public class TransportOptionsValidatorTests
         options.AllowUnsecureTransport = false;
 
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "http://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "http://localhost:1234";
 
         var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
         var result = validator.Validate(null, options);
@@ -38,7 +38,7 @@ public class TransportOptionsValidatorTests
         options.AllowUnsecureTransport = false;
 
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "http://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "http://localhost:1234";
 
         var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
         var result = validator.Validate(null, options);
@@ -56,7 +56,7 @@ public class TransportOptionsValidatorTests
         var options = new TransportOptions();
 
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "http://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "http://localhost:1234";
 
         var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
         var result = validator.Validate(null, options);
@@ -74,7 +74,7 @@ public class TransportOptionsValidatorTests
         var options = new TransportOptions();
 
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "http://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "http://localhost:1234";
 
         var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
         var result = validator.Validate(null, options);
@@ -91,7 +91,7 @@ public class TransportOptionsValidatorTests
 
         var invalidUrl = "...invalid...url...";
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = invalidUrl;
+        config[KnownAspNetCoreConfigNames.Urls] = invalidUrl;
 
         var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
         var result = validator.Validate(null, options);
@@ -126,7 +126,7 @@ public class TransportOptionsValidatorTests
         options.AllowUnsecureTransport = false;
 
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = string.Empty;
+        config[KnownAspNetCoreConfigNames.Urls] = string.Empty;
 
         var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
         var result = validator.Validate(null, options);
@@ -144,7 +144,7 @@ public class TransportOptionsValidatorTests
         options.AllowUnsecureTransport = false;
 
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "https://localhost:1234";
         config[resourceServiceEndpointUrlKey] = string.Empty;
         config[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "https://localhost:1236";
 
@@ -164,7 +164,7 @@ public class TransportOptionsValidatorTests
         options.AllowUnsecureTransport = false;
 
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "https://localhost:1234";
         config[KnownConfigNames.ResourceServiceEndpointUrl] = "https://localhost:1235";
         config[dashboardOtlpGrpcEndpointUrlKey] = string.Empty;
 
@@ -185,7 +185,7 @@ public class TransportOptionsValidatorTests
 
         var invalidUrl = "...invalid...url...";
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "https://localhost:1234";
         config[resourceServiceEndpointUrlKey] = invalidUrl;
         config[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "https://localhost:1236";
 
@@ -212,7 +212,7 @@ public class TransportOptionsValidatorTests
 
         var invalidUrl = "...invalid...url...";
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "https://localhost:1234";
         config[KnownConfigNames.ResourceServiceEndpointUrl] = "https://localhost:1235";
         config[otlpEndpointConfigName] = invalidUrl;
 
@@ -236,7 +236,7 @@ public class TransportOptionsValidatorTests
         options.AllowUnsecureTransport = false;
 
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "https://localhost:1234";
         config[KnownConfigNames.ResourceServiceEndpointUrl] = "https://localhost:1235";
         config[otlpEndpointConfigName] = "http://localhost:1236";
 
@@ -260,7 +260,7 @@ public class TransportOptionsValidatorTests
         options.AllowUnsecureTransport = false;
 
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "https://localhost:1234";
         config[resourceServiceEndpointUrlKey] = "http://localhost:1235";
         config[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "https://localhost:1236";
 
@@ -282,7 +282,7 @@ public class TransportOptionsValidatorTests
         options.AllowUnsecureTransport = true;
 
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "http://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "http://localhost:1234";
 
         var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
         var result = validator.Validate(null, options);
@@ -298,7 +298,7 @@ public class TransportOptionsValidatorTests
         options.AllowUnsecureTransport = true;
 
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "https://localhost:1234";
 
         var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
         var result = validator.Validate(null, options);
@@ -318,7 +318,7 @@ public class TransportOptionsValidatorTests
         options.AllowUnsecureTransport = false;
 
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "https://localhost:1234";
         config[dashboardOtlpHttpEndpointUrlKey] = "https://localhost:1235";
         config[resourceServiceEndpointUrlKey] = "https://localhost:1236";
 
@@ -338,7 +338,7 @@ public class TransportOptionsValidatorTests
         // This is a valid Kestrel binding address but fails Uri.TryCreate validation
         var bindingAddress = "https://0:0:0:0:17008";
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = bindingAddress;
+        config[KnownAspNetCoreConfigNames.Urls] = bindingAddress;
         config[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "https://localhost:1236";
         config[KnownConfigNames.ResourceServiceEndpointUrl] = "https://localhost:1237";
 
@@ -362,7 +362,7 @@ public class TransportOptionsValidatorTests
         // This is a valid Kestrel binding address but fails Uri.TryCreate validation
         var grpcBindingAddress = "https://0:0:0:0:18001";
         var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
-        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownAspNetCoreConfigNames.Urls] = "https://localhost:1234";
         config[otlpEndpointConfigName] = grpcBindingAddress;
         config[KnownConfigNames.ResourceServiceEndpointUrl] = "https://localhost:1237";
 

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1737,7 +1737,7 @@ public class DcpExecutorTests
             Assert.Contains("""portForServing "ServiceA-NoPortNoTargetPort" """, envVarVal);
 
             // ASPNETCORE_URLS should not include dontinjectme, as it was excluded using WithEndpointsInEnvironment
-            var aspnetCoreUrls = dcpExe.Spec.Env?.Single(v => v.Name == "ASPNETCORE_URLS").Value;
+            var aspnetCoreUrls = dcpExe.Spec.Env?.Single(v => v.Name == KnownAspNetCoreConfigNames.Urls).Value;
             Assert.Equal("http://localhost:{{- portForServing \"ServiceA-http\" -}};http://localhost:{{- portForServing \"ServiceA-hp1\" -}}", aspnetCoreUrls);
         }
     }
@@ -1810,7 +1810,7 @@ public class DcpExecutorTests
         Assert.Equal(desiredPort, svc.Status?.EffectivePort);
         Assert.Equal(desiredPort, spAnnList.Single(ann => ann.ServiceName == "ServiceA").Port);
 
-        var aspnetCoreUrls = dcpExe.Spec.Env?.Single(v => v.Name == "ASPNETCORE_URLS").Value;
+        var aspnetCoreUrls = dcpExe.Spec.Env?.Single(v => v.Name == KnownAspNetCoreConfigNames.Urls).Value;
         Assert.Equal($"http://localhost:{desiredPort}", aspnetCoreUrls);
     }
 
@@ -1847,7 +1847,7 @@ public class DcpExecutorTests
         Assert.Equal(desiredPort, svc.Status?.EffectivePort);
         Assert.Equal(desiredPort, spAnnList.Single(ann => ann.ServiceName == "ServiceA").Port);
 
-        var aspnetCoreUrls = dcpExe.Spec.Env?.Single(v => v.Name == "ASPNETCORE_URLS").Value;
+        var aspnetCoreUrls = dcpExe.Spec.Env?.Single(v => v.Name == KnownAspNetCoreConfigNames.Urls).Value;
         Assert.Equal($"http://localhost:{desiredPort}", aspnetCoreUrls);
     }
 
@@ -1887,7 +1887,7 @@ public class DcpExecutorTests
         Assert.NotEqual(desiredPort, svc.Status?.EffectivePort);
         Assert.Null(spAnnList.Single(ann => ann.ServiceName == "ServiceA").Port);
 
-        var aspnetCoreUrls = dcpExe.Spec.Env?.Single(v => v.Name == "ASPNETCORE_URLS").Value;
+        var aspnetCoreUrls = dcpExe.Spec.Env?.Single(v => v.Name == KnownAspNetCoreConfigNames.Urls).Value;
         Assert.Contains("""portForServing "ServiceA" """, aspnetCoreUrls);
     }
 

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpHostNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpHostNotificationTests.cs
@@ -577,8 +577,8 @@ public sealed class DcpHostNotificationTests
         {
             ["aspnetcore_urls"] = "http://localhost:5000",
             ["DOTNET_LAUNCH_PROFILE"] = "MyProfile",
-            ["ASPNETCORE_ENVIRONMENT"] = "Development",
-            ["DOTNET_ENVIRONMENT"] = "Development",
+            [KnownAspNetCoreConfigNames.Environment] = "Development",
+            [KnownAspNetCoreConfigNames.DotNetEnvironment] = "Development",
             ["aspire_loglevel"] = "Debug",
         };
 
@@ -607,8 +607,8 @@ public sealed class DcpHostNotificationTests
             [
                 "aspnetcore_urls",
                 "DOTNET_LAUNCH_PROFILE",
-                "ASPNETCORE_ENVIRONMENT",
-                "DOTNET_ENVIRONMENT",
+                KnownAspNetCoreConfigNames.Environment,
+                KnownAspNetCoreConfigNames.DotNetEnvironment,
                 "aspire_loglevel",
             ];
 

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -1338,7 +1338,7 @@ public class DistributedApplicationTests
     {
         const string testName = "dashboard-urls-display";
         var args = new string[] {
-            $"{KnownConfigNames.AspNetCoreUrls}=https://localhost:0;http://localhost:0",
+            $"{KnownAspNetCoreConfigNames.Urls}=https://localhost:0;http://localhost:0",
             $"{KnownConfigNames.DashboardOtlpGrpcEndpointUrl}=http://localhost:0"
         };
         using var testProgram = CreateTestProgram(testName, args: args, disableDashboard: false);
@@ -1369,7 +1369,7 @@ public class DistributedApplicationTests
         const string testName = "dashboard-auth-config";
         var browserToken = "ThisIsATestToken";
         var args = new string[] {
-            $"{KnownConfigNames.AspNetCoreUrls}=http://localhost:0",
+            $"{KnownAspNetCoreConfigNames.Urls}=http://localhost:0",
             $"{KnownConfigNames.DashboardOtlpGrpcEndpointUrl}=http://localhost:0",
             $"{tokenEnvVarName}={browserToken}"
         };
@@ -1406,7 +1406,7 @@ public class DistributedApplicationTests
     {
         const string testName = "dashboard-allow-anonymous";
         var args = new string[] {
-            $"{KnownConfigNames.AspNetCoreUrls}=http://localhost:0",
+            $"{KnownAspNetCoreConfigNames.Urls}=http://localhost:0",
             $"{KnownConfigNames.DashboardOtlpGrpcEndpointUrl}=http://localhost:0",
             $"{KnownConfigNames.DashboardUnsecuredAllowAnonymous}=true"
         };

--- a/tests/Aspire.Hosting.Tests/KestrelConfigTests.cs
+++ b/tests/Aspire.Hosting.Tests/KestrelConfigTests.cs
@@ -41,7 +41,7 @@ public class KestrelConfigTests
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
         // When using Kestrel, we should not be setting ASPNETCORE_URLS at all
-        Assert.False(config.ContainsKey("ASPNETCORE_URLS"));
+        Assert.False(config.ContainsKey(KnownAspNetCoreConfigNames.Urls));
 
         // Instead, we should be setting the Kestrel override
         Assert.Equal("http://*:port_http", config["Kestrel__Endpoints__http__Url"]);
@@ -79,7 +79,7 @@ public class KestrelConfigTests
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
         // We're ignoring Kestrel, so we should be setting ASPNETCORE_URLS
-        Assert.Equal("http://localhost:port_http;http://localhost:port_ExplicitHttp", config["ASPNETCORE_URLS"]);
+        Assert.Equal("http://localhost:port_http;http://localhost:port_ExplicitHttp", config[KnownAspNetCoreConfigNames.Urls]);
 
         // And we should not be setting the Kestrel override
         Assert.False(config.ContainsKey("Kestrel__Endpoints__http__Url"));

--- a/tests/Aspire.Hosting.Tests/ProjectResourceBuilderExtensionTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceBuilderExtensionTests.cs
@@ -45,9 +45,9 @@ public class ProjectResourceBuilderExtensionTests
         await new HttpsCertificateExecutionConfigurationGatherer(CreateHttpsCertificateConfigurationContextFactory())
             .GatherAsync(context, resource, NullLogger.Instance, builder.ExecutionContext);
 
-        var certificatePath = Assert.IsAssignableFrom<IValueProvider>(context.EnvironmentVariables["Kestrel__Certificates__Default__Path"]);
+        var certificatePath = Assert.IsAssignableFrom<IValueProvider>(context.EnvironmentVariables[KnownAspNetCoreConfigNames.KestrelCertificatesDefaultPath]);
         Assert.Equal("/etc/ssl/certs/server.pfx", await certificatePath.GetValueAsync());
-        Assert.Same(password.Resource, context.EnvironmentVariables["Kestrel__Certificates__Default__Password"]);
+        Assert.Same(password.Resource, context.EnvironmentVariables[KnownAspNetCoreConfigNames.KestrelCertificatesDefaultPassword]);
 
         var metadata = context.AdditionalConfigurationData.OfType<HttpsCertificateExecutionConfigurationData>().Single();
         Assert.False(metadata.IsKeyPathReferenced);
@@ -63,7 +63,7 @@ public class ProjectResourceBuilderExtensionTests
 
         var resource = builder.AddProject<TestProject>("test", options => options.ExcludeLaunchProfile = true)
             .WithHttpsEndpoint()
-            .WithEnvironment("Kestrel__Certificates__Default__Password", "stale-password")
+            .WithEnvironment(KnownAspNetCoreConfigNames.KestrelCertificatesDefaultPassword, "stale-password")
             .WithHttpsCertificate(cert)
             .Resource;
 
@@ -75,9 +75,9 @@ public class ProjectResourceBuilderExtensionTests
         await new HttpsCertificateExecutionConfigurationGatherer(CreateHttpsCertificateConfigurationContextFactory())
             .GatherAsync(context, resource, NullLogger.Instance, builder.ExecutionContext);
 
-        var certificatePath = Assert.IsAssignableFrom<IValueProvider>(context.EnvironmentVariables["Kestrel__Certificates__Default__Path"]);
+        var certificatePath = Assert.IsAssignableFrom<IValueProvider>(context.EnvironmentVariables[KnownAspNetCoreConfigNames.KestrelCertificatesDefaultPath]);
         Assert.Equal("/etc/ssl/certs/server.pfx", await certificatePath.GetValueAsync());
-        Assert.DoesNotContain("Kestrel__Certificates__Default__Password", context.EnvironmentVariables.Keys);
+        Assert.DoesNotContain(KnownAspNetCoreConfigNames.KestrelCertificatesDefaultPassword, context.EnvironmentVariables.Keys);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ProjectResourceBuilderExtensionTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceBuilderExtensionTests.cs
@@ -2,8 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREPERSISTENCE001 // Resource lifetime APIs are experimental.
+#pragma warning disable ASPIRECERTIFICATES001
 
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Tests;
 
@@ -20,6 +24,105 @@ public class ProjectResourceBuilderExtensionTests
 
         var annotation = project.Resource.Annotations.OfType<PersistenceAnnotation>().Single();
         Assert.Equal(PersistenceMode.Persistent, annotation.Mode);
+    }
+
+    [Fact]
+    public async Task WithProjectDefaultsAddsHttpsCertificateConfigurationForTlsEndpoints()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Configuration["Parameters:password"] = "test-password";
+        var cert = CreateTestCertificateWithPrivateKey();
+        var password = builder.AddParameter("password", secret: true);
+
+        var resource = builder.AddProject<TestProject>("test", options => options.ExcludeLaunchProfile = true)
+            .WithHttpsEndpoint()
+            .WithHttpsCertificate(cert, password)
+            .Resource;
+
+        await builder.BuildAsync();
+
+        var context = new ExecutionConfigurationGathererContext();
+        await new HttpsCertificateExecutionConfigurationGatherer(CreateHttpsCertificateConfigurationContextFactory())
+            .GatherAsync(context, resource, NullLogger.Instance, builder.ExecutionContext);
+
+        var certificatePath = Assert.IsAssignableFrom<IValueProvider>(context.EnvironmentVariables["Kestrel__Certificates__Default__Path"]);
+        Assert.Equal("/etc/ssl/certs/server.pfx", await certificatePath.GetValueAsync());
+        Assert.Same(password.Resource, context.EnvironmentVariables["Kestrel__Certificates__Default__Password"]);
+
+        var metadata = context.AdditionalConfigurationData.OfType<HttpsCertificateExecutionConfigurationData>().Single();
+        Assert.False(metadata.IsKeyPathReferenced);
+        Assert.False(metadata.IsCertificateWithKeyPathReferenced);
+        Assert.True(metadata.IsPfxPathReferenced);
+    }
+
+    [Fact]
+    public async Task WithProjectDefaultsRemovesStaleKestrelCertificatePassword()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var cert = CreateTestCertificateWithPrivateKey();
+
+        var resource = builder.AddProject<TestProject>("test", options => options.ExcludeLaunchProfile = true)
+            .WithHttpsEndpoint()
+            .WithEnvironment("Kestrel__Certificates__Default__Password", "stale-password")
+            .WithHttpsCertificate(cert)
+            .Resource;
+
+        await builder.BuildAsync();
+
+        var context = new ExecutionConfigurationGathererContext();
+        await new EnvironmentVariablesExecutionConfigurationGatherer()
+            .GatherAsync(context, resource, NullLogger.Instance, builder.ExecutionContext);
+        await new HttpsCertificateExecutionConfigurationGatherer(CreateHttpsCertificateConfigurationContextFactory())
+            .GatherAsync(context, resource, NullLogger.Instance, builder.ExecutionContext);
+
+        var certificatePath = Assert.IsAssignableFrom<IValueProvider>(context.EnvironmentVariables["Kestrel__Certificates__Default__Path"]);
+        Assert.Equal("/etc/ssl/certs/server.pfx", await certificatePath.GetValueAsync());
+        Assert.DoesNotContain("Kestrel__Certificates__Default__Password", context.EnvironmentVariables.Keys);
+    }
+
+    [Fact]
+    public async Task WithProjectDefaultsDoesNotAddHttpsCertificateConfigurationWithoutTlsEndpoints()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var cert = CreateTestCertificateWithPrivateKey();
+
+        var resource = builder.AddProject<TestProject>("test", options => options.ExcludeLaunchProfile = true)
+            .WithHttpsCertificate(cert)
+            .Resource;
+
+        await builder.BuildAsync();
+
+        var context = new ExecutionConfigurationGathererContext();
+        await new HttpsCertificateExecutionConfigurationGatherer(CreateHttpsCertificateConfigurationContextFactory())
+            .GatherAsync(context, resource, NullLogger.Instance, builder.ExecutionContext);
+
+        Assert.Empty(context.EnvironmentVariables);
+
+        var metadata = context.AdditionalConfigurationData.OfType<HttpsCertificateExecutionConfigurationData>().Single();
+        Assert.False(metadata.IsPfxPathReferenced);
+    }
+
+    private static X509Certificate2 CreateTestCertificateWithPrivateKey()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            new X500DistinguishedName("CN=test"),
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        return request.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(1));
+    }
+
+    private static Func<X509Certificate2, HttpsCertificateExecutionConfigurationContext> CreateHttpsCertificateConfigurationContextFactory()
+    {
+        return cert => new HttpsCertificateExecutionConfigurationContext
+        {
+            CertificatePath = ReferenceExpression.Create($"/etc/ssl/certs/server.crt"),
+            KeyPath = ReferenceExpression.Create($"/etc/ssl/private/server.key"),
+            CertificateWithKeyPath = ReferenceExpression.Create($"/etc/ssl/certs/server.pem"),
+            PfxPath = ReferenceExpression.Create($"/etc/ssl/certs/server.pfx")
+        };
     }
 
     private sealed class TestProject : IProjectMetadata

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -373,8 +373,8 @@ public class ProjectResourceTests
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource, DistributedApplicationOperation.Publish).DefaultTimeout();
 
-        Assert.False(config.ContainsKey("ASPNETCORE_URLS"));
-        Assert.False(config.ContainsKey("ASPNETCORE_HTTPS_PORT"));
+        Assert.False(config.ContainsKey(KnownAspNetCoreConfigNames.Urls));
+        Assert.False(config.ContainsKey(KnownAspNetCoreConfigNames.HttpsPort));
     }
 
     [Fact]
@@ -416,8 +416,8 @@ public class ProjectResourceTests
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.Equal("http://localhost:p0;https://localhost:p1", config["ASPNETCORE_URLS"]);
-        Assert.Equal("5001", config["ASPNETCORE_HTTPS_PORT"]);
+        Assert.Equal("http://localhost:p0;https://localhost:p1", config[KnownAspNetCoreConfigNames.Urls]);
+        Assert.Equal("5001", config[KnownAspNetCoreConfigNames.HttpsPort]);
         Assert.Equal("p2", config["SOME_ENV"]);
     }
 
@@ -459,8 +459,8 @@ public class ProjectResourceTests
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.Equal("http://localhost:p0;https://localhost:p1", config["ASPNETCORE_URLS"]);
-        Assert.Equal("5001", config["ASPNETCORE_HTTPS_PORT"]);
+        Assert.Equal("http://localhost:p0;https://localhost:p1", config[KnownAspNetCoreConfigNames.Urls]);
+        Assert.Equal("5001", config[KnownAspNetCoreConfigNames.HttpsPort]);
         Assert.Equal("p2", config["SOME_ENV"]);
     }
 
@@ -481,8 +481,8 @@ public class ProjectResourceTests
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.False(config.ContainsKey("ASPNETCORE_URLS"));
-        Assert.False(config.ContainsKey("ASPNETCORE_HTTPS_PORT"));
+        Assert.False(config.ContainsKey(KnownAspNetCoreConfigNames.Urls));
+        Assert.False(config.ContainsKey(KnownAspNetCoreConfigNames.HttpsPort));
     }
 
     [Fact]
@@ -506,8 +506,8 @@ public class ProjectResourceTests
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.Equal("http://localhost:p0", config["ASPNETCORE_URLS"]);
-        Assert.False(config.ContainsKey("ASPNETCORE_HTTPS_PORT"));
+        Assert.Equal("http://localhost:p0", config[KnownAspNetCoreConfigNames.Urls]);
+        Assert.False(config.ContainsKey(KnownAspNetCoreConfigNames.HttpsPort));
     }
 
     [Fact]
@@ -533,10 +533,10 @@ public class ProjectResourceTests
         var resource = Assert.Single(projectResources);
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.Equal("https://localhost:p2;http://localhost:p0;http://localhost:p1;https://localhost:p3;https://localhost:p4", config["ASPNETCORE_URLS"]);
+        Assert.Equal("https://localhost:p2;http://localhost:p0;http://localhost:p1;https://localhost:p3;https://localhost:p4", config[KnownAspNetCoreConfigNames.Urls]);
 
         // The first https port is the one that should be used for ASPNETCORE_HTTPS_PORT
-        Assert.Equal("7144", config["ASPNETCORE_HTTPS_PORT"]);
+        Assert.Equal("7144", config[KnownAspNetCoreConfigNames.HttpsPort]);
     }
 
     [Fact]
@@ -732,14 +732,14 @@ public class ProjectResourceTests
         if (isProxied)
         {
             // When the end point is proxied, the host should be localhost and the port should match the targetPortExpression
-            Assert.Equal("http://*:p0;https://*:p1", config["ASPNETCORE_URLS"]);
+            Assert.Equal("http://*:p0;https://*:p1", config[KnownAspNetCoreConfigNames.Urls]);
         }
         else
         {
-            Assert.Equal($"http://*:{http.TargetPort};https://*:{https.TargetPort}", config["ASPNETCORE_URLS"]);
+            Assert.Equal($"http://*:{http.TargetPort};https://*:{https.TargetPort}", config[KnownAspNetCoreConfigNames.Urls]);
         }
 
-        Assert.Equal(https.Port.ToString(), config["ASPNETCORE_HTTPS_PORT"]);
+        Assert.Equal(https.Port.ToString(), config[KnownAspNetCoreConfigNames.HttpsPort]);
     }
 
     [Fact]
@@ -1041,7 +1041,7 @@ public class ProjectResourceTests
                     ApplicationUrl = "http://localhost:5031",
                     EnvironmentVariables = new()
                     {
-                        ["ASPNETCORE_ENVIRONMENT"] = "Development"
+                        [KnownAspNetCoreConfigNames.Environment] = "Development"
                     }
                 }
             };
@@ -1062,7 +1062,7 @@ public class ProjectResourceTests
                     ApplicationUrl = "https://localhost:7144;http://localhost:5193;http://localhost:5194;https://localhost:7145;https://localhost:7146",
                     EnvironmentVariables = new()
                     {
-                        ["ASPNETCORE_ENVIRONMENT"] = "Development"
+                        [KnownAspNetCoreConfigNames.Environment] = "Development"
                     }
                 }
             };
@@ -1083,7 +1083,7 @@ public class ProjectResourceTests
                     ApplicationUrl = "http://*:5031;https://*:5033",
                     EnvironmentVariables = new()
                     {
-                        ["ASPNETCORE_ENVIRONMENT"] = "Development"
+                        [KnownAspNetCoreConfigNames.Environment] = "Development"
                     }
                 }
             };


### PR DESCRIPTION
## Description

ASP.NET project resources can now use Aspire HTTPS certificate configuration without each project having to provide its own Kestrel mapping. When a project has a TLS-enabled endpoint and an HTTPS certificate is available, the project defaults map the generated PFX path and optional password to Kestrel's default certificate environment variables.

If no certificate password is present, the default project setup removes any stale `Kestrel__Certificates__Default__Password` value that may have been configured earlier, so Kestrel does not try to load the generated PFX with the wrong password.

### User-facing usage

Existing certificate APIs can be used with project resources:

```csharp
var certificate = new X509Certificate2("path/to/certificate.pfx", "password");
builder.AddProject<Projects.ApiService>("api")
    .WithHttpsEndpoint()
    .WithHttpsCertificate(certificate);
```

The project defaults apply the corresponding Kestrel certificate environment variables for TLS endpoints.

Validation:

```bash
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.ProjectResourceBuilderExtensionTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No