### PR TITLE
Add Aspire.Hosting.Azure.Azd: import existing azd projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,11 @@ tests/PolyglotAppHosts/**/Java/**/*.class
 /playground/**/next-steps.md
 *.svclog
 
+# The AzdImport playground checks in a real azd project on purpose: its azure.yaml is the
+# hand-authored INPUT that the Aspire importer (builder.addAzdProject) consumes, not azd-generated
+# output. Un-ignore it so the sample is complete and importable after a fresh clone.
+!/playground/AzdImport/azd-app/azure.yaml
+
 # Python virtual environments
 .venv
 

--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -91,6 +91,7 @@
     <Project Path="src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj" />
     <Project Path="src/Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.ApplicationInsights.csproj" />
     <Project Path="src/Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AppService.csproj" />
+    <Project Path="src/Aspire.Hosting.Azure.Azd/Aspire.Hosting.Azure.Azd.csproj" />
     <Project Path="src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj" />
     <Project Path="src/Aspire.Hosting.Azure.ContainerRegistry/Aspire.Hosting.Azure.ContainerRegistry.csproj" />
     <Project Path="src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj" />
@@ -506,6 +507,7 @@
     <Project Path="tests/Aspire.Hosting.Analyzers.Tests/Aspire.Hosting.Analyzers.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.Foundry.Tests/Aspire.Hosting.Foundry.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.Azure.Kusto.Tests/Aspire.Hosting.Azure.Kusto.Tests.csproj" />
+    <Project Path="tests/Aspire.Hosting.Azure.Azd.Tests/Aspire.Hosting.Azure.Azd.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.Azure.Kubernetes.Tests/Aspire.Hosting.Azure.Kubernetes.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.Browsers.Tests/Aspire.Hosting.Browsers.Tests.csproj" />

--- a/playground/AzdImport/README.md
+++ b/playground/AzdImport/README.md
@@ -1,0 +1,83 @@
+# AzdImport playground
+
+This sample shows how an existing **Azure Developer CLI (azd)** project can be adopted by Aspire,
+**without changing the azd assets**, using the experimental `builder.addAzdProject(...)` API from
+`Aspire.Hosting.Azure.Azd`.
+
+Everything here is **TypeScript** — including the Aspire app host (`apphost.mts`) and the adopted
+service. It tells the "grow up from `azure.yaml` into Aspire, lose nothing" story end to end.
+
+## Layout
+
+```text
+AzdImport/
+├── apphost.mts                    # the Aspire app host (TypeScript) that adopts azd-app
+├── aspire.config.json             # selects the packages exposed to the TypeScript app host
+├── package.json / tsconfig.json
+└── azd-app/                       # an existing azd repo, checked in
+    ├── azure.yaml                 # services: store (ts); resources: cache (db.redis), orders (db.postgres)
+    ├── infra/                     # existing Bicep (preserved by reference, not regenerated)
+    │   ├── main.bicep
+    │   └── main.parameters.json
+    ├── .azure/                    # azd environment (reused, not recreated)
+    │   ├── config.json            # defaultEnvironment: dev
+    │   └── dev/.env               # AZURE_SUBSCRIPTION_ID / LOCATION / RESOURCE_GROUP / ...
+    └── src/store/                 # the service source code (TypeScript + Express)
+        ├── package.json
+        └── src/server.ts
+```
+
+## What the app host does
+
+```typescript
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+// 1. Adopt the existing azd project as-is. Nothing in ./azd-app is rewritten.
+const azd = await builder.addAzdProject('./azd-app');
+
+// 2. Grow up: add a brand-new native Aspire resource and make it depend on an imported one.
+const orders = await azd.getResource('orders');
+const analytics = await builder.addRedis('analytics');
+await analytics.waitFor(orders);
+
+await builder.build().run();
+```
+
+`addAzdProject` reads `azure.yaml`, the selected `.azure` environment, and the `infra/` folder, then
+projects the azd model onto native Aspire resources:
+
+| azd asset | Imported Aspire resource |
+| --- | --- |
+| `services.store` (`host: containerapp`, `language: ts`) | a native Aspire **JavaScript app** for `src/store` (runs via npm locally, containerized on publish) |
+| `resources.cache` (`db.redis`) | `AddAzureManagedRedis("cache")` (a Redis container locally) |
+| `resources.orders` (`db.postgres`) | `AddAzurePostgresFlexibleServer("orders")` (a Postgres container locally) |
+| `services.store.uses: [cache, orders]` | `WithReference(...)` wiring (`ConnectionStrings__cache` / `ConnectionStrings__orders`) |
+| `infra/` | preserved by reference (an informational diagnostic is emitted) |
+
+The imported model is not frozen: you keep composing it with the normal Aspire TypeScript API. The
+loosely-typed `getResource` / `getService` accessors hand back resource handles that compose with
+name-based operations such as `waitFor`, so brand-new native resources and imported azd resources
+live in one application model.
+
+## Run it locally
+
+```bash
+aspire run
+```
+
+Locally the Azure resources run as containers (`db.redis` and `db.postgres`), so a container runtime
+is the only prerequisite — no Azure subscription or login is needed. Open the dashboard, then browse
+the `store` endpoints:
+
+- `/cache` — increments a counter in the imported Redis cache.
+- `/catalog` — runs `SELECT version()` against the imported PostgreSQL database.
+
+## Publish / deploy
+
+Because the importer reuses the project's `.azure` environment and preserves the existing `infra/`
+folder, the same model is what you would publish. The TypeScript `store` service is containerized
+automatically on publish (a Dockerfile is generated if one is not present). This playground uses
+placeholder Azure IDs in `.azure/dev/.env` so it can run locally; point it at a real azd environment
+to deploy.

--- a/playground/AzdImport/apphost.mts
+++ b/playground/AzdImport/apphost.mts
@@ -1,0 +1,32 @@
+// Aspire TypeScript AppHost — adopt an existing azd project, then grow it up natively.
+//
+// Run with:     aspire run
+// Publish with: aspire publish
+//
+// The azd project in ./azd-app is checked in unchanged. addAzdProject reads its azure.yaml, the
+// selected .azure environment, and the existing infra/ folder, and projects the azd services and
+// resources onto native, fully mutable Aspire resources:
+//   services.store  (language: ts, host: containerapp) -> a native Aspire JavaScript app (runs via npm
+//                                                          locally, containerized automatically on publish)
+//   resources.cache  (db.redis)                        -> Azure Managed Redis (azd's Azure Cache for Redis successor; a Redis container locally)
+//   resources.orders (db.postgres)                     -> Azure Database for PostgreSQL (a Postgres container locally)
+//   services.store.uses: [cache, orders]               -> WithReference wiring (ConnectionStrings__cache/__orders)
+// Locally everything runs as containers, so `aspire run` needs only a container runtime — no Azure login.
+
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+// 1. Adopt the existing azd project as-is. Nothing in ./azd-app is rewritten.
+const azd = await builder.addAzdProject('./azd-app');
+
+// 2. Grow up: keep building natively on top of the imported model. Here we add a brand-new Aspire
+//    resource the azd project never had, and make it depend on an imported one. getResource returns a
+//    base resource handle from the loosely-typed import that composes with name-based operations such as
+//    waitFor, so brand-new native resources and imported azd resources live in one application model.
+const orders = await azd.getResource('orders');
+const analytics = await builder.addRedis('analytics');
+await analytics.waitFor(orders);
+
+// build() flushes all pending operations before running.
+await builder.build().run();

--- a/playground/AzdImport/aspire.config.json
+++ b/playground/AzdImport/aspire.config.json
@@ -1,0 +1,10 @@
+{
+  "appHost": {
+    "path": "apphost.mts",
+    "language": "typescript/nodejs"
+  },
+  "packages": {
+    "Aspire.Hosting.Azure.Azd": "",
+    "Aspire.Hosting.Redis": ""
+  }
+}

--- a/playground/AzdImport/azd-app/.azure/config.json
+++ b/playground/AzdImport/azd-app/.azure/config.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "defaultEnvironment": "dev"
+}

--- a/playground/AzdImport/azd-app/.azure/dev/.env
+++ b/playground/AzdImport/azd-app/.azure/dev/.env
@@ -1,0 +1,11 @@
+# azd environment values for the "dev" environment.
+#
+# In a real azd repo this file is git-ignored and carries the customer's actual subscription,
+# location, and resource IDs. The Aspire importer reuses these values (it does not regenerate the
+# environment), so adopting the project keeps pointing at the same Azure environment. The IDs below
+# are placeholders so the playground can run locally without an Azure login.
+AZURE_ENV_NAME="dev"
+AZURE_LOCATION="eastus2"
+AZURE_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
+AZURE_TENANT_ID="00000000-0000-0000-0000-000000000000"
+AZURE_RESOURCE_GROUP="rg-dev"

--- a/playground/AzdImport/azd-app/azure.yaml
+++ b/playground/AzdImport/azd-app/azure.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+# This is the existing Azure Developer CLI (azd) project for a fictional "Contoso Store" app.
+# It is checked in on purpose: the Aspire app host next to it (../apphost.mts) adopts these assets
+# as-is via builder.addAzdProject(...). Nothing here is rewritten by the import.
+name: contoso-store
+metadata:
+  template: contoso-store@1.0.0
+infra:
+  provider: bicep
+  path: infra
+  module: main
+services:
+  store:
+    project: ./src/store
+    language: ts
+    host: containerapp
+    uses:
+      - cache
+      - orders
+    env:
+      NODE_ENV: development
+resources:
+  cache:
+    type: db.redis
+  orders:
+    type: db.postgres

--- a/playground/AzdImport/azd-app/infra/main.bicep
+++ b/playground/AzdImport/azd-app/infra/main.bicep
@@ -1,0 +1,27 @@
+// Existing azd infrastructure for the Contoso Store template.
+//
+// The Aspire importer preserves this folder by reference (it records the infra path and emits a
+// diagnostic) instead of regenerating it, so the customer keeps the exact Bicep they already ship.
+// It is intentionally minimal here because the playground runs locally on containers and never
+// provisions Azure; in a real azd repo this is the full deployment definition.
+targetScope = 'subscription'
+
+@minLength(1)
+@maxLength(64)
+@description('Name of the environment used to generate a short unique hash for resources.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+var tags = { 'azd-env-name': environmentName }
+
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+output AZURE_LOCATION string = location
+output AZURE_RESOURCE_GROUP string = rg.name

--- a/playground/AzdImport/azd-app/infra/main.parameters.json
+++ b/playground/AzdImport/azd-app/infra/main.parameters.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    }
+  }
+}

--- a/playground/AzdImport/azd-app/src/store/package-lock.json
+++ b/playground/AzdImport/azd-app/src/store/package-lock.json
@@ -1,0 +1,1722 @@
+{
+  "name": "contoso-store",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "contoso-store",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.21.2",
+        "pg": "^8.13.1",
+        "redis": "^4.7.0",
+        "tsx": "^4.19.2"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.11.0",
+        "@types/pg": "^8.11.10",
+        "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/playground/AzdImport/azd-app/src/store/package.json
+++ b/playground/AzdImport/azd-app/src/store/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "contoso-store",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Contoso Store service - originally an azd 'store' service, now adopted by Aspire unchanged.",
+  "scripts": {
+    "start": "tsx src/server.ts",
+    "dev": "tsx watch src/server.ts"
+  },
+  "dependencies": {
+    "express": "^4.21.2",
+    "pg": "^8.13.1",
+    "redis": "^4.7.0",
+    "tsx": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.0",
+    "@types/pg": "^8.11.10",
+    "typescript": "^5.6.3"
+  }
+}

--- a/playground/AzdImport/azd-app/src/store/src/server.ts
+++ b/playground/AzdImport/azd-app/src/store/src/server.ts
@@ -1,0 +1,146 @@
+import express, { type Request, type Response } from 'express';
+import { Pool } from 'pg';
+import { createClient, type RedisClientType } from 'redis';
+
+// Aspire assigns this service an HTTP endpoint and tells it which port to listen on via PORT.
+const port = Number(process.env.PORT ?? 8080);
+
+// The Aspire app host imported this service's azd `uses: [cache, orders]` edges and wired them with
+// WithReference, which injects the dependencies' connection strings as ConnectionStrings__<name>.
+//   - "cache"  -> the db.redis resource (Azure Managed Redis, azd's Azure Cache for Redis successor; runs as a Redis container locally)
+//   - "orders" -> the db.postgres resource (Azure Database for PostgreSQL; runs as a Postgres container locally)
+const cacheConnectionString = process.env['ConnectionStrings__cache'];
+const ordersConnectionString = process.env['ConnectionStrings__orders'];
+
+// Redis (StackExchange-style) connection string emitted by Aspire's Redis resource:
+//   "host:port"                         (local container, no auth)
+//   "host:port,password=<pwd>,ssl=true" (when a password / TLS is configured)
+function parseRedisConnectionString(connectionString: string): { host: string; port: number; password?: string; tls: boolean } {
+    const segments = connectionString.split(',');
+    const [host, portText] = segments[0].split(':');
+
+    let password: string | undefined;
+    let tls = false;
+    for (const segment of segments.slice(1)) {
+        const separator = segment.indexOf('=');
+        if (separator < 0) {
+            continue;
+        }
+        const key = segment.slice(0, separator).trim().toLowerCase();
+        const value = segment.slice(separator + 1).trim();
+        if (key === 'password') {
+            password = value;
+        } else if (key === 'ssl' && value.toLowerCase() === 'true') {
+            tls = true;
+        }
+    }
+
+    return { host, port: Number(portText), password, tls };
+}
+
+// Postgres (Npgsql key-value) connection string emitted by Aspire's PostgreSQL resource:
+//   "Host=host;Port=port;Username=postgres;Password=<pwd>"
+function parsePostgresConnectionString(connectionString: string): {
+    host: string;
+    port: number;
+    user?: string;
+    password?: string;
+    database: string;
+} {
+    const values: Record<string, string> = {};
+    for (const segment of connectionString.split(';')) {
+        if (segment.length === 0) {
+            continue;
+        }
+        const separator = segment.indexOf('=');
+        if (separator < 0) {
+            continue;
+        }
+        values[segment.slice(0, separator).trim().toLowerCase()] = segment.slice(separator + 1).trim();
+    }
+
+    return {
+        host: values['host'] ?? values['server'] ?? 'localhost',
+        port: Number(values['port'] ?? '5432'),
+        user: values['username'] ?? values['user id'] ?? values['user'],
+        password: values['password'],
+        // The server connection string has no database, so target the default "postgres" database.
+        database: values['database'] ?? 'postgres',
+    };
+}
+
+let redisClient: RedisClientType | undefined;
+if (cacheConnectionString) {
+    const redis = parseRedisConnectionString(cacheConnectionString);
+    // Locally, Aspire runs Azure Cache for Redis as a Redis container that terminates TLS with the
+    // .NET developer certificate (a self-signed cert for CN=localhost). Node rejects that cert by
+    // default, so relax verification only when talking to a loopback host. Against real Azure Cache
+    // for Redis (a non-loopback hostname with a publicly trusted cert) verification stays enabled.
+    const isLoopbackHost = redis.host === 'localhost' || redis.host === '127.0.0.1' || redis.host === '::1';
+    redisClient = createClient({
+        socket: redis.tls
+            ? { host: redis.host, port: redis.port, tls: true, rejectUnauthorized: !isLoopbackHost }
+            : { host: redis.host, port: redis.port },
+        password: redis.password,
+    });
+    redisClient.on('error', (error) => console.error('Redis error:', error));
+    await redisClient.connect();
+}
+
+let postgresPool: Pool | undefined;
+if (ordersConnectionString) {
+    postgresPool = new Pool(parsePostgresConnectionString(ordersConnectionString));
+}
+
+const app = express();
+
+app.get('/', (_req: Request, res: Response) => {
+    res.type('html').send(`
+        <!DOCTYPE html>
+        <html>
+        <head><title>Contoso Store</title></head>
+        <body style="font-family: sans-serif">
+          <h1>Contoso Store</h1>
+          <p>This service was an existing <strong>azd</strong> service (a TypeScript app), adopted by
+             Aspire via <code>builder.addAzdProject(...)</code> with no changes to the azd assets.</p>
+          <ul>
+            <li><a href="/cache">/cache</a> &mdash; increments a counter in the imported Redis cache</li>
+            <li><a href="/catalog">/catalog</a> &mdash; queries the imported PostgreSQL database</li>
+          </ul>
+        </body>
+        </html>`);
+});
+
+app.get('/cache', async (_req: Request, res: Response) => {
+    if (!redisClient) {
+        res.status(503).json({ error: 'Cache connection string (ConnectionStrings__cache) is not configured.' });
+        return;
+    }
+
+    try {
+        const pageHits = await redisClient.incr('page:hits');
+        res.json({ backend: 'Azure Cache for Redis (running as a container)', pageHits });
+    } catch (error) {
+        res.status(500).json({ error: error instanceof Error ? error.message : 'Unknown cache error' });
+    }
+});
+
+app.get('/catalog', async (_req: Request, res: Response) => {
+    if (!postgresPool) {
+        res.status(503).json({ error: 'Orders connection string (ConnectionStrings__orders) is not configured.' });
+        return;
+    }
+
+    try {
+        const result = await postgresPool.query<{ version: string }>('SELECT version()');
+        res.json({ backend: 'Azure Database for PostgreSQL (running as a container)', serverVersion: result.rows[0].version });
+    } catch (error) {
+        res.status(500).json({ error: error instanceof Error ? error.message : 'Unknown database error' });
+    }
+});
+
+app.listen(port, () => {
+    console.log(`Contoso Store listening on port ${port}`);
+    console.log(`  cache configured:   ${Boolean(cacheConnectionString)}`);
+    console.log(`  orders configured:  ${Boolean(ordersConnectionString)}`);
+});

--- a/playground/AzdImport/azd-app/src/store/tsconfig.json
+++ b/playground/AzdImport/azd-app/src/store/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/playground/AzdImport/package-lock.json
+++ b/playground/AzdImport/package-lock.json
@@ -1,0 +1,578 @@
+{
+  "name": "azdimport-apphost",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "azdimport-apphost",
+      "version": "1.0.0",
+      "dependencies": {
+        "vscode-jsonrpc": "^8.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    }
+  }
+}

--- a/playground/AzdImport/package.json
+++ b/playground/AzdImport/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "azdimport-apphost",
+  "version": "1.0.0",
+  "description": "Aspire TypeScript AppHost that adopts an existing azd project (azure.yaml).",
+  "type": "module",
+  "scripts": {
+    "start": "aspire run"
+  },
+  "dependencies": {
+    "vscode-jsonrpc": "^8.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/playground/AzdImport/tsconfig.json
+++ b/playground/AzdImport/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "apphost.mts",
+    ".aspire/modules/**/*.mts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/src/Aspire.Hosting.Azure.Azd/Aspire.Hosting.Azure.Azd.csproj
+++ b/src/Aspire.Hosting.Azure.Azd/Aspire.Hosting.Azure.Azd.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <PackageTags>aspire integration hosting azure azd migration import</PackageTags>
+    <Description>Imports an existing Azure Developer CLI (azd) project (azure.yaml) into an Aspire app model so existing azd assets can be adopted without rewriting them.</Description>
+    <PackageIconFullPath>$(SharedDir)Azure_256x.png</PackageIconFullPath>
+    <!-- New package with no shipped baseline yet; disable API-compat baseline validation. -->
+    <EnablePackageValidation>false</EnablePackageValidation>
+    <!-- The importer surface is experimental (POC). Suppress the diagnostic for the package's own
+         usage of its experimental types; external consumers still receive the warning. -->
+    <NoWarn>$(NoWarn);ASPIREAZUREAZD001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.AppContainers\Aspire.Hosting.Azure.AppContainers.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.AppService\Aspire.Hosting.Azure.AppService.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.CognitiveServices\Aspire.Hosting.Azure.CognitiveServices.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.CosmosDB\Aspire.Hosting.Azure.CosmosDB.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.EventHubs\Aspire.Hosting.Azure.EventHubs.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.Functions\Aspire.Hosting.Azure.Functions.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.KeyVault\Aspire.Hosting.Azure.KeyVault.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.PostgreSQL\Aspire.Hosting.Azure.PostgreSQL.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.Redis\Aspire.Hosting.Azure.Redis.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.Search\Aspire.Hosting.Azure.Search.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.ServiceBus\Aspire.Hosting.Azure.ServiceBus.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.Storage\Aspire.Hosting.Azure.Storage.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.JavaScript\Aspire.Hosting.JavaScript.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Azure.Azd.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Aspire.Hosting.Azure.Azd/AzdEnvironment.cs
+++ b/src/Aspire.Hosting.Azure.Azd/AzdEnvironment.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Azd;
+
+/// <summary>
+/// Represents a single azd environment, as stored under the project's <c>.azure</c> directory.
+/// </summary>
+/// <remarks>
+/// azd persists per-environment configuration in <c>.azure/&lt;name&gt;/.env</c>. These values capture
+/// the deployment target (subscription, location, resource group) and the outputs of the most recent
+/// provisioning, and are surfaced here so an importer can reuse them instead of re-prompting the user.
+/// </remarks>
+public sealed class AzdEnvironment
+{
+    internal AzdEnvironment(string name, IReadOnlyDictionary<string, string> values)
+    {
+        Name = name;
+        Values = values;
+    }
+
+    /// <summary>
+    /// Gets the environment name (the directory name under <c>.azure</c>).
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the raw key/value pairs read from the environment's <c>.env</c> file.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Values { get; }
+
+    /// <summary>
+    /// Gets the Azure subscription id (<c>AZURE_SUBSCRIPTION_ID</c>), if present.
+    /// </summary>
+    public string? SubscriptionId => GetValueOrDefault("AZURE_SUBSCRIPTION_ID");
+
+    /// <summary>
+    /// Gets the Azure location/region (<c>AZURE_LOCATION</c>), if present.
+    /// </summary>
+    public string? Location => GetValueOrDefault("AZURE_LOCATION");
+
+    /// <summary>
+    /// Gets the target resource group (<c>AZURE_RESOURCE_GROUP</c>), if present.
+    /// </summary>
+    public string? ResourceGroup => GetValueOrDefault("AZURE_RESOURCE_GROUP");
+
+    /// <summary>
+    /// Gets the deploying principal's object id (<c>AZURE_PRINCIPAL_ID</c>), if present.
+    /// </summary>
+    public string? PrincipalId => GetValueOrDefault("AZURE_PRINCIPAL_ID");
+
+    /// <summary>
+    /// Gets the Azure tenant id (<c>AZURE_TENANT_ID</c>), if present.
+    /// </summary>
+    public string? TenantId => GetValueOrDefault("AZURE_TENANT_ID");
+
+    /// <summary>
+    /// Gets the deploying principal's type (<c>AZURE_PRINCIPAL_TYPE</c>, for example <c>User</c> or
+    /// <c>ServicePrincipal</c>), if present.
+    /// </summary>
+    public string? PrincipalType => GetValueOrDefault("AZURE_PRINCIPAL_TYPE");
+
+    /// <summary>
+    /// Gets the value for the specified key, or <see langword="null"/> when it is not present.
+    /// </summary>
+    /// <param name="key">The environment variable name.</param>
+    /// <returns>The value, or <see langword="null"/>.</returns>
+    public string? GetValueOrDefault(string key)
+        => Values.TryGetValue(key, out var value) ? value : null;
+}

--- a/src/Aspire.Hosting.Azure.Azd/AzdEnvironmentReader.cs
+++ b/src/Aspire.Hosting.Azure.Azd/AzdEnvironmentReader.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+
+namespace Aspire.Hosting.Azure.Azd;
+
+/// <summary>
+/// Reads azd environment state from a project's <c>.azure</c> directory.
+/// </summary>
+/// <remarks>
+/// The on-disk layout written by azd is:
+/// <list type="bullet">
+/// <item><c>.azure/config.json</c> &#8212; selects the default environment via a <c>defaultEnvironment</c> field.</item>
+/// <item><c>.azure/&lt;name&gt;/.env</c> &#8212; a dotenv file holding that environment's values.</item>
+/// </list>
+/// </remarks>
+internal static class AzdEnvironmentReader
+{
+    /// <summary>
+    /// Reads an azd environment from the project's <c>.azure</c> directory.
+    /// </summary>
+    /// <param name="projectDirectory">The directory that contains <c>azure.yaml</c> (and the <c>.azure</c> folder).</param>
+    /// <param name="environmentName">
+    /// The environment to load. When <see langword="null"/>, the default environment from
+    /// <c>.azure/config.json</c> is used.
+    /// </param>
+    /// <returns>The loaded <see cref="AzdEnvironment"/>, or <see langword="null"/> when no environment exists.</returns>
+    public static AzdEnvironment? Read(string projectDirectory, string? environmentName = null)
+    {
+        var azureDir = Path.Combine(projectDirectory, ".azure");
+        if (!Directory.Exists(azureDir))
+        {
+            return null;
+        }
+
+        var name = environmentName ?? ReadDefaultEnvironmentName(azureDir);
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        var envFile = Path.Combine(azureDir, name, ".env");
+        var values = File.Exists(envFile)
+            ? ParseDotEnv(File.ReadAllLines(envFile))
+            : new Dictionary<string, string>();
+
+        return new AzdEnvironment(name, values);
+    }
+
+    private static string? ReadDefaultEnvironmentName(string azureDir)
+    {
+        var configFile = Path.Combine(azureDir, "config.json");
+        if (!File.Exists(configFile))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(configFile));
+            return document.RootElement.TryGetProperty("defaultEnvironment", out var value)
+                ? value.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            // A malformed config.json should not prevent import; the caller can still proceed
+            // without environment values.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses a dotenv file as written by azd.
+    /// </summary>
+    /// <remarks>
+    /// azd writes values that are JSON-quoted, for example:
+    /// <code>
+    /// AZURE_ENV_NAME="dev"
+    /// AZURE_LOCATION="eastus2"
+    /// # provisioning outputs
+    /// SERVICE_WEB_ENDPOINT_URL="https://web.example.com"
+    /// </code>
+    /// Blank lines and lines beginning with <c>#</c> are ignored. The first <c>=</c> separates key and
+    /// value, so values may themselves contain <c>=</c>. Surrounding single or double quotes are removed.
+    /// </remarks>
+    private static Dictionary<string, string> ParseDotEnv(IEnumerable<string> lines)
+    {
+        var values = new Dictionary<string, string>();
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line[0] == '#')
+            {
+                continue;
+            }
+
+            var separator = line.IndexOf('=');
+            if (separator <= 0)
+            {
+                continue;
+            }
+
+            var key = line[..separator].Trim();
+            var value = line[(separator + 1)..].Trim();
+
+            // azd writes values with godotenv, which double-quotes and escapes them much like JSON
+            // (\n, \r, \t, \", \\, \uXXXX). Unescape double-quoted values via the JSON string reader so
+            // connection strings or values containing quotes/newlines round-trip correctly. Fall back to
+            // a plain trim for single-quoted or hand-edited values that are not valid JSON strings.
+            if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+            {
+                try
+                {
+                    value = JsonSerializer.Deserialize<string>(value) ?? value;
+                }
+                catch (JsonException)
+                {
+                    value = value[1..^1];
+                }
+            }
+            else if (value.Length >= 2 && value[0] == '\'' && value[^1] == '\'')
+            {
+                value = value[1..^1];
+            }
+
+            values[key] = value;
+        }
+
+        return values;
+    }
+}

--- a/src/Aspire.Hosting.Azure.Azd/AzdImport.cs
+++ b/src/Aspire.Hosting.Azure.Azd/AzdImport.cs
@@ -1,0 +1,321 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.Azd;
+
+/// <summary>
+/// Represents the result of importing an azd project into an Aspire application model.
+/// </summary>
+/// <remarks>
+/// An <see cref="AzdImport"/> is returned from
+/// <see cref="AzdProjectBuilderExtensions.AddAzdProject(IDistributedApplicationBuilder, string?, System.Action{AzdImportOptions}?)"/>.
+/// It exposes the parsed <see cref="AzdProject"/>, the resolved <see cref="Environment"/>, the Aspire
+/// resource builders created for each azd service and resource, and any <see cref="Diagnostics"/>
+/// produced. Use <see cref="GetService(string)"/> and <see cref="GetResource(string)"/> to grab a
+/// reference to an imported service or resource and customize it like any other Aspire resource, or the
+/// strongly-typed <see cref="GetService{T}(string)"/> and <see cref="GetResource{T}(string)"/> overloads
+/// when you need the concrete resource type to call type-specific extension methods.
+/// </remarks>
+[Experimental("ASPIREAZUREAZD001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+// Exposed to polyglot (e.g. TypeScript) app hosts so the loosely-typed GetService/GetResource accessors
+// can be called over the Aspire Type System. The generic GetService{T}/GetResource{T} overloads are not
+// exported because ATS does not support generic methods; polyglot hosts use the loose accessors, which
+// hand back a base resource handle that composes with name-based operations such as WaitFor.
+[AspireExport(ExposeMethods = true)]
+public sealed class AzdImport
+{
+    private readonly IDistributedApplicationBuilder _builder;
+    private readonly Dictionary<string, IResourceBuilder<IResource>> _services = [];
+    private readonly Dictionary<string, IResourceBuilder<IResource>> _resources = [];
+
+    // Names requested through GetService/GetResource that did not match an imported service or resource.
+    // The failure is intentionally deferred (see Resolve): the app host keeps a usable reference in hand
+    // and the application only fails later, when the deferred BeforeStartEvent validation runs.
+    private readonly List<UnresolvedReference> _unresolved = [];
+    private int _placeholderCount;
+    private bool _deferredValidationRegistered;
+
+    internal AzdImport(IDistributedApplicationBuilder builder, AzdProject project, string projectDirectory, AzdEnvironment? environment)
+    {
+        _builder = builder;
+        Project = project;
+        ProjectDirectory = projectDirectory;
+        Environment = environment;
+    }
+
+    /// <summary>
+    /// Gets the parsed azd project model.
+    /// </summary>
+    public AzdProject Project { get; }
+
+    /// <summary>
+    /// Gets the absolute path of the directory that contains the imported <c>azure.yaml</c>.
+    /// </summary>
+    public string ProjectDirectory { get; }
+
+    /// <summary>
+    /// Gets the azd environment that was loaded from the project's <c>.azure</c> directory, if any.
+    /// </summary>
+    public AzdEnvironment? Environment { get; }
+
+    /// <summary>
+    /// Gets the diagnostics produced during the import.
+    /// </summary>
+    public AzdImportDiagnostics Diagnostics { get; } = new();
+
+    /// <summary>
+    /// Gets the Aspire resource builders created for each azd <c>services</c> entry, keyed by service name.
+    /// </summary>
+    public IReadOnlyDictionary<string, IResourceBuilder<IResource>> Services => _services;
+
+    /// <summary>
+    /// Gets the Aspire resource builders created for each azd <c>resources</c> entry, keyed by resource name.
+    /// </summary>
+    public IReadOnlyDictionary<string, IResourceBuilder<IResource>> Resources => _resources;
+
+    /// <summary>
+    /// Gets the directory that holds the project's existing infrastructure-as-code, when present and preserved.
+    /// </summary>
+    /// <value>
+    /// The absolute path to the azd <c>infra</c> directory, or <see langword="null"/> when the project
+    /// has no discoverable infrastructure folder. The importer does not regenerate these files; they
+    /// remain available for the existing deployment workflow.
+    /// </value>
+    public string? InfraPath { get; internal set; }
+
+    /// <summary>
+    /// Gets a reference to the Aspire resource created for the named azd <c>services</c> entry.
+    /// </summary>
+    /// <param name="name">The service name as it appears under <c>services:</c> in <c>azure.yaml</c>.</param>
+    /// <returns>The resource builder for the imported service.</returns>
+    /// <remarks>
+    /// The reference is always returned so app host authoring code reads naturally
+    /// (for example <c>azd.GetService("web").WithReplicas(2)</c>). If <paramref name="name"/> does not
+    /// match an imported service the failure is deferred: the returned reference is a placeholder and the
+    /// application fails later — when it is run, published, or deployed — with a diagnostic that names the
+    /// missing service, rather than throwing at the call site.
+    /// </remarks>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
+    public IResourceBuilder<IResource> GetService(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        return Resolve(name, _services, AzdReferenceKind.Service);
+    }
+
+    /// <summary>
+    /// Gets a reference to the Aspire resource created for the named azd <c>resources</c> entry.
+    /// </summary>
+    /// <param name="name">The resource name as it appears under <c>resources:</c> in <c>azure.yaml</c>.</param>
+    /// <returns>The resource builder for the imported resource.</returns>
+    /// <remarks>
+    /// The reference is always returned so app host authoring code reads naturally
+    /// (for example <c>azd.GetResource("cache").WithReplicas(2)</c>). If <paramref name="name"/> does not
+    /// match an imported resource the failure is deferred: the returned reference is a placeholder and the
+    /// application fails later — when it is run, published, or deployed — with a diagnostic that names the
+    /// missing resource, rather than throwing at the call site.
+    /// </remarks>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
+    public IResourceBuilder<IResource> GetResource(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        return Resolve(name, _resources, AzdReferenceKind.Resource);
+    }
+
+    /// <summary>
+    /// Gets a strongly-typed reference to the Aspire resource created for the named azd <c>services</c> entry.
+    /// </summary>
+    /// <typeparam name="T">The expected resource type, for example <c>ProjectResource</c>.</typeparam>
+    /// <param name="name">The service name as it appears under <c>services:</c> in <c>azure.yaml</c>.</param>
+    /// <returns>A strongly-typed resource builder for the imported service.</returns>
+    /// <remarks>
+    /// The import keeps every service in a loosely-typed model (<see cref="IResourceBuilder{IResource}"/>).
+    /// This overload re-wraps the underlying resource with <c>CreateResourceBuilder</c> so it composes with
+    /// the strongly-typed extension methods for <typeparamref name="T"/>. The builder it returns mutates the
+    /// same underlying resource as the one in <see cref="Services"/>. Because a typed placeholder cannot be
+    /// synthesized, an unknown name or a type mismatch is reported immediately rather than deferred.
+    /// </remarks>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// No service named <paramref name="name"/> was imported, or it is not a <typeparamref name="T"/>.
+    /// </exception>
+    [AspireExportIgnore(Reason = "ATS does not support generic methods; polyglot hosts use the non-generic GetService overload.")]
+    public IResourceBuilder<T> GetService<T>(string name) where T : IResource
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        return ResolveTyped<T>(name, _services, AzdReferenceKind.Service);
+    }
+
+    /// <summary>
+    /// Gets a strongly-typed reference to the Aspire resource created for the named azd <c>resources</c> entry.
+    /// </summary>
+    /// <typeparam name="T">The expected resource type, for example <c>AzureKeyVaultResource</c>.</typeparam>
+    /// <param name="name">The resource name as it appears under <c>resources:</c> in <c>azure.yaml</c>.</param>
+    /// <returns>A strongly-typed resource builder for the imported resource.</returns>
+    /// <remarks>
+    /// The import keeps every resource in a loosely-typed model (<see cref="IResourceBuilder{IResource}"/>).
+    /// This overload re-wraps the underlying resource with <c>CreateResourceBuilder</c> so it composes with
+    /// the strongly-typed extension methods for <typeparamref name="T"/> (for example
+    /// <c>azd.GetResource&lt;AzureCosmosDBResource&gt;("orders").AddDatabase(...)</c>). The builder it returns
+    /// mutates the same underlying resource as the one in <see cref="Resources"/>. Because a typed placeholder
+    /// cannot be synthesized, an unknown name or a type mismatch is reported immediately rather than deferred.
+    /// </remarks>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// No resource named <paramref name="name"/> was imported, or it is not a <typeparamref name="T"/>.
+    /// </exception>
+    [AspireExportIgnore(Reason = "ATS does not support generic methods; polyglot hosts use the non-generic GetResource overload.")]
+    public IResourceBuilder<T> GetResource<T>(string name) where T : IResource
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        return ResolveTyped<T>(name, _resources, AzdReferenceKind.Resource);
+    }
+
+    private IResourceBuilder<IResource> Resolve(string name, Dictionary<string, IResourceBuilder<IResource>> source, AzdReferenceKind kind)
+    {
+        if (source.TryGetValue(name, out var builder))
+        {
+            return builder;
+        }
+
+        // Defer the failure instead of throwing here. We hand back a placeholder reference so the caller's
+        // fluent chain keeps compiling and reading naturally, and register a one-time validation that runs
+        // before the app starts (BeforeStartEvent fires for both `aspire run` and `aspire publish`/`deploy`)
+        // to report every bad reference together. The placeholder is created with CreateResourceBuilder, so
+        // it is NOT added to the application model; the deferred validation is the only thing that fails,
+        // which means an unused bad reference still surfaces rather than silently passing.
+        EnsureDeferredValidationRegistered();
+        _unresolved.Add(new UnresolvedReference(name, kind));
+
+        var placeholderName = $"azd-unresolved-{++_placeholderCount}";
+        return _builder.CreateResourceBuilder<IResource>(new UnresolvedAzdReferenceResource(placeholderName));
+    }
+
+    private IResourceBuilder<T> ResolveTyped<T>(string name, Dictionary<string, IResourceBuilder<IResource>> source, AzdReferenceKind kind)
+        where T : IResource
+    {
+        if (source.TryGetValue(name, out var existing))
+        {
+            if (existing.Resource is T typed)
+            {
+                // The model holds IResourceBuilder<IResource> (the concrete builder upcast on import), and
+                // IResourceBuilder<T> is invariant, so the stored builder cannot be cast to the typed builder.
+                // Re-wrap the underlying resource so the caller gets a typed builder that composes with the
+                // type-specific extension methods while still mutating the same underlying resource.
+                return _builder.CreateResourceBuilder(typed);
+            }
+
+            // The name resolved but to the wrong type. A typed placeholder cannot be synthesized for an
+            // arbitrary T, so unlike the loosely-typed accessors this cannot be deferred; report it now.
+            throw new InvalidOperationException(
+                $"The azd {DescribeKind(kind)} '{name}' imported from '{ProjectDirectory}' is '{existing.Resource.GetType().Name}', " +
+                $"not '{typeof(T).Name}'. Use {Accessor(kind)}<{existing.Resource.GetType().Name}>(\"{name}\") or the loosely-typed {Accessor(kind)}(\"{name}\").");
+        }
+
+        // Unknown name: a typed placeholder cannot be synthesized either, so this is reported immediately.
+        // The loosely-typed GetService/GetResource overloads are the ones that defer the failure to startup.
+        throw new InvalidOperationException(
+            $"The azd project imported from '{ProjectDirectory}': {DescribeReference(name, kind)} Check the names against azure.yaml.");
+    }
+
+    /// <summary>
+    /// Resolves a reference to either an imported service or resource. Used internally to wire azd
+    /// <c>uses</c> edges, where a dependency may target either section of <c>azure.yaml</c>.
+    /// </summary>
+    internal bool TryResolveReference(string name, [NotNullWhen(true)] out IResourceBuilder<IResource>? builder)
+        => _services.TryGetValue(name, out builder) || _resources.TryGetValue(name, out builder);
+
+    internal void AddService(string name, IResourceBuilder<IResource> builder) => _services[name] = builder;
+
+    internal void AddResource(string name, IResourceBuilder<IResource> builder) => _resources[name] = builder;
+
+    private void EnsureDeferredValidationRegistered()
+    {
+        if (_deferredValidationRegistered)
+        {
+            return;
+        }
+
+        _deferredValidationRegistered = true;
+
+        // BeforeStartEvent is the earliest hook that runs for both `aspire run` and `aspire publish`/`deploy`
+        // (see DistributedApplication.StartAsync), so it surfaces a bad reference regardless of how the app
+        // host is invoked. Returning a faulted task guarantees the exception propagates out of PublishAsync.
+        _builder.Eventing.Subscribe<BeforeStartEvent>((_, _) =>
+            _unresolved.Count == 0
+                ? Task.CompletedTask
+                : Task.FromException(new InvalidOperationException(BuildUnresolvedReferenceMessage())));
+    }
+
+    private string BuildUnresolvedReferenceMessage()
+    {
+        var message = new StringBuilder();
+        message.Append("The azd project imported from '")
+               .Append(ProjectDirectory)
+               .Append("' could not resolve the following reference(s) requested from the app host:");
+
+        foreach (var reference in _unresolved)
+        {
+            message.AppendLine();
+            message.Append(" - ").Append(DescribeReference(reference.Name, reference.Kind));
+        }
+
+        message.AppendLine();
+        message.Append("Check the names against azure.yaml.");
+        return message.ToString();
+    }
+
+    // Builds a single-reference diagnostic that points the caller at the right accessor, e.g.
+    //   GetService("web") — no such service. Imported services: api, legacy.
+    //   GetResource("web") — 'web' is a service, not a resource. Use GetService("web").
+    private string DescribeReference(string name, AzdReferenceKind kind)
+    {
+        var description = new StringBuilder();
+        description.Append(Accessor(kind)).Append("(\"").Append(name).Append("\") ");
+
+        // If the requested name exists under the other azure.yaml section, point at the right accessor;
+        // mixing up services and resources is the most likely mistake.
+        var otherSection = kind == AzdReferenceKind.Service ? _resources : _services;
+        if (otherSection.ContainsKey(name))
+        {
+            var otherKind = kind == AzdReferenceKind.Service ? AzdReferenceKind.Resource : AzdReferenceKind.Service;
+            description.Append("— '").Append(name).Append("' is a ").Append(DescribeKind(otherKind))
+                       .Append(", not a ").Append(DescribeKind(kind))
+                       .Append(". Use ").Append(Accessor(otherKind)).Append("(\"").Append(name).Append("\").");
+        }
+        else
+        {
+            var available = kind == AzdReferenceKind.Service ? _services : _resources;
+            description.Append("— no such ").Append(DescribeKind(kind))
+                       .Append(". Imported ").Append(kind == AzdReferenceKind.Service ? "services" : "resources").Append(": ")
+                       .Append(available.Count == 0 ? "(none)" : string.Join(", ", available.Keys.OrderBy(static k => k, StringComparer.Ordinal)))
+                       .Append('.');
+        }
+
+        return description.ToString();
+    }
+
+    private static string Accessor(AzdReferenceKind kind) => kind == AzdReferenceKind.Service ? "GetService" : "GetResource";
+
+    private static string DescribeKind(AzdReferenceKind kind) => kind == AzdReferenceKind.Service ? "service" : "resource";
+
+    private enum AzdReferenceKind
+    {
+        Service,
+        Resource
+    }
+
+    private readonly record struct UnresolvedReference(string Name, AzdReferenceKind Kind);
+
+    // A stand-in for a service/resource name that did not match the import. It is never added to the
+    // application model; it exists only to satisfy the IResourceBuilder<IResource> return type while the
+    // real failure is reported by the deferred BeforeStartEvent validation.
+    private sealed class UnresolvedAzdReferenceResource(string name) : Resource(name);
+}

--- a/src/Aspire.Hosting.Azure.Azd/AzdImportDiagnostics.cs
+++ b/src/Aspire.Hosting.Azure.Azd/AzdImportDiagnostics.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Azd;
+
+/// <summary>
+/// Indicates the severity of an <see cref="AzdImportDiagnostic"/>.
+/// </summary>
+public enum AzdImportDiagnosticSeverity
+{
+    /// <summary>
+    /// Informational message about an import decision (for example, that existing infrastructure was preserved).
+    /// </summary>
+    Information,
+
+    /// <summary>
+    /// A non-fatal issue: part of the azd project could not be fully represented and may need manual attention.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// An unsafe-to-deploy condition: the import produced a model that will likely fail or behave
+    /// incorrectly at publish/deploy time (for example a service depends on a resource that could not
+    /// be referenced) and must be resolved before deploying.
+    /// </summary>
+    Error,
+}
+
+/// <summary>
+/// Represents a single observation produced while importing an azd project.
+/// </summary>
+/// <remarks>
+/// Diagnostics make the import non-destructive and transparent: anything the importer cannot map (an
+/// unsupported host kind, an unknown resource type, a missing source path) is reported here rather
+/// than being silently dropped, so a user migrating from azd can see exactly what needs follow-up.
+/// </remarks>
+/// <param name="Severity">The severity of the diagnostic.</param>
+/// <param name="Message">A human-readable description of the observation.</param>
+/// <param name="Target">The name of the azd service or resource the diagnostic relates to, if any.</param>
+public sealed record AzdImportDiagnostic(AzdImportDiagnosticSeverity Severity, string Message, string? Target = null)
+{
+    /// <inheritdoc />
+    public override string ToString()
+        => Target is null ? $"[{Severity}] {Message}" : $"[{Severity}] ({Target}) {Message}";
+}
+
+/// <summary>
+/// Collects the <see cref="AzdImportDiagnostic"/> instances produced during an import.
+/// </summary>
+public sealed class AzdImportDiagnostics
+{
+    private readonly List<AzdImportDiagnostic> _items = [];
+
+    /// <summary>
+    /// Gets the diagnostics produced during the import, in the order they were reported.
+    /// </summary>
+    public IReadOnlyList<AzdImportDiagnostic> Items => _items;
+
+    /// <summary>
+    /// Gets a value indicating whether any <see cref="AzdImportDiagnosticSeverity.Warning"/> diagnostics were produced.
+    /// </summary>
+    public bool HasWarnings => _items.Any(static d => d.Severity == AzdImportDiagnosticSeverity.Warning);
+
+    /// <summary>
+    /// Gets a value indicating whether any <see cref="AzdImportDiagnosticSeverity.Error"/> diagnostics were produced.
+    /// An import that has errors produced a model that is unsafe to deploy without manual changes.
+    /// </summary>
+    public bool HasErrors => _items.Any(static d => d.Severity == AzdImportDiagnosticSeverity.Error);
+
+    internal void Add(AzdImportDiagnostic diagnostic) => _items.Add(diagnostic);
+
+    internal void Information(string message, string? target = null)
+        => Add(new AzdImportDiagnostic(AzdImportDiagnosticSeverity.Information, message, target));
+
+    internal void Warning(string message, string? target = null)
+        => Add(new AzdImportDiagnostic(AzdImportDiagnosticSeverity.Warning, message, target));
+
+    internal void Error(string message, string? target = null)
+        => Add(new AzdImportDiagnostic(AzdImportDiagnosticSeverity.Error, message, target));
+}

--- a/src/Aspire.Hosting.Azure.Azd/AzdImportOptions.cs
+++ b/src/Aspire.Hosting.Azure.Azd/AzdImportOptions.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.Azure.Azd;
+
+/// <summary>
+/// Options that control how an azd project is imported into an Aspire application model.
+/// </summary>
+[Experimental("ASPIREAZUREAZD001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class AzdImportOptions
+{
+    /// <summary>
+    /// Gets or sets the azd environment name to load from the project's <c>.azure</c> directory.
+    /// </summary>
+    /// <value>
+    /// When <see langword="null"/> (the default), the default environment recorded in
+    /// <c>.azure/config.json</c> is used.
+    /// </value>
+    public string? EnvironmentName { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the importer should create Azure compute environments
+    /// (Azure Container Apps or Azure App Service) on demand for the services it imports.
+    /// </summary>
+    /// <value>
+    /// Defaults to <see langword="true"/>. Set to <see langword="false"/> when the app host already
+    /// declares its own compute environment that imported services should bind to.
+    /// </value>
+    public bool CreateComputeEnvironments { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the name used for the Azure Container Apps environment created for
+    /// <c>host: containerapp</c> services.
+    /// </summary>
+    public string ContainerAppEnvironmentName { get; set; } = "aca";
+
+    /// <summary>
+    /// Gets or sets the name used for the Azure App Service environment created for
+    /// <c>host: appservice</c> services.
+    /// </summary>
+    public string AppServiceEnvironmentName { get; set; } = "appservice";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether imported Azure resources that support a local
+    /// development experience are switched to a container or emulator when the app host runs locally
+    /// (<c>aspire run</c> / F5).
+    /// </summary>
+    /// <value>
+    /// Defaults to <see langword="true"/>. When enabled, resources are run locally without touching
+    /// Azure: Azure Cache for Redis and Azure Database for PostgreSQL run as containers, and Azure
+    /// Storage, Cosmos DB, Service Bus, and Event Hubs run as emulators. This only affects run mode;
+    /// publish/deploy always targets the real Azure resources. Resources without a local option (Key
+    /// Vault, OpenAI, AI Search) continue to bind to Azure using the reused <c>.azure</c> environment.
+    /// </value>
+    public bool UseEmulatorsForLocalRun { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether azd resources marked <c>existing: true</c> are bound to
+    /// the already-provisioned Azure resource instead of being provisioned again.
+    /// </summary>
+    /// <value>
+    /// Defaults to <see langword="true"/>. When enabled, an imported resource flagged as existing in
+    /// <c>azure.yaml</c> is annotated as existing (equivalent to calling <c>AsExisting</c>) using the
+    /// azd resource name and the resource group from the reused <c>.azure</c> environment, so neither
+    /// <c>aspire run</c> nor <c>aspire publish</c> recreates a resource the customer already owns.
+    /// </value>
+    public bool BindExistingResources { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the subscription, location, resource group, and tenant
+    /// recorded in the project's <c>.azure</c> environment are reused as the Aspire provisioning target.
+    /// </summary>
+    /// <value>
+    /// Defaults to <see langword="true"/>. When enabled, the importer seeds the <c>Azure:*</c>
+    /// configuration section (consumed by <c>AddAzureProvisioning</c>) from the loaded environment so a
+    /// migrated app provisions into the same subscription/region/resource group azd used. Values the app
+    /// host already configured are never overwritten.
+    /// </value>
+    public bool ReuseAzureEnvironment { get; set; } = true;
+
+    /// <summary>
+    /// Gets the list of custom resource mappers consulted before the built-in mappers.
+    /// </summary>
+    /// <remarks>
+    /// Add mappers here to support azd resource types the built-in mappers do not cover, or to
+    /// override the default mapping for a given type. Mappers are consulted in order.
+    /// </remarks>
+    public IList<IAzdResourceMapper> ResourceMappers { get; } = [];
+}

--- a/src/Aspire.Hosting.Azure.Azd/AzdInfrastructureLocator.cs
+++ b/src/Aspire.Hosting.Azure.Azd/AzdInfrastructureLocator.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.Azure.Azd;
+
+/// <summary>
+/// Locates an azd project's existing infrastructure-as-code folder and classifies its provider, mirroring
+/// azd's own resolution so both the runtime importer and the code generator preserve the same assets.
+/// </summary>
+/// <remarks>
+/// azd defaults to an <c>infra</c> folder containing a <c>main</c> module, and auto-detects the provider from
+/// the file extensions present when it is not pinned in <c>azure.yaml</c>: <c>.bicep</c>/<c>.bicepparam</c>
+/// imply Bicep and <c>.tf</c>/<c>.tfvars</c>(<c>.json</c>) imply Terraform.
+/// See <see href="https://github.com/Azure/azure-dev/blob/main/cli/azd/pkg/project/importer.go"/>.
+/// </remarks>
+internal static class AzdInfrastructureLocator
+{
+    /// <summary>
+    /// Attempts to locate the project's infrastructure folder.
+    /// </summary>
+    /// <param name="projectDirectory">The directory that contains <c>azure.yaml</c>.</param>
+    /// <param name="project">The parsed azd project (its <c>infra</c> block, if any, overrides the defaults).</param>
+    /// <param name="infraPath">When found, the absolute path to the infrastructure folder.</param>
+    /// <param name="provider">When found, the detected provider (<c>bicep</c> or <c>terraform</c>).</param>
+    /// <param name="relativePath">When found, the infrastructure path relative to the project (as authored).</param>
+    /// <returns><see langword="true"/> if an infrastructure folder exists; otherwise <see langword="false"/>.</returns>
+    public static bool TryLocate(
+        string projectDirectory,
+        AzdProject project,
+        [NotNullWhen(true)] out string? infraPath,
+        [NotNullWhen(true)] out string? provider,
+        [NotNullWhen(true)] out string? relativePath)
+    {
+        infraPath = null;
+        provider = null;
+        relativePath = project.Infra?.Path ?? "infra";
+
+        var candidate = Path.GetFullPath(Path.Combine(projectDirectory, relativePath));
+        if (!Directory.Exists(candidate))
+        {
+            relativePath = null;
+            return false;
+        }
+
+        infraPath = candidate;
+        provider = project.Infra?.Provider ?? DetectProvider(candidate);
+        return true;
+    }
+
+    private static string DetectProvider(string infraPath)
+    {
+        // Best-effort classification only; the folder is referenced, not parsed. Match azd's extension scan.
+        var hasBicep = Directory.EnumerateFiles(infraPath, "*.bicep", SearchOption.AllDirectories).Any()
+            || Directory.EnumerateFiles(infraPath, "*.bicepparam", SearchOption.AllDirectories).Any();
+        var hasTerraform = Directory.EnumerateFiles(infraPath, "*.tf", SearchOption.AllDirectories).Any()
+            || Directory.EnumerateFiles(infraPath, "*.tfvars", SearchOption.AllDirectories).Any()
+            || Directory.EnumerateFiles(infraPath, "*.tf.json", SearchOption.AllDirectories).Any();
+
+        // When only Terraform files are present, report terraform; otherwise default to bicep (azd's default,
+        // and the provider Aspire understands).
+        return hasTerraform && !hasBicep ? "terraform" : "bicep";
+    }
+}

--- a/src/Aspire.Hosting.Azure.Azd/AzdProjectBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Azd/AzdProjectBuilderExtensions.cs
@@ -1,0 +1,898 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure;
+using Aspire.Hosting.Azure.Azd;
+using Aspire.Hosting.JavaScript;
+using Microsoft.Extensions.Configuration;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides extension methods for importing an existing Azure Developer CLI (azd) project into an
+/// Aspire application model.
+/// </summary>
+/// <remarks>
+/// These APIs let a team that already uses azd adopt Aspire without abandoning their existing assets.
+/// The importer reads the project's <c>azure.yaml</c>, its selected <c>.azure</c> environment, and its
+/// existing <c>infra</c> folder, and projects the azd services and resources onto equivalent Aspire
+/// resources. Existing infrastructure-as-code is preserved (not regenerated), and anything that cannot
+/// be represented automatically is reported through <see cref="AzdImport.Diagnostics"/>.
+/// </remarks>
+public static partial class AzdProjectBuilderExtensions
+{
+    /// <summary>
+    /// Imports an existing azd project (described by an <c>azure.yaml</c> file) into the application model.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="azureYamlPath">
+    /// The path to the project's <c>azure.yaml</c> file or the directory that contains it. The path may
+    /// be absolute or relative to the app host directory. When <see langword="null"/>, the app host
+    /// directory is searched for <c>azure.yaml</c> (or <c>azure.yml</c>).
+    /// </param>
+    /// <param name="configureOptions">An optional callback used to configure how the project is imported.</param>
+    /// <returns>
+    /// An <see cref="AzdImport"/> describing the parsed project, the resolved environment, the Aspire
+    /// resource builders that were created, and any diagnostics produced.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when an <c>azure.yaml</c> file cannot be located.</exception>
+    /// <example>
+    /// Import an azd project that sits next to the app host and reference an imported resource:
+    /// <code>
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// var azd = builder.AddAzdProject();
+    ///
+    /// foreach (var diagnostic in azd.Diagnostics.Items)
+    /// {
+    ///     Console.WriteLine(diagnostic);
+    /// }
+    ///
+    /// builder.Build().Run();
+    /// </code>
+    /// </example>
+    [Experimental("ASPIREAZUREAZD001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [AspireExportIgnore(Reason = "azd import is a .NET app host authoring API and is not part of the polyglot ATS surface.")]
+    public static AzdImport AddAzdProject(
+        this IDistributedApplicationBuilder builder,
+        string? azureYamlPath = null,
+        Action<AzdImportOptions>? configureOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var options = new AzdImportOptions();
+        configureOptions?.Invoke(options);
+
+        var resolvedPath = ResolveAzureYamlPath(builder, azureYamlPath);
+        var projectDirectory = Path.GetDirectoryName(resolvedPath)!;
+
+        var project = AzdProjectParser.Parse(File.ReadAllText(resolvedPath));
+        var environment = AzdEnvironmentReader.Read(projectDirectory, options.EnvironmentName);
+
+        var import = new AzdImport(builder, project, projectDirectory, environment);
+
+        if (environment is not null)
+        {
+            import.Diagnostics.Information($"Loaded azd environment '{environment.Name}' from the .azure directory.");
+        }
+
+        // Reuse the subscription/location/resource group azd recorded so a migrated app provisions into
+        // the same place, instead of re-prompting or creating a parallel environment.
+        ApplyAzureEnvironment(builder, project, environment, options, import);
+
+        PreserveInfrastructure(import, project);
+
+        var mappers = new List<IAzdResourceMapper>(options.ResourceMappers);
+        mappers.AddRange(BuiltInResourceMappers.Create());
+
+        // Services and resources share a single Aspire resource-name namespace; track allocated names so
+        // two azd keys that sanitize to the same name do not collide (which would throw in AppHost build).
+        var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Resources are imported before services so that service `uses` references can resolve to them.
+        ImportResources(builder, import, project, environment, mappers, usedNames, options);
+        ImportServices(builder, import, project, environment, projectDirectory, options, usedNames);
+        WireUses(builder, import, project);
+        ReportUnwiredResourceUses(import, project);
+
+        return import;
+    }
+
+    /// <summary>
+    /// Imports an existing azd project (described by an <c>azure.yaml</c> file) into the application model.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="azureYamlPath">
+    /// The path to the project's <c>azure.yaml</c> file or the directory that contains it. The path may
+    /// be absolute or relative to the app host directory.
+    /// </param>
+    /// <returns>
+    /// An <see cref="AzdImport"/> describing the parsed project, the resolved environment, the Aspire
+    /// resource builders that were created, and any diagnostics produced.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// This overload exists so the importer can be called from polyglot (for example TypeScript) app hosts
+    /// through the Aspire Type System. It is the path-only form of
+    /// <see cref="AddAzdProject(IDistributedApplicationBuilder, string?, System.Action{AzdImportOptions}?)"/>;
+    /// callers that need to customize the import (environment name, emulator behavior, custom mappers) use
+    /// the C# overload that accepts an <see cref="AzdImportOptions"/> callback.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="azureYamlPath"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when an <c>azure.yaml</c> file cannot be located.</exception>
+    /// <example>
+    /// Import an azd project from a TypeScript app host:
+    /// <code>
+    /// const azd = await builder.addAzdProject("./azd-app");
+    /// await builder.build().run();
+    /// </code>
+    /// </example>
+    [Experimental("ASPIREAZUREAZD001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [AspireExport]
+    public static AzdImport AddAzdProject(this IDistributedApplicationBuilder builder, string azureYamlPath)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(azureYamlPath);
+
+        return AddAzdProject(builder, azureYamlPath, configureOptions: null);
+    }
+
+    private static void ImportResources(
+        IDistributedApplicationBuilder builder,
+        AzdImport import,
+        AzdProject project,
+        AzdEnvironment? environment,
+        List<IAzdResourceMapper> mappers,
+        HashSet<string> usedNames,
+        AzdImportOptions options)
+    {
+        foreach (var (key, resource) in project.Resources)
+        {
+            var resourceName = AllocateUniqueName(BuiltInResourceMappers.Sanitize(resource.Name ?? key), usedNames, import, key);
+            var context = new AzdResourceMapContext(builder, resourceName, resource, environment, import.Diagnostics);
+
+            var mapper = mappers.FirstOrDefault(m => m.CanMap(context));
+            if (mapper is null)
+            {
+                import.Diagnostics.Warning(
+                    $"No mapper is registered for azd resource type '{resource.Type ?? "(none)"}'. The resource was skipped; add a custom IAzdResourceMapper to handle it.",
+                    key);
+                continue;
+            }
+
+            var mapped = mapper.Map(context);
+            if (mapped is not null)
+            {
+                import.AddResource(key, mapped);
+                ConfigureProvisioning(builder, mapped, resource, environment, project, options, import, key);
+            }
+        }
+    }
+
+    // Turns each imported Azure resource into something that both runs locally and deploys to the
+    // customer's existing Azure environment, which is what makes the import behave natively end to end.
+    private static void ConfigureProvisioning(
+        IDistributedApplicationBuilder builder,
+        IResourceBuilder<IResource> mapped,
+        AzdResource resource,
+        AzdEnvironment? environment,
+        AzdProject project,
+        AzdImportOptions options,
+        AzdImport import,
+        string key)
+    {
+        // azd's `existing: true` means "reference, don't provision". Bind the imported resource to the
+        // already-provisioned Azure resource so neither run nor publish recreates something the customer
+        // already owns. This is the annotation form of AsExisting; we set it directly because the builder
+        // is upcast to IResourceBuilder<IResource> here, so the generic AsExisting<T> overload is not callable.
+        if (resource.Existing && options.BindExistingResources && mapped.Resource is IAzureResource)
+        {
+            var existingName = resource.Name ?? key;
+            var resourceGroup = ResolveResourceGroup(environment, project);
+
+            mapped.WithAnnotation(
+                resourceGroup is null
+                    ? new ExistingAzureResourceAnnotation(existingName)
+                    : new ExistingAzureResourceAnnotation(existingName, resourceGroup),
+                ResourceAnnotationMutationBehavior.Replace);
+
+            var resourceGroupSuffix = resourceGroup is null ? string.Empty : $" in resource group '{resourceGroup}'";
+            import.Diagnostics.Information(
+                $"azd resource '{key}' is marked 'existing: true'; it was bound to the existing Azure resource '{existingName}'{resourceGroupSuffix} instead of being provisioned again.",
+                key);
+        }
+
+        if (options.UseEmulatorsForLocalRun && builder.ExecutionContext.IsRunMode)
+        {
+            ApplyLocalRunMode(builder, mapped, import, key);
+        }
+    }
+
+    // In run mode, swap resources that support a local development experience to a container or emulator
+    // so `aspire run` works offline. Publish mode leaves the real Azure resource untouched; the
+    // RunAs* methods also self-gate to run mode, but gating here keeps the intent explicit.
+    private static void ApplyLocalRunMode(
+        IDistributedApplicationBuilder builder,
+        IResourceBuilder<IResource> mapped,
+        AzdImport import,
+        string key)
+    {
+        switch (mapped.Resource)
+        {
+            case AzureManagedRedisResource redis:
+                builder.CreateResourceBuilder(redis).RunAsContainer();
+                import.Diagnostics.Information($"azd resource '{key}' runs locally as a Redis container; it provisions Azure Managed Redis on publish.", key);
+                break;
+            case AzurePostgresFlexibleServerResource postgres:
+                builder.CreateResourceBuilder(postgres).RunAsContainer();
+                import.Diagnostics.Information($"azd resource '{key}' runs locally as a PostgreSQL container; it provisions Azure Database for PostgreSQL on publish.", key);
+                break;
+            case AzureStorageResource storage:
+                builder.CreateResourceBuilder(storage).RunAsEmulator();
+                import.Diagnostics.Information($"azd resource '{key}' runs locally on the Azurite storage emulator; it provisions Azure Storage on publish.", key);
+                break;
+            case AzureCosmosDBResource cosmos:
+                builder.CreateResourceBuilder(cosmos).RunAsEmulator();
+                import.Diagnostics.Information($"azd resource '{key}' runs locally on the Cosmos DB emulator; it provisions Azure Cosmos DB on publish.", key);
+                break;
+            case AzureServiceBusResource serviceBus:
+                builder.CreateResourceBuilder(serviceBus).RunAsEmulator();
+                import.Diagnostics.Information($"azd resource '{key}' runs locally on the Service Bus emulator; it provisions Azure Service Bus on publish.", key);
+                break;
+            case AzureEventHubsResource eventHubs:
+                builder.CreateResourceBuilder(eventHubs).RunAsEmulator();
+                import.Diagnostics.Information($"azd resource '{key}' runs locally on the Event Hubs emulator; it provisions Azure Event Hubs on publish.", key);
+                break;
+        }
+    }
+
+    // The existing Azure resource group comes from the customer's .azure environment (a concrete value).
+    // The azure.yaml resourceGroup may be an azd expandable string (for example "rg-${AZURE_ENV_NAME}"),
+    // so resolve it against the environment before using it as a fallback. If it still cannot be resolved
+    // to a concrete value (no environment, or an unresolved "${...}" token remains), it is meaningless to
+    // Aspire as a deployment target, so it is ignored.
+    private static string? ResolveResourceGroup(AzdEnvironment? environment, AzdProject project)
+    {
+        if (!string.IsNullOrEmpty(environment?.ResourceGroup))
+        {
+            return environment.ResourceGroup;
+        }
+
+        var resourceGroup = ExpandAzdExpandableString(project.ResourceGroup, environment);
+
+        // A remaining '$' means an azd token (either "${VAR}" or the bare "$VAR" form) could not be
+        // resolved against the environment. Azure resource group names never contain '$', so treat any
+        // leftover token as unresolved and ignore the value rather than passing a bogus target (for example
+        // "rg-$UNKNOWN") to provisioning.
+        if (string.IsNullOrEmpty(resourceGroup) || resourceGroup.Contains('$', StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return resourceGroup;
+    }
+
+    // Matches an azd expandable-string token: "${VAR}" or "$VAR". For "${...}" azd uses os.Expand
+    // semantics and reads everything up to the closing brace; for the bare form it reads a shell-style
+    // name ([A-Za-z_][A-Za-z0-9_]*).
+    [GeneratedRegex(@"\$\{(?<name>[^}]*)\}|\$(?<name>[A-Za-z_][A-Za-z0-9_]*)")]
+    private static partial Regex AzdExpandableStringRegex();
+
+    // azd treats several azure.yaml fields (notably resourceGroup and service env values) as
+    // "expandable strings" and resolves "${VAR}" / "$VAR" against the selected environment before use,
+    // e.g. `resourceGroup: rg-${AZURE_ENV_NAME}`. Mirror that resolution against the .azure environment's
+    // recorded values so a migrated project targets the same resource group / values azd would have.
+    //
+    // azd uses os.Expand semantics, where a missing variable expands to an empty string. We deviate in
+    // one deliberate, safe way: an unknown variable is left as its literal "${VAR}" token rather than
+    // blanked, so we never silently empty an adopter's value when a variable is not recorded in the
+    // environment. In practice the AZURE_* variables referenced from azure.yaml are always written to
+    // .azure/<env>/.env by azd, so they resolve; only genuinely unknown tokens are preserved.
+    // See osutil.ExpandableString.Envsubst in https://github.com/Azure/azure-dev.
+    [return: NotNullIfNotNull(nameof(value))]
+    private static string? ExpandAzdExpandableString(string? value, AzdEnvironment? environment)
+    {
+        if (string.IsNullOrEmpty(value) || environment is null || !value.Contains('$', StringComparison.Ordinal))
+        {
+            return value;
+        }
+
+        return AzdExpandableStringRegex().Replace(value, match =>
+        {
+            var name = match.Groups["name"].Value;
+
+            if (environment.Values.TryGetValue(name, out var resolved))
+            {
+                return resolved;
+            }
+
+            // azd always writes AZURE_ENV_NAME into the environment and it equals the environment's
+            // directory name, so resolve it from Name even if the key is absent from .env.
+            if (string.Equals(name, "AZURE_ENV_NAME", StringComparison.Ordinal))
+            {
+                return environment.Name;
+            }
+
+            return match.Value;
+        });
+    }
+
+    // Reuse the azd environment for Azure provisioning by seeding two configuration shapes from the same
+    // recorded values, so a migrated app targets the same subscription/region/resource group azd already
+    // used instead of re-prompting or creating a parallel environment. Values the app host author already
+    // set are preserved.
+    //
+    // The two shapes feed different parts of the Azure hosting stack:
+    //   - Azure:*        binds into AzureProvisionerOptions and is what BaseProvisioningContextProvider
+    //                    reads to pick the subscription/location/resource group during run-mode
+    //                    provisioning and `aspire deploy`.
+    //   - Parameters:*   backs the AzureEnvironmentResource that AddAzureProvisioning always adds (its
+    //                    Location/ResourceGroupName/PrincipalId are ParameterResources named "location",
+    //                    "resourceGroupName", and "principalId"; see AzureEnvironmentResourceExtensions.
+    //                    AddAzureEnvironment). That resource is the canonical deployment target the
+    //                    generated main.bicep is parameterized on. Without these, resolving those
+    //                    parameters throws MissingParameterValueException, so a grown-up app would prompt
+    //                    for (or fail on) values azd already knew at `aspire publish`/`aspire deploy` time.
+    private static void ApplyAzureEnvironment(
+        IDistributedApplicationBuilder builder,
+        AzdProject project,
+        AzdEnvironment? environment,
+        AzdImportOptions options,
+        AzdImport import)
+    {
+        if (!options.ReuseAzureEnvironment || environment is null)
+        {
+            return;
+        }
+
+        var resourceGroup = ResolveResourceGroup(environment, project);
+
+        var settings = new Dictionary<string, string?>();
+
+        AddConfigIfMissing(builder, settings, "Azure:SubscriptionId", environment.SubscriptionId);
+        AddConfigIfMissing(builder, settings, "Azure:Location", environment.Location);
+        AddConfigIfMissing(builder, settings, "Azure:ResourceGroup", resourceGroup);
+        AddConfigIfMissing(builder, settings, "Azure:TenantId", environment.TenantId);
+
+        // Populate the AzureEnvironmentResource parameters from the same azd values. The parameter names
+        // must match those AddAzureEnvironment creates.
+        AddConfigIfMissing(builder, settings, "Parameters:location", environment.Location);
+        AddConfigIfMissing(builder, settings, "Parameters:resourceGroupName", resourceGroup);
+        AddConfigIfMissing(builder, settings, "Parameters:principalId", environment.PrincipalId);
+
+        if (settings.Count == 0)
+        {
+            return;
+        }
+
+        builder.Configuration.AddInMemoryCollection(settings);
+
+        import.Diagnostics.Information(
+            $"Reusing the azd environment '{environment.Name}' for Azure provisioning ({string.Join(", ", settings.Keys)}). Run 'AddAzdProject' with ReuseAzureEnvironment disabled to opt out.");
+    }
+
+    private static void AddConfigIfMissing(
+        IDistributedApplicationBuilder builder,
+        Dictionary<string, string?> settings,
+        string key,
+        string? value)
+    {
+        // Don't clobber a value the app host author already configured (config, user secrets, env vars).
+        if (!string.IsNullOrEmpty(value) && string.IsNullOrEmpty(builder.Configuration[key]))
+        {
+            settings[key] = value;
+        }
+    }
+
+    private static void ImportServices(
+        IDistributedApplicationBuilder builder,
+        AzdImport import,
+        AzdProject project,
+        AzdEnvironment? environment,
+        string projectDirectory,
+        AzdImportOptions options,
+        HashSet<string> usedNames)
+    {
+        // Compute environments are created on demand the first time a service needs one.
+        IResourceBuilder<IComputeEnvironmentResource>? acaEnvironment = null;
+        IResourceBuilder<IComputeEnvironmentResource>? appServiceEnvironment = null;
+
+        IResourceBuilder<IComputeEnvironmentResource>? GetComputeEnvironment(AzdService service)
+        {
+            if (!options.CreateComputeEnvironments)
+            {
+                return null;
+            }
+
+            switch (service.Host?.ToLowerInvariant())
+            {
+                case "containerapp":
+                    return acaEnvironment ??= builder.AddAzureContainerAppEnvironment(options.ContainerAppEnvironmentName);
+                // azd's `function` host is Microsoft.Web/sites. Only .NET function services are imported as
+                // Azure Functions projects (the Aspire Functions integration is .NET-only), and their supported
+                // Aspire compute target is Azure Container Apps. Non-.NET function services fall through to the
+                // container/JS paths and retain azd's original unmapped behavior, so they are not placed on a
+                // compute environment here.
+                case "function" when IsDotNet(service):
+                    return acaEnvironment ??= builder.AddAzureContainerAppEnvironment(options.ContainerAppEnvironmentName);
+                case "appservice":
+                    return appServiceEnvironment ??= builder.AddAzureAppServiceEnvironment(options.AppServiceEnvironmentName);
+                default:
+                    return null;
+            }
+        }
+
+        foreach (var (key, service) in project.Services)
+        {
+            var serviceName = AllocateUniqueName(BuiltInResourceMappers.Sanitize(key), usedNames, import, key);
+
+            if (!TryCreateServiceResource(builder, import, service, serviceName, projectDirectory, key, out var resourceBuilder))
+            {
+                continue;
+            }
+
+            ConfigureService(builder, resourceBuilder, service, environment, GetComputeEnvironment(service), import, key);
+            import.AddService(key, resourceBuilder.AsGeneric());
+        }
+    }
+
+    private static bool TryCreateServiceResource(
+        IDistributedApplicationBuilder builder,
+        AzdImport import,
+        AzdService service,
+        string serviceName,
+        string projectDirectory,
+        string serviceKey,
+        [NotNullWhen(true)] out IResourceBuilder<IComputeResource>? resourceBuilder)
+    {
+        resourceBuilder = null;
+
+        var serviceSource = service.Project is null
+            ? projectDirectory
+            : Path.GetFullPath(Path.Combine(projectDirectory, service.Project));
+
+        // azd's `project` usually names a directory but may point directly at a project file. The service's
+        // base directory (used to resolve docker context/paths and the fallback Dockerfile) is then its parent.
+        var serviceBaseDirectory = File.Exists(serviceSource)
+            ? Path.GetDirectoryName(serviceSource)!
+            : serviceSource;
+
+        // 1. A prebuilt image deploys directly as a container.
+        if (!string.IsNullOrEmpty(service.Image))
+        {
+            resourceBuilder = builder.AddContainer(serviceName, service.Image);
+            return true;
+        }
+
+        // 2. An explicit docker block builds from a Dockerfile.
+        if (service.Docker is not null)
+        {
+            var context = service.Docker.Context is null
+                ? serviceBaseDirectory
+                : Path.GetFullPath(Path.Combine(serviceBaseDirectory, service.Docker.Context));
+
+            // azd resolves docker.path relative to the service directory, whereas AddDockerfile resolves
+            // the Dockerfile path relative to the build context. Resolve to an absolute path so the two
+            // agree even when the context is not the service directory.
+            var dockerfilePath = string.IsNullOrEmpty(service.Docker.Path)
+                ? null
+                : Path.GetFullPath(Path.Combine(serviceBaseDirectory, service.Docker.Path));
+
+            // Pass the docker target as the build stage so multi-stage Dockerfiles build the right stage.
+            resourceBuilder = builder.AddDockerfile(serviceName, context, dockerfilePath, service.Docker.Target);
+            return true;
+        }
+
+        // 3. A .NET service whose azd host is `function` becomes an Azure Functions project so the Functions
+        //    host model and its generated infrastructure are preserved instead of being flattened to a generic
+        //    compute app. azd runs Functions on Microsoft.Web/sites; the Aspire Functions integration deploys
+        //    to Azure Container Apps (its supported compute target), which ConfigureService applies. That
+        //    integration is .NET-specific, so non-.NET function apps fall through to the paths below.
+        if (IsFunctionHost(service) && IsDotNet(service) && TryResolveProjectFile(serviceSource, out var functionProjectFile))
+        {
+            resourceBuilder = builder.AddAzureFunctionsProject(serviceName, functionProjectFile);
+            import.Diagnostics.Warning(
+                $"Service '{serviceKey}' uses azd host 'function'. It was imported as an Azure Functions project deployed to Azure Container Apps (the Aspire Functions compute target), whereas azd hosts Functions on Microsoft.Web/sites. Verify Container Apps hosting is acceptable.",
+                serviceKey);
+            return true;
+        }
+
+        // 4. A .NET project becomes an Aspire project resource.
+        if (IsDotNet(service) && TryResolveProjectFile(serviceSource, out var projectFile))
+        {
+            resourceBuilder = builder.AddProject(serviceName, projectFile);
+            return true;
+        }
+
+        // 5. A JavaScript or TypeScript service becomes a native Aspire JavaScript app. It runs locally via
+        //    the project's package manager (npm) and is containerized automatically on publish, which mirrors
+        //    how azd builds js/ts services for `host: containerapp`/`appservice` while giving a first-class
+        //    local run experience instead of requiring a container build.
+        if (IsJavaScript(service))
+        {
+            var runScript = DetectJavaScriptRunScript(serviceBaseDirectory);
+            var jsApp = builder.AddJavaScriptApp(serviceName, serviceBaseDirectory, runScript);
+
+            // AddJavaScriptApp always configures a "build" build-script, which suits apps that compile or
+            // bundle (Vite, tsc). Many azd Node services instead execute their sources directly through a
+            // runtime loader (e.g. tsx) and define no "build" script, so the auto-generated Dockerfile's
+            // `npm run build` would fail the image build. Drop the default build-script unless the service's
+            // package.json actually defines one.
+            if (!JavaScriptScriptExists(serviceBaseDirectory, "build"))
+            {
+                foreach (var buildScriptAnnotation in jsApp.Resource.Annotations.OfType<JavaScriptBuildScriptAnnotation>().ToList())
+                {
+                    jsApp.Resource.Annotations.Remove(buildScriptAnnotation);
+                }
+            }
+
+            // azd services targeted at a web compute host (containerapp/appservice) are HTTP apps, so give
+            // the app an HTTP endpoint whose assigned port is published via the PORT environment variable.
+            // That mirrors azd's ACA/App Service ingress (which routes to a target port) and matches the
+            // convention Node web servers use to choose their listen port. A service with no host is treated
+            // as a web app too, since that is the common case for an adopted azd service.
+            if (service.Host is null || IsKnownComputeHost(service.Host))
+            {
+                jsApp.WithHttpEndpoint(env: "PORT");
+
+                // azd gives a scaffolded `host: containerapp`/`appservice` service public (external) ingress by
+                // default when azure.yaml declares no explicit ingress override: the Container App is created
+                // with `ingress { external: true }` and azd writes a public `SERVICE_<NAME>_ENDPOINT_URL`. An
+                // Aspire HTTP endpoint defaults to internal-only ingress on publish, so mark the endpoint
+                // external to preserve the same reachability the service had under azd (otherwise a migrated
+                // front end would silently become unreachable from the internet).
+                jsApp.WithExternalHttpEndpoints();
+
+                // azd builds and runs a js/ts compute service as a long-lived server container. By default an
+                // Aspire JavaScript app publishes as a build-only image (intended for a static front end that
+                // is consumed by another resource via PublishWithContainerFiles), which is excluded from
+                // publish and deploy. Configure a standalone runtime that runs the production package script
+                // with production node_modules present, so the imported service is containerized and deployed
+                // the same way azd would run it. Prefer the production "start" script; otherwise reuse the
+                // detected run script (azd has no separate run-script concept).
+                var publishScript = JavaScriptScriptExists(serviceBaseDirectory, "start") ? "start" : runScript;
+#pragma warning disable ASPIREJAVASCRIPT001 // PublishAsPackageScript is experimental and subject to change.
+                jsApp.PublishAsPackageScript(publishScript);
+#pragma warning restore ASPIREJAVASCRIPT001
+            }
+
+            resourceBuilder = jsApp;
+            import.Diagnostics.Information(
+                $"Service '{serviceKey}' (language '{service.Language}') was imported as a JavaScript app running the '{runScript}' script.",
+                serviceKey);
+            return true;
+        }
+
+        // 6. Fall back to a Dockerfile in the service directory for other non-.NET languages.
+        var fallbackDockerfile = Path.Combine(serviceBaseDirectory, "Dockerfile");
+        if (File.Exists(fallbackDockerfile))
+        {
+            resourceBuilder = builder.AddDockerfile(serviceName, serviceBaseDirectory);
+            import.Diagnostics.Information(
+                $"Service '{serviceKey}' (language '{service.Language ?? "unknown"}') was imported from its Dockerfile.",
+                serviceKey);
+            return true;
+        }
+
+        import.Diagnostics.Warning(
+            $"Service '{serviceKey}' could not be imported automatically (host '{service.Host ?? "unknown"}', language '{service.Language ?? "unknown"}'). Map it manually using AddProject, AddContainer, or AddDockerfile.",
+            serviceKey);
+        return false;
+    }
+
+    private static void ConfigureService(
+        IDistributedApplicationBuilder builder,
+        IResourceBuilder<IComputeResource> resourceBuilder,
+        AzdService service,
+        AzdEnvironment? environment,
+        IResourceBuilder<IComputeEnvironmentResource>? computeEnvironment,
+        AzdImport import,
+        string serviceKey)
+    {
+        if (computeEnvironment is not null)
+        {
+            resourceBuilder.WithComputeEnvironment(computeEnvironment);
+        }
+        else if (service.Host is { } host && !IsKnownComputeHost(host))
+        {
+            import.Diagnostics.Warning(
+                $"azd host '{host}' is not yet supported for automatic compute placement. Service '{serviceKey}' was imported without a compute environment.",
+                serviceKey);
+        }
+
+        // Compute resources implement IResourceWithEnvironment; recreate a builder typed to that
+        // interface so environment values can be applied regardless of the concrete resource type.
+        if (service.Env.Count > 0 && resourceBuilder.Resource is IResourceWithEnvironment environmentResource)
+        {
+            var environmentBuilder = builder.CreateResourceBuilder(environmentResource);
+            foreach (var (name, value) in service.Env)
+            {
+                // azd resolves "${VAR}"/"$VAR" in service env values against the environment, so do the same.
+                environmentBuilder.WithEnvironment(name, ExpandAzdExpandableString(value, environment));
+            }
+        }
+    }
+
+    private static void WireUses(IDistributedApplicationBuilder builder, AzdImport import, AzdProject project)
+    {
+        foreach (var (serviceKey, service) in project.Services)
+        {
+            if (service.Uses.Count == 0 || !import.Services.TryGetValue(serviceKey, out var consumerResource))
+            {
+                continue;
+            }
+
+            // The consuming resource must accept environment/configuration injection.
+            if (consumerResource.Resource is not IResourceWithEnvironment consumerWithEnv)
+            {
+                continue;
+            }
+
+            var consumer = builder.CreateResourceBuilder(consumerWithEnv);
+
+            foreach (var used in service.Uses)
+            {
+                if (!import.TryResolveReference(used, out var target))
+                {
+                    import.Diagnostics.Warning(
+                        $"Service '{serviceKey}' declares a dependency on '{used}', which was not imported. The reference was skipped.",
+                        serviceKey);
+                    continue;
+                }
+
+                switch (target.Resource)
+                {
+                    case IResourceWithConnectionString connectionStringResource:
+                        consumer.WithReference(builder.CreateResourceBuilder(connectionStringResource));
+                        break;
+
+                    case IResourceWithServiceDiscovery serviceDiscoveryResource:
+                        consumer.WithReference(builder.CreateResourceBuilder(serviceDiscoveryResource));
+                        break;
+
+                    default:
+                        // The resource was imported but exposes no Aspire reference surface (for example
+                        // AzureStorageResource is IResourceWithEndpoints, not IResourceWithConnectionString).
+                        // This is unsafe to deploy: the consuming service will be missing the dependency at
+                        // runtime, so report it as an error rather than a quiet note.
+                        import.Diagnostics.Error(
+                            $"Service '{serviceKey}' uses '{used}', but the imported resource exposes neither a connection string nor service discovery, so no reference could be wired. Reference the appropriate child resource (for example a storage blob service) manually.",
+                            serviceKey);
+                        break;
+                }
+
+                // azd injects a well-known set of environment variables into the consumer for each
+                // `uses` edge; Aspire's WithReference uses different (connection-string) conventions.
+                // Surface the azd names so a customer whose app code reads them knows what to preserve
+                // (e.g. with WithEnvironment) rather than discovering the change at runtime.
+                if (project.Resources.TryGetValue(used, out var usedResource))
+                {
+                    var azdEnvironmentVariables = BuiltInResourceMappers.GetAzdInjectedEnvironmentVariables(usedResource.Type);
+                    if (azdEnvironmentVariables.Count > 0)
+                    {
+                        import.Diagnostics.Information(
+                            $"In azd, service '{serviceKey}' received {string.Join(", ", azdEnvironmentVariables)} from '{used}'. Aspire wires this dependency with WithReference using its own connection conventions; if your application code reads the azd variable names, add WithEnvironment to preserve them.",
+                            serviceKey);
+                    }
+                }
+            }
+        }
+    }
+
+    // azd also supports resource-level `uses` (resources[].uses) for resource-to-resource edges, which in
+    // azd drive connection-setting injection and role assignments on the consuming resource. The importer
+    // wires service `uses` (see WireUses) but does not reproduce resource-to-resource wiring yet. Surface it
+    // as a diagnostic rather than dropping it silently, consistent with the importer's "nothing is lost
+    // without a diagnostic" contract, so a migrating customer can re-establish the dependency.
+    private static void ReportUnwiredResourceUses(AzdImport import, AzdProject project)
+    {
+        foreach (var (resourceKey, resource) in project.Resources)
+        {
+            if (resource.Uses.Count == 0)
+            {
+                continue;
+            }
+
+            import.Diagnostics.Warning(
+                $"azd resource '{resourceKey}' declares uses [{string.Join(", ", resource.Uses)}], a resource-to-resource dependency that the importer does not wire automatically. In azd this injects connection settings (and role assignments) on '{resourceKey}'; re-establish it manually (for example with WithReference or an explicit role assignment).",
+                resourceKey);
+        }
+    }
+
+    private static void PreserveInfrastructure(AzdImport import, AzdProject project)
+    {
+        if (!AzdInfrastructureLocator.TryLocate(import.ProjectDirectory, project, out var infraPath, out var provider, out var infraRelativePath))
+        {
+            return;
+        }
+
+        import.InfraPath = infraPath;
+
+        import.Diagnostics.Information(
+            $"Existing azd infrastructure ('{provider}') at '{infraRelativePath}' is preserved. It is not regenerated by the import; continue to manage it with your existing deployment workflow.");
+
+        // Aspire models infrastructure as Bicep. A Terraform infra folder is preserved on disk, but
+        // Aspire cannot provision it, so flag that explicitly rather than implying it will be deployed.
+        if (string.Equals(provider, "terraform", StringComparison.OrdinalIgnoreCase))
+        {
+            import.Diagnostics.Warning(
+                $"The azd infrastructure at '{infraRelativePath}' uses Terraform, which Aspire does not provision. The files are preserved; continue to deploy them with azd.");
+        }
+    }
+
+    private static string ResolveAzureYamlPath(IDistributedApplicationBuilder builder, string? azureYamlPath)
+    {
+        // Candidate filenames azd recognizes, in priority order.
+        string[] candidateFileNames = ["azure.yaml", "azure.yml"];
+
+        if (string.IsNullOrEmpty(azureYamlPath))
+        {
+            foreach (var candidate in candidateFileNames)
+            {
+                var probe = Path.Combine(builder.AppHostDirectory, candidate);
+                if (File.Exists(probe))
+                {
+                    return probe;
+                }
+            }
+
+            throw new FileNotFoundException(
+                $"Could not find 'azure.yaml' in the app host directory '{builder.AppHostDirectory}'. Pass an explicit path to AddAzdProject.");
+        }
+
+        var fullPath = Path.IsPathRooted(azureYamlPath)
+            ? azureYamlPath
+            : Path.GetFullPath(Path.Combine(builder.AppHostDirectory, azureYamlPath));
+
+        if (Directory.Exists(fullPath))
+        {
+            foreach (var candidate in candidateFileNames)
+            {
+                var probe = Path.Combine(fullPath, candidate);
+                if (File.Exists(probe))
+                {
+                    return probe;
+                }
+            }
+
+            throw new FileNotFoundException($"Could not find 'azure.yaml' in directory '{fullPath}'.");
+        }
+
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException($"The azd project file '{fullPath}' does not exist.", fullPath);
+        }
+
+        return fullPath;
+    }
+
+    private static string AllocateUniqueName(string sanitized, HashSet<string> usedNames, AzdImport import, string azdKey)
+    {
+        if (usedNames.Add(sanitized))
+        {
+            return sanitized;
+        }
+
+        // Two azd keys can sanitize to the same Aspire resource name (for example "foo.bar" and
+        // "foo-bar"), and services share the namespace with resources. Disambiguate deterministically so
+        // neither asset is dropped and AppHost construction does not throw on a duplicate name.
+        for (var suffix = 2; ; suffix++)
+        {
+            var candidate = $"{sanitized}-{suffix}";
+            if (usedNames.Add(candidate))
+            {
+                import.Diagnostics.Warning(
+                    $"azd name '{azdKey}' maps to Aspire resource name '{sanitized}', which is already in use. It was imported as '{candidate}' to avoid a collision.",
+                    azdKey);
+                return candidate;
+            }
+        }
+    }
+
+    private static bool IsDotNet(AzdService service)
+    {
+        if (service.Language is { } language &&
+            (language.Equals("dotnet", StringComparison.OrdinalIgnoreCase) ||
+             language.Equals("csharp", StringComparison.OrdinalIgnoreCase) ||
+             language.Equals("fsharp", StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        // azd often omits `language` for .NET services and infers it from a project file reference.
+        return service.Project is { } project &&
+               (project.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) || project.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsFunctionHost(AzdService service)
+        => service.Host is { } host && host.Equals("function", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsJavaScript(AzdService service)
+    {
+        // azd's schema uses the short forms `js`/`ts` for Node services; accept the spelled-out forms too.
+        return service.Language is { } language &&
+            (language.Equals("js", StringComparison.OrdinalIgnoreCase) ||
+             language.Equals("ts", StringComparison.OrdinalIgnoreCase) ||
+             language.Equals("javascript", StringComparison.OrdinalIgnoreCase) ||
+             language.Equals("typescript", StringComparison.OrdinalIgnoreCase) ||
+             language.Equals("node", StringComparison.OrdinalIgnoreCase) ||
+             language.Equals("nodejs", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // Picks the npm script the JavaScript app host should run. azure.yaml does not record a run script, so
+    // prefer a conventional "start" script, then "dev", and otherwise fall back to "start". The script is
+    // resolved again at launch time, so a missing script surfaces as a normal run error rather than here.
+    private static string DetectJavaScriptRunScript(string serviceDirectory)
+    {
+        if (JavaScriptScriptExists(serviceDirectory, "start"))
+        {
+            return "start";
+        }
+
+        if (JavaScriptScriptExists(serviceDirectory, "dev"))
+        {
+            return "dev";
+        }
+
+        return "start";
+    }
+
+    // Returns true when the service's package.json defines the named npm script.
+    private static bool JavaScriptScriptExists(string serviceDirectory, string scriptName)
+    {
+        var packageJsonPath = Path.Combine(serviceDirectory, "package.json");
+        if (!File.Exists(packageJsonPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            // package.json shape we read:
+            //   { "scripts": { "start": "node server.js", "dev": "tsx watch src/server.ts", "build": "tsc" } }
+            using var document = JsonDocument.Parse(File.ReadAllText(packageJsonPath));
+            return document.RootElement.TryGetProperty("scripts", out var scripts) &&
+                   scripts.ValueKind == JsonValueKind.Object &&
+                   scripts.TryGetProperty(scriptName, out _);
+        }
+        catch (JsonException)
+        {
+            // A malformed package.json is the customer's to fix; treat the script as absent.
+            return false;
+        }
+    }
+
+    private static bool TryResolveProjectFile(string serviceDirectory, [NotNullWhen(true)] out string? projectFile)
+    {
+        projectFile = null;
+
+        // The azd `project` value can point directly at a project file or at a directory containing one.
+        if (File.Exists(serviceDirectory) &&
+            (serviceDirectory.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) || serviceDirectory.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase)))
+        {
+            projectFile = serviceDirectory;
+            return true;
+        }
+
+        if (!Directory.Exists(serviceDirectory))
+        {
+            return false;
+        }
+
+        projectFile = Directory.EnumerateFiles(serviceDirectory, "*.csproj").FirstOrDefault()
+            ?? Directory.EnumerateFiles(serviceDirectory, "*.fsproj").FirstOrDefault();
+
+        return projectFile is not null;
+    }
+
+    private static bool IsKnownComputeHost(string host)
+        => host.Equals("containerapp", StringComparison.OrdinalIgnoreCase)
+           || host.Equals("appservice", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Aspire.Hosting.Azure.Azd/AzdProjectParser.cs
+++ b/src/Aspire.Hosting.Azure.Azd/AzdProjectParser.cs
@@ -1,0 +1,214 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using YamlDotNet.Serialization;
+
+namespace Aspire.Hosting.Azure.Azd;
+
+/// <summary>
+/// Parses an azd <c>azure.yaml</c> document into the typed <see cref="AzdProject"/> model.
+/// </summary>
+/// <remarks>
+/// Parsing is intentionally tolerant: the document is first read into an untyped object graph and
+/// then projected onto the typed model. Unknown keys never cause failures; they are retained in
+/// <see cref="AzdProject.Raw"/> and on each <see cref="AzdResource.Properties"/> so that callers and
+/// diagnostics can still observe them.
+/// </remarks>
+internal static class AzdProjectParser
+{
+    /// <summary>
+    /// Parses the contents of an <c>azure.yaml</c> document.
+    /// </summary>
+    /// <param name="yaml">The raw YAML text.</param>
+    /// <returns>The parsed <see cref="AzdProject"/>.</returns>
+    public static AzdProject Parse(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+
+        var deserializer = new DeserializerBuilder().Build();
+
+        // YamlDotNet yields Dictionary<object, object?> for mappings, List<object?> for sequences,
+        // and string for scalars when deserializing to object. Normalize the whole tree to
+        // string-keyed dictionaries so the rest of the importer can treat it uniformly.
+        var rootObject = deserializer.Deserialize<object?>(yaml);
+        var root = Normalize(rootObject) as IReadOnlyDictionary<string, object?> ?? new Dictionary<string, object?>();
+
+        var project = new AzdProject
+        {
+            Raw = root,
+            Name = GetString(root, "name"),
+            ResourceGroup = GetString(root, "resourceGroup"),
+            Metadata = ParseMetadata(GetMap(root, "metadata")),
+            Infra = ParseInfra(GetMap(root, "infra")),
+            Services = ParseServices(GetMap(root, "services")),
+            Resources = ParseResources(GetMap(root, "resources")),
+        };
+
+        return project;
+    }
+
+    private static AzdMetadata? ParseMetadata(IReadOnlyDictionary<string, object?>? map)
+        => map is null ? null : new AzdMetadata { Template = GetString(map, "template") };
+
+    private static AzdInfra? ParseInfra(IReadOnlyDictionary<string, object?>? map)
+        => map is null ? null : new AzdInfra
+        {
+            Provider = GetString(map, "provider"),
+            Path = GetString(map, "path"),
+            Module = GetString(map, "module"),
+        };
+
+    private static IReadOnlyDictionary<string, AzdService> ParseServices(IReadOnlyDictionary<string, object?>? map)
+    {
+        var services = new Dictionary<string, AzdService>();
+        if (map is null)
+        {
+            return services;
+        }
+
+        foreach (var (key, value) in map)
+        {
+            if (value is not IReadOnlyDictionary<string, object?> serviceMap)
+            {
+                continue;
+            }
+
+            services[key] = new AzdService
+            {
+                Project = GetString(serviceMap, "project"),
+                Host = GetString(serviceMap, "host"),
+                Language = GetString(serviceMap, "language"),
+                Image = GetString(serviceMap, "image"),
+                Docker = ParseDocker(GetMap(serviceMap, "docker")),
+                Uses = GetStringList(serviceMap, "uses"),
+                Env = GetStringMap(serviceMap, "env"),
+            };
+        }
+
+        return services;
+    }
+
+    private static AzdDocker? ParseDocker(IReadOnlyDictionary<string, object?>? map)
+        => map is null ? null : new AzdDocker
+        {
+            Context = GetString(map, "context"),
+            Path = GetString(map, "path"),
+            Target = GetString(map, "target"),
+        };
+
+    private static IReadOnlyDictionary<string, AzdResource> ParseResources(IReadOnlyDictionary<string, object?>? map)
+    {
+        var resources = new Dictionary<string, AzdResource>();
+        if (map is null)
+        {
+            return resources;
+        }
+
+        foreach (var (key, value) in map)
+        {
+            if (value is not IReadOnlyDictionary<string, object?> resourceMap)
+            {
+                continue;
+            }
+
+            // Everything other than the well-known fields is type-specific configuration; keep it
+            // in Properties so individual resource mappers can read it (databases, queues, models...).
+            var properties = new Dictionary<string, object?>();
+            foreach (var (propKey, propValue) in resourceMap)
+            {
+                if (propKey is "type" or "name" or "uses" or "existing")
+                {
+                    continue;
+                }
+
+                properties[propKey] = propValue;
+            }
+
+            resources[key] = new AzdResource
+            {
+                Type = GetString(resourceMap, "type"),
+                Name = GetString(resourceMap, "name"),
+                Uses = GetStringList(resourceMap, "uses"),
+                Existing = GetBool(resourceMap, "existing"),
+                Properties = properties,
+            };
+        }
+
+        return resources;
+    }
+
+    private static object? Normalize(object? value)
+    {
+        switch (value)
+        {
+            case IDictionary<object, object> dictionary:
+                var map = new Dictionary<string, object?>();
+                foreach (var entry in dictionary)
+                {
+                    map[Convert.ToString(entry.Key, CultureInfo.InvariantCulture) ?? string.Empty] = Normalize(entry.Value);
+                }
+
+                return map;
+
+            case IList<object> list:
+                var items = new List<object?>(list.Count);
+                foreach (var item in list)
+                {
+                    items.Add(Normalize(item));
+                }
+
+                return items;
+
+            default:
+                return value;
+        }
+    }
+
+    private static IReadOnlyDictionary<string, object?>? GetMap(IReadOnlyDictionary<string, object?> map, string key)
+        => map.TryGetValue(key, out var value) && value is IReadOnlyDictionary<string, object?> nested ? nested : null;
+
+    private static string? GetString(IReadOnlyDictionary<string, object?> map, string key)
+        => map.TryGetValue(key, out var value) && value is not null ? Convert.ToString(value, CultureInfo.InvariantCulture) : null;
+
+    private static bool GetBool(IReadOnlyDictionary<string, object?> map, string key)
+        => map.TryGetValue(key, out var value) && value is not null
+           && bool.TryParse(Convert.ToString(value, CultureInfo.InvariantCulture), out var result) && result;
+
+    private static IReadOnlyList<string> GetStringList(IReadOnlyDictionary<string, object?> map, string key)
+    {
+        if (!map.TryGetValue(key, out var value) || value is null)
+        {
+            return [];
+        }
+
+        // `uses` may be authored either as a sequence or, occasionally, as a single scalar.
+        if (value is IReadOnlyList<object?> list)
+        {
+            return list
+                .Select(item => Convert.ToString(item, CultureInfo.InvariantCulture))
+                .Where(item => !string.IsNullOrEmpty(item))
+                .Select(item => item!)
+                .ToList();
+        }
+
+        var single = Convert.ToString(value, CultureInfo.InvariantCulture);
+        return string.IsNullOrEmpty(single) ? [] : [single];
+    }
+
+    private static IReadOnlyDictionary<string, string?> GetStringMap(IReadOnlyDictionary<string, object?> map, string key)
+    {
+        if (GetMap(map, key) is not { } nested)
+        {
+            return new Dictionary<string, string?>();
+        }
+
+        var result = new Dictionary<string, string?>();
+        foreach (var (k, v) in nested)
+        {
+            result[k] = v is null ? null : Convert.ToString(v, CultureInfo.InvariantCulture);
+        }
+
+        return result;
+    }
+}

--- a/src/Aspire.Hosting.Azure.Azd/Mapping/BuiltInResourceMappers.cs
+++ b/src/Aspire.Hosting.Azure.Azd/Mapping/BuiltInResourceMappers.cs
@@ -1,0 +1,324 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.Azd;
+
+/// <summary>
+/// Provides the built-in <see cref="IAzdResourceMapper"/> set used to translate azd <c>resources</c>
+/// entries into Aspire Azure resources.
+/// </summary>
+/// <remarks>
+/// The mappers cover the resource types most commonly found in azd templates. Each mapper creates the
+/// top-level Azure resource and, where the azd entry declares them, the nested resources (databases,
+/// queues, topics, blob containers, event hubs, or model deployments). Unsupported types fall through
+/// so the importer can report a diagnostic rather than mapping them incorrectly.
+/// </remarks>
+internal static class BuiltInResourceMappers
+{
+    public static IReadOnlyList<IAzdResourceMapper> Create() =>
+    [
+        // Secrets / configuration.
+        new DelegateResourceMapper(
+            ctx => MatchesType(ctx, "keyvault"),
+            ctx => ctx.Builder.AddAzureKeyVault(ctx.ResourceName).AsGeneric()),
+
+        // Storage account (+ blob containers).
+        new DelegateResourceMapper(
+            ctx => MatchesType(ctx, "storage"),
+            ctx =>
+            {
+                var storage = ctx.Builder.AddAzureStorage(ctx.ResourceName);
+                foreach (var container in ExtractNames(ctx.Resource.Properties, "containers", "blobContainers"))
+                {
+                    storage.AddBlobContainer(Sanitize($"{ctx.ResourceName}-{container}"), container);
+                }
+
+                return storage.AsGeneric();
+            }),
+
+        // Redis cache. azd's `db.redis` provisions Azure Cache for Redis (Microsoft.Cache/redis), which
+        // Azure is retiring (https://learn.microsoft.com/azure/azure-cache-for-redis/retirement-faq). For
+        // the same reason Aspire's AddAzureRedis (Azure Cache for Redis) is obsolete, so the importer maps
+        // db.redis to Azure Managed Redis (Microsoft.Cache/redisEnterprise) via AddAzureManagedRedis, the
+        // recommended successor. That is a deliberate SKU substitution, not a faithful 1:1 mapping, so it
+        // is surfaced as a warning: a customer with an existing Azure Cache for Redis instance should
+        // confirm the successor SKU fits before deploying (or register a custom mapper to override it).
+        new DelegateResourceMapper(
+            ctx => MatchesType(ctx, "db.redis"),
+            ctx =>
+            {
+                ctx.Diagnostics.Warning(
+                    $"azd resource '{ctx.ResourceName}' is type 'db.redis' (Azure Cache for Redis, which Azure is retiring). " +
+                    "Aspire maps it to Azure Managed Redis, its supported successor, via AddAzureManagedRedis. " +
+                    "Confirm this SKU change is acceptable for your migration, or register a custom IAzdResourceMapper to override it.",
+                    ctx.ResourceName);
+                return ctx.Builder.AddAzureManagedRedis(ctx.ResourceName).AsGeneric();
+            }),
+
+        // PostgreSQL flexible server. azd's generic database resources do not list databases inline;
+        // the resource provisions a single database named after the resource itself. (azd's
+        // db.postgres / db.mysql / db.redis / db.mongo all share a props-less ResourceConfig.)
+        // https://github.com/Azure/azure-dev/blob/main/cli/azd/pkg/project/resources.go
+        new DelegateResourceMapper(
+            ctx => MatchesType(ctx, "db.postgres"),
+            ctx =>
+            {
+                var postgres = ctx.Builder.AddAzurePostgresFlexibleServer(ctx.ResourceName);
+                postgres.AddDatabase(Sanitize($"{ctx.ResourceName}-db"), ctx.ResourceName);
+                return postgres.AsGeneric();
+            }),
+
+        // Cosmos DB (NoSQL). azd declares containers directly (CosmosDBProps.Containers); they live
+        // under an implicit database named after the resource.
+        // https://github.com/Azure/azure-dev/blob/main/cli/azd/pkg/project/resources.go
+        new DelegateResourceMapper(
+            ctx => MatchesType(ctx, "db.cosmos"),
+            ctx =>
+            {
+                var cosmos = ctx.Builder.AddAzureCosmosDB(ctx.ResourceName);
+                var database = cosmos.AddCosmosDatabase(Sanitize($"{ctx.ResourceName}-db"), ctx.ResourceName);
+                foreach (var (name, partitionKeys) in ExtractContainers(ctx.Resource.Properties))
+                {
+                    database.AddContainer(Sanitize($"{ctx.ResourceName}-{name}"), partitionKeys, name);
+                }
+
+                return cosmos.AsGeneric();
+            }),
+
+        // Service Bus namespace (+ queues and topics).
+        new DelegateResourceMapper(
+            ctx => MatchesType(ctx, "messaging.servicebus"),
+            ctx =>
+            {
+                var serviceBus = ctx.Builder.AddAzureServiceBus(ctx.ResourceName);
+                foreach (var queue in ExtractNames(ctx.Resource.Properties, "queues"))
+                {
+                    serviceBus.AddServiceBusQueue(Sanitize($"{ctx.ResourceName}-{queue}"), queue);
+                }
+
+                foreach (var topic in ExtractNames(ctx.Resource.Properties, "topics"))
+                {
+                    serviceBus.AddServiceBusTopic(Sanitize($"{ctx.ResourceName}-{topic}"), topic);
+                }
+
+                return serviceBus.AsGeneric();
+            }),
+
+        // Event Hubs namespace (+ hubs).
+        new DelegateResourceMapper(
+            ctx => MatchesType(ctx, "messaging.eventhubs"),
+            ctx =>
+            {
+                var eventHubs = ctx.Builder.AddAzureEventHubs(ctx.ResourceName);
+                foreach (var hub in ExtractNames(ctx.Resource.Properties, "hubs", "eventHubs"))
+                {
+                    eventHubs.AddHub(Sanitize($"{ctx.ResourceName}-{hub}"), hub);
+                }
+
+                return eventHubs.AsGeneric();
+            }),
+
+        // AI Search.
+        new DelegateResourceMapper(
+            ctx => MatchesType(ctx, "ai.search"),
+            ctx => ctx.Builder.AddAzureSearch(ctx.ResourceName).AsGeneric()),
+
+        // Azure OpenAI account (+ a model deployment).
+        new DelegateResourceMapper(
+            ctx => MatchesType(ctx, "ai.openai.model", "ai.openai"),
+            ctx =>
+            {
+                var openai = ctx.Builder.AddAzureOpenAI(ctx.ResourceName);
+
+                // azd describes the model either via a nested `model: { name, version }` map or via
+                // flat `model`/`version` scalars. Be tolerant of both shapes.
+                var modelName = GetNestedString(ctx.Resource.Properties, "model", "name")
+                    ?? GetString(ctx.Resource.Properties, "model");
+                var modelVersion = GetNestedString(ctx.Resource.Properties, "model", "version")
+                    ?? GetString(ctx.Resource.Properties, "version");
+
+                if (!string.IsNullOrEmpty(modelName) && !string.IsNullOrEmpty(modelVersion))
+                {
+                    openai.AddDeployment(Sanitize($"{ctx.ResourceName}-{modelName}"), modelName, modelVersion);
+                }
+                else
+                {
+                    ctx.Diagnostics.Information(
+                        "OpenAI resource imported without a model deployment because the model name/version could not be determined.",
+                        ctx.ResourceName);
+                }
+
+                return openai.AsGeneric();
+            }),
+    ];
+
+    private static bool MatchesType(AzdResourceMapContext context, params string[] types)
+    {
+        var actual = context.Resource.Type;
+        return actual is not null && types.Any(t => string.Equals(t, actual, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Gets the environment variables azd injects into a service that <c>uses</c> a resource of the
+    /// given type, so the importer can tell the customer which variable names their application code
+    /// previously relied on.
+    /// </summary>
+    /// <remarks>
+    /// azd derives these names as <c>&lt;PREFIX&gt;_&lt;VAR&gt;</c> (snake/upper-cased) and injects them into the
+    /// consuming service (passwordless by default; secrets come from Key Vault references). Aspire wires
+    /// the same dependency with <c>WithReference</c> using its own connection conventions, so these names
+    /// are reported as a diagnostic rather than silently changed.
+    /// See <c>internal/scaffold/resource_meta.go</c> (EnvVarName) in https://github.com/Azure/azure-dev.
+    /// </remarks>
+    internal static IReadOnlyList<string> GetAzdInjectedEnvironmentVariables(string? type) => type?.ToLowerInvariant() switch
+    {
+        "db.redis" => ["REDIS_HOST", "REDIS_PORT", "REDIS_PASSWORD", "REDIS_URL", "REDIS_ENDPOINT"],
+        "db.postgres" => ["POSTGRES_HOST", "POSTGRES_DATABASE", "POSTGRES_USERNAME", "POSTGRES_PORT", "POSTGRES_PASSWORD", "POSTGRES_URL"],
+        "db.mysql" => ["MYSQL_HOST", "MYSQL_DATABASE", "MYSQL_USERNAME", "MYSQL_PORT", "MYSQL_PASSWORD", "MYSQL_URL"],
+        "db.mongo" => ["MONGODB_URL"],
+        "db.cosmos" => ["AZURE_COSMOS_ENDPOINT"],
+        "ai.openai.model" or "ai.openai" => ["AZURE_OPENAI_ENDPOINT"],
+        "ai.project" => ["AZURE_AI_PROJECT_ENDPOINT"],
+        "ai.search" => ["AZURE_AI_SEARCH_ENDPOINT"],
+        "messaging.eventhubs" => ["AZURE_EVENT_HUBS_NAME", "AZURE_EVENT_HUBS_HOST"],
+        "messaging.servicebus" => ["AZURE_SERVICE_BUS_NAME", "AZURE_SERVICE_BUS_HOST"],
+        "storage" => ["AZURE_STORAGE_ACCOUNT_NAME", "AZURE_STORAGE_BLOB_ENDPOINT"],
+        "keyvault" => ["AZURE_KEY_VAULT_NAME", "AZURE_KEY_VAULT_ENDPOINT"],
+        _ => [],
+    };
+
+    /// <summary>
+    /// Extracts a list of names from one of several possible property keys.
+    /// </summary>
+    /// <remarks>
+    /// azd authors collections in more than one shape, so this accepts any of:
+    /// a sequence of scalars (<c>[orders, payments]</c>), a sequence of maps each with a <c>name</c>
+    /// field, or a map keyed by name (<c>{ orders: { ... } }</c>).
+    /// </remarks>
+    internal static IEnumerable<string> ExtractNames(IReadOnlyDictionary<string, object?> properties, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (!properties.TryGetValue(key, out var value) || value is null)
+            {
+                continue;
+            }
+
+            switch (value)
+            {
+                case IReadOnlyList<object?> list:
+                    foreach (var item in list)
+                    {
+                        if (item is IReadOnlyDictionary<string, object?> map && map.TryGetValue("name", out var n) && n is not null)
+                        {
+                            yield return Convert.ToString(n, CultureInfo.InvariantCulture)!;
+                        }
+                        else if (item is not null)
+                        {
+                            yield return Convert.ToString(item, CultureInfo.InvariantCulture)!;
+                        }
+                    }
+
+                    break;
+
+                case IReadOnlyDictionary<string, object?> namedMap:
+                    foreach (var name in namedMap.Keys)
+                    {
+                        yield return name;
+                    }
+
+                    break;
+
+                default:
+                    yield return Convert.ToString(value, CultureInfo.InvariantCulture)!;
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extracts cosmos container specifications (name + partition key paths) from the
+    /// <c>containers</c> property.
+    /// </summary>
+    /// <remarks>
+    /// azd authors cosmos containers as a sequence of maps, each with a <c>name</c> and a
+    /// <c>partitionKeys</c> list (for example <c>- name: items\n  partitionKeys: [/id]</c>). When no
+    /// partition key is supplied, Cosmos defaults to <c>/id</c>.
+    /// See https://github.com/Azure/azure-dev/blob/main/cli/azd/pkg/project/resources.go (CosmosDBProps).
+    /// </remarks>
+    internal static IEnumerable<(string Name, string[] PartitionKeys)> ExtractContainers(IReadOnlyDictionary<string, object?> properties)
+    {
+        if (!properties.TryGetValue("containers", out var value) || value is not IReadOnlyList<object?> list)
+        {
+            yield break;
+        }
+
+        foreach (var item in list)
+        {
+            if (item is not IReadOnlyDictionary<string, object?> map ||
+                !map.TryGetValue("name", out var nameValue) || nameValue is null)
+            {
+                continue;
+            }
+
+            var name = Convert.ToString(nameValue, CultureInfo.InvariantCulture)!;
+
+            var partitionKeys = map.TryGetValue("partitionKeys", out var keys) && keys is IReadOnlyList<object?> keyList && keyList.Count > 0
+                ? keyList.Select(k => Convert.ToString(k, CultureInfo.InvariantCulture)!).ToArray()
+                : ["/id"];
+
+            yield return (name, partitionKeys);
+        }
+    }
+
+    internal static string? GetString(IReadOnlyDictionary<string, object?> properties, string key)
+        => properties.TryGetValue(key, out var value) && value is not null
+            ? Convert.ToString(value, CultureInfo.InvariantCulture)
+            : null;
+
+    internal static string? GetNestedString(IReadOnlyDictionary<string, object?> properties, string key, string nestedKey)
+        => properties.TryGetValue(key, out var value) && value is IReadOnlyDictionary<string, object?> nested
+            ? GetString(nested, nestedKey)
+            : null;
+
+    /// <summary>
+    /// Sanitizes an arbitrary azd name into a valid Aspire resource name (lowercase alphanumerics and hyphens).
+    /// </summary>
+    internal static string Sanitize(string name)
+    {
+        var chars = name
+            .Select(c => char.IsLetterOrDigit(c) ? char.ToLowerInvariant(c) : '-')
+            .ToArray();
+
+        var sanitized = new string(chars).Trim('-');
+
+        // Resource names must start with a letter; prefix when the source started with a digit/hyphen.
+        if (sanitized.Length == 0)
+        {
+            return "resource";
+        }
+
+        return char.IsLetter(sanitized[0]) ? sanitized : $"r-{sanitized}";
+    }
+
+    private sealed class DelegateResourceMapper(
+        Func<AzdResourceMapContext, bool> canMap,
+        Func<AzdResourceMapContext, IResourceBuilder<IResource>?> map) : IAzdResourceMapper
+    {
+        public bool CanMap(AzdResourceMapContext context) => canMap(context);
+
+        public IResourceBuilder<IResource>? Map(AzdResourceMapContext context) => map(context);
+    }
+}
+
+internal static class ResourceBuilderGenericExtensions
+{
+    /// <summary>
+    /// Upcasts a strongly-typed resource builder to <see cref="IResourceBuilder{IResource}"/>.
+    /// </summary>
+    internal static IResourceBuilder<IResource> AsGeneric<T>(this IResourceBuilder<T> builder) where T : class, IResource
+        => builder;
+}

--- a/src/Aspire.Hosting.Azure.Azd/Mapping/IAzdResourceMapper.cs
+++ b/src/Aspire.Hosting.Azure.Azd/Mapping/IAzdResourceMapper.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.Azd;
+
+/// <summary>
+/// Provides the context required to map a single azd <see cref="AzdResource"/> to an Aspire resource.
+/// </summary>
+[Experimental("ASPIREAZUREAZD001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class AzdResourceMapContext
+{
+    internal AzdResourceMapContext(
+        IDistributedApplicationBuilder builder,
+        string resourceName,
+        AzdResource resource,
+        AzdEnvironment? environment,
+        AzdImportDiagnostics diagnostics)
+    {
+        Builder = builder;
+        ResourceName = resourceName;
+        Resource = resource;
+        Environment = environment;
+        Diagnostics = diagnostics;
+    }
+
+    /// <summary>
+    /// Gets the distributed application builder the mapped resource should be added to.
+    /// </summary>
+    public IDistributedApplicationBuilder Builder { get; }
+
+    /// <summary>
+    /// Gets the Aspire resource name to use, already sanitized to a valid resource name.
+    /// </summary>
+    public string ResourceName { get; }
+
+    /// <summary>
+    /// Gets the azd resource being mapped.
+    /// </summary>
+    public AzdResource Resource { get; }
+
+    /// <summary>
+    /// Gets the selected azd environment, when one was loaded from the <c>.azure</c> directory.
+    /// </summary>
+    public AzdEnvironment? Environment { get; }
+
+    /// <summary>
+    /// Gets the diagnostics sink for reporting issues encountered while mapping this resource.
+    /// </summary>
+    public AzdImportDiagnostics Diagnostics { get; }
+}
+
+/// <summary>
+/// Maps an azd <c>resources</c> entry to a concrete Aspire resource.
+/// </summary>
+/// <remarks>
+/// Mappers are consulted in order; the first one whose <see cref="CanMap"/> returns <see langword="true"/>
+/// is used. Provide custom mappers through <see cref="AzdImportOptions.ResourceMappers"/> to support
+/// resource types the built-in mappers do not cover, or to override the default mapping for a type.
+/// </remarks>
+[Experimental("ASPIREAZUREAZD001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public interface IAzdResourceMapper
+{
+    /// <summary>
+    /// Determines whether this mapper can handle the resource described by <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The resource mapping context.</param>
+    /// <returns><see langword="true"/> if this mapper should map the resource; otherwise <see langword="false"/>.</returns>
+    bool CanMap(AzdResourceMapContext context);
+
+    /// <summary>
+    /// Maps the azd resource to an Aspire resource and adds it to the application model.
+    /// </summary>
+    /// <param name="context">The resource mapping context.</param>
+    /// <returns>
+    /// The created resource builder, or <see langword="null"/> if the resource could not be mapped
+    /// (in which case the mapper should report a diagnostic via <see cref="AzdResourceMapContext.Diagnostics"/>).
+    /// </returns>
+    IResourceBuilder<IResource>? Map(AzdResourceMapContext context);
+}

--- a/src/Aspire.Hosting.Azure.Azd/Model/AzdProject.cs
+++ b/src/Aspire.Hosting.Azure.Azd/Model/AzdProject.cs
@@ -1,0 +1,221 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Azd;
+
+/// <summary>
+/// Represents a parsed Azure Developer CLI (azd) project, as described by an <c>azure.yaml</c> file.
+/// </summary>
+/// <remarks>
+/// This is a tolerant, read-only projection of the <c>azure.yaml</c> schema
+/// (<see href="https://github.com/Azure/azure-dev/blob/main/schemas/v1.0/azure.yaml.json"/>).
+/// Unknown or unsupported fields are preserved where practical and surfaced through diagnostics
+/// during import rather than causing a parse failure, so that future azd schema additions do not
+/// break adoption of an existing project.
+/// </remarks>
+public sealed class AzdProject
+{
+    /// <summary>
+    /// Gets the name of the azd project. Corresponds to the top-level <c>name</c> field.
+    /// </summary>
+    public string? Name { get; internal set; }
+
+    /// <summary>
+    /// Gets the target resource group name, if specified. Corresponds to the <c>resourceGroup</c> field.
+    /// </summary>
+    public string? ResourceGroup { get; internal set; }
+
+    /// <summary>
+    /// Gets the infrastructure configuration. Corresponds to the <c>infra</c> field.
+    /// </summary>
+    /// <value>
+    /// The parsed <see cref="AzdInfra"/> describing where the project's Bicep (or other IaC) lives,
+    /// or <see langword="null"/> when the project relies on azd defaults.
+    /// </value>
+    public AzdInfra? Infra { get; internal set; }
+
+    /// <summary>
+    /// Gets the services defined by the project. Corresponds to the <c>services</c> map.
+    /// </summary>
+    /// <value>
+    /// A dictionary keyed by the service name (the YAML map key), where each value describes a
+    /// deployable unit such as a .NET project, container image, or Dockerfile build.
+    /// </value>
+    public IReadOnlyDictionary<string, AzdService> Services { get; internal set; } = new Dictionary<string, AzdService>();
+
+    /// <summary>
+    /// Gets the managed resources defined by the project. Corresponds to the <c>resources</c> map.
+    /// </summary>
+    /// <value>
+    /// A dictionary keyed by the resource name (the YAML map key), where each value describes a
+    /// backing Azure resource such as a database, cache, or storage account.
+    /// </value>
+    public IReadOnlyDictionary<string, AzdResource> Resources { get; internal set; } = new Dictionary<string, AzdResource>();
+
+    /// <summary>
+    /// Gets the metadata block associated with the project. Corresponds to the <c>metadata</c> field.
+    /// </summary>
+    public AzdMetadata? Metadata { get; internal set; }
+
+    /// <summary>
+    /// Gets the raw, untyped representation of the parsed <c>azure.yaml</c> document.
+    /// </summary>
+    /// <remarks>
+    /// This is provided as an escape hatch so callers can inspect fields that the typed model does
+    /// not yet surface (for example custom <c>pipeline</c>, <c>hooks</c>, or <c>workflows</c> sections).
+    /// </remarks>
+    public IReadOnlyDictionary<string, object?> Raw { get; internal set; } = new Dictionary<string, object?>();
+}
+
+/// <summary>
+/// Represents the <c>metadata</c> block of an azd project.
+/// </summary>
+public sealed class AzdMetadata
+{
+    /// <summary>
+    /// Gets the template identifier the project was created from, if any.
+    /// </summary>
+    public string? Template { get; internal set; }
+}
+
+/// <summary>
+/// Represents the <c>infra</c> block of an azd project, describing where its infrastructure-as-code lives.
+/// </summary>
+public sealed class AzdInfra
+{
+    /// <summary>
+    /// Gets the infrastructure provider (for example <c>bicep</c> or <c>terraform</c>). Defaults to <c>bicep</c> in azd.
+    /// </summary>
+    public string? Provider { get; internal set; }
+
+    /// <summary>
+    /// Gets the directory, relative to the project root, that contains the infrastructure files.
+    /// </summary>
+    /// <value>The configured path, or <see langword="null"/> when azd's default of <c>infra</c> applies.</value>
+    public string? Path { get; internal set; }
+
+    /// <summary>
+    /// Gets the name of the entry-point infrastructure module (without extension).
+    /// </summary>
+    /// <value>The configured module name, or <see langword="null"/> when azd's default of <c>main</c> applies.</value>
+    public string? Module { get; internal set; }
+}
+
+/// <summary>
+/// Represents a single entry in the <c>services</c> map of an azd project.
+/// </summary>
+/// <remarks>
+/// A service is a deployable unit. The <see cref="Host"/> field determines the Azure compute target
+/// (for example Azure Container Apps or Azure App Service), while <see cref="Project"/>,
+/// <see cref="Image"/>, and <see cref="Docker"/> describe how the workload is built.
+/// </remarks>
+public sealed class AzdService
+{
+    /// <summary>
+    /// Gets the path, relative to the project root, to the service's source (a directory or project file).
+    /// Corresponds to the <c>project</c> field.
+    /// </summary>
+    public string? Project { get; internal set; }
+
+    /// <summary>
+    /// Gets the azd host kind for the service (for example <c>containerapp</c>, <c>appservice</c>,
+    /// <c>function</c>, <c>staticwebapp</c>, or <c>aks</c>). Corresponds to the required <c>host</c> field.
+    /// </summary>
+    public string? Host { get; internal set; }
+
+    /// <summary>
+    /// Gets the implementation language (for example <c>dotnet</c>, <c>csharp</c>, <c>js</c>, <c>ts</c>,
+    /// <c>python</c>, or <c>docker</c>). Corresponds to the <c>language</c> field.
+    /// </summary>
+    public string? Language { get; internal set; }
+
+    /// <summary>
+    /// Gets a prebuilt container image reference, when the service is deployed from an existing image
+    /// rather than built from source. Corresponds to the <c>image</c> field.
+    /// </summary>
+    public string? Image { get; internal set; }
+
+    /// <summary>
+    /// Gets the Docker build configuration, when the service is built from a Dockerfile.
+    /// Corresponds to the <c>docker</c> field.
+    /// </summary>
+    public AzdDocker? Docker { get; internal set; }
+
+    /// <summary>
+    /// Gets the names of resources or services that this service depends on. Corresponds to the <c>uses</c> field.
+    /// </summary>
+    /// <value>
+    /// During import each referenced name is wired up as an Aspire reference so connection
+    /// information flows into the service's environment.
+    /// </value>
+    public IReadOnlyList<string> Uses { get; internal set; } = [];
+
+    /// <summary>
+    /// Gets the environment variables declared on the service. Corresponds to the <c>env</c> field.
+    /// </summary>
+    public IReadOnlyDictionary<string, string?> Env { get; internal set; } = new Dictionary<string, string?>();
+}
+
+/// <summary>
+/// Represents the <c>docker</c> build configuration of an azd service.
+/// </summary>
+public sealed class AzdDocker
+{
+    /// <summary>
+    /// Gets the Docker build context path, relative to the service's <see cref="AzdService.Project"/> directory.
+    /// </summary>
+    public string? Context { get; internal set; }
+
+    /// <summary>
+    /// Gets the path to the Dockerfile, relative to the service's <see cref="AzdService.Project"/> directory.
+    /// </summary>
+    public string? Path { get; internal set; }
+
+    /// <summary>
+    /// Gets the target build stage to use for a multi-stage Dockerfile.
+    /// </summary>
+    public string? Target { get; internal set; }
+}
+
+/// <summary>
+/// Represents a single entry in the <c>resources</c> map of an azd project.
+/// </summary>
+/// <remarks>
+/// Resources are backing Azure services (databases, caches, storage, messaging, AI, and so on). The
+/// <see cref="Type"/> field selects the resource kind, and <see cref="Properties"/> exposes the
+/// type-specific configuration that azd reads inline (for example a model name or a set of queues).
+/// </remarks>
+public sealed class AzdResource
+{
+    /// <summary>
+    /// Gets the azd resource type (for example <c>db.redis</c>, <c>db.postgres</c>, <c>storage</c>,
+    /// <c>keyvault</c>, <c>messaging.servicebus</c>, or <c>ai.openai.model</c>). Corresponds to the <c>type</c> field.
+    /// </summary>
+    public string? Type { get; internal set; }
+
+    /// <summary>
+    /// Gets the explicit resource name, when the YAML overrides the map key. Corresponds to the <c>name</c> field.
+    /// </summary>
+    public string? Name { get; internal set; }
+
+    /// <summary>
+    /// Gets the names of other resources this resource depends on. Corresponds to the <c>uses</c> field.
+    /// </summary>
+    public IReadOnlyList<string> Uses { get; internal set; } = [];
+
+    /// <summary>
+    /// Gets a value indicating whether the resource refers to an already-existing Azure resource.
+    /// Corresponds to the <c>existing</c> field.
+    /// </summary>
+    public bool Existing { get; internal set; }
+
+    /// <summary>
+    /// Gets the type-specific configuration declared inline on the resource.
+    /// </summary>
+    /// <value>
+    /// A dictionary of the remaining YAML keys (those not represented by a dedicated property),
+    /// preserving values as parsed (scalars, lists, or nested maps). Resource mappers read this to
+    /// reproduce settings such as databases, containers, queues, or model details.
+    /// </value>
+    public IReadOnlyDictionary<string, object?> Properties { get; internal set; } = new Dictionary<string, object?>();
+}

--- a/src/Aspire.Hosting.Azure.Azd/README.md
+++ b/src/Aspire.Hosting.Azure.Azd/README.md
@@ -1,0 +1,187 @@
+# Azure Developer CLI (azd) import hosting integration
+
+Use this integration to adopt an existing [Azure Developer CLI (azd)](https://learn.microsoft.com/azure/developer/azure-developer-cli/) project in an Aspire AppHost without rewriting your assets. It reads an existing `azure.yaml`, the selected `.azure` environment, and the project's `infra` folder, and projects the azd services and resources onto equivalent Aspire resources.
+
+`builder.AddAzdProject(...)` is a **native, end-to-end integration**: the imported model runs locally (`aspire run`) on emulators and containers without touching Azure, and it publishes/deploys (`aspire publish` / `aspire deploy`) to the **same** subscription, region, and resource group your azd environment already records — binding to resources you marked `existing` instead of recreating them.
+
+> [!IMPORTANT]
+> This integration is **experimental**. The APIs are decorated with `[Experimental("ASPIREAZUREAZD001")]` and may change in a future release. Suppress the diagnostic (for example with `#pragma warning disable ASPIREAZUREAZD001` or a project-level `<NoWarn>` entry) to use them.
+
+## Why
+
+Teams that already use azd have meaningful assets: a hand-tuned `azure.yaml`, Bicep under `infra/`, and per-environment configuration under `.azure/`. Moving to Aspire should not mean throwing those away. This integration lets you point Aspire at an existing azd project so you can start orchestrating and extending it from an AppHost while keeping your existing infrastructure-as-code intact.
+
+The direction is **azd → Aspire** (import/adopt). This integration does not emit `azure.yaml`.
+
+`builder.AddAzdProject(...)` reads the azd assets when the AppHost starts and materializes equivalent Aspire resources in-memory. The result is a fully functional Aspire app that runs locally on emulators/containers and deploys to your existing Azure environment (see [Run and deploy natively](#run-and-deploy-natively)). `azure.yaml` stays the source of truth, and you can reference and customize any imported resource from your AppHost like any other Aspire resource.
+
+## Getting started
+
+### Prerequisites
+
+- An existing azd project (a directory that contains an `azure.yaml` file).
+- Azure subscription (only required when you eventually provision/deploy the imported resources).
+
+### Add the integration
+
+From your AppHost directory, add the `Aspire.Hosting.Azure.Azd` integration with the Aspire CLI:
+
+```bash
+aspire add Aspire.Hosting.Azure.Azd
+```
+
+## Run and deploy natively
+
+Point the AppHost at the directory (or `azure.yaml` file) of your existing azd project. The call returns an `AzdImport` describing everything that was created, plus diagnostics for anything that needs follow-up:
+
+```csharp
+#pragma warning disable ASPIREAZUREAZD001
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+// Resolve azure.yaml from the AppHost directory, or pass a path/directory explicitly.
+var azd = builder.AddAzdProject("../../existing-azd-app");
+
+// Surface anything that could not be imported automatically.
+foreach (var diagnostic in azd.Diagnostics.Items)
+{
+    Console.WriteLine(diagnostic);
+}
+
+// Continue to customize imported resources as normal Aspire resources. GetService/GetResource
+// return a reference immediately; if the name is not in azure.yaml the app fails when it runs or deploys.
+var web = azd.GetService("web");
+web.WithReplicas(2);
+
+// Need the concrete resource type to call type-specific extension methods? Ask for it. The generic
+// overloads re-wrap the loosely-typed import as a strongly-typed builder so it composes naturally.
+azd.GetResource<AzureCosmosDBResource>("orders").AddCosmosDatabase("appdb");
+
+builder.Build().Run();
+```
+
+That single call gives you a model that works in both directions:
+
+- **`aspire run` (local development).** Resources that have a local development experience are switched to a container or emulator so nothing touches Azure: **Azure Cache for Redis** and **Azure Database for PostgreSQL** run as containers, and **Azure Storage**, **Cosmos DB**, **Service Bus**, and **Event Hubs** run as emulators. Resources without a local option (Key Vault, OpenAI, AI Search) continue to bind to Azure.
+- **`aspire publish` / `aspire deploy` (the cloud).** Aspire generates the deployable Azure infrastructure (Bicep) for every mapped resource and targets the **same** subscription, region, and resource group recorded in your `.azure` environment — so a migrated app provisions into the place azd already used instead of standing up a parallel environment.
+- **`existing: true` resources** are bound to the already-provisioned Azure resource (the annotation form of `AsExisting`) using the azd resource name and the environment's resource group, so neither run nor publish recreates something you already own.
+
+These behaviors are on by default and can be tuned through `AzdImportOptions`:
+
+```csharp
+var azd = builder.AddAzdProject("../../existing-azd-app", options =>
+{
+    // Provision the real Azure resources locally instead of running emulators/containers.
+    options.UseEmulatorsForLocalRun = false;
+
+    // Provision a fresh copy instead of binding to resources marked `existing: true`.
+    options.BindExistingResources = false;
+
+    // Don't reuse the subscription/location/resource group from .azure for provisioning.
+    options.ReuseAzureEnvironment = false;
+});
+```
+
+## What gets imported
+
+### Services (`services:`) → compute resources
+
+| azd service shape | Aspire resource |
+| --- | --- |
+| `language: dotnet` (or a `project:` pointing at a `.csproj`/`.fsproj`) | `AddProject` |
+| `host: function` with `language: dotnet` (a `.csproj`/`.fsproj`) | `AddAzureFunctionsProject` |
+| `image:` (prebuilt container image) | `AddContainer` |
+| `docker:` block, or any service with a `Dockerfile` | `AddDockerfile` |
+
+Each service's `host:` selects a compute environment, created on demand:
+
+| azd `host:` | Aspire compute environment |
+| --- | --- |
+| `containerapp` | `AddAzureContainerAppEnvironment` |
+| `appservice` | `AddAzureAppServiceEnvironment` |
+| `function` (with `language: dotnet`) | `AddAzureContainerAppEnvironment` — the service is imported as an `AddAzureFunctionsProject`. azd hosts Functions on `Microsoft.Web/sites`, but the Aspire Functions compute target is Azure Container Apps, so a diagnostic notes the substitution. |
+| `function` (non-.NET), `aks`, `staticwebapp`, … | *Deferred* — reported as a diagnostic; the service is imported without a compute environment |
+
+Service `env:` entries are applied with `WithEnvironment`, and `uses:` entries are wired with `WithReference`.
+
+> [!NOTE]
+> azd injects a fixed set of environment variables into a service for each `uses:` edge (for example `REDIS_HOST`/`REDIS_URL`, `AZURE_KEY_VAULT_ENDPOINT`, `POSTGRES_*`). Aspire's `WithReference` uses its own connection conventions, so the importer reports the azd variable names as a diagnostic. If your application code reads the azd names, add `WithEnvironment` to preserve them.
+
+### Resources (`resources:`) → Azure integrations
+
+The built-in mappers cover the resource types most commonly found in azd templates. The azd resource-type names below are taken from the [azd `azure.yaml` schema](https://github.com/Azure/azure-dev/blob/main/schemas/v1.0/azure.yaml.json).
+
+| azd resource `type` | Aspire resource | Child resources |
+| --- | --- | --- |
+| `keyvault` | `AddAzureKeyVault` | — |
+| `storage` | `AddAzureStorage` | `containers:` → blob containers |
+| `db.redis` | `AddAzureManagedRedis` | — |
+| `db.postgres` | `AddAzurePostgresFlexibleServer` | a database named after the resource |
+| `db.cosmos` | `AddAzureCosmosDB` | a database named after the resource + `containers:` (with `partitionKeys`) |
+| `messaging.servicebus` | `AddAzureServiceBus` | `queues:`, `topics:` |
+| `messaging.eventhubs` | `AddAzureEventHubs` | `hubs:` |
+| `ai.search` | `AddAzureSearch` | — |
+| `ai.openai.model` | `AddAzureOpenAI` | `model:` (`name`/`version`) → a model deployment |
+| `db.mysql`, `db.mongo`, `ai.project`, `host.*` | *Deferred* — reported as a diagnostic | — |
+
+> [!NOTE]
+> `db.redis` is a deliberate **SKU substitution**, not a 1:1 mapping. In azd, `db.redis` provisions [Azure Cache for Redis](https://learn.microsoft.com/azure/azure-cache-for-redis/) (`Microsoft.Cache/redis`), which Azure is [retiring](https://learn.microsoft.com/azure/azure-cache-for-redis/retirement-faq). Aspire maps it to **Azure Managed Redis** (`Microsoft.Cache/redisEnterprise`) — its supported successor — via `AddAzureManagedRedis`, and reports a warning. If you have an existing Azure Cache for Redis instance, confirm the successor SKU fits your migration, or register a custom `IAzdResourceMapper` to override the mapping.
+
+### Preserved assets
+
+- **`infra/` (Bicep)** is **referenced, not regenerated**. The path is exposed as `AzdImport.InfraPath`; continue to manage it with your existing deployment workflow. The provider is taken from `azure.yaml` or, when not pinned, detected from the folder's file extensions (as azd does). A **Terraform** `infra/` folder is preserved but flagged with a diagnostic, because Aspire provisions Bicep.
+- **`.azure/<env>/.env` and `.azure/config.json`** are loaded into `AzdImport.Environment`, exposing the subscription, location, resource group, tenant, and principal recorded by azd. The default environment from `config.json` is used unless you set `AzdImportOptions.EnvironmentName`. These values also seed Azure provisioning: the subscription/location/resource group are applied to `AzureProvisionerOptions` (the `Azure:*` configuration) **and** to the `AzureEnvironmentResource` that Aspire adds for deployment (its `location`, `resourceGroupName`, and `principalId` parameters), so a grown-up app targets the same place on `aspire publish`/`aspire deploy` without re-prompting. Values you set yourself always win. Set `AzdImportOptions.ReuseAzureEnvironment = false` to opt out.
+- A resource marked **`existing: true`** in `azure.yaml` is reference-only in azd. The importer binds it to the already-provisioned Azure resource automatically (the annotation form of `AsExisting`, using the azd resource name and the environment's resource group), so neither run nor publish creates a duplicate. Set `AzdImportOptions.BindExistingResources = false` to import it as a new resource instead.
+- **azd expandable strings** (`${VAR}` / `$VAR`) in the project's `resourceGroup` and in a service's `env:` values are resolved against the selected `.azure` environment, exactly as azd does — so `resourceGroup: rg-${AZURE_ENV_NAME}` targets the same group azd would. A variable that isn't recorded in the environment is left as its literal `${VAR}` token rather than blanked, so an adopter's value is never silently emptied.
+
+## Diagnostics
+
+The import is **non-destructive and transparent**: anything that cannot be mapped (an unsupported host kind, an unknown resource type, a missing source path) is reported through `AzdImport.Diagnostics` instead of being silently dropped, so nothing is lost when you migrate.
+
+```csharp
+if (azd.Diagnostics.HasWarnings)
+{
+    foreach (var warning in azd.Diagnostics.Items.Where(d => d.Severity == AzdImportDiagnosticSeverity.Warning))
+    {
+        Console.WriteLine($"Needs attention: {warning}");
+    }
+}
+```
+
+## Known limitations
+
+This integration is an early adoption aid, not a full azd replacement. In particular, a `uses:` edge is wired with Aspire's `WithReference` and the azd variable **names** are reported as a diagnostic, but the importer does **not** yet reproduce the exact azd variable **values** — azd assembles those from Key Vault secrets and Bicep outputs and adds managed-identity role assignments. Until that lands, assemble any azd-shaped connection values you still need with `WithEnvironment`. The following are also deferred (each surfaced as a diagnostic, never silently dropped): non-ACA host kinds, Terraform provisioning, hooks, pipelines/workflows/state/platform/cloud, `${AZURE_*}` parameter substitution, resource-level `uses`, and the `db.mysql`/`db.mongo`/`ai.project`/`host.*` resource types.
+
+## Extending the mapping
+
+Supply a custom `IAzdResourceMapper` to support a resource type the built-in mappers do not cover, or to override the default mapping for a type. Mappers are consulted in order, before the built-ins:
+
+```csharp
+public sealed class MyAccountMapper : IAzdResourceMapper
+{
+    public bool CanMap(AzdResourceMapContext context)
+        => context.Resource.Type == "db.mysql";
+
+    public IResourceBuilder<IResource>? Map(AzdResourceMapContext context)
+        => context.Builder.AddMySql(context.ResourceName);
+}
+
+var azd = builder.AddAzdProject("../../existing-azd-app", options =>
+{
+    options.ResourceMappers.Add(new MyAccountMapper());
+
+    // Bind imported services to a compute environment you already declared instead of creating new ones.
+    options.CreateComputeEnvironments = false;
+
+    // Import a specific azd environment rather than the default from .azure/config.json.
+    options.EnvironmentName = "prod";
+});
+```
+
+## Additional documentation
+
+* https://aspire.dev/integrations/gallery/
+
+## Feedback & contributing
+
+https://github.com/microsoft/aspire

--- a/tests/Aspire.Hosting.Azure.Azd.Tests/AddAzdProjectTests.cs
+++ b/tests/Aspire.Hosting.Azure.Azd.Tests/AddAzdProjectTests.cs
@@ -1,0 +1,801 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.AppContainers;
+using Aspire.Hosting.JavaScript;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Azure.Azd.Tests;
+
+public class AddAzdProjectTests
+{
+    [Fact]
+    public void ImportsServicesWithExpectedResourceKinds()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        Assert.Equal(["api", "legacy", "web"], import.Services.Keys.OrderBy(k => k));
+
+        // A .NET project becomes a project resource; the Docker-based and fallback services become containers.
+        Assert.IsType<ProjectResource>(import.Services["web"].Resource);
+        Assert.IsType<ContainerResource>(import.Services["api"].Resource);
+        Assert.IsType<ContainerResource>(import.Services["legacy"].Resource);
+    }
+
+    [Fact]
+    public void MapsResourcesToAzureIntegrations()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        // db2 (db.mysql) has no built-in mapper, so it is not imported.
+        Assert.Equal(["cache", "files", "openai", "orders", "pg", "sb", "search", "secrets"], import.Resources.Keys.OrderBy(k => k, StringComparer.Ordinal));
+
+        Assert.IsType<AzureManagedRedisResource>(import.Resources["cache"].Resource);
+        Assert.IsType<AzureKeyVaultResource>(import.Resources["secrets"].Resource);
+        Assert.IsType<AzurePostgresFlexibleServerResource>(import.Resources["pg"].Resource);
+        Assert.IsType<AzureCosmosDBResource>(import.Resources["orders"].Resource);
+        Assert.IsType<AzureServiceBusResource>(import.Resources["sb"].Resource);
+        Assert.IsType<AzureStorageResource>(import.Resources["files"].Resource);
+        Assert.IsType<AzureSearchResource>(import.Resources["search"].Resource);
+        Assert.IsType<AzureOpenAIResource>(import.Resources["openai"].Resource);
+    }
+
+    [Fact]
+    public void ExpandsNestedChildResources()
+    {
+        using var sample = SampleAzdProject.Create();
+        // Use publish mode: it reflects the Azure resource graph that gets deployed. In run mode the
+        // importer swaps Redis/Postgres for local containers (which removes the Azure child resources),
+        // so the canonical Azure shape is only observable when publishing.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzdProject(sample.AzureYamlPath);
+
+        // Generic db.postgres provisions a single database named after the resource.
+        Assert.Single(builder.Resources.OfType<AzurePostgresFlexibleServerDatabaseResource>());
+        Assert.Single(builder.Resources.OfType<AzureServiceBusQueueResource>());
+        Assert.Single(builder.Resources.OfType<AzureServiceBusTopicResource>());
+        Assert.Single(builder.Resources.OfType<AzureBlobStorageContainerResource>());
+        Assert.Single(builder.Resources.OfType<AzureOpenAIDeploymentResource>());
+        // Cosmos containers live under an implicit database named after the resource.
+        Assert.Single(builder.Resources.OfType<AzureCosmosDBDatabaseResource>());
+        Assert.Single(builder.Resources.OfType<AzureCosmosDBContainerResource>());
+    }
+
+    [Fact]
+    public void CreatesComputeEnvironmentsForHostedServices()
+    {
+        using var sample = SampleAzdProject.Create();
+        // Azure compute environments are only materialized into the model in publish mode.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzdProject(sample.AzureYamlPath);
+
+        Assert.Single(builder.Resources.OfType<AzureContainerAppEnvironmentResource>());
+        Assert.Single(builder.Resources.OfType<AzureAppServiceEnvironmentResource>());
+    }
+
+    [Fact]
+    public void DoesNotCreateComputeEnvironmentsWhenDisabled()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzdProject(sample.AzureYamlPath, options => options.CreateComputeEnvironments = false);
+
+        Assert.Empty(builder.Resources.OfType<AzureContainerAppEnvironmentResource>());
+        Assert.Empty(builder.Resources.OfType<AzureAppServiceEnvironmentResource>());
+    }
+
+    [Fact]
+    public void WiresUsesToReferencedResources()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        var web = import.Services["web"].Resource;
+        var referenced = web.Annotations
+            .OfType<ResourceRelationshipAnnotation>()
+            .Select(a => a.Resource.Name)
+            .ToHashSet();
+
+        Assert.Contains("cache", referenced);
+        Assert.Contains("secrets", referenced);
+        Assert.Contains("pg", referenced);
+    }
+
+    [Fact]
+    public void AppliesServiceEnvironmentVariables()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        // The env block on the web service should be projected onto the resource as an env callback.
+        Assert.Contains(import.Services["web"].Resource.Annotations, a => a is EnvironmentCallbackAnnotation);
+    }
+
+    [Fact]
+    public void LoadsDefaultEnvironment()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        Assert.NotNull(import.Environment);
+        Assert.Equal("dev", import.Environment.Name);
+        Assert.Equal("eastus2", import.Environment.Location);
+    }
+
+    [Fact]
+    public void PreservesExistingInfrastructure()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        Assert.NotNull(import.InfraPath);
+        Assert.EndsWith("infra", import.InfraPath);
+        Assert.True(Directory.Exists(import.InfraPath));
+        Assert.Contains(import.Diagnostics.Items, d => d.Severity == AzdImportDiagnosticSeverity.Information && d.Message.Contains("preserved"));
+    }
+
+    [Fact]
+    public void ReportsDiagnosticsForUnsupportedResourceAndHost()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        // db.mysql has no mapper.
+        Assert.Contains(import.Diagnostics.Items, d => d.Severity == AzdImportDiagnosticSeverity.Warning && d.Target == "db2");
+        // The function host is not yet supported for automatic compute placement.
+        Assert.Contains(import.Diagnostics.Items, d => d.Severity == AzdImportDiagnosticSeverity.Warning && d.Target == "legacy" && d.Message.Contains("function"));
+    }
+
+    [Fact]
+    public void BindsExistingResourceInsteadOfReprovisioning()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        // 'secrets' is marked existing: true in the sample. The importer binds it to the already-provisioned
+        // Azure resource (the annotation form of AsExisting) so it is not recreated on run or publish.
+        Assert.True(import.Resources["secrets"].Resource.IsExisting());
+
+        // The binding is surfaced as information (not a warning); nothing is silently dropped or duplicated.
+        Assert.Contains(import.Diagnostics.Items, d => d.Severity == AzdImportDiagnosticSeverity.Information && d.Target == "secrets" && d.Message.Contains("existing"));
+    }
+
+    [Fact]
+    public void ReportsAzdEnvironmentContractForUses()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        // web uses cache (db.redis); the customer's app code may read azd's REDIS_* variables, so the
+        // importer must surface that contract rather than silently switching to Aspire conventions.
+        Assert.Contains(
+            import.Diagnostics.Items,
+            d => d.Severity == AzdImportDiagnosticSeverity.Information && d.Target == "web" && d.Message.Contains("REDIS_HOST"));
+    }
+
+    [Fact]
+    public void DetectsTerraformInfrastructureAndWarns()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-tf-");
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "azure.yaml"), "name: tf-app\n");
+            Directory.CreateDirectory(Path.Combine(root.FullName, "infra"));
+            File.WriteAllText(Path.Combine(root.FullName, "infra", "main.tf"), "# terraform");
+
+            using var builder = TestDistributedApplicationBuilder.Create();
+
+            var import = builder.AddAzdProject(root.FullName);
+
+            // The provider is not pinned in azure.yaml, so it is detected from the file extensions; a
+            // Terraform infra folder is preserved but flagged because Aspire cannot provision it.
+            Assert.Contains(
+                import.Diagnostics.Items,
+                d => d.Severity == AzdImportDiagnosticSeverity.Warning && d.Message.Contains("Terraform"));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void AppliesDockerBuildStage()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        // The api service declares docker.target: build; that must flow through as the Dockerfile build stage.
+        var build = import.Services["api"].Resource.Annotations.OfType<DockerfileBuildAnnotation>().Single();
+        Assert.Equal("build", build.Stage);
+    }
+
+    [Fact]
+    public void MapsJavaScriptServicesToNativeJavaScriptApps()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-js-");
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "azure.yaml"),
+                """
+                name: js-app
+                services:
+                  web:
+                    project: ./src/web
+                    language: ts
+                    host: containerapp
+                  api:
+                    project: ./src/api
+                    language: js
+                    host: appservice
+                  worker:
+                    project: ./src/worker
+                    language: node
+                    host: function
+                """);
+
+            // "web" exposes a conventional start script (preferred), "api" exposes only dev, and
+            // "worker" has no scripts block so the importer falls back to the npm default of "start".
+            WritePackageJson(root.FullName, "src/web", """{ "scripts": { "start": "node server.js", "dev": "tsx watch src/server.ts" } }""");
+            WritePackageJson(root.FullName, "src/api", """{ "scripts": { "dev": "node server.js" } }""");
+            WritePackageJson(root.FullName, "src/worker", """{ "name": "worker" }""");
+
+            using var builder = TestDistributedApplicationBuilder.Create();
+            var import = builder.AddAzdProject(root.FullName);
+
+            // js/ts/node services become native Aspire JavaScript apps rather than requiring a container build.
+            Assert.IsType<JavaScriptAppResource>(import.Services["web"].Resource);
+            Assert.IsType<JavaScriptAppResource>(import.Services["api"].Resource);
+            Assert.IsType<JavaScriptAppResource>(import.Services["worker"].Resource);
+
+            Assert.Equal("start", GetRunScript(import.Services["web"].Resource));
+            Assert.Equal("dev", GetRunScript(import.Services["api"].Resource));
+            Assert.Equal("start", GetRunScript(import.Services["worker"].Resource));
+
+            // Web-hosted services get an HTTP endpoint so the imported app is reachable.
+            var endpoint = import.Services["web"].Resource.Annotations.OfType<EndpointAnnotation>().Single();
+            Assert.Equal("http", endpoint.UriScheme);
+
+            // azd gives a scaffolded compute service public ingress by default, so the imported endpoint must
+            // be external; otherwise a migrated front end would silently become unreachable from the internet.
+            Assert.True(endpoint.IsExternal);
+
+            // A non-web host (here treated as a plain executable) does not get an HTTP endpoint implicitly.
+            Assert.DoesNotContain(import.Services["worker"].Resource.Annotations, a => a is EndpointAnnotation);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+
+        static void WritePackageJson(string root, string relativeDirectory, string contents)
+        {
+            var directory = Path.Combine(root, relativeDirectory.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, "package.json"), contents);
+        }
+
+        static string GetRunScript(IResource resource) =>
+            resource.Annotations.OfType<JavaScriptRunScriptAnnotation>().Single().ScriptName;
+    }
+
+    [Fact]
+    public void PublishesJavaScriptComputeServicesAsDeployableContainers()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-js-publish-");
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "azure.yaml"),
+                """
+                name: js-publish-app
+                services:
+                  runtimeloader:
+                    project: ./src/runtimeloader
+                    language: ts
+                    host: containerapp
+                  builder:
+                    project: ./src/builder
+                    language: ts
+                    host: containerapp
+                """);
+
+            // "runtimeloader" executes its sources directly (e.g. via tsx) with only a start script and no
+            // build step; "builder" compiles with a build script before starting.
+            WritePackageJson(root.FullName, "src/runtimeloader", """{ "scripts": { "start": "tsx src/server.ts" } }""");
+            WritePackageJson(root.FullName, "src/builder", """{ "scripts": { "build": "tsc", "start": "node dist/server.js" } }""");
+
+            using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+            var import = builder.AddAzdProject(root.FullName);
+
+            var runtimeLoader = import.Services["runtimeloader"].Resource;
+
+            // azd builds and runs a js/ts compute service as a long-lived server container. The imported app
+            // must publish with a standalone runtime (PublishAsPackageScript) so it is deployed, not treated as
+            // a build-only image. PublishAsPackageScript clears the default container-files source that
+            // AddJavaScriptApp configures for build-only (static front end) publishing, so its absence in
+            // publish mode confirms the service is deployable.
+            Assert.DoesNotContain(runtimeLoader.Annotations, a => a is ContainerFilesSourceAnnotation);
+
+            // The service has no "build" script, so the default build-script must be dropped to keep the
+            // generated Dockerfile's `npm run build` from failing the image build.
+            Assert.DoesNotContain(runtimeLoader.Annotations, a => a is JavaScriptBuildScriptAnnotation);
+
+            // A service that does define a "build" script is still deployable and keeps its build step.
+            var builderService = import.Services["builder"].Resource;
+            Assert.DoesNotContain(builderService.Annotations, a => a is ContainerFilesSourceAnnotation);
+            Assert.Contains(builderService.Annotations, a => a is JavaScriptBuildScriptAnnotation);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+
+        static void WritePackageJson(string root, string relativeDirectory, string contents)
+        {
+            var directory = Path.Combine(root, relativeDirectory.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, "package.json"), contents);
+        }
+    }
+
+    [Fact]
+    public void ReportsErrorWhenUsedResourceCannotBeReferenced()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-storageuses-");
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "azure.yaml"),
+                """
+                name: storage-uses-app
+                services:
+                  app:
+                    project: ./src/app
+                    language: dotnet
+                    host: containerapp
+                    uses:
+                      - files
+                resources:
+                  files:
+                    type: storage
+                """);
+            Directory.CreateDirectory(Path.Combine(root.FullName, "src", "app"));
+            File.WriteAllText(Path.Combine(root.FullName, "src", "app", "app.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+
+            using var builder = TestDistributedApplicationBuilder.Create();
+            var import = builder.AddAzdProject(root.FullName);
+
+            // AzureStorageResource is not a connection-string resource, so the 'uses' edge cannot be wired
+            // and must be surfaced as an error rather than silently dropped.
+            Assert.True(import.Diagnostics.HasErrors);
+            Assert.Contains(
+                import.Diagnostics.Items,
+                d => d.Severity == AzdImportDiagnosticSeverity.Error && d.Target == "app" && d.Message.Contains("connection string"));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ResolvesAzdExpandableStringsInResourceGroupAndServiceEnv()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-subst-");
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "azure.yaml"),
+                """
+                name: subst-app
+                resourceGroup: rg-${AZURE_ENV_NAME}
+                services:
+                  app:
+                    image: nginx:latest
+                    env:
+                      RESOLVED: ${AZURE_ENV_NAME}-suffix
+                      LITERAL: plain-value
+                      UNKNOWN: ${NOT_IN_ENV}
+                """);
+
+            // No AZURE_RESOURCE_GROUP is recorded, so the importer must resolve the azure.yaml
+            // resourceGroup expandable string against the environment instead of ignoring it.
+            File.WriteAllText(WriteEnvFile(root.FullName, "dev"), "AZURE_ENV_NAME=\"dev\"\nAZURE_LOCATION=\"eastus2\"\n");
+            File.WriteAllText(Path.Combine(root.FullName, ".azure", "config.json"), "{ \"version\": 1, \"defaultEnvironment\": \"dev\" }");
+
+            using var builder = TestDistributedApplicationBuilder.Create();
+            var import = builder.AddAzdProject(root.FullName);
+
+            // resourceGroup: rg-${AZURE_ENV_NAME} resolves against AZURE_ENV_NAME=dev for both the
+            // provisioner option and the AzureEnvironmentResource parameter.
+            Assert.Equal("rg-dev", builder.Configuration["Azure:ResourceGroup"]);
+            Assert.Equal("rg-dev", builder.Configuration["Parameters:resourceGroupName"]);
+
+            var app = Assert.IsAssignableFrom<IResourceWithEnvironment>(import.Services["app"].Resource);
+#pragma warning disable CS0618 // GetEnvironmentVariableValuesAsync is obsolete but is the supported way to resolve env values in tests.
+            var env = await app.GetEnvironmentVariableValuesAsync();
+#pragma warning restore CS0618
+
+            // A known variable is resolved, a literal is untouched, and an unknown token is preserved
+            // (rather than blanked) so an adopter's value is never silently emptied.
+            Assert.Equal("dev-suffix", env["RESOLVED"]);
+            Assert.Equal("plain-value", env["LITERAL"]);
+            Assert.Equal("${NOT_IN_ENV}", env["UNKNOWN"]);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+
+        static string WriteEnvFile(string projectRoot, string environmentName)
+        {
+            var path = Path.Combine(projectRoot, ".azure", environmentName, ".env");
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            return path;
+        }
+    }
+
+    [Fact]
+    public void ImportsDotNetFunctionHostAsAzureFunctionsProject()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-fn-");
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "azure.yaml"),
+                """
+                name: fn-app
+                services:
+                  fn:
+                    project: ./src/fn
+                    language: dotnet
+                    host: function
+                  jsfn:
+                    project: ./src/jsfn
+                    language: ts
+                    host: function
+                """);
+            Directory.CreateDirectory(Path.Combine(root.FullName, "src", "fn"));
+            File.WriteAllText(Path.Combine(root.FullName, "src", "fn", "fn.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+            Directory.CreateDirectory(Path.Combine(root.FullName, "src", "jsfn"));
+            File.WriteAllText(Path.Combine(root.FullName, "src", "jsfn", "package.json"), "{ \"scripts\": { \"start\": \"node server.js\" } }");
+
+            // Compute environments are only materialized into the model in publish mode, so use it here to
+            // assert the Functions project lands on the Azure Container Apps environment.
+            using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+            var import = builder.AddAzdProject(root.FullName);
+
+            // azd host: function on a .NET service preserves the Functions host model as an Azure Functions
+            // project rather than being flattened to a generic project/container resource.
+            Assert.IsType<AzureFunctionsProjectResource>(import.Services["fn"].Resource);
+
+            // The Functions integration is .NET-specific, so a non-.NET function service is not misrouted to
+            // it; the TypeScript service still becomes a JavaScript app.
+            Assert.IsType<JavaScriptAppResource>(import.Services["jsfn"].Resource);
+
+            // The Functions project is placed on the Azure Container Apps compute environment (the supported
+            // Aspire Functions target), and the compute-target substitution is surfaced as a diagnostic.
+            Assert.Single(builder.Resources.OfType<AzureContainerAppEnvironmentResource>());
+            Assert.Contains(
+                import.Diagnostics.Items,
+                d => d.Severity == AzdImportDiagnosticSeverity.Warning && d.Target == "fn" && d.Message.Contains("Container Apps"));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DisambiguatesCollidingResourceNames()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-collision-");
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "azure.yaml"),
+                """
+                name: collision-app
+                resources:
+                  my.cache:
+                    type: db.redis
+                  my-cache:
+                    type: db.redis
+                """);
+
+            using var builder = TestDistributedApplicationBuilder.Create();
+            var import = builder.AddAzdProject(root.FullName);
+
+            // Both azd keys sanitize to "my-cache"; both must still import (keyed by their azd name), the
+            // collision must be reported, and AppHost construction must not throw on a duplicate name.
+            Assert.True(import.Resources.ContainsKey("my.cache"));
+            Assert.True(import.Resources.ContainsKey("my-cache"));
+            Assert.Contains(
+                import.Diagnostics.Items,
+                d => d.Severity == AzdImportDiagnosticSeverity.Warning && d.Message.Contains("collision"));
+
+            var names = new[] { import.Resources["my.cache"].Resource.Name, import.Resources["my-cache"].Resource.Name };
+            Assert.Equal(2, names.Distinct().Count());
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CustomResourceMapperTakesPrecedence()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath, options =>
+            options.ResourceMappers.Add(new MySqlMapper()));
+
+        // The custom mapper handles db.mysql, so db2 is imported and produces no "no mapper" warning.
+        Assert.True(import.Resources.ContainsKey("db2"));
+        Assert.DoesNotContain(import.Diagnostics.Items, d => d.Severity == AzdImportDiagnosticSeverity.Warning && d.Target == "db2");
+    }
+
+    [Fact]
+    public void ResolvesAzureYamlFromDirectory()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.Root.FullName);
+
+        Assert.Equal("contoso-app", import.Project.Name);
+    }
+
+    [Fact]
+    public void ThrowsWhenAzureYamlMissing()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        Assert.Throws<FileNotFoundException>(() => builder.AddAzdProject("does-not-exist.yaml"));
+    }
+
+    [Fact]
+    public void GetServiceAndGetResourceReturnTheImportedReference()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        // The accessors hand back the same builder the importer materialized, so further customization
+        // (WithReference, WithReplicas, ...) mutates the real imported resource.
+        Assert.Same(import.Services["web"], import.GetService("web"));
+        Assert.Same(import.Resources["cache"], import.GetResource("cache"));
+    }
+
+    [Fact]
+    public async Task GetResourceReturnsReferenceButFailsAtStartupForUnknownName()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-ref-");
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "azure.yaml"),
+                """
+                name: ref-app
+                resources:
+                  cache:
+                    type: db.redis
+                """);
+
+            using var builder = TestDistributedApplicationBuilder.Create();
+            var import = builder.AddAzdProject(root.FullName);
+
+            // The reference is returned immediately; an invalid name does not throw at the call site.
+            var missing = import.GetResource("does-not-exist");
+            Assert.NotNull(missing);
+
+            // The failure is deferred to BeforeStartEvent, which runs for both `aspire run` and publish/deploy.
+            using var app = builder.Build();
+            var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => builder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, model)));
+
+            Assert.Contains("does-not-exist", ex.Message);
+            Assert.Contains("no such resource", ex.Message);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task GetServiceForAResourceNameDefersFailureWithACorrectiveHint()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-ref2-");
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "azure.yaml"),
+                """
+                name: ref-app
+                resources:
+                  cache:
+                    type: db.redis
+                """);
+
+            using var builder = TestDistributedApplicationBuilder.Create();
+            var import = builder.AddAzdProject(root.FullName);
+
+            // "cache" exists, but it is a resource, not a service.
+            import.GetService("cache");
+
+            using var app = builder.Build();
+            var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => builder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, model)));
+
+            Assert.Contains("'cache' is a resource, not a service", ex.Message);
+            Assert.Contains("GetResource(\"cache\")", ex.Message);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetResourceGenericReturnsTypedBuilderOverTheSameUnderlyingResource()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        // The generic overload re-wraps the loosely-typed import as a strongly-typed builder (via
+        // CreateResourceBuilder) so it composes with type-specific extension methods, while still pointing
+        // at the same underlying resource the importer materialized.
+        IResourceBuilder<AzureManagedRedisResource> cache = import.GetResource<AzureManagedRedisResource>("cache");
+        Assert.Same(import.Resources["cache"].Resource, cache.Resource);
+    }
+
+    [Fact]
+    public void GetServiceGenericReturnsTypedBuilderOverTheSameUnderlyingResource()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        IResourceBuilder<ProjectResource> web = import.GetService<ProjectResource>("web");
+        Assert.Same(import.Services["web"].Resource, web.Resource);
+    }
+
+    [Fact]
+    public void GetResourceGenericThrowsImmediatelyForWrongType()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        // "cache" is an AzureManagedRedisResource. A typed placeholder cannot be synthesized for the wrong
+        // type, so unlike the loosely-typed overload the mismatch is reported immediately.
+        var ex = Assert.Throws<InvalidOperationException>(() => import.GetResource<AzureKeyVaultResource>("cache"));
+        Assert.Contains(nameof(AzureManagedRedisResource), ex.Message);
+        Assert.Contains(nameof(AzureKeyVaultResource), ex.Message);
+    }
+
+    [Fact]
+    public void GetResourceGenericThrowsImmediatelyForUnknownName()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => import.GetResource<AzureKeyVaultResource>("does-not-exist"));
+        Assert.Contains("does-not-exist", ex.Message);
+        Assert.Contains("no such resource", ex.Message);
+    }
+
+    [Fact]
+    public void ReportsResourceLevelUsesAsUnwiredDiagnostic()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-resuses-");
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "azure.yaml"),
+                """
+                name: res-uses-app
+                resources:
+                  files:
+                    type: storage
+                    uses:
+                      - secrets
+                  secrets:
+                    type: keyvault
+                """);
+
+            using var builder = TestDistributedApplicationBuilder.Create();
+            var import = builder.AddAzdProject(root.FullName);
+
+            // azd resource-to-resource `uses` (resources[].uses) is not wired automatically, but it must not
+            // be dropped silently: the importer's contract is that anything it cannot reproduce surfaces as a
+            // diagnostic so a migrating customer can re-establish the dependency.
+            Assert.Contains(
+                import.Diagnostics.Items,
+                d => d.Severity == AzdImportDiagnosticSeverity.Warning
+                    && d.Target == "files"
+                    && d.Message.Contains("resource-to-resource"));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IgnoresResourceGroupWithUnresolvedBareToken()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-rg-unresolved-");
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "azure.yaml"),
+                """
+                name: rg-unresolved-app
+                resourceGroup: rg-$UNKNOWN_VAR
+                resources:
+                  cache:
+                    type: db.redis
+                """);
+
+            // The environment loads (AZURE_ENV_NAME/AZURE_LOCATION present) but records no AZURE_RESOURCE_GROUP
+            // and no UNKNOWN_VAR, so the azure.yaml resourceGroup expandable string cannot be resolved.
+            var envPath = Path.Combine(root.FullName, ".azure", "dev", ".env");
+            Directory.CreateDirectory(Path.GetDirectoryName(envPath)!);
+            File.WriteAllText(envPath, "AZURE_ENV_NAME=\"dev\"\nAZURE_LOCATION=\"eastus2\"\n");
+            File.WriteAllText(Path.Combine(root.FullName, ".azure", "config.json"), "{ \"version\": 1, \"defaultEnvironment\": \"dev\" }");
+
+            using var builder = TestDistributedApplicationBuilder.Create();
+            builder.AddAzdProject(root.FullName);
+
+            // A bare "$VAR" that cannot be resolved must not leak into the provisioning target as the literal
+            // "rg-$UNKNOWN_VAR" (an invalid resource group name); it is ignored instead.
+            Assert.Null(builder.Configuration["Azure:ResourceGroup"]);
+            Assert.Null(builder.Configuration["Parameters:resourceGroupName"]);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    private sealed class MySqlMapper : IAzdResourceMapper
+    {
+        public bool CanMap(AzdResourceMapContext context)
+            => string.Equals(context.Resource.Type, "db.mysql", StringComparison.OrdinalIgnoreCase);
+
+        public IResourceBuilder<IResource> Map(AzdResourceMapContext context)
+            => context.Builder.AddAzureKeyVault(context.ResourceName);
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Azd.Tests/Aspire.Hosting.Azure.Azd.Tests.csproj
+++ b/tests/Aspire.Hosting.Azure.Azd.Tests/Aspire.Hosting.Azure.Azd.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <!-- The azd importer surface is experimental; tests exercise it directly. -->
+    <NoWarn>$(NoWarn);ASPIREAZUREAZD001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aspire.Hosting.AppHost\Aspire.Hosting.AppHost.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Azd\Aspire.Hosting.Azure.Azd.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.Tests\Aspire.Hosting.Azure.Tests.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(TestsSharedDir)TestModuleInitializer.cs" LinkBase="shared" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Aspire.Hosting.Azure.Azd.Tests/AzdEnvironmentReaderTests.cs
+++ b/tests/Aspire.Hosting.Azure.Azd.Tests/AzdEnvironmentReaderTests.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Azd.Tests;
+
+public class AzdEnvironmentReaderTests
+{
+    [Fact]
+    public void ReadsDefaultEnvironmentFromConfig()
+    {
+        using var sample = SampleAzdProject.Create();
+
+        var environment = AzdEnvironmentReader.Read(sample.Root.FullName);
+
+        Assert.NotNull(environment);
+        Assert.Equal("dev", environment.Name);
+        Assert.Equal("eastus2", environment.Location);
+        Assert.Equal("00000000-0000-0000-0000-000000000000", environment.SubscriptionId);
+        Assert.Equal("rg-contoso-dev", environment.ResourceGroup);
+        Assert.Equal("11111111-1111-1111-1111-111111111111", environment.PrincipalId);
+        Assert.Equal("22222222-2222-2222-2222-222222222222", environment.TenantId);
+        Assert.Equal("User", environment.PrincipalType);
+    }
+
+    [Fact]
+    public void StripsQuotesAndIgnoresComments()
+    {
+        using var sample = SampleAzdProject.Create();
+
+        var environment = AzdEnvironmentReader.Read(sample.Root.FullName);
+
+        Assert.NotNull(environment);
+        // The value is quoted in the .env file; quotes must be removed.
+        Assert.Equal("https://web.example.com", environment.GetValueOrDefault("SERVICE_WEB_ENDPOINT_URL"));
+        // Comment lines must not become entries.
+        Assert.DoesNotContain(environment.Values.Keys, k => k.StartsWith('#'));
+    }
+
+    [Fact]
+    public void UnescapesJsonQuotedValues()
+    {
+        using var sample = SampleAzdProject.Create();
+
+        var environment = AzdEnvironmentReader.Read(sample.Root.FullName);
+
+        Assert.NotNull(environment);
+        // azd/godotenv writes the value as AZURE_TAGS="{\"env\":\"dev\",\"team\":\"contoso\"}"; the
+        // embedded escaped quotes must be unescaped, not left in the value.
+        Assert.Equal("{\"env\":\"dev\",\"team\":\"contoso\"}", environment.GetValueOrDefault("AZURE_TAGS"));
+    }
+
+    [Fact]
+    public void ReadsExplicitlyNamedEnvironment()
+    {
+        using var sample = SampleAzdProject.Create();
+
+        var environment = AzdEnvironmentReader.Read(sample.Root.FullName, "prod");
+
+        Assert.NotNull(environment);
+        Assert.Equal("prod", environment.Name);
+        Assert.Equal("westus3", environment.Location);
+    }
+
+    [Fact]
+    public void ReturnsNullWhenNoAzureDirectory()
+    {
+        var emptyDir = Directory.CreateTempSubdirectory("azd-empty-");
+        try
+        {
+            Assert.Null(AzdEnvironmentReader.Read(emptyDir.FullName));
+        }
+        finally
+        {
+            emptyDir.Delete(recursive: true);
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Azd.Tests/AzdProjectParserTests.cs
+++ b/tests/Aspire.Hosting.Azure.Azd.Tests/AzdProjectParserTests.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Azd.Tests;
+
+public class AzdProjectParserTests
+{
+    [Fact]
+    public void ParsesTopLevelFields()
+    {
+        using var sample = SampleAzdProject.Create();
+
+        var project = AzdProjectParser.Parse(File.ReadAllText(sample.AzureYamlPath));
+
+        Assert.Equal("contoso-app", project.Name);
+        Assert.Equal("contoso@1.0", project.Metadata?.Template);
+        Assert.Equal("bicep", project.Infra?.Provider);
+        Assert.Equal("infra", project.Infra?.Path);
+        Assert.Equal("main", project.Infra?.Module);
+    }
+
+    [Fact]
+    public void ParsesServices()
+    {
+        using var sample = SampleAzdProject.Create();
+
+        var project = AzdProjectParser.Parse(File.ReadAllText(sample.AzureYamlPath));
+
+        Assert.Equal(["api", "legacy", "web"], project.Services.Keys.OrderBy(k => k));
+
+        var web = project.Services["web"];
+        Assert.Equal("./src/web", web.Project);
+        Assert.Equal("dotnet", web.Language);
+        Assert.Equal("containerapp", web.Host);
+        Assert.Equal(["cache", "secrets", "pg"], web.Uses);
+        Assert.Equal("Production", web.Env["ASPNETCORE_ENVIRONMENT"]);
+
+        var api = project.Services["api"];
+        Assert.Equal("appservice", api.Host);
+        Assert.Equal("./Dockerfile", api.Docker?.Path);
+
+        var legacy = project.Services["legacy"];
+        Assert.Equal("python", legacy.Language);
+        Assert.Equal("function", legacy.Host);
+    }
+
+    [Fact]
+    public void ParsesResourcesWithTypeSpecificProperties()
+    {
+        using var sample = SampleAzdProject.Create();
+
+        var project = AzdProjectParser.Parse(File.ReadAllText(sample.AzureYamlPath));
+
+        Assert.Equal("db.redis", project.Resources["cache"].Type);
+        Assert.Equal("keyvault", project.Resources["secrets"].Type);
+        Assert.Equal("db.postgres", project.Resources["pg"].Type);
+        Assert.Equal("db.mysql", project.Resources["db2"].Type);
+
+        var sb = project.Resources["sb"];
+        var queues = Assert.IsAssignableFrom<IReadOnlyList<object?>>(sb.Properties["queues"]);
+        var topics = Assert.IsAssignableFrom<IReadOnlyList<object?>>(sb.Properties["topics"]);
+        Assert.Equal(["jobs"], queues.Select(q => q?.ToString()));
+        Assert.Equal(["events"], topics.Select(t => t?.ToString()));
+
+        var orders = project.Resources["orders"];
+        Assert.Equal("db.cosmos", orders.Type);
+        var containers = Assert.IsAssignableFrom<IReadOnlyList<object?>>(orders.Properties["containers"]);
+        var firstContainer = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(containers[0]);
+        Assert.Equal("items", firstContainer["name"]);
+
+        var openai = project.Resources["openai"];
+        var model = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(openai.Properties["model"]);
+        Assert.Equal("gpt-4o", model["name"]);
+        Assert.Equal("2024-08-06", model["version"]);
+    }
+
+    [Fact]
+    public void ToleratesUnknownTopLevelKeys()
+    {
+        var yaml =
+            """
+            name: tolerant
+            workflows:
+              up:
+                steps:
+                  - azd: provision
+            customField: anything
+            services:
+              app:
+                host: containerapp
+            """;
+
+        var project = AzdProjectParser.Parse(yaml);
+
+        Assert.Equal("tolerant", project.Name);
+        Assert.True(project.Services.ContainsKey("app"));
+        Assert.True(project.Raw.ContainsKey("workflows"));
+        Assert.True(project.Raw.ContainsKey("customField"));
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Azd.Tests/NativeIntegrationTests.cs
+++ b/tests/Aspire.Hosting.Azure.Azd.Tests/NativeIntegrationTests.cs
@@ -1,0 +1,178 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Azure.Azd.Tests;
+
+/// <summary>
+/// Verifies that an imported azd project behaves natively end-to-end: it runs locally on emulators and
+/// containers, it reuses the customer's azd environment, and it produces deployable Azure infrastructure
+/// on publish.
+/// </summary>
+public class NativeIntegrationTests
+{
+    [Fact]
+    public void RunModeRunsLocalResourcesAsEmulatorsAndContainers()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        // Resources with an emulator run locally without touching Azure.
+        Assert.True(import.Resources["files"].Resource.IsEmulator(), "Storage should run on the Azurite emulator locally.");
+        Assert.True(import.Resources["orders"].Resource.IsEmulator(), "Cosmos DB should run on the emulator locally.");
+        Assert.True(import.Resources["sb"].Resource.IsEmulator(), "Service Bus should run on the emulator locally.");
+
+        // Resources without an emulator run as containers; RunAsContainer swaps the Azure resource for a
+        // same-named container, so the container is observable on the application model.
+        Assert.Contains(builder.Resources, r => string.Equals(r.Name, "cache", StringComparison.Ordinal) && r.IsContainer());
+        Assert.Contains(builder.Resources, r => string.Equals(r.Name, "pg", StringComparison.Ordinal) && r.IsContainer());
+    }
+
+    [Fact]
+    public void PublishModeKeepsAzureResourcesForDeployment()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath);
+
+        // Publish targets the real Azure resources, so nothing is swapped for an emulator or container.
+        Assert.False(import.Resources["files"].Resource.IsEmulator());
+        Assert.False(import.Resources["orders"].Resource.IsEmulator());
+        Assert.DoesNotContain(builder.Resources, r => string.Equals(r.Name, "cache", StringComparison.Ordinal) && r.IsContainer());
+        Assert.DoesNotContain(builder.Resources, r => string.Equals(r.Name, "pg", StringComparison.Ordinal) && r.IsContainer());
+
+        // The Azure resources (and therefore their generated infrastructure) are still present.
+        Assert.Contains(builder.Resources.OfType<AzureManagedRedisResource>(), r => string.Equals(r.Name, "cache", StringComparison.Ordinal));
+        Assert.Contains(builder.Resources.OfType<AzurePostgresFlexibleServerResource>(), r => string.Equals(r.Name, "pg", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ReusesAzureEnvironmentForProvisioning()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzdProject(sample.AzureYamlPath);
+
+        // The subscription/location/resource group recorded by azd become the Aspire provisioning target,
+        // so a migrated app deploys into the same place instead of re-prompting or creating a parallel env.
+        Assert.Equal("00000000-0000-0000-0000-000000000000", builder.Configuration["Azure:SubscriptionId"]);
+        Assert.Equal("eastus2", builder.Configuration["Azure:Location"]);
+        Assert.Equal("rg-contoso-dev", builder.Configuration["Azure:ResourceGroup"]);
+        Assert.Equal("22222222-2222-2222-2222-222222222222", builder.Configuration["Azure:TenantId"]);
+    }
+
+    [Fact]
+    public void ReuseAzureEnvironmentDoesNotOverwriteConfiguredValues()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A value the app host author already set must win over the reused azd environment.
+        builder.Configuration["Azure:Location"] = "westeurope";
+
+        builder.AddAzdProject(sample.AzureYamlPath);
+
+        Assert.Equal("westeurope", builder.Configuration["Azure:Location"]);
+        // Keys the author did not set are still filled in from the azd environment.
+        Assert.Equal("rg-contoso-dev", builder.Configuration["Azure:ResourceGroup"]);
+    }
+
+    [Fact]
+    public void DisablingEmulatorsKeepsAzureResourcesInRunMode()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var import = builder.AddAzdProject(sample.AzureYamlPath, options => options.UseEmulatorsForLocalRun = false);
+
+        // Opting out leaves the Azure resources in place even when running locally.
+        Assert.False(import.Resources["files"].Resource.IsEmulator());
+        Assert.DoesNotContain(builder.Resources, r => string.Equals(r.Name, "cache", StringComparison.Ordinal) && r.IsContainer());
+        Assert.Contains(builder.Resources.OfType<AzureManagedRedisResource>(), r => string.Equals(r.Name, "cache", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PublishGeneratesDeployableBicepForMappedResources()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        // Focus the proof on the data resources; compute environments add deployment-target wiring that is
+        // orthogonal to "do the imported resources emit deployable infrastructure?".
+        var import = builder.AddAzdProject(sample.AzureYamlPath, options => options.CreateComputeEnvironments = false);
+
+        // Build the model from just the Azure resources so the bicep preparer does not require a compute
+        // environment for the imported services.
+        var azureModel = new DistributedApplicationModel(
+            builder.Resources.Where(r => r is not ProjectResource and not ContainerResource).ToList());
+
+        var (_, cosmosBicep) = await AzureManifestUtils.GetManifestWithBicep(azureModel, import.Resources["orders"].Resource);
+        var (_, serviceBusBicep) = await AzureManifestUtils.GetManifestWithBicep(azureModel, import.Resources["sb"].Resource);
+
+        // The imported resources produce real Aspire-generated ARM, which is what makes the migrated app
+        // deployable with `aspire publish` / `aspire deploy`.
+        Assert.Contains("Microsoft.DocumentDB/databaseAccounts", cosmosBicep);
+        Assert.Contains("Microsoft.ServiceBus/namespaces", serviceBusBicep);
+    }
+
+    [Fact]
+    public void RedisIsMappedToAzureManagedRedisWithASkuSubstitutionWarning()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-redis-sku-");
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "azure.yaml"),
+                """
+                name: redis-app
+                resources:
+                  cache:
+                    type: db.redis
+                """);
+
+            using var builder = TestDistributedApplicationBuilder.Create();
+            var import = builder.AddAzdProject(root.FullName);
+
+            // azd's db.redis is Azure Cache for Redis (Microsoft.Cache/redis), which Azure is retiring.
+            // Aspire maps it to its supported successor, Azure Managed Redis, and surfaces the SKU change
+            // as a warning rather than silently swapping products.
+            Assert.IsType<AzureManagedRedisResource>(import.Resources["cache"].Resource);
+            Assert.Contains(
+                import.Diagnostics.Items,
+                d => d.Severity == AzdImportDiagnosticSeverity.Warning
+                    && d.Target == "cache"
+                    && d.Message.Contains("Azure Managed Redis"));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+#pragma warning disable ASPIREAZURE001
+    [Fact]
+    public async Task ReusesAzureEnvironmentForTheAzureEnvironmentResource()
+    {
+        using var sample = SampleAzdProject.Create();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddAzdProject(sample.AzureYamlPath);
+
+        // AddAzureProvisioning (invoked when the imported Azure resources are added) always adds an
+        // AzureEnvironmentResource. Its Location/ResourceGroupName/PrincipalId parameters are the canonical
+        // deployment target the generated bicep is parameterized on, so reusing the azd environment must
+        // populate them; otherwise resolving them throws MissingParameterValueException and a grown-up app
+        // would prompt for values azd already recorded.
+        var environment = Assert.Single(builder.Resources.OfType<Aspire.Hosting.Azure.AzureEnvironmentResource>());
+
+        Assert.Equal("eastus2", await environment.Location.GetValueAsync(default));
+        Assert.Equal("rg-contoso-dev", await environment.ResourceGroupName.GetValueAsync(default));
+        Assert.Equal("11111111-1111-1111-1111-111111111111", await environment.PrincipalId.GetValueAsync(default));
+    }
+#pragma warning restore ASPIREAZURE001
+}

--- a/tests/Aspire.Hosting.Azure.Azd.Tests/SampleAzdProject.cs
+++ b/tests/Aspire.Hosting.Azure.Azd.Tests/SampleAzdProject.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Azd.Tests;
+
+/// <summary>
+/// Writes a realistic azd project layout (azure.yaml + infra + .azure + service sources) to a
+/// temporary directory so the importer can be exercised end-to-end against on-disk assets.
+/// </summary>
+internal sealed class SampleAzdProject : IDisposable
+{
+    private SampleAzdProject(DirectoryInfo root)
+    {
+        Root = root;
+    }
+
+    public DirectoryInfo Root { get; }
+
+    public string AzureYamlPath => Path.Combine(Root.FullName, "azure.yaml");
+
+    public static SampleAzdProject Create()
+    {
+        var root = Directory.CreateTempSubdirectory("azd-import-test-");
+        var sample = new SampleAzdProject(root);
+        sample.Write();
+        return sample;
+    }
+
+    private void Write()
+    {
+        File.WriteAllText(AzureYamlPath, AzureYaml);
+
+        // The .NET service points at a directory that contains a project file.
+        WriteFile("src/web/web.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+
+        // The container service builds from a Dockerfile relative to its project directory.
+        WriteFile("src/api/Dockerfile", "FROM mcr.microsoft.com/dotnet/aspnet:8.0");
+
+        // The non-.NET service has no project file but does have a Dockerfile to fall back to.
+        WriteFile("src/legacy/Dockerfile", "FROM python:3.12-slim");
+
+        // Existing infrastructure that must be preserved by the import.
+        WriteFile("infra/main.bicep", "// existing azd infrastructure");
+        WriteFile("infra/main.parameters.json", "{ \"parameters\": {} }");
+
+        // azd environment state.
+        WriteFile(".azure/config.json", "{ \"version\": 1, \"defaultEnvironment\": \"dev\" }");
+        WriteFile(".azure/dev/.env", DevDotEnv);
+        WriteFile(".azure/prod/.env", "AZURE_ENV_NAME=\"prod\"\nAZURE_LOCATION=\"westus3\"\n");
+    }
+
+    private void WriteFile(string relativePath, string contents)
+    {
+        var fullPath = Path.Combine(Root.FullName, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, contents);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Root.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; a leaked temp directory should not fail a test.
+        }
+    }
+
+    private const string AzureYaml =
+        """
+        name: contoso-app
+        metadata:
+          template: contoso@1.0
+        infra:
+          provider: bicep
+          path: infra
+          module: main
+        services:
+          web:
+            project: ./src/web
+            language: dotnet
+            host: containerapp
+            uses:
+              - cache
+              - secrets
+              - pg
+            env:
+              ASPNETCORE_ENVIRONMENT: Production
+          api:
+            project: ./src/api
+            language: docker
+            host: appservice
+            docker:
+              path: ./Dockerfile
+              target: build
+          legacy:
+            project: ./src/legacy
+            language: python
+            host: function
+        resources:
+          cache:
+            type: db.redis
+          secrets:
+            type: keyvault
+            existing: true
+          pg:
+            type: db.postgres
+          orders:
+            type: db.cosmos
+            containers:
+              - name: items
+                partitionKeys:
+                  - /id
+          sb:
+            type: messaging.servicebus
+            queues:
+              - jobs
+            topics:
+              - events
+          files:
+            type: storage
+            containers:
+              - uploads
+          search:
+            type: ai.search
+          openai:
+            type: ai.openai.model
+            model:
+              name: gpt-4o
+              version: "2024-08-06"
+          db2:
+            type: db.mysql
+        """;
+
+    private const string DevDotEnv =
+        """
+        AZURE_ENV_NAME="dev"
+        AZURE_LOCATION="eastus2"
+        AZURE_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
+        AZURE_RESOURCE_GROUP="rg-contoso-dev"
+        AZURE_PRINCIPAL_ID="11111111-1111-1111-1111-111111111111"
+        AZURE_TENANT_ID="22222222-2222-2222-2222-222222222222"
+        AZURE_PRINCIPAL_TYPE="User"
+        # a JSON-escaped value, as godotenv writes it
+        AZURE_TAGS="{\"env\":\"dev\",\"team\":\"contoso\"}"
+        # provisioning output
+        SERVICE_WEB_ENDPOINT_URL="https://web.example.com"
+        """;
+}


### PR DESCRIPTION
## Description

Lets an existing **Azure Developer CLI (azd)** customer adopt their project in **Aspire** without losing or rewriting their assets. Today, moving from azd to Aspire means hand-porting `azure.yaml`, `infra/`, and `.azure/<env>/.env` into AppHost code. This PR makes that a one-liner: Aspire *imports* the azd project as-is and produces real Aspire resources you can `run`, `publish`, and `deploy`.

```csharp
// C# AppHost
builder.AddAzdProject("../path/to/azd-app");
```

```ts
// TypeScript AppHost
builder.addAzdProject("./azd-app");
```

### Approach

New top-level package `src/Aspire.Hosting.Azure.Azd` (it must sit above the integration packages because it maps onto `AddAzureRedis`, `AddAzurePostgres`, etc., which reference `Aspire.Hosting.Azure`, not the other way around):

- **Parser** (`AzdProjectParser`, YamlDotNet) reads the public `azure.yaml` JSON-schema contract into a typed model, tolerant of unknown keys.
- **Env reader** loads `.azure/config.json` (default environment) + `.azure/<env>/.env`, and resolves azd `${AZURE_*}` expandable strings.
- **Importer** maps the azd model to Aspire:
  - `services:` -> compute (`host: containerapp` -> ACA, `appservice` -> App Service, `function` -> Azure Functions project), for .NET/JS/TS/Dockerfile/prebuilt-image sources.
  - `resources:` -> curated `AddAzure*` integrations (redis, postgres, mysql, mongo, cosmos, keyvault, storage, servicebus, eventhubs, openai, etc.) via a pluggable `IAzdResourceMapper` registry.
  - `uses:` -> `WithReference` wiring (service-level and host-resource-level).
  - existing `infra/` bicep -> referenced and preserved, never regenerated.
- **Diagnostics** (`AzdImportDiagnostics`) loudly surface anything unmapped (deferred host kinds, hooks, terraform/pulumi infra) so nothing is silently dropped.

A `playground/AzdImport` sample carries a real, hand-authored azd project (a Contoso Store TS service with `db.redis` + `db.postgres`) that the AppHost adopts with zero changes to the azd assets.

### Things worth a careful look

- **Fidelity is intentionally a "successor, not byte-identical" mapping in a couple of places.** Most notably `db.redis`: azd provisions `Microsoft.Cache/redis` (Azure Cache for Redis), but that API is `[Obsolete]` in Aspire and the product is being retired, so the importer maps to **Azure Managed Redis** and emits a diagnostic explaining the substitution. The faithful-vs-successor call is a product-owner decision; the diagnostic keeps it honest.
- **Passwordless by default.** Imported Azure resources use Aspire's managed-identity defaults (role assignments + `AZURE_TOKEN_CREDENTIALS=ManagedIdentityCredential`), not azd's Key Vault password seeding. This is the right secure default, but it means a migrated app must use Entra-token auth rather than password connection strings. Validated against a real deploy (see below).
- **Deliberate v1 deferrals (diagnostic-only):** hooks execution, `aks`/`staticwebapp`/`springapp`/`ai.*` host kinds, pipeline files, and terraform/pulumi infra. These are surfaced, not mapped.

### Validation

- `Aspire.Hosting.Azure.Azd.Tests` green (parser, env reader, mappers, native integration).
- `aspire publish` produces a complete, correct deployable model; local `aspire run` exercises the imported Redis + Postgres bindings end-to-end.
- **Real Azure `aspire deploy` succeeded** (the importer-generated model provisioned managed identities, ACR + image build/push, Managed Redis, Postgres, role assignments, ACA env, and a publicly reachable container app). The only non-green data-plane calls were the expected passwordless tradeoff above, which is a sample-app concern, not an importer defect.

Fixes # N/A

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected. (POC with deliberate deferrals listed above; not yet API-reviewed.)
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No (uses Aspire's existing Azure provisioning + managed-identity defaults)