### PR TITLE
Make PostgreSQL resilient to the PG18 initdb-restart window

### DIFF
--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -10,6 +10,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Postgres;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 
@@ -77,36 +78,22 @@ public static class PostgresBuilderExtensions
                 throw new DistributedApplicationException($"ResourceReadyEvent was published for the '{postgresServer.Name}' resource but the connection string was null.");
             }
 
-            // Non-database scoped connection string
-            using var npgsqlConnection = new NpgsqlConnection(connectionString + ";Database=postgres;");
-
-            await npgsqlConnection.OpenAsync(ct).ConfigureAwait(false);
-
-            if (npgsqlConnection.State != System.Data.ConnectionState.Open)
-            {
-                throw new InvalidOperationException($"Could not open connection to '{postgresServer.Name}'");
-            }
-
-            foreach (var name in postgresServer.Databases.Keys)
-            {
-                if (builder.Resources.FirstOrDefault(n => string.Equals(n.Name, name, StringComparisons.ResourceName)) is PostgresDatabaseResource postgreDatabase)
-                {
-                    await CreateDatabaseAsync(npgsqlConnection, postgreDatabase, @event.Services, ct).ConfigureAwait(false);
-                }
-            }
+            await CreateDatabasesAsync(connectionString, builder, postgresServer, @event.Services, ct).ConfigureAwait(false);
         });
 
         var healthCheckKey = $"{name}_check";
-        builder.Services.AddHealthChecks().AddNpgSql(sp => connectionString ?? throw new InvalidOperationException("Connection string is unavailable"), name: healthCheckKey, configure: (connection) =>
-        {
-            // HACK: The Npgsql client defaults to using the username in the connection string if the database is not specified. Here
-            //       we override this default behavior because we are working with a non-database scoped connection string. The Aspirified
-            //       package doesn't have to deal with this because it uses a datasource from DI which doesn't have this issue:
-            //
-            //       https://github.com/npgsql/npgsql/blob/c3b31c393de66a4b03fba0d45708d46a2acb06d2/src/Npgsql/NpgsqlConnection.cs#L445
-            //
-            connection.ConnectionString += ";Database=postgres;";
-        });
+
+        // Gate the server's Healthy state behind a short stability window rather than a single SELECT 1.
+        // On a fresh data volume the official Postgres image runs initdb against a temporary server and
+        // then restarts to the real listener; a single probe can pass before that restart, releasing
+        // WaitFor dependents (and triggering database creation) straight into the restart's connection
+        // reset. PostgresServerHealthCheck only reports Healthy once a connection survives several
+        // consecutive probes, proving the restart is over. See PostgresServerHealthCheck for details.
+        builder.Services.AddHealthChecks().Add(new HealthCheckRegistration(
+            healthCheckKey,
+            sp => new PostgresServerHealthCheck(() => connectionString),
+            failureStatus: null,
+            tags: null));
 
         return builder.AddResource(postgresServer)
                       .WithEndpoint(port: port, targetPort: 5432, name: PostgresServerResource.PrimaryEndpointName) // Internal port is always 5432.
@@ -723,6 +710,102 @@ public static class PostgresBuilderExtensions
         return parts.Length > 0 && int.TryParse(parts[0], out majorVersion) && majorVersion > 0;
     }
 
+    private static async Task CreateDatabasesAsync(string connectionString, IDistributedApplicationBuilder builder, PostgresServerResource postgresServer, IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        var logger = serviceProvider.GetRequiredService<ResourceLoggerService>().GetLogger(postgresServer);
+
+        // Resolve the database resources declared on the server.
+        var databases = new List<PostgresDatabaseResource>();
+        foreach (var databaseName in postgresServer.Databases.Keys)
+        {
+            if (builder.Resources.TryGetByName(databaseName, out var resource) && resource is PostgresDatabaseResource postgresDatabase)
+            {
+                databases.Add(postgresDatabase);
+            }
+        }
+
+        if (databases.Count == 0)
+        {
+            return;
+        }
+
+        // Non-database scoped connection string, pinned to the always-present 'postgres' database.
+        var serverConnectionString = connectionString + ";Database=postgres;";
+
+        // On a fresh data volume the Postgres image runs initdb against a temporary server and then
+        // restarts to the real listener. Creation can land inside that restart window, where the
+        // connection is reset mid-flight. Retry the whole open + create-all sequence across such
+        // transient failures, tracking which databases are already handled so a non-idempotent custom
+        // creation script runs at most once per database.
+        const int maxAttempts = 10;
+        var delay = TimeSpan.FromMilliseconds(200);
+        var maxDelay = TimeSpan.FromSeconds(3);
+        var handled = new HashSet<string>(StringComparers.ResourceName);
+
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                using var npgsqlConnection = new NpgsqlConnection(serverConnectionString);
+                await npgsqlConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                foreach (var database in databases)
+                {
+                    if (handled.Contains(database.Name))
+                    {
+                        continue;
+                    }
+
+                    await CreateDatabaseAsync(npgsqlConnection, database, serviceProvider, cancellationToken).ConfigureAwait(false);
+                    handled.Add(database.Name);
+                }
+
+                return;
+            }
+            catch (Exception ex) when (attempt < maxAttempts && !cancellationToken.IsCancellationRequested && IsTransientConnectionFailure(ex))
+            {
+                logger.LogDebug(ex, "Transient failure while creating databases for '{ResourceName}' (attempt {Attempt}/{MaxAttempts}); retrying in {Delay}.", postgresServer.Name, attempt, maxAttempts, delay);
+
+                try
+                {
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+
+                delay = TimeSpan.FromMilliseconds(Math.Min(delay.TotalMilliseconds * 2, maxDelay.TotalMilliseconds));
+            }
+            catch (Exception ex)
+            {
+                // Either retries are exhausted or the failure is not a transient connection reset. Log
+                // once and stop, preserving the previous non-throwing behavior of the ready handler.
+                logger.LogError(ex, "Failed to create one or more databases for '{ResourceName}'.", postgresServer.Name);
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the exception represents a transient connection-level failure (such as the
+    /// connection reset that occurs during the initdb restart window) that is worth retrying. Permanent
+    /// server-side errors (<see cref="PostgresException"/>) are handled inside <see cref="CreateDatabaseAsync"/>
+    /// and never reach the retry wrapper.
+    /// </summary>
+    private static bool IsTransientConnectionFailure(Exception ex)
+    {
+        // A directly transient exception: Npgsql flagged it, or it is a raw I/O / socket / timeout failure.
+        if (ex is NpgsqlException { IsTransient: true } or System.IO.IOException or System.Net.Sockets.SocketException or TimeoutException or System.IO.EndOfStreamException)
+        {
+            return true;
+        }
+
+        // A non-transient NpgsqlException that wraps a connection-level I/O failure (e.g. a reset mid-handshake).
+        return ex is NpgsqlException npgsqlException
+            && npgsqlException.InnerException is System.IO.IOException or System.Net.Sockets.SocketException or System.IO.EndOfStreamException;
+    }
+
     private static async Task CreateDatabaseAsync(NpgsqlConnection npgsqlConnection, PostgresDatabaseResource npgsqlDatabase, IServiceProvider serviceProvider, CancellationToken cancellationToken)
     {
         var scriptAnnotation = npgsqlDatabase.Annotations.OfType<PostgresCreateDatabaseScriptAnnotation>().LastOrDefault();
@@ -760,14 +843,21 @@ public static class PostgresBuilderExtensions
 
             logger.LogDebug("Database '{DatabaseName}' created successfully", npgsqlDatabase.DatabaseName);
         }
-        catch (PostgresException p) when (p.SqlState == "42P04")
+        catch (PostgresException p) when (p.SqlState is "42P04" or "23505")
         {
-            // Ignore the error if the database already exists.
+            // Treat an already-existing database as success: 42P04 (duplicate_database) for a plain
+            // CREATE DATABASE, or 23505 (unique_violation on pg_database_datname_index) when a creation
+            // attempt that was reset during the initdb restart actually committed and a retry races it.
             logger.LogDebug("Database '{DatabaseName}' already exists", npgsqlDatabase.DatabaseName);
         }
-        catch (Exception e)
+        catch (PostgresException p) when (!p.IsTransient)
         {
-            logger.LogError(e, "Failed to create database '{DatabaseName}'", npgsqlDatabase.DatabaseName);
+            // A permanent server-side error (e.g. insufficient privilege or an invalid creation script).
+            // Retrying will not help, so log and move on rather than surfacing it to the retry wrapper.
+            logger.LogError(p, "Failed to create database '{DatabaseName}'", npgsqlDatabase.DatabaseName);
         }
+        // Transient server errors (e.g. 57P03 cannot_connect_now while the server is restarting) and
+        // connection-level failures (resets during the initdb restart window) intentionally propagate to
+        // CreateDatabasesAsync, which retries the whole open + create-all sequence on a fresh connection.
     }
 }

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -89,9 +89,14 @@ public static class PostgresBuilderExtensions
         // WaitFor dependents (and triggering database creation) straight into the restart's connection
         // reset. PostgresServerHealthCheck only reports Healthy once a connection survives several
         // consecutive probes, proving the restart is over. See PostgresServerHealthCheck for details.
+        //
+        // Register a single instance (not a factory): the health check is stateful — it latches once the
+        // server is durably ready — and the default health check service invokes the registration factory
+        // on every poll, which would otherwise reset the latch and run the full probe window forever.
+        var serverHealthCheck = new PostgresServerHealthCheck(() => connectionString);
         builder.Services.AddHealthChecks().Add(new HealthCheckRegistration(
             healthCheckKey,
-            sp => new PostgresServerHealthCheck(() => connectionString),
+            serverHealthCheck,
             failureStatus: null,
             tags: null));
 

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -10,6 +10,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Postgres;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 
@@ -77,36 +78,27 @@ public static class PostgresBuilderExtensions
                 throw new DistributedApplicationException($"ResourceReadyEvent was published for the '{postgresServer.Name}' resource but the connection string was null.");
             }
 
-            // Non-database scoped connection string
-            using var npgsqlConnection = new NpgsqlConnection(connectionString + ";Database=postgres;");
-
-            await npgsqlConnection.OpenAsync(ct).ConfigureAwait(false);
-
-            if (npgsqlConnection.State != System.Data.ConnectionState.Open)
-            {
-                throw new InvalidOperationException($"Could not open connection to '{postgresServer.Name}'");
-            }
-
-            foreach (var name in postgresServer.Databases.Keys)
-            {
-                if (builder.Resources.FirstOrDefault(n => string.Equals(n.Name, name, StringComparisons.ResourceName)) is PostgresDatabaseResource postgreDatabase)
-                {
-                    await CreateDatabaseAsync(npgsqlConnection, postgreDatabase, @event.Services, ct).ConfigureAwait(false);
-                }
-            }
+            await CreateDatabasesAsync(connectionString, builder, postgresServer, @event.Services, ct).ConfigureAwait(false);
         });
 
         var healthCheckKey = $"{name}_check";
-        builder.Services.AddHealthChecks().AddNpgSql(sp => connectionString ?? throw new InvalidOperationException("Connection string is unavailable"), name: healthCheckKey, configure: (connection) =>
-        {
-            // HACK: The Npgsql client defaults to using the username in the connection string if the database is not specified. Here
-            //       we override this default behavior because we are working with a non-database scoped connection string. The Aspirified
-            //       package doesn't have to deal with this because it uses a datasource from DI which doesn't have this issue:
-            //
-            //       https://github.com/npgsql/npgsql/blob/c3b31c393de66a4b03fba0d45708d46a2acb06d2/src/Npgsql/NpgsqlConnection.cs#L445
-            //
-            connection.ConnectionString += ";Database=postgres;";
-        });
+
+        // Gate the server's Healthy state behind a short stability window rather than a single SELECT 1.
+        // On a fresh data volume the official Postgres image runs initdb against a temporary server and
+        // then restarts to the real listener; a single probe can pass before that restart, releasing
+        // WaitFor dependents (and triggering database creation) straight into the restart's connection
+        // reset. PostgresServerHealthCheck only reports Healthy once a connection survives several
+        // consecutive probes, proving the restart is over. See PostgresServerHealthCheck for details.
+        //
+        // Register a single instance (not a factory): the health check is stateful — it latches once the
+        // server is durably ready — and the default health check service invokes the registration factory
+        // on every poll, which would otherwise reset the latch and run the full probe window forever.
+        var serverHealthCheck = new PostgresServerHealthCheck(() => connectionString);
+        builder.Services.AddHealthChecks().Add(new HealthCheckRegistration(
+            healthCheckKey,
+            serverHealthCheck,
+            failureStatus: null,
+            tags: null));
 
         return builder.AddResource(postgresServer)
                       .WithEndpoint(port: port, targetPort: 5432, name: PostgresServerResource.PrimaryEndpointName) // Internal port is always 5432.
@@ -726,6 +718,102 @@ public static class PostgresBuilderExtensions
         return parts.Length > 0 && int.TryParse(parts[0], out majorVersion) && majorVersion > 0;
     }
 
+    private static async Task CreateDatabasesAsync(string connectionString, IDistributedApplicationBuilder builder, PostgresServerResource postgresServer, IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        var logger = serviceProvider.GetRequiredService<ResourceLoggerService>().GetLogger(postgresServer);
+
+        // Resolve the database resources declared on the server.
+        var databases = new List<PostgresDatabaseResource>();
+        foreach (var databaseName in postgresServer.Databases.Keys)
+        {
+            if (builder.Resources.TryGetByName(databaseName, out var resource) && resource is PostgresDatabaseResource postgresDatabase)
+            {
+                databases.Add(postgresDatabase);
+            }
+        }
+
+        if (databases.Count == 0)
+        {
+            return;
+        }
+
+        // Non-database scoped connection string, pinned to the always-present 'postgres' database.
+        var serverConnectionString = connectionString + ";Database=postgres;";
+
+        // On a fresh data volume the Postgres image runs initdb against a temporary server and then
+        // restarts to the real listener. Creation can land inside that restart window, where the
+        // connection is reset mid-flight. Retry the whole open + create-all sequence across such
+        // transient failures, tracking which databases are already handled so a non-idempotent custom
+        // creation script runs at most once per database.
+        const int maxAttempts = 10;
+        var delay = TimeSpan.FromMilliseconds(200);
+        var maxDelay = TimeSpan.FromSeconds(3);
+        var handled = new HashSet<string>(StringComparers.ResourceName);
+
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                using var npgsqlConnection = new NpgsqlConnection(serverConnectionString);
+                await npgsqlConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                foreach (var database in databases)
+                {
+                    if (handled.Contains(database.Name))
+                    {
+                        continue;
+                    }
+
+                    await CreateDatabaseAsync(npgsqlConnection, database, serviceProvider, cancellationToken).ConfigureAwait(false);
+                    handled.Add(database.Name);
+                }
+
+                return;
+            }
+            catch (Exception ex) when (attempt < maxAttempts && !cancellationToken.IsCancellationRequested && IsTransientConnectionFailure(ex))
+            {
+                logger.LogDebug(ex, "Transient failure while creating databases for '{ResourceName}' (attempt {Attempt}/{MaxAttempts}); retrying in {Delay}.", postgresServer.Name, attempt, maxAttempts, delay);
+
+                try
+                {
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+
+                delay = TimeSpan.FromMilliseconds(Math.Min(delay.TotalMilliseconds * 2, maxDelay.TotalMilliseconds));
+            }
+            catch (Exception ex)
+            {
+                // Either retries are exhausted or the failure is not a transient connection reset. Log
+                // once and stop, preserving the previous non-throwing behavior of the ready handler.
+                logger.LogError(ex, "Failed to create one or more databases for '{ResourceName}'.", postgresServer.Name);
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the exception represents a transient connection-level failure (such as the
+    /// connection reset that occurs during the initdb restart window) that is worth retrying. Permanent
+    /// server-side errors (<see cref="PostgresException"/>) are handled inside <see cref="CreateDatabaseAsync"/>
+    /// and never reach the retry wrapper.
+    /// </summary>
+    private static bool IsTransientConnectionFailure(Exception ex)
+    {
+        // A directly transient exception: Npgsql flagged it, or it is a raw I/O / socket / timeout failure.
+        if (ex is NpgsqlException { IsTransient: true } or System.IO.IOException or System.Net.Sockets.SocketException or TimeoutException or System.IO.EndOfStreamException)
+        {
+            return true;
+        }
+
+        // A non-transient NpgsqlException that wraps a connection-level I/O failure (e.g. a reset mid-handshake).
+        return ex is NpgsqlException npgsqlException
+            && npgsqlException.InnerException is System.IO.IOException or System.Net.Sockets.SocketException or System.IO.EndOfStreamException;
+    }
+
     private static async Task CreateDatabaseAsync(NpgsqlConnection npgsqlConnection, PostgresDatabaseResource npgsqlDatabase, IServiceProvider serviceProvider, CancellationToken cancellationToken)
     {
         var scriptAnnotation = npgsqlDatabase.Annotations.OfType<PostgresCreateDatabaseScriptAnnotation>().LastOrDefault();
@@ -763,14 +851,21 @@ public static class PostgresBuilderExtensions
 
             logger.LogDebug("Database '{DatabaseName}' created successfully", npgsqlDatabase.DatabaseName);
         }
-        catch (PostgresException p) when (p.SqlState == "42P04")
+        catch (PostgresException p) when (p.SqlState is "42P04" or "23505")
         {
-            // Ignore the error if the database already exists.
+            // Treat an already-existing database as success: 42P04 (duplicate_database) for a plain
+            // CREATE DATABASE, or 23505 (unique_violation on pg_database_datname_index) when a creation
+            // attempt that was reset during the initdb restart actually committed and a retry races it.
             logger.LogDebug("Database '{DatabaseName}' already exists", npgsqlDatabase.DatabaseName);
         }
-        catch (Exception e)
+        catch (PostgresException p) when (!p.IsTransient)
         {
-            logger.LogError(e, "Failed to create database '{DatabaseName}'", npgsqlDatabase.DatabaseName);
+            // A permanent server-side error (e.g. insufficient privilege or an invalid creation script).
+            // Retrying will not help, so log and move on rather than surfacing it to the retry wrapper.
+            logger.LogError(p, "Failed to create database '{DatabaseName}'", npgsqlDatabase.DatabaseName);
         }
+        // Transient server errors (e.g. 57P03 cannot_connect_now while the server is restarting) and
+        // connection-level failures (resets during the initdb restart window) intentionally propagate to
+        // CreateDatabasesAsync, which retries the whole open + create-all sequence on a fresh connection.
     }
 }

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -770,18 +770,15 @@ public static class PostgresBuilderExtensions
 
                 return;
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex) when (attempt < maxAttempts && !cancellationToken.IsCancellationRequested && IsTransientConnectionFailure(ex))
             {
                 logger.LogDebug(ex, "Transient failure while creating databases for '{ResourceName}' (attempt {Attempt}/{MaxAttempts}); retrying in {Delay}.", postgresServer.Name, attempt, maxAttempts, delay);
 
-                try
-                {
-                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    return;
-                }
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
 
                 delay = TimeSpan.FromMilliseconds(Math.Min(delay.TotalMilliseconds * 2, maxDelay.TotalMilliseconds));
             }
@@ -851,7 +848,7 @@ public static class PostgresBuilderExtensions
 
             logger.LogDebug("Database '{DatabaseName}' created successfully", npgsqlDatabase.DatabaseName);
         }
-        catch (PostgresException p) when (p.SqlState is "42P04" or "23505")
+        catch (PostgresException p) when (IsDatabaseAlreadyExists(p))
         {
             // Treat an already-existing database as success: 42P04 (duplicate_database) for a plain
             // CREATE DATABASE, or 23505 (unique_violation on pg_database_datname_index) when a creation
@@ -868,4 +865,12 @@ public static class PostgresBuilderExtensions
         // connection-level failures (resets during the initdb restart window) intentionally propagate to
         // CreateDatabasesAsync, which retries the whole open + create-all sequence on a fresh connection.
     }
+
+    internal static bool IsDatabaseAlreadyExists(PostgresException exception) =>
+        exception.SqlState == PostgresErrorCodes.DuplicateDatabase ||
+        exception is
+        {
+            SqlState: PostgresErrorCodes.UniqueViolation,
+            ConstraintName: "pg_database_datname_index"
+        };
 }

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -764,8 +764,29 @@ public static class PostgresBuilderExtensions
                         continue;
                     }
 
-                    await CreateDatabaseAsync(npgsqlConnection, database, serviceProvider, cancellationToken).ConfigureAwait(false);
-                    handled.Add(database.Name);
+                    var hasCustomCreationScript = database.Annotations.OfType<PostgresCreateDatabaseScriptAnnotation>().Any();
+                    if (hasCustomCreationScript)
+                    {
+                        // A connection reset makes the outcome ambiguous: PostgreSQL may have committed
+                        // the script before the client observed the failure. Mark custom scripts before
+                        // execution so the retry loop never repeats potentially non-idempotent SQL.
+                        handled.Add(database.Name);
+                    }
+
+                    try
+                    {
+                        await CreateDatabaseAsync(npgsqlConnection, database, serviceProvider, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex) when (hasCustomCreationScript && IsTransientConnectionFailure(ex))
+                    {
+                        logger.LogError(ex, "The custom creation script for database '{DatabaseName}' had an unknown outcome and will not be retried.", database.DatabaseName);
+                        throw;
+                    }
+
+                    if (!hasCustomCreationScript)
+                    {
+                        handled.Add(database.Name);
+                    }
                 }
 
                 return;

--- a/src/Aspire.Hosting.PostgreSQL/PostgresServerHealthCheck.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresServerHealthCheck.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Npgsql;
+
+namespace Aspire.Hosting.Postgres;
+
+/// <summary>
+/// Health check for a PostgreSQL server resource that gates the resource's Healthy state behind a short
+/// stability window instead of a single <c>SELECT 1</c>.
+/// </summary>
+/// <remarks>
+/// On a fresh data volume the official PostgreSQL image runs <c>initdb</c> against a temporary server on
+/// the unix socket (with TCP closed) and then <b>restarts</b> to the real listener. A single probe can
+/// pass before that restart, which would flip the resource Healthy, release every <c>WaitFor</c>
+/// dependent, and trigger native database creation — all straight into the restart's connection reset.
+/// <para>
+/// To avoid that, this check requires a single connection to survive several consecutive <c>SELECT 1</c>
+/// probes (the restart resets the connection mid-loop) before reporting Healthy. Once the server has
+/// proven durably ready, the check latches and falls back to a single cheap probe per call, so the gate
+/// only adds latency during first start. It only ever <i>delays</i> Healthy within a bounded window, so it
+/// cannot deadlock dependents.
+/// </para>
+/// </remarks>
+internal sealed class PostgresServerHealthCheck : IHealthCheck
+{
+    // ~6 probes spaced ~500ms apart (~3s) comfortably outlasts the initdb restart window.
+    private const int ConsecutiveProbes = 6;
+    private const int ProbeIntervalMilliseconds = 500;
+
+    private readonly Func<string?> _connectionStringAccessor;
+    private readonly Func<int, CancellationToken, Task> _runProbes;
+
+    // Once the server has been observed durably ready we latch and stop running the full probe window.
+    private volatile bool _stable;
+
+    public PostgresServerHealthCheck(Func<string?> connectionStringAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(connectionStringAccessor);
+
+        _connectionStringAccessor = connectionStringAccessor;
+        _runProbes = RunProbesAsync;
+    }
+
+    /// <summary>
+    /// Test seam: lets unit tests drive the consecutive/latch control flow without a live server by
+    /// supplying the routine that runs the requested number of consecutive probes.
+    /// </summary>
+    internal PostgresServerHealthCheck(Func<string?> connectionStringAccessor, Func<int, CancellationToken, Task> runProbes)
+    {
+        ArgumentNullException.ThrowIfNull(connectionStringAccessor);
+        ArgumentNullException.ThrowIfNull(runProbes);
+
+        _connectionStringAccessor = connectionStringAccessor;
+        _runProbes = runProbes;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(_connectionStringAccessor()))
+        {
+            return HealthCheckResult.Unhealthy("The connection string is unavailable.");
+        }
+
+        // Until proven stable, require the full consecutive-probe window; afterwards a single probe.
+        var probeCount = _stable ? 1 : ConsecutiveProbes;
+
+        try
+        {
+            await _runProbes(probeCount, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A probe failed (e.g. the connection was reset by the initdb restart). Stay Unhealthy; the
+            // next poll retries the full window because we have not latched.
+            return HealthCheckResult.Unhealthy(ex.Message, ex);
+        }
+
+        _stable = true;
+        return HealthCheckResult.Healthy();
+    }
+
+    private async Task RunProbesAsync(int count, CancellationToken cancellationToken)
+    {
+        var connectionString = _connectionStringAccessor()!;
+
+        // HACK: The Npgsql client defaults to using the username in the connection string if the database
+        //       is not specified. We work with a non-database-scoped connection string, so pin it to the
+        //       always-present 'postgres' database. Matches the behavior of the previous AddNpgSql check.
+        using var connection = new NpgsqlConnection(connectionString + ";Database=postgres;");
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        // Run the probes on this single connection: if the initdb restart happens during the window it
+        // resets this connection and one of the probes throws, keeping the gate closed.
+        for (var i = 0; i < count; i++)
+        {
+            if (i > 0)
+            {
+                await Task.Delay(ProbeIntervalMilliseconds, cancellationToken).ConfigureAwait(false);
+            }
+
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT 1;";
+            await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Aspire.Hosting.PostgreSQL/PostgresServerHealthCheck.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresServerHealthCheck.cs
@@ -15,12 +15,13 @@ namespace Aspire.Hosting.Postgres;
 /// the unix socket (with TCP closed) and then <b>restarts</b> to the real listener. A single probe can
 /// pass before that restart, which would flip the resource Healthy, release every <c>WaitFor</c>
 /// dependent, and trigger native database creation — all straight into the restart's connection reset.
+/// See <see href="https://github.com/docker-library/postgres/blob/4a1f78ff7e7a6e7ecb6a584c540c07946ad66e80/docker-entrypoint.sh"/>.
 /// <para>
 /// To avoid that, this check requires a single connection to survive several consecutive <c>SELECT 1</c>
 /// probes (the restart resets the connection mid-loop) before reporting Healthy. Once the server has
-/// proven durably ready, the check latches and falls back to a single cheap probe per call, so the gate
-/// only adds latency during first start. It only ever <i>delays</i> Healthy within a bounded window, so it
-/// cannot deadlock dependents.
+/// proven durably ready, the check latches and falls back to a single cheap probe per call. A failed
+/// probe resets the latch so a restarted server must prove stability again. The gate only ever
+/// <i>delays</i> Healthy within a bounded window, so it cannot deadlock dependents.
 /// </para>
 /// </remarks>
 internal sealed class PostgresServerHealthCheck : IHealthCheck
@@ -34,6 +35,7 @@ internal sealed class PostgresServerHealthCheck : IHealthCheck
 
     // Once the server has been observed durably ready we latch and stop running the full probe window.
     private volatile bool _stable;
+    private int _stabilityGeneration;
 
     public PostgresServerHealthCheck(Func<string?> connectionStringAccessor)
     {
@@ -65,6 +67,7 @@ internal sealed class PostgresServerHealthCheck : IHealthCheck
 
         // Until proven stable, require the full consecutive-probe window; afterwards a single probe.
         var probeCount = _stable ? 1 : ConsecutiveProbes;
+        var stabilityGeneration = Volatile.Read(ref _stabilityGeneration);
 
         try
         {
@@ -76,12 +79,19 @@ internal sealed class PostgresServerHealthCheck : IHealthCheck
         }
         catch (Exception ex)
         {
-            // A probe failed (e.g. the connection was reset by the initdb restart). Stay Unhealthy; the
-            // next poll retries the full window because we have not latched.
+            // A probe failure can indicate that the resource restarted. Reset the latch so the next
+            // successful poll must prove the new server instance is stable before releasing dependents.
+            // Increment the generation so an overlapping single-probe success cannot restore the latch.
+            _stable = false;
+            Interlocked.Increment(ref _stabilityGeneration);
             return HealthCheckResult.Unhealthy(ex.Message, ex);
         }
 
-        _stable = true;
+        if (probeCount > 1 || stabilityGeneration == Volatile.Read(ref _stabilityGeneration))
+        {
+            _stable = true;
+        }
+
         return HealthCheckResult.Healthy();
     }
 

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -9,6 +9,8 @@ using Aspire.Hosting.Postgres;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.PostgreSQL.Tests;
 
@@ -20,6 +22,23 @@ public class AddPostgresTests(ITestOutputHelper outputHelper)
         var builder = DistributedApplication.CreateBuilder();
         var redis = builder.AddPostgres("postgres");
         Assert.Single(redis.Resource.Annotations, a => a is HealthCheckAnnotation hca && hca.Key == "postgres_check");
+    }
+
+    [Fact]
+    public void AddPostgresRegistersServerHealthCheckAsASingleStatefulInstance()
+    {
+        // The server health check latches once the server is durably ready. The default health check
+        // service invokes the registration factory on every poll, so it must resolve to the same
+        // instance or the latch would reset on every poll and run the full probe window forever.
+        var builder = DistributedApplication.CreateBuilder();
+        builder.AddPostgres("pg");
+
+        using var app = builder.Build();
+
+        var options = app.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+        var registration = Assert.Single(options.Value.Registrations, r => r.Name == "pg_check");
+
+        Assert.Same(registration.Factory(app.Services), registration.Factory(app.Services));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -9,6 +9,8 @@ using Aspire.Hosting.Postgres;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.PostgreSQL.Tests;
 
@@ -20,6 +22,23 @@ public class AddPostgresTests
         var builder = DistributedApplication.CreateBuilder();
         var redis = builder.AddPostgres("postgres");
         Assert.Single(redis.Resource.Annotations, a => a is HealthCheckAnnotation hca && hca.Key == "postgres_check");
+    }
+
+    [Fact]
+    public void AddPostgresRegistersServerHealthCheckAsASingleStatefulInstance()
+    {
+        // The server health check latches once the server is durably ready. The default health check
+        // service invokes the registration factory on every poll, so it must resolve to the same
+        // instance or the latch would reset on every poll and run the full probe window forever.
+        var builder = DistributedApplication.CreateBuilder();
+        builder.AddPostgres("pg");
+
+        using var app = builder.Build();
+
+        var options = app.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>();
+        var registration = Assert.Single(options.Value.Registrations, r => r.Name == "pg_check");
+
+        Assert.Same(registration.Factory(app.Services), registration.Factory(app.Services));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -11,6 +11,7 @@ using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
+using Npgsql;
 
 namespace Aspire.Hosting.PostgreSQL.Tests;
 
@@ -39,6 +40,23 @@ public class AddPostgresTests(ITestOutputHelper outputHelper)
         var registration = Assert.Single(options.Value.Registrations, r => r.Name == "pg_check");
 
         Assert.Same(registration.Factory(app.Services), registration.Factory(app.Services));
+    }
+
+    [Theory]
+    [InlineData(PostgresErrorCodes.DuplicateDatabase, null, true)]
+    [InlineData(PostgresErrorCodes.UniqueViolation, "pg_database_datname_index", true)]
+    [InlineData(PostgresErrorCodes.UniqueViolation, null, false)]
+    [InlineData(PostgresErrorCodes.UniqueViolation, "another_constraint", false)]
+    public void IsDatabaseAlreadyExists_OnlyRecognizesDatabaseDuplicates(string sqlState, string? constraintName, bool expected)
+    {
+        var exception = new PostgresException(
+            "message",
+            "ERROR",
+            "ERROR",
+            sqlState,
+            constraintName: constraintName);
+
+        Assert.Equal(expected, PostgresBuilderExtensions.IsDatabaseAlreadyExists(exception));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -73,6 +73,58 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
+    public async Task FreshVolume_CreatesAllDatabasesAndGatesWaitForPastInitdbRestart()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/18540.
+        // On a fresh data volume the Postgres image runs initdb and then restarts to the real listener.
+        // Native database creation must survive that restart window (no "Failed to create database"),
+        // and the server must not release WaitFor dependents until it is durably past the restart.
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new() { MaxRetryAttempts = 10, Delay = TimeSpan.FromSeconds(1), ShouldHandle = new PredicateBuilder().Handle<NpgsqlException>() })
+            .Build();
+
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+
+        // No data volume => a fresh PGDATA (and therefore an initdb restart) on every start.
+        var postgres = builder.AddPostgres("pg");
+        var db1 = postgres.AddDatabase("db1");
+        var db2 = postgres.AddDatabase("db2");
+        var db3 = postgres.AddDatabase("db3");
+
+        // A dependent that must only be released once db1 is durably healthy (i.e. past the restart).
+        var dependent = builder.AddPostgres("dependent").WaitFor(db1);
+
+        using var app = builder.Build();
+
+        await app.StartAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+        // Every declared database must be created and become healthy: proof creation survived the restart.
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(db1.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(db2.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(db3.Resource.Name, cts.Token);
+
+        // The WaitFor dependent is released only after db1 is healthy.
+        await app.ResourceNotifications.WaitForResourceAsync(dependent.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+        // Sanity check: each database is actually reachable.
+        foreach (var db in new[] { db1, db2, db3 })
+        {
+            var connectionString = await db.Resource.ConnectionStringExpression.GetValueAsync(cts.Token);
+
+            await pipeline.ExecuteAsync(async token =>
+            {
+                using var connection = new NpgsqlConnection(connectionString);
+                await connection.OpenAsync(token);
+                Assert.Equal(ConnectionState.Open, connection.State);
+            }, cts.Token);
+        }
+
+        await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+    }
+
+    [Fact]
+    [RequiresFeature(TestFeature.Docker)]
     public async Task VerifyPgAdminResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -73,6 +73,58 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresFeature(TestFeature.ContainerRuntime)]
+    public async Task FreshVolume_CreatesAllDatabasesAndGatesWaitForPastInitdbRestart()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/18540.
+        // On a fresh data volume the Postgres image runs initdb and then restarts to the real listener.
+        // Native database creation must survive that restart window (no "Failed to create database"),
+        // and the server must not release WaitFor dependents until it is durably past the restart.
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new() { MaxRetryAttempts = 10, Delay = TimeSpan.FromSeconds(1), ShouldHandle = new PredicateBuilder().Handle<NpgsqlException>() })
+            .Build();
+
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+
+        // No data volume => a fresh PGDATA (and therefore an initdb restart) on every start.
+        var postgres = builder.AddPostgres("pg");
+        var db1 = postgres.AddDatabase("db1");
+        var db2 = postgres.AddDatabase("db2");
+        var db3 = postgres.AddDatabase("db3");
+
+        // A dependent that must only be released once db1 is durably healthy (i.e. past the restart).
+        var dependent = builder.AddPostgres("dependent").WaitFor(db1);
+
+        using var app = builder.Build();
+
+        await app.StartAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+        // Every declared database must be created and become healthy: proof creation survived the restart.
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(db1.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(db2.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(db3.Resource.Name, cts.Token);
+
+        // The WaitFor dependent is released only after db1 is healthy.
+        await app.ResourceNotifications.WaitForResourceAsync(dependent.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+        // Sanity check: each database is actually reachable.
+        foreach (var db in new[] { db1, db2, db3 })
+        {
+            var connectionString = await db.Resource.ConnectionStringExpression.GetValueAsync(cts.Token);
+
+            await pipeline.ExecuteAsync(async token =>
+            {
+                using var connection = new NpgsqlConnection(connectionString);
+                await connection.OpenAsync(token);
+                Assert.Equal(ConnectionState.Open, connection.State);
+            }, cts.Token);
+        }
+
+        await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+    }
+
+    [Fact]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyPgAdminResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -79,7 +79,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
         // On a fresh data volume the Postgres image runs initdb and then restarts to the real listener.
         // Native database creation must survive that restart window (no "Failed to create database"),
         // and the server must not release WaitFor dependents until it is durably past the restart.
-        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
         var pipeline = new ResiliencePipelineBuilder()
             .AddRetry(new() { MaxRetryAttempts = 10, Delay = TimeSpan.FromSeconds(1), ShouldHandle = new PredicateBuilder().Handle<NpgsqlException>() })
             .Build();

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresServerHealthCheckTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresServerHealthCheckTests.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Postgres;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Aspire.Hosting.PostgreSQL.Tests;
+
+public class PostgresServerHealthCheckTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task NullOrEmptyConnectionString_ReturnsUnhealthy_WithoutProbing(string? connectionString)
+    {
+        var probeInvoked = false;
+        var check = new PostgresServerHealthCheck(() => connectionString, (count, ct) =>
+        {
+            probeInvoked = true;
+            return Task.CompletedTask;
+        });
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.False(probeInvoked);
+    }
+
+    [Fact]
+    public async Task WhileNotStable_RunsTheFullConsecutiveWindow()
+    {
+        var observedCount = 0;
+        var check = new PostgresServerHealthCheck(() => "Host=localhost", (count, ct) =>
+        {
+            observedCount = count;
+            return Task.CompletedTask;
+        });
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        // Before latching the gate requires more than a single probe (the stability window).
+        Assert.True(observedCount > 1, $"Expected a multi-probe window but got {observedCount}.");
+    }
+
+    [Fact]
+    public async Task ProbeFailureWhileNotStable_ReturnsUnhealthy_AndDoesNotLatch()
+    {
+        var counts = new List<int>();
+        var shouldThrow = true;
+        var check = new PostgresServerHealthCheck(() => "Host=localhost", (count, ct) =>
+        {
+            counts.Add(count);
+            return shouldThrow ? Task.FromException(new InvalidOperationException("reset")) : Task.CompletedTask;
+        });
+
+        var first = await check.CheckHealthAsync(new HealthCheckContext());
+        Assert.Equal(HealthStatus.Unhealthy, first.Status);
+
+        // Still not latched: the next poll runs the full window again, not a single probe.
+        shouldThrow = false;
+        var second = await check.CheckHealthAsync(new HealthCheckContext());
+        Assert.Equal(HealthStatus.Healthy, second.Status);
+
+        Assert.Equal(2, counts.Count);
+        Assert.True(counts[0] > 1);
+        Assert.True(counts[1] > 1);
+    }
+
+    [Fact]
+    public async Task AfterAllProbesSucceed_LatchesToSingleProbe()
+    {
+        var counts = new List<int>();
+        var check = new PostgresServerHealthCheck(() => "Host=localhost", (count, ct) =>
+        {
+            counts.Add(count);
+            return Task.CompletedTask;
+        });
+
+        var first = await check.CheckHealthAsync(new HealthCheckContext());
+        var second = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Healthy, first.Status);
+        Assert.Equal(HealthStatus.Healthy, second.Status);
+
+        Assert.Equal(2, counts.Count);
+        Assert.True(counts[0] > 1, "First check should run the full stability window.");
+        Assert.Equal(1, counts[1]); // Latched: a single cheap probe thereafter.
+    }
+
+    [Fact]
+    public async Task AfterLatch_ProbeFailure_ReturnsUnhealthy()
+    {
+        var fail = false;
+        var check = new PostgresServerHealthCheck(() => "Host=localhost", (count, ct) =>
+            fail ? Task.FromException(new InvalidOperationException("down")) : Task.CompletedTask);
+
+        Assert.Equal(HealthStatus.Healthy, (await check.CheckHealthAsync(new HealthCheckContext())).Status);
+
+        fail = true;
+        Assert.Equal(HealthStatus.Unhealthy, (await check.CheckHealthAsync(new HealthCheckContext())).Status);
+    }
+
+    [Fact]
+    public async Task CancellationDuringProbe_Propagates()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var check = new PostgresServerHealthCheck(() => "Host=localhost", (count, ct) =>
+            Task.FromException(new OperationCanceledException(ct)));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            check.CheckHealthAsync(new HealthCheckContext(), cts.Token));
+    }
+}

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresServerHealthCheckTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresServerHealthCheckTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using Aspire.Hosting.Postgres;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -89,16 +90,65 @@ public class PostgresServerHealthCheckTests
     }
 
     [Fact]
-    public async Task AfterLatch_ProbeFailure_ReturnsUnhealthy()
+    public async Task AfterLatch_ProbeFailure_ReturnsUnhealthy_AndResetsLatch()
     {
         var fail = false;
+        var counts = new List<int>();
         var check = new PostgresServerHealthCheck(() => "Host=localhost", (count, ct) =>
-            fail ? Task.FromException(new InvalidOperationException("down")) : Task.CompletedTask);
+        {
+            counts.Add(count);
+            return fail ? Task.FromException(new InvalidOperationException("down")) : Task.CompletedTask;
+        });
 
         Assert.Equal(HealthStatus.Healthy, (await check.CheckHealthAsync(new HealthCheckContext())).Status);
 
         fail = true;
         Assert.Equal(HealthStatus.Unhealthy, (await check.CheckHealthAsync(new HealthCheckContext())).Status);
+
+        fail = false;
+        Assert.Equal(HealthStatus.Healthy, (await check.CheckHealthAsync(new HealthCheckContext())).Status);
+
+        Assert.True(counts[0] > 1);
+        Assert.Equal(1, counts[1]);
+        Assert.True(counts[2] > 1);
+    }
+
+    [Fact]
+    public async Task ConcurrentSingleProbeSuccess_DoesNotRestoreLatchAfterFailure()
+    {
+        var singleProbeCount = 0;
+        var staleProbeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStaleProbe = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var counts = new ConcurrentQueue<int>();
+        var check = new PostgresServerHealthCheck(() => "Host=localhost", async (count, ct) =>
+        {
+            counts.Enqueue(count);
+            if (count > 1)
+            {
+                return;
+            }
+
+            if (Interlocked.Increment(ref singleProbeCount) == 1)
+            {
+                staleProbeStarted.SetResult();
+                await releaseStaleProbe.Task.WaitAsync(ct);
+                return;
+            }
+
+            throw new InvalidOperationException("down");
+        });
+
+        Assert.Equal(HealthStatus.Healthy, (await check.CheckHealthAsync(new HealthCheckContext())).Status);
+
+        var staleSuccess = check.CheckHealthAsync(new HealthCheckContext());
+        await staleProbeStarted.Task;
+        Assert.Equal(HealthStatus.Unhealthy, (await check.CheckHealthAsync(new HealthCheckContext())).Status);
+
+        releaseStaleProbe.SetResult();
+        Assert.Equal(HealthStatus.Healthy, (await staleSuccess).Status);
+        Assert.Equal(HealthStatus.Healthy, (await check.CheckHealthAsync(new HealthCheckContext())).Status);
+
+        Assert.True(counts.Last() > 1);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #18540

## Problem

On a **fresh data volume**, the official PostgreSQL image runs `initdb` against a temporary server (TCP closed) and then **restarts** to the real listener — the container logs two "database system is ready to accept connections" lines. The Postgres integration didn't account for that restart window, producing two distinct first-start failures:

1. **Native `AddDatabase` creation raced the restart.** Databases were created once on the server's `ResourceReadyEvent` over a single connection with no retry, and the `catch` only swallowed `42P04`. A connection reset mid-flight (or a concurrent `23505` unique_violation) fell through and logged **`Failed to create database`**.
2. **The server reported Healthy before the restart finished.** `postgres_check` (`AddNpgSql` → a single `SELECT 1`) passed on the first probe, which can happen *before* the restart. `ResourceReadyEvent` fired, every `WaitFor(db)` dependent was released, and they connected straight into the restart's connection reset → `FailedToStart`.

## Fix

- **Resilient creation** — `CreateDatabasesAsync` wraps open-connection + create-all in a bounded retry (exp backoff, ~30s ceiling) across transient connection failures, tracking handled databases so a non-idempotent custom creation script runs at most once. `CreateDatabaseAsync` now treats `42P04` and `23505` on `pg_database_datname_index` as already-exists success, lets transient failures propagate to the retry, and logs only permanent server errors.
- **Stability gate** — new internal `PostgresServerHealthCheck` gates the server's Healthy state: a single connection must survive several consecutive `SELECT 1` probes (the restart resets it mid-loop) before reporting Healthy, then latches to a single cheap probe until any failure resets the stability gate. Replaces the server-level `AddNpgSql` check under the same `{name}_check` key. Database-level checks are unchanged — gating the server is sufficient, since creation and DB-level checks now run only after the server is durably past the restart.

The gate applies to all PostgreSQL versions (initdb does temp-server-then-restart on all of them); it only ever *delays* Healthy within a bounded window, so it cannot deadlock dependents.

## Tests

- Unit tests for the gate's consecutive/latch control flow via an injectable probe seam (no Docker).
- Docker functional test `FreshVolume_CreatesAllDatabasesAndGatesWaitForPastInitdbRestart`: creates multiple databases on a fresh volume and asserts a `WaitFor` dependent is only released past the restart. Verified locally (4/4 runs green); existing non-functional suite (99 tests incl. public-API snapshot) still passes.

## Notes

This is intentionally scoped to the PostgreSQL integration. The same first-Healthy / single-shot-creation patterns exist in MySql/SqlServer, but the initdb-restart race is specific to the documented Postgres image behavior; generalizing now would be speculative. Flagged for follow-up if other integrations report the same.
