### PR TITLE
Clear global AppHosts when switching to workspace view

### DIFF
--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -1984,6 +1984,41 @@ suite('AppHostDataRepository', () => {
         }
     });
 
+    test('switching from global to workspace view in an empty window clears global AppHosts', async () => {
+        let psOptions: any;
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ps') {
+                psOptions = options;
+            }
+            return new TestChildProcess();
+        });
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        try {
+            repository.activate();
+            repository.setViewMode('global');
+            repository.setPanelVisible(true);
+            await waitForCondition(() => psOptions !== undefined, 'global ps watch did not start');
+
+            psOptions.lineCallback(JSON.stringify([
+                {
+                    appHostPath: '/other/apps/Store/AppHost.csproj',
+                    appHostPid: 125881,
+                    dashboardUrl: 'https://localhost:17193/login?t=061212',
+                },
+            ]));
+
+            assert.strictEqual(repository.appHosts.length, 1);
+
+            repository.setViewMode('workspace');
+
+            assert.strictEqual(repository.appHosts.length, 0);
+            assert.strictEqual(repository.workspaceAppHost, undefined);
+        } finally {
+            repository.dispose();
+        }
+    });
+
     test('workspace ps empty snapshot keeps loading while workspace discovery is pending', async () => {
         const workspaceFolder = {
             uri: vscode.Uri.file('/workspace'),

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -2019,6 +2019,123 @@ suite('AppHostDataRepository', () => {
         }
     });
 
+    test('switching from global to workspace view filters AppHosts to the open workspace before discovery completes', async () => {
+        const workspaceFolder = {
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
+        const discovery = createDeferred<CandidateAppHostDisplayInfo[]>();
+        const appHostDiscoveryService = {
+            onDidChangeCandidates: () => ({ dispose: () => { } }),
+            discover: async () => discovery.promise,
+            dispose: () => { },
+        };
+        let psOptions: any;
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ps') {
+                psOptions = options;
+            }
+            return new TestChildProcess();
+        });
+        const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
+
+        try {
+            repository.activate();
+            repository.setViewMode('global');
+            repository.setPanelVisible(true);
+            await waitForCondition(() => psOptions !== undefined, 'global ps watch did not start');
+
+            psOptions.lineCallback(JSON.stringify([
+                {
+                    appHostPath: '/workspace/apps/Store/AppHost.csproj',
+                    appHostPid: 125881,
+                    dashboardUrl: 'https://localhost:17193/login?t=061212',
+                },
+                {
+                    appHostPath: '/other/apps/Store/AppHost.csproj',
+                    appHostPid: 225881,
+                    dashboardUrl: 'https://localhost:27193/login?t=061212',
+                },
+            ]));
+
+            assert.strictEqual(repository.appHosts.length, 2);
+
+            repository.setViewMode('workspace');
+
+            assert.strictEqual(repository.isWorkspaceAppHostDiscoveryComplete, false);
+            assert.strictEqual(repository.appHosts.length, 1);
+            assert.strictEqual(repository.appHosts[0].appHostPath, '/workspace/apps/Store/AppHost.csproj');
+            assert.strictEqual(repository.workspaceAppHost?.appHostPid, 125881);
+        } finally {
+            repository.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
+    test('switching from global to workspace view filters AppHosts to discovered workspace candidates', async () => {
+        const workspaceFolder = {
+            uri: vscode.Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        const workspaceFoldersStub = stubWorkspaceFolders([workspaceFolder]);
+        const appHostDiscoveryService = {
+            onDidChangeCandidates: () => ({ dispose: () => { } }),
+            discover: async () => [{
+                path: '/workspace/apps/Store/AppHost.csproj',
+                language: 'csharp' as const,
+                status: 'buildable' as const,
+            }],
+            dispose: () => { },
+        };
+        let psOptions: any;
+        spawnStub.callsFake((_terminalProvider, _command, args, options) => {
+            if (args[0] === 'ps') {
+                psOptions = options;
+            }
+            return new TestChildProcess();
+        });
+        const repository = new AppHostDataRepository(terminalProvider, appHostDiscoveryService as unknown as AppHostDiscoveryService);
+
+        try {
+            repository.activate();
+            repository.setPanelVisible(true);
+            await waitForCondition(() => repository.isWorkspaceAppHostDiscoveryComplete, 'workspace discovery did not complete');
+
+            repository.setViewMode('global');
+            await waitForCondition(() => psOptions !== undefined, 'global ps watch did not start');
+
+            psOptions.lineCallback(JSON.stringify([
+                {
+                    appHostPath: '/workspace/apps/Store/AppHost.csproj',
+                    appHostPid: 125881,
+                    dashboardUrl: 'https://localhost:17193/login?t=061212',
+                },
+                {
+                    appHostPath: '/workspace/apps/Other/AppHost.csproj',
+                    appHostPid: 225881,
+                    dashboardUrl: 'https://localhost:27193/login?t=061212',
+                },
+            ]));
+
+            assert.strictEqual(repository.appHosts.length, 2);
+
+            repository.setViewMode('workspace');
+
+            assert.deepStrictEqual(repository.workspaceAppHostCandidatePaths, [
+                '/workspace/apps/Store/AppHost.csproj',
+            ]);
+            assert.strictEqual(repository.appHosts.length, 1);
+            assert.strictEqual(repository.appHosts[0].appHostPath, '/workspace/apps/Store/AppHost.csproj');
+            assert.strictEqual(repository.workspaceAppHost?.appHostPid, 125881);
+        } finally {
+            repository.dispose();
+            workspaceFoldersStub.restore();
+        }
+    });
+
     test('workspace ps empty snapshot keeps loading while workspace discovery is pending', async () => {
         const workspaceFolder = {
             uri: vscode.Uri.file('/workspace'),

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -351,6 +351,12 @@ export class AppHostDataRepository {
         this._viewMode = mode;
         vscode.commands.executeCommand('setContext', 'aspire.viewMode', mode);
         this._clearErrors();
+        if (mode === 'workspace') {
+            // Reinterpret the current `aspire ps` snapshot through the workspace filters when
+            // leaving global view. Otherwise an empty window can keep rendering global AppHosts
+            // until the next workspace-mode poll clears them.
+            this._handleWorkspacePsOutput(this._appHosts);
+        }
         this._updateLoadingContext();
         this._syncPolling();
         this._onDidChangeData.fire();
@@ -1688,6 +1694,7 @@ export class AppHostDataRepository {
         }
 
         this._appHosts = workspaceAppHosts;
+        this._appHostsSnapshot = JSON.stringify(this._appHosts);
         this._workspaceAppHost = workspaceAppHost;
 
         // When multiple workspace AppHost candidates exist, start per-AppHost describe


### PR DESCRIPTION
Fixes #18506.

This keeps workspace view from showing AppHosts discovered in global view when VS Code has no open workspace. When switching back to workspace view, the repository now re-applies the workspace filters to the current ps snapshot immediately instead of waiting for the next poll.

Proof:
- Generated proof GIF locally at `/tmp/pr18516-proof.gif` from the focused regression run. GitHub's documented REST/gh APIs do not support direct PR attachment upload from CLI; the private upload endpoint rejected the file. The GIF is ready for manual drag/drop upload to this PR.
- Focused regression proof:

```text
  AppHostDataRepository
    ✔ switching from global to workspace view in an empty window clears global AppHosts
    ✔ switching from global to workspace view filters AppHosts to the open workspace before discovery completes
    ✔ switching from global to workspace view filters AppHosts to discovered workspace candidates
  3 passing (40ms)
  Exit code:   0
```

Validation:
- Added regressions that fail before the fix and pass after it for empty windows, workspace-folder filtering while discovery is pending, and discovered-candidate filtering.
- `corepack yarn run compile-tests`
- Focused vscode-test regression for `switching from global to workspace view`
- `vscode-test --grep "^AppHostDataRepository"`
- `corepack yarn run lint`
- `corepack yarn run compile`

