### PR TITLE
Fix markdown content wrapping in TextVisualizerDialog

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
@@ -38,7 +38,6 @@
 .markdown-content {
     max-height: 60vh;
     overflow-y: auto;
-    overflow-wrap: break-word;
-    word-break: break-all;
+    overflow-wrap: anywhere;
     margin-bottom: 16px;
 }

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
@@ -38,5 +38,6 @@
 .markdown-content {
     max-height: 60vh;
     overflow-y: auto;
+    overflow-wrap: break-word;
     margin-bottom: 16px;
 }

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
@@ -39,5 +39,6 @@
     max-height: 60vh;
     overflow-y: auto;
     overflow-wrap: break-word;
+    word-break: break-all;
     margin-bottom: 16px;
 }


### PR DESCRIPTION
## Summary

When viewing the TextVisualizerDialog in the dashboard with markdown format selected, long content (e.g., long URLs, tokens, or words without spaces) would overflow horizontally off the side of the dialog.

Before:
<img width="1832" height="540" alt="image" src="https://github.com/user-attachments/assets/b5d4a2fc-e0df-407c-9212-061011ba65f0" />

After:
<img width="1475" height="415" alt="image" src="https://github.com/user-attachments/assets/4eed167e-ebc3-446e-9a1c-2483a107cf89" />
