### PR TITLE
Update OpenTelemetry.Instrumentation.StackExchangeRedis

### DIFF
--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -101,14 +101,17 @@ internal static class RedisProfilerEntryToActivityConverter
             StackExchangeRedisConnectionInstrumentation.ActivitySourceNew :
             StackExchangeRedisConnectionInstrumentation.ActivitySource;
 
+        var creationTags =
+            options.EmitOldAttributes && options.EmitNewAttributes ? StackExchangeRedisConnectionInstrumentation.BothCreationTags :
+            options.EmitNewAttributes ? StackExchangeRedisConnectionInstrumentation.NewCreationTags :
+            options.EmitOldAttributes ? StackExchangeRedisConnectionInstrumentation.OldCreationTags :
+            [];
+
         var activity = activitySource.StartActivity(
             name,
             ActivityKind.Client,
             parentActivity?.Context ?? default,
-            [
-                .. options.EmitOldAttributes ? StackExchangeRedisConnectionInstrumentation.OldCreationTags : [],
-                .. options.EmitNewAttributes ? StackExchangeRedisConnectionInstrumentation.NewCreationTags : [],
-            ],
+            creationTags,
             startTime: command.CommandCreated);
 
         if (activity == null)
@@ -120,11 +123,11 @@ internal static class RedisProfilerEntryToActivityConverter
 
         if (activity.IsAllDataRequested)
         {
-            // see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md
+            // See https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/db/database-spans.md
 
             // Timing example:
-            // command.CommandCreated; //2019-01-10 22:18:28Z
 
+            // command.CommandCreated;          // 2019-01-10 22:18:28Z
             // command.CreationToEnqueued;      // 00:00:32.4571995
             // command.EnqueuedToSending;       // 00:00:00.0352838
             // command.SentToResponse;          // 00:00:00.0060586
@@ -169,7 +172,7 @@ internal static class RedisProfilerEntryToActivityConverter
 
             if (options.EmitNewAttributes)
             {
-                string? queryText = command.Command;
+                var queryText = command.Command;
                 if (options.SetVerboseDatabaseStatements && !string.IsNullOrEmpty(commandAndKey))
                 {
                     queryText = commandAndKey;
@@ -189,9 +192,10 @@ internal static class RedisProfilerEntryToActivityConverter
             {
                 if (command.EndPoint is IPEndPoint ipEndPoint)
                 {
-                    activity.SetTag(SemanticConventions.AttributeServerAddress, ipEndPoint.Address.ToString());
+                    var address = ipEndPoint.Address.ToString();
+                    activity.SetTag(SemanticConventions.AttributeServerAddress, address);
                     activity.SetTag(SemanticConventions.AttributeServerPort, ipEndPoint.Port);
-                    activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, ipEndPoint.Address.ToString());
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, address);
                     activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, ipEndPoint.Port);
                 }
                 else if (command.EndPoint is DnsEndPoint dnsEndPoint)
@@ -202,8 +206,9 @@ internal static class RedisProfilerEntryToActivityConverter
 #if NET
                 else if (command.EndPoint is UnixDomainSocketEndPoint unixDomainSocketEndPoint)
                 {
-                    activity.SetTag(SemanticConventions.AttributeServerAddress, unixDomainSocketEndPoint.ToString());
-                    activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, unixDomainSocketEndPoint.ToString());
+                    var address = unixDomainSocketEndPoint.ToString();
+                    activity.SetTag(SemanticConventions.AttributeServerAddress, address);
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, address);
                 }
 #endif
             }

--- a/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
@@ -22,7 +22,7 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
     internal static readonly Version SemanticConventionsVersion = new(1, 23, 0);
     internal static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create(typeof(StackExchangeRedisConnectionInstrumentation), SemanticConventionsVersion, name: ActivitySourceName);
 
-    internal static readonly Version SemanticConventionsVersionNew = new(1, 28, 0);
+    internal static readonly Version SemanticConventionsVersionNew = new(1, 42, 0);
     internal static readonly ActivitySource ActivitySourceNew = ActivitySourceFactory.Create(typeof(StackExchangeRedisConnectionInstrumentation), SemanticConventionsVersionNew, name: ActivitySourceName);
 
     internal static readonly ActivitySource ActivitySourceBoth = ActivitySourceFactory.Create(typeof(StackExchangeRedisConnectionInstrumentation), null, name: ActivitySourceName);
@@ -37,6 +37,12 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
     internal static readonly IEnumerable<KeyValuePair<string, object?>> NewCreationTags =
     [
         new(SemanticConventions.AttributeDbSystemName, "redis")
+    ];
+
+    internal static readonly IEnumerable<KeyValuePair<string, object?>> BothCreationTags =
+    [
+        new(SemanticConventions.AttributeDbSystem, "redis"),
+        new(SemanticConventions.AttributeDbSystemName, "redis"),
     ];
 
     internal readonly ConcurrentDictionary<(ActivityTraceId TraceId, ActivitySpanId SpanId), (Activity Activity, ProfilingSession Session)> Cache

--- a/src/Vendoring/README.md
+++ b/src/Vendoring/README.md
@@ -23,7 +23,7 @@ git checkout tags/Instrumentation.ConfluentKafka-0.1.0-alpha.2
 ```console
 git clone https://github.com/open-telemetry/opentelemetry-dotnet-contrib.git
 git fetch --tags
-git checkout tags/Instrumentation.StackExchangeRedis-1.15.1-beta.2
+git checkout tags/Instrumentation.StackExchangeRedis-1.16.0-beta.1
 ```
 
 ### Instructions


### PR DESCRIPTION
## Description

Updated vendored code for OpenTelemetry.Instrumentation.StackExchangeRedis to [Instrumentation.StackExchangeRedis-1.16.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/releases/tag/Instrumentation.StackExchangeRedis-1.16.0-beta.1).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
