### PR TITLE
Fix Deployment E2E nightly: stage real DCP binary so the AppHost build can resolve the CLI bundle

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -108,6 +108,7 @@ jobs:
           mkdir -p "$ARTIFACT_DIR/bin"
           mkdir -p "$ARTIFACT_DIR/packages"
           mkdir -p "$ARTIFACT_DIR/managed"
+          mkdir -p "$ARTIFACT_DIR/dcp"
 
           # Copy CLI binary and dependencies
           cp -r "${{ github.workspace }}/artifacts/bin/Aspire.Cli/Release/net10.0/"* "$ARTIFACT_DIR/bin/"
@@ -120,6 +121,27 @@ jobs:
             echo "⚠️ Aspire.Managed build output not found at $MANAGED_DIR"
           fi
 
+          # Stage the DCP binary into the bundle layout. Since #18188 ("Default AppHosts to
+          # use the CLI bundle") AppHosts default to AspireUseCliBundle=true, so the AppHost
+          # build runs the ResolveAspireCliBundle task. That task only treats a layout as a
+          # valid bundle when a real dcp executable exists at <bundle>/dcp/dcp — an empty dcp
+          # directory is not enough (see src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs).
+          # Without it the AppHost build fails with ASPIRE009 and `aspire deploy` aborts before
+          # producing a backchannel, so every deploy test times out. The binary originates from
+          # the Microsoft.DeveloperControlPlane.linux-amd64 package the build already restored.
+          DCP_SRC=""
+          for NUGET_ROOT in "$HOME/.nuget/packages" "${{ github.workspace }}/.packages"; do
+            CANDIDATE=$(find "$NUGET_ROOT/microsoft.developercontrolplane.linux-amd64" -path "*/tools/dcp" -type f 2>/dev/null | head -1)
+            if [ -n "$CANDIDATE" ]; then DCP_SRC="$CANDIDATE"; break; fi
+          done
+          if [ -n "$DCP_SRC" ]; then
+            cp -r "$(dirname "$DCP_SRC")/"* "$ARTIFACT_DIR/dcp/"
+            chmod +x "$ARTIFACT_DIR/dcp/dcp"
+            echo "✅ DCP binary staged from $DCP_SRC"
+          else
+            echo "⚠️ DCP binary (microsoft.developercontrolplane.linux-amd64) not found in NuGet caches"
+          fi
+
           # Copy NuGet packages
           PACKAGES_DIR="${{ github.workspace }}/artifacts/packages/Release/Shipping"
           if [ -d "$PACKAGES_DIR" ]; then
@@ -130,6 +152,8 @@ jobs:
           ls -la "$ARTIFACT_DIR/bin/"
           echo "Managed artifacts:"
           ls -la "$ARTIFACT_DIR/managed/" 2>/dev/null || echo "(none)"
+          echo "DCP artifacts:"
+          ls -la "$ARTIFACT_DIR/dcp/" 2>/dev/null || echo "(none)"
           echo "Package count: $(find "$ARTIFACT_DIR/packages" -name "*.nupkg" | wc -l)"
 
       - name: Upload CLI artifacts
@@ -196,8 +220,17 @@ jobs:
             chmod +x "$ASPIRE_HOME/managed/aspire-managed" 2>/dev/null || true
           fi
 
-          # Create dcp directory stub (required for layout discovery validation)
+          # Lay the real DCP binary into the bundle layout. The AppHost build resolves the
+          # bundle via ResolveAspireCliBundle, which requires an actual dcp executable at
+          # <bundle>/dcp/dcp — an empty directory is rejected and the build fails with ASPIRE009.
+          # The binary is staged into the CLI artifact by the build job's "Prepare CLI artifacts" step.
           mkdir -p "$ASPIRE_HOME/dcp"
+          if [ -d "${{ github.workspace }}/cli-artifacts/dcp" ] && [ -n "$(ls -A "${{ github.workspace }}/cli-artifacts/dcp" 2>/dev/null)" ]; then
+            cp -r "${{ github.workspace }}/cli-artifacts/dcp/"* "$ASPIRE_HOME/dcp/"
+            chmod +x "$ASPIRE_HOME/dcp/dcp" 2>/dev/null || true
+          else
+            echo "⚠️ DCP artifacts missing; AppHost builds will fail with ASPIRE009"
+          fi
 
           # Set up NuGet hive for local packages
           HIVE_DIR="$ASPIRE_HOME/hives/local/packages"


### PR DESCRIPTION
## What broke

Every Azure deploy job in the **Deployment E2E** nightly builds fine, then times out after 25 minutes. This has been the deploy-stage failure mode since the 2026-06-20 nightly (the first nightly after the root-cause PR merged on 06-19):

```
error ASPIRE009: apphost is configured to use the Aspire CLI bundle, but the bundle
could not be resolved. New features require the Aspire CLI to be installed...
The build failed. Fix the build errors and run again.
❌ An unexpected error occurred: Run completed without returning a backchannel.

Hex1b.Automation.WaitUntilTimeoutException : WaitUntil timed out after 00:25:00
waiting for: pipeline succeeded or failed
```

## Root cause

#18188 ("Default AppHosts to use the CLI bundle") flipped `AspireUseCliBundle` to `true` by default. The AppHost build now runs the `ResolveAspireCliBundle` task, which only accepts a layout as a valid bundle when a **real `dcp` executable** exists at `<bundle>/dcp/dcp` (alongside `<bundle>/managed/aspire-managed`) — see `src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs`.

`deployment-tests.yml` assembled the bundle layout with `managed/aspire-managed`, but for DCP it only did `mkdir -p "$ASPIRE_HOME/dcp"` — an **empty stub with no `dcp` binary**. So resolution failed, the AppHost build aborted with ASPIRE009, `aspire deploy` exited before opening a backchannel, and every deploy test sat until its 25-minute timeout.

## The fix

Stage the real DCP binary into the bundle the test harness builds:

- In the build job's **Prepare CLI artifacts** step, copy the `dcp` tools payload from the `Microsoft.DeveloperControlPlane.linux-amd64` package (already restored by the build) into the CLI artifact's `dcp/` directory.
- In the deploy job's **Install Aspire CLI from artifacts** step, lay that `dcp/` payload into `$ASPIRE_HOME/dcp/` instead of creating an empty stub.

The AppHost build now resolves the bundle the same way a real `aspire` install does (`dcp/dcp` + `managed/aspire-managed`, with the dashboard served by `aspire-managed`).

## Call-outs

- **Can't be verified by PR CI** — the Deployment E2E workflow runs on a nightly schedule against live Azure, not on PRs. Verification is by reasoning about the bundle-resolution contract plus the next scheduled nightly. The change is workflow-only.
- The DCP source package is globbed version-agnostically across both Arcade NuGet roots (`$HOME/.nuget/packages` and `$repo/.packages`), so a future DCP bump won't re-break it.
- This only addresses the deploy-stage ASPIRE009 timeout. A separate build-break (a `Task.DefaultTimeout()` compile error in `TelemetryConfigurationTests.cs`) also red-lit the 06-25/06-26 nightlies; that was already fixed on main by #18454.
