### PR TITLE
Fix flaky LoggerFactoryIsUsedByRegisteredClient conformance test

### DIFF
--- a/tests/Aspire.Azure.AI.Inference.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.AI.Inference.Tests/ConformanceTests.cs
@@ -18,7 +18,7 @@ public class ConformanceTests : ConformanceTests<IChatClient, ChatCompletionsCli
 
     protected override string ActivitySourceName => "Experimental.Microsoft.Extensions.AI";
 
-    protected override string[] RequiredLogCategories => ["Azure.Identity"];
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Azure.Identity")];
 
     protected override string? ConfigurationSectionName => "Aspire:Azure:AI:Inference";
 

--- a/tests/Aspire.Azure.AI.OpenAI.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.AI.OpenAI.Tests/ConformanceTests.cs
@@ -17,9 +17,10 @@ public class ConformanceTests : ConformanceTests<IChatClient, AzureOpenAISetting
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
-    protected override string[] RequiredLogCategories => [
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
         // since we don't have a way to connect to the server, we can't test the actual calls
-        "Azure.Identity"
+        new("Azure.Identity"),
     ];
 
     protected override bool SupportsKeyedRegistrations => true;

--- a/tests/Aspire.Azure.Data.Tables.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Data.Tables.Tests/ConformanceTests.cs
@@ -55,11 +55,11 @@ public class ConformanceTests : ConformanceTests<TableServiceClient, AzureDataTa
             ("""{"Aspire": { "Azure": { "Data":{ "Tables": { "ServiceUri": "http://YOUR_URI", "ClientOptions": {"Retry": {"NetworkTimeout": "3S"}}}}}}}""", "The string value is not a match for the indicated regular expression")
         };
 
-    protected override string[] RequiredLogCategories => new string[]
-    {
-        "Azure.Identity",
-        "Azure.Core"
-    };
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("Azure.Identity"),
+        new("Azure.Core"),
+    ];
 
     protected override bool SupportsKeyedRegistrations => true;
 

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/ConformanceTests.EventProcessorClient.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/ConformanceTests.EventProcessorClient.cs
@@ -3,13 +3,14 @@
 
 using Azure.Identity;
 using Azure.Messaging.EventHubs;
+using Aspire.Components.ConformanceTests;
 using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Azure.Messaging.EventHubs.Tests;
 
 public class ConformanceTests_EventProcessorClient : ConformanceTestsBase<EventProcessorClient, AzureMessagingEventHubsProcessorSettings>
 {
-    protected override string[] RequiredLogCategories => ["Azure.Core", "Azure.Messaging.EventHubs.Processor.BlobEventStore"];
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Azure.Core"), new("Azure.Messaging.EventHubs.Processor.BlobEventStore")];
 
     protected override void SetHealthCheck(AzureMessagingEventHubsProcessorSettings options, bool enabled)
         => options.DisableHealthChecks = !enabled;

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/ConformanceTestsBase.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/ConformanceTestsBase.cs
@@ -22,7 +22,7 @@ public abstract class ConformanceTestsBase<TService, TOptions> : ConformanceTest
 
     protected override string ActivitySourceName => $"Azure.Messaging.EventHubs.{typeof(TService).Name}";
 
-    protected override string[] RequiredLogCategories => ["Azure.Messaging.EventHubs"];
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Azure.Messaging.EventHubs", AllowPrefixMatch: true)];
 
     protected override string ValidJsonConfig => $$"""
         {

--- a/tests/Aspire.Azure.Messaging.ServiceBus.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Messaging.ServiceBus.Tests/ConformanceTests.cs
@@ -26,7 +26,7 @@ public abstract class ConformanceTests : ConformanceTests<ServiceBusClient, Azur
 
     protected override string ActivitySourceName => "Azure.Messaging.ServiceBus.ServiceBusReceiver";
 
-    protected override string[] RequiredLogCategories => new string[] { "Azure.Messaging.ServiceBus" };
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Azure.Messaging.ServiceBus")];
 
     protected override bool SupportsKeyedRegistrations => true;
 

--- a/tests/Aspire.Azure.Messaging.WebPubSub.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Messaging.WebPubSub.Tests/ConformanceTests.cs
@@ -21,7 +21,7 @@ public class ConformanceTests : ConformanceTests<WebPubSubServiceClient, AzureMe
 
     protected override string ActivitySourceName => "Azure.Messaging.WebPubSub.*";
 
-    protected override string[] RequiredLogCategories => ["Azure.Core"];
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Azure.Core")];
 
     protected override bool SupportsKeyedRegistrations => true;
 

--- a/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
@@ -22,20 +22,20 @@ public class ConformanceTests : ConformanceTests<TestDbContext, AzureNpgsqlEntit
     // https://github.com/npgsql/npgsql/blob/ef9db1ffe9e432c1562d855b46dfac3514726b1b/src/Npgsql.OpenTelemetry/TracerProviderBuilderExtensions.cs#L18
     protected override string ActivitySourceName => "Npgsql";
 
-    protected override string[] RequiredLogCategories => new string[]
-    {
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.ChangeTracking",
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.Database.Command",
-        "Microsoft.EntityFrameworkCore.Query",
-        "Microsoft.EntityFrameworkCore.Database.Transaction",
-        "Microsoft.EntityFrameworkCore.Database.Connection",
-        "Microsoft.EntityFrameworkCore.Model",
-        "Microsoft.EntityFrameworkCore.Model.Validation",
-        "Microsoft.EntityFrameworkCore.Update",
-        "Microsoft.EntityFrameworkCore.Migrations"
-    };
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.ChangeTracking"),
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.Database.Command"),
+        new("Microsoft.EntityFrameworkCore.Query"),
+        new("Microsoft.EntityFrameworkCore.Database.Transaction"),
+        new("Microsoft.EntityFrameworkCore.Database.Connection"),
+        new("Microsoft.EntityFrameworkCore.Model"),
+        new("Microsoft.EntityFrameworkCore.Model.Validation"),
+        new("Microsoft.EntityFrameworkCore.Update"),
+        new("Microsoft.EntityFrameworkCore.Migrations"),
+    ];
 
     // we don't want to have both EF and Npgsql loggers to be enabled
     protected override string[] NotAcceptableLogCategories => new string[]

--- a/tests/Aspire.Azure.Npgsql.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Npgsql.Tests/ConformanceTests.cs
@@ -21,15 +21,15 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, AzureNpgsqlSe
     // https://github.com/npgsql/npgsql/blob/ef9db1ffe9e432c1562d855b46dfac3514726b1b/src/Npgsql.OpenTelemetry/TracerProviderBuilderExtensions.cs#L18
     protected override string ActivitySourceName => "Npgsql";
 
-    protected override string[] RequiredLogCategories => new string[]
-    {
-        "Npgsql.Connection",
-        "Npgsql.Command",
-        "Npgsql.Transaction",
-        "Npgsql.Copy",
-        "Npgsql.Replication",
-        "Npgsql.Exception"
-    };
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("Npgsql.Connection"),
+        new("Npgsql.Command"),
+        new("Npgsql.Transaction"),
+        new("Npgsql.Copy"),
+        new("Npgsql.Replication"),
+        new("Npgsql.Exception"),
+    ];
 
     protected override bool SupportsKeyedRegistrations => true;
 

--- a/tests/Aspire.Azure.Search.Documents.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Search.Documents.Tests/ConformanceTests.cs
@@ -17,7 +17,7 @@ public class ConformanceTests : ConformanceTests<SearchIndexClient, AzureSearchS
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
-    protected override string[] RequiredLogCategories => ["Azure.Identity"];
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Azure.Identity")];
 
     protected override bool SupportsKeyedRegistrations => true;
 

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/CertificateClientConformanceTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/CertificateClientConformanceTests.cs
@@ -22,7 +22,7 @@ public class CertificateClientConformanceTests : ConformanceTests<CertificateCli
 
     protected override string ActivitySourceName => "Azure.Security.KeyVault.Certificates.CertificateClient";
 
-    protected override string[] RequiredLogCategories => new string[] { "Azure.Core" };
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Azure.Core")];
 
     protected override bool SupportsKeyedRegistrations => true;
 

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/KeyClientConformanceTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/KeyClientConformanceTests.cs
@@ -24,7 +24,7 @@ public class KeyClientConformanceTests : ConformanceTests<KeyClient, AzureSecuri
 
     protected override string ActivitySourceName => "Azure.Security.KeyVault.Keys.KeyClient";
 
-    protected override string[] RequiredLogCategories => new string[] { "Azure.Core" };
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Azure.Core")];
 
     protected override bool SupportsKeyedRegistrations => true;
 

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/SecretClientConformanceTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/SecretClientConformanceTests.cs
@@ -23,7 +23,7 @@ public class SecretClientConformanceTests : ConformanceTests<SecretClient, Azure
 
     protected override string ActivitySourceName => "Azure.Security.KeyVault.Secrets.SecretClient";
 
-    protected override string[] RequiredLogCategories => new string[] { "Azure.Core" };
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Azure.Core")];
 
     protected override bool SupportsKeyedRegistrations => true;
 

--- a/tests/Aspire.Azure.Storage.Blobs.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Storage.Blobs.Tests/ConformanceTests.cs
@@ -26,11 +26,11 @@ public class ConformanceTests : ConformanceTests<BlobServiceClient, AzureStorage
     // AzureStorageBlobsSettings subclassed by AzureBlobStorageContainerSettings
     protected override bool CheckOptionClassSealed => false;
 
-    protected override string[] RequiredLogCategories => new string[]
-    {
-        "Azure.Core",
-        "Azure.Identity"
-    };
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("Azure.Core"),
+        new("Azure.Identity"),
+    ];
 
     protected override bool SupportsKeyedRegistrations => true;
 

--- a/tests/Aspire.Azure.Storage.Files.DataLake.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Storage.Files.DataLake.Tests/ConformanceTests.cs
@@ -23,7 +23,7 @@ public sealed class ConformanceTests : ConformanceTests<DataLakeServiceClient, A
 
     // AzureDataLakeSettings subclassed by AzureDataLakeFileSystemSettings
     protected override bool CheckOptionClassSealed => false;
-    protected override string[] RequiredLogCategories => ["Azure.Core", "Azure.Identity"];
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Azure.Core"), new("Azure.Identity")];
     protected override bool SupportsKeyedRegistrations => true;
     protected override bool CanConnectToServer => s_canConnectToServer.Value;
     protected override string ConfigurationSectionName => "Aspire:Azure:Storage:Files:DataLake";

--- a/tests/Aspire.Azure.Storage.Queues.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Storage.Queues.Tests/ConformanceTests.cs
@@ -25,11 +25,11 @@ public class ConformanceTests : ConformanceTests<QueueServiceClient, AzureStorag
 
     protected override bool CheckOptionClassSealed => false;
 
-    protected override string[] RequiredLogCategories => new string[]
-    {
-        "Azure.Core",
-        "Azure.Identity"
-    };
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("Azure.Core"),
+        new("Azure.Identity"),
+    ];
 
     protected override bool SupportsKeyedRegistrations => true;
 

--- a/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
@@ -17,6 +17,13 @@ using Microsoft.DotNet.RemoteExecutor;
 
 namespace Aspire.Components.ConformanceTests;
 
+/// <summary>
+/// Describes a logger category that must appear during a conformance test.
+/// When <see cref="AllowPrefixMatch"/> is <see langword="true"/>, any logged
+/// category that starts with <see cref="Name"/> satisfies the requirement.
+/// </summary>
+public readonly record struct RequiredLogCategory(string Name, bool AllowPrefixMatch = false);
+
 public abstract class ConformanceTests<TService, TOptions>
     where TService : class
     where TOptions : class, new()
@@ -52,7 +59,7 @@ public abstract class ConformanceTests<TService, TOptions>
 
     protected virtual (string json, string error)[] InvalidJsonToErrorMessage => Array.Empty<(string json, string error)>();
 
-    protected abstract string[] RequiredLogCategories { get; }
+    protected abstract RequiredLogCategory[] RequiredLogCategories { get; }
 
     protected virtual string[] NotAcceptableLogCategories => Array.Empty<string>();
 
@@ -334,10 +341,13 @@ public abstract class ConformanceTests<TService, TOptions>
             }
             Output.WriteLine("");
             Output.WriteLine("=== Required Categories ===");
-            foreach (var category in RequiredLogCategories.OrderBy(c => c))
+            foreach (var req in RequiredLogCategories.OrderBy(c => c.Name))
             {
-                var found = loggerFactory.Categories.Contains(category);
-                Output.WriteLine($"  {(found ? "✓" : "✗")} {category}");
+                var found = req.AllowPrefixMatch
+                    ? loggerFactory.Categories.Any(c => c.StartsWith(req.Name, StringComparison.Ordinal))
+                    : loggerFactory.Categories.Contains(req.Name);
+                var suffix = req.AllowPrefixMatch ? " (prefix)" : "";
+                Output.WriteLine($"  {(found ? "✓" : "✗")} {req.Name}{suffix}");
             }
             if (NotAcceptableLogCategories.Length > 0)
             {
@@ -352,9 +362,16 @@ public abstract class ConformanceTests<TService, TOptions>
             Output.WriteLine("");
         }
 
-        foreach (string logCategory in RequiredLogCategories)
+        foreach (var req in RequiredLogCategories)
         {
-            Assert.Contains(logCategory, loggerFactory.Categories);
+            if (req.AllowPrefixMatch)
+            {
+                Assert.Contains(loggerFactory.Categories, c => c.StartsWith(req.Name, StringComparison.Ordinal));
+            }
+            else
+            {
+                Assert.Contains(req.Name, loggerFactory.Categories);
+            }
         }
 
         foreach (string logCategory in NotAcceptableLogCategories)

--- a/tests/Aspire.Confluent.Kafka.Tests/ConsumerConformanceTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/ConsumerConformanceTests.cs
@@ -15,9 +15,7 @@ public class ConsumerConformanceTests : ConformanceTests<IConsumer<string, strin
 
     protected override string ActivitySourceName => throw new NotImplementedException();
 
-    protected override string[] RequiredLogCategories => [
-        "Aspire.Confluent.Kafka"
-        ];
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Aspire.Confluent.Kafka")];
 
     protected override string? ConfigurationSectionName => "Aspire:Confluent:Kafka:Consumer";
 

--- a/tests/Aspire.Confluent.Kafka.Tests/ProducerConformanceTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/ProducerConformanceTests.cs
@@ -16,9 +16,7 @@ public class ProducerConformanceTests : ConformanceTests<IProducer<string, strin
 
     protected override string ActivitySourceName => throw new NotImplementedException();
 
-    protected override string[] RequiredLogCategories => [
-        "Aspire.Confluent.Kafka"
-        ];
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Aspire.Confluent.Kafka")];
 
     protected override string? ConfigurationSectionName => "Aspire:Confluent:Kafka:Producer";
 

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConformanceTests.cs
@@ -16,7 +16,7 @@ public class ConformanceTests : ConformanceTests<CosmosClient, MicrosoftAzureCos
 
     protected override string ActivitySourceName => "Azure.Cosmos.Operation";
 
-    protected override string[] RequiredLogCategories => Array.Empty<string>();
+    protected override RequiredLogCategory[] RequiredLogCategories => [];
 
     protected override void PopulateConfiguration(ConfigurationManager configuration, string? key = null)
         => configuration.AddInMemoryCollection(new KeyValuePair<string, string?>[1]

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/ConformanceTests.cs
@@ -22,7 +22,7 @@ public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSql
     protected override string ActivitySourceName => "OpenTelemetry.Instrumentation.SqlClient";
 
     // TODO
-    protected override string[] RequiredLogCategories => Array.Empty<string>();
+    protected override RequiredLogCategory[] RequiredLogCategories => [];
 
     protected override bool SupportsKeyedRegistrations => true;
 

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/ConformanceTests.cs
@@ -17,13 +17,13 @@ public class ConformanceTests : ConformanceTests<TestDbContext, EntityFrameworkC
 
     protected override string ActivitySourceName => "Azure.Cosmos.Operation";
 
-    protected override string[] RequiredLogCategories => new string[]
-    {
-        "Microsoft.EntityFrameworkCore.ChangeTracking",
-        "Microsoft.EntityFrameworkCore.Database.Command",
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.Query",
-    };
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("Microsoft.EntityFrameworkCore.ChangeTracking"),
+        new("Microsoft.EntityFrameworkCore.Database.Command"),
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.Query"),
+    ];
 
     protected override void PopulateConfiguration(ConfigurationManager configuration, string? key = null)
         => configuration.AddInMemoryCollection(new KeyValuePair<string, string?>[]

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests.cs
@@ -23,20 +23,20 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MicrosoftEntityF
     // https://github.com/open-telemetry/opentelemetry-dotnet/blob/031ed48714e16ba4a5b099b6e14647994a0b9c1b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs#L31
     protected override string ActivitySourceName => "OpenTelemetry.Instrumentation.SqlClient";
 
-    protected override string[] RequiredLogCategories => new string[]
-    {
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.ChangeTracking",
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.Database.Command",
-        "Microsoft.EntityFrameworkCore.Query",
-        "Microsoft.EntityFrameworkCore.Database.Transaction",
-        "Microsoft.EntityFrameworkCore.Database.Connection",
-        "Microsoft.EntityFrameworkCore.Model",
-        "Microsoft.EntityFrameworkCore.Model.Validation",
-        "Microsoft.EntityFrameworkCore.Update",
-        "Microsoft.EntityFrameworkCore.Migrations"
-    };
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.ChangeTracking"),
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.Database.Command"),
+        new("Microsoft.EntityFrameworkCore.Query"),
+        new("Microsoft.EntityFrameworkCore.Database.Transaction"),
+        new("Microsoft.EntityFrameworkCore.Database.Connection"),
+        new("Microsoft.EntityFrameworkCore.Model"),
+        new("Microsoft.EntityFrameworkCore.Model.Validation"),
+        new("Microsoft.EntityFrameworkCore.Update"),
+        new("Microsoft.EntityFrameworkCore.Migrations"),
+    ];
 
     protected override string ValidJsonConfig => """
         {

--- a/tests/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.Tests/ConformanceTests.cs
@@ -20,7 +20,7 @@ public class ConformanceTests : ConformanceTests<IConfigurationRefresherProvider
 
     protected override string ActivitySourceName => "Microsoft.Extensions.Configuration.AzureAppConfiguration";
 
-    protected override string[] RequiredLogCategories => new string[] { "Microsoft.Extensions.Configuration.AzureAppConfiguration.Refresh" };
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("Microsoft.Extensions.Configuration.AzureAppConfiguration.Refresh")];
 
     protected override bool SupportsKeyedRegistrations => false;
 

--- a/tests/Aspire.Milvus.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Milvus.Client.Tests/ConformanceTests.cs
@@ -31,7 +31,7 @@ public class ConformanceTests : ConformanceTests<MilvusClient, MilvusClientSetti
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
-    protected override string[] RequiredLogCategories => Array.Empty<string>();
+    protected override RequiredLogCategory[] RequiredLogCategories => [];
 
     protected override string ActivitySourceName => "";
 

--- a/tests/Aspire.MongoDB.Driver.Tests/ConformanceTests.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/ConformanceTests.cs
@@ -52,10 +52,11 @@ public class ConformanceTests : ConformanceTests<IMongoClient, MongoDBSettings>,
         ("""{"Aspire": { "MongoDB":{ "Driver": { "DisableTracing": "true"}}}}""", "Value is \"string\" but should be \"boolean\""),
     };
 
-    protected override string[] RequiredLogCategories => [
-        "MongoDB.SDAM",
-        "MongoDB.ServerSelection",
-        "MongoDB.Connection",
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("MongoDB.SDAM"),
+        new("MongoDB.ServerSelection"),
+        new("MongoDB.Connection"),
     ];
 
     protected override void PopulateConfiguration(ConfigurationManager configuration, string? key = null)

--- a/tests/Aspire.MongoDB.EntityFrameworkCore.Tests/ConformanceTests.cs
+++ b/tests/Aspire.MongoDB.EntityFrameworkCore.Tests/ConformanceTests.cs
@@ -22,18 +22,18 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MongoDBEntityFra
     protected override string ActivitySourceName => "MongoDB.Driver.Core.Extensions.DiagnosticSources";
     protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
 
-    protected override string[] RequiredLogCategories => new string[]
-    {
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.ChangeTracking",
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.Database.Command",
-        "Microsoft.EntityFrameworkCore.Query",
-        "Microsoft.EntityFrameworkCore.Database.Transaction",
-        "Microsoft.EntityFrameworkCore.Model",
-        "Microsoft.EntityFrameworkCore.Model.Validation",
-        "Microsoft.EntityFrameworkCore.Update"
-    };
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.ChangeTracking"),
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.Database.Command"),
+        new("Microsoft.EntityFrameworkCore.Query"),
+        new("Microsoft.EntityFrameworkCore.Database.Transaction"),
+        new("Microsoft.EntityFrameworkCore.Model"),
+        new("Microsoft.EntityFrameworkCore.Model.Validation"),
+        new("Microsoft.EntityFrameworkCore.Update"),
+    ];
 
     // we don't want to have both EF and MongoDB loggers to be enabled
     protected override string[] NotAcceptableLogCategories => new string[]

--- a/tests/Aspire.MySqlConnector.Tests/ConformanceTests.cs
+++ b/tests/Aspire.MySqlConnector.Tests/ConformanceTests.cs
@@ -21,12 +21,13 @@ public class ConformanceTests : ConformanceTests<MySqlDataSource, MySqlConnector
     // https://github.com/mysql-net/MySqlConnector/blob/d895afc013a5849d33a123a7061442e2cbb9ce76/src/MySqlConnector/Utilities/ActivitySourceHelper.cs#L61
     protected override string ActivitySourceName => "MySqlConnector";
 
-    protected override string[] RequiredLogCategories => [
-        "MySqlConnector.ConnectionPool",
-        "MySqlConnector.MySqlBulkCopy",
-        "MySqlConnector.MySqlCommand",
-        "MySqlConnector.MySqlConnection",
-        "MySqlConnector.MySqlDataSource",
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("MySqlConnector.ConnectionPool"),
+        new("MySqlConnector.MySqlBulkCopy"),
+        new("MySqlConnector.MySqlCommand"),
+        new("MySqlConnector.MySqlConnection"),
+        new("MySqlConnector.MySqlDataSource"),
     ];
 
     protected override bool SupportsKeyedRegistrations => true;

--- a/tests/Aspire.NATS.Net.Tests/ConformanceTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/ConformanceTests.cs
@@ -26,12 +26,13 @@ public class ConformanceTests : ConformanceTests<INatsConnection, NatsClientSett
     protected override bool SupportsKeyedRegistrations => true;
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
     protected override string ActivitySourceName => "NATS.Net";
-    protected override string[] RequiredLogCategories => [
-        "NATS.Client.Core.Commands.CommandWriter",
-        "NATS.Client.Core.Internal.SubscriptionManager",
-        "NATS.Client.Core.Internal.InboxSubBuilder",
-        "NATS.Client.Core.NatsSubBase",
-        "NATS.Client.Core.NatsConnection",
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("NATS.Client.Core.Commands.CommandWriter"),
+        new("NATS.Client.Core.Internal.SubscriptionManager"),
+        new("NATS.Client.Core.Internal.InboxSubBuilder"),
+        new("NATS.Client.Core.NatsSubBase"),
+        new("NATS.Client.Core.NatsConnection"),
     ];
 
     protected override string? ConfigurationSectionName => "Aspire:NATS:Net";

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
@@ -25,20 +25,20 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
     // Sub-classed in Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL
     protected override bool CheckOptionClassSealed => false;
 
-    protected override string[] RequiredLogCategories => new string[]
-    {
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.ChangeTracking",
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.Database.Command",
-        "Microsoft.EntityFrameworkCore.Query",
-        "Microsoft.EntityFrameworkCore.Database.Transaction",
-        "Microsoft.EntityFrameworkCore.Database.Connection",
-        "Microsoft.EntityFrameworkCore.Model",
-        "Microsoft.EntityFrameworkCore.Model.Validation",
-        "Microsoft.EntityFrameworkCore.Update",
-        "Microsoft.EntityFrameworkCore.Migrations"
-    };
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.ChangeTracking"),
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.Database.Command"),
+        new("Microsoft.EntityFrameworkCore.Query"),
+        new("Microsoft.EntityFrameworkCore.Database.Transaction"),
+        new("Microsoft.EntityFrameworkCore.Database.Connection"),
+        new("Microsoft.EntityFrameworkCore.Model"),
+        new("Microsoft.EntityFrameworkCore.Model.Validation"),
+        new("Microsoft.EntityFrameworkCore.Update"),
+        new("Microsoft.EntityFrameworkCore.Migrations"),
+    ];
 
     // we don't want to have both EF and Npgsql loggers to be enabled
     protected override string[] NotAcceptableLogCategories => new string[]

--- a/tests/Aspire.Npgsql.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Npgsql.Tests/ConformanceTests.cs
@@ -21,15 +21,15 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, NpgsqlSetting
     // https://github.com/npgsql/npgsql/blob/ef9db1ffe9e432c1562d855b46dfac3514726b1b/src/Npgsql.OpenTelemetry/TracerProviderBuilderExtensions.cs#L18
     protected override string ActivitySourceName => "Npgsql";
 
-    protected override string[] RequiredLogCategories => new string[]
-    {
-        "Npgsql.Connection",
-        "Npgsql.Command",
-        "Npgsql.Transaction",
-        "Npgsql.Copy",
-        "Npgsql.Replication",
-        "Npgsql.Exception"
-    };
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("Npgsql.Connection"),
+        new("Npgsql.Command"),
+        new("Npgsql.Transaction"),
+        new("Npgsql.Copy"),
+        new("Npgsql.Replication"),
+        new("Npgsql.Exception"),
+    ];
 
     protected override bool SupportsKeyedRegistrations => true;
 

--- a/tests/Aspire.OpenAI.Tests/ConformanceTests.cs
+++ b/tests/Aspire.OpenAI.Tests/ConformanceTests.cs
@@ -41,7 +41,7 @@ public class ConformanceTests : ConformanceTests<IChatClient, OpenAISettings>
 
     protected override string ActivitySourceName => "Experimental.Microsoft.Extensions.AI";
 
-    protected override string[] RequiredLogCategories => [];
+    protected override RequiredLogCategory[] RequiredLogCategories => [];
 
     protected override string? ConfigurationSectionName => "Aspire:OpenAI";
 

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests.cs
@@ -26,20 +26,20 @@ public class ConformanceTests : ConformanceTests<TestDbContext, OracleEntityFram
 
     protected override string ActivitySourceName => "Oracle.ManagedDataAccess.Core";
 
-    protected override string[] RequiredLogCategories => new string[]
-    {
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.ChangeTracking",
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.Database.Command",
-        "Microsoft.EntityFrameworkCore.Query",
-        "Microsoft.EntityFrameworkCore.Database.Transaction",
-        "Microsoft.EntityFrameworkCore.Database.Connection",
-        "Microsoft.EntityFrameworkCore.Model",
-        "Microsoft.EntityFrameworkCore.Model.Validation",
-        "Microsoft.EntityFrameworkCore.Update",
-        "Microsoft.EntityFrameworkCore.Migrations"
-    };
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.ChangeTracking"),
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.Database.Command"),
+        new("Microsoft.EntityFrameworkCore.Query"),
+        new("Microsoft.EntityFrameworkCore.Database.Transaction"),
+        new("Microsoft.EntityFrameworkCore.Database.Connection"),
+        new("Microsoft.EntityFrameworkCore.Model"),
+        new("Microsoft.EntityFrameworkCore.Model.Validation"),
+        new("Microsoft.EntityFrameworkCore.Update"),
+        new("Microsoft.EntityFrameworkCore.Migrations"),
+    ];
 
     protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
 

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConformanceTests.cs
@@ -24,25 +24,25 @@ public class ConformanceTests : ConformanceTests<TestDbContext, PomeloEntityFram
     // https://github.com/mysql-net/MySqlConnector/blob/6a63fa49795b54318085938e4a09cda0bc0ab2cd/src/MySqlConnector/Utilities/ActivitySourceHelper.cs#L61
     protected override string ActivitySourceName => "MySqlConnector";
 
-    protected override string[] RequiredLogCategories => new string[]
-    {
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.ChangeTracking",
-        "Microsoft.EntityFrameworkCore.Infrastructure",
-        "Microsoft.EntityFrameworkCore.Database.Command",
-        "Microsoft.EntityFrameworkCore.Query",
-        "Microsoft.EntityFrameworkCore.Database.Transaction",
-        "Microsoft.EntityFrameworkCore.Database.Connection",
-        "Microsoft.EntityFrameworkCore.Model",
-        "Microsoft.EntityFrameworkCore.Model.Validation",
-        "Microsoft.EntityFrameworkCore.Update",
-        "Microsoft.EntityFrameworkCore.Migrations",
-        "MySqlConnector.ConnectionPool",
-        "MySqlConnector.MySqlBulkCopy",
-        "MySqlConnector.MySqlCommand",
-        "MySqlConnector.MySqlConnection",
-        "MySqlConnector.MySqlDataSource",
-    };
+    protected override RequiredLogCategory[] RequiredLogCategories =>
+    [
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.ChangeTracking"),
+        new("Microsoft.EntityFrameworkCore.Infrastructure"),
+        new("Microsoft.EntityFrameworkCore.Database.Command"),
+        new("Microsoft.EntityFrameworkCore.Query"),
+        new("Microsoft.EntityFrameworkCore.Database.Transaction"),
+        new("Microsoft.EntityFrameworkCore.Database.Connection"),
+        new("Microsoft.EntityFrameworkCore.Model"),
+        new("Microsoft.EntityFrameworkCore.Model.Validation"),
+        new("Microsoft.EntityFrameworkCore.Update"),
+        new("Microsoft.EntityFrameworkCore.Migrations"),
+        new("MySqlConnector.ConnectionPool"),
+        new("MySqlConnector.MySqlBulkCopy"),
+        new("MySqlConnector.MySqlCommand"),
+        new("MySqlConnector.MySqlConnection"),
+        new("MySqlConnector.MySqlDataSource"),
+    ];
 
     protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
 

--- a/tests/Aspire.Qdrant.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Qdrant.Client.Tests/ConformanceTests.cs
@@ -25,7 +25,7 @@ public class ConformanceTests : ConformanceTests<QdrantClient, QdrantClientSetti
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
-    protected override string[] RequiredLogCategories => Array.Empty<string>();
+    protected override RequiredLogCategory[] RequiredLogCategories => [];
 
     protected override string ActivitySourceName => "";
 

--- a/tests/Aspire.RabbitMQ.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/ConformanceTests.cs
@@ -39,7 +39,7 @@ public class ConformanceTests : ConformanceTests<IConnection, RabbitMQClientSett
 
     protected override bool SupportsKeyedRegistrations => true;
 
-    protected override string[] RequiredLogCategories => Array.Empty<string>();
+    protected override RequiredLogCategory[] RequiredLogCategories => [];
 
 #if RABBITMQ_V6
     protected override string ActivitySourceName => "Aspire.RabbitMQ.Client";

--- a/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
@@ -23,7 +23,7 @@ public class ConformanceTests : ConformanceTests<IConnectionMultiplexer, StackEx
 
     protected override bool SupportsKeyedRegistrations => true;
 
-    protected override string[] RequiredLogCategories => ["StackExchange.Redis.ConnectionMultiplexer"];
+    protected override RequiredLogCategory[] RequiredLogCategories => [new("StackExchange.Redis.ConnectionMultiplexer")];
 
     protected override string? ConfigurationSectionName => "Aspire:StackExchange:Redis";
 


### PR DESCRIPTION
## Summary

Fixes flaky `ConformanceTests_EventHubProducerClient.LoggerFactoryIsUsedByRegisteredClient` test that intermittently fails on CI.

## Problem

The test asserts that the exact logger category `"Azure.Messaging.EventHubs"` is present after triggering SDK activity. However, the Azure SDK's EventSource logging is non-deterministic — depending on the error path and environment, only more specific sub-categories (like `"Azure.Messaging.EventHubs.Processor.BlobEventStore"`) are created while the base category is not.

**CI failure:** https://github.com/microsoft/aspire/actions/runs/28343091815/job/83961581207?pr=18493

```
Assert.Contains() Failure: Item not found in collection
Collection: ["Azure.Messaging.EventHubs.Processor.BlobEventStore", "Azure.Core", ...]
Not found:  "Azure.Messaging.EventHubs"
```

## Fix

Introduce a `RequiredLogCategory` record struct that supports an `AllowPrefixMatch` option. When enabled, any logged category starting with the required name satisfies the assertion (e.g., `"Azure.Messaging.EventHubs.Processor.BlobEventStore"` satisfies `"Azure.Messaging.EventHubs"`).

The EventHubs conformance test base now uses `AllowPrefixMatch: true` for its `"Azure.Messaging.EventHubs"` category — the only site that needs it. All other conformance tests use exact matching (the default).

## Changes

- Added `RequiredLogCategory` record struct in `ConformanceTests.cs`
- Changed `RequiredLogCategories` property type from `string[]` to `RequiredLogCategory[]`
- Updated assertion logic to support prefix matching
- Updated all ~35 override sites across conformance test projects