### PR TITLE
Flatten single-AppHost group nodes in the AppHosts tree view

### DIFF
--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -632,13 +632,11 @@ suite('AspireAppHostTreeProvider', () => {
             sendAspireCommandToAspireTerminal: (command: AspireSubcommand) => commands.push(command),
         } as unknown as AspireTerminalProvider;
         const provider = new AspireAppHostTreeProvider(repository, terminalProvider, makeLaunchService());
-        const [groupItem] = provider.getChildren();
-        const [item] = provider.getChildren(groupItem);
+        const [item] = provider.getChildren();
 
         provider.stopAppHost(item as any);
 
-        const [updatedGroupItem] = provider.getChildren();
-        const [updatedItem] = provider.getChildren(updatedGroupItem);
+        const [updatedItem] = provider.getChildren();
         assert.strictEqual(updatedItem.contextValue, 'workspaceResources:stopping');
         assert.strictEqual(updatedItem.description, 'Stopping...');
         assert.strictEqual((updatedItem.iconPath as vscode.ThemeIcon).id, 'loading~spin');
@@ -2269,8 +2267,7 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         } as unknown as AspireTerminalProvider;
         const provider = new AspireAppHostTreeProvider(repository, terminalProvider, makeLaunchService());
 
-        const [runningGroup] = provider.getChildren();
-        const [runningAppHostItem] = provider.getChildren(runningGroup);
+        const [runningAppHostItem] = provider.getChildren();
         const resourceItem = provider.getChildren(runningAppHostItem)[0];
 
         provider.viewResourceLogs(resourceItem as any);

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -1898,8 +1898,11 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
             'aspire-vscode.debugAppHost',
             undefined,
         ]);
+        // findAppHostElement rebuilds the tree (getChildren is not cached), so the returned
+        // element is a fresh instance. Match by stable id/contextValue rather than reference.
         assert.ok(result, 'Expected to find the workspace AppHost candidate');
-        assert.strictEqual(result, appHostItem);
+        assert.strictEqual(result?.id, appHostItem.id);
+        assert.strictEqual(result?.contextValue, 'workspaceAppHost');
         provider.dispose();
     });
 

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -567,8 +567,7 @@ suite('AspireAppHostTreeProvider', () => {
         provider.notifyAppHostStopping(appHostPath);
         provider.notifyAppHostStopping(unknownAppHostPath);
 
-        const [groupItem] = provider.getChildren();
-        const [candidateItem] = provider.getChildren(groupItem);
+        const [candidateItem] = provider.getChildren();
         assert.strictEqual(candidateItem.contextValue, 'workspaceAppHost');
         assert.notStrictEqual(candidateItem.description, 'Stopping...');
         assert.strictEqual(provider.stoppingPaths.length, 0);
@@ -1866,7 +1865,7 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         provider.dispose();
     });
 
-    test('workspace mode renders selected non-running AppHost candidate without resources', () => {
+    test('workspace mode renders single non-running AppHost candidate without a grouping node', () => {
         const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
         const repository = {
             viewMode: 'workspace' as ViewMode,
@@ -1879,12 +1878,13 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         } as unknown as AppHostDataRepository;
         const provider = new AspireAppHostTreeProvider(repository, makeTerminalProvider(), makeLaunchService());
 
-        const [groupItem] = provider.getChildren();
+        // A single AppHost is surfaced directly at the root with no "Workspace AppHosts"
+        // grouping node (https://github.com/microsoft/aspire/issues/18420).
+        const topLevel = provider.getChildren();
+        assert.strictEqual(topLevel.length, 1);
+        const appHostItem = topLevel[0];
         const result = provider.findAppHostElement('/repo/AppHost/AppHost.csproj');
 
-        assert.ok(groupItem, 'Expected the Workspace AppHosts group');
-        assert.strictEqual(groupItem.contextValue, 'workspaceAppHostsGroup');
-        const [appHostItem] = provider.getChildren(groupItem);
         assert.strictEqual(appHostItem.label, 'AppHost.csproj');
         assert.strictEqual(appHostItem.contextValue, 'workspaceAppHost');
         assert.strictEqual(appHostItem.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed);
@@ -1901,6 +1901,7 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
             undefined,
         ]);
         assert.ok(result, 'Expected to find the workspace AppHost candidate');
+        assert.strictEqual(result, appHostItem);
         provider.dispose();
     });
 
@@ -1959,9 +1960,8 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         } as unknown as AppHostDataRepository;
         const provider = new AspireAppHostTreeProvider(repository, makeTerminalProvider(), launchService);
 
-        const [groupItem] = provider.getChildren();
-        assert.strictEqual(groupItem?.contextValue, 'workspaceAppHostsGroup');
-        const [item] = provider.getChildren(groupItem);
+        // A single launching AppHost is surfaced directly at the root with no grouping node.
+        const [item] = provider.getChildren();
 
         assert.ok(item, 'Expected a launching workspace AppHost item');
         assert.strictEqual(item.contextValue, 'workspaceAppHostLaunching');
@@ -2074,9 +2074,8 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         } as unknown as AppHostDataRepository;
         const provider = new AspireAppHostTreeProvider(repository, makeTerminalProvider(), launchService);
 
-        // Get the workspace item from inside the Workspace AppHosts group and pass it to runAppHost
-        const [groupItem] = provider.getChildren();
-        const [item] = provider.getChildren(groupItem);
+        // A single candidate is surfaced directly at the root (no grouping node); pass it to runAppHost.
+        const [item] = provider.getChildren();
         await provider.runAppHost(item as any, false);
 
         assert.ok(launchStub.calledOnce, 'Expected launch to be called');
@@ -2107,8 +2106,7 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         } as unknown as AppHostDataRepository;
         const provider = new AspireAppHostTreeProvider(repository, makeTerminalProvider(), launchService);
 
-        const [groupItem] = provider.getChildren();
-        const [item] = provider.getChildren(groupItem);
+        const [item] = provider.getChildren();
         await assert.rejects(provider.runAppHost(item as any, false), /startDebugging blew up/);
 
         assert.ok(launchStub.calledOnce, 'Expected launch to be called');

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -1972,6 +1972,42 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
     test('workspace mode groups idle AppHosts under WorkspaceAppHostsGroupItem when running AppHost exists', () => {
         const runningPath = '/repo/apps/Store/AppHost.csproj';
         const idlePath = '/repo/apps/Backend/AppHost.csproj';
+        const secondIdlePath = '/repo/apps/Web/AppHost.csproj';
+        const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
+        const repository = {
+            viewMode: 'workspace' as ViewMode,
+            appHosts: [makeAppHost({ appHostPath: runningPath, appHostPid: 1234, cliPid: 5678, resources: [makeResource()] })],
+            workspaceResources: [],
+            workspaceAppHostPath: runningPath,
+            workspaceAppHostCandidatePaths: [runningPath, idlePath, secondIdlePath],
+            workspaceAppHostName: undefined,
+            onDidChangeData,
+        } as unknown as AppHostDataRepository;
+        const provider = new AspireAppHostTreeProvider(repository, makeTerminalProvider(), makeLaunchService());
+
+        const topLevelItems = provider.getChildren();
+
+        // With a running AppHost and two or more idle AppHosts, both sets are wrapped in
+        // sibling groups so they nest at the same depth and read symmetrically in the tree.
+        assert.strictEqual(topLevelItems.length, 2);
+        assert.strictEqual(topLevelItems[0].contextValue, 'runningAppHostsGroup');
+        assert.strictEqual(topLevelItems[1].contextValue, 'workspaceAppHostsGroup');
+
+        // Running group contains the running AppHost (rendered as WorkspaceResourcesItem)
+        const runningChildren = provider.getChildren(topLevelItems[0]);
+        assert.strictEqual(runningChildren.length, 1);
+        assert.ok(runningChildren[0].contextValue?.startsWith('workspaceResources'));
+
+        // Workspace group contains the two idle AppHosts
+        const idleChildren = provider.getChildren(topLevelItems[1]);
+        assert.strictEqual(idleChildren.length, 2);
+        assert.deepStrictEqual(idleChildren.map(item => item.contextValue), ['workspaceAppHost', 'workspaceAppHost']);
+        provider.dispose();
+    });
+
+    test('workspace mode surfaces a single idle AppHost directly when a running AppHost exists', () => {
+        const runningPath = '/repo/apps/Store/AppHost.csproj';
+        const idlePath = '/repo/apps/Backend/AppHost.csproj';
         const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
         const repository = {
             viewMode: 'workspace' as ViewMode,
@@ -1986,21 +2022,15 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
 
         const topLevelItems = provider.getChildren();
 
-        // When both running and idle AppHosts exist, both sets are wrapped in sibling
-        // groups so they nest at the same depth and read symmetrically in the tree.
+        // A lone idle AppHost is surfaced directly as a sibling of the running group,
+        // with no "Workspace AppHosts (1)" wrapper (https://github.com/microsoft/aspire/issues/18420).
         assert.strictEqual(topLevelItems.length, 2);
         assert.strictEqual(topLevelItems[0].contextValue, 'runningAppHostsGroup');
-        assert.strictEqual(topLevelItems[1].contextValue, 'workspaceAppHostsGroup');
+        assert.strictEqual(topLevelItems[1].contextValue, 'workspaceAppHost');
 
-        // Running group contains the running AppHost (rendered as WorkspaceResourcesItem)
         const runningChildren = provider.getChildren(topLevelItems[0]);
         assert.strictEqual(runningChildren.length, 1);
         assert.ok(runningChildren[0].contextValue?.startsWith('workspaceResources'));
-
-        // Workspace group contains the idle AppHost
-        const idleChildren = provider.getChildren(topLevelItems[1]);
-        assert.strictEqual(idleChildren.length, 1);
-        assert.strictEqual(idleChildren[0].contextValue, 'workspaceAppHost');
         provider.dispose();
     });
 
@@ -2026,13 +2056,13 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
 
         const topLevelItems = provider.getChildren();
 
-        // Both groups must appear: the .csproj candidate should be recognized as running
-        // (rendered in the running group), and the unrelated idle candidate stays in
-        // the workspace group. Without directory-equivalence matching, the .csproj
-        // candidate would be misclassified as idle.
+        // The .csproj candidate should be recognized as running (rendered in the running
+        // group), and the unrelated lone idle candidate is surfaced directly as a sibling.
+        // Without directory-equivalence matching, the .csproj candidate would be
+        // misclassified as idle.
         assert.strictEqual(topLevelItems.length, 2);
         assert.strictEqual(topLevelItems[0].contextValue, 'runningAppHostsGroup');
-        assert.strictEqual(topLevelItems[1].contextValue, 'workspaceAppHostsGroup');
+        assert.strictEqual(topLevelItems[1].contextValue, 'workspaceAppHost');
 
         const runningChildren = provider.getChildren(topLevelItems[0]);
         assert.strictEqual(runningChildren.length, 1);
@@ -2040,10 +2070,6 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         const resourceChildren = provider.getChildren(runningChildren[0]);
         assert.strictEqual(resourceChildren.length, 1);
         assert.strictEqual(resourceChildren[0].label, 'workspace-service');
-
-        const idleChildren = provider.getChildren(topLevelItems[1]);
-        assert.strictEqual(idleChildren.length, 1);
-        assert.strictEqual(idleChildren[0].contextValue, 'workspaceAppHost');
         provider.dispose();
     });
 

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -1969,17 +1969,21 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
         provider.dispose();
     });
 
-    test('workspace mode groups idle AppHosts under WorkspaceAppHostsGroupItem when running AppHost exists', () => {
+    test('workspace mode groups both running and idle AppHosts under their group nodes when each has two or more', () => {
         const runningPath = '/repo/apps/Store/AppHost.csproj';
+        const secondRunningPath = '/repo/apps/Api/AppHost.csproj';
         const idlePath = '/repo/apps/Backend/AppHost.csproj';
         const secondIdlePath = '/repo/apps/Web/AppHost.csproj';
         const onDidChangeData: vscode.Event<void> = () => ({ dispose: () => { } });
         const repository = {
             viewMode: 'workspace' as ViewMode,
-            appHosts: [makeAppHost({ appHostPath: runningPath, appHostPid: 1234, cliPid: 5678, resources: [makeResource()] })],
+            appHosts: [
+                makeAppHost({ appHostPath: runningPath, appHostPid: 1234, cliPid: 5678, resources: [makeResource()] }),
+                makeAppHost({ appHostPath: secondRunningPath, appHostPid: 4321, cliPid: 8765, resources: [makeResource()] }),
+            ],
             workspaceResources: [],
             workspaceAppHostPath: runningPath,
-            workspaceAppHostCandidatePaths: [runningPath, idlePath, secondIdlePath],
+            workspaceAppHostCandidatePaths: [runningPath, secondRunningPath, idlePath, secondIdlePath],
             workspaceAppHostName: undefined,
             onDidChangeData,
         } as unknown as AppHostDataRepository;
@@ -1987,16 +1991,16 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
 
         const topLevelItems = provider.getChildren();
 
-        // With a running AppHost and two or more idle AppHosts, both sets are wrapped in
+        // With two or more running AND two or more idle AppHosts, both sets are wrapped in
         // sibling groups so they nest at the same depth and read symmetrically in the tree.
         assert.strictEqual(topLevelItems.length, 2);
         assert.strictEqual(topLevelItems[0].contextValue, 'runningAppHostsGroup');
         assert.strictEqual(topLevelItems[1].contextValue, 'workspaceAppHostsGroup');
 
-        // Running group contains the running AppHost (rendered as WorkspaceResourcesItem)
+        // Running group contains the two running AppHosts (rendered as nested AppHostItems)
         const runningChildren = provider.getChildren(topLevelItems[0]);
-        assert.strictEqual(runningChildren.length, 1);
-        assert.ok(runningChildren[0].contextValue?.startsWith('workspaceResources'));
+        assert.strictEqual(runningChildren.length, 2);
+        assert.deepStrictEqual(runningChildren.map(item => item.contextValue), ['appHost', 'appHost']);
 
         // Workspace group contains the two idle AppHosts
         const idleChildren = provider.getChildren(topLevelItems[1]);
@@ -2022,15 +2026,12 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
 
         const topLevelItems = provider.getChildren();
 
-        // A lone idle AppHost is surfaced directly as a sibling of the running group,
-        // with no "Workspace AppHosts (1)" wrapper (https://github.com/microsoft/aspire/issues/18420).
+        // A single running AppHost and a single idle AppHost are each surfaced directly,
+        // with no "Running AppHosts (1)" or "Workspace AppHosts (1)" wrapper
+        // (https://github.com/microsoft/aspire/issues/18420).
         assert.strictEqual(topLevelItems.length, 2);
-        assert.strictEqual(topLevelItems[0].contextValue, 'runningAppHostsGroup');
+        assert.ok(topLevelItems[0].contextValue?.startsWith('workspaceResources'));
         assert.strictEqual(topLevelItems[1].contextValue, 'workspaceAppHost');
-
-        const runningChildren = provider.getChildren(topLevelItems[0]);
-        assert.strictEqual(runningChildren.length, 1);
-        assert.ok(runningChildren[0].contextValue?.startsWith('workspaceResources'));
         provider.dispose();
     });
 
@@ -2056,18 +2057,15 @@ suite('AspireAppHostTreeProvider.findAppHostElement', () => {
 
         const topLevelItems = provider.getChildren();
 
-        // The .csproj candidate should be recognized as running (rendered in the running
-        // group), and the unrelated lone idle candidate is surfaced directly as a sibling.
-        // Without directory-equivalence matching, the .csproj candidate would be
-        // misclassified as idle.
+        // The .csproj candidate should be recognized as running (surfaced directly as a
+        // flat WorkspaceResourcesItem since it's the only running AppHost), and the
+        // unrelated lone idle candidate is surfaced directly as a sibling. Without
+        // directory-equivalence matching, the .csproj candidate would be misclassified as idle.
         assert.strictEqual(topLevelItems.length, 2);
-        assert.strictEqual(topLevelItems[0].contextValue, 'runningAppHostsGroup');
+        assert.ok(topLevelItems[0].contextValue?.startsWith('workspaceResources'));
         assert.strictEqual(topLevelItems[1].contextValue, 'workspaceAppHost');
 
-        const runningChildren = provider.getChildren(topLevelItems[0]);
-        assert.strictEqual(runningChildren.length, 1);
-        assert.ok(runningChildren[0].contextValue?.startsWith('workspaceResources'));
-        const resourceChildren = provider.getChildren(runningChildren[0]);
+        const resourceChildren = provider.getChildren(topLevelItems[0]);
         assert.strictEqual(resourceChildren.length, 1);
         assert.strictEqual(resourceChildren[0].label, 'workspace-service');
         provider.dispose();

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -1051,8 +1051,18 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
                     const runningGroup = new RunningAppHostsGroupItem(runningItems);
                     return [runningGroup, new WorkspaceAppHostsGroupItem(workspaceItems)];
                 }
-                // When nothing is running, still wrap idle items in the group so they
-                // render under the "Workspace AppHosts" header. This keeps the tree shape
+                // For a single idle AppHost, skip the "Workspace AppHosts" grouping node
+                // and surface the AppHost directly at the root. The "(1)" header just wraps
+                // a lone child, adding nesting and a redundant click target without value
+                // (mirrors VS Code's SCM view for a single repo).
+                // See https://github.com/microsoft/aspire/issues/18420.
+                // Reaching here with one idle item means exactly one AppHost, because the
+                // mixed running/idle case already returned above.
+                if (workspaceItems.length === 1) {
+                    return [workspaceItems[0]];
+                }
+                // When two or more idle AppHosts exist (and none are running), wrap them
+                // under the "Workspace AppHosts" header. This keeps the tree shape
                 // consistent with the mixed case and avoids loose root-level items.
                 if (workspaceItems.length > 0) {
                     return [new WorkspaceAppHostsGroupItem(workspaceItems)];

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -1046,24 +1046,28 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
                 }
 
                 if (workspaceItems.length > 0 && runningItems.length > 0) {
-                    // Wrap running items in a sibling group so both sets share the same
+                    // Wrap running items in a sibling group so both sets nest at the same
                     // indentation depth and the visual hierarchy reads symmetrically.
                     const runningGroup = new RunningAppHostsGroupItem(runningItems);
-                    return [runningGroup, new WorkspaceAppHostsGroupItem(workspaceItems)];
+                    // The "Workspace AppHosts (N)" header only appears for two or more idle
+                    // AppHosts. A lone idle AppHost is surfaced directly as a sibling of the
+                    // running group instead of being wrapped in a "(1)" node that adds nesting
+                    // and a redundant click target without value.
+                    // See https://github.com/microsoft/aspire/issues/18420.
+                    const workspaceChild = workspaceItems.length === 1
+                        ? workspaceItems[0]
+                        : new WorkspaceAppHostsGroupItem(workspaceItems);
+                    return [runningGroup, workspaceChild];
                 }
-                // For a single idle AppHost, skip the "Workspace AppHosts" grouping node
-                // and surface the AppHost directly at the root. The "(1)" header just wraps
-                // a lone child, adding nesting and a redundant click target without value
-                // (mirrors VS Code's SCM view for a single repo).
+                // For a single idle AppHost (nothing running), skip the "Workspace AppHosts"
+                // grouping node and surface the AppHost directly at the root, for the same
+                // reason as the mixed case above (mirrors VS Code's SCM view for a single repo).
                 // See https://github.com/microsoft/aspire/issues/18420.
-                // Reaching here with one idle item means exactly one AppHost, because the
-                // mixed running/idle case already returned above.
                 if (workspaceItems.length === 1) {
                     return [workspaceItems[0]];
                 }
-                // When two or more idle AppHosts exist (and none are running), wrap them
-                // under the "Workspace AppHosts" header. This keeps the tree shape
-                // consistent with the mixed case and avoids loose root-level items.
+                // When two or more idle AppHosts exist, wrap them under the "Workspace AppHosts"
+                // header so the tree shape stays consistent and avoids loose root-level items.
                 if (workspaceItems.length > 0) {
                     return [new WorkspaceAppHostsGroupItem(workspaceItems)];
                 }

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -1046,18 +1046,20 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
                 }
 
                 if (workspaceItems.length > 0 && runningItems.length > 0) {
-                    // Wrap running items in a sibling group so both sets nest at the same
-                    // indentation depth and the visual hierarchy reads symmetrically.
-                    const runningGroup = new RunningAppHostsGroupItem(runningItems);
-                    // The "Workspace AppHosts (N)" header only appears for two or more idle
-                    // AppHosts. A lone idle AppHost is surfaced directly as a sibling of the
-                    // running group instead of being wrapped in a "(1)" node that adds nesting
-                    // and a redundant click target without value.
+                    // Each set (running / idle) only gets a "(N)" grouping header when it
+                    // contains two or more AppHosts. A lone AppHost on either side is surfaced
+                    // directly as a top-level sibling instead of being wrapped in a "(1)" node
+                    // that adds nesting and a redundant click target without value.
                     // See https://github.com/microsoft/aspire/issues/18420.
+                    // A single running AppHost is a flat WorkspaceResourcesItem (resources shown
+                    // inline), matching the pure single-running case below.
+                    const runningChild = runningItems.length === 1
+                        ? runningItems[0]
+                        : new RunningAppHostsGroupItem(runningItems);
                     const workspaceChild = workspaceItems.length === 1
                         ? workspaceItems[0]
                         : new WorkspaceAppHostsGroupItem(workspaceItems);
-                    return [runningGroup, workspaceChild];
+                    return [runningChild, workspaceChild];
                 }
                 // For a single idle AppHost (nothing running), skip the "Workspace AppHosts"
                 // grouping node and surface the AppHost directly at the root, for the same


### PR DESCRIPTION
Fixes #18420.

## Problem

In the Aspire VS Code extension''s AppHosts tree (workspace mode), the **"Workspace AppHosts (N)"** and **"Running AppHosts (N)"** grouping nodes were shown even when their group contained only a single AppHost. A "(1)" header just wraps a lone child, adding unnecessary nesting and a redundant click target.

## Change

In `_getWorkspaceChildren` (`AspireAppHostTreeProvider.ts`), each set (running / idle) now only gets a "(N)" grouping header when it contains **two or more** AppHosts. A lone AppHost on either side is surfaced directly as a top-level sibling:

- **1 idle, nothing running** → the idle AppHost renders at the tree root (no group).
- **1 running + 1 idle** → both are surfaced directly as sibling top-level items (no "Running AppHosts (1)" / "Workspace AppHosts (1)" wrappers).
- **1 running + 2+ idle** → running AppHost is surfaced directly; idle AppHosts stay under "Workspace AppHosts (N)".
- **2+ running + 1 idle** → running AppHosts stay under "Running AppHosts (N)"; idle AppHost is surfaced directly.
- **2+ running + 2+ idle** → both groups are shown.

A single running AppHost is surfaced as a flat `WorkspaceResourcesItem` (resources shown inline), matching the existing single-running-only behavior. Navigation/lookup (`findAppHostElement`, `getParent`) already tolerate bare root items, so no other changes were needed.

## Demo

**Single running + two idle** — the running `aspnetcore.AppHost.csproj` is surfaced directly with its resources inline (no "Running AppHosts (1)" wrapper), while the two idle AppHosts stay grouped under **Workspace AppHosts (2)**:

<img width="515" height="441" alt="Screenshot 2026-06-26 122324" src="https://github.com/user-attachments/assets/d64a88bf-3b0f-4041-bee4-c6079c3066c0" />

**Two running + one idle** — the two running AppHosts stay grouped under **Running AppHosts (2)**, while the single idle `starter.AppHost.csproj` is surfaced directly (no "Workspace AppHosts (1)" wrapper):

<img width="521" height="902" alt="Screenshot 2026-06-26 122406" src="https://github.com/user-attachments/assets/7d05e150-5b85-4a7f-9321-9e640ce7b471" />

## Tests

Updated unit tests in `appHostTreeView.test.ts`:

- Single-candidate (idle) tests assert the lone AppHost is surfaced directly (no group).
- A focused test asserts a single running + single idle AppHost are each surfaced directly as siblings.
- The directory-matching test (running + 1 idle) asserts both are bare siblings.
- A grouping test uses **2 running + 2 idle** to verify both "Running AppHosts (N)" and "Workspace AppHosts (N)" groups still appear with multiple AppHosts.