### PR TITLE
Fix thread-safety race in RootCommand causing flaky NRE in LsCommandTests

### DIFF
--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -6,11 +6,6 @@ using System.CommandLine.Help;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
-#if DEBUG
-using System.Globalization;
-using System.Diagnostics;
-#endif
-
 using Aspire.Cli.Bundles;
 using Aspire.Cli.Commands.Sdk;
 using Aspire.Cli.Configuration;
@@ -183,33 +178,6 @@ internal sealed class RootCommand : BaseRootCommand
     {
         _interactionService = interactionService;
         _ansiConsole = ansiConsole;
-
-#if DEBUG
-        // Add the validator to the command (this.Validators), not to the static CliWaitForDebuggerOption.
-        // Option validators on a static option are shared across all command trees. Since RootCommand is
-        // registered as Transient, concurrent test classes each construct their own instance, causing
-        // concurrent List<T>.Add on the shared validators list — a thread-safety violation that corrupts
-        // the list and surfaces as a NullReferenceException during Parse().
-        Validators.Add((result) =>
-        {
-            var waitForDebugger = result.GetValue(CliWaitForDebuggerOption);
-
-            if (waitForDebugger)
-            {
-                _interactionService.ShowStatus(
-                    string.Format(CultureInfo.CurrentCulture, RootCommandStrings.WaitingForDebugger, Environment.ProcessId),
-                    () =>
-                    {
-                        while (!Debugger.IsAttached)
-                        {
-                            Thread.Sleep(1000);
-                        }
-
-                        Debugger.Break();
-                    }, emoji: KnownEmojis.Bug);
-            }
-        });
-#endif
 
         Options.Add(DebugOption);
         Options.Add(DebugLevelOption);

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -185,10 +185,9 @@ internal sealed class RootCommand : BaseRootCommand
         _ansiConsole = ansiConsole;
 
 #if DEBUG
-        CliWaitForDebuggerOption.Validators.Add((result) =>
+        Validators.Add((result) =>
         {
-
-            var waitForDebugger = result.GetValueOrDefault<bool>();
+            var waitForDebugger = result.GetValue(CliWaitForDebuggerOption);
 
             if (waitForDebugger)
             {

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -185,6 +185,11 @@ internal sealed class RootCommand : BaseRootCommand
         _ansiConsole = ansiConsole;
 
 #if DEBUG
+        // Add the validator to the command (this.Validators), not to the static CliWaitForDebuggerOption.
+        // Option validators on a static option are shared across all command trees. Since RootCommand is
+        // registered as Transient, concurrent test classes each construct their own instance, causing
+        // concurrent List<T>.Add on the shared validators list — a thread-safety violation that corrupts
+        // the list and surfaces as a NullReferenceException during Parse().
         Validators.Add((result) =>
         {
             var waitForDebugger = result.GetValue(CliWaitForDebuggerOption);

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -128,7 +128,6 @@ internal sealed class RootCommand : BaseRootCommand
         }
     }
 
-    private readonly IInteractionService _interactionService;
     private readonly IAnsiConsole _ansiConsole;
 
     public RootCommand(
@@ -176,7 +175,6 @@ internal sealed class RootCommand : BaseRootCommand
         CliExecutionContext executionContext)
         : base(RootCommandStrings.Description)
     {
-        _interactionService = interactionService;
         _ansiConsole = ansiConsole;
 
         Options.Add(DebugOption);

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -1047,27 +1047,7 @@ public class Program
                 var parseResult = rootCommand.Parse(args);
 
 #if DEBUG
-                // Handle --cli-wait-for-debugger here rather than as an option or command
-                // validator. Adding a validator to the static CliWaitForDebuggerOption causes
-                // a thread-safety race (concurrent List<T>.Add from parallel test classes
-                // that each construct a Transient RootCommand), and command-level validators
-                // only run for the innermost command — not for RootCommand when a subcommand
-                // is invoked (e.g. "aspire run --cli-wait-for-debugger").
-                if (parseResult.GetValue(RootCommand.CliWaitForDebuggerOption))
-                {
-                    var interactionService = app.Services.GetRequiredService<IInteractionService>();
-                    interactionService.ShowStatus(
-                        string.Format(CultureInfo.CurrentCulture, RootCommandStrings.WaitingForDebugger, Environment.ProcessId),
-                        () =>
-                        {
-                            while (!Debugger.IsAttached)
-                            {
-                                Thread.Sleep(1000);
-                            }
-
-                            Debugger.Break();
-                        }, emoji: KnownEmojis.Bug);
-                }
+                WaitForDebuggerIfRequested(parseResult, app.Services);
 #endif
 
                 var commandName = GetCommandName(parseResult);
@@ -1176,6 +1156,40 @@ public class Program
         }
         parentNames.Reverse();
         return string.Join(' ', parentNames);
+    }
+
+    /// <summary>
+    /// Waits for a debugger to attach if --cli-wait-for-debugger was passed.
+    /// </summary>
+    /// <remarks>
+    /// This is handled here rather than as an option or command validator because:
+    /// (1) adding a validator to the static CliWaitForDebuggerOption causes a thread-safety
+    ///     race (concurrent List&lt;T&gt;.Add from parallel test classes that each construct a
+    ///     Transient RootCommand), and
+    /// (2) command-level validators only run for the innermost command — not for RootCommand
+    ///     when a subcommand is invoked (e.g. "aspire run --cli-wait-for-debugger").
+    /// </remarks>
+    internal static void WaitForDebuggerIfRequested(ParseResult parseResult, IServiceProvider services, Action? waitAction = null)
+    {
+        if (!parseResult.GetValue(RootCommand.CliWaitForDebuggerOption))
+        {
+            return;
+        }
+
+        waitAction ??= static () =>
+        {
+            while (!Debugger.IsAttached)
+            {
+                Thread.Sleep(1000);
+            }
+
+            Debugger.Break();
+        };
+
+        var interactionService = services.GetRequiredService<IInteractionService>();
+        interactionService.ShowStatus(
+            string.Format(CultureInfo.CurrentCulture, RootCommandStrings.WaitingForDebugger, Environment.ProcessId),
+            waitAction, emoji: KnownEmojis.Bug);
     }
 
     private static void AddInteractionServices(HostApplicationBuilder builder)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -1158,6 +1158,7 @@ public class Program
         return string.Join(' ', parentNames);
     }
 
+#if DEBUG
     /// <summary>
     /// Waits for a debugger to attach if --cli-wait-for-debugger was passed.
     /// </summary>
@@ -1191,6 +1192,7 @@ public class Program
 
         Debugger.Break();
     }
+#endif
 
     private static void AddInteractionServices(HostApplicationBuilder builder)
     {

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -1047,7 +1047,7 @@ public class Program
                 var parseResult = rootCommand.Parse(args);
 
 #if DEBUG
-                WaitForDebuggerIfRequested(parseResult, app.Services);
+                WaitForDebuggerIfRequested(parseResult, app.Services, WaitForDebugger);
 #endif
 
                 var commandName = GetCommandName(parseResult);
@@ -1169,27 +1169,27 @@ public class Program
     /// (2) command-level validators only run for the innermost command — not for RootCommand
     ///     when a subcommand is invoked (e.g. "aspire run --cli-wait-for-debugger").
     /// </remarks>
-    internal static void WaitForDebuggerIfRequested(ParseResult parseResult, IServiceProvider services, Action? waitAction = null)
+    internal static void WaitForDebuggerIfRequested(ParseResult parseResult, IServiceProvider services, Action waitAction)
     {
         if (!parseResult.GetValue(RootCommand.CliWaitForDebuggerOption))
         {
             return;
         }
 
-        waitAction ??= static () =>
-        {
-            while (!Debugger.IsAttached)
-            {
-                Thread.Sleep(1000);
-            }
-
-            Debugger.Break();
-        };
-
         var interactionService = services.GetRequiredService<IInteractionService>();
         interactionService.ShowStatus(
             string.Format(CultureInfo.CurrentCulture, RootCommandStrings.WaitingForDebugger, Environment.ProcessId),
             waitAction, emoji: KnownEmojis.Bug);
+    }
+
+    private static void WaitForDebugger()
+    {
+        while (!Debugger.IsAttached)
+        {
+            Thread.Sleep(1000);
+        }
+
+        Debugger.Break();
     }
 
     private static void AddInteractionServices(HostApplicationBuilder builder)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -1046,6 +1046,30 @@ public class Program
                 logger.LogDebug("Parsing arguments: {Args}", string.Join(" ", args));
                 var parseResult = rootCommand.Parse(args);
 
+#if DEBUG
+                // Handle --cli-wait-for-debugger here rather than as an option or command
+                // validator. Adding a validator to the static CliWaitForDebuggerOption causes
+                // a thread-safety race (concurrent List<T>.Add from parallel test classes
+                // that each construct a Transient RootCommand), and command-level validators
+                // only run for the innermost command — not for RootCommand when a subcommand
+                // is invoked (e.g. "aspire run --cli-wait-for-debugger").
+                if (parseResult.GetValue(RootCommand.CliWaitForDebuggerOption))
+                {
+                    var interactionService = app.Services.GetRequiredService<IInteractionService>();
+                    interactionService.ShowStatus(
+                        string.Format(CultureInfo.CurrentCulture, RootCommandStrings.WaitingForDebugger, Environment.ProcessId),
+                        () =>
+                        {
+                            while (!Debugger.IsAttached)
+                            {
+                                Thread.Sleep(1000);
+                            }
+
+                            Debugger.Break();
+                        }, emoji: KnownEmojis.Bug);
+                }
+#endif
+
                 var commandName = GetCommandName(parseResult);
                 logger.LogDebug("Executing command: {CommandName}", commandName);
 

--- a/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
+++ b/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
@@ -1,16 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using System.Reflection;
 using Aspire.Cli.Acquisition;
-using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+
+#if DEBUG
+using System.Globalization;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Resources;
+#endif
 
 namespace Aspire.Cli.Tests;
 
@@ -206,6 +209,7 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
         Assert.Null(context.NuGetServiceIndexOverride);
     }
 
+#if DEBUG
     [Theory]
     [InlineData("ls --cli-wait-for-debugger")]
     [InlineData("run --cli-wait-for-debugger")]
@@ -249,6 +253,7 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
         Assert.False(waitActionCalled);
         Assert.Empty(testInteractionService.ShownStatuses);
     }
+#endif
 
     private static string WriteBinaryWithSidecar(string binaryDir, string source, string? channel = null)
     {

--- a/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
+++ b/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Reflection;
 using Aspire.Cli.Acquisition;
 using Aspire.Cli.Commands;
@@ -224,8 +225,8 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
         Program.WaitForDebuggerIfRequested(parseResult, provider, waitAction: () => waitActionCalled = true);
 
         Assert.True(waitActionCalled);
-        Assert.Single(testInteractionService.ShownStatuses);
-        Assert.Contains(Environment.ProcessId.ToString(), testInteractionService.ShownStatuses[0]);
+        var expectedStatus = string.Format(CultureInfo.CurrentCulture, "Waiting for debugger to attach to CLI process ID: {0}", Environment.ProcessId);
+        Assert.Collection(testInteractionService.ShownStatuses, status => Assert.Equal(expectedStatus, status));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
+++ b/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using Aspire.Cli.Acquisition;
+using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
@@ -201,6 +202,47 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
 
         Assert.False(context.IdentityOverridden);
         Assert.Null(context.NuGetServiceIndexOverride);
+    }
+
+    [Theory]
+    [InlineData("ls --cli-wait-for-debugger")]
+    [InlineData("run --cli-wait-for-debugger")]
+    [InlineData("doctor --cli-wait-for-debugger")]
+    public void WaitForDebuggerIfRequested_WithSubcommand_CallsShowStatus(string commandLine)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestInteractionService();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var parseResult = command.Parse(commandLine);
+
+        // Pass a no-op action so the test doesn't block waiting for a debugger.
+        Program.WaitForDebuggerIfRequested(parseResult, provider, waitAction: () => { });
+
+        Assert.Single(testInteractionService.ShownStatuses);
+        Assert.Contains(Environment.ProcessId.ToString(), testInteractionService.ShownStatuses[0]);
+    }
+
+    [Fact]
+    public void WaitForDebuggerIfRequested_WithoutFlag_DoesNotCallShowStatus()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestInteractionService();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var parseResult = command.Parse("ls");
+
+        Program.WaitForDebuggerIfRequested(parseResult, provider, waitAction: () => { });
+
+        Assert.Empty(testInteractionService.ShownStatuses);
     }
 
     private static string WriteBinaryWithSidecar(string binaryDir, string source, string? channel = null)

--- a/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
+++ b/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
@@ -220,9 +220,10 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
         var command = provider.GetRequiredService<RootCommand>();
         var parseResult = command.Parse(commandLine);
 
-        // Pass a no-op action so the test doesn't block waiting for a debugger.
-        Program.WaitForDebuggerIfRequested(parseResult, provider, waitAction: () => { });
+        var waitActionCalled = false;
+        Program.WaitForDebuggerIfRequested(parseResult, provider, waitAction: () => waitActionCalled = true);
 
+        Assert.True(waitActionCalled);
         Assert.Single(testInteractionService.ShownStatuses);
         Assert.Contains(Environment.ProcessId.ToString(), testInteractionService.ShownStatuses[0]);
     }
@@ -240,8 +241,10 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
         var command = provider.GetRequiredService<RootCommand>();
         var parseResult = command.Parse("ls");
 
-        Program.WaitForDebuggerIfRequested(parseResult, provider, waitAction: () => { });
+        var waitActionCalled = false;
+        Program.WaitForDebuggerIfRequested(parseResult, provider, waitAction: () => waitActionCalled = true);
 
+        Assert.False(waitActionCalled);
         Assert.Empty(testInteractionService.ShownStatuses);
     }
 

--- a/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
+++ b/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Aspire.Cli.Acquisition;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -225,7 +226,7 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
         Program.WaitForDebuggerIfRequested(parseResult, provider, waitAction: () => waitActionCalled = true);
 
         Assert.True(waitActionCalled);
-        var expectedStatus = string.Format(CultureInfo.CurrentCulture, "Waiting for debugger to attach to CLI process ID: {0}", Environment.ProcessId);
+        var expectedStatus = string.Format(CultureInfo.CurrentCulture, RootCommandStrings.WaitingForDebugger, Environment.ProcessId);
         Assert.Collection(testInteractionService.ShownStatuses, status => Assert.Equal(expectedStatus, status));
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
@@ -10,7 +10,6 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
-using Aspire.TestUtilities;
 using Aspire.Tests;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -207,7 +206,6 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/microsoft/aspire/issues/18476")]
     public async Task LsCommand_JsonFormat_OnlyJsonOnStdout_StatusMessagesOnStderr()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Summary

Fixes #18476

## Root Cause

In `#if DEBUG` builds, the `RootCommand` constructor adds a validator to the **shared static** `CliWaitForDebuggerOption` on every construction:

```csharp
CliWaitForDebuggerOption.Validators.Add((result) => { ... });
```

Since `RootCommand` is registered as `Transient` in DI, every test that resolves one constructs a new instance. With xUnit's inter-class parallelism (58 test classes in `Aspire.Cli.Tests`), many tests construct `RootCommand` concurrently, causing concurrent `List<T>.Add` on the same static option's validators list.

`List<T>.Add` is not thread-safe — concurrent adds corrupt the internal `T[]` array, leaving null slots. During `Parse()`, `CommandResult.ValidateOptionsAndAddDefaultResults` iterates the validators and invokes `Validators[j](optionResult)`. When `Validators[j]` returns null due to the corrupted list, invoking the null delegate throws `NullReferenceException`.

### Stack trace from CI

```
System.NullReferenceException : Object reference not set to an instance of an object.
   at System.CommandLine.Parsing.CommandResult.ValidateOptionsAndAddDefaultResults(Boolean completeValidation)
   at System.CommandLine.Parsing.CommandResult.Validate(Boolean isInnermostCommand)
   at System.CommandLine.Parsing.ParseOperation.ValidateAndAddDefaultResults()
   at System.CommandLine.Parsing.ParseOperation.Parse()
   at System.CommandLine.Parsing.CommandLineParser.Parse(...)
   at System.CommandLine.Command.Parse(String commandLine, ParserConfiguration configuration)
   at Aspire.Cli.Tests.Commands.LsCommandTests.LsCommand_JsonFormat_OnlyJsonOnStdout_StatusMessagesOnStderr()
```

### Why this is timing-sensitive

The race only manifests when:
1. Multiple test classes construct `RootCommand` simultaneously (xUnit inter-class parallelism)
2. One thread is mid-`List<T>.Add` (internal array resize) while another thread calls `Parse()` which reads from the same validators list
3. The 2-core Linux CI runners have timing characteristics that make this window more likely to hit than local development machines

## Fix

Remove the `--cli-wait-for-debugger` validator from `RootCommand`'s constructor entirely and instead read `parseResult.GetValue(CliWaitForDebuggerOption)` in `Program.Main` after `Parse()` and before `InvokeAsync()`.

This approach avoids two problems:
1. **Thread-safety**: The old code mutated the shared static option's `Validators` list from every `RootCommand` construction — concurrent `List<T>.Add` corrupted the list.
2. **Command validator limitation**: Moving the validator to the per-instance `this.Validators` (command-level) would also not work because System.CommandLine 2.0.8 only runs command validators for the innermost command. Since `RootCommand` is always an ancestor when a subcommand is invoked (e.g. `aspire run --cli-wait-for-debugger`), a `RootCommand`-level command validator would never fire for subcommands.

The extracted `WaitForDebuggerIfRequested` method and `WaitForDebugger` helper are both wrapped in `#if DEBUG`, matching the original scoping.

## Changes

- `src/Aspire.Cli/Commands/RootCommand.cs`: Removed the `#if DEBUG` validator block from the constructor and the associated `using` directives
- `src/Aspire.Cli/Program.cs`: Added `WaitForDebuggerIfRequested` (reads the option from `ParseResult` and calls `IInteractionService.ShowStatus`) and `WaitForDebugger` (polls for debugger attach), both wrapped in `#if DEBUG`. Call site added in `Main` between `Parse()` and `InvokeAsync()`
- `tests/Aspire.Cli.Tests/CliBootstrapTests.cs`: Added unit tests for `WaitForDebuggerIfRequested` covering subcommand invocation (ls, run, doctor) and the no-flag path
- `tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs`: Removed `[QuarantinedTest]` attribute from `LsCommand_JsonFormat_OnlyJsonOnStdout_StatusMessagesOnStderr`