### PR TITLE
Flush logs before terminal resource notifications

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
@@ -138,18 +138,6 @@ public class ResourceLoggerService : IDisposable
     }
 
     /// <summary>
-    /// The internal logger is used when adding logs from resource's stream logs.
-    /// It allows the parsed date from text to be used as the log line date.
-    /// </summary>
-    internal Action<LogEntry> GetInternalLogger(string resourceName)
-    {
-        ArgumentNullException.ThrowIfNull(resourceName);
-
-        var state = GetResourceLoggerState(resourceName);
-        return (logEntry) => state.AddLog(logEntry, inMemorySource: false);
-    }
-
-    /// <summary>
     /// Get all logs for a resource. This will return all logs that have been written to the log stream for the resource and then complete.
     /// </summary>
     /// <param name="resource">The resource to get all logs for.</param>
@@ -211,6 +199,21 @@ public class ResourceLoggerService : IDisposable
         ArgumentNullException.ThrowIfNull(resourceName);
 
         return GetResourceLoggerState(resourceName).WatchAsync();
+    }
+
+    internal IDisposable Subscribe(string resourceName, Action<IReadOnlyList<LogLine>> onLogs)
+    {
+        ArgumentNullException.ThrowIfNull(resourceName);
+        ArgumentNullException.ThrowIfNull(onLogs);
+
+        return GetResourceLoggerState(resourceName).Subscribe(onLogs);
+    }
+
+    internal Task WaitForCompletionAsync(string resourceName, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(resourceName);
+
+        return GetResourceLoggerState(resourceName).WaitForCompletionAsync(cancellationToken);
     }
 
     /// <summary>
@@ -349,6 +352,20 @@ public class ResourceLoggerService : IDisposable
             return state;
         },
         this);
+
+    internal bool HasActiveSubscribers(string resourceName)
+    {
+        return _loggers.TryGetValue(resourceName, out var logger) && logger.HasActiveSubscribers;
+    }
+
+    internal void AddLogEntries(string resourceName, IReadOnlyList<LogEntry> logEntries, bool inMemorySource, bool skipExisting)
+    {
+        ArgumentNullException.ThrowIfNull(resourceName);
+        ArgumentNullException.ThrowIfNull(logEntries);
+
+        GetResourceLoggerState(resourceName).AddLogs(logEntries, inMemorySource, skipExisting);
+    }
+
     internal Dictionary<string, ResourceLoggerState> Loggers => _loggers.ToDictionary();
 
     /// <summary>
@@ -360,6 +377,7 @@ public class ResourceLoggerService : IDisposable
 
         private readonly ResourceLogger _logger;
         private readonly CancellationTokenSource _logStreamCts = new();
+        private readonly TaskCompletionSource _logStreamCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly object _lock = new();
 
         private readonly CircularBuffer<LogEntry> _inMemoryEntries = new(MaxLogCount);
@@ -378,6 +396,12 @@ public class ResourceLoggerService : IDisposable
         }
 
         private Action<bool>? _onSubscribersChanged;
+
+        // Internal test hook for pausing synchronous Subscribe after it has attached its callback
+        // but before it delivers the backlog. This makes the backlog/live transition deterministic
+        // without sleeps.
+        internal Action? SynchronousSubscribeRegistered { get; set; }
+
         public event Action<bool> OnSubscribersChanged
         {
             add
@@ -481,12 +505,137 @@ public class ResourceLoggerService : IDisposable
             }
         }
 
+        public IDisposable Subscribe(Action<IReadOnlyList<LogLine>> onLogs)
+        {
+            // This is not a replacement for WatchAsync. WatchAsync intentionally decouples
+            // producers and consumers through a channel, which is the right shape for dashboard
+            // and backchannel consumers. This path is for ResourceLoggerForwarderService, which
+            // forwards resource logs into host ILogger when resource logging is enabled. That
+            // forwarder needs stronger ordering: after DCP flushes logs for a terminal state,
+            // those logs must reach ILogger before ResourceNotificationService publishes the
+            // terminal state that unblocks WaitForResourceAsync. Subscribe provides that
+            // producer-thread delivery once the backlog has been drained.
+
+            // Line number always restarts from 1 when watching logs.
+            var lineNumber = 1;
+            var subscriberLock = new object();
+            var backlogDelivered = false;
+
+            // Logs can arrive after we attach OnNewLog but before the backlog has been delivered.
+            // Queue those entries so the subscriber sees backlog first without dropping live logs
+            // from that small transition window.
+            var pendingLiveEntries = new List<LogEntry>();
+
+            void Log(LogEntry log)
+            {
+                if (_logStreamCts.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                IReadOnlyList<LogLine>? logLines = null;
+
+                lock (subscriberLock)
+                {
+                    if (!backlogDelivered)
+                    {
+                        pendingLiveEntries.Add(log);
+                        return;
+                    }
+
+                    logLines = CreateLogLines(ref lineNumber, [log]);
+                }
+
+                onLogs(logLines);
+            }
+
+            LogEntry[] backlogSnapshot;
+            lock (_lock)
+            {
+                // If there are no subscribers then the backlog must be empty. Populate it with any in-memory logs.
+                if (!HasSubscribers)
+                {
+                    Debug.Assert(_backlog.EntriesCount == 0, "The backlog should be empty if there are no subscribers.");
+
+                    // Populate backlog with in-memory log messages on first subscription.
+                    foreach (var logEntry in _inMemoryEntries)
+                    {
+                        _backlog.InsertSorted(logEntry);
+                    }
+                }
+
+                backlogSnapshot = GetBacklogSnapshot();
+                OnNewLog += Log;
+            }
+
+            var subscription = new Subscription(this, Log);
+
+            try
+            {
+                SynchronousSubscribeRegistered?.Invoke();
+
+                var batches = new List<IReadOnlyList<LogLine>>();
+                if (backlogSnapshot.Length > 0)
+                {
+                    batches.Add(CreateLogLines(ref lineNumber, backlogSnapshot));
+                }
+
+                // Drain the backlog and any live entries that arrived during backlog delivery before
+                // returning the subscription. After this point, future AddLogs calls invoke onLogs
+                // synchronously from the producer's thread.
+                while (true)
+                {
+                    foreach (var batch in batches)
+                    {
+                        onLogs(batch);
+                    }
+
+                    lock (subscriberLock)
+                    {
+                        if (pendingLiveEntries.Count == 0)
+                        {
+                            backlogDelivered = true;
+                            break;
+                        }
+
+                        batches = [CreateLogLines(ref lineNumber, pendingLiveEntries)];
+                        pendingLiveEntries.Clear();
+                    }
+                }
+            }
+            catch
+            {
+                subscription.Dispose();
+                throw;
+            }
+
+            return subscription;
+        }
+
+        public Task WaitForCompletionAsync(CancellationToken cancellationToken)
+        {
+            return _logStreamCompletion.Task.WaitAsync(cancellationToken);
+        }
+
         private bool HasSubscribers
         {
             get
             {
                 Debug.Assert(Monitor.IsEntered(_lock));
                 return _onNewLog != null;
+            }
+        }
+
+        internal bool HasActiveSubscribers
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    // Completed streams should not trigger a terminal-state snapshot flush. The
+                    // subscriber might still be disposing, but no more logs should be delivered.
+                    return !_logStreamCts.IsCancellationRequested && HasSubscribers;
+                }
             }
         }
 
@@ -542,6 +691,7 @@ public class ResourceLoggerService : IDisposable
         {
             // REVIEW: Do we clean up the backlog?
             _logStreamCts.Cancel();
+            _logStreamCompletion.TrySetResult();
         }
 
         public void ClearBacklog()
@@ -572,8 +722,8 @@ public class ResourceLoggerService : IDisposable
                     _backlog.InsertSorted(logEntry);
                 }
 
-                // Keep in-memory logs (i.e. logs not loaded from DCP) in their own collection.
-                // These logs are replayed into the backlog when a log watch starts.
+                // Keep replayable logs in their own collection. These logs are replayed into
+                // the backlog when a log watch starts without fetching them from an external source.
                 if (inMemorySource)
                 {
                     _inMemoryEntries.Add(logEntry);
@@ -581,6 +731,96 @@ public class ResourceLoggerService : IDisposable
             }
 
             _onNewLog?.Invoke(logEntry);
+        }
+
+        public void AddLogs(IReadOnlyList<LogEntry> logEntries, bool inMemorySource, bool skipExisting)
+        {
+            if (logEntries.Count == 0)
+            {
+                return;
+            }
+
+            List<LogEntry>? addedEntries = null;
+            lock (_lock)
+            {
+                Dictionary<(DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type), int>? existingLogCounts = null;
+                if (skipExisting)
+                {
+                    // Terminal-state snapshots and the normal follow stream can overlap. Use
+                    // occurrence counts instead of a set so repeated identical log lines are
+                    // preserved while only overlapping copies from the later source are skipped.
+                    var existingEntries = HasSubscribers ? _backlog.GetEntries() : _inMemoryEntries;
+                    existingLogCounts = [];
+
+                    foreach (var existingEntry in existingEntries)
+                    {
+                        IncrementCount(existingLogCounts, GetLogEntryKey(existingEntry));
+                    }
+                }
+
+                foreach (var logEntry in logEntries)
+                {
+                    if (existingLogCounts is not null)
+                    {
+                        var key = GetLogEntryKey(logEntry);
+                        if (existingLogCounts.TryGetValue(key, out var count) && count > 0)
+                        {
+                            existingLogCounts[key] = count - 1;
+                            continue;
+                        }
+                    }
+
+                    addedEntries ??= [];
+
+                    // Only add logs into the backlog if there are subscribers. If there aren't subscribers then
+                    // logs are replayed into this collection from various sources (DCP, in-memory).
+                    if (HasSubscribers)
+                    {
+                        _backlog.InsertSorted(logEntry);
+                    }
+
+                    // Keep replayable logs in their own collection. These logs are replayed into
+                    // the backlog when a log watch starts without fetching them from an external source.
+                    if (inMemorySource)
+                    {
+                        _inMemoryEntries.Add(logEntry);
+                    }
+
+                    addedEntries.Add(logEntry);
+                }
+            }
+
+            if (addedEntries is null)
+            {
+                return;
+            }
+
+            foreach (var logEntry in addedEntries)
+            {
+                _onNewLog?.Invoke(logEntry);
+            }
+
+            static (DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type) GetLogEntryKey(LogEntry logEntry)
+            {
+                return (logEntry.Timestamp, logEntry.Content, logEntry.RawContent, logEntry.Type);
+            }
+
+            static void IncrementCount(Dictionary<(DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type), int> counts, (DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type) key)
+            {
+                counts.TryGetValue(key, out var count);
+                counts[key] = count + 1;
+            }
+        }
+
+        private sealed class Subscription(ResourceLoggerState loggerState, Action<LogEntry> log) : IDisposable
+        {
+            public void Dispose()
+            {
+                lock (loggerState._lock)
+                {
+                    loggerState.OnNewLog -= log;
+                }
+            }
         }
 
         private sealed class ResourceLogger(ResourceLoggerState loggerState) : ILogger

--- a/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
@@ -743,7 +743,7 @@ public class ResourceLoggerService : IDisposable
             List<LogEntry>? addedEntries = null;
             lock (_lock)
             {
-                Dictionary<(DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type), int>? existingLogCounts = null;
+                Dictionary<LogEntryKey, int>? existingLogCounts = null;
                 if (skipExisting)
                 {
                     // Terminal-state snapshots and the normal follow stream can overlap. Use
@@ -754,7 +754,7 @@ public class ResourceLoggerService : IDisposable
 
                     foreach (var existingEntry in existingEntries)
                     {
-                        IncrementCount(existingLogCounts, GetLogEntryKey(existingEntry));
+                        IncrementCount(existingLogCounts, LogEntryKey.Create(existingEntry));
                     }
                 }
 
@@ -762,7 +762,7 @@ public class ResourceLoggerService : IDisposable
                 {
                     if (existingLogCounts is not null)
                     {
-                        var key = GetLogEntryKey(logEntry);
+                        var key = LogEntryKey.Create(logEntry);
                         if (existingLogCounts.TryGetValue(key, out var count) && count > 0)
                         {
                             existingLogCounts[key] = count - 1;
@@ -800,12 +800,7 @@ public class ResourceLoggerService : IDisposable
                 _onNewLog?.Invoke(logEntry);
             }
 
-            static (DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type) GetLogEntryKey(LogEntry logEntry)
-            {
-                return (logEntry.Timestamp, logEntry.Content, logEntry.RawContent, logEntry.Type);
-            }
-
-            static void IncrementCount(Dictionary<(DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type), int> counts, (DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type) key)
+            static void IncrementCount(Dictionary<LogEntryKey, int> counts, LogEntryKey key)
             {
                 counts.TryGetValue(key, out var count);
                 counts[key] = count + 1;

--- a/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
@@ -746,8 +746,13 @@ public class ResourceLoggerService : IDisposable
                 Dictionary<LogEntryKey, int>? existingLogCounts = null;
                 if (skipExisting)
                 {
-                    // Terminal-state snapshots and the normal follow stream can overlap. Use
-                    // occurrence counts instead of a set so repeated identical log lines are
+                    // This path is intentionally reserved for one-shot replay sources, such as
+                    // terminal-state log snapshots, that can overlap with entries already observed
+                    // from another source. It rebuilds counts from the replay target, so steady-state
+                    // follow streams should avoid skipExisting and deduplicate only against the small
+                    // overlap window tracked by DcpResourceWatcher.
+                    //
+                    // Use occurrence counts instead of a set so repeated identical log lines are
                     // preserved while only overlapping copies from the later source are skipped.
                     var existingEntries = HasSubscribers ? _backlog.GetEntries() : _inMemoryEntries;
                     existingLogCounts = [];

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -121,7 +121,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         _appResources = appResources;
         _userSecretsManager = userSecretsManager;
 
-        _resourceWatcher = new DcpResourceWatcher(logger, kubernetesService, loggerService, executorEvents, model, _appResources, _configuration, profilingTelemetry, _shutdownCancellation.Token);
+        _resourceWatcher = new DcpResourceWatcher(logger, kubernetesService, loggerService, executorEvents, model, _appResources, profilingTelemetry, _shutdownCancellation.Token);
 
         DeleteResourceRetryPipeline = DcpPipelineBuilder.BuildDeleteRetryPipeline(logger);
 
@@ -130,6 +130,9 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         _containerCreator = containerCreator;
         _proxylessEndpointPortAllocator = proxylessEndpointPortAllocator;
     }
+
+    // Internal for testing.
+    internal DcpResourceWatcher ResourceWatcher => _resourceWatcher;
 
     private string ContainerHostName => _configuration["AppHost:ContainerHostname"] ??
         (_options.Value.EnableAspireContainerTunnel ? KnownHostNames.DefaultContainerTunnelHostName : _dcpInfo?.Containers?.HostName ?? KnownHostNames.DockerDesktopHostBridge);

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -284,7 +284,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                         KnownResourceStates.TerminalStates.Contains(status.State) &&
                         _loggerService.HasActiveSubscribers(resource.Metadata.Name))
                     {
-                        await FlushCurrentLogsAsync(resource, _shutdownToken).ConfigureAwait(false);
+                        await FlushCurrentLogsAsync(resource, status, _shutdownToken).ConfigureAwait(false);
                     }
 
                     await _executorEvents.PublishAsync(new OnResourceChangedContext(_shutdownToken, resourceType, appModelResource, resource.Metadata.Name, status, s => snapshotFactory(resource, s))).ConfigureAwait(false);
@@ -325,16 +325,23 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         }
     }
 
-    private async Task FlushCurrentLogsAsync<T>(T resource, CancellationToken cancellationToken)
+    private async Task FlushCurrentLogsAsync<T>(T resource, ResourceStatus status, CancellationToken cancellationToken)
         where T : CustomResource, IKubernetesStaticMetadata
     {
         try
         {
             // Fast-failing resources can publish their terminal state before the follow stream has
-            // drained stderr/stdout. Flush a snapshot first so tests waiting on terminal states see
-            // the logs from the same startup attempt without adding sleeps.
+            // drained stderr/stdout. Open a follow stream before publishing the terminal state
+            // because DCP only completes follow streams after all logs for the resource are known
+            // to have been delivered.
+            //
+            // FailedToStart is different: the process never starts, so there may be no completing
+            // process log stream to follow. DCP emits the system failure logs before the FailedToStart
+            // state is observed, so use a current snapshot there to avoid blocking terminal state
+            // publication indefinitely.
+            var follow = status.State != KnownResourceStates.FailedToStart;
             var logEntries = new List<LogEntry>();
-            var logSource = new ResourceLogSource<T>(_logger, _kubernetesService, resource, follow: false);
+            var logSource = new ResourceLogSource<T>(_logger, _kubernetesService, resource, follow: follow);
             await foreach (var batch in logSource.WithCancellation(cancellationToken).ConfigureAwait(false))
             {
                 logEntries.AddRange(CreateLogEntries(batch));

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -13,7 +13,6 @@ using Aspire.Hosting.Dcp.Model;
 using Aspire.Shared.ConsoleLogs;
 using k8s;
 using k8s.Autorest;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Polly;
 
@@ -25,13 +24,15 @@ namespace Aspire.Hosting.Dcp;
 /// </summary>
 internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 {
+    private static readonly TimeSpan s_defaultTerminalLogFlushTimeout = TimeSpan.FromSeconds(5);
+
     private readonly IKubernetesService _kubernetesService;
     private readonly ResourceLoggerService _loggerService;
     private readonly DcpExecutorEvents _executorEvents;
     private readonly ILogger _logger;
-    private readonly IConfiguration _configuration;
     private readonly ProfilingTelemetry _profilingTelemetry;
     private readonly CancellationToken _shutdownToken;
+    private TimeSpan _terminalLogFlushTimeout = s_defaultTerminalLogFlushTimeout;
 
     private readonly DcpResourceState _resourceState;
     private readonly ResourceSnapshotBuilder _snapshotBuilder;
@@ -56,7 +57,6 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         DcpExecutorEvents executorEvents,
         DistributedApplicationModel model,
         DcpAppResourceStore appResources,
-        IConfiguration configuration,
         ProfilingTelemetry profilingTelemetry,
         CancellationToken shutdownToken)
     {
@@ -64,14 +64,22 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         _loggerService = loggerService;
         _executorEvents = executorEvents;
         _logger = logger;
-        _configuration = configuration;
         _profilingTelemetry = profilingTelemetry;
         _shutdownToken = shutdownToken;
 
         _resourceState = new(model.Resources.ToDictionary(r => r.Name), appResources.Get());
         _snapshotBuilder = new(_resourceState);
-
         WatchResourceRetryPipeline = DcpPipelineBuilder.BuildWatchResourcePipeline(logger);
+    }
+
+    // Internal for testing.
+    internal TimeSpan TerminalLogFlushTimeout
+    {
+        get => _terminalLogFlushTimeout;
+        set
+        {
+            _terminalLogFlushTimeout = value > TimeSpan.Zero ? value : s_defaultTerminalLogFlushTimeout;
+        }
     }
 
     public void Start()
@@ -328,6 +336,10 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
     private async Task FlushCurrentLogsAsync<T>(T resource, ResourceStatus status, CancellationToken cancellationToken)
         where T : CustomResource, IKubernetesStaticMetadata
     {
+        var logEntries = new List<LogEntry>();
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(_terminalLogFlushTimeout);
+
         try
         {
             // Fast-failing resources can publish their terminal state before the follow stream has
@@ -340,22 +352,22 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             // state is observed, so use a current snapshot there to avoid blocking terminal state
             // publication indefinitely.
             var follow = status.State != KnownResourceStates.FailedToStart;
-            var logEntries = new List<LogEntry>();
             var logSource = new ResourceLogSource<T>(_logger, _kubernetesService, resource, follow: follow);
-            await foreach (var batch in logSource.WithCancellation(cancellationToken).ConfigureAwait(false))
+
+            // This runs under the single resource-watch semaphore. Bound the best-effort flush so
+            // a stalled DCP follow stream cannot prevent unrelated resources from publishing state.
+            await foreach (var batch in logSource.WithCancellation(timeoutCts.Token).ConfigureAwait(false))
             {
                 logEntries.AddRange(CreateLogEntries(batch));
             }
-
-            // These logs came from DCP's external log store, not in-process ILogger. Do not store
-            // them as in-memory entries; otherwise GetAllAsync would replay them before querying
-            // the same DCP log source again.
-            SetPendingFollowLogDeduplication(resource.Metadata.Name, logEntries);
-            _loggerService.AddLogEntries(resource.Metadata.Name, logEntries, inMemorySource: false, skipExisting: true);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            _logger.LogDebug("Current log flush for {ResourceName} timed out after {Timeout}.", resource.Metadata.Name, _terminalLogFlushTimeout);
         }
         catch (HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
@@ -365,6 +377,12 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         {
             _logger.LogError(ex, "Error flushing current logs for {ResourceName}.", resource.Metadata.Name);
         }
+
+        // These logs came from DCP's external log store, not in-process ILogger. Do not store
+        // them as in-memory entries; otherwise GetAllAsync would replay them before querying
+        // the same DCP log source again.
+        SetPendingFollowLogDeduplication(resource.Metadata.Name, logEntries);
+        _loggerService.AddLogEntries(resource.Metadata.Name, logEntries, inMemorySource: false, skipExisting: true);
     }
 
     private static bool HasLogsAvailable(CustomResource resource)
@@ -540,13 +558,13 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             return;
         }
 
-        var counts = new Dictionary<(DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type), int>();
+        var counts = new Dictionary<LogEntryKey, int>();
         DateTime? latestTimestamp = null;
         var remainingCount = 0;
 
         foreach (var logEntry in flushedLogEntries)
         {
-            var key = GetLogEntryKey(logEntry);
+            var key = LogEntryKey.Create(logEntry);
             counts.TryGetValue(key, out var count);
             counts[key] = count + 1;
             remainingCount++;
@@ -571,7 +589,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         List<LogEntry>? addedEntries = null;
         foreach (var logEntry in logEntries)
         {
-            var key = GetLogEntryKey(logEntry);
+            var key = LogEntryKey.Create(logEntry);
             if (pendingDeduplication.Counts.TryGetValue(key, out var count) && count > 0)
             {
                 pendingDeduplication.Counts[key] = count - 1;
@@ -594,11 +612,6 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         }
 
         return addedEntries ?? [];
-    }
-
-    private static (DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type) GetLogEntryKey(LogEntry logEntry)
-    {
-        return (logEntry.Timestamp, logEntry.Content, logEntry.RawContent, logEntry.Type);
     }
 
     private async Task ProcessEndpointChange(WatchEventType watchEventType, Endpoint endpoint)
@@ -700,11 +713,11 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
     }
 
     private sealed class PendingFollowLogDeduplication(
-        Dictionary<(DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type), int> counts,
+        Dictionary<LogEntryKey, int> counts,
         DateTime? latestTimestamp,
         int remainingCount)
     {
-        public Dictionary<(DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type), int> Counts { get; } = counts;
+        public Dictionary<LogEntryKey, int> Counts { get; } = counts;
 
         public DateTime? LatestTimestamp { get; } = latestTimestamp;
 

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -271,11 +271,22 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     var resourceType = DcpExecutor.GetResourceType(resource, appModelResource);
                     var status = GetResourceStatus(resource);
                     AddDcpResourceObservedEvent(resource, appModelResource, resourceKind, status);
+
+                    // Publishing the terminal state unblocks WaitForResourceAsync. For fast-failing
+                    // resources, DCP can report Exited/FailedToStart before the follow log stream
+                    // has delivered stderr/stdout. Flush only when a subscriber is active so normal
+                    // dashboard-less runs do not pay for an extra snapshot read.
+                    if (HasLogsAvailable(resource) &&
+                        status.State is not null &&
+                        KnownResourceStates.TerminalStates.Contains(status.State) &&
+                        _loggerService.HasActiveSubscribers(resource.Metadata.Name))
+                    {
+                        await FlushCurrentLogsAsync(resource, _shutdownToken).ConfigureAwait(false);
+                    }
+
                     await _executorEvents.PublishAsync(new OnResourceChangedContext(_shutdownToken, resourceType, appModelResource, resource.Metadata.Name, status, s => snapshotFactory(resource, s))).ConfigureAwait(false);
 
-                    if (resource is Container { LogsAvailable: true } ||
-                        resource is Executable { LogsAvailable: true } ||
-                        resource is ContainerExec { LogsAvailable: true })
+                    if (HasLogsAvailable(resource))
                     {
                         _logInformationChannel.Writer.TryWrite(new(resource.Metadata.Name, LogsAvailable: true, HasSubscribers: null));
                     }
@@ -309,6 +320,47 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                 }
             }
         }
+    }
+
+    private async Task FlushCurrentLogsAsync<T>(T resource, CancellationToken cancellationToken)
+        where T : CustomResource, IKubernetesStaticMetadata
+    {
+        try
+        {
+            // Fast-failing resources can publish their terminal state before the follow stream has
+            // drained stderr/stdout. Flush a snapshot first so tests waiting on terminal states see
+            // the logs from the same startup attempt without adding sleeps.
+            var logEntries = new List<LogEntry>();
+            var logSource = new ResourceLogSource<T>(_logger, _kubernetesService, resource, follow: false);
+            await foreach (var batch in logSource.WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                logEntries.AddRange(CreateLogEntries(batch));
+            }
+
+            // These logs came from DCP's external log store, not in-process ILogger. Do not store
+            // them as in-memory entries; otherwise GetAllAsync would replay them before querying
+            // the same DCP log source again.
+            _loggerService.AddLogEntries(resource.Metadata.Name, logEntries, inMemorySource: false, skipExisting: true);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _logger.LogDebug("Current log flush for {ResourceName} ended because the resource was deleted.", resource.Metadata.Name);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error flushing current logs for {ResourceName}.", resource.Metadata.Name);
+        }
+    }
+
+    private static bool HasLogsAvailable(CustomResource resource)
+    {
+        return resource is Container { LogsAvailable: true } ||
+               resource is Executable { LogsAvailable: true } ||
+               resource is ContainerExec { LogsAvailable: true };
     }
 
     internal static ResourceStatus GetResourceStatus(CustomResource resource)
@@ -437,15 +489,10 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                         _logger.LogDebug("Starting log streaming for {ResourceName}.", resource.Metadata.Name);
                     }
 
-                    // Pump the logs from the enumerable into the logger
-                    var logger = _loggerService.GetInternalLogger(resource.Metadata.Name);
-
                     await foreach (var batch in enumerable.WithCancellation(cancellation.Token).ConfigureAwait(false))
                     {
-                        foreach (var logEntry in CreateLogEntries(batch))
-                        {
-                            logger(logEntry);
-                        }
+                        var logEntries = CreateLogEntries(batch).ToList();
+                        _loggerService.AddLogEntries(resource.Metadata.Name, logEntries, inMemorySource: false, skipExisting: true);
                     }
                 }
                 catch (OperationCanceledException)

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -37,6 +37,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
     private readonly ResourceSnapshotBuilder _snapshotBuilder;
 
     private readonly ConcurrentDictionary<string, (CancellationTokenSource Cancellation, Task Task)> _logStreams = new();
+    private readonly ConcurrentDictionary<string, PendingFollowLogDeduplication> _pendingFollowLogDeduplications = new();
     private Task? _resourceWatchTask;
 
     private readonly record struct LogInformationEntry(string ResourceName, bool? LogsAvailable, bool? HasSubscribers);
@@ -255,6 +256,8 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                         logStream.Cancellation.Cancel();
                     }
 
+                    _pendingFollowLogDeduplications.TryRemove(resource.Metadata.Name, out _);
+
                     // TODO: Handle resource deletion
                     if (_logger.IsEnabled(LogLevel.Trace))
                     {
@@ -340,6 +343,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             // These logs came from DCP's external log store, not in-process ILogger. Do not store
             // them as in-memory entries; otherwise GetAllAsync would replay them before querying
             // the same DCP log source again.
+            SetPendingFollowLogDeduplication(resource.Metadata.Name, logEntries);
             _loggerService.AddLogEntries(resource.Metadata.Name, logEntries, inMemorySource: false, skipExisting: true);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -476,7 +480,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 
         // This does not run concurrently for the same resource so we can safely use GetOrAdd without
         // creating multiple log streams.
-        _logStreams.GetOrAdd(resource.Metadata.Name, (_) =>
+        _logStreams.GetOrAdd(resource.Metadata.Name, resourceName =>
         {
             var cancellation = new CancellationTokenSource();
 
@@ -486,34 +490,108 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                 {
                     if (_logger.IsEnabled(LogLevel.Debug))
                     {
-                        _logger.LogDebug("Starting log streaming for {ResourceName}.", resource.Metadata.Name);
+                        _logger.LogDebug("Starting log streaming for {ResourceName}.", resourceName);
                     }
 
                     await foreach (var batch in enumerable.WithCancellation(cancellation.Token).ConfigureAwait(false))
                     {
                         var logEntries = CreateLogEntries(batch).ToList();
-                        _loggerService.AddLogEntries(resource.Metadata.Name, logEntries, inMemorySource: false, skipExisting: true);
+                        logEntries = DeduplicateFollowBatch(resourceName, logEntries);
+                        _loggerService.AddLogEntries(resourceName, logEntries, inMemorySource: false, skipExisting: false);
                     }
                 }
                 catch (OperationCanceledException)
                 {
                     // Ignore
-                    _logger.LogDebug("Log streaming for {ResourceName} was cancelled.", resource.Metadata.Name);
+                    _logger.LogDebug("Log streaming for {ResourceName} was cancelled.", resourceName);
                 }
                 catch (HttpOperationException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
                     // Resource was deleted — this is expected for short-lived resources like rebuilders.
-                    _logger.LogDebug("Log streaming for {ResourceName} ended because the resource was deleted.", resource.Metadata.Name);
+                    _logger.LogDebug("Log streaming for {ResourceName} ended because the resource was deleted.", resourceName);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error streaming logs for {ResourceName}.", resource.Metadata.Name);
+                    _logger.LogError(ex, "Error streaming logs for {ResourceName}.", resourceName);
+                }
+                finally
+                {
+                    _pendingFollowLogDeduplications.TryRemove(resourceName, out _);
                 }
             },
             cancellation.Token);
 
             return (cancellation, task);
         });
+    }
+
+    private void SetPendingFollowLogDeduplication(string resourceName, IReadOnlyList<LogEntry> flushedLogEntries)
+    {
+        if (flushedLogEntries.Count == 0)
+        {
+            _pendingFollowLogDeduplications.TryRemove(resourceName, out _);
+            return;
+        }
+
+        var counts = new Dictionary<(DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type), int>();
+        DateTime? latestTimestamp = null;
+        var remainingCount = 0;
+
+        foreach (var logEntry in flushedLogEntries)
+        {
+            var key = GetLogEntryKey(logEntry);
+            counts.TryGetValue(key, out var count);
+            counts[key] = count + 1;
+            remainingCount++;
+
+            if (logEntry.Timestamp is { } timestamp &&
+                (latestTimestamp is null || timestamp > latestTimestamp.Value))
+            {
+                latestTimestamp = timestamp;
+            }
+        }
+
+        _pendingFollowLogDeduplications[resourceName] = new(counts, latestTimestamp, remainingCount);
+    }
+
+    private List<LogEntry> DeduplicateFollowBatch(string resourceName, List<LogEntry> logEntries)
+    {
+        if (!_pendingFollowLogDeduplications.TryGetValue(resourceName, out var pendingDeduplication))
+        {
+            return logEntries;
+        }
+
+        List<LogEntry>? addedEntries = null;
+        foreach (var logEntry in logEntries)
+        {
+            var key = GetLogEntryKey(logEntry);
+            if (pendingDeduplication.Counts.TryGetValue(key, out var count) && count > 0)
+            {
+                pendingDeduplication.Counts[key] = count - 1;
+                pendingDeduplication.RemainingCount--;
+                continue;
+            }
+
+            addedEntries ??= [];
+            addedEntries.Add(logEntry);
+        }
+
+        // Terminal-state snapshots can overlap with the follow stream, but only around the flush.
+        // Deduplicate against the flushed snapshot itself instead of rebuilding the full backlog
+        // for every follow batch for the lifetime of a chatty resource.
+        if (pendingDeduplication.LatestTimestamp is null ||
+            pendingDeduplication.RemainingCount == 0 ||
+            logEntries.Any(entry => entry.Timestamp is null || entry.Timestamp > pendingDeduplication.LatestTimestamp.Value))
+        {
+            _pendingFollowLogDeduplications.TryRemove(resourceName, out _);
+        }
+
+        return addedEntries ?? [];
+    }
+
+    private static (DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type) GetLogEntryKey(LogEntry logEntry)
+    {
+        return (logEntry.Timestamp, logEntry.Content, logEntry.RawContent, logEntry.Type);
     }
 
     private async Task ProcessEndpointChange(WatchEventType watchEventType, Endpoint endpoint)
@@ -612,5 +690,17 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         }
 
         return true;
+    }
+
+    private sealed class PendingFollowLogDeduplication(
+        Dictionary<(DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type), int> counts,
+        DateTime? latestTimestamp,
+        int remainingCount)
+    {
+        public Dictionary<(DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type), int> Counts { get; } = counts;
+
+        public DateTime? LatestTimestamp { get; } = latestTimestamp;
+
+        public int RemainingCount { get; set; } = remainingCount;
     }
 }

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -283,10 +283,16 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     var status = GetResourceStatus(resource);
                     AddDcpResourceObservedEvent(resource, appModelResource, resourceKind, status);
 
-                    // Publishing the terminal state unblocks WaitForResourceAsync. For fast-failing
-                    // resources, DCP can report Exited/FailedToStart before the follow log stream
-                    // has delivered stderr/stdout. Flush only when a subscriber is active so normal
-                    // dashboard-less runs do not pay for an extra snapshot read.
+                    // DCP resource watches and DCP log streams are independent. For a fast-failing
+                    // resource the terminal resource event can arrive before the existing follow log
+                    // stream has delivered the final stderr/stdout batches. Publishing that terminal
+                    // state unblocks WaitForResourceAsync, and tests often inspect forwarded ILogger
+                    // output immediately after the wait completes. Flush here to create a best-effort
+                    // happens-before edge between terminal notification and synchronous log subscribers.
+                    //
+                    // Only do this when a subscriber is active. Without subscribers there is no caller
+                    // depending on the ordering, and GetAllAsync can still query DCP's external log
+                    // store later without this extra read on every terminal transition.
                     if (HasLogsAvailable(resource) &&
                         status.State is not null &&
                         KnownResourceStates.TerminalStates.Contains(status.State) &&
@@ -337,6 +343,10 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         where T : CustomResource, IKubernetesStaticMetadata
     {
         var logEntries = new List<LogEntry>();
+        // The resource watcher serializes all resource-change handling through one semaphore in
+        // Start(). A follow stream gives the strongest DCP guarantee for terminal logs, but it is
+        // still an external stream: if DCP stalls or the resource disappears mid-stream, waiting
+        // forever would block unrelated Container/Executable/Service/Endpoint notifications.
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutCts.CancelAfter(_terminalLogFlushTimeout);
 
@@ -345,7 +355,8 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             // Fast-failing resources can publish their terminal state before the follow stream has
             // drained stderr/stdout. Open a follow stream before publishing the terminal state
             // because DCP only completes follow streams after all logs for the resource are known
-            // to have been delivered.
+            // to have been delivered. A non-follow stream is only a point-in-time snapshot and can
+            // race with DCP's own cleanup/log-drain work.
             //
             // FailedToStart is different: the process never starts, so there may be no completing
             // process log stream to follow. DCP emits the system failure logs before the FailedToStart
@@ -354,8 +365,8 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             var follow = status.State != KnownResourceStates.FailedToStart;
             var logSource = new ResourceLogSource<T>(_logger, _kubernetesService, resource, follow: follow);
 
-            // This runs under the single resource-watch semaphore. Bound the best-effort flush so
-            // a stalled DCP follow stream cannot prevent unrelated resources from publishing state.
+            // Treat the flush as best-effort: logs collected before the timeout are still forwarded
+            // below, then the terminal notification is allowed to proceed.
             await foreach (var batch in logSource.WithCancellation(timeoutCts.Token).ConfigureAwait(false))
             {
                 logEntries.AddRange(CreateLogEntries(batch));
@@ -558,6 +569,10 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             return;
         }
 
+        // The terminal flush reads from the same external DCP log store as the normal follow stream.
+        // The next follow batch can therefore replay entries that were just flushed. Keep occurrence
+        // counts for the flushed entries only; using counts rather than a set preserves legitimate
+        // repeated lines while skipping only the overlapping copies.
         var counts = new Dictionary<LogEntryKey, int>();
         DateTime? latestTimestamp = null;
         var remainingCount = 0;
@@ -589,6 +604,9 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         List<LogEntry>? addedEntries = null;
         foreach (var logEntry in logEntries)
         {
+            // Consume at most one pending occurrence per matching entry. If a flushed snapshot
+            // contained the same line twice, the follow stream must replay it twice before both
+            // copies are treated as overlap.
             var key = LogEntryKey.Create(logEntry);
             if (pendingDeduplication.Counts.TryGetValue(key, out var count) && count > 0)
             {
@@ -603,7 +621,11 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 
         // Terminal-state snapshots can overlap with the follow stream, but only around the flush.
         // Deduplicate against the flushed snapshot itself instead of rebuilding the full backlog
-        // for every follow batch for the lifetime of a chatty resource.
+        // for every follow batch for the lifetime of a chatty resource. DCP log timestamps are
+        // monotonic enough for this boundary: once the follow stream yields a newer timestamp, it
+        // has moved past the overlap window. Timestamp-less entries cannot establish that boundary,
+        // so drop the pending state after the first such batch to avoid suppressing future repeated
+        // messages that happen to have the same content.
         if (pendingDeduplication.LatestTimestamp is null ||
             pendingDeduplication.RemainingCount == 0 ||
             logEntries.Any(entry => entry.Timestamp is null || entry.Timestamp > pendingDeduplication.LatestTimestamp.Value))

--- a/src/Aspire.Hosting/ResourceLoggerForwarderService.cs
+++ b/src/Aspire.Hosting/ResourceLoggerForwarderService.cs
@@ -64,7 +64,10 @@ internal sealed class ResourceLoggerForwarderService(
         {
             var applicationName = hostEnvironment.ApplicationName;
             var logger = loggerFactory.CreateLogger($"{applicationName}.Resources.{resource.Name}");
-            await foreach (var logEvent in resourceLoggerService.WatchAsync(resourceId).WithCancellation(cancellationToken).ConfigureAwait(false))
+
+            // Use the synchronous subscription path so terminal-state log flushes from DCP reach
+            // ILogger before ResourceNotificationService publishes the terminal state to tests.
+            using var subscription = resourceLoggerService.Subscribe(resourceId, logEvent =>
             {
                 foreach (var line in logEvent)
                 {
@@ -77,9 +80,12 @@ internal sealed class ResourceLoggerForwarderService(
                         OnResourceLog?.Invoke(resourceId);
                     }
                 }
-            }
+            });
+
+            // Keep the subscription alive until the resource log stream completes or the app stops.
+            await resourceLoggerService.WaitForCompletionAsync(resourceId, cancellationToken).ConfigureAwait(false);
         }
-        catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             // this was expected as the token was canceled
         }

--- a/src/Shared/ConsoleLogs/LogEntry.cs
+++ b/src/Shared/ConsoleLogs/LogEntry.cs
@@ -62,6 +62,11 @@ internal sealed class LogEntry
 /// <summary>
 /// Represents the stable identity fields used to deduplicate overlapping log entries.
 /// </summary>
+/// <remarks>
+/// Keep this key aligned with the fields that come from the underlying log source. Display-only
+/// fields such as line number and resource prefix can differ depending on whether the entry came
+/// from a terminal snapshot, a follow stream, or an in-memory logger replay, so they are excluded.
+/// </remarks>
 internal readonly record struct LogEntryKey(DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type)
 {
     /// <summary>

--- a/src/Shared/ConsoleLogs/LogEntry.cs
+++ b/src/Shared/ConsoleLogs/LogEntry.cs
@@ -59,6 +59,20 @@ internal sealed class LogEntry
     }
 }
 
+/// <summary>
+/// Represents the stable identity fields used to deduplicate overlapping log entries.
+/// </summary>
+internal readonly record struct LogEntryKey(DateTime? Timestamp, string? Content, string? RawContent, LogEntryType Type)
+{
+    /// <summary>
+    /// Creates a deduplication key for the specified log entry.
+    /// </summary>
+    public static LogEntryKey Create(LogEntry logEntry)
+    {
+        return new(logEntry.Timestamp, logEntry.Content, logEntry.RawContent, logEntry.Type);
+    }
+}
+
 #if ASPIRE_DASHBOARD
 public enum LogEntryType
 #else

--- a/tests/Aspire.Hosting.Containers.Tests/ResourceFailureLoggingTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/ResourceFailureLoggingTests.cs
@@ -86,6 +86,32 @@ public class ContainerResourceFailureLoggingTests(ITestOutputHelper testOutputHe
         Assert.Contains(logLines, x => x.Contains("Error response from daemon"));
     }
 
+    [Fact]
+    [RequiresFeature(TestFeature.Docker)]
+    public async Task ContainerExitsImmediatelyAfterStart()
+    {
+        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.DefaultOrchestratorTestLongTimeout);
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var container = builder.AddContainer("container", "nginx")
+            .WithArgs("--illegal-argument");
+        AddFakeLogging(container);
+
+        FakeLogCollector logCollector;
+        using (var app = builder.Build())
+        {
+            logCollector = app.Services.GetFakeLogCollector();
+            await app.StartAsync(cts.Token).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+            await app.ResourceNotifications.WaitForResourceAsync(container.Resource.Name, [KnownResourceStates.Exited, KnownResourceStates.FailedToStart], cts.Token).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+
+            var logLines = GetLogLines(logCollector);
+            AssertSingleLogLine(
+                logLines,
+                x => x.Contains("exec: --illegal-argument: not found"),
+                "container startup failure from nginx entrypoint");
+        }
+    }
+
     private static void AddFakeLogging<T>(IResourceBuilder<T> builder)
         where T : IResource
     {
@@ -99,5 +125,20 @@ public class ContainerResourceFailureLoggingTests(ITestOutputHelper testOutputHe
                 .Select(x => x.StructuredState?.SingleOrDefault(x => x.Key == "LineContent"))
                 .Where(x => x is not null)
                 .Select(x => x?.Value!)];
+    }
+
+    private static void AssertSingleLogLine(List<string> logLines, Func<string, bool> predicate, string expected)
+    {
+        var matches = logLines.Where(predicate).ToList();
+        Assert.True(
+            matches.Count == 1,
+            $"Expected exactly one log line for {expected}, but found {matches.Count}.{Environment.NewLine}Captured resource logs:{Environment.NewLine}{FormatLogLines(logLines)}");
+    }
+
+    private static string FormatLogLines(List<string> logLines)
+    {
+        return logLines.Count == 0
+            ? "<none>"
+            : string.Join(Environment.NewLine, logLines.Select((line, index) => $"{index + 1}: {line}"));
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1535,6 +1535,67 @@ public class DcpExecutorTests
     }
 
     [Fact]
+    public async Task ResourceLogging_TerminalLogFlushTimeoutDoesNotBlockOtherResourceNotifications()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("blocking", "image");
+        builder.AddContainer("other", "image");
+
+        string? blockingDcpResourceName = null;
+        var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
+        {
+            if (obj.Metadata.Name == blockingDcpResourceName &&
+                obj is Container { Status.State: ContainerState.Exited } &&
+                follow == true)
+            {
+                return new Pipe().Reader.AsStream();
+            }
+
+            return new MemoryStream();
+        });
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var dcpOptions = new DcpOptions { DashboardPath = "./dashboard" };
+        var resourceLoggerService = new ResourceLoggerService();
+        var otherTerminalNotification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        string? otherDcpResourceName = null;
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceChangedContext>(context =>
+        {
+            if (context.DcpResourceName == otherDcpResourceName && context.Status.State == ContainerState.Exited)
+            {
+                otherTerminalNotification.TrySetResult();
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions, resourceLoggerService: resourceLoggerService, events: events);
+        appExecutor.ResourceWatcher.TerminalLogFlushTimeout = TimeSpan.FromMilliseconds(100);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var blockingContainer = Assert.Single(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == "blocking");
+        var otherContainer = Assert.Single(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == "other");
+        blockingDcpResourceName = blockingContainer.Metadata.Name;
+        otherDcpResourceName = otherContainer.Metadata.Name;
+
+        using var subscription = resourceLoggerService.Subscribe(blockingDcpResourceName, _ => { });
+
+        blockingContainer.Status = new ContainerStatus { State = ContainerState.Exited };
+        kubernetesService.PushResourceModified(blockingContainer);
+
+        otherContainer.Status = new ContainerStatus { State = ContainerState.Exited };
+        kubernetesService.PushResourceModified(otherContainer);
+
+        await otherTerminalNotification.Task.DefaultTimeout();
+    }
+
+    [Fact]
     public async Task ResourceLogging_FollowStreamDeduplicatesOnlyPendingTerminalFlush()
     {
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1460,6 +1460,77 @@ public class DcpExecutorTests
     }
 
     [Fact]
+    public async Task ResourceLogging_TerminalStateFlushesSnapshotBeforeNotification()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        const string terminalLogMessage = "crash before terminal notification";
+        var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
+        {
+            if (follow == false && logStreamType == Logs.StreamTypeStdErr)
+            {
+                return new MemoryStream(Encoding.UTF8.GetBytes("2024-08-19T06:10:33.473275911Z " + terminalLogMessage + Environment.NewLine));
+            }
+
+            return new MemoryStream();
+        });
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var dcpOptions = new DcpOptions { DashboardPath = "./dashboard" };
+        var resourceLoggerService = new ResourceLoggerService();
+        var logLines = new List<LogLine>();
+        var logLinesLock = new object();
+        var terminalLogCountAtNotification = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        string? dcpResourceName = null;
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceChangedContext>(context =>
+        {
+            if (context.DcpResourceName == dcpResourceName && context.Status.State == ContainerState.Exited)
+            {
+                int logCount;
+                lock (logLinesLock)
+                {
+                    logCount = logLines.Count(l => l.Content.Contains(terminalLogMessage));
+                }
+
+                terminalLogCountAtNotification.TrySetResult(logCount);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions, resourceLoggerService: resourceLoggerService, events: events);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        dcpResourceName = container.Metadata.Name;
+
+        using var subscription = resourceLoggerService.Subscribe(dcpResourceName, batch =>
+        {
+            lock (logLinesLock)
+            {
+                logLines.AddRange(batch);
+            }
+        });
+
+        container.Status = new ContainerStatus { State = ContainerState.Exited };
+        kubernetesService.PushResourceModified(container);
+
+        Assert.Equal(1, await terminalLogCountAtNotification.Task.DefaultTimeout());
+
+        lock (logLinesLock)
+        {
+            Assert.Single(logLines, l => l.Content.Contains(terminalLogMessage));
+        }
+    }
+
+    [Fact]
     public async Task ResourceLogging_SystemStream_FormatsWithSysPrefix()
     {
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1531,6 +1531,82 @@ public class DcpExecutorTests
     }
 
     [Fact]
+    public async Task ResourceLogging_FollowStreamDeduplicatesOnlyPendingTerminalFlush()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        var followStdErrPipeChannel = Channel.CreateUnbounded<Pipe>();
+        var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
+        {
+            if (logStreamType == Logs.StreamTypeStdErr)
+            {
+                if (follow == true)
+                {
+                    var pipe = new Pipe();
+                    followStdErrPipeChannel.Writer.TryWrite(pipe);
+                    return pipe.Reader.AsStream();
+                }
+
+                return new MemoryStream(Encoding.UTF8.GetBytes("same" + Environment.NewLine));
+            }
+
+            return new MemoryStream();
+        });
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var dcpOptions = new DcpOptions { DashboardPath = "./dashboard" };
+        var resourceLoggerService = new ResourceLoggerService();
+        var logLines = new List<LogLine>();
+        var logLinesLock = new object();
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions, resourceLoggerService: resourceLoggerService);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+
+        using var subscription = resourceLoggerService.Subscribe(container.Metadata.Name, batch =>
+        {
+            lock (logLinesLock)
+            {
+                logLines.AddRange(batch);
+            }
+        });
+
+        container.Status = new ContainerStatus { State = ContainerState.Running };
+        kubernetesService.PushResourceModified(container);
+
+        var followStdErrPipe = await followStdErrPipeChannel.Reader.ReadAsync().AsTask().DefaultTimeout();
+
+        container.Status = new ContainerStatus { State = ContainerState.Exited };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(() =>
+        {
+            lock (logLinesLock)
+            {
+                return logLines.Count(l => l.Content == "same") == 1;
+            }
+        },
+        "Terminal flush should deliver the snapshot log.");
+
+        await followStdErrPipe.Writer.WriteAsync(Encoding.UTF8.GetBytes("same" + Environment.NewLine + "same" + Environment.NewLine));
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(() =>
+        {
+            lock (logLinesLock)
+            {
+                return logLines.Count(l => l.Content == "same") == 2;
+            }
+        },
+        "Follow stream should skip the overlapping flushed line but preserve a later identical line.");
+    }
+
+    [Fact]
     public async Task ResourceLogging_SystemStream_FormatsWithSysPrefix()
     {
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1460,7 +1460,7 @@ public class DcpExecutorTests
     }
 
     [Fact]
-    public async Task ResourceLogging_TerminalStateFlushesSnapshotBeforeNotification()
+    public async Task ResourceLogging_TerminalStateFollowsLogsBeforeNotification()
     {
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
@@ -1470,10 +1470,13 @@ public class DcpExecutorTests
         builder.AddContainer("database", "image");
 
         const string terminalLogMessage = "crash before terminal notification";
+        bool? terminalStdErrFollow = null;
         var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
         {
-            if (follow == false && logStreamType == Logs.StreamTypeStdErr)
+            if (obj is Container { Status.State: ContainerState.Exited } &&
+                logStreamType == Logs.StreamTypeStdErr)
             {
+                terminalStdErrFollow = follow;
                 return new MemoryStream(Encoding.UTF8.GetBytes("2024-08-19T06:10:33.473275911Z " + terminalLogMessage + Environment.NewLine));
             }
 
@@ -1523,6 +1526,7 @@ public class DcpExecutorTests
         kubernetesService.PushResourceModified(container);
 
         Assert.Equal(1, await terminalLogCountAtNotification.Task.DefaultTimeout());
+        Assert.True(terminalStdErrFollow == true);
 
         lock (logLinesLock)
         {
@@ -1541,18 +1545,24 @@ public class DcpExecutorTests
         builder.AddContainer("database", "image");
 
         var followStdErrPipeChannel = Channel.CreateUnbounded<Pipe>();
+        var followStdErrStreamCount = 0;
         var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
         {
             if (logStreamType == Logs.StreamTypeStdErr)
             {
                 if (follow == true)
                 {
-                    var pipe = new Pipe();
-                    followStdErrPipeChannel.Writer.TryWrite(pipe);
-                    return pipe.Reader.AsStream();
+                    if (Interlocked.Increment(ref followStdErrStreamCount) == 1)
+                    {
+                        var pipe = new Pipe();
+                        followStdErrPipeChannel.Writer.TryWrite(pipe);
+                        return pipe.Reader.AsStream();
+                    }
+
+                    return new MemoryStream(Encoding.UTF8.GetBytes("same" + Environment.NewLine));
                 }
 
-                return new MemoryStream(Encoding.UTF8.GetBytes("same" + Environment.NewLine));
+                return new MemoryStream();
             }
 
             return new MemoryStream();

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -25,13 +25,19 @@ internal sealed class TestKubernetesService : IKubernetesService
     public ConcurrentQueue<string> DeletedResources { get; } = [];
 
     private readonly List<Channel<(WatchEventType, CustomResource)>> _watchChannels = [];
-    private readonly Func<CustomResource, string, Stream> _startStream;
+    private readonly Func<CustomResource, string, bool?, Stream> _startStream;
     private readonly bool _ignoreDeletes;
     private int _nextPort = StartOfAutoPortRange;
 
-    public TestKubernetesService(Func<CustomResource, string, Stream>? startStream = null, bool ignoreDeletes = false)
+    public TestKubernetesService(
+        Func<CustomResource, string, Stream>? startStream = null,
+        bool ignoreDeletes = false,
+        Func<CustomResource, string, bool?, Stream>? startStreamWithFollow = null)
     {
-        _startStream = startStream ?? ((obj, logStreamType) => new MemoryStream(Encoding.UTF8.GetBytes($"Logs for {obj.Metadata.Name} ({logStreamType})")));
+        _startStream = startStreamWithFollow ??
+            (startStream is not null
+                ? (obj, logStreamType, follow) => startStream(obj, logStreamType)
+                : (obj, logStreamType, follow) => new MemoryStream(Encoding.UTF8.GetBytes($"Logs for {obj.Metadata.Name} ({logStreamType})")));
         _ignoreDeletes = ignoreDeletes;
     }
 
@@ -226,7 +232,7 @@ internal sealed class TestKubernetesService : IKubernetesService
         long? skip = null
     ) where T : CustomResource, IKubernetesStaticMetadata
     {
-        return Task.FromResult(_startStream(obj, logStreamType));
+        return Task.FromResult(_startStream(obj, logStreamType, follow));
     }
 
     public Task<T> PatchAsync<T>(T obj, V1Patch patch, CancellationToken cancellationToken = default) where T : CustomResource, IKubernetesStaticMetadata

--- a/tests/Aspire.Hosting.Tests/ResourceFailureLoggingTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceFailureLoggingTests.cs
@@ -42,6 +42,34 @@ public class ExecutableResourceFailureLoggingTests(ITestOutputHelper testOutputH
         Assert.Contains(logLines, x => x.EndsWith("Hello from Stderr"));
     }
 
+    [Fact]
+    public async Task ExecutableDoesNotExist()
+    {
+        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.DefaultOrchestratorTestLongTimeout);
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var executable = builder.AddExecutable("exe", "does-not-exist", ".");
+        AddFakeLogging(executable);
+
+        FakeLogCollector logCollector;
+        using (var app = builder.Build())
+        {
+            logCollector = app.Services.GetFakeLogCollector();
+            await app.StartAsync(cts.Token).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+            await app.ResourceNotifications.WaitForResourceAsync(executable.Resource.Name, KnownResourceStates.FailedToStart, cts.Token).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+
+            var logLines = GetLogLines(logCollector);
+            AssertSingleLogLine(
+                logLines,
+                x => x.Contains("[sys] Failed to start a process:") && x.Contains("executable file not found"),
+                "process start failure");
+            AssertSingleLogLine(
+                logLines,
+                x => x.Contains("[sys] The Executable failed to start:"),
+                "executable failed-to-start status");
+        }
+    }
+
     private static void AddFakeLogging<T>(IResourceBuilder<T> builder)
         where T : IResource
     {
@@ -55,5 +83,20 @@ public class ExecutableResourceFailureLoggingTests(ITestOutputHelper testOutputH
                 .Select(x => x.StructuredState?.SingleOrDefault(x => x.Key == "LineContent"))
                 .Where(x => x is not null)
                 .Select(x => x?.Value!)];
+    }
+
+    private static void AssertSingleLogLine(List<string> logLines, Func<string, bool> predicate, string expected)
+    {
+        var matches = logLines.Where(predicate).ToList();
+        Assert.True(
+            matches.Count == 1,
+            $"Expected exactly one log line for {expected}, but found {matches.Count}.{Environment.NewLine}Captured resource logs:{Environment.NewLine}{FormatLogLines(logLines)}");
+    }
+
+    private static string FormatLogLines(List<string> logLines)
+    {
+        return logLines.Count == 0
+            ? "<none>"
+            : string.Join(Environment.NewLine, logLines.Select((line, index) => $"{index + 1}: {line}"));
     }
 }

--- a/tests/Aspire.Hosting.Tests/ResourceLoggerServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceLoggerServiceTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Threading.Channels;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Shared.ConsoleLogs;
@@ -307,6 +308,367 @@ public class ResourceLoggerServiceTests
     }
 
     [Fact]
+    public async Task AddLogEntries_OverlappingSnapshotAndFollow_DedupesByOccurrence()
+    {
+        await Task.Run(() =>
+        {
+            const string resourceName = "myResource";
+            var service = ConsoleLoggingTestHelpers.GetResourceLoggerService();
+            var logLines = new List<LogLine>();
+
+            using var subscription = service.Subscribe(resourceName, logLines.AddRange);
+
+            service.AddLogEntries(resourceName,
+                [
+                    CreateLogEntry("snapshot-before-overlap"),
+                    CreateLogEntry("overlap"),
+                    CreateLogEntry("snapshot-after-overlap")
+                ],
+                inMemorySource: false,
+                skipExisting: true);
+            service.AddLogEntries(resourceName,
+                [
+                    CreateLogEntry("overlap"),
+                    CreateLogEntry("follow-only")
+                ],
+                inMemorySource: false,
+                skipExisting: true);
+
+            Assert.Collection(logLines,
+                l => { Assert.Equal(1, l.LineNumber); Assert.Equal("snapshot-before-overlap", l.Content); },
+                l => { Assert.Equal(2, l.LineNumber); Assert.Equal("overlap", l.Content); },
+                l => { Assert.Equal(3, l.LineNumber); Assert.Equal("snapshot-after-overlap", l.Content); },
+                l => { Assert.Equal(4, l.LineNumber); Assert.Equal("follow-only", l.Content); });
+        }).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task AddLogEntries_RepeatedIdenticalLines_ArePreservedWhenDedupingOverlap()
+    {
+        await Task.Run(() =>
+        {
+            const string resourceName = "myResource";
+            var service = ConsoleLoggingTestHelpers.GetResourceLoggerService();
+            var logLines = new List<LogLine>();
+
+            using var subscription = service.Subscribe(resourceName, logLines.AddRange);
+
+            service.AddLogEntries(resourceName,
+                [
+                    CreateLogEntry("same"),
+                    CreateLogEntry("same")
+                ],
+                inMemorySource: false,
+                skipExisting: true);
+            service.AddLogEntries(resourceName,
+                [
+                    CreateLogEntry("same"),
+                    CreateLogEntry("same"),
+                    CreateLogEntry("same")
+                ],
+                inMemorySource: false,
+                skipExisting: true);
+
+            Assert.Collection(logLines,
+                l => { Assert.Equal(1, l.LineNumber); Assert.Equal("same", l.Content); },
+                l => { Assert.Equal(2, l.LineNumber); Assert.Equal("same", l.Content); },
+                l => { Assert.Equal(3, l.LineNumber); Assert.Equal("same", l.Content); });
+        }).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task Subscribe_DeliversBacklogBeforeLiveLogs_WithContinuousLineNumbers()
+    {
+        const string resourceName = "myResource";
+        var service = ConsoleLoggingTestHelpers.GetResourceLoggerService();
+        var logLines = new List<LogLine>();
+        var logLinesLock = new object();
+        var subscribeRegistered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueBacklogDelivery = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        service.AddLogEntries(resourceName, [CreateLogEntry("backlog")], inMemorySource: true, skipExisting: false);
+        var loggerState = service.GetResourceLoggerState(resourceName);
+        loggerState.SynchronousSubscribeRegistered = () =>
+        {
+            subscribeRegistered.TrySetResult();
+            continueBacklogDelivery.Task.DefaultTimeout().GetAwaiter().GetResult();
+        };
+
+        IDisposable? subscription = null;
+        var subscribeTask = Task.Run(() =>
+        {
+            subscription = service.Subscribe(resourceName, batch =>
+            {
+                lock (logLinesLock)
+                {
+                    logLines.AddRange(batch);
+                }
+            });
+        });
+
+        try
+        {
+            await subscribeRegistered.Task.DefaultTimeout();
+
+            service.AddLogEntries(resourceName, [CreateLogEntry("live-during-backlog-delivery")], inMemorySource: false, skipExisting: false);
+
+            continueBacklogDelivery.SetResult();
+            await subscribeTask.DefaultTimeout();
+
+            service.AddLogEntries(resourceName, [CreateLogEntry("live-after-subscribe")], inMemorySource: false, skipExisting: false);
+
+            lock (logLinesLock)
+            {
+                Assert.Collection(logLines,
+                    l => { Assert.Equal(1, l.LineNumber); Assert.Equal("backlog", l.Content); },
+                    l => { Assert.Equal(2, l.LineNumber); Assert.Equal("live-during-backlog-delivery", l.Content); },
+                    l => { Assert.Equal(3, l.LineNumber); Assert.Equal("live-after-subscribe", l.Content); });
+            }
+        }
+        finally
+        {
+            loggerState.SynchronousSubscribeRegistered = null;
+            continueBacklogDelivery.TrySetResult();
+            subscription?.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task WaitForCompletionAsync_CompletesWhenResourceLogStreamCompletes()
+    {
+        const string resourceName = "myResource";
+        var service = ConsoleLoggingTestHelpers.GetResourceLoggerService();
+
+        var completionTask = service.WaitForCompletionAsync(resourceName, CancellationToken.None);
+        Assert.False(completionTask.IsCompleted);
+
+        service.Complete(resourceName);
+
+        await completionTask.DefaultTimeout();
+        await service.WaitForCompletionAsync(resourceName, CancellationToken.None).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task HasActiveSubscribers_ReturnsFalseAfterCompletion()
+    {
+        await Task.Run(() =>
+        {
+            const string resourceName = "myResource";
+            var service = ConsoleLoggingTestHelpers.GetResourceLoggerService();
+
+            Assert.False(service.HasActiveSubscribers(resourceName));
+
+            using var subscription = service.Subscribe(resourceName, _ => { });
+
+            Assert.True(service.HasActiveSubscribers(resourceName));
+
+            service.Complete(resourceName);
+
+            Assert.False(service.HasActiveSubscribers(resourceName));
+        }).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_DoesNotReplayNonInMemoryEntries()
+    {
+        var testResource = new TestResource("myResource");
+        var service = ConsoleLoggingTestHelpers.GetResourceLoggerService();
+
+        using (service.Subscribe(testResource.Name, _ => { }))
+        {
+            service.AddLogEntries(testResource.Name, [CreateLogEntry("dcp-snapshot-log")], inMemorySource: false, skipExisting: false);
+        }
+
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<LogEntry>>();
+        consoleLogsChannel.Writer.TryWrite([CreateLogEntry("dcp-snapshot-log")]);
+        consoleLogsChannel.Writer.Complete();
+
+        service.SetConsoleLogsService(new TestConsoleLogsService(name => name == testResource.Name
+            ? consoleLogsChannel
+            : throw new InvalidOperationException($"Unexpected {name}")));
+
+        var allLogs = new List<LogLine>();
+        await foreach (var logs in service.GetAllAsync(testResource).DefaultTimeout())
+        {
+            allLogs.AddRange(logs);
+        }
+
+        var logLine = Assert.Single(allLogs);
+        Assert.Equal("dcp-snapshot-log", logLine.Content);
+    }
+
+    [Fact]
+    public async Task Subscribe_ConcurrentAddLogEntries_DeliversEachEntryOnceWithUniqueLineNumbers()
+    {
+        const string resourceName = "myResource";
+        const int producerCount = 8;
+        const int entriesPerProducer = 100;
+        var service = ConsoleLoggingTestHelpers.GetResourceLoggerService();
+        var logLines = new List<LogLine>();
+        var logLinesLock = new object();
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = service.Subscribe(resourceName, batch =>
+        {
+            lock (logLinesLock)
+            {
+                logLines.AddRange(batch);
+            }
+        });
+
+        var producerTasks = Enumerable.Range(0, producerCount).Select(async producerIndex =>
+        {
+            await start.Task.DefaultTimeout();
+
+            for (var entryIndex = 0; entryIndex < entriesPerProducer; entryIndex++)
+            {
+                service.AddLogEntries(
+                    resourceName,
+                    [CreateConcurrentLogEntry(producerIndex, entryIndex)],
+                    inMemorySource: false,
+                    skipExisting: false);
+            }
+        });
+
+        start.SetResult();
+        await Task.WhenAll(producerTasks).DefaultTimeout();
+
+        lock (logLinesLock)
+        {
+            Assert.Equal(producerCount * entriesPerProducer, logLines.Count);
+            Assert.Equal(logLines.Count, logLines.Select(l => l.Content).Distinct().Count());
+            Assert.Equal(Enumerable.Range(1, logLines.Count), logLines.Select(l => l.LineNumber).Order());
+        }
+    }
+
+    [Fact]
+    public async Task AddLogEntries_ConcurrentOverlappingBatches_DedupesByOccurrence()
+    {
+        const string resourceName = "myResource";
+        const int producerCount = 16;
+        var service = ConsoleLoggingTestHelpers.GetResourceLoggerService();
+        var logLines = new List<LogLine>();
+        var logLinesLock = new object();
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = service.Subscribe(resourceName, batch =>
+        {
+            lock (logLinesLock)
+            {
+                logLines.AddRange(batch);
+            }
+        });
+
+        var producerTasks = Enumerable.Range(0, producerCount).Select(async _ =>
+        {
+            await start.Task.DefaultTimeout();
+
+            service.AddLogEntries(
+                resourceName,
+                [
+                    CreateLogEntry("same"),
+                    CreateLogEntry("same"),
+                    CreateLogEntry("unique")
+                ],
+                inMemorySource: false,
+                skipExisting: true);
+        });
+
+        start.SetResult();
+        await Task.WhenAll(producerTasks).DefaultTimeout();
+
+        lock (logLinesLock)
+        {
+            Assert.Equal(3, logLines.Count);
+            Assert.Equal(2, logLines.Count(l => l.Content == "same"));
+            Assert.Single(logLines, l => l.Content == "unique");
+            Assert.Equal([1, 2, 3], logLines.Select(l => l.LineNumber).Order());
+        }
+    }
+
+    [Fact]
+    public async Task SubscribeAndDispose_ConcurrentWithLogging_DoesNotThrowOrDeadlock()
+    {
+        const string resourceName = "myResource";
+        const int subscriberCount = 8;
+        const int subscribeIterations = 50;
+        const int producerCount = 4;
+        const int entriesPerProducer = 100;
+        var service = ConsoleLoggingTestHelpers.GetResourceLoggerService();
+        var exceptions = new ConcurrentQueue<Exception>();
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observedByStableSubscription = 0;
+
+        using var stableSubscription = service.Subscribe(resourceName, batch =>
+        {
+            foreach (var line in batch)
+            {
+                if (line.LineNumber <= 0)
+                {
+                    throw new InvalidOperationException("Expected positive line numbers.");
+                }
+            }
+
+            Interlocked.Add(ref observedByStableSubscription, batch.Count);
+        });
+
+        var subscriberTasks = Enumerable.Range(0, subscriberCount).Select(async subscriberIndex =>
+        {
+            await start.Task.DefaultTimeout();
+
+            try
+            {
+                for (var i = 0; i < subscribeIterations; i++)
+                {
+                    using var subscription = service.Subscribe(resourceName, batch =>
+                    {
+                        foreach (var line in batch)
+                        {
+                            if (line.LineNumber <= 0)
+                            {
+                                throw new InvalidOperationException($"Subscriber {subscriberIndex} observed non-positive line number.");
+                            }
+                        }
+                    });
+
+                    await Task.Yield();
+                }
+            }
+            catch (Exception ex)
+            {
+                exceptions.Enqueue(ex);
+            }
+        });
+
+        var producerTasks = Enumerable.Range(0, producerCount).Select(async producerIndex =>
+        {
+            await start.Task.DefaultTimeout();
+
+            try
+            {
+                for (var entryIndex = 0; entryIndex < entriesPerProducer; entryIndex++)
+                {
+                    service.AddLogEntries(
+                        resourceName,
+                        [CreateConcurrentLogEntry(producerIndex, entryIndex)],
+                        inMemorySource: false,
+                        skipExisting: false);
+                }
+            }
+            catch (Exception ex)
+            {
+                exceptions.Enqueue(ex);
+            }
+        });
+
+        start.SetResult();
+        await Task.WhenAll(subscriberTasks.Concat(producerTasks)).DefaultTimeout();
+
+        Assert.Empty(exceptions);
+        Assert.Equal(producerCount * entriesPerProducer, observedByStableSubscription);
+    }
+
+    [Fact]
     public async Task WatchAsyncCompletesOnDispose()
     {
         var testResource = new TestResource("myResource");
@@ -431,6 +793,16 @@ public class ResourceLoggerServiceTests
     private sealed class TestResource(string name) : Resource(name)
     {
 
+    }
+
+    private static LogEntry CreateLogEntry(string content)
+    {
+        return LogEntry.Create(timestamp: null, content, isErrorMessage: false);
+    }
+
+    private static LogEntry CreateConcurrentLogEntry(int producerIndex, int entryIndex)
+    {
+        return CreateLogEntry($"concurrent log from producer {producerIndex}, entry {entryIndex}");
     }
 
     private static Task WatchForSubscribers(ResourceLoggerService service)


### PR DESCRIPTION
## Description

Fast-failing containers and executables could reach a terminal state before DCP stdout/stderr logs were forwarded to the host logger. That made `DistributedApplicationTestingBuilder` failures difficult to diagnose because `WaitForResourceAsync` could return before the relevant logs were visible.

This change flushes current DCP logs to active resource-log subscribers before terminal state notifications are published. The synchronous subscription path is internal and used by `ResourceLoggerForwarderService`; `WatchAsync` keeps its existing async stream semantics for dashboard/backchannel consumers. Snapshot/follow overlap is deduped with count-based matching so repeated identical log lines are preserved.

### User-facing behavior

When a resource fails during startup, test code that waits for the resource to fail can include the container or executable stdout/stderr in captured host logs.

### Validation

- `./restore.sh && ./build.sh --build /p:SkipNativeBuild=true`
- `ResourceLoggerServiceTests`, including repeated stress runs
- `ResourceLoggerForwarderServiceTests`
- DCP resource logging tests
- `ResourceFailureLoggingTests.ExecutableDoesNotExist`
- `ResourceFailureLoggingTests.ContainerExitsImmediatelyAfterStart`
- Manual playground CLI E2E: temporary fast-failing Alpine container, `aspire wait ... --status down`, then `aspire logs` showed `aspire-cli-fast-fail-e2e`

Fixes: #10218

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No