### PR TITLE
Fix AzurePromptAgentResource run-mode pipeline step dependency

### DIFF
--- a/src/Aspire.Hosting.Foundry/PromptAgent/AzurePromptAgentResource.cs
+++ b/src/Aspire.Hosting.Foundry/PromptAgent/AzurePromptAgentResource.cs
@@ -33,7 +33,6 @@ namespace Aspire.Hosting.Foundry;
 public class AzurePromptAgentResource : Resource, IResourceWithEnvironment, IResourceWithConnectionString
 {
     private const string BeforeStartStepName = "before-start";
-    private const string RunModeAzureProvisionStepName = "run-mode-azure-provision";
     private const int ProjectEndpointReadinessMaxRetryAttempts = 11;
     private static readonly TimeSpan s_projectEndpointReadinessDelay = TimeSpan.FromSeconds(5);
     private readonly List<IFoundryTool> _tools = [];
@@ -75,7 +74,7 @@ public class AzurePromptAgentResource : Resource, IResourceWithEnvironment, IRes
                     Action = DeployBeforeStartAsync,
                     RequiredBySteps = [BeforeStartStepName],
                     Resource = this,
-                    DependsOnSteps = [RunModeAzureProvisionStepName]
+                    DependsOnSteps = [AzureEnvironmentResource.PrepareResourcesStepName]
                 };
                 steps.Add(beforeStartDeployStep);
             }

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -142,6 +142,7 @@
     <InternalsVisibleTo Include="Aspire.Cli.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Kubernetes" />
     <InternalsVisibleTo Include="Aspire.Hosting.RemoteHost.Tests" />
+    <InternalsVisibleTo Include="Aspire.Hosting.Foundry.Tests" />
   </ItemGroup>
 
   <!-- Include the integration analyzer in the package -->

--- a/tests/Aspire.Hosting.Foundry.Tests/Aspire.Hosting.Foundry.Tests.csproj
+++ b/tests/Aspire.Hosting.Foundry.Tests/Aspire.Hosting.Foundry.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" LinkBase="shared" />
     <Compile Include="$(TestsSharedDir)TestModuleInitializer.cs" LinkBase="shared" />
+    <Compile Include="$(TestsSharedDir)TestPipelineActivityReporter.cs" LinkBase="shared" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
@@ -583,4 +583,82 @@ public class PromptAgentTests
         // causing a pipeline validation failure at runtime.
         Assert.Equal(new[] { AzureEnvironmentResource.PrepareResourcesStepName }, beforeStartStep.DependsOnSteps);
     }
+
+    [Fact]
+    public async Task AddPromptAgent_RunMode_AllPipelineStepDependenciesResolve()
+    {
+        // Integration test: verifies that all DependsOnSteps and RequiredBySteps references
+        // from AzurePromptAgentResource resolve to steps that actually exist in the pipeline,
+        // including steps produced by AzureEnvironmentResource and the framework's well-known steps.
+        // This catches regressions where a step name is removed or renamed elsewhere without
+        // updating AzurePromptAgentResource.
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+        var model = project.AddModelDeployment("gpt41", FoundryModel.OpenAI.Gpt41);
+        project.AddPromptAgent("my-agent", model, instructions: "Test agent");
+
+        builder.Build();
+
+        using var serviceProvider = builder.Services.BuildServiceProvider();
+        var pipelineContext = new PipelineContext(
+            serviceProvider.GetRequiredService<DistributedApplicationModel>(),
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            serviceProvider,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        // Collect all steps from all resources in the model (mirrors what the pipeline does at runtime).
+        var allSteps = new List<PipelineStep>();
+        foreach (var resource in pipelineContext.Model.Resources)
+        {
+            foreach (var annotation in resource.Annotations.OfType<PipelineStepAnnotation>())
+            {
+                allSteps.AddRange(await annotation.CreateStepsAsync(new PipelineStepFactoryContext
+                {
+                    PipelineContext = pipelineContext,
+                    Resource = resource
+                }));
+            }
+        }
+
+        // Add the well-known framework steps that are always present at runtime.
+        var frameworkStepNames = new HashSet<string>(StringComparer.Ordinal)
+        {
+            WellKnownPipelineSteps.BeforeStart,
+            WellKnownPipelineSteps.Deploy,
+            WellKnownPipelineSteps.DeployPrereq,
+            WellKnownPipelineSteps.Build,
+            WellKnownPipelineSteps.BuildPrereq,
+            WellKnownPipelineSteps.Push,
+            WellKnownPipelineSteps.PushPrereq,
+            WellKnownPipelineSteps.Publish,
+            WellKnownPipelineSteps.PublishPrereq,
+            WellKnownPipelineSteps.Destroy,
+            WellKnownPipelineSteps.DestroyPrereq,
+            WellKnownPipelineSteps.ProcessParameters,
+            WellKnownPipelineSteps.CheckContainerRuntime,
+            WellKnownPipelineSteps.ValidateComputeEnvironments,
+            WellKnownPipelineSteps.Diagnostics,
+        };
+
+        var allStepNames = new HashSet<string>(allSteps.Select(s => s.Name), StringComparer.Ordinal);
+        allStepNames.UnionWith(frameworkStepNames);
+
+        // Validate: every DependsOnSteps and RequiredBySteps reference must resolve to an existing step.
+        foreach (var step in allSteps)
+        {
+            foreach (var dep in step.DependsOnSteps)
+            {
+                Assert.True(allStepNames.Contains(dep),
+                    $"Step '{step.Name}' depends on unknown step '{dep}'");
+            }
+            foreach (var req in step.RequiredBySteps)
+            {
+                Assert.True(allStepNames.Contains(req),
+                    $"Step '{step.Name}' is required by unknown step '{req}'");
+            }
+        }
+    }
 }

--- a/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
@@ -3,10 +3,16 @@
 
 #pragma warning disable ASPIRECOMPUTE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREFOUNDRY001 // Preview tool types
+#pragma warning disable ASPIREPIPELINES001 // Pipeline APIs are experimental
+#pragma warning disable ASPIREAZURE001 // Azure types are experimental
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure;
+using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Foundry.Tests;
 
@@ -534,5 +540,49 @@ public class PromptAgentTests
         Assert.Same(project.Resource, ci.Resource.Project);
         Assert.Same(project.Resource, fs.Resource.Project);
         Assert.Same(project.Resource, ws.Resource.Project);
+    }
+
+    [Fact]
+    public async Task AddPromptAgent_RunMode_BeforeStartStepDependsOnPrepareResources()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+        var model = project.AddModelDeployment("gpt41", FoundryModel.OpenAI.Gpt41);
+
+        var agent = project.AddPromptAgent("my-agent", model, instructions: "Test agent");
+
+        builder.Build();
+
+        var agentResource = builder.Resources.Single(r => r.Name == "my-agent");
+        var annotations = agentResource.Annotations.OfType<PipelineStepAnnotation>().ToList();
+        Assert.NotEmpty(annotations);
+
+        using var serviceProvider = builder.Services.BuildServiceProvider();
+        var pipelineContext = new PipelineContext(
+            serviceProvider.GetRequiredService<DistributedApplicationModel>(),
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            serviceProvider,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        var steps = new List<PipelineStep>();
+        foreach (var annotation in annotations)
+        {
+            steps.AddRange(await annotation.CreateStepsAsync(new PipelineStepFactoryContext
+            {
+                PipelineContext = pipelineContext,
+                Resource = agentResource
+            }));
+        }
+
+        var beforeStartStep = steps.SingleOrDefault(s => s.Name == "deploy-my-agent-before-start");
+        Assert.NotNull(beforeStartStep);
+
+        // The step must depend on the azure-prepare-resources step (which actually exists in the pipeline).
+        // Previously it depended on 'run-mode-azure-provision' which was never registered,
+        // causing a pipeline validation failure at runtime.
+        Assert.Contains(AzureEnvironmentResource.PrepareResourcesStepName, beforeStartStep.DependsOnSteps);
+        Assert.DoesNotContain("run-mode-azure-provision", beforeStartStep.DependsOnSteps);
     }
 }

--- a/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
@@ -584,11 +584,6 @@ public class PromptAgentTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task AddPromptAgent_RunMode_BeforeStartPipelineExecutesSuccessfully()
     {
-        // Integration test: runs the real before-start pipeline with both AzureEnvironmentResource
-        // and AzurePromptAgentResource in the model. This catches regressions where a step dependency
-        // is renamed or removed elsewhere without updating AzurePromptAgentResource (the original bug
-        // was a reference to 'run-mode-azure-provision' which was removed from the pipeline).
-
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
 
         var activityReporter = new TestPipelineActivityReporter(testOutputHelper);

--- a/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
@@ -6,6 +6,7 @@
 #pragma warning disable ASPIREPIPELINES001 // Pipeline APIs are experimental
 #pragma warning disable ASPIREAZURE001 // Azure types are experimental
 
+using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Pipelines;
@@ -585,80 +586,44 @@ public class PromptAgentTests
     }
 
     [Fact]
-    public async Task AddPromptAgent_RunMode_AllPipelineStepDependenciesResolve()
+    public async Task AddPromptAgent_RunMode_BeforeStartPipelineExecutesSuccessfully()
     {
-        // Integration test: verifies that all DependsOnSteps and RequiredBySteps references
-        // from AzurePromptAgentResource resolve to steps that actually exist in the pipeline,
-        // including steps produced by AzureEnvironmentResource and the framework's well-known steps.
-        // This catches regressions where a step name is removed or renamed elsewhere without
-        // updating AzurePromptAgentResource.
+        // Integration test: runs the real before-start pipeline with both AzureEnvironmentResource
+        // and AzurePromptAgentResource in the model. This catches regressions where a step dependency
+        // is renamed or removed elsewhere without updating AzurePromptAgentResource (the original bug
+        // was a reference to 'run-mode-azure-provision' which was removed from the pipeline).
 
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var activityReporter = new TestPipelineActivityReporter(new NullTestOutputHelper());
+        builder.Services.AddSingleton<IPipelineActivityReporter>(activityReporter);
+
         var project = builder.AddFoundry("account")
             .AddProject("my-project");
         var model = project.AddModelDeployment("gpt41", FoundryModel.OpenAI.Gpt41);
         project.AddPromptAgent("my-agent", model, instructions: "Test agent");
 
-        builder.Build();
+        using var app = builder.Build();
 
-        using var serviceProvider = builder.Services.BuildServiceProvider();
-        var pipelineContext = new PipelineContext(
-            serviceProvider.GetRequiredService<DistributedApplicationModel>(),
-            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
-            serviceProvider,
-            NullLogger.Instance,
-            CancellationToken.None);
+        // This calls the real pipeline resolution + validation + execution.
+        // If any DependsOnSteps reference a non-existent step, it throws InvalidOperationException.
+        await ExecuteBeforeStartHooksAsync(app, default);
 
-        // Collect all steps from all resources in the model (mirrors what the pipeline does at runtime).
-        var allSteps = new List<PipelineStep>();
-        foreach (var resource in pipelineContext.Model.Resources)
-        {
-            foreach (var annotation in resource.Annotations.OfType<PipelineStepAnnotation>())
-            {
-                allSteps.AddRange(await annotation.CreateStepsAsync(new PipelineStepFactoryContext
-                {
-                    PipelineContext = pipelineContext,
-                    Resource = resource
-                }));
-            }
-        }
+        // Verify the prompt agent's deploy step was created and executed by the pipeline.
+        Assert.Contains("deploy-my-agent-before-start", activityReporter.CreatedSteps);
+        // Verify the azure-prepare-resources step (the dependency) was also executed.
+        Assert.Contains(AzureEnvironmentResource.PrepareResourcesStepName, activityReporter.CreatedSteps);
+    }
 
-        // Add the well-known framework steps that are always present at runtime.
-        var frameworkStepNames = new HashSet<string>(StringComparer.Ordinal)
-        {
-            WellKnownPipelineSteps.BeforeStart,
-            WellKnownPipelineSteps.Deploy,
-            WellKnownPipelineSteps.DeployPrereq,
-            WellKnownPipelineSteps.Build,
-            WellKnownPipelineSteps.BuildPrereq,
-            WellKnownPipelineSteps.Push,
-            WellKnownPipelineSteps.PushPrereq,
-            WellKnownPipelineSteps.Publish,
-            WellKnownPipelineSteps.PublishPrereq,
-            WellKnownPipelineSteps.Destroy,
-            WellKnownPipelineSteps.DestroyPrereq,
-            WellKnownPipelineSteps.ProcessParameters,
-            WellKnownPipelineSteps.CheckContainerRuntime,
-            WellKnownPipelineSteps.ValidateComputeEnvironments,
-            WellKnownPipelineSteps.Diagnostics,
-        };
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]
+    private static extern Task ExecuteBeforeStartHooksAsync(DistributedApplication app, CancellationToken cancellationToken);
 
-        var allStepNames = new HashSet<string>(allSteps.Select(s => s.Name), StringComparer.Ordinal);
-        allStepNames.UnionWith(frameworkStepNames);
-
-        // Validate: every DependsOnSteps and RequiredBySteps reference must resolve to an existing step.
-        foreach (var step in allSteps)
-        {
-            foreach (var dep in step.DependsOnSteps)
-            {
-                Assert.True(allStepNames.Contains(dep),
-                    $"Step '{step.Name}' depends on unknown step '{dep}'");
-            }
-            foreach (var req in step.RequiredBySteps)
-            {
-                Assert.True(allStepNames.Contains(req),
-                    $"Step '{step.Name}' is required by unknown step '{req}'");
-            }
-        }
+    private sealed class NullTestOutputHelper : ITestOutputHelper
+    {
+        public string Output => string.Empty;
+        public void Write(string message) { }
+        public void Write(string format, params object[] args) { }
+        public void WriteLine(string message) { }
+        public void WriteLine(string format, params object[] args) { }
     }
 }

--- a/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
@@ -6,7 +6,6 @@
 #pragma warning disable ASPIREPIPELINES001 // Pipeline APIs are experimental
 #pragma warning disable ASPIREAZURE001 // Azure types are experimental
 
-using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Pipelines;
@@ -17,7 +16,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Foundry.Tests;
 
-public class PromptAgentTests
+public class PromptAgentTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
     public void AddPromptAgent_CreatesResource()
@@ -579,9 +578,6 @@ public class PromptAgentTests
         var beforeStartStep = steps.SingleOrDefault(s => s.Name == "deploy-my-agent-before-start");
         Assert.NotNull(beforeStartStep);
 
-        // The step must depend on the azure-prepare-resources step (which actually exists in the pipeline).
-        // Previously it depended on 'run-mode-azure-provision' which was never registered,
-        // causing a pipeline validation failure at runtime.
         Assert.Equal(new[] { AzureEnvironmentResource.PrepareResourcesStepName }, beforeStartStep.DependsOnSteps);
     }
 
@@ -595,7 +591,7 @@ public class PromptAgentTests
 
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
 
-        var activityReporter = new TestPipelineActivityReporter(new NullTestOutputHelper());
+        var activityReporter = new TestPipelineActivityReporter(testOutputHelper);
         builder.Services.AddSingleton<IPipelineActivityReporter>(activityReporter);
 
         var project = builder.AddFoundry("account")
@@ -607,23 +603,11 @@ public class PromptAgentTests
 
         // This calls the real pipeline resolution + validation + execution.
         // If any DependsOnSteps reference a non-existent step, it throws InvalidOperationException.
-        await ExecuteBeforeStartHooksAsync(app, default);
+        await app.ExecuteBeforeStartHooksAsync(default);
 
         // Verify the prompt agent's deploy step was created and executed by the pipeline.
         Assert.Contains("deploy-my-agent-before-start", activityReporter.CreatedSteps);
         // Verify the azure-prepare-resources step (the dependency) was also executed.
         Assert.Contains(AzureEnvironmentResource.PrepareResourcesStepName, activityReporter.CreatedSteps);
-    }
-
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]
-    private static extern Task ExecuteBeforeStartHooksAsync(DistributedApplication app, CancellationToken cancellationToken);
-
-    private sealed class NullTestOutputHelper : ITestOutputHelper
-    {
-        public string Output => string.Empty;
-        public void Write(string message) { }
-        public void Write(string format, params object[] args) { }
-        public void WriteLine(string message) { }
-        public void WriteLine(string format, params object[] args) { }
     }
 }

--- a/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
@@ -554,8 +554,7 @@ public class PromptAgentTests
 
         builder.Build();
 
-        var agentResource = builder.Resources.Single(r => r.Name == "my-agent");
-        var annotations = agentResource.Annotations.OfType<PipelineStepAnnotation>().ToList();
+        var annotations = agent.Resource.Annotations.OfType<PipelineStepAnnotation>().ToList();
         Assert.NotEmpty(annotations);
 
         using var serviceProvider = builder.Services.BuildServiceProvider();
@@ -572,7 +571,7 @@ public class PromptAgentTests
             steps.AddRange(await annotation.CreateStepsAsync(new PipelineStepFactoryContext
             {
                 PipelineContext = pipelineContext,
-                Resource = agentResource
+                Resource = agent.Resource
             }));
         }
 
@@ -582,7 +581,6 @@ public class PromptAgentTests
         // The step must depend on the azure-prepare-resources step (which actually exists in the pipeline).
         // Previously it depended on 'run-mode-azure-provision' which was never registered,
         // causing a pipeline validation failure at runtime.
-        Assert.Contains(AzureEnvironmentResource.PrepareResourcesStepName, beforeStartStep.DependsOnSteps);
-        Assert.DoesNotContain("run-mode-azure-provision", beforeStartStep.DependsOnSteps);
+        Assert.Equal(new[] { AzureEnvironmentResource.PrepareResourcesStepName }, beforeStartStep.DependsOnSteps);
     }
 }


### PR DESCRIPTION
## Description

Fixes #18508

Fixes a runtime crash in the FoundryAgents playground (and any app using `AzurePromptAgentResource` in run mode) caused by a pipeline step dependency on a non-existent step.

**Error:**
```
System.InvalidOperationException: Step &#39;deploy-research-agent-before-start&#39; depends on unknown step &#39;run-mode-azure-provision&#39;
   at Aspire.Hosting.Pipelines.DistributedApplicationPipeline.ValidateSteps(...)
```

**Root cause:** The `deploy-{Name}-before-start` pipeline step in `AzurePromptAgentResource` references `run-mode-azure-provision` in its `DependsOnSteps`. This step was valid when the Foundry prompt agent feature was first added (April 29, PR #16353), but was subsequently removed on June 10 by commit b1bdd6d24d ("Move Azure run provisioning to resource initialization"), which moved Azure run-mode provisioning from a `BeforeStart` pipeline step into the resource initialization lifecycle path (`OnInitializeResource`). That commit removed `RunModeProvisionStepName` from `AzureEnvironmentResource` but didn't update `AzurePromptAgentResource` which still depended on it.

**Fix:** Changed the dependency to `AzureEnvironmentResource.PrepareResourcesStepName` (`azure-prepare-resources`), which is the existing step that runs in the before-start pipeline to prepare Azure resources (role assignments, etc.). The actual wait for Azure provisioning to complete already happens inside `WaitForProjectAndToolsAsync` via `ProvisioningTaskCompletionSource`, so the pipeline step only needs to ensure resource preparation has run first.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `` and `<code/>` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No