### PR TITLE
Disable VS Code extension E2E tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -708,7 +708,12 @@ jobs:
 
   extension_e2e_tests:
     name: Run VS Code extension E2E tests
-    if: ${{ needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
+    # Temporarily disabled: the VS Code extension E2E shards are flaky and currently failing in CI
+    # (intermittent teardown AggregateError, see https://github.com/microsoft/aspire/issues/18098),
+    # so they block unrelated PRs. Keep the job defined (it stays in the aggregate gate's needs) but
+    # force it to skip until the flakiness is fixed. Re-enable by removing the `false &&` guard below.
+    # Tracked by https://github.com/microsoft/aspire/issues/18412.
+    if: ${{ false && needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
     uses: ./.github/workflows/extension-e2e-tests.yml
     needs: [setup_for_tests, build_packages, build_cli_archive_linux, build_cli_archive_windows, extension_tests_win, extension_bootstrap_linux]
 
@@ -826,8 +831,10 @@ jobs:
         #   bucket actually had work. Before selective CI these were always populated on a full run.
         # - cli_starter_validation_windows: this job only runs for pull requests and is expected to
         #   be skipped for other workflow events.
-        # - extension_e2e_tests: this job only runs when the PR/push changes the VS Code extension,
-        #   Aspire CLI, or the extension E2E workflow wiring.
+        # - extension_e2e_tests: temporarily disabled (always skipped) because the E2E shards are
+        #   flaky/failing; see https://github.com/microsoft/aspire/issues/18412. While
+        #   disabled, a 'skipped' result must NOT fail this gate, so the run_extension_e2e skip checks
+        #   were removed below. Restore them when re-enabling the job.
         # - polyglot_validation: this job runs for pull requests and main branch builds; it is
         #   expected to be skipped for other workflow events.
         # All other jobs in this gate are required, and a 'skipped' result is treated as a failure.
@@ -837,8 +844,6 @@ jobs:
                contains(needs.*.result, 'cancelled') ||
                (github.event_name == 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
-                 (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
-                  needs.extension_e2e_tests.result == 'skipped') ||
                  (needs.cli_starter_validation_windows.result == 'skipped' && (needs.setup_for_tests.outputs.run_cli_starter == 'true')) ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
@@ -863,8 +868,6 @@ jobs:
                  (needs.polyglot_validation.result == 'skipped' && (needs.setup_for_tests.outputs.run_polyglot == 'true')))) ||
                (github.event_name != 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
-                 (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
-                  needs.extension_e2e_tests.result == 'skipped') ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
                  needs.build_cli_archive_macos_x64.result == 'skipped' ||


### PR DESCRIPTION
## Description

The VS Code extension E2E tests (specifically the `Windows, debug-dashboard` shard) are consistently failing on main, blocking unrelated PRs from merging.

This PR adds a `false &&` guard to the `extension_e2e_tests` job condition and removes the corresponding gate skip-checks, following the same pattern as #18413.

## Recent failures on main (last 5 days)

| Date | Run | Commit | Failing Job |
|------|-----|--------|-------------|
| Jun 28 | [CI #25637](https://github.com/microsoft/aspire/actions/runs/28305924035) | Update OpenTelemetry.Instrumentation.StackExchangeRedis (#18532) | `VS Code extension E2E (Windows, debug-dashboard)` |
| Jun 27 | [CI #25621](https://github.com/microsoft/aspire/actions/runs/28272004515) | Prepare VS Code extension release v1.16.0 (#18528) | `VS Code extension E2E (Windows, debug-dashboard)` |
| Jun 27 | [CI #25616](https://github.com/microsoft/aspire/actions/runs/28270495418) | Fix VS Code extension CLI install (#18459) (#18522) | `VS Code extension E2E (Windows, debug-dashboard)` |
| Jun 26 | [CI #25543](https://github.com/microsoft/aspire/actions/runs/28224516561) | Make dashboard launch opt-in by default (#18361) | `VS Code extension E2E (Windows, debug-dashboard)` |

Tracked by https://github.com/microsoft/aspire/issues/18412