### PR TITLE
Fix spurious error logging for expected backchannel disconnects in `aspire run`

### DIFF
--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -567,9 +567,13 @@ internal sealed class RunCommand : BaseCommand
         }
         catch (FailedToConnectBackchannelConnection ex)
         {
+            // The AppHost process exited before the backchannel could connect. This is an
+            // AppHost startup failure (e.g. the user's code crashed), not a CLI infrastructure
+            // error. WaitForAppHostStartupAsync normally wraps this in AppHostExitedDuringStartupException
+            // with the real exit code; this catch is a defensive fallback for edge-case races.
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "backchannel_connection_failed");
+            _logger.LogDebug(ex, "AppHost exited before backchannel connected.");
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ErrorConnectingToAppHost, ex.Message);
-            Telemetry.RecordError(errorMessage, ex);
             return CommandResult.Failure(CliExitCodes.FailedToDotnetRunAppHost, errorMessage);
         }
         catch (ConnectionLostException) when (isExtensionHost)

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -1036,9 +1036,12 @@ internal sealed class RunCommand : BaseCommand
             // Swallow the exception if the operation was cancelled.
             return;
         }
-        catch (ConnectionLostException) when (cancellationToken.IsCancellationRequested)
+        catch (Exception ex) when (AppHostFollowDisconnectHelpers.IsExpectedDisconnect(ex))
         {
-            // Just swallow this exception because this is an orderly shutdown of the backchannel.
+            // The AppHost process exited and the backchannel connection was lost. This is
+            // expected during orderly shutdown — the connection drops before the cancellation
+            // token fires because logCaptureCancellationSource.Cancel() runs in the finally
+            // block after the AppHost process has already exited.
             return;
         }
     }

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1264,7 +1264,9 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             catch (SocketException ex) when (serverSession.HasServerExited == true && !cancellationToken.IsCancellationRequested)
             {
                 var exitCode = serverSession.TryGetServerExitCode() ?? -1;
-                _logger.LogError("AppHost server process has exited with code {ExitCode}. Unable to connect to backchannel at {SocketPath}", exitCode, socketPath);
+                // Log at Debug level - this is expected when AppHost crashes during startup.
+                // The real error is in the AppHost output, not this connection-level detail.
+                _logger.LogDebug("AppHost server process has exited with code {ExitCode}. Unable to connect to backchannel at {SocketPath}", exitCode, socketPath);
                 var message = exitCode == CliExitCodes.Success
                     ? "AppHost server process has exited"
                     : "AppHost server process has exited unexpectedly";

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -2919,6 +2919,46 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task CaptureAppHostLogsAsync_ConnectionLostException_TreatedAsNormalCompletion()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var logFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "test.log");
+        var errorWriter = new TestStartupErrorWriter();
+        using var fileLoggerProvider = new FileLoggerProvider(logFilePath, errorWriter);
+
+        var backchannel = new TestAppHostBackchannel();
+        backchannel.GetAppHostLogEntriesAsyncCallback = ThrowConnectionLostAfterOneEntry;
+        var interactionService = new TestInteractionService();
+
+        // Should complete without throwing, even though the cancellation token is NOT cancelled.
+        // This simulates the AppHost process exiting and the backchannel dropping before the
+        // logCaptureCancellationSource.Cancel() fires in the RunCommand finally block.
+        await RunCommand.CaptureAppHostLogsAsync(fileLoggerProvider, backchannel, interactionService, CancellationToken.None);
+
+        fileLoggerProvider.Dispose();
+
+        var lines = await File.ReadAllLinesAsync(logFilePath);
+        var nonEmptyLines = lines.Where(l => !string.IsNullOrWhiteSpace(l)).ToArray();
+
+        Assert.Single(nonEmptyLines);
+        Assert.Equal("[2026-03-16 12:00:00.000] [INFO] [AppHost/Lifetime] Application started", nonEmptyLines[0]);
+
+        async static IAsyncEnumerable<BackchannelLogEntry> ThrowConnectionLostAfterOneEntry([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            yield return new BackchannelLogEntry
+            {
+                Timestamp = new DateTimeOffset(2026, 3, 16, 12, 0, 0, TimeSpan.Zero),
+                LogLevel = LogLevel.Information,
+                Message = "Application started",
+                EventId = new EventId(),
+                CategoryName = "Microsoft.Hosting.Lifetime"
+            };
+            await Task.CompletedTask;
+            throw new ConnectionLostException();
+        }
+    }
+
+    [Fact]
     public async Task RunCommand_NonInteractive_SkipsExtensionDelegation()
     {
         // When `aspire start` spawns `aspire run --non-interactive`, the child process


### PR DESCRIPTION
## Description

Fixes spurious error-level logging and telemetry noise from two expected exception scenarios in `aspire run`:

### 1. `StreamJsonRpc.ConnectionLostException` in `CaptureAppHostLogsAsync`

```
StreamJsonRpc.ConnectionLostException: The JSON-RPC connection with the remote party was lost before the request could complete.
   at StreamJsonRpc.JsonRpc.<InvokeCoreAsync>d__170.MoveNext()
   ...
   at Aspire.Cli.Backchannel.AppHostCliBackchannel.<EnumerateWithReconnect>d__15`1.MoveNext()
   at Aspire.Cli.Backchannel.AppHostCliBackchannel.<GetAppHostLogEntriesAsync>d__13.MoveNext()
   at Aspire.Cli.Commands.RunCommand.<CaptureAppHostLogsAsync>d__25.MoveNext()
   at Aspire.Cli.Commands.RunCommand.<ExecuteAsync>d__21.MoveNext()
```

**Root cause:** When the AppHost process exits, the backchannel connection drops. `CaptureAppHostLogsAsync` only caught `ConnectionLostException` when `cancellationToken.IsCancellationRequested` — but there's a race condition where the connection drops *before* `logCaptureCancellationSource.Cancel()` fires in the `RunCommand.ExecuteAsync` finally block. This caused the exception to propagate and get logged as a warning with a user-facing "No longer receiving logs from AppHost" message.

**Fix:** Widen the catch to treat any connection-lost exception (matching `AppHostFollowDisconnectHelpers.IsExpectedDisconnect`) as normal stream completion, regardless of cancellation state.

### 2. `FailedToConnectBackchannelConnection` — "AppHost process has exited unexpectedly"

```
Aspire.Cli.Backchannel.FailedToConnectBackchannelConnection: AppHost process has exited unexpectedly.
   at Aspire.Cli.Commands.RunCommand.<<ExecuteAsync>b__0>d.MoveNext()
   at Spectre.Console.Status.<StartAsync>...
   at Aspire.Cli.Interaction.ConsoleInteractionService.<ShowStatusAsync>d__23`1.MoveNext()
   at Aspire.Cli.Commands.RunCommand.<ExecuteAsync>d__21.MoveNext()
```

**Root cause:** When the AppHost crashes during startup, the CLI detects the process exit and creates a `FailedToConnectBackchannelConnection`. This is an *AppHost* startup failure (user's code crashed), not a CLI infrastructure error. However:
- `GuestAppHostProject` logged it at `LogError` level (while `DotNetCliRunner` already correctly used `LogDebug`)
- `RunCommand` called `Telemetry.RecordError()` which inflated CLI error telemetry counts

**Fix:**
- Downgrade `GuestAppHostProject` logging from `LogError` to `LogDebug`, matching `DotNetCliRunner`
- Remove `Telemetry.RecordError()` from the defensive catch in `RunCommand` — the error message and exit code are still surfaced to the user

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No