### PR TITLE
Detach Unix start process from launcher group

### DIFF
--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -320,7 +320,7 @@ internal sealed class AppHostLauncher(
         return environment;
     }
 
-    private record LaunchResult(Process? ChildProcess, IAppHostAuxiliaryBackchannel? Backchannel, DashboardUrlsState? DashboardUrls, bool ChildExitedEarly, int ChildExitCode, DateTimeOffset? ChildStartedAt = null);
+    private record LaunchResult(IDetachedProcess? ChildProcess, IAppHostAuxiliaryBackchannel? Backchannel, DashboardUrlsState? DashboardUrls, bool ChildExitedEarly, int ChildExitCode, DateTimeOffset? ChildStartedAt = null);
 
     private async Task<LaunchResult> LaunchAndWaitForBackchannelAsync(
         string executablePath,
@@ -331,7 +331,7 @@ internal sealed class AppHostLauncher(
         Action<string> updateStatus,
         CancellationToken cancellationToken)
     {
-        Process childProcess;
+        IDetachedProcess childProcess;
 
         using (var spawnActivity = profilingTelemetry.StartDetachedSpawnChild(executablePath, childArgs, "run"))
         {
@@ -492,7 +492,7 @@ internal sealed class AppHostLauncher(
         return new LaunchResult(childProcess, null, dashboardUrls, false, 0, childStartedAt);
     }
 
-    private Task RequestGracefulShutdownThenForceKillAsync(Process childProcess, DateTimeOffset childStartedAt)
+    private Task RequestGracefulShutdownThenForceKillAsync(IDetachedProcess childProcess, DateTimeOffset childStartedAt)
     {
         return processShutdownService.StopProcessTreeAsync(
             childProcess.Id,
@@ -501,7 +501,7 @@ internal sealed class AppHostLauncher(
             CancellationToken.None);
     }
 
-    private LaunchResult CreateChildExitedLaunchResult(Process childProcess, ProfilingTelemetry.ActivityScope waitForBackchannelActivity, DateTimeOffset childStartedAt)
+    private LaunchResult CreateChildExitedLaunchResult(IDetachedProcess childProcess, ProfilingTelemetry.ActivityScope waitForBackchannelActivity, DateTimeOffset childStartedAt)
     {
         var exitCode = childProcess.ExitCode;
         waitForBackchannelActivity.SetProcessExitCode(exitCode);

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Unix.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Unix.cs
@@ -18,9 +18,10 @@ internal static partial class DetachedProcessLauncher
         const string shellPath = "/bin/sh";
         const string nullDevice = "/dev/null";
 
+        using var fileNameString = new NativeUtf8String(fileName);
         using var shellPathString = new NativeUtf8String(shellPath);
         using var nullDeviceString = new NativeUtf8String(nullDevice);
-        using var argv = NativeStringArray.Create(CreateShellArguments(fileName, arguments, workingDirectory));
+        using var workingDirectoryString = new NativeUtf8String(workingDirectory);
         using var environment = NativeStringArray.CreateEnvironment(shouldRemoveEnvironmentVariable, additionalEnvironmentVariables);
         using var fileActions = new PosixSpawnFileActions();
         using var attributes = new PosixSpawnAttributes();
@@ -30,13 +31,30 @@ internal static partial class DetachedProcessLauncher
         fileActions.AddOpen(StandardErrorFileDescriptor, nullDeviceString.Pointer, OpenWriteOnly);
         attributes.SetNewProcessGroup();
 
-        var spawnResult = posix_spawn(
-            out var processId,
-            shellPathString.Pointer,
-            fileActions.Pointer,
-            attributes.Pointer,
-            argv.Pointer,
-            environment.Pointer);
+        // Prefer spawning the requested executable directly. The cwd file action is a non-portable
+        // libc extension (available on macOS and newer glibc), so keep the shell exec handoff as a
+        // fallback for older glibc/musl systems without mutating this process's global cwd.
+        var canSetWorkingDirectory = fileActions.TryAddChangeDirectory(workingDirectoryString.Pointer);
+        using var argv = NativeStringArray.Create(canSetWorkingDirectory
+            ? CreateDirectArguments(fileName, arguments)
+            : CreateShellArguments(fileName, arguments, workingDirectory));
+
+        int processId;
+        var spawnResult = canSetWorkingDirectory
+            ? posix_spawnp(
+                out processId,
+                fileNameString.Pointer,
+                fileActions.Pointer,
+                attributes.Pointer,
+                argv.Pointer,
+                environment.Pointer)
+            : posix_spawn(
+                out processId,
+                shellPathString.Pointer,
+                fileActions.Pointer,
+                attributes.Pointer,
+                argv.Pointer,
+                environment.Pointer);
         if (spawnResult != 0)
         {
             throw CreatePosixSpawnException("posix_spawn", spawnResult);
@@ -51,6 +69,17 @@ internal static partial class DetachedProcessLauncher
         {
             throw new InvalidOperationException("The detached process exited before it could be observed.", ex);
         }
+    }
+
+    private static IReadOnlyList<string> CreateDirectArguments(string fileName, IReadOnlyList<string> arguments)
+    {
+        var directArguments = new List<string>(arguments.Count + 1)
+        {
+            fileName
+        };
+
+        directArguments.AddRange(arguments);
+        return directArguments;
     }
 
     private static IReadOnlyList<string> CreateShellArguments(string fileName, IReadOnlyList<string> arguments, string workingDirectory)
@@ -101,6 +130,22 @@ internal static partial class DetachedProcessLauncher
             {
                 throw CreatePosixSpawnException("posix_spawn_file_actions_addopen", result);
             }
+        }
+
+        public bool TryAddChangeDirectory(IntPtr path)
+        {
+            if (s_posixSpawnFileActionsAddChangeDirectory is not { } addChangeDirectory)
+            {
+                return false;
+            }
+
+            var result = addChangeDirectory(Pointer, path);
+            if (result != 0)
+            {
+                throw CreatePosixSpawnException("posix_spawn_file_actions_addchdir_np", result);
+            }
+
+            return true;
         }
 
         public void Dispose()
@@ -324,11 +369,32 @@ internal static partial class DetachedProcessLauncher
     private const int OpenWriteOnly = 1;
     private const int SigKill = 9;
     private const short PosixSpawnSetProcessGroup = 0x02;
+    private static readonly PosixSpawnFileActionsAddChangeDirectoryDelegate? s_posixSpawnFileActionsAddChangeDirectory = ResolvePosixSpawnFileActionsAddChangeDirectory();
+
+    private static PosixSpawnFileActionsAddChangeDirectoryDelegate? ResolvePosixSpawnFileActionsAddChangeDirectory()
+    {
+        return NativeLibrary.TryLoad("libc", out var libcHandle)
+            && NativeLibrary.TryGetExport(libcHandle, "posix_spawn_file_actions_addchdir_np", out var export)
+            ? Marshal.GetDelegateForFunctionPointer<PosixSpawnFileActionsAddChangeDirectoryDelegate>(export)
+            : null;
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int PosixSpawnFileActionsAddChangeDirectoryDelegate(IntPtr fileActions, IntPtr path);
 
     [LibraryImport("libc")]
     private static partial int posix_spawn(
         out int pid,
         IntPtr path,
+        IntPtr fileActions,
+        IntPtr attrp,
+        IntPtr argv,
+        IntPtr envp);
+
+    [LibraryImport("libc")]
+    private static partial int posix_spawnp(
+        out int pid,
+        IntPtr file,
         IntPtr fileActions,
         IntPtr attrp,
         IntPtr argv,

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Unix.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Unix.cs
@@ -1,76 +1,363 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace Aspire.Cli.Processes;
 
 internal static partial class DetachedProcessLauncher
 {
     /// <summary>
-    /// Unix implementation using Process.Start with stdio redirection.
-    /// On Linux/macOS, the redirect pipes' original fds are created with O_CLOEXEC,
-    /// but dup2 onto fd 0/1/2 clears that flag — so grandchildren DO inherit the pipe
-    /// as their stdio. However, since we close the parent's read-end immediately, the
-    /// pipe has no reader and writes produce EPIPE (harmless). The key difference from
-    /// Windows is that on Unix, only fds 0/1/2 survive exec — no extra handle leakage.
+    /// Unix implementation using posix_spawn with a new process group and stdio bound to /dev/null.
     /// </summary>
-    private static Process StartUnix(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable, IReadOnlyDictionary<string, string>? additionalEnvironmentVariables)
+    private static IDetachedProcess StartUnix(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable, IReadOnlyDictionary<string, string>? additionalEnvironmentVariables)
     {
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = fileName,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            RedirectStandardInput = false,
-            WorkingDirectory = workingDirectory
-        };
+        const string shellPath = "/bin/sh";
+        const string nullDevice = "/dev/null";
 
-        foreach (var arg in arguments)
+        using var shellPathString = new NativeUtf8String(shellPath);
+        using var nullDeviceString = new NativeUtf8String(nullDevice);
+        using var argv = NativeStringArray.Create(CreateShellArguments(fileName, arguments, workingDirectory));
+        using var environment = NativeStringArray.CreateEnvironment(shouldRemoveEnvironmentVariable, additionalEnvironmentVariables);
+        using var fileActions = new PosixSpawnFileActions();
+        using var attributes = new PosixSpawnAttributes();
+
+        fileActions.AddOpen(StandardInputFileDescriptor, nullDeviceString.Pointer, OpenReadOnly);
+        fileActions.AddOpen(StandardOutputFileDescriptor, nullDeviceString.Pointer, OpenWriteOnly);
+        fileActions.AddOpen(StandardErrorFileDescriptor, nullDeviceString.Pointer, OpenWriteOnly);
+        attributes.SetNewProcessGroup();
+
+        var spawnResult = posix_spawn(
+            out var processId,
+            shellPathString.Pointer,
+            fileActions.Pointer,
+            attributes.Pointer,
+            argv.Pointer,
+            environment.Pointer);
+        if (spawnResult != 0)
         {
-            startInfo.ArgumentList.Add(arg);
+            throw CreatePosixSpawnException("posix_spawn", spawnResult);
         }
 
-        // Remove specified environment variables from the child process.
-        // Accessing startInfo.Environment auto-populates from the current process.
-        if (shouldRemoveEnvironmentVariable is not null)
+        try
         {
-            var keysToRemove = new List<string>();
-            foreach (var key in startInfo.Environment.Keys)
+            using var process = Process.GetProcessById(processId);
+            return new PosixDetachedProcess(processId, process.StartTime);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new InvalidOperationException("The detached process exited before it could be observed.", ex);
+        }
+    }
+
+    private static IReadOnlyList<string> CreateShellArguments(string fileName, IReadOnlyList<string> arguments, string workingDirectory)
+    {
+        var shellArguments = new List<string>(arguments.Count + 6)
+        {
+            "sh",
+            "-c",
+            "cd \"$1\" || exit 127; shift; exec \"$@\"",
+            "aspire-detached",
+            workingDirectory,
+            fileName
+        };
+
+        shellArguments.AddRange(arguments);
+        return shellArguments;
+    }
+
+    private static Win32Exception CreatePosixSpawnException(string operation, int errorCode) =>
+        new(errorCode, $"Failed to invoke {operation} while starting detached process.");
+
+    private sealed class PosixSpawnFileActions : IDisposable
+    {
+        // posix_spawn_file_actions_t is intentionally opaque. macOS defines it as a pointer-sized
+        // handle, while glibc and musl currently expose an 80-byte struct on 64-bit platforms.
+        // Allocate a conservative native buffer and let libc initialize/destroy its representation.
+        private const int BufferSize = 256;
+
+        public PosixSpawnFileActions()
+        {
+            Pointer = Marshal.AllocHGlobal(BufferSize);
+
+            var result = posix_spawn_file_actions_init(Pointer);
+            if (result != 0)
             {
-                if (shouldRemoveEnvironmentVariable(key))
+                Marshal.FreeHGlobal(Pointer);
+                Pointer = IntPtr.Zero;
+                throw CreatePosixSpawnException("posix_spawn_file_actions_init", result);
+            }
+        }
+
+        public IntPtr Pointer { get; private set; }
+
+        public void AddOpen(int descriptor, IntPtr path, int flags)
+        {
+            var result = posix_spawn_file_actions_addopen(Pointer, descriptor, path, flags, mode: 0);
+            if (result != 0)
+            {
+                throw CreatePosixSpawnException("posix_spawn_file_actions_addopen", result);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Pointer == IntPtr.Zero)
+            {
+                return;
+            }
+
+            _ = posix_spawn_file_actions_destroy(Pointer);
+            Marshal.FreeHGlobal(Pointer);
+            Pointer = IntPtr.Zero;
+        }
+    }
+
+    private sealed class PosixSpawnAttributes : IDisposable
+    {
+        private const int BufferSize = 1024;
+
+        public PosixSpawnAttributes()
+        {
+            Pointer = Marshal.AllocHGlobal(BufferSize);
+
+            var result = posix_spawnattr_init(Pointer);
+            if (result != 0)
+            {
+                Marshal.FreeHGlobal(Pointer);
+                Pointer = IntPtr.Zero;
+                throw CreatePosixSpawnException("posix_spawnattr_init", result);
+            }
+        }
+
+        public IntPtr Pointer { get; private set; }
+
+        public void SetNewProcessGroup()
+        {
+            var setGroupResult = posix_spawnattr_setpgroup(Pointer, pgroup: 0);
+            if (setGroupResult != 0)
+            {
+                throw CreatePosixSpawnException("posix_spawnattr_setpgroup", setGroupResult);
+            }
+
+            // POSIX_SPAWN_SETPGROUP with pgroup 0 makes the child the root of a new process
+            // group, so later cleanup of the launcher's process group does not signal it.
+            // See https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_spawnattr_setpgroup.html.
+            var setFlagsResult = posix_spawnattr_setflags(Pointer, PosixSpawnSetProcessGroup);
+            if (setFlagsResult != 0)
+            {
+                throw CreatePosixSpawnException("posix_spawnattr_setflags", setFlagsResult);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Pointer == IntPtr.Zero)
+            {
+                return;
+            }
+
+            _ = posix_spawnattr_destroy(Pointer);
+            Marshal.FreeHGlobal(Pointer);
+            Pointer = IntPtr.Zero;
+        }
+    }
+
+    private sealed class NativeUtf8String : IDisposable
+    {
+        public NativeUtf8String(string value)
+        {
+            Pointer = Marshal.StringToCoTaskMemUTF8(value);
+        }
+
+        public IntPtr Pointer { get; }
+
+        public void Dispose()
+        {
+            Marshal.FreeCoTaskMem(Pointer);
+        }
+    }
+
+    private sealed class NativeStringArray : IDisposable
+    {
+        private readonly NativeUtf8String[] _strings;
+
+        private NativeStringArray(NativeUtf8String[] strings, IntPtr pointer)
+        {
+            _strings = strings;
+            Pointer = pointer;
+        }
+
+        public IntPtr Pointer { get; }
+
+        public static NativeStringArray Create(IReadOnlyList<string> values)
+        {
+            var strings = values.Select(static value => new NativeUtf8String(value)).ToArray();
+            var pointer = Marshal.AllocHGlobal(IntPtr.Size * (strings.Length + 1));
+
+            for (var i = 0; i < strings.Length; i++)
+            {
+                Marshal.WriteIntPtr(pointer, i * IntPtr.Size, strings[i].Pointer);
+            }
+
+            Marshal.WriteIntPtr(pointer, strings.Length * IntPtr.Size, IntPtr.Zero);
+            return new NativeStringArray(strings, pointer);
+        }
+
+        public static NativeStringArray CreateEnvironment(Func<string, bool>? shouldRemoveEnvironmentVariable, IReadOnlyDictionary<string, string>? additionalEnvironmentVariables)
+        {
+            var values = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+            {
+                if (entry.Key is string key && (shouldRemoveEnvironmentVariable is null || !shouldRemoveEnvironmentVariable(key)))
                 {
-                    keysToRemove.Add(key);
+                    values[key] = entry.Value as string ?? string.Empty;
                 }
             }
 
-            foreach (var key in keysToRemove)
+            if (additionalEnvironmentVariables is not null)
             {
-                startInfo.Environment.Remove(key);
+                foreach (var (key, value) in additionalEnvironmentVariables)
+                {
+                    values[key] = value;
+                }
             }
+
+            return Create(values.Select(static kvp => $"{kvp.Key}={kvp.Value}").ToArray());
         }
 
-        // Add additional environment variables to the child process without mutating the parent.
-        if (additionalEnvironmentVariables is not null)
+        public void Dispose()
         {
-            foreach (var (key, value) in additionalEnvironmentVariables)
+            Marshal.FreeHGlobal(Pointer);
+            foreach (var value in _strings)
             {
-                startInfo.Environment[key] = value;
+                value.Dispose();
+            }
+        }
+    }
+
+    private sealed class PosixDetachedProcess : IDetachedProcess
+    {
+        private readonly Task<int> _exitCodeTask;
+
+        public PosixDetachedProcess(int processId, DateTime startTime)
+        {
+            Id = processId;
+            StartTime = startTime;
+            _exitCodeTask = Task.Run(() => WaitForExit(processId));
+        }
+
+        public int Id { get; }
+
+        public bool HasExited => _exitCodeTask.IsCompleted;
+
+        public int ExitCode
+        {
+            get
+            {
+                if (!_exitCodeTask.IsCompleted)
+                {
+                    throw new InvalidOperationException("Process must exit before requested information can be determined.");
+                }
+
+                return _exitCodeTask.GetAwaiter().GetResult();
             }
         }
 
-        var process = Process.Start(startInfo)
-            ?? throw new InvalidOperationException("Failed to start detached process");
+        public DateTime StartTime { get; }
 
-        // Close the parent's read-end of the pipes. This means the pipe has no reader,
-        // so if the grandchild (AppHost) writes to inherited stdout/stderr, it gets EPIPE
-        // which is harmless. The important thing is no caller is blocked waiting on the
-        // pipe — unlike Windows where the handle stays open and blocks execSync callers.
-        process.StandardOutput.Close();
-        process.StandardError.Close();
+        public async Task WaitForExitAsync(CancellationToken cancellationToken = default)
+        {
+            await _exitCodeTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
 
-        return process;
+        public void Kill(bool entireProcessTree)
+        {
+            var pid = entireProcessTree ? -Id : Id;
+            if (sys_kill(pid, SigKill) != 0 && Marshal.GetLastPInvokeError() != Esrch)
+            {
+                throw new Win32Exception(Marshal.GetLastPInvokeError(), "Failed to kill detached process.");
+            }
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private static int WaitForExit(int processId)
+        {
+            while (true)
+            {
+                var result = waitpid(processId, out var status, 0);
+                if (result == processId)
+                {
+                    return GetPosixExitCode(status);
+                }
+
+                if (Marshal.GetLastPInvokeError() != Eintr)
+                {
+                    throw new Win32Exception(Marshal.GetLastPInvokeError(), "Failed to wait for detached process.");
+                }
+            }
+        }
+
+        private static int GetPosixExitCode(int status)
+        {
+            if ((status & 0x7f) == 0)
+            {
+                return (status >> 8) & 0xff;
+            }
+
+            return 128 + (status & 0x7f);
+        }
     }
+
+    private const int StandardInputFileDescriptor = 0;
+    private const int StandardOutputFileDescriptor = 1;
+    private const int StandardErrorFileDescriptor = 2;
+    private const int Eintr = 4;
+    private const int Esrch = 3;
+    private const int OpenReadOnly = 0;
+    private const int OpenWriteOnly = 1;
+    private const int SigKill = 9;
+    private const short PosixSpawnSetProcessGroup = 0x02;
+
+    [LibraryImport("libc")]
+    private static partial int posix_spawn(
+        out int pid,
+        IntPtr path,
+        IntPtr fileActions,
+        IntPtr attrp,
+        IntPtr argv,
+        IntPtr envp);
+
+    [LibraryImport("libc")]
+    private static partial int posix_spawn_file_actions_addopen(IntPtr fileActions, int descriptor, IntPtr path, int flags, int mode);
+
+    [LibraryImport("libc")]
+    private static partial int posix_spawn_file_actions_destroy(IntPtr fileActions);
+
+    [LibraryImport("libc")]
+    private static partial int posix_spawn_file_actions_init(IntPtr fileActions);
+
+    [LibraryImport("libc")]
+    private static partial int posix_spawnattr_destroy(IntPtr attributes);
+
+    [LibraryImport("libc")]
+    private static partial int posix_spawnattr_init(IntPtr attributes);
+
+    [LibraryImport("libc")]
+    private static partial int posix_spawnattr_setflags(IntPtr attributes, short flags);
+
+    [LibraryImport("libc")]
+    private static partial int posix_spawnattr_setpgroup(IntPtr attributes, int pgroup);
+
+    [LibraryImport("libc", SetLastError = true, EntryPoint = "kill")]
+    private static partial int sys_kill(int pid, int signal);
+
+    [LibraryImport("libc", SetLastError = true)]
+    private static partial int waitpid(int pid, out int status, int options);
 }

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
@@ -18,7 +18,7 @@ internal static partial class DetachedProcessLauncher
     /// that the AppHost outlives the launching CLI.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    private static Process StartWindows(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable, IReadOnlyDictionary<string, string>? additionalEnvironmentVariables)
+    private static IDetachedProcess StartWindows(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable, IReadOnlyDictionary<string, string>? additionalEnvironmentVariables)
     {
         // Open NUL for the child's stdout/stderr — child writes go nowhere. The handle must be
         // inheritable (PROC_THREAD_ATTRIBUTE_HANDLE_LIST whitelists but does NOT promote
@@ -98,6 +98,6 @@ internal static partial class DetachedProcessLauncher
             WindowsProcessInterop.CloseHandle(pi.hThread);
         }
 
-        return detachedProcess;
+        return new ProcessBackedDetachedProcess(detachedProcess);
     }
 }

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.cs
@@ -7,7 +7,7 @@ namespace Aspire.Cli.Processes;
 
 internal interface IDetachedProcessLauncher
 {
-    Process Start(
+    IDetachedProcess Start(
         string fileName,
         IReadOnlyList<string> arguments,
         string workingDirectory,
@@ -15,9 +15,24 @@ internal interface IDetachedProcessLauncher
         IReadOnlyDictionary<string, string>? additionalEnvironmentVariables = null);
 }
 
+internal interface IDetachedProcess : IDisposable
+{
+    int Id { get; }
+
+    bool HasExited { get; }
+
+    int ExitCode { get; }
+
+    DateTime StartTime { get; }
+
+    Task WaitForExitAsync(CancellationToken cancellationToken = default);
+
+    void Kill(bool entireProcessTree);
+}
+
 internal sealed class DefaultDetachedProcessLauncher : IDetachedProcessLauncher
 {
-    public Process Start(
+    public IDetachedProcess Start(
         string fileName,
         IReadOnlyList<string> arguments,
         string workingDirectory,
@@ -26,6 +41,23 @@ internal sealed class DefaultDetachedProcessLauncher : IDetachedProcessLauncher
     {
         return DetachedProcessLauncher.Start(fileName, arguments, workingDirectory, shouldRemoveEnvironmentVariable, additionalEnvironmentVariables);
     }
+}
+
+internal sealed class ProcessBackedDetachedProcess(Process process) : IDetachedProcess
+{
+    public int Id => process.Id;
+
+    public bool HasExited => process.HasExited;
+
+    public int ExitCode => process.ExitCode;
+
+    public DateTime StartTime => process.StartTime;
+
+    public Task WaitForExitAsync(CancellationToken cancellationToken = default) => process.WaitForExitAsync(cancellationToken);
+
+    public void Kill(bool entireProcessTree) => process.Kill(entireProcessTree);
+
+    public void Dispose() => process.Dispose();
 }
 
 // ============================================================================
@@ -68,13 +100,12 @@ internal sealed class DefaultDetachedProcessLauncher : IDetachedProcessLauncher
 // │         │ grandchild inherits nothing useful. Child stdout/stderr go to │
 // │         │ the NUL device.                                               │
 // │         │                                                               │
-// │ Linux / │ Process.Start with RedirectStandard{Output,Error} = true,     │
-// │ macOS   │ then immediately close the parent's read-end pipe streams.    │
-// │         │ The original pipe fds have O_CLOEXEC, but dup2 onto fd 0/1/2 │
-// │         │ clears it — so grandchildren inherit the pipe as their stdio. │
-// │         │ With no reader, writes produce harmless EPIPE. The critical   │
-// │         │ difference from Windows is that no caller gets stuck waiting  │
-// │         │ on a pipe handle — closing the read-end is sufficient.        │
+// │ Linux / │ posix_spawn /bin/sh with POSIX_SPAWN_SETPGROUP, stdio bound  │
+// │ macOS   │ to /dev/null, and a small exec handoff. The new process group │
+// │         │ keeps the child CLI and AppHost out of launcher process-group │
+// │         │ cleanup after `aspire start` returns, while /dev/null stdio   │
+// │         │ prevents the detached child from corrupting parent output or  │
+// │         │ keeping caller-observed pipes alive.                          │
 // └─────────┴────────────────────────────────────────────────────────────────┘
 //
 
@@ -93,8 +124,8 @@ internal static partial class DetachedProcessLauncher
     /// <param name="workingDirectory">The working directory for the child process.</param>
     /// <param name="shouldRemoveEnvironmentVariable">Optional predicate that returns <see langword="true" /> for environment variable names that should be removed from the child process.</param>
     /// <param name="additionalEnvironmentVariables">Optional dictionary of environment variables to add to the child process without mutating the parent.</param>
-    /// <returns>A <see cref="Process"/> object representing the launched child.</returns>
-    public static Process Start(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable = null, IReadOnlyDictionary<string, string>? additionalEnvironmentVariables = null)
+    /// <returns>An <see cref="IDetachedProcess"/> object representing the launched child.</returns>
+    public static IDetachedProcess Start(string fileName, IReadOnlyList<string> arguments, string workingDirectory, Func<string, bool>? shouldRemoveEnvironmentVariable = null, IReadOnlyDictionary<string, string>? additionalEnvironmentVariables = null)
     {
         if (OperatingSystem.IsWindows())
         {

--- a/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
@@ -805,7 +805,7 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
             }
         }
 
-        public Process Start(
+        public IDetachedProcess Start(
             string fileName,
             IReadOnlyList<string> arguments,
             string workingDirectory,
@@ -824,7 +824,7 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
 
             StartedProcess = Process.Start(CreateProcessStartInfo(workingDirectory)) ?? throw new InvalidOperationException("Failed to start test child process.");
             Started.SetResult();
-            return StartedProcess;
+            return new ProcessBackedDetachedProcess(StartedProcess);
         }
 
         public void Dispose()

--- a/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
@@ -451,7 +450,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
 
     private sealed class TestDetachedProcessLauncher(Action onStart) : IDetachedProcessLauncher
     {
-        public Process Start(
+        public IDetachedProcess Start(
             string fileName,
             IReadOnlyList<string> arguments,
             string workingDirectory,
@@ -459,7 +458,28 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
             IReadOnlyDictionary<string, string>? additionalEnvironmentVariables = null)
         {
             onStart();
-            return new Process { StartInfo = new ProcessStartInfo(fileName) };
+            return new TestDetachedProcess();
+        }
+    }
+
+    private sealed class TestDetachedProcess : IDetachedProcess
+    {
+        public int Id => int.MaxValue;
+
+        public bool HasExited => true;
+
+        public int ExitCode => 1;
+
+        public DateTime StartTime => DateTime.UnixEpoch;
+
+        public Task WaitForExitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public void Kill(bool entireProcessTree)
+        {
+        }
+
+        public void Dispose()
+        {
         }
     }
 

--- a/tests/Aspire.Cli.Tests/Processes/DetachedProcessLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/DetachedProcessLauncherTests.cs
@@ -1,9 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable SYSLIB1054 // Test project does not allow unsafe code required by LibraryImport.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Text;
 using Aspire.Cli.Processes;
+using Microsoft.DotNet.RemoteExecutor;
 
 namespace Aspire.Cli.Tests.Processes;
 
@@ -31,4 +38,434 @@ public class DetachedProcessLauncherTests
 
         Assert.True(child.Id > 0);
     }
+
+    [Fact]
+    public async Task Start_OnUnix_SurvivesLauncherProcessGroupCleanup()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "Unix-only test.");
+
+        var temporaryDirectory = Directory.CreateTempSubdirectory("aspire-detached-launcher-");
+        var childPidFile = Path.Combine(temporaryDirectory.FullName, "child.pid");
+        int? childPid = null;
+        int? childProcessGroupId = null;
+        RemoteInvokeHandle? launchCommand = null;
+
+        try
+        {
+            launchCommand = RemoteExecutor.Invoke(static (pidFile, workingDirectory) =>
+            {
+                using var child = DetachedProcessLauncher.Start(
+                    "/bin/sh",
+                    ["-c", "sleep 30"],
+                    workingDirectory);
+
+                File.WriteAllText(pidFile, child.Id.ToString(CultureInfo.InvariantCulture));
+            }, childPidFile, temporaryDirectory.FullName, new RemoteInvokeOptions { Start = false });
+
+            // RemoteExecutor gives us the command line for an isolated helper process, but this
+            // test must start that helper in its own process group. We own that spawned process
+            // with posix_spawn/waitpid below instead of RemoteInvokeHandle.Dispose, whose descendant
+            // cleanup conflicts with the intentionally surviving detached child being asserted.
+            var launcherPid = StartInNewProcessGroup(launchCommand.Process.StartInfo);
+            var launcherProcessGroupId = GetProcessGroupId(launcherPid);
+            Assert.Equal(launcherPid, launcherProcessGroupId);
+
+            var launcherExitCode = await WaitForSpawnedProcessExitAsync(launcherPid);
+            AssertRemoteExecutorDidNotFail(launchCommand);
+            Assert.Equal(RemoteExecutor.SuccessExitCode, launcherExitCode);
+
+            childPid = await ReadChildPidAsync(childPidFile);
+            childProcessGroupId = GetProcessGroupId(childPid.Value);
+
+            // This mirrors an agent/CI command runner cleaning up the process group it created
+            // for the completed launcher command; it is not modeling any specific runner.
+            SendSignalToProcessGroup(launcherProcessGroupId, SigTerm, ignoreMissingProcessGroup: true);
+
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            Assert.True(IsProcessRunning(childPid.Value));
+            Assert.NotEqual(launcherProcessGroupId, childProcessGroupId.Value);
+        }
+        finally
+        {
+            if (childProcessGroupId is { } processGroupId)
+            {
+                SendSignalToProcessGroup(processGroupId, SigKill, ignoreMissingProcessGroup: true);
+            }
+
+            if (childPid is { } pid)
+            {
+                SendSignalToProcess(pid, SigKill, ignoreMissingProcess: true);
+                await WaitForProcessExitAsync(pid);
+            }
+
+            try
+            {
+                DisposeRemoteExecutorLaunchCommand(launchCommand);
+            }
+            finally
+            {
+                temporaryDirectory.Delete(recursive: true);
+            }
+        }
+    }
+
+    private static int StartInNewProcessGroup(ProcessStartInfo startInfo)
+    {
+        if (startInfo.UseShellExecute)
+        {
+            throw new InvalidOperationException("The test launcher expects UseShellExecute=false.");
+        }
+
+        var arguments = SplitArguments(startInfo.Arguments);
+        using var fileName = new NativeUtf8String(startInfo.FileName);
+        using var argv = NativeStringArray.Create([startInfo.FileName, .. arguments]);
+        using var environment = NativeStringArray.CreateEnvironment(startInfo.Environment);
+        using var attributes = new PosixSpawnAttributes();
+
+        attributes.SetNewProcessGroup();
+
+        var spawnResult = posix_spawnp(
+            out var processId,
+            fileName.Pointer,
+            IntPtr.Zero,
+            attributes.Pointer,
+            argv.Pointer,
+            environment.Pointer);
+        if (spawnResult != 0)
+        {
+            throw CreatePosixSpawnException("posix_spawnp", spawnResult);
+        }
+
+        return processId;
+    }
+
+    private static IReadOnlyList<string> SplitArguments(string arguments)
+    {
+        var result = new List<string>();
+        var current = new StringBuilder();
+        var inQuotes = false;
+
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var c = arguments[i];
+            if (c == '\\' && i + 1 < arguments.Length && arguments[i + 1] == '"')
+            {
+                current.Append('"');
+                i++;
+            }
+            else if (c == '"')
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (char.IsWhiteSpace(c) && !inQuotes)
+            {
+                AddCurrentArgument(result, current);
+            }
+            else
+            {
+                current.Append(c);
+            }
+        }
+
+        AddCurrentArgument(result, current);
+        return result;
+    }
+
+    private static void AddCurrentArgument(List<string> result, StringBuilder current)
+    {
+        if (current.Length == 0)
+        {
+            return;
+        }
+
+        result.Add(current.ToString());
+        current.Clear();
+    }
+
+    private static async Task<int> ReadChildPidAsync(string childPidFile)
+    {
+        var deadline = TimeProvider.System.GetUtcNow() + TimeSpan.FromSeconds(10);
+        while (TimeProvider.System.GetUtcNow() < deadline)
+        {
+            if (File.Exists(childPidFile)
+                && int.TryParse(await File.ReadAllTextAsync(childPidFile), CultureInfo.InvariantCulture, out var pid))
+            {
+                return pid;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+        }
+
+        throw new TimeoutException($"Timed out waiting for child PID file '{childPidFile}'.");
+    }
+
+    private static int GetProcessGroupId(int processId)
+    {
+        var processGroupId = getpgid(processId);
+        if (processGroupId < 0)
+        {
+            throw CreatePosixException("getpgid");
+        }
+
+        return processGroupId;
+    }
+
+    private static bool IsProcessRunning(int processId)
+    {
+        if (sys_kill(processId, signal: 0) == 0)
+        {
+            return true;
+        }
+
+        return Marshal.GetLastPInvokeError() != Esrch;
+    }
+
+    private static void SendSignalToProcessGroup(int processGroupId, int signal, bool ignoreMissingProcessGroup)
+    {
+        if (sys_kill(-processGroupId, signal) == 0)
+        {
+            return;
+        }
+
+        if (ignoreMissingProcessGroup && Marshal.GetLastPInvokeError() == Esrch)
+        {
+            return;
+        }
+
+        throw CreatePosixException("kill");
+    }
+
+    private static void SendSignalToProcess(int processId, int signal, bool ignoreMissingProcess)
+    {
+        if (sys_kill(processId, signal) == 0)
+        {
+            return;
+        }
+
+        if (ignoreMissingProcess && Marshal.GetLastPInvokeError() == Esrch)
+        {
+            return;
+        }
+
+        throw CreatePosixException("kill");
+    }
+
+    private static async Task WaitForProcessExitAsync(int processId)
+    {
+        var deadline = TimeProvider.System.GetUtcNow() + TimeSpan.FromSeconds(10);
+        while (TimeProvider.System.GetUtcNow() < deadline)
+        {
+            if (!IsProcessRunning(processId))
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+        }
+    }
+
+    private static async Task<int> WaitForSpawnedProcessExitAsync(int processId)
+    {
+        return await Task.Run(() =>
+        {
+            while (true)
+            {
+                var result = waitpid(processId, out var status, 0);
+                if (result == processId)
+                {
+                    return GetPosixExitCode(status);
+                }
+
+                if (Marshal.GetLastPInvokeError() != Eintr)
+                {
+                    throw CreatePosixException("waitpid");
+                }
+            }
+        }).WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    private static int GetPosixExitCode(int status)
+    {
+        if ((status & 0x7f) == 0)
+        {
+            return (status >> 8) & 0xff;
+        }
+
+        return 128 + (status & 0x7f);
+    }
+
+    private static void AssertRemoteExecutorDidNotFail(RemoteInvokeHandle launchCommand)
+    {
+        if (File.Exists(launchCommand.Options.ExceptionFile))
+        {
+            Assert.Fail(File.ReadAllText(launchCommand.Options.ExceptionFile));
+        }
+    }
+
+    private static void DisposeRemoteExecutorLaunchCommand(RemoteInvokeHandle? launchCommand)
+    {
+        if (launchCommand is null)
+        {
+            return;
+        }
+
+        var completedProcess = Process.Start(new ProcessStartInfo("/bin/sh")
+        {
+            ArgumentList = { "-c", $"exit {RemoteExecutor.SuccessExitCode}" }
+        }) ?? throw new InvalidOperationException("Failed to start completed RemoteExecutor disposal process.");
+        completedProcess.WaitForExit();
+        launchCommand.Process = completedProcess;
+        launchCommand.Dispose();
+    }
+
+    private static Win32Exception CreatePosixException(string operation) =>
+        new(Marshal.GetLastPInvokeError(), $"Failed to invoke {operation}.");
+
+    private static Win32Exception CreatePosixSpawnException(string operation, int errorCode) =>
+        new(errorCode, $"Failed to invoke {operation}.");
+
+    private sealed class PosixSpawnAttributes : IDisposable
+    {
+        private const int BufferSize = 1024;
+
+        public PosixSpawnAttributes()
+        {
+            Pointer = Marshal.AllocHGlobal(BufferSize);
+
+            var result = posix_spawnattr_init(Pointer);
+            if (result != 0)
+            {
+                Marshal.FreeHGlobal(Pointer);
+                Pointer = IntPtr.Zero;
+                throw CreatePosixSpawnException("posix_spawnattr_init", result);
+            }
+        }
+
+        public IntPtr Pointer { get; private set; }
+
+        public void SetNewProcessGroup()
+        {
+            var setGroupResult = posix_spawnattr_setpgroup(Pointer, pgroup: 0);
+            if (setGroupResult != 0)
+            {
+                throw CreatePosixSpawnException("posix_spawnattr_setpgroup", setGroupResult);
+            }
+
+            var setFlagsResult = posix_spawnattr_setflags(Pointer, PosixSpawnSetProcessGroup);
+            if (setFlagsResult != 0)
+            {
+                throw CreatePosixSpawnException("posix_spawnattr_setflags", setFlagsResult);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Pointer == IntPtr.Zero)
+            {
+                return;
+            }
+
+            _ = posix_spawnattr_destroy(Pointer);
+            Marshal.FreeHGlobal(Pointer);
+            Pointer = IntPtr.Zero;
+        }
+    }
+
+    private sealed class NativeUtf8String : IDisposable
+    {
+        public NativeUtf8String(string value)
+        {
+            Pointer = Marshal.StringToCoTaskMemUTF8(value);
+        }
+
+        public IntPtr Pointer { get; }
+
+        public void Dispose()
+        {
+            Marshal.FreeCoTaskMem(Pointer);
+        }
+    }
+
+    private sealed class NativeStringArray : IDisposable
+    {
+        private readonly NativeUtf8String[] _strings;
+
+        private NativeStringArray(NativeUtf8String[] strings, IntPtr pointer)
+        {
+            _strings = strings;
+            Pointer = pointer;
+        }
+
+        public IntPtr Pointer { get; }
+
+        public static NativeStringArray Create(IReadOnlyList<string> values)
+        {
+            var strings = values.Select(static value => new NativeUtf8String(value)).ToArray();
+            var pointer = Marshal.AllocHGlobal(IntPtr.Size * (strings.Length + 1));
+
+            for (var i = 0; i < strings.Length; i++)
+            {
+                Marshal.WriteIntPtr(pointer, i * IntPtr.Size, strings[i].Pointer);
+            }
+
+            Marshal.WriteIntPtr(pointer, strings.Length * IntPtr.Size, IntPtr.Zero);
+            return new NativeStringArray(strings, pointer);
+        }
+
+        public static NativeStringArray CreateEnvironment(IDictionary<string, string?> environment)
+        {
+            var values = environment
+                .Where(static kvp => kvp.Value is not null)
+                .Select(static kvp => $"{kvp.Key}={kvp.Value}")
+                .ToArray();
+
+            return Create(values);
+        }
+
+        public void Dispose()
+        {
+            Marshal.FreeHGlobal(Pointer);
+            foreach (var value in _strings)
+            {
+                value.Dispose();
+            }
+        }
+    }
+
+    private const int Esrch = 3;
+    private const int Eintr = 4;
+    private const int SigKill = 9;
+    private const int SigTerm = 15;
+    private const short PosixSpawnSetProcessGroup = 0x02;
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int getpgid(int pid);
+
+    [DllImport("libc")]
+    private static extern int posix_spawnp(
+        out int pid,
+        IntPtr file,
+        IntPtr fileActions,
+        IntPtr attrp,
+        IntPtr argv,
+        IntPtr envp);
+
+    [DllImport("libc", SetLastError = true, EntryPoint = "kill")]
+    private static extern int sys_kill(int pid, int signal);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int waitpid(int pid, out int status, int options);
+
+    [DllImport("libc")]
+    private static extern int posix_spawnattr_destroy(IntPtr attributes);
+
+    [DllImport("libc")]
+    private static extern int posix_spawnattr_init(IntPtr attributes);
+
+    [DllImport("libc")]
+    private static extern int posix_spawnattr_setflags(IntPtr attributes, short flags);
+
+    [DllImport("libc")]
+    private static extern int posix_spawnattr_setpgroup(IntPtr attributes, int pgroup);
 }


### PR DESCRIPTION
## Description

`aspire start` on Unix could return successfully while leaving the background child CLI in the launcher's process group. If an agent or CI runner later cleaned up that launcher process group, the child CLI received SIGTERM, AppHost startup waiting was canceled, and the AppHost stopped after observing the monitor/CLI exit.

This change starts Unix detached child CLI processes with `posix_spawn`/`posix_spawnp`, `POSIX_SPAWN_SETPGROUP`, and `/dev/null` stdio so the child becomes the root of a separate process group before `aspire start` returns. When libc exposes `posix_spawn_file_actions_addchdir_np`, the launcher spawns the requested executable directly while preserving the requested working directory. On older glibc/musl systems where that non-portable cwd action is unavailable, it falls back to a fixed shell `exec` handoff rather than mutating this process's global cwd. The change also adds an internal `IDetachedProcess` abstraction with a `waitpid`-backed Unix implementation so the raw `posix_spawn` child is tracked and reaped correctly. Windows keeps the existing native `CreateProcess` path behind the same abstraction.

### User-facing usage

Existing detached start commands now survive launcher process-group cleanup after the command returns:

```bash
aspire start --isolated --non-interactive --apphost <apphost.csproj> --format Json
```

### Security considerations

The Unix fallback uses `/bin/sh` for a static handoff script only when libc cannot set the spawned process working directory directly. The executable path and arguments are passed as positional parameters and executed via `exec "$@"`, not interpolated into the shell script.

### Validation

```bash
dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.DetachedProcessLauncherTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes: #18484

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
