### PR TITLE
Log asciinema upload output on failure (safely)

### DIFF
--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -419,7 +419,21 @@ jobs:
                   TEST_UNKNOWN_COUNT=$((TEST_UNKNOWN_COUNT + 1))
                 fi
 
-                # Upload to asciinema with retry logic for transient failures
+                # Upload to asciinema with retry logic for transient failures.
+                # On failure we echo the captured asciinema output so post-mortems can
+                # distinguish an asciinema.org outage (HTTP 5xx, connection errors) from
+                # a client-side problem (rejected cast format, auth, rate limit, etc.).
+                # Without this the logs only say "Upload attempt N failed", which forces
+                # guessing about whether the issue is upstream or in our pipeline.
+                #
+                # SECURITY: this workflow runs in the elevated workflow_run context
+                # (pull-requests: write) and processes .cast artifacts that originate
+                # from PR builds, including fork PRs. asciinema's error output could
+                # echo back attacker-controlled bytes from a malicious .cast file.
+                # Wrap the echo in ::stop-commands::<token>...::<token>:: so the runner
+                # does not interpret any '::workflow-command::' sequences (set-output,
+                # add-mask, add-path, etc.) the output happens to contain.
+                # See https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#stopping-and-starting-workflow-commands
                 ASCIINEMA_URL=""
                 for attempt in $(seq 1 "$MAX_UPLOAD_RETRIES"); do
                   UPLOAD_OUTPUT=$(asciinema upload "$castfile" 2>&1) || true
@@ -427,9 +441,14 @@ jobs:
                   if [ -n "$ASCIINEMA_URL" ]; then
                     break
                   fi
+                  STOP_TOKEN=$(uuidgen)
+                  echo "Upload attempt $attempt failed. asciinema output:"
+                  echo "::stop-commands::${STOP_TOKEN}"
+                  echo "$UPLOAD_OUTPUT" | sed 's/^/  /'
+                  echo "::${STOP_TOKEN}::"
                   if [ "$attempt" -lt "$MAX_UPLOAD_RETRIES" ]; then
                     DELAY=$((attempt * RETRY_BASE_DELAY_SECONDS))
-                    echo "Upload attempt $attempt failed, retrying in ${DELAY}s..."
+                    echo "Retrying in ${DELAY}s..."
                     sleep "$DELAY"
                   fi
                 done


### PR DESCRIPTION
# Description

When the CLI E2E recording-comment workflow fails to upload a `.cast` file to asciinema.org, the only thing it logs is `Upload attempt N failed, retrying in Ys...`. The captured asciinema stdout/stderr (`$UPLOAD_OUTPUT`) is discarded, which makes post-mortems hard — there is no way to tell from the logs whether the failure is an asciinema.org outage (HTTP 5xx, connection error) or a client-side problem (rejected cast format, auth, rate limit, etc.).

This came up while investigating https://github.com/microsoft/aspire/pull/18442#issuecomment-4794857577, where 5 uploads failed back-to-back across ~75 minutes with no information about *why*. Multiple unrelated comment workflow runs in the same ~3 hour window hit the same pattern, strongly suggesting an asciinema.org outage — but we had to test from a clean machine to confirm that, instead of reading it straight from the run log.

## Change

Echo `$UPLOAD_OUTPUT` (indented for readability) after each failed upload attempt.

## Security

This workflow runs in the elevated `workflow_run` context with `pull-requests: write` and processes `.cast` artifacts that originate from PR builds, including fork PRs. asciinema's error output could in principle echo back attacker-controlled bytes from a malicious `.cast` file (e.g. a validation error that quotes file content).

GitHub Actions parses workflow commands like `::set-output ...`, `::add-mask::...`, `::add-path::...` from any stdout the runner sees, so blindly echoing untrusted output is a real injection risk. To mitigate, the echo is wrapped in `::stop-commands::<token>` / `::<token>::`, per [GitHub's documented mitigation](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#stopping-and-starting-workflow-commands). A fresh `uuidgen` token is generated per attempt so an attacker cannot pre-guess the closing marker.

## Testing

Workflow-only change; behavior on success is unchanged. The new log lines only appear on failed upload attempts.