### PR TITLE
Add field IDs to issue templates for prefill support

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -19,18 +19,21 @@ body:
         - label: I have searched the existing issues
           required: true
   - type: textarea
+    id: description
     attributes:
       label: Describe the bug
       description: A clear and concise description of what the bug is.
     validations:
       required: true
   - type: textarea
+    id: expected-behavior
     attributes:
       label: Expected Behavior
       description: A clear and concise description of what you expected to happen.
     validations:
       required: false
   - type: textarea
+    id: repro-steps
     attributes:
       label: Steps To Reproduce
       description: |
@@ -44,6 +47,7 @@ body:
     validations:
       required: false
   - type: textarea
+    id: exceptions
     attributes:
       label: Exceptions (if any)
       description: Include the exception you get when facing this issue.
@@ -51,6 +55,7 @@ body:
     validations:
       required: false
   - type: textarea
+    id: aspire-doctor-output
     attributes:
       label: Aspire doctor output
       description: |
@@ -58,6 +63,7 @@ body:
     validations:
       required: false
   - type: textarea
+    id: additional-context
     attributes:
       label: Anything else?
       description: |

--- a/.github/ISSUE_TEMPLATE/20_feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/20_feature-request.yml
@@ -14,6 +14,7 @@ body:
         - label: I have searched the existing issues
           required: true
   - type: textarea
+    id: problem
     attributes:
       label: Is your feature request related to a problem? Please describe the problem.
       description: A clear and concise description of what the problem is.
@@ -21,6 +22,7 @@ body:
     validations:
       required: false
   - type: textarea
+    id: solution
     attributes:
       label: Describe the solution you'd like
       description: |
@@ -28,6 +30,7 @@ body:
     validations:
       required: true
   - type: textarea
+    id: additional-context
     attributes:
       label: Additional context
       description: |


### PR DESCRIPTION
Adds stable id attributes to the textarea fields in the bug report (`10_bug_report.yml`) and feature request (`20_feature-request.yml`) issue forms.

### Why
GitHub issue-form prefill URLs target fields by their `id` (e.g. `/issues/new?template=10_bug_report.yml&description=...&aspire-doctor-output=...`). Without explicit IDs, GitHub auto-generates unstable IDs that can't be reliably referenced. The in-product feedback flow (#18377) builds these prefill URLs and needs the IDs to be stable.

### What
- `10_bug_report.yml`: `description`, `expected-behavior`, `repro-steps`, `exceptions`, `aspire-doctor-output`, `additional-context`
- `20_feature-request.yml`: `problem`, `solution`, `additional-context`

No label/description/visible content changes — only `id` attributes added.

Split out from #18377 per review feedback so it can merge quickly and unblock end-to-end testing of the feedback experience. The same changes remain in #18377 and should merge cleanly over the top.