### PR TITLE
Keep mobile nav focus visible at high zoom

### DIFF
--- a/src/Aspire.Dashboard/BlazorAssets.targets
+++ b/src/Aspire.Dashboard/BlazorAssets.targets
@@ -9,6 +9,32 @@
     NuGet package for each supported major runtime version.
   -->
 
+  <UsingTask
+    TaskName="RemoveUnsupportedBlazorEventProperties"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <FilePaths ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Code Type="Fragment" Language="cs">
+<![CDATA[
+foreach (var filePath in FilePaths)
+{
+    var sourceText = File.ReadAllText(filePath.ItemSpec);
+    var updatedText = sourceText.Replace(",isComposing:t.isComposing", string.Empty);
+
+    if (updatedText != sourceText)
+    {
+        File.WriteAllText(filePath.ItemSpec, updatedText);
+    }
+}
+]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
   <ItemGroup>
     <!--
       Download both asset packages to the NuGet global cache (no assembly reference added).
@@ -32,6 +58,11 @@
           DestinationFiles="$(MSBuildProjectDirectory)\wwwroot\framework\blazor.web.%(BlazorAssetPackage.Identity).js"
           SkipUnchangedFiles="true"
           OverwriteReadOnlyFiles="true" />
+
+        <!-- The dashboard is a net8.0 app that rolls forward to newer shared frameworks.
+          Some newer blazor.web.js assets include event fields that older compatible
+          runtimes reject as unknown JSON properties. -->
+        <RemoveUnsupportedBlazorEventProperties FilePaths="@(BlazorAssetPackage->'$(MSBuildProjectDirectory)\wwwroot\framework\blazor.web.%(Identity).js')" />
   </Target>
 
   <Target Name="CleanBlazorWebJs" AfterTargets="Clean">

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -88,11 +88,12 @@
            visible viewport instead of extending underneath the header at high zoom. */
         --mobile-header-height: 52px;
         --mobile-nav-menu-offset: 2px;
+        --mobile-nav-menu-focus-padding: 4px;
         height: 100vh;
         width: 100vw;
         display: grid;
         grid-template-columns: auto 1fr;
-        grid-template-rows: var(--mobile-header-height) auto auto 1fr;
+        grid-template-rows: var(--mobile-header-height) minmax(0, auto) auto minmax(0, 1fr);
         grid-template-areas:
             "icon head"
             "nav-menu nav-menu"

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
@@ -1,10 +1,11 @@
-﻿<FluentMenu Class="aspire-menu-container mobile-nav-menu" Open="@IsNavMenuOpen" Anchored="false" Style="grid-area: nav-menu; max-height: calc(100dvh - var(--mobile-header-height) - var(--mobile-nav-menu-offset)); margin-top: var(--mobile-nav-menu-offset); overflow-y: auto; padding-block: var(--mobile-nav-menu-focus-padding); scroll-padding-block: var(--mobile-nav-menu-focus-padding);">
+﻿<FluentMenu Id="@MobileNavMenuId" Class="aspire-menu-container mobile-nav-menu" Open="@IsNavMenuOpen" Anchored="false" Style="grid-area: nav-menu; max-height: calc(100dvh - var(--mobile-header-height) - var(--mobile-nav-menu-offset)); margin-top: var(--mobile-nav-menu-offset); overflow-y: auto; padding-block: var(--mobile-nav-menu-focus-padding); scroll-padding-block: var(--mobile-nav-menu-focus-padding);">
     @foreach (var item in GetMobileNavMenuEntries())
     {
         var isActive = item.LinkMatchRegex is not null && item.LinkMatchRegex.IsMatch($"/{NavigationManager.ToBaseRelativePath(NavigationManager.Uri)}");
         var menuItemAttributes = new Dictionary<string, object>
         {
-            ["title"] = item.Text
+            ["title"] = item.Text,
+            ["tabindex"] = "0"
         };
         if (isActive)
         {

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
@@ -4,8 +4,7 @@
         var isActive = item.LinkMatchRegex is not null && item.LinkMatchRegex.IsMatch($"/{NavigationManager.ToBaseRelativePath(NavigationManager.Uri)}");
         var menuItemAttributes = new Dictionary<string, object>
         {
-            ["title"] = item.Text,
-            ["tabindex"] = "0"
+            ["title"] = item.Text
         };
         if (isActive)
         {

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
@@ -1,4 +1,4 @@
-﻿<FluentMenu Class="aspire-menu-container" Open="@IsNavMenuOpen" Anchored="false" Style="grid-area: nav-menu; max-height: calc(100dvh - var(--mobile-header-height) - var(--mobile-nav-menu-offset)); margin-top: var(--mobile-nav-menu-offset); overflow-y: auto;">
+﻿<FluentMenu Class="aspire-menu-container mobile-nav-menu" Open="@IsNavMenuOpen" Anchored="false" Style="grid-area: nav-menu; max-height: calc(100dvh - var(--mobile-header-height) - var(--mobile-nav-menu-offset)); margin-top: var(--mobile-nav-menu-offset); overflow-y: auto; padding-block: var(--mobile-nav-menu-focus-padding); scroll-padding-block: var(--mobile-nav-menu-focus-padding);">
     @foreach (var item in GetMobileNavMenuEntries())
     {
         var isActive = item.LinkMatchRegex is not null && item.LinkMatchRegex.IsMatch($"/{NavigationManager.ToBaseRelativePath(NavigationManager.Uri)}");

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
@@ -11,8 +11,15 @@ using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components.Layout;
 
-public partial class MobileNavMenu : ComponentBase
+public partial class MobileNavMenu : ComponentBase, IAsyncDisposable
 {
+    internal const string MobileNavMenuId = "dashboard-mobile-nav-menu";
+
+    private IJSObjectReference? _keyboardNavigation;
+    private DotNetObjectReference<MobileNavMenu>? _mobileNavMenuReference;
+    private bool _keyboardNavigationInitializing;
+    private bool _disposed;
+
     [Inject]
     public required NavigationManager NavigationManager { get; init; }
 
@@ -32,6 +39,74 @@ public partial class MobileNavMenu : ComponentBase
     {
         NavigationManager.NavigateTo(url);
         return Task.CompletedTask;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!_disposed && IsNavMenuOpen && _keyboardNavigation is null && !_keyboardNavigationInitializing)
+        {
+            _keyboardNavigationInitializing = true;
+            try
+            {
+                _mobileNavMenuReference ??= DotNetObjectReference.Create(this);
+                var keyboardNavigation = await JS.InvokeAsync<IJSObjectReference>("initializeMobileNavMenuKeyboardNavigation", MobileNavMenuId, _mobileNavMenuReference);
+                if (_disposed || !IsNavMenuOpen)
+                {
+                    await DisposeKeyboardNavigationAsync(keyboardNavigation);
+                }
+                else
+                {
+                    _keyboardNavigation = keyboardNavigation;
+                }
+            }
+            finally
+            {
+                _keyboardNavigationInitializing = false;
+            }
+        }
+        else if (!IsNavMenuOpen && _keyboardNavigation is not null)
+        {
+            await DisposeKeyboardNavigationAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _disposed = true;
+        await DisposeKeyboardNavigationAsync();
+        _mobileNavMenuReference?.Dispose();
+    }
+
+    [JSInvokable]
+    public async Task CloseMobileNavMenuFromKeyboardAsync()
+    {
+        CloseNavMenu();
+        await InvokeAsync(StateHasChanged);
+        await JS.InvokeVoidAsync("focusElement", MainLayout.NavigationButtonId);
+    }
+
+    private async ValueTask DisposeKeyboardNavigationAsync()
+    {
+        if (_keyboardNavigation is { } keyboardNavigation)
+        {
+            _keyboardNavigation = null;
+            await DisposeKeyboardNavigationAsync(keyboardNavigation);
+        }
+    }
+
+    private async ValueTask DisposeKeyboardNavigationAsync(IJSObjectReference keyboardNavigation)
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("disposeMobileNavMenuKeyboardNavigation", keyboardNavigation);
+        }
+        catch (JSDisconnectedException)
+        {
+            // The Blazor circuit can disconnect while the layout is being disposed.
+            // In that case the browser listener is already gone with the page.
+        }
+
+        await JSInteropHelpers.SafeDisposeAsync(keyboardNavigation);
     }
 
     private IEnumerable<MobileNavMenuEntry> GetMobileNavMenuEntries()

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
@@ -81,15 +81,14 @@ public partial class MobileNavMenu : ComponentBase, IAsyncDisposable
     public async Task CloseMobileNavMenuFromKeyboardAsync()
     {
         CloseNavMenu();
-        await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("focusElement", MainLayout.NavigationButtonId);
     }
 
     [JSInvokable]
-    public async Task CloseMobileNavMenuFromFocusLossAsync()
+    public Task CloseMobileNavMenuFromFocusLossAsync()
     {
         CloseNavMenu();
-        await InvokeAsync(StateHasChanged);
+        return Task.CompletedTask;
     }
 
     private async ValueTask DisposeKeyboardNavigationAsync()

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
@@ -49,7 +49,7 @@ public partial class MobileNavMenu : ComponentBase, IAsyncDisposable
             try
             {
                 _mobileNavMenuReference ??= DotNetObjectReference.Create(this);
-                var keyboardNavigation = await JS.InvokeAsync<IJSObjectReference>("initializeMobileNavMenuKeyboardNavigation", _mobileNavMenuReference);
+                var keyboardNavigation = await JS.InvokeAsync<IJSObjectReference>("initializeMobileNavMenuKeyboardNavigation", _mobileNavMenuReference, MobileNavMenuId);
                 if (_disposed || !IsNavMenuOpen)
                 {
                     await DisposeKeyboardNavigationAsync(keyboardNavigation);
@@ -83,6 +83,13 @@ public partial class MobileNavMenu : ComponentBase, IAsyncDisposable
         CloseNavMenu();
         await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("focusElement", MainLayout.NavigationButtonId);
+    }
+
+    [JSInvokable]
+    public async Task CloseMobileNavMenuFromFocusLossAsync()
+    {
+        CloseNavMenu();
+        await InvokeAsync(StateHasChanged);
     }
 
     private async ValueTask DisposeKeyboardNavigationAsync()

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
@@ -49,7 +49,7 @@ public partial class MobileNavMenu : ComponentBase, IAsyncDisposable
             try
             {
                 _mobileNavMenuReference ??= DotNetObjectReference.Create(this);
-                var keyboardNavigation = await JS.InvokeAsync<IJSObjectReference>("initializeMobileNavMenuKeyboardNavigation", MobileNavMenuId, _mobileNavMenuReference);
+                var keyboardNavigation = await JS.InvokeAsync<IJSObjectReference>("initializeMobileNavMenuKeyboardNavigation", _mobileNavMenuReference);
                 if (_disposed || !IsNavMenuOpen)
                 {
                     await DisposeKeyboardNavigationAsync(keyboardNavigation);

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -946,6 +946,10 @@ fluent-tooltip[anchor="dialog_close"] > div {
     text-overflow: ellipsis;
 }
 
+.aspire-menu-container.mobile-nav-menu fluent-menu-item {
+    scroll-margin-block: var(--mobile-nav-menu-focus-padding);
+}
+
 .aspire-menu-container fluent-menu-item.mobile-nav-menu-item-active {
     /* Mirror the desktop FluentAppBar selected treatment with an accent bar on
        the leading edge. position: relative anchors the ::before bar to the

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -344,61 +344,17 @@ window.initializeMobileNavMenuKeyboardNavigation = function (menuId, dotnetHelpe
         if (event.key === "Escape") {
             event.preventDefault();
             dotnetHelper.invokeMethodAsync("CloseMobileNavMenuFromKeyboardAsync");
-            return;
         }
-
-        if (event.key !== "Tab") {
-            return;
-        }
-
-        const menuItems = Array.from(menu.querySelectorAll("fluent-menu-item"));
-        if (menuItems.length === 0) {
-            return;
-        }
-
-        const activeMenuItem = getActiveMenuItem();
-        if (!activeMenuItem) {
-            return;
-        }
-
-        event.preventDefault();
-        const activeIndex = menuItems.indexOf(activeMenuItem);
-        const nextIndex = event.shiftKey
-            ? (activeIndex <= 0 ? menuItems.length - 1 : activeIndex - 1)
-            : (activeIndex >= menuItems.length - 1 ? 0 : activeIndex + 1);
-
-        menuItems[nextIndex].focus();
     };
 
-    // The FluentMenu web component uses roving focus for menu items, which makes
-    // Tab leave the open mobile navigation after the first item. Capture Tab while
-    // focus is inside the menu so keyboard users can reach all navigation items.
+    // Keep Escape-to-close available while focus is inside the mobile navigation.
+    // Do not trap Tab: this menu is inline page navigation, not a modal dialog.
     menu.addEventListener("keydown", keydownListener, true);
 
     return {
         menu,
         keydownListener
     };
-
-    function getActiveMenuItem() {
-        const visited = new Set();
-        let element = document.activeElement;
-        while (element && !visited.has(element)) {
-            visited.add(element);
-            if (element.matches?.("fluent-menu-item")) {
-                return element;
-            }
-
-            if (element.shadowRoot?.activeElement) {
-                element = element.shadowRoot.activeElement;
-                continue;
-            }
-
-            element = element.getRootNode?.().host ?? null;
-        }
-
-        return null;
-    }
 };
 
 window.disposeMobileNavMenuKeyboardNavigation = function (obj) {

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -334,12 +334,7 @@ window.focusElement = function (selector, suppressFocusVisible) {
     }
 };
 
-window.initializeMobileNavMenuKeyboardNavigation = function (menuId, dotnetHelper) {
-    const menu = document.getElementById(menuId);
-    if (!menu) {
-        return null;
-    }
-
+window.initializeMobileNavMenuKeyboardNavigation = function (dotnetHelper) {
     const keydownListener = function (event) {
         if (event.key === "Escape") {
             event.preventDefault();
@@ -353,13 +348,12 @@ window.initializeMobileNavMenuKeyboardNavigation = function (menuId, dotnetHelpe
     document.addEventListener("keydown", keydownListener, true);
 
     return {
-        menu,
         keydownListener
     };
 };
 
 window.disposeMobileNavMenuKeyboardNavigation = function (obj) {
-    document.removeEventListener("keydown", obj?.keydownListener, true);
+    document.removeEventListener("keydown", obj.keydownListener, true);
 };
 
 window.getWindowDimensions = function() {

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -334,7 +334,9 @@ window.focusElement = function (selector, suppressFocusVisible) {
     }
 };
 
-window.initializeMobileNavMenuKeyboardNavigation = function (dotnetHelper) {
+window.initializeMobileNavMenuKeyboardNavigation = function (dotnetHelper, menuId) {
+    const menu = document.getElementById(menuId);
+
     const keydownListener = function (event) {
         if (event.key === "Escape") {
             event.preventDefault();
@@ -342,18 +344,28 @@ window.initializeMobileNavMenuKeyboardNavigation = function (dotnetHelper) {
         }
     };
 
+    const focusoutListener = function (event) {
+        if (!menu.contains(event.relatedTarget)) {
+            dotnetHelper.invokeMethodAsync("CloseMobileNavMenuFromFocusLossAsync");
+        }
+    };
+
     // Keep Escape-to-close available as soon as the menu opens, including while
     // focus is still on the navigation button that opened this inline menu.
-    // Do not trap Tab: this menu is inline page navigation, not a modal dialog.
+    // Do not trap Tab: focusout closes the menu after focus naturally leaves it.
     document.addEventListener("keydown", keydownListener, true);
+    menu?.addEventListener("focusout", focusoutListener);
 
     return {
-        keydownListener
+        keydownListener,
+        focusoutListener,
+        menu
     };
 };
 
 window.disposeMobileNavMenuKeyboardNavigation = function (obj) {
     document.removeEventListener("keydown", obj.keydownListener, true);
+    obj.menu?.removeEventListener("focusout", obj.focusoutListener);
 };
 
 window.getWindowDimensions = function() {

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -334,11 +334,82 @@ window.focusElement = function (selector, suppressFocusVisible) {
     }
 };
 
+window.initializeMobileNavMenuKeyboardNavigation = function (menuId, dotnetHelper) {
+    const menu = document.getElementById(menuId);
+    if (!menu) {
+        return null;
+    }
+
+    const keydownListener = function (event) {
+        if (event.key === "Escape") {
+            event.preventDefault();
+            dotnetHelper.invokeMethodAsync("CloseMobileNavMenuFromKeyboardAsync");
+            return;
+        }
+
+        if (event.key !== "Tab") {
+            return;
+        }
+
+        const menuItems = Array.from(menu.querySelectorAll("fluent-menu-item"));
+        if (menuItems.length === 0) {
+            return;
+        }
+
+        const activeMenuItem = getActiveMenuItem();
+        if (!activeMenuItem) {
+            return;
+        }
+
+        event.preventDefault();
+        const activeIndex = menuItems.indexOf(activeMenuItem);
+        const nextIndex = event.shiftKey
+            ? (activeIndex <= 0 ? menuItems.length - 1 : activeIndex - 1)
+            : (activeIndex >= menuItems.length - 1 ? 0 : activeIndex + 1);
+
+        menuItems[nextIndex].focus();
+    };
+
+    // The FluentMenu web component uses roving focus for menu items, which makes
+    // Tab leave the open mobile navigation after the first item. Capture Tab while
+    // focus is inside the menu so keyboard users can reach all navigation items.
+    menu.addEventListener("keydown", keydownListener, true);
+
+    return {
+        menu,
+        keydownListener
+    };
+
+    function getActiveMenuItem() {
+        const visited = new Set();
+        let element = document.activeElement;
+        while (element && !visited.has(element)) {
+            visited.add(element);
+            if (element.matches?.("fluent-menu-item")) {
+                return element;
+            }
+
+            if (element.shadowRoot?.activeElement) {
+                element = element.shadowRoot.activeElement;
+                continue;
+            }
+
+            element = element.getRootNode?.().host ?? null;
+        }
+
+        return null;
+    }
+};
+
+window.disposeMobileNavMenuKeyboardNavigation = function (obj) {
+    obj?.menu?.removeEventListener("keydown", obj.keydownListener, true);
+};
+
 window.getWindowDimensions = function() {
     return {
         width: window.innerWidth,
         height: window.innerHeight
-    }
+    };
 }
 
 window.listenToWindowResize = function(dotnetHelper) {

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -347,9 +347,10 @@ window.initializeMobileNavMenuKeyboardNavigation = function (menuId, dotnetHelpe
         }
     };
 
-    // Keep Escape-to-close available while focus is inside the mobile navigation.
+    // Keep Escape-to-close available as soon as the menu opens, including while
+    // focus is still on the navigation button that opened this inline menu.
     // Do not trap Tab: this menu is inline page navigation, not a modal dialog.
-    menu.addEventListener("keydown", keydownListener, true);
+    document.addEventListener("keydown", keydownListener, true);
 
     return {
         menu,
@@ -358,7 +359,7 @@ window.initializeMobileNavMenuKeyboardNavigation = function (menuId, dotnetHelpe
 };
 
 window.disposeMobileNavMenuKeyboardNavigation = function (obj) {
-    obj?.menu?.removeEventListener("keydown", obj.keydownListener, true);
+    document.removeEventListener("keydown", obj?.keydownListener, true);
 };
 
 window.getWindowDimensions = function() {

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
@@ -495,8 +495,7 @@ public partial class MainLayoutTests : DashboardTestContext
 
         JSInterop.SetupModule("window.registerGlobalKeydownListener", _ => true);
         JSInterop.SetupModule("window.registerOpenTextVisualizerOnClick", _ => true);
-        JSInterop.SetupModule("initializeMobileNavMenuKeyboardNavigation", _ => true);
-        JSInterop.SetupVoid("disposeMobileNavMenuKeyboardNavigation", _ => true);
+        LayoutSetupHelpers.SetupMobileNavMenuKeyboardNavigation(this);
 
         JSInterop.Setup<BrowserInfo>("window.getBrowserInfo").SetResult(new BrowserInfo { TimeZone = "abc", UserAgent = "mozilla" });
     }

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
@@ -495,6 +495,8 @@ public partial class MainLayoutTests : DashboardTestContext
 
         JSInterop.SetupModule("window.registerGlobalKeydownListener", _ => true);
         JSInterop.SetupModule("window.registerOpenTextVisualizerOnClick", _ => true);
+        JSInterop.SetupModule("initializeMobileNavMenuKeyboardNavigation", _ => true);
+        JSInterop.SetupVoid("disposeMobileNavMenuKeyboardNavigation", _ => true);
 
         JSInterop.Setup<BrowserInfo>("window.getBrowserInfo").SetResult(new BrowserInfo { TimeZone = "abc", UserAgent = "mozilla" });
     }

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
@@ -72,9 +72,9 @@ public class MobileNavMenuTests : DashboardTestContext
     public async Task CloseMobileNavMenuFromFocusLossAsync_ClosesMenuWithoutRestoringFocus()
     {
         var closeNavMenuCalled = false;
-        var cut = RenderMobileNavMenu(DashboardUrls.ResourcesUrl(), () => closeNavMenuCalled = true);
+        var cut = RenderMobileNavMenu(DashboardUrls.ResourcesUrl(), () => closeNavMenuCalled = true, isNavMenuOpen: false);
 
-        await cut.Instance.CloseMobileNavMenuFromFocusLossAsync();
+        await cut.InvokeAsync(cut.Instance.CloseMobileNavMenuFromFocusLossAsync);
 
         Assert.True(closeNavMenuCalled);
         Assert.DoesNotContain(JSInterop.Invocations, invocation => invocation.Identifier == "focusElement");
@@ -83,11 +83,11 @@ public class MobileNavMenuTests : DashboardTestContext
     [Fact]
     public async Task CloseMobileNavMenuFromKeyboardAsync_ClosesMenuAndRestoresFocus()
     {
-        JSInterop.SetupVoid("focusElement", _ => true);
+        JSInterop.SetupVoid("focusElement", _ => true).SetVoidResult();
         var closeNavMenuCalled = false;
-        var cut = RenderMobileNavMenu(DashboardUrls.ResourcesUrl(), () => closeNavMenuCalled = true);
+        var cut = RenderMobileNavMenu(DashboardUrls.ResourcesUrl(), () => closeNavMenuCalled = true, isNavMenuOpen: false);
 
-        await cut.Instance.CloseMobileNavMenuFromKeyboardAsync();
+        await cut.InvokeAsync(cut.Instance.CloseMobileNavMenuFromKeyboardAsync);
 
         Assert.True(closeNavMenuCalled);
         var invocation = Assert.Single(JSInterop.Invocations, invocation => invocation.Identifier == "focusElement");
@@ -95,7 +95,7 @@ public class MobileNavMenuTests : DashboardTestContext
         Assert.Equal(MainLayout.NavigationButtonId, argument);
     }
 
-    private IRenderedComponent<MobileNavMenu> RenderMobileNavMenu(string currentUrl, Action? closeNavMenu = null)
+    private IRenderedComponent<MobileNavMenu> RenderMobileNavMenu(string currentUrl, Action? closeNavMenu = null, bool isNavMenuOpen = true)
     {
         FluentUISetupHelpers.AddCommonDashboardServices(this);
         Services.AddSingleton<IDashboardClient>(new TestDashboardClient(isEnabled: true));
@@ -110,7 +110,7 @@ public class MobileNavMenuTests : DashboardTestContext
 
         return RenderComponent<MobileNavMenu>(builder =>
         {
-            builder.Add(p => p.IsNavMenuOpen, true);
+            builder.Add(p => p.IsNavMenuOpen, isNavMenuOpen);
             builder.Add(p => p.IsAIEnabled, false);
             builder.Add(p => p.CloseNavMenu, closeNavMenu ?? (() => { }));
             builder.Add(p => p.LaunchHelpAsync, () => Task.CompletedTask);

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Utils;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
 using Xunit;
 
 namespace Aspire.Dashboard.Components.Tests.Layout;
@@ -53,6 +54,16 @@ public class MobileNavMenuTests : DashboardTestContext
         Assert.Contains("padding-block: var(--mobile-nav-menu-focus-padding)", style);
         Assert.Contains("scroll-padding-block: var(--mobile-nav-menu-focus-padding)", style);
         Assert.Contains("mobile-nav-menu", cut.Find("fluent-menu").ClassList);
+    }
+
+    [Fact]
+    public void Render_OpenMenu_InitializesKeyboardNavigationWithComponentReferenceOnly()
+    {
+        _ = RenderMobileNavMenu(DashboardUrls.ResourcesUrl());
+
+        var invocation = Assert.Single(JSInterop.Invocations, i => i.Identifier == "initializeMobileNavMenuKeyboardNavigation");
+        var argument = Assert.Single(invocation.Arguments);
+        Assert.IsAssignableFrom<DotNetObjectReference<MobileNavMenu>>(argument);
     }
 
     private IRenderedComponent<MobileNavMenu> RenderMobileNavMenu(string currentUrl)

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
@@ -57,16 +57,45 @@ public class MobileNavMenuTests : DashboardTestContext
     }
 
     [Fact]
-    public void Render_OpenMenu_InitializesKeyboardNavigationWithComponentReferenceOnly()
+    public void Render_OpenMenu_InitializesKeyboardNavigationWithComponentReferenceAndMenuId()
     {
         _ = RenderMobileNavMenu(DashboardUrls.ResourcesUrl());
 
         var invocation = Assert.Single(JSInterop.Invocations, i => i.Identifier == "initializeMobileNavMenuKeyboardNavigation");
-        var argument = Assert.Single(invocation.Arguments);
-        Assert.IsAssignableFrom<DotNetObjectReference<MobileNavMenu>>(argument);
+        Assert.Collection(
+            invocation.Arguments,
+            argument => Assert.IsAssignableFrom<DotNetObjectReference<MobileNavMenu>>(argument),
+            argument => Assert.Equal(MobileNavMenu.MobileNavMenuId, argument));
     }
 
-    private IRenderedComponent<MobileNavMenu> RenderMobileNavMenu(string currentUrl)
+    [Fact]
+    public async Task CloseMobileNavMenuFromFocusLossAsync_ClosesMenuWithoutRestoringFocus()
+    {
+        var closeNavMenuCalled = false;
+        var cut = RenderMobileNavMenu(DashboardUrls.ResourcesUrl(), () => closeNavMenuCalled = true);
+
+        await cut.Instance.CloseMobileNavMenuFromFocusLossAsync();
+
+        Assert.True(closeNavMenuCalled);
+        Assert.DoesNotContain(JSInterop.Invocations, invocation => invocation.Identifier == "focusElement");
+    }
+
+    [Fact]
+    public async Task CloseMobileNavMenuFromKeyboardAsync_ClosesMenuAndRestoresFocus()
+    {
+        JSInterop.SetupVoid("focusElement", _ => true);
+        var closeNavMenuCalled = false;
+        var cut = RenderMobileNavMenu(DashboardUrls.ResourcesUrl(), () => closeNavMenuCalled = true);
+
+        await cut.Instance.CloseMobileNavMenuFromKeyboardAsync();
+
+        Assert.True(closeNavMenuCalled);
+        var invocation = Assert.Single(JSInterop.Invocations, invocation => invocation.Identifier == "focusElement");
+        var argument = Assert.Single(invocation.Arguments);
+        Assert.Equal(MainLayout.NavigationButtonId, argument);
+    }
+
+    private IRenderedComponent<MobileNavMenu> RenderMobileNavMenu(string currentUrl, Action? closeNavMenu = null)
     {
         FluentUISetupHelpers.AddCommonDashboardServices(this);
         Services.AddSingleton<IDashboardClient>(new TestDashboardClient(isEnabled: true));
@@ -83,7 +112,7 @@ public class MobileNavMenuTests : DashboardTestContext
         {
             builder.Add(p => p.IsNavMenuOpen, true);
             builder.Add(p => p.IsAIEnabled, false);
-            builder.Add(p => p.CloseNavMenu, () => { });
+            builder.Add(p => p.CloseNavMenu, closeNavMenu ?? (() => { }));
             builder.Add(p => p.LaunchHelpAsync, () => Task.CompletedTask);
             builder.Add(p => p.LaunchAIAgentsAsync, () => Task.CompletedTask);
             builder.Add(p => p.IsAgentHelpEnabled, false);

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
@@ -50,6 +50,9 @@ public class MobileNavMenuTests : DashboardTestContext
         Assert.DoesNotContain("height: 100vh", style);
         Assert.Contains("margin-top: var(--mobile-nav-menu-offset)", style);
         Assert.Contains("overflow-y: auto", style);
+        Assert.Contains("padding-block: var(--mobile-nav-menu-focus-padding)", style);
+        Assert.Contains("scroll-padding-block: var(--mobile-nav-menu-focus-padding)", style);
+        Assert.Contains("mobile-nav-menu", cut.Find("fluent-menu").ClassList);
     }
 
     private IRenderedComponent<MobileNavMenu> RenderMobileNavMenu(string currentUrl)

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
@@ -53,6 +53,7 @@ public class MobileNavMenuTests : DashboardTestContext
         Assert.Contains("padding-block: var(--mobile-nav-menu-focus-padding)", style);
         Assert.Contains("scroll-padding-block: var(--mobile-nav-menu-focus-padding)", style);
         Assert.Contains("mobile-nav-menu", cut.Find("fluent-menu").ClassList);
+        Assert.All(cut.FindAll("fluent-menu-item"), item => Assert.Equal("0", item.GetAttribute("tabindex")));
     }
 
     private IRenderedComponent<MobileNavMenu> RenderMobileNavMenu(string currentUrl)
@@ -63,6 +64,8 @@ public class MobileNavMenuTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentMenu(this);
         FluentUISetupHelpers.SetupFluentDivider(this);
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        JSInterop.SetupModule("initializeMobileNavMenuKeyboardNavigation", _ => true);
+        JSInterop.SetupVoid("disposeMobileNavMenuKeyboardNavigation", _ => true);
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo(currentUrl);

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
@@ -64,8 +64,7 @@ public class MobileNavMenuTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentMenu(this);
         FluentUISetupHelpers.SetupFluentDivider(this);
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
-        JSInterop.SetupModule("initializeMobileNavMenuKeyboardNavigation", _ => true);
-        JSInterop.SetupVoid("disposeMobileNavMenuKeyboardNavigation", _ => true);
+        LayoutSetupHelpers.SetupMobileNavMenuKeyboardNavigation(this);
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo(currentUrl);

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
@@ -53,7 +53,6 @@ public class MobileNavMenuTests : DashboardTestContext
         Assert.Contains("padding-block: var(--mobile-nav-menu-focus-padding)", style);
         Assert.Contains("scroll-padding-block: var(--mobile-nav-menu-focus-padding)", style);
         Assert.Contains("mobile-nav-menu", cut.Find("fluent-menu").ClassList);
-        Assert.All(cut.FindAll("fluent-menu-item"), item => Assert.Equal("0", item.GetAttribute("tabindex")));
     }
 
     private IRenderedComponent<MobileNavMenu> RenderMobileNavMenu(string currentUrl)

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/LayoutSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/LayoutSetupHelpers.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Bunit;
+
+namespace Aspire.Dashboard.Components.Tests.Shared;
+
+internal static class LayoutSetupHelpers
+{
+    public static void SetupMobileNavMenuKeyboardNavigation(TestContext context)
+    {
+        context.JSInterop.SetupModule(invocation => invocation.Identifier == "initializeMobileNavMenuKeyboardNavigation");
+        context.JSInterop.SetupVoid("disposeMobileNavMenuKeyboardNavigation", _ => true);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/BlazorAssetsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/BlazorAssetsTests.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class BlazorAssetsTests
+{
+    [Theory]
+    [InlineData("10")]
+    [InlineData("11")]
+    public void BlazorWebJs_DoesNotSendUnsupportedKeyboardEventProperties(string runtimeMajorVersion)
+    {
+        var blazorWebJs = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "wwwroot", "framework", $"blazor.web.{runtimeMajorVersion}.js"));
+
+        Assert.Contains("keydown", blazorWebJs, StringComparison.Ordinal);
+        Assert.False(
+            blazorWebJs.Contains("isComposing", StringComparison.Ordinal),
+            "The dashboard Blazor script must not emit KeyboardEvent.isComposing because the server event parser rejects the unknown property.");
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/BlazorAssetsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/BlazorAssetsTests.cs
@@ -12,11 +12,26 @@ public class BlazorAssetsTests
     [InlineData("11")]
     public void BlazorWebJs_DoesNotSendUnsupportedKeyboardEventProperties(string runtimeMajorVersion)
     {
-        var blazorWebJs = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "wwwroot", "framework", $"blazor.web.{runtimeMajorVersion}.js"));
+        var blazorWebJsPath = Path.Combine(GetRepoRoot(), "src", "Aspire.Dashboard", "wwwroot", "framework", $"blazor.web.{runtimeMajorVersion}.js");
+        Assert.True(File.Exists(blazorWebJsPath), $"Expected generated Blazor asset at {blazorWebJsPath}");
+
+        var blazorWebJs = File.ReadAllText(blazorWebJsPath);
 
         Assert.Contains("keydown", blazorWebJs, StringComparison.Ordinal);
         Assert.False(
             blazorWebJs.Contains("isComposing", StringComparison.Ordinal),
             "The dashboard Blazor script must not emit KeyboardEvent.isComposing because the server event parser rejects the unknown property.");
+    }
+
+    private static string GetRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Aspire.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return directory.FullName;
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/MobileNavMenuTests.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
+using Aspire.TestUtilities;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Integration.Playwright;
+
+[RequiresFeature(TestFeature.Playwright)]
+public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixture>
+{
+    private const string SettingsMenuItemTitle = "Settings";
+
+    public MobileNavMenuTests(DashboardServerFixture dashboardServerFixture)
+        : base(dashboardServerFixture)
+    {
+    }
+
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task MobileNavFocusRemainsVisibleAtHighZoomViewport()
+    {
+        await using var context = await PlaywrightFixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            IgnoreHTTPSErrors = true,
+            BaseURL = DashboardServerFixture.DashboardApp.FrontendSingleEndPointAccessor().GetResolvedAddress(),
+            ViewportSize = new ViewportSize { Width = 640, Height = 384 }
+        });
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync("/").DefaultTimeout();
+        await Assertions.Expect(page.GetByText(MockDashboardClient.TestResource1.DisplayName)).ToBeVisibleAsync();
+
+        await page.Locator(".navigation-button").ClickAsync();
+        var menu = page.Locator("fluent-menu.mobile-nav-menu");
+        await Assertions.Expect(menu).ToBeVisibleAsync();
+
+        var settingsItem = page.Locator($"fluent-menu.mobile-nav-menu fluent-menu-item[title='{SettingsMenuItemTitle}']");
+        await settingsItem.FocusAsync();
+
+        var metrics = await settingsItem.EvaluateAsync<MobileNavFocusMetrics>("""
+            element => {
+                const menu = document.querySelector('fluent-menu.mobile-nav-menu');
+                const menuRect = menu.getBoundingClientRect();
+                const focusedRect = element.getBoundingClientRect();
+                const style = getComputedStyle(menu);
+                return {
+                    activeTitle: element.getAttribute('title'),
+                    menuTop: menuRect.top,
+                    menuBottom: menuRect.bottom,
+                    focusedTop: focusedRect.top,
+                    focusedBottom: focusedRect.bottom,
+                    viewportHeight: innerHeight,
+                    paddingTop: style.paddingTop,
+                    paddingBottom: style.paddingBottom,
+                    scrollPaddingTop: style.scrollPaddingTop,
+                    scrollPaddingBottom: style.scrollPaddingBottom
+                };
+            }
+            """);
+
+        Assert.Equal(SettingsMenuItemTitle, metrics.ActiveTitle);
+        Assert.True(metrics.MenuTop >= 0, $"Menu starts above viewport: {metrics}");
+        Assert.True(metrics.MenuBottom <= metrics.ViewportHeight, $"Menu extends below viewport: {metrics}");
+        Assert.True(metrics.FocusedTop >= metrics.MenuTop, $"Focused item starts above menu scrollport: {metrics}");
+        Assert.True(metrics.FocusedBottom <= metrics.MenuBottom, $"Focused item extends below menu scrollport: {metrics}");
+        Assert.Equal("4px", metrics.PaddingTop);
+        Assert.Equal("4px", metrics.PaddingBottom);
+        Assert.Equal("4px", metrics.ScrollPaddingTop);
+        Assert.Equal("4px", metrics.ScrollPaddingBottom);
+    }
+
+    private sealed class MobileNavFocusMetrics
+    {
+        public string? ActiveTitle { get; set; }
+
+        public double MenuTop { get; set; }
+
+        public double MenuBottom { get; set; }
+
+        public double FocusedTop { get; set; }
+
+        public double FocusedBottom { get; set; }
+
+        public double ViewportHeight { get; set; }
+
+        public string PaddingTop { get; set; } = null!;
+
+        public string PaddingBottom { get; set; } = null!;
+
+        public string ScrollPaddingTop { get; set; } = null!;
+
+        public string ScrollPaddingBottom { get; set; } = null!;
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/MobileNavMenuTests.cs
@@ -38,6 +38,14 @@ public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixt
         var menu = page.Locator("fluent-menu.mobile-nav-menu");
         await Assertions.Expect(menu).ToBeVisibleAsync();
 
+        await page.Keyboard.PressAsync("Escape");
+        await Assertions.Expect(menu).ToBeHiddenAsync();
+        var activeElementId = await page.EvaluateAsync<string?>("() => document.activeElement?.id");
+        Assert.Equal("dashboard-navigation-button", activeElementId);
+
+        await page.Locator(".navigation-button").ClickAsync();
+        await Assertions.Expect(menu).ToBeVisibleAsync();
+
         await page.Keyboard.PressAsync("Tab");
 
         var focusHistory = new List<string?>();
@@ -74,6 +82,8 @@ public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixt
                     viewportHeight: innerHeight,
                     paddingTop: style.paddingTop,
                     paddingBottom: style.paddingBottom,
+                    paddingTopValue: Number.parseFloat(style.paddingTop),
+                    paddingBottomValue: Number.parseFloat(style.paddingBottom),
                     scrollPaddingTop: style.scrollPaddingTop,
                     scrollPaddingBottom: style.scrollPaddingBottom
                 };
@@ -103,8 +113,8 @@ public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixt
         Assert.True(metrics.ActiveTitle == SettingsMenuItemTitle, $"Focus did not reach the Settings menu item. History: {string.Join(" -> ", focusHistory)}");
         Assert.True(metrics.MenuTop >= 0, $"Menu starts above viewport: {metrics}");
         Assert.True(metrics.MenuBottom <= metrics.ViewportHeight, $"Menu extends below viewport: {metrics}");
-        Assert.True(metrics.FocusedTop >= metrics.MenuTop, $"Focused item starts above menu scrollport: {metrics}");
-        Assert.True(metrics.FocusedBottom <= metrics.MenuBottom, $"Focused item extends below menu scrollport: {metrics}");
+        Assert.True(metrics.FocusedTop >= metrics.MenuTop + metrics.PaddingTopValue - 0.5, $"Focused item starts inside the menu focus padding: {metrics}");
+        Assert.True(metrics.FocusedBottom <= metrics.MenuBottom - metrics.PaddingBottomValue + 0.5, $"Focused item ends inside the menu focus padding: {metrics}");
         Assert.Equal("4px", metrics.PaddingTop);
         Assert.Equal("4px", metrics.PaddingBottom);
         Assert.Equal("4px", metrics.ScrollPaddingTop);
@@ -113,7 +123,7 @@ public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixt
         await page.Keyboard.PressAsync("Escape");
         await Assertions.Expect(menu).ToBeHiddenAsync();
 
-        var activeElementId = await page.EvaluateAsync<string?>("() => document.activeElement?.id");
+        activeElementId = await page.EvaluateAsync<string?>("() => document.activeElement?.id");
         Assert.Equal("dashboard-navigation-button", activeElementId);
     }
 
@@ -156,6 +166,10 @@ public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixt
         public string PaddingTop { get; set; } = null!;
 
         public string PaddingBottom { get; set; } = null!;
+
+        public double PaddingTopValue { get; set; }
+
+        public double PaddingBottomValue { get; set; }
 
         public string ScrollPaddingTop { get; set; } = null!;
 

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/MobileNavMenuTests.cs
@@ -21,6 +21,43 @@ public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixt
 
     [Fact]
     [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task MobileNavMenuClosesWhenFocusLeavesMenu()
+    {
+        await using var context = await PlaywrightFixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            IgnoreHTTPSErrors = true,
+            BaseURL = DashboardServerFixture.DashboardApp.FrontendSingleEndPointAccessor().GetResolvedAddress(),
+            ViewportSize = new ViewportSize { Width = 640, Height = 384 }
+        });
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync("/").DefaultTimeout();
+        await Assertions.Expect(page.GetByText(MockDashboardClient.TestResource1.DisplayName)).ToBeVisibleAsync();
+
+        await page.Locator(".navigation-button").ClickAsync();
+        var menu = page.Locator("fluent-menu.mobile-nav-menu");
+        await Assertions.Expect(menu).ToBeVisibleAsync();
+
+        await page.Keyboard.PressAsync("Tab");
+        Assert.True(await page.EvaluateAsync<bool>(IsFocusInsideMobileNavMenuScript));
+
+        await page.EvaluateAsync("""
+            () => {
+                const button = document.createElement('button');
+                button.id = 'outside-mobile-nav';
+                button.textContent = 'Outside mobile nav';
+                document.body.appendChild(button);
+            }
+            """);
+        await page.Locator("#outside-mobile-nav").FocusAsync();
+
+        await Assertions.Expect(menu).ToBeHiddenAsync();
+        var activeElementId = await page.EvaluateAsync<string?>("() => document.activeElement?.id");
+        Assert.Equal("outside-mobile-nav", activeElementId);
+    }
+
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
     public async Task MobileNavFocusRemainsVisibleAtHighZoomViewport()
     {
         await using var context = await PlaywrightFixture.Browser.NewContextAsync(new BrowserNewContextOptions
@@ -146,6 +183,29 @@ public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixt
             }
 
             return null;
+        }
+        """;
+
+    private const string IsFocusInsideMobileNavMenuScript = """
+        () => {
+            const menu = document.querySelector('fluent-menu.mobile-nav-menu');
+            const visited = new Set();
+            let element = document.activeElement;
+            while (element && !visited.has(element)) {
+                visited.add(element);
+                if (element === menu) {
+                    return true;
+                }
+
+                if (element.shadowRoot?.activeElement) {
+                    element = element.shadowRoot.activeElement;
+                    continue;
+                }
+
+                element = element.getRootNode?.().host ?? null;
+            }
+
+            return false;
         }
         """;
 

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/MobileNavMenuTests.cs
@@ -38,11 +38,11 @@ public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixt
         var menu = page.Locator("fluent-menu.mobile-nav-menu");
         await Assertions.Expect(menu).ToBeVisibleAsync();
 
+        await page.Keyboard.PressAsync("Tab");
+
         var focusHistory = new List<string?>();
         for (var i = 0; i < 15; i++)
         {
-            await page.Keyboard.PressAsync("Tab");
-
             var activeTitle = await page.EvaluateAsync<string?>(GetActiveMenuItemTitleScript);
             focusHistory.Add(activeTitle ?? await page.EvaluateAsync<string>("""
                 () => {
@@ -54,6 +54,8 @@ public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixt
             {
                 break;
             }
+
+            await page.Keyboard.PressAsync("ArrowDown");
         }
 
         var metrics = await page.EvaluateAsync<MobileNavFocusMetrics>("""

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/MobileNavMenuTests.cs
@@ -38,17 +38,33 @@ public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixt
         var menu = page.Locator("fluent-menu.mobile-nav-menu");
         await Assertions.Expect(menu).ToBeVisibleAsync();
 
-        var settingsItem = page.Locator($"fluent-menu.mobile-nav-menu fluent-menu-item[title='{SettingsMenuItemTitle}']");
-        await settingsItem.FocusAsync();
+        var focusHistory = new List<string?>();
+        for (var i = 0; i < 15; i++)
+        {
+            await page.Keyboard.PressAsync("Tab");
 
-        var metrics = await settingsItem.EvaluateAsync<MobileNavFocusMetrics>("""
-            element => {
+            var activeTitle = await page.EvaluateAsync<string?>(GetActiveMenuItemTitleScript);
+            focusHistory.Add(activeTitle ?? await page.EvaluateAsync<string>("""
+                () => {
+                    const element = document.activeElement;
+                    return `${element?.tagName ?? '<null>'}:${element?.className ?? ''}:${element?.getAttribute?.('title') ?? ''}`;
+                }
+                """));
+            if (activeTitle == SettingsMenuItemTitle)
+            {
+                break;
+            }
+        }
+
+        var metrics = await page.EvaluateAsync<MobileNavFocusMetrics>("""
+            () => {
                 const menu = document.querySelector('fluent-menu.mobile-nav-menu');
+                const focusedMenuItem = getActiveMenuItem();
                 const menuRect = menu.getBoundingClientRect();
-                const focusedRect = element.getBoundingClientRect();
+                const focusedRect = focusedMenuItem?.getBoundingClientRect() ?? new DOMRect();
                 const style = getComputedStyle(menu);
                 return {
-                    activeTitle: element.getAttribute('title'),
+                    activeTitle: focusedMenuItem?.getAttribute('title'),
                     menuTop: menuRect.top,
                     menuBottom: menuRect.bottom,
                     focusedTop: focusedRect.top,
@@ -59,10 +75,30 @@ public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixt
                     scrollPaddingTop: style.scrollPaddingTop,
                     scrollPaddingBottom: style.scrollPaddingBottom
                 };
+
+                function getActiveMenuItem() {
+                    const visited = new Set();
+                    let element = document.activeElement;
+                    while (element && !visited.has(element)) {
+                        visited.add(element);
+                        if (element.matches?.('fluent-menu-item')) {
+                            return element;
+                        }
+
+                        if (element.shadowRoot?.activeElement) {
+                            element = element.shadowRoot.activeElement;
+                            continue;
+                        }
+
+                        element = element.getRootNode?.().host ?? null;
+                    }
+
+                    return null;
+                }
             }
             """);
 
-        Assert.Equal(SettingsMenuItemTitle, metrics.ActiveTitle);
+        Assert.True(metrics.ActiveTitle == SettingsMenuItemTitle, $"Focus did not reach the Settings menu item. History: {string.Join(" -> ", focusHistory)}");
         Assert.True(metrics.MenuTop >= 0, $"Menu starts above viewport: {metrics}");
         Assert.True(metrics.MenuBottom <= metrics.ViewportHeight, $"Menu extends below viewport: {metrics}");
         Assert.True(metrics.FocusedTop >= metrics.MenuTop, $"Focused item starts above menu scrollport: {metrics}");
@@ -71,7 +107,35 @@ public sealed class MobileNavMenuTests : PlaywrightTestsBase<DashboardServerFixt
         Assert.Equal("4px", metrics.PaddingBottom);
         Assert.Equal("4px", metrics.ScrollPaddingTop);
         Assert.Equal("4px", metrics.ScrollPaddingBottom);
+
+        await page.Keyboard.PressAsync("Escape");
+        await Assertions.Expect(menu).ToBeHiddenAsync();
+
+        var activeElementId = await page.EvaluateAsync<string?>("() => document.activeElement?.id");
+        Assert.Equal("dashboard-navigation-button", activeElementId);
     }
+
+    private const string GetActiveMenuItemTitleScript = """
+        () => {
+            const visited = new Set();
+            let element = document.activeElement;
+            while (element && !visited.has(element)) {
+                visited.add(element);
+                if (element.matches?.('fluent-menu-item')) {
+                    return element.getAttribute('title');
+                }
+
+                if (element.shadowRoot?.activeElement) {
+                    element = element.shadowRoot.activeElement;
+                    continue;
+                }
+
+                element = element.getRootNode?.().host ?? null;
+            }
+
+            return null;
+        }
+        """;
 
     private sealed class MobileNavFocusMetrics
     {


### PR DESCRIPTION
## Description

Fixes #17657.

Keeps the mobile Resources navigation focus ring visible at the reported 1280x768 / 200% zoom size by adding focus-safe padding/scroll padding to the mobile nav scrollport, scroll margins on nav items, and minmax grid rows so the constrained menu can shrink inside the viewport.

The menu remains inline page navigation rather than a modal focus trap, but it now registers an Escape key handler while open so users can close it from the keyboard and return focus to the navigation button.

While validating the keyboard behavior on rolled-forward dashboard builds, the .NET 10/11 Blazor assets emitted `KeyboardEvent.isComposing`, which the dashboard's compatible server event parser rejects as an unknown property. This PR post-processes the copied `blazor.web.{major}.js` files to remove that unsupported event field from the dashboard asset pipeline.

Validation:
- `dotnet test --project tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj --no-launch-profile -- --filter-class "*.MobileNavMenuTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj --no-launch-profile -- --filter-class "*.MainLayoutTests" --filter-class "*.MobileNavMenuTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-method "*.MobileNavFocusRemainsVisibleAtHighZoomViewport" --filter-not-trait "quarantined=true"`
- `dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-method "*.BlazorWebJs_DoesNotSendUnsupportedKeyboardEventProperties" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
