### PR TITLE
Add PostgreSQL major version detection for pg-prefixed image tags

### DIFF
--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -3,9 +3,10 @@
 
 #pragma warning disable ASPIREMCP001
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
-using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Postgres;
 using Microsoft.Extensions.Configuration;
@@ -18,7 +19,7 @@ namespace Aspire.Hosting;
 /// <summary>
 /// Provides extension methods for adding PostgreSQL resources to an <see cref="IDistributedApplicationBuilder"/>.
 /// </summary>
-public static class PostgresBuilderExtensions
+public static partial class PostgresBuilderExtensions
 {
     private const string UserEnvVarName = "POSTGRES_USER";
     private const string PasswordEnvVarName = "POSTGRES_PASSWORD";
@@ -714,6 +715,13 @@ public static class PostgresBuilderExtensions
             return false;
         }
 
+        // Handle tags like "2.28.1-pg17", "pg18-trixie", etc.
+        var match = PostgresMajorVersionPgPrefixedRegex().Match(tag);
+        if (match.Success && int.TryParse(match.Groups[1].Value, out majorVersion) && majorVersion > 0)
+        {
+            return true;
+        }
+
         // Handle tags like "18.1-alpine", "17.6-bookworm", etc.
         var versionPart = tag.Split('-')[0];
 
@@ -722,6 +730,9 @@ public static class PostgresBuilderExtensions
 
         return parts.Length > 0 && int.TryParse(parts[0], out majorVersion) && majorVersion > 0;
     }
+
+    [GeneratedRegex("pg([0-9]{2})")]
+    private static partial Regex PostgresMajorVersionPgPrefixedRegex();
 
     private static async Task CreateDatabaseAsync(NpgsqlConnection npgsqlConnection, PostgresDatabaseResource npgsqlDatabase, IServiceProvider serviceProvider, CancellationToken cancellationToken)
     {

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -731,7 +731,7 @@ public static partial class PostgresBuilderExtensions
         return parts.Length > 0 && int.TryParse(parts[0], out majorVersion) && majorVersion > 0;
     }
 
-    [GeneratedRegex("pg([0-9]{2})")]
+    [GeneratedRegex("(?:^|-)pg([0-9]{2})(?:-|$)")]
     private static partial Regex PostgresMajorVersionPgPrefixedRegex();
 
     private static async Task CreateDatabaseAsync(NpgsqlConnection npgsqlConnection, PostgresDatabaseResource npgsqlDatabase, IServiceProvider serviceProvider, CancellationToken cancellationToken)

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -759,6 +759,8 @@ public class AddPostgresTests
     [InlineData("17.6-bookworm", 17)]
     [InlineData("16.0", 16)]
     [InlineData("9.6", 9)]
+    [InlineData("0.8.3-pg18-trixie", 18)]
+    [InlineData("2.28.1-pg17", 17)]
     public void TryParsePostgresMajorVersionReturnsTrueForValidTags(string tag, int expectedMajorVersion)
     {
         var result = PostgresBuilderExtensions.TryParsePostgresMajorVersion(tag, out var majorVersion);

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -760,6 +760,7 @@ public class AddPostgresTests
     [InlineData("16.0", 16)]
     [InlineData("9.6", 9)]
     [InlineData("0.8.3-pg18-trixie", 18)]
+    [InlineData("pg18-trixie", 18)]
     [InlineData("2.28.1-pg17", 17)]
     public void TryParsePostgresMajorVersionReturnsTrueForValidTags(string tag, int expectedMajorVersion)
     {
@@ -775,6 +776,9 @@ public class AddPostgresTests
     [InlineData("")]
     [InlineData("  ")]
     [InlineData("abc")]
+    [InlineData("xpg18")]
+    [InlineData("pg180")]
+    [InlineData("pg9")]
     public void TryParsePostgresMajorVersionReturnsFalseForInvalidTags(string tag)
     {
         var result = PostgresBuilderExtensions.TryParsePostgresMajorVersion(tag, out var majorVersion);


### PR DESCRIPTION
## Description

Adds a regex to extract the PostgreSQL major version from image tags that use a "pgNN" convention, such as "2.28.1-pg17", "pg18-trixie", or "pg17". This complements the existing version detection logic so tags without a standard semantic version prefix are still recognized.

Fixes #11710

## Checklist

- Is this feature complete?
  - [ x ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ x ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ x ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ x ] No
