### PR TITLE
Harden extension terminal display fallback

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -59,7 +59,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const rpcServer = await AspireRpcServer.create(
     (rpcServerConnectionInfo: RpcServerConnectionInfo, connection: MessageConnection, token: string, debugSessionId: string | null) => {
-      const client: RpcClient = new RpcClient(terminalProvider, connection, debugSessionId, () => aspireExtensionContext.getAspireDebugSession(client.debugSessionId));
+      const client: RpcClient = new RpcClient(connection, debugSessionId, () => aspireExtensionContext.getAspireDebugSession(client.debugSessionId));
       return client;
     }
   );

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -8,7 +8,7 @@ import { ProgressNotifier } from './progressNotifier';
 import { applyTextStyle, formatText } from '../utils/strings';
 import { extensionLogOutputChannel } from '../utils/logging';
 import { AspireExtendedDebugConfiguration, EnvVar } from '../dcp/types';
-import { AnsiColors, AspireTerminal } from '../utils/AspireTerminalProvider';
+import { AnsiColors } from '../utils/AspireTerminalProvider';
 import { AspireDebugSession, DashboardBrowserType } from '../debugger/AspireDebugSession';
 import { isDirectory } from '../utils/io';
 
@@ -109,14 +109,12 @@ type DebugSessionOptions = {
 
 export class InteractionService implements IInteractionService {
     private _getAspireDebugSession: () => AspireDebugSession | null;
-    private _getAspireTerminal?: () => AspireTerminal;
 
     private _rpcClient?: ICliRpcClient;
     private _progressNotifier: ProgressNotifier;
 
-    constructor(getAspireDebugSession: () => AspireDebugSession | null, rpcClient: ICliRpcClient, getAspireTerminal?: () => AspireTerminal) {
+    constructor(getAspireDebugSession: () => AspireDebugSession | null, rpcClient: ICliRpcClient) {
         this._getAspireDebugSession = getAspireDebugSession;
-        this._getAspireTerminal = getAspireTerminal;
         this._rpcClient = rpcClient;
         this._progressNotifier = new ProgressNotifier(this._rpcClient);
     }
@@ -433,8 +431,8 @@ export class InteractionService implements IInteractionService {
             }
         }
 
-        if (!debugSession) {
-            extensionLogOutputChannel.show(undefined, true);
+        if (!debugSession && lines.length > 0) {
+            extensionLogOutputChannel.show(true);
         }
     }
 

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -424,18 +424,17 @@ export class InteractionService implements IInteractionService {
         this.clearProgressNotification();
 
         const debugSession = this._getAspireDebugSession();
-        const aspireTerminal = !debugSession ? this._getAspireTerminal?.() : undefined;
         for (const line of lines) {
             const text = getConsoleLineText(line);
             const stream = line.stream ?? line.Stream;
             extensionLogOutputChannel.info(formatText(text));
             if (debugSession) {
                 debugSession.sendMessage(text, true, stream !== 'stderr' ? 'stdout' : 'stderr');
-            } else if (aspireTerminal) {
-                // This is display-only output from the CLI. Passing true submits the text to the
-                // shell, which would execute it instead of only showing it to the user.
-                aspireTerminal.terminal.sendText(text, false);
             }
+        }
+
+        if (!debugSession) {
+            extensionLogOutputChannel.show(undefined, true);
         }
     }
 

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -432,7 +432,7 @@ export class InteractionService implements IInteractionService {
             if (debugSession) {
                 debugSession.sendMessage(text, true, stream !== 'stderr' ? 'stdout' : 'stderr');
             } else if (aspireTerminal) {
-                aspireTerminal.terminal.sendText(text, true);
+                aspireTerminal.terminal.sendText(text, false);
             }
         }
     }

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -432,6 +432,8 @@ export class InteractionService implements IInteractionService {
             if (debugSession) {
                 debugSession.sendMessage(text, true, stream !== 'stderr' ? 'stdout' : 'stderr');
             } else if (aspireTerminal) {
+                // This is display-only output from the CLI. Passing true submits the text to the
+                // shell, which would execute it instead of only showing it to the user.
                 aspireTerminal.terminal.sendText(text, false);
             }
         }

--- a/extension/src/server/rpcClient.ts
+++ b/extension/src/server/rpcClient.ts
@@ -1,7 +1,6 @@
 import { MessageConnection } from 'vscode-jsonrpc';
 import { extensionLogOutputChannel, logAsyncOperation } from '../utils/logging';
 import { IInteractionService, InteractionService } from './interactionService';
-import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 import { AspireDebugSession } from '../debugger/AspireDebugSession';
 
 export interface ICliRpcClient {
@@ -21,17 +20,15 @@ export type ValidationResult = {
 export class RpcClient implements ICliRpcClient {
     private _messageConnection: MessageConnection;
     private _connectionClosed: boolean;
-    private _terminalProvider: AspireTerminalProvider;
 
     public debugSessionId: string | null;
     public interactionService: IInteractionService;
 
-    constructor(terminalProvider: AspireTerminalProvider, messageConnection: MessageConnection, debugSessionId: string | null, getAspireDebugSession: () => AspireDebugSession | null) {
-        this._terminalProvider = terminalProvider;
+    constructor(messageConnection: MessageConnection, debugSessionId: string | null, getAspireDebugSession: () => AspireDebugSession | null) {
         this._messageConnection = messageConnection;
         this._connectionClosed = false;
         this.debugSessionId = debugSessionId;
-        this.interactionService = new InteractionService(getAspireDebugSession, this, () => terminalProvider.getAspireTerminal());
+        this.interactionService = new InteractionService(getAspireDebugSession, this);
 
         this._messageConnection.onClose(() => {
             this._connectionClosed = true;

--- a/extension/src/test/rpc/interactionServiceTests.test.ts
+++ b/extension/src/test/rpc/interactionServiceTests.test.ts
@@ -230,7 +230,7 @@ suite('InteractionService endpoints', () => {
 			sendRequest: sinon.stub()
 		} as any;
 
-		const rpcClient = new RpcClient({} as any, messageConnection, null, () => null);
+		const rpcClient = new RpcClient(messageConnection, null, () => null);
 
 		rpcClient.interactionService.showStatus('Scanning for running AppHosts...');
 		assert.strictEqual((rpcClient.interactionService as any)._progressNotifier.isActive, true);
@@ -461,14 +461,7 @@ suite('InteractionService endpoints', () => {
 		try {
 			const infoStub = sandbox.stub(extensionLogOutputChannel, 'info');
 			const showStub = sandbox.stub(extensionLogOutputChannel, 'show');
-			const mockTerminal = {
-				terminal: {
-					sendText: () => assert.fail('display-only lines must not be written to shell stdin')
-				},
-				dispose: () => {}
-			};
 			const testInfo = await createTestRpcServer(null, () => null);
-			(testInfo.interactionService as any)._getAspireTerminal = () => mockTerminal;
 
 			testInfo.interactionService.displayLines([
 				{ Stream: 'stdout', Line: 'line1' },
@@ -476,7 +469,27 @@ suite('InteractionService endpoints', () => {
 			]);
 
 			assert.deepStrictEqual(infoStub.args.map(args => args[0]).slice(-2), ['line1', 'line2']);
-			assert.strictEqual(showStub.calledOnceWithExactly(undefined, true), true);
+			assert.strictEqual(showStub.calledOnce, true);
+			assert.deepStrictEqual(showStub.firstCall.args, [true]);
+		}
+		finally {
+			sandbox.restore();
+		}
+	});
+
+	test("displayLines without debug session does not show output channel for empty lines", async () => {
+		const sandbox = sinon.createSandbox();
+
+		try {
+			const infoStub = sandbox.stub(extensionLogOutputChannel, 'info');
+			const showStub = sandbox.stub(extensionLogOutputChannel, 'show');
+			const testInfo = await createTestRpcServer(null, () => null);
+			const infoCallCount = infoStub.callCount;
+
+			testInfo.interactionService.displayLines([]);
+
+			assert.strictEqual(infoStub.callCount, infoCallCount);
+			assert.strictEqual(showStub.called, false);
 		}
 		finally {
 			sandbox.restore();

--- a/extension/src/test/rpc/interactionServiceTests.test.ts
+++ b/extension/src/test/rpc/interactionServiceTests.test.ts
@@ -460,11 +460,11 @@ suite('InteractionService endpoints', () => {
 
 		try {
 			sandbox.stub(extensionLogOutputChannel, 'info');
-			const sentTexts: string[] = [];
+			const sentTexts: { text: string; addNewLine: boolean }[] = [];
 			const mockTerminal = {
 				terminal: {
 					sendText: (text: string, addNewLine: boolean) => {
-						sentTexts.push(text);
+						sentTexts.push({ text, addNewLine });
 					}
 				},
 				dispose: () => {}
@@ -479,8 +479,10 @@ suite('InteractionService endpoints', () => {
 			]);
 
 			assert.strictEqual(sentTexts.length, 2, 'Should send two lines to Aspire terminal');
-			assert.strictEqual(sentTexts[0], 'line1');
-			assert.strictEqual(sentTexts[1], 'line2');
+			assert.deepStrictEqual(sentTexts, [
+				{ text: 'line1', addNewLine: false },
+				{ text: 'line2', addNewLine: false }
+			]);
 		}
 		finally {
 			sandbox.restore();

--- a/extension/src/test/rpc/interactionServiceTests.test.ts
+++ b/extension/src/test/rpc/interactionServiceTests.test.ts
@@ -455,22 +455,19 @@ suite('InteractionService endpoints', () => {
 		}
 	});
 
-	test("displayLines without debug session falls back to Aspire terminal", async () => {
+	test("displayLines without debug session writes to output channel only", async () => {
 		const sandbox = sinon.createSandbox();
 
 		try {
-			sandbox.stub(extensionLogOutputChannel, 'info');
-			const sentTexts: { text: string; addNewLine: boolean }[] = [];
+			const infoStub = sandbox.stub(extensionLogOutputChannel, 'info');
+			const showStub = sandbox.stub(extensionLogOutputChannel, 'show');
 			const mockTerminal = {
 				terminal: {
-					sendText: (text: string, addNewLine: boolean) => {
-						sentTexts.push({ text, addNewLine });
-					}
+					sendText: () => assert.fail('display-only lines must not be written to shell stdin')
 				},
 				dispose: () => {}
 			};
 			const testInfo = await createTestRpcServer(null, () => null);
-			// Inject a mock terminal provider via the InteractionService constructor
 			(testInfo.interactionService as any)._getAspireTerminal = () => mockTerminal;
 
 			testInfo.interactionService.displayLines([
@@ -478,11 +475,8 @@ suite('InteractionService endpoints', () => {
 				{ Stream: 'stderr', Line: 'line2' }
 			]);
 
-			assert.strictEqual(sentTexts.length, 2, 'Should send two lines to Aspire terminal');
-			assert.deepStrictEqual(sentTexts, [
-				{ text: 'line1', addNewLine: false },
-				{ text: 'line2', addNewLine: false }
-			]);
+			assert.deepStrictEqual(infoStub.args.map(args => args[0]).slice(-2), ['line1', 'line2']);
+			assert.strictEqual(showStub.calledOnceWithExactly(undefined, true), true);
 		}
 		finally {
 			sandbox.restore();


### PR DESCRIPTION
## Description

Hardens the VS Code extension's CLI display fallback so text sent through `InteractionService.displayLines` is never written to the integrated terminal as shell input when there is no active debug session.

The no-debug-session fallback used to call `sendText(text, true)`, which appends a newline and tells VS Code to submit the line. That made the display sink capable of executing whatever line the CLI asked it to show. This now routes display-only fallback output to the Aspire log output channel instead. The output channel is revealed only when there are lines to display, and the dead terminal plumbing from this path has been removed.

### Security considerations

This change is intentionally security hardening for terminal input handling. It avoids sending CLI-provided display text to a shell-backed terminal at all, closing the terminal-injection path for command-shaped, newline-delimited, or control-character-containing text that reaches the display fallback.

Security review completed with no findings.

Validation:

```bash
corepack yarn run compile-tests
corepack yarn run lint
corepack yarn run unit-test --config .vscode-test-pr18500.mjs --grep "displayLines"
```

The focused VS Code test used a temporary short `--user-data-dir` test config for the macOS socket path limit.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] Yes
      - [ ] No
  - [ ] No
