### PR TITLE
Branding: use "Aspire" instead of ".NET Aspire"

### DIFF
--- a/docs/specs/bundle.md
+++ b/docs/specs/bundle.md
@@ -429,7 +429,7 @@ The bundle includes NuGet operations via the `aspire-managed nuget` subcommand, 
       "id": "Aspire.Hosting.Redis",
       "version": "13.2.0",
       "allVersions": ["13.1.0", "13.2.0"],
-      "description": "Redis hosting integration for .NET Aspire",
+      "description": "Redis hosting integration for Aspire",
       "authors": ["Microsoft"],
       "source": "nuget.org",
       "deprecated": false

--- a/src/Components/Aspire.Azure.Storage.Files.DataLake/README.md
+++ b/src/Components/Aspire.Azure.Storage.Files.DataLake/README.md
@@ -11,7 +11,7 @@ Registers a [DataLakeServiceClient](https://learn.microsoft.com/en-us/dotnet/api
 
 ### Install the package
 
-Install the .NET Aspire Azure Storage DataLake library with [NuGet](https://www.nuget.org):
+Install the Aspire Azure Storage DataLake library with [NuGet](https://www.nuget.org):
 
 ```dotnetcli
 dotnet add package Aspire.Azure.Storage.Files.DataLake
@@ -43,7 +43,7 @@ See the [Azure.Storage.Files.DataLake documentation](https://github.com/Azure/az
 
 ## Configuration
 
-The .NET Aspire Azure DataLake Storage library provides multiple options to configure the Azure Data Lake Storage connection based on the requirements and conventions of your project. Note that either a `ServiceUri` or a `ConnectionString` is a required to be supplied.
+The Aspire Azure DataLake Storage library provides multiple options to configure the Azure Data Lake Storage connection based on the requirements and conventions of your project. Note that either a `ServiceUri` or a `ConnectionString` is a required to be supplied.
 
 ### Use a connection string
 
@@ -83,7 +83,7 @@ Alternatively, an [Azure Storage connection string](https://learn.microsoft.com/
 
 ### Use configuration providers
 
-The .NET Aspire Azure Data Lake Storage library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureDataLakeSettings` and `DataLakeClientOptions` from configuration by using the `Aspire:Azure:Storage:Files:DataLake` key. Example `appsettings.json` that configures some of the options:
+The Aspire Azure Data Lake Storage library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureDataLakeSettings` and `DataLakeClientOptions` from configuration by using the `Aspire:Azure:Storage:Files:DataLake` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {


### PR DESCRIPTION
## Use "Aspire" instead of ".NET Aspire"

Aspire was rebranded from **".NET Aspire"** to simply **"Aspire"**. This PR updates current references in this repository to the new name.

### What changed
- Replaced `.NET Aspire` → `Aspire` in prose/docs/samples.

### What was intentionally left unchanged
- Historical mentions (release notes, changelogs, and sentences explaining the former name).
- `ASP.NET`-adjacent text (the replacement is guarded so `ASP.NET Aspire` is not affected).

> Opened as a **draft** for maintainer review. Generated as part of a coordinated branding cleanup — happy to adjust scope or wording.
