### PR TITLE
Add text filter to the console logs page

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -19,6 +19,13 @@
                     <span>@Loc[nameof(ConsoleLogs.ConsoleLogsNoLogsFound)]</span>
                 </div>
             }
+            else if (!string.IsNullOrWhiteSpace(FilterText) && logEntries.EntriesCount > 0 && GetVisibleEntries().Count == 0)
+            {
+                <div class="console-empty-message" role="status" aria-live="polite">
+                    <FluentIcon Value="@(new Icons.Regular.Size24.SlideText())" aria-hidden="true" />
+                    <span>@Loc[nameof(ConsoleLogs.ConsoleLogsNoLogsMatchFilter)]</span>
+                </div>
+            }
             <Virtualize @ref="VirtualizeRef" ItemsProvider="@GetItems" ItemSize="20" OverscanCount="200" TItem="LogEntry">
                 @if (context.Pause is { } pause)
                 {

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -122,12 +122,14 @@ public sealed partial class LogViewer
         {
             _visibleEntriesCache = null;
 
-            // Virtualize caches the items it last fetched and only re-queries GetItems on an explicit
-            // RefreshDataAsync. Filtering is applied inside GetItems and depends on the rendered row
-            // fields, so we record the current parameters here and defer the Virtualize refresh to
-            // OnAfterRenderAsync: observe the parameters, let the component render, then refresh
-            // Virtualize. Refreshing earlier, e.g. from the parent's bind handler before this assignment,
-            // would re-query with the previous filter value.
+            // Virtualize only re-queries GetItems on an explicit RefreshDataAsync call.
+            // We can't call it here (OnParametersSet) because Virtualize.RefreshDataAsync()
+            // triggers a child-component re-render mid-lifecycle, which creates re-entrant
+            // rendering in Blazor Server. Additionally, OnParametersSetAsync would cause a
+            // double-render (sync portion renders stale items, then re-renders after await).
+            // Deferring to OnAfterRenderAsync guarantees the full component tree has rendered
+            // with the new state, and the cache is already warm from the razor markup's call
+            // to GetVisibleEntries() (for the "no logs match" message).
             _visibleEntriesChanged = true;
         }
 

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -148,7 +148,7 @@ public sealed partial class LogViewer
     // spans markup or a color boundary. Pause markers aren't log content, so they're hidden while a
     // filter is active.
     private static bool MatchesFilter(LogEntry entry, string filterText)
-        => entry.Type != LogEntryType.Pause
+        => entry.Type is not LogEntryType.Pause
             && entry.GetStrippedRawContent() is { } stripped
             && stripped.Contains(filterText, StringComparison.OrdinalIgnoreCase);
 

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -141,14 +141,16 @@ public sealed partial class LogViewer
         return _visibleEntriesCache = entries.Where(e => MatchesFilter(e, filterText)).ToList();
     }
 
-    // Filter on RawContent rather than Content. Content contains embedded HTML links and other
-    // markup added during ANSI conversion, so matching against it would match the markup rather
-    // than the visible text. RawContent is the plain text the user sees (it also includes the
-    // timestamp). Pause markers aren't log content, so they're hidden while a filter is active.
+    // Filter on the ANSI-stripped raw content, which is the plain text the user actually sees
+    // (including the timestamp). Content can't be used because it contains embedded HTML links and
+    // other markup added during ANSI conversion, and the unstripped RawContent still contains raw
+    // ANSI escape sequences - matching against either produces false negatives when the search term
+    // spans markup or a color boundary. Pause markers aren't log content, so they're hidden while a
+    // filter is active.
     private static bool MatchesFilter(LogEntry entry, string filterText)
         => entry.Type != LogEntryType.Pause
-            && entry.RawContent is { } raw
-            && raw.Contains(filterText, StringComparison.OrdinalIgnoreCase);
+            && entry.GetStrippedRawContent() is { } stripped
+            && stripped.Contains(filterText, StringComparison.OrdinalIgnoreCase);
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -23,6 +23,10 @@ public sealed partial class LogViewer
     private LogEntries? _logEntries;
     private bool _logsChanged;
 
+    private IList<LogEntry>? _visibleEntriesCache;
+    private string? _appliedFilterText;
+    private bool _filterChanged;
+
     [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }
 
@@ -50,6 +54,9 @@ public sealed partial class LogViewer
     [Parameter]
     public bool ShowNoLogsMessage { get; set; }
 
+    [Parameter]
+    public string? FilterText { get; set; }
+
     private Virtualize<LogEntry>? VirtualizeRef
     {
         get => field;
@@ -72,6 +79,10 @@ public sealed partial class LogViewer
             return;
         }
 
+        // Entries may have been appended or evicted (circular buffer) since the last render, so drop
+        // the cached filtered view before Virtualize re-queries through GetItems.
+        _visibleEntriesCache = null;
+
         await VirtualizeRef.RefreshDataAsync();
         StateHasChanged();
     }
@@ -84,6 +95,19 @@ public sealed partial class LogViewer
 
             _logsChanged = true;
             _logEntries = LogEntries;
+            _visibleEntriesCache = null;
+        }
+
+        if (!string.Equals(_appliedFilterText, FilterText, StringComparison.Ordinal))
+        {
+            _appliedFilterText = FilterText;
+            _visibleEntriesCache = null;
+
+            // Virtualize caches the items it last fetched and only re-queries GetItems on an explicit
+            // RefreshDataAsync. The filter is applied inside GetItems, so the refresh must run after
+            // FilterText has been assigned here (in OnAfterRenderAsync) - refreshing earlier, e.g. from
+            // the parent's bind handler, would re-query with the previous filter value.
+            _filterChanged = true;
         }
 
         base.OnParametersSet();
@@ -91,14 +115,40 @@ public sealed partial class LogViewer
 
     private ValueTask<ItemsProviderResult<LogEntry>> GetItems(ItemsProviderRequest r)
     {
-        var entries = _logEntries?.GetEntries();
-        if (entries == null)
-        {
-            return ValueTask.FromResult(new ItemsProviderResult<LogEntry>(Enumerable.Empty<LogEntry>(), 0));
-        }
-
+        var entries = GetVisibleEntries();
         return ValueTask.FromResult(new ItemsProviderResult<LogEntry>(entries.Skip(r.StartIndex).Take(r.Count), entries.Count));
     }
+
+    private IList<LogEntry> GetVisibleEntries()
+    {
+        if (_visibleEntriesCache is { } cached)
+        {
+            return cached;
+        }
+
+        var entries = _logEntries?.GetEntries();
+        if (entries is null)
+        {
+            return _visibleEntriesCache = Array.Empty<LogEntry>();
+        }
+
+        var filterText = FilterText;
+        if (string.IsNullOrWhiteSpace(filterText))
+        {
+            return _visibleEntriesCache = entries;
+        }
+
+        return _visibleEntriesCache = entries.Where(e => MatchesFilter(e, filterText)).ToList();
+    }
+
+    // Filter on RawContent rather than Content. Content contains embedded HTML links and other
+    // markup added during ANSI conversion, so matching against it would match the markup rather
+    // than the visible text. RawContent is the plain text the user sees (it also includes the
+    // timestamp). Pause markers aren't log content, so they're hidden while a filter is active.
+    private static bool MatchesFilter(LogEntry entry, string filterText)
+        => entry.Type != LogEntryType.Pause
+            && entry.RawContent is { } raw
+            && raw.Contains(filterText, StringComparison.OrdinalIgnoreCase);
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -106,6 +156,11 @@ public sealed partial class LogViewer
         {
             await JS.InvokeVoidAsync("resetContinuousScrollPosition");
             _logsChanged = false;
+        }
+        if (_filterChanged)
+        {
+            _filterChanged = false;
+            await RefreshDataAsync();
         }
         if (firstRender)
         {

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Text;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
@@ -25,7 +26,10 @@ public sealed partial class LogViewer
 
     private IList<LogEntry>? _visibleEntriesCache;
     private string? _appliedFilterText;
-    private bool _filterChanged;
+    private bool _appliedShowTimestamp;
+    private bool _appliedShowResourcePrefix;
+    private bool _appliedIsTimestampUtc;
+    private bool _visibleEntriesChanged;
 
     [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }
@@ -103,17 +107,28 @@ public sealed partial class LogViewer
             _visibleEntriesCache = null;
         }
 
-        if (!string.Equals(_appliedFilterText, FilterText, StringComparison.Ordinal))
+        var filterChanged = !string.Equals(_appliedFilterText, FilterText, StringComparison.Ordinal);
+        var searchableFieldsChanged =
+            _appliedShowTimestamp != ShowTimestamp ||
+            _appliedShowResourcePrefix != ShowResourcePrefix ||
+            _appliedIsTimestampUtc != IsTimestampUtc;
+
+        _appliedFilterText = FilterText;
+        _appliedShowTimestamp = ShowTimestamp;
+        _appliedShowResourcePrefix = ShowResourcePrefix;
+        _appliedIsTimestampUtc = IsTimestampUtc;
+
+        if (filterChanged || (searchableFieldsChanged && !string.IsNullOrWhiteSpace(FilterText)))
         {
-            _appliedFilterText = FilterText;
             _visibleEntriesCache = null;
 
             // Virtualize caches the items it last fetched and only re-queries GetItems on an explicit
-            // RefreshDataAsync. The filter is applied inside GetItems, so we record the new filter here
-            // and defer the Virtualize refresh to OnAfterRenderAsync: observe the parameter, let the
-            // component render, then refresh Virtualize. Refreshing earlier, e.g. from the parent's bind
-            // handler before this assignment, would re-query with the previous filter value.
-            _filterChanged = true;
+            // RefreshDataAsync. Filtering is applied inside GetItems and depends on the rendered row
+            // fields, so we record the current parameters here and defer the Virtualize refresh to
+            // OnAfterRenderAsync: observe the parameters, let the component render, then refresh
+            // Virtualize. Refreshing earlier, e.g. from the parent's bind handler before this assignment,
+            // would re-query with the previous filter value.
+            _visibleEntriesChanged = true;
         }
 
         base.OnParametersSet();
@@ -147,16 +162,61 @@ public sealed partial class LogViewer
         return _visibleEntriesCache = entries.Where(e => MatchesFilter(e, filterText)).ToList();
     }
 
-    // Filter on the ANSI-stripped raw content, which is the plain text the user actually sees
-    // (including the timestamp). Content can't be used because it contains embedded HTML links and
-    // other markup added during ANSI conversion, and the unstripped RawContent still contains raw
-    // ANSI escape sequences - matching against either produces false negatives when the search term
-    // spans markup or a color boundary. Pause markers aren't log content, so they're hidden while a
-    // filter is active.
-    private static bool MatchesFilter(LogEntry entry, string filterText)
-        => entry.Type is not LogEntryType.Pause
-            && entry.GetStrippedRawContent() is { } stripped
-            && stripped.Contains(filterText, StringComparison.OrdinalIgnoreCase);
+    private bool MatchesFilter(LogEntry entry, string filterText)
+    {
+        if (entry.Type is LogEntryType.Pause)
+        {
+            return false;
+        }
+
+        return GetSearchableText(entry).Contains(filterText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string GetSearchableText(LogEntry entry)
+    {
+        var builder = new StringBuilder();
+
+        // Keep this in sync with the row markup in LogViewer.razor. Filtering should match only text
+        // users can see: optional/display-formatted timestamps, optional resource prefixes, the stderr
+        // badge, and the ANSI-stripped log message. RawContent is not enough because it contains hidden
+        // ISO timestamps and raw ANSI escape sequences.
+        if (ShowTimestamp && entry.Timestamp is { } timestamp)
+        {
+            AppendSearchablePart(builder, GetDisplayTimestamp(timestamp));
+        }
+
+        if (ShowResourcePrefix && entry.ResourcePrefix is { } resourcePrefix)
+        {
+            AppendSearchablePart(builder, resourcePrefix);
+        }
+
+        if (entry.Type is LogEntryType.Error)
+        {
+            AppendSearchablePart(builder, "stderr");
+        }
+
+        if (entry.GetStrippedLogContent() is { } content)
+        {
+            AppendSearchablePart(builder, content);
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendSearchablePart(StringBuilder builder, string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        if (builder.Length > 0)
+        {
+            builder.Append(' ');
+        }
+
+        builder.Append(value);
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -165,11 +225,11 @@ public sealed partial class LogViewer
             await JS.InvokeVoidAsync("resetContinuousScrollPosition");
             _logsChanged = false;
         }
-        if (_filterChanged)
+        if (_visibleEntriesChanged)
         {
-            _filterChanged = false;
+            _visibleEntriesChanged = false;
 
-            // The filtered view was already rebuilt for the new filter during this render pass
+            // The filtered view was already rebuilt for the new parameters during this render pass
             // (GetVisibleEntries runs from the markup to decide the "no logs match" message), so just
             // re-query Virtualize. Calling the public RefreshDataAsync here would null the cache and
             // force a second full scan of the log buffer.

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -74,14 +74,19 @@ public sealed partial class LogViewer
 
     public async Task RefreshDataAsync()
     {
+        // Entries may have been appended or evicted (circular buffer) since the last render, so drop
+        // the cached filtered view before Virtualize re-queries through GetItems.
+        _visibleEntriesCache = null;
+
+        await RefreshVirtualizeAsync();
+    }
+
+    private async Task RefreshVirtualizeAsync()
+    {
         if (VirtualizeRef == null)
         {
             return;
         }
-
-        // Entries may have been appended or evicted (circular buffer) since the last render, so drop
-        // the cached filtered view before Virtualize re-queries through GetItems.
-        _visibleEntriesCache = null;
 
         await VirtualizeRef.RefreshDataAsync();
         StateHasChanged();
@@ -104,9 +109,10 @@ public sealed partial class LogViewer
             _visibleEntriesCache = null;
 
             // Virtualize caches the items it last fetched and only re-queries GetItems on an explicit
-            // RefreshDataAsync. The filter is applied inside GetItems, so the refresh must run after
-            // FilterText has been assigned here (in OnAfterRenderAsync) - refreshing earlier, e.g. from
-            // the parent's bind handler, would re-query with the previous filter value.
+            // RefreshDataAsync. The filter is applied inside GetItems, so we record the new filter here
+            // and defer the Virtualize refresh to OnAfterRenderAsync: observe the parameter, let the
+            // component render, then refresh Virtualize. Refreshing earlier, e.g. from the parent's bind
+            // handler before this assignment, would re-query with the previous filter value.
             _filterChanged = true;
         }
 
@@ -162,7 +168,12 @@ public sealed partial class LogViewer
         if (_filterChanged)
         {
             _filterChanged = false;
-            await RefreshDataAsync();
+
+            // The filtered view was already rebuilt for the new filter during this render pass
+            // (GetVisibleEntries runs from the markup to decide the "no logs match" message), so just
+            // re-query Virtualize. Calling the public RefreshDataAsync here would null the cache and
+            // force a second full scan of the log buffer.
+            await RefreshVirtualizeAsync();
         }
         if (firstRender)
         {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -138,6 +138,7 @@
                               Immediate="true"
                               ImmediateDelay="@FluentUIExtensions.InputDelay"
                               Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
+                              Label="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)].Value"
                               title="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTextFilter)]"
                               slot="end" />
 

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -115,6 +115,14 @@
                 {
                     <FluentLabel Typo="Typography.Body" aria-live="polite" aria-label="@Loc[nameof(Dashboard.Resources.ConsoleLogs.LogStatusLabel)]" slot="end">@PageViewModel.Status</FluentLabel>
 
+                    <FluentSearch @bind-Value="_logFilter"
+                                  Name="console-logs-search"
+                                  Immediate="true"
+                                  ImmediateDelay="@FluentUIExtensions.InputDelay"
+                                  Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
+                                  title="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTextFilter)]"
+                                  slot="end" />
+
                     <AspireMenuButton
                         ButtonAppearance="Appearance.Lightweight"
                         Icon="@(new Icons.Regular.Size20.Options())"
@@ -125,6 +133,14 @@
             }
             else if (!_selectedResourceHasTerminal)
             {
+                <FluentSearch @bind-Value="_logFilter"
+                              Name="console-logs-search"
+                              Immediate="true"
+                              ImmediateDelay="@FluentUIExtensions.InputDelay"
+                              Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
+                              title="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTextFilter)]"
+                              slot="end" />
+
                 <AspireMenuButton
                     Icon="@(new Icons.Regular.Size20.Options())"
                     Items="@_logsMenuItems"
@@ -164,6 +180,7 @@
                 <LogViewer
                 @ref="_logViewerRef"
                 LogEntries="@_logEntries"
+                FilterText="@_logFilter"
                 ShowTimestamp="@_showTimestamp"
                 IsTimestampUtc="@_isTimestampUtc"
                 NoWrapLogs="@_noWrapLogs"

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -286,6 +286,15 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
                     foreach (var (changeType, resource) in changes)
                     {
+                        // Detect a genuine resource addition before OnResourceChanged inserts it into
+                        // _resourceByName. An Upsert covers both new resources and updates to existing
+                        // ones, so the map lookup distinguishes the two. Match the visibility condition
+                        // used to decide subscription below so a render only happens when the addition
+                        // will actually appear in the resource picker.
+                        var isNewResource = changeType == ResourceViewModelChangeType.Upsert &&
+                            !_resourceByName.ContainsKey(resource.Name) &&
+                            !resource.IsResourceHidden(_showHiddenResources);
+
                         await OnResourceChanged(changeType, resource);
 
                         // Track whether this batch contains changes that affect the visible page UI
@@ -295,6 +304,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                         // FluentSearch's ImmediateDelay input buffer from being clobbered by stale
                         // parameter values pushed during the debounce window.
                         if (changeType == ResourceViewModelChangeType.Delete ||
+                            isNewResource ||
                             string.Equals(resource.Name, selectedResourceName, StringComparisons.ResourceName))
                         {
                             needsRender = true;

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -183,6 +183,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     private bool _isTimestampUtc;
     private bool _noWrapLogs;
     private bool _showNoLogsMessage;
+    private string _logFilter = string.Empty;
     public ConsoleLogsViewModel PageViewModel { get; set; } = null!;
     private IDisposable? _consoleLogsFiltersChangedSubscription;
 

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -281,9 +281,24 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
             {
                 await foreach (var changes in subscription.WithCancellation(_resourceSubscriptionToken).ConfigureAwait(false))
                 {
+                    var selectedResourceName = PageViewModel.SelectedResource?.Id?.InstanceId;
+                    var needsRender = false;
+
                     foreach (var (changeType, resource) in changes)
                     {
                         await OnResourceChanged(changeType, resource);
+
+                        // Track whether this batch contains changes that affect the visible page UI
+                        // (selected resource modified, or resources added/removed). Frequent property
+                        // updates on non-selected resources (health checks, state transitions) don't
+                        // require a full page re-render. Avoiding unnecessary re-renders prevents
+                        // FluentSearch's ImmediateDelay input buffer from being clobbered by stale
+                        // parameter values pushed during the debounce window.
+                        if (changeType == ResourceViewModelChangeType.Delete ||
+                            string.Equals(resource.Name, selectedResourceName, StringComparisons.ResourceName))
+                        {
+                            needsRender = true;
+                        }
 
                         // the initial snapshot we obtain is [almost] never correct (it's always empty)
                         // we still want to select the user's initial queried resource on page load,
@@ -293,17 +308,21 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                         if (ResourceName is not null && PageViewModel.SelectedResource is null && changeType == ResourceViewModelChangeType.Upsert && string.Equals(ResourceName, resource.Name, StringComparisons.ResourceName))
                         {
                             SetSelectedResourceOption(resource);
+                            needsRender = true;
                         }
                     }
 
-                    await InvokeAsync(() =>
+                    if (needsRender)
                     {
-                        // The selected resource may have changed, so update resource action buttons.
-                        // Update inside in the render's sync context so the buttons don't change while the UI is rendering.
-                        UpdateMenuButtons();
+                        await InvokeAsync(() =>
+                        {
+                            // The selected resource may have changed, so update resource action buttons.
+                            // Update inside the render's sync context so the buttons don't change while the UI is rendering.
+                            UpdateMenuButtons();
 
-                        StateHasChanged();
-                    });
+                            StateHasChanged();
+                        });
+                    }
                 }
             });
         }

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
@@ -75,6 +75,18 @@ namespace Aspire.Dashboard.Resources {
             }
         }
         
+        public static string ConsoleLogsNoLogsMatchFilter {
+            get {
+                return ResourceManager.GetString("ConsoleLogsNoLogsMatchFilter", resourceCulture);
+            }
+        }
+        
+        public static string ConsoleLogsTextFilter {
+            get {
+                return ResourceManager.GetString("ConsoleLogsTextFilter", resourceCulture);
+            }
+        }
+        
         public static string ConsoleLogsWatchingLogs {
             get {
                 return ResourceManager.GetString("ConsoleLogsWatchingLogs", resourceCulture);

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
@@ -133,6 +133,12 @@
   <data name="ConsoleLogsNoLogsFound" xml:space="preserve">
     <value>No logs found</value>
   </data>
+  <data name="ConsoleLogsNoLogsMatchFilter" xml:space="preserve">
+    <value>No logs match the filter</value>
+  </data>
+  <data name="ConsoleLogsTextFilter" xml:space="preserve">
+    <value>Console logs filter</value>
+  </data>
   <data name="ConsoleLogsWatchingLogs" xml:space="preserve">
     <value>Watching logs...</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Nevybrán žádný prostředek</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">Nastavení</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Keine Ressource ausgewählt</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">Einstellungen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">No hay ningún recurso seleccionado</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">Configuración</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Aucune ressource sélectionnée</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">Paramètres</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Nessuna risorsa selezionata</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">Impostazioni</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">リソースが選択されていません</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">設定</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">리소스를 선택하지 않음</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">설정</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Nie wybrano zasobu</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">Ustawienia</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Não há nenhum recurso selecionado</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">Configurações</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Нет выбранных ресурсов</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">Настройки</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Hiçbir kaynak seçilmedi</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">Ayarlar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">未选择资源</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">设置</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="new">No logs found</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsMatchFilter">
+        <source>No logs match the filter</source>
+        <target state="new">No logs match the filter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">未選取任何資源</target>
@@ -65,6 +70,11 @@
       <trans-unit id="ConsoleLogsSettings">
         <source>Settings</source>
         <target state="translated">設定</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConsoleLogsTextFilter">
+        <source>Console logs filter</source>
+        <target state="new">Console logs filter</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsTimestampHide">

--- a/src/Shared/ConsoleLogs/LogEntry.cs
+++ b/src/Shared/ConsoleLogs/LogEntry.cs
@@ -18,6 +18,31 @@ internal sealed class LogEntry
     /// The text content of the log entry. This is the same as <see cref="Content"/>, but without embedded links or other transformations and including the timestamp.
     /// </summary>
     public string? RawContent { get; private set; }
+
+    private string? _strippedRawContent;
+
+    /// <summary>
+    /// <see cref="RawContent"/> with ANSI control sequences removed. This is the plain text the user
+    /// actually sees rendered (including the timestamp). Use this for matching against user-entered
+    /// text - <see cref="Content"/> contains HTML markup added during ANSI conversion and
+    /// <see cref="RawContent"/> still contains the raw escape sequences, so matching against either
+    /// produces false negatives when the term spans markup or a color boundary (for example, the
+    /// default .NET console emits the level prefix as <c>info\x1b[..m:</c>, so a search for
+    /// <c>info:</c> would never match the raw content).
+    /// </summary>
+    /// <remarks>
+    /// The stripped value is cached because filtering runs over the entire log buffer on each update.
+    /// </remarks>
+    public string? GetStrippedRawContent()
+    {
+        if (RawContent is null)
+        {
+            return null;
+        }
+
+        return _strippedRawContent ??= AnsiParser.StripControlSequences(RawContent);
+    }
+
     public DateTime? Timestamp { get; private set; }
     public LogEntryType Type { get; private set; } = LogEntryType.Default;
     public int LineNumber { get; set; }

--- a/src/Shared/ConsoleLogs/LogEntry.cs
+++ b/src/Shared/ConsoleLogs/LogEntry.cs
@@ -20,6 +20,7 @@ internal sealed class LogEntry
     public string? RawContent { get; private set; }
 
     private string? _strippedRawContent;
+    private string? _strippedLogContent;
 
     /// <summary>
     /// <see cref="RawContent"/> with ANSI control sequences removed. This is the plain text the user
@@ -41,6 +42,28 @@ internal sealed class LogEntry
         }
 
         return _strippedRawContent ??= AnsiParser.StripControlSequences(RawContent);
+    }
+
+    /// <summary>
+    /// <see cref="RawContent"/> with the parsed timestamp and ANSI control sequences removed. This
+    /// represents the rendered log message text without optional row adornments such as timestamps,
+    /// resource prefixes, or stderr badges.
+    /// </summary>
+    /// <remarks>
+    /// The stripped value is cached because filtering runs over the entire log buffer on each update.
+    /// </remarks>
+    public string? GetStrippedLogContent()
+    {
+        if (RawContent is null)
+        {
+            return null;
+        }
+
+        _strippedLogContent ??= TimestampParser.TryParseConsoleTimestamp(RawContent, out var timestampParseResult)
+            ? AnsiParser.StripControlSequences(timestampParseResult.Value.ModifiedText)
+            : GetStrippedRawContent();
+
+        return _strippedLogContent;
     }
 
     public DateTime? Timestamp { get; private set; }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/LogViewerTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/LogViewerTests.cs
@@ -89,6 +89,126 @@ public class LogViewerTests : DashboardTestContext
         });
     }
 
+    [Fact]
+    public void LogViewer_FilterText_ShowsOnlyMatchingEntries()
+    {
+        SetupLogViewerServices();
+
+        var logEntries = CreateLogEntries("apple log", "banana log", "cherry log");
+
+        var cut = RenderComponent<LogViewer>(builder =>
+        {
+            builder.Add(p => p.LogEntries, logEntries);
+            builder.Add(p => p.FilterText, "banana");
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            var contents = cut.FindAll(".log-content").Select(e => e.TextContent.Trim()).ToList();
+            var content = Assert.Single(contents);
+            Assert.Contains("banana log", content);
+        });
+    }
+
+    [Fact]
+    public void LogViewer_FilterText_IsCaseInsensitive()
+    {
+        SetupLogViewerServices();
+
+        var logEntries = CreateLogEntries("Error connecting", "Information ready");
+
+        var cut = RenderComponent<LogViewer>(builder =>
+        {
+            builder.Add(p => p.LogEntries, logEntries);
+            builder.Add(p => p.FilterText, "ERROR");
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            var contents = cut.FindAll(".log-content").Select(e => e.TextContent.Trim()).ToList();
+            var content = Assert.Single(contents);
+            Assert.Contains("Error connecting", content);
+        });
+    }
+
+    [Fact]
+    public void LogViewer_FilterText_NoMatch_ShowsNoMatchMessage()
+    {
+        SetupLogViewerServices();
+
+        var logEntries = CreateLogEntries("apple log", "banana log");
+
+        var cut = RenderComponent<LogViewer>(builder =>
+        {
+            builder.Add(p => p.LogEntries, logEntries);
+            builder.Add(p => p.FilterText, "no-such-text");
+        });
+
+        var loc = Services.GetRequiredService<IStringLocalizer<Resources.ConsoleLogs>>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Empty(cut.FindAll(".log-content"));
+            var message = Assert.Single(cut.FindAll(".console-empty-message"));
+            Assert.Contains(loc[nameof(Resources.ConsoleLogs.ConsoleLogsNoLogsMatchFilter)].Value, message.TextContent);
+        });
+    }
+
+    [Fact]
+    public void LogViewer_FilterText_ExcludesPauseEntries()
+    {
+        SetupLogViewerServices();
+
+        var pauseStart = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var pauseEnd = pauseStart.AddSeconds(1);
+
+        var logEntries = new LogEntries(maximumEntryCount: int.MaxValue) { BaseLineNumber = 1 };
+
+        // A completed pause that captured filtered lines renders as a pause marker (EndTime set,
+        // FilteredCount > 0). With a filter active it must be hidden because it isn't log content.
+        var pauseEntry = LogEntry.CreatePause("resource", pauseStart, pauseEnd);
+        pauseEntry.Pause!.FilteredCount = 2;
+        logEntries.InsertSorted(pauseEntry);
+
+        logEntries.InsertSorted(LogEntry.Create(
+            timestamp: pauseStart.AddSeconds(2),
+            logMessage: "matching banana log",
+            rawLogContent: "matching banana log",
+            isErrorMessage: false,
+            resourcePrefix: null));
+
+        var cut = RenderComponent<LogViewer>(builder =>
+        {
+            builder.Add(p => p.LogEntries, logEntries);
+            builder.Add(p => p.FilterText, "banana");
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Empty(cut.FindAll(".log-pause"));
+            var content = Assert.Single(cut.FindAll(".log-content"));
+            Assert.Contains("matching banana log", content.TextContent);
+        });
+    }
+
+    private static LogEntries CreateLogEntries(params string[] messages)
+    {
+        var logEntries = new LogEntries(maximumEntryCount: int.MaxValue) { BaseLineNumber = 1 };
+        var timestamp = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        foreach (var message in messages)
+        {
+            logEntries.InsertSorted(LogEntry.Create(
+                timestamp: timestamp,
+                logMessage: message,
+                rawLogContent: message,
+                isErrorMessage: false,
+                resourcePrefix: null));
+            timestamp = timestamp.AddSeconds(1);
+        }
+
+        return logEntries;
+    }
+
     private static string GetBackgroundAccentVariableName(string style)
     {
         var background = GetCssPropertyValue(style, "background");

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/LogViewerTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/LogViewerTests.cs
@@ -191,6 +191,129 @@ public class LogViewerTests : DashboardTestContext
         });
     }
 
+    [Fact]
+    public void LogViewer_FilterText_MatchesAnsiStrippedContent()
+    {
+        SetupLogViewerServices();
+
+        // Default .NET console output colors the level prefix, so ANSI escape sequences sit between
+        // "info" and ":" in the raw content. The user only sees "info: Application started", so a
+        // filter of "info:" must match even though the raw content is
+        // "info\x1b[39m\x1b[22m\x1b[49m: Application started".
+        const string rawContent = "info\x1b[39m\x1b[22m\x1b[49m: Application started";
+
+        var logEntries = new LogEntries(maximumEntryCount: int.MaxValue) { BaseLineNumber = 1 };
+        logEntries.InsertSorted(LogEntry.Create(
+            timestamp: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            logMessage: "info: Application started",
+            rawLogContent: rawContent,
+            isErrorMessage: false,
+            resourcePrefix: null));
+
+        var cut = RenderComponent<LogViewer>(builder =>
+        {
+            builder.Add(p => p.LogEntries, logEntries);
+            builder.Add(p => p.FilterText, "info:");
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            var content = Assert.Single(cut.FindAll(".log-content"));
+            Assert.Contains("Application started", content.TextContent);
+        });
+    }
+
+    [Fact]
+    public void LogViewer_FilterText_ChangingFilterUpdatesVisibleEntries()
+    {
+        SetupLogViewerServices();
+
+        var logEntries = CreateLogEntries("apple log", "banana log", "cherry log");
+
+        var cut = RenderComponent<LogViewer>(builder =>
+        {
+            builder.Add(p => p.LogEntries, logEntries);
+            builder.Add(p => p.FilterText, "apple");
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            var content = Assert.Single(cut.FindAll(".log-content"));
+            Assert.Contains("apple log", content.TextContent);
+        });
+
+        // Changing the filter on an already-rendered component must invalidate the cached filtered
+        // view and re-query Virtualize through the deferred RefreshDataAsync in OnAfterRenderAsync.
+        cut.SetParametersAndRender(builder => builder.Add(p => p.FilterText, "cherry"));
+
+        cut.WaitForAssertion(() =>
+        {
+            var content = Assert.Single(cut.FindAll(".log-content"));
+            Assert.Contains("cherry log", content.TextContent);
+        });
+    }
+
+    [Fact]
+    public void LogViewer_FilterText_ClearingFilterShowsAllEntries()
+    {
+        SetupLogViewerServices();
+
+        var logEntries = CreateLogEntries("apple log", "banana log", "cherry log");
+
+        var cut = RenderComponent<LogViewer>(builder =>
+        {
+            builder.Add(p => p.LogEntries, logEntries);
+            builder.Add(p => p.FilterText, "banana");
+        });
+
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll(".log-content")));
+
+        // A whitespace-only filter is treated as empty and must short-circuit back to showing every
+        // entry, restoring the unfiltered (live buffer) view.
+        cut.SetParametersAndRender(builder => builder.Add(p => p.FilterText, "   "));
+
+        cut.WaitForAssertion(() =>
+        {
+            var contents = cut.FindAll(".log-content").Select(e => e.TextContent.Trim()).ToList();
+            Assert.Equal(3, contents.Count);
+        });
+    }
+
+    [Fact]
+    public async Task LogViewer_FilterText_RefreshAfterAppendShowsNewMatchingEntries()
+    {
+        SetupLogViewerServices();
+
+        var logEntries = CreateLogEntries("apple log", "banana log");
+
+        var cut = RenderComponent<LogViewer>(builder =>
+        {
+            builder.Add(p => p.LogEntries, logEntries);
+            builder.Add(p => p.FilterText, "banana");
+        });
+
+        cut.WaitForAssertion(() => Assert.Single(cut.FindAll(".log-content")));
+
+        // Simulate streaming: a new matching entry is appended to the existing buffer (same reference,
+        // so no parameter change fires), then the parent calls RefreshDataAsync. The cached filtered
+        // snapshot must be dropped so the newly appended entry becomes visible.
+        logEntries.InsertSorted(LogEntry.Create(
+            timestamp: new DateTime(2024, 1, 1, 0, 0, 5, DateTimeKind.Utc),
+            logMessage: "another banana log",
+            rawLogContent: "another banana log",
+            isErrorMessage: false,
+            resourcePrefix: null));
+
+        await cut.InvokeAsync(cut.Instance.RefreshDataAsync);
+
+        cut.WaitForAssertion(() =>
+        {
+            var contents = cut.FindAll(".log-content").Select(e => e.TextContent.Trim()).ToList();
+            Assert.Equal(2, contents.Count);
+            Assert.Contains(contents, c => c.Contains("another banana log", StringComparison.Ordinal));
+        });
+    }
+
     private static LogEntries CreateLogEntries(params string[] messages)
     {
         var logEntries = new LogEntries(maximumEntryCount: int.MaxValue) { BaseLineNumber = 1 };

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/LogViewerTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/LogViewerTests.cs
@@ -314,6 +314,101 @@ public class LogViewerTests : DashboardTestContext
         });
     }
 
+    [Fact]
+    public void LogViewer_FilterText_RespectsRenderedResourcePrefix()
+    {
+        SetupLogViewerServices();
+
+        var logEntries = new LogEntries(maximumEntryCount: int.MaxValue) { BaseLineNumber = 1 };
+        logEntries.InsertSorted(LogEntry.Create(
+            timestamp: null,
+            logMessage: "ready",
+            rawLogContent: "ready",
+            isErrorMessage: false,
+            resourcePrefix: "frontend"));
+
+        var cut = RenderComponent<LogViewer>(builder =>
+        {
+            builder.Add(p => p.LogEntries, logEntries);
+            builder.Add(p => p.FilterText, "frontend");
+            builder.Add(p => p.ShowResourcePrefix, false);
+        });
+
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindAll(".log-content")));
+
+        cut.SetParametersAndRender(builder => builder.Add(p => p.ShowResourcePrefix, true));
+
+        cut.WaitForAssertion(() =>
+        {
+            var content = Assert.Single(cut.FindAll(".log-content"));
+            Assert.Contains("frontend", content.TextContent);
+            Assert.Contains("ready", content.TextContent);
+        });
+    }
+
+    [Fact]
+    public void LogViewer_FilterText_MatchesRenderedStderrBadge()
+    {
+        SetupLogViewerServices();
+
+        var logEntries = new LogEntries(maximumEntryCount: int.MaxValue) { BaseLineNumber = 1 };
+        logEntries.InsertSorted(LogEntry.Create(
+            timestamp: null,
+            logMessage: "failed",
+            rawLogContent: "failed",
+            isErrorMessage: true,
+            resourcePrefix: null));
+
+        var cut = RenderComponent<LogViewer>(builder =>
+        {
+            builder.Add(p => p.LogEntries, logEntries);
+            builder.Add(p => p.FilterText, "stderr");
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            var content = Assert.Single(cut.FindAll(".log-content"));
+            Assert.Contains("stderr", content.TextContent);
+            Assert.Contains("failed", content.TextContent);
+        });
+    }
+
+    [Fact]
+    public void LogViewer_FilterText_UsesDisplayedTimestampOnlyWhenVisible()
+    {
+        SetupLogViewerServices();
+
+        var logEntries = new LogEntries(maximumEntryCount: int.MaxValue) { BaseLineNumber = 1 };
+        logEntries.InsertSorted(LogEntry.Create(
+            timestamp: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            logMessage: "timestamped log",
+            rawLogContent: "2024-01-01T00:00:00Z timestamped log",
+            isErrorMessage: false,
+            resourcePrefix: null));
+
+        var cut = RenderComponent<LogViewer>(builder =>
+        {
+            builder.Add(p => p.LogEntries, logEntries);
+            builder.Add(p => p.FilterText, "2024-01-01T01:00:00");
+            builder.Add(p => p.ShowTimestamp, true);
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            var content = Assert.Single(cut.FindAll(".log-content"));
+            Assert.Contains("2024-01-01T01:00:00", content.TextContent);
+            Assert.Contains("timestamped log", content.TextContent);
+        });
+
+        cut.SetParametersAndRender(builder =>
+        {
+            builder.Add(p => p.FilterText, "2024-01-01T00:00:00Z");
+            builder.Add(p => p.ShowTimestamp, false);
+        });
+
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindAll(".log-content")));
+    }
+
     private static LogEntries CreateLogEntries(params string[] messages)
     {
         var logEntries = new LogEntries(maximumEntryCount: int.MaxValue) { BaseLineNumber = 1 };

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
@@ -11,6 +11,7 @@ using Aspire.Tests.Shared.DashboardModel;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
 using Value = Google.Protobuf.WellKnownTypes.Value;
 
@@ -141,6 +142,73 @@ public partial class ConsoleLogsTests
         Assert.Single(cut.FindComponents<LogViewer>());
 
         await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task SwitchingFromTerminalToNonTerminalResource_RestoresSearchFilter()
+    {
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var terminalResource = CreateTerminalResource("terminal-resource", replicaIndex: 0, replicaCount: 1);
+        var plainResource = ModelTestHelpers.CreateResource(resourceName: "plain-resource", state: KnownResourceState.Running);
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: _ => consoleLogsChannel,
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [terminalResource, plainResource]);
+
+        SetupConsoleLogsServices(dashboardClient);
+        SetupTerminalViewJsInterop();
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: "terminal-resource"));
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var cut = RenderComponent<Components.Pages.ConsoleLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, "terminal-resource");
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+
+        var instance = cut.Instance;
+        cut.WaitForState(() => instance.PageViewModel.SelectedResource.Id?.InstanceId == terminalResource.Name);
+        cut.WaitForState(() => cut.FindComponents<TerminalView>().Count > 0);
+        Assert.Empty(cut.FindComponents<FluentSearch>());
+
+        navigationManager.LocationChanged += (sender, e) =>
+        {
+            cut.SetParametersAndRender(builder =>
+            {
+                builder.Add(m => m.ResourceName, "plain-resource");
+            });
+        };
+        var resourceSelect = cut.FindComponent<ResourceSelect>();
+        var innerSelect = resourceSelect.Find("fluent-select");
+        innerSelect.Change("plain-resource");
+
+        cut.WaitForState(() => instance.PageViewModel.SelectedResource.Id?.InstanceId == plainResource.Name);
+        cut.WaitForState(() => cut.FindComponents<LogViewer>().Count > 0);
+
+        consoleLogsChannel.Writer.TryWrite([
+            new ResourceLogLine(1, "first log", IsErrorMessage: false),
+            new ResourceLogLine(2, "filtered log", IsErrorMessage: false)
+        ]);
+        cut.WaitForAssertion(() => Assert.Equal(2, cut.FindAll(".log-content").Count));
+
+        var search = Assert.Single(cut.FindComponents<FluentSearch>());
+        await cut.InvokeAsync(() => search.Instance.ValueChanged.InvokeAsync("filtered"));
+
+        cut.WaitForAssertion(() =>
+        {
+            var logViewer = Assert.Single(cut.FindComponents<LogViewer>());
+            Assert.Equal("filtered", logViewer.Instance.FilterText);
+
+            var content = Assert.Single(cut.FindAll(".log-content"));
+            Assert.Contains("filtered log", content.TextContent);
+        });
     }
 
     private void SetupTerminalViewJsInterop()

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -370,6 +370,73 @@ public partial class ConsoleLogsTests : DashboardTestContext
         cut.WaitForState(() => instance._logEntries.EntriesCount > 0);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SearchFilter_UpdatesLogViewerFilterAndVisibleLogs(bool isDesktop)
+    {
+        var testResource = ModelTestHelpers.CreateResource(resourceName: "test-resource", state: KnownResourceState.Running);
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: _ => consoleLogsChannel,
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [testResource]);
+        var viewport = CreateViewport(isDesktop);
+        SetupConsoleLogsServices(dashboardClient);
+        var dialogProvider = isDesktop ? null : RenderDialogProvider(viewport);
+
+        var cut = RenderConsoleLogsPage(viewport, resourceName: "test-resource");
+        var instance = cut.Instance;
+        cut.WaitForState(() => instance.PageViewModel.SelectedResource.Id?.InstanceId == testResource.Name);
+
+        consoleLogsChannel.Writer.TryWrite([
+            new ResourceLogLine(1, "apple log", IsErrorMessage: false),
+            new ResourceLogLine(2, "banana log", IsErrorMessage: false)
+        ]);
+
+        cut.WaitForAssertion(() => Assert.Equal(2, cut.FindAll(".log-content").Count));
+
+        var search = isDesktop
+            ? Assert.Single(cut.FindComponents<FluentSearch>())
+            : OpenMobileToolbarAndFindSearch(cut, dialogProvider!);
+        await cut.InvokeAsync(() => search.Instance.ValueChanged.InvokeAsync("banana"));
+
+        cut.WaitForAssertion(() =>
+        {
+            var logViewer = Assert.Single(cut.FindComponents<LogViewer>());
+            Assert.Equal("banana", logViewer.Instance.FilterText);
+
+            var content = Assert.Single(cut.FindAll(".log-content"));
+            Assert.Contains("banana log", content.TextContent);
+        });
+    }
+
+    [Fact]
+    public void SearchFilter_MobileHasVisibleLabel()
+    {
+        var testResource = ModelTestHelpers.CreateResource(resourceName: "test-resource", state: KnownResourceState.Running);
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: _ => consoleLogsChannel,
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [testResource]);
+        var viewport = CreateViewport(isDesktop: false);
+        SetupConsoleLogsServices(dashboardClient);
+        var dialogProvider = RenderDialogProvider(viewport);
+
+        var cut = RenderConsoleLogsPage(viewport, resourceName: "test-resource");
+        cut.WaitForState(() => cut.Instance.PageViewModel.SelectedResource.Id?.InstanceId == testResource.Name);
+
+        var loc = Services.GetRequiredService<IStringLocalizer<Resources.ControlsStrings>>();
+        var search = OpenMobileToolbarAndFindSearch(cut, dialogProvider);
+
+        Assert.Equal(loc[nameof(Resources.ControlsStrings.FilterPlaceholder)].Value, search.Instance.Label);
+    }
+
     [Fact]
     public async Task ReadingLogs_ErrorDuringRead_SetStatusAndLog()
     {
@@ -832,6 +899,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
 
     private void SetupConsoleLogsServices(TestDashboardClient? dashboardClient = null, TestTimeProvider? timeProvider = null)
     {
+        FluentUISetupHelpers.SetupFluentDialogProvider(this);
         FluentUISetupHelpers.SetupFluentDivider(this);
         FluentUISetupHelpers.SetupFluentInputLabel(this);
         FluentUISetupHelpers.SetupFluentList(this);
@@ -856,5 +924,46 @@ public partial class ConsoleLogsTests : DashboardTestContext
         Services.AddSingleton<IDashboardClient>(dashboardClient ?? new TestDashboardClient());
         Services.AddScoped<DashboardCommandExecutor>();
         Services.AddSingleton<ConsoleLogsManager>();
+    }
+
+    private IRenderedComponent<Components.Pages.ConsoleLogs> RenderConsoleLogsPage(ViewportInformation viewport, string resourceName)
+    {
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        return RenderComponent<Components.Pages.ConsoleLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, resourceName);
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+    }
+
+    private static ViewportInformation CreateViewport(bool isDesktop)
+    {
+        return new ViewportInformation(IsDesktop: isDesktop, IsUltraLowHeight: false, IsUltraLowWidth: false);
+    }
+
+    private static IRenderedComponent<FluentSearch> OpenMobileToolbarAndFindSearch(IRenderedComponent<Components.Pages.ConsoleLogs> cut, IRenderedFragment dialogProvider)
+    {
+        cut.Find(".mobile-toolbar").Click();
+
+        dialogProvider.WaitForAssertion(() => Assert.Single(dialogProvider.FindComponents<FluentSearch>()));
+
+        return Assert.Single(dialogProvider.FindComponents<FluentSearch>());
+    }
+
+    private IRenderedFragment RenderDialogProvider(ViewportInformation viewport)
+    {
+        return Render(builder =>
+        {
+            builder.OpenComponent<CascadingValue<ViewportInformation>>(0);
+            builder.AddAttribute(1, nameof(CascadingValue<ViewportInformation>.Value), viewport);
+            builder.AddAttribute(2, nameof(CascadingValue<ViewportInformation>.ChildContent), (RenderFragment)(childBuilder =>
+            {
+                childBuilder.OpenComponent<FluentDialogProvider>(0);
+                childBuilder.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
     }
 }


### PR DESCRIPTION
Adds a FluentSearch filter box to the Console Logs toolbar that filters displayed log lines by a case-insensitive substring match on raw content.

Fixes #11122

<img width="2475" height="104" alt="Screenshot 2026-06-29 153406" src="https://github.com/user-attachments/assets/6f41be96-5384-402d-9c38-82250d24c472" />

https://github.com/user-attachments/assets/ddb9caa0-086b-4e3f-b239-ba10b17a18b2

