### PR TITLE
Fixes several use cases where aspire-managed processes may leak

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -198,6 +198,7 @@
     <Compile Include="$(SharedDir)ConsoleLogs\TimestampParser.cs" Link="ConsoleLogs\TimestampParser.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\UrlParser.cs" Link="ConsoleLogs\UrlParser.cs" />
     <Compile Include="$(SharedDir)ProcessSignaler.cs" Link="Utils\ProcessSignaler.cs" />
+    <Compile Include="$(SharedDir)ProcessStartTimeHelper.cs" Link="Utils\ProcessStartTimeHelper.cs" />
     <Compile Include="$(SharedDir)NpmVersionHelper.cs" Link="Utils\NpmVersionHelper.cs" />
   </ItemGroup>
 

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -199,6 +199,7 @@
     <Compile Include="$(SharedDir)ConsoleLogs\UrlParser.cs" Link="ConsoleLogs\UrlParser.cs" />
     <Compile Include="$(SharedDir)ProcessSignaler.cs" Link="Utils\ProcessSignaler.cs" />
     <Compile Include="$(SharedDir)ProcessStartTimeHelper.cs" Link="Utils\ProcessStartTimeHelper.cs" />
+    <Compile Include="$(SharedDir)ParentProcessLivenessMonitor.cs" Link="Utils\ParentProcessLivenessMonitor.cs" />
     <Compile Include="$(SharedDir)NpmVersionHelper.cs" Link="Utils\NpmVersionHelper.cs" />
   </ItemGroup>
 

--- a/src/Aspire.Cli/Backchannel/AuxiliaryBackchannelMonitor.cs
+++ b/src/Aspire.Cli/Backchannel/AuxiliaryBackchannelMonitor.cs
@@ -10,6 +10,7 @@ using Aspire.Cli.Commands;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.Hosting.Backchannel;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -188,16 +189,23 @@ internal sealed class AuxiliaryBackchannelMonitor(
             .ToList();
     }
 
-    private static bool IsAppHostInScopeOfDirectory(string? appHostPath, string workingDirectory)
+    /// <summary>
+    /// Determines whether <paramref name="appHostPath"/> lives within <paramref name="workingDirectory"/>.
+    /// This is the single in-scope implementation shared by <see cref="IsAppHostInScope"/>.
+    /// </summary>
+    internal static bool IsAppHostInScopeOfDirectory(string? appHostPath, string workingDirectory)
     {
         if (string.IsNullOrEmpty(appHostPath))
         {
             return false;
         }
 
-        // Normalize the paths for comparison
-        var normalizedWorkingDirectory = Path.GetFullPath(workingDirectory);
-        var normalizedAppHostPath = Path.GetFullPath(appHostPath);
+        // Resolve symlinks (not just Path.GetFullPath) on both operands. The OS reports a process's current
+        // directory in physical form (for example macOS temp dirs under /var -> /private/var), while a
+        // file-based AppHost reports its path unresolved, so comparing without resolving symlinks would treat
+        // an in-scope AppHost as out of scope. 
+        var normalizedWorkingDirectory = PathNormalizer.ResolveSymlinks(workingDirectory);
+        var normalizedAppHostPath = PathNormalizer.ResolveSymlinks(appHostPath);
 
         // Check if the AppHost path is within the working directory
         var relativePath = Path.GetRelativePath(normalizedWorkingDirectory, normalizedAppHostPath);
@@ -545,21 +553,7 @@ internal sealed class AuxiliaryBackchannelMonitor(
     }
 
     private bool IsAppHostInScope(string? appHostPath)
-    {
-        if (string.IsNullOrEmpty(appHostPath))
-        {
-            return false;
-        }
-
-        // Normalize the paths for comparison
-        var workingDirectory = Path.GetFullPath(executionContext.WorkingDirectory.FullName);
-        var normalizedAppHostPath = Path.GetFullPath(appHostPath);
-
-        // Check if the AppHost path is within the working directory using a robust, cross-platform method
-        var relativePath = Path.GetRelativePath(workingDirectory, normalizedAppHostPath);
-        // If the relative path starts with ".." or is equal to "..", then it's outside the working directory
-        return !relativePath.StartsWith("..", StringComparison.Ordinal) && !Path.IsPathRooted(relativePath);
-    }
+        => IsAppHostInScopeOfDirectory(appHostPath, executionContext.WorkingDirectory.FullName);
 
     private static async Task DisconnectAsync(IAppHostAuxiliaryBackchannel connection)
     {

--- a/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
+++ b/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
@@ -97,8 +97,8 @@ internal sealed class OrphanedAppHostCollector(
 
         if (connection.AppHostInfo.CliStableStartedAt is { } cliStableStartedAt)
         {
-            // Current AppHosts report the launching CLI's in Unix milliseconds. 
-            // It is immune to wall-clock shifts steps, so a millisecond comparison reliably distinguishes the
+            // Current AppHosts report the launching CLI's start time in Unix milliseconds.
+            // It is immune to wall-clock shifts, so a millisecond comparison reliably distinguishes the
             // original launcher from a recycled PID: a mismatch here is trustworthy evidence the launcher is gone.
             return !ProcessStartTimeHelper.IsProcessRunning(cliPid, cliStableStartedAt.ToUnixTimeMilliseconds());
         }

--- a/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
+++ b/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
@@ -97,10 +97,10 @@ internal sealed class OrphanedAppHostCollector(
 
         if (connection.AppHostInfo.CliStableStartedAt is { } cliStableStartedAt)
         {
-            // Current AppHosts report the launching CLI's /proc-derived identity. It is immune to
-            // wall-clock steps, so an exact comparison reliably distinguishes the original launcher
-            // from a recycled PID: a mismatch here is trustworthy evidence the launcher is gone.
-            return !ProcessStartTimeHelper.IsProcessRunning(cliPid, cliStableStartedAt.ToUnixTimeSeconds());
+            // Current AppHosts report the launching CLI's in Unix milliseconds. 
+            // It is immune to wall-clock shifts steps, so a millisecond comparison reliably distinguishes the
+            // original launcher from a recycled PID: a mismatch here is trustworthy evidence the launcher is gone.
+            return !ProcessStartTimeHelper.IsProcessRunning(cliPid, cliStableStartedAt.ToUnixTimeMilliseconds());
         }
 
         // Legacy fallback (older AppHost): only ASPIRE_CLI_STARTED is available, which is stamped from Process.StartTime. 

--- a/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
+++ b/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
@@ -22,9 +22,22 @@ internal sealed class OrphanedAppHostCollector(
     /// <returns>The number of orphaned AppHosts that were collected.</returns>
     public async Task<int> CollectAsync(CancellationToken cancellationToken)
     {
-        await backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
+        List<IAppHostAuxiliaryBackchannel> orphans;
+        try
+        {
+            await backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
 
-        var orphans = backchannelMonitor.Connections.Where(IsOrphaned).ToList();
+            orphans = backchannelMonitor.Connections.Where(IsOrphaned).ToList();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Discovering orphans is best effort: a scan or liveness-probe failure must not fail the
+            // caller (e.g. `aspire ps`/`aspire stop`), which honors the "(best effort)" contract without
+            // requiring every call site to guard. Cancellation still propagates so callers can abort.
+            logger.LogDebug(ex, "Failed to scan for orphaned AppHosts.");
+            return 0;
+        }
+
         if (orphans.Count == 0)
         {
             return 0;
@@ -91,7 +104,7 @@ internal sealed class OrphanedAppHostCollector(
             return !ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(
                 cliPid,
                 cliStartedAt.ToUnixTimeSeconds(),
-                TimeSpan.FromSeconds(1));
+                ProcessStartTimeHelper.RuntimeStartTimeComparisonTolerance);
         }
 
         return !ProcessStartTimeHelper.IsProcessRunning(cliPid);

--- a/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
+++ b/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
@@ -13,7 +13,7 @@ namespace Aspire.Cli.Backchannel;
 /// </summary>
 internal sealed class OrphanedAppHostCollector(
     IAuxiliaryBackchannelMonitor backchannelMonitor,
-    ProcessTreeGracefulShutdownService processShutdownService,
+    IAppHostStopper processShutdownService,
     ILogger<OrphanedAppHostCollector> logger)
 {
     /// <summary>

--- a/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
+++ b/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
@@ -104,7 +104,7 @@ internal sealed class OrphanedAppHostCollector(
             return !ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(
                 cliPid,
                 cliStartedAt.ToUnixTimeSeconds(),
-                ProcessStartTimeHelper.RuntimeStartTimeComparisonTolerance);
+                ProcessStartTimeHelper.CrossProcessIdentityTimeTolerance);
         }
 
         return !ProcessStartTimeHelper.IsProcessRunning(cliPid);

--- a/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
+++ b/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Processes;
+using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Backchannel;
+
+/// <summary>
+/// Utility class for cleaning up AppHost process trees whose launching CLI is no longer running 
+/// (including removing their backchannel sockets).
+/// </summary>
+internal sealed class OrphanedAppHostCollector(
+    IAuxiliaryBackchannelMonitor backchannelMonitor,
+    ProcessTreeGracefulShutdownService processShutdownService,
+    ILogger<OrphanedAppHostCollector> logger)
+{
+    /// <summary>
+    /// Scans for running AppHosts and stops every one whose launching CLI is no longer alive (best effort).
+    /// </summary>
+    /// <returns>The number of orphaned AppHosts that were collected.</returns>
+    public async Task<int> CollectAsync(CancellationToken cancellationToken)
+    {
+        await backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
+
+        var orphans = backchannelMonitor.Connections.Where(IsOrphaned).ToList();
+        if (orphans.Count == 0)
+        {
+            return 0;
+        }
+
+        var collected = 0;
+        foreach (var connection in orphans)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var appHostInfo = connection.AppHostInfo;
+            try
+            {
+                var stopped = await processShutdownService.StopAppHostAsync(
+                    appHostInfo,
+                    connection.StopAppHostAsync,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (stopped)
+                {
+                    // The process is confirmed gone, so the socket's owner is gone and the file is safe
+                    // to remove by exact path (mirrors StopCommand). Leaving it behind would have later
+                    // commands rediscover a dead AppHost.
+                    AppHostHelper.TryDeleteSocketFile(connection.SocketPath, logger);
+                    collected++;
+                    logger.LogDebug(
+                        "Collected orphaned AppHost {AppHostPath} (PID {AppHostPid}); its launching CLI {CliPid} is no longer running.",
+                        appHostInfo?.AppHostPath,
+                        appHostInfo?.ProcessId,
+                        appHostInfo?.CliProcessId);
+                }
+                else
+                {
+                    logger.LogDebug(
+                        "Failed to collect orphaned AppHost {AppHostPath} (PID {AppHostPid}).",
+                        appHostInfo?.AppHostPath,
+                        appHostInfo?.ProcessId);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogDebug(ex, "Error while collecting orphaned AppHost at {SocketPath}.", connection.SocketPath);
+            }
+        }
+
+        return collected;
+    }
+
+    internal static bool IsOrphaned(IAppHostAuxiliaryBackchannel connection)
+    {
+        // Only AppHosts launched by a CLI can be attributed to an owner. 
+        // Without a CliProcessId we cannot tell whether the AppHost is orphaned, so we leave it alone.
+        if (connection.AppHostInfo is not { CliProcessId: int cliPid })
+        {
+            return false;
+        }
+
+        var cliStartedUnix = connection.AppHostInfo.CliStartedAt?.ToUnixTimeSeconds();
+        return !ProcessStartTimeHelper.IsProcessRunning(cliPid, cliStartedUnix);
+    }
+}

--- a/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
+++ b/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
@@ -82,7 +82,18 @@ internal sealed class OrphanedAppHostCollector(
             return false;
         }
 
-        var cliStartedUnix = connection.AppHostInfo.CliStartedAt?.ToUnixTimeSeconds();
-        return !ProcessStartTimeHelper.IsProcessRunning(cliPid, cliStartedUnix);
+        if (connection.AppHostInfo.CliStartedAt is { } cliStartedAt)
+        {
+            // AppHostInfo.CliStartedAt is populated from ASPIRE_CLI_STARTED for backchannel
+            // compatibility with released AppHosts. That variable intentionally stays in the
+            // Process.StartTime clock domain, so compare it with the legacy verifier instead of
+            // the Linux /proc-based stable verifier.
+            return !ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(
+                cliPid,
+                cliStartedAt.ToUnixTimeSeconds(),
+                TimeSpan.FromSeconds(1));
+        }
+
+        return !ProcessStartTimeHelper.IsProcessRunning(cliPid);
     }
 }

--- a/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
+++ b/src/Aspire.Cli/Backchannel/OrphanedAppHostCollector.cs
@@ -95,18 +95,19 @@ internal sealed class OrphanedAppHostCollector(
             return false;
         }
 
-        if (connection.AppHostInfo.CliStartedAt is { } cliStartedAt)
+        if (connection.AppHostInfo.CliStableStartedAt is { } cliStableStartedAt)
         {
-            // AppHostInfo.CliStartedAt is populated from ASPIRE_CLI_STARTED for backchannel
-            // compatibility with released AppHosts. That variable intentionally stays in the
-            // Process.StartTime clock domain, so compare it with the legacy verifier instead of
-            // the Linux /proc-based stable verifier.
-            return !ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(
-                cliPid,
-                cliStartedAt.ToUnixTimeSeconds(),
-                ProcessStartTimeHelper.CrossProcessIdentityTimeTolerance);
+            // Current AppHosts report the launching CLI's /proc-derived identity. It is immune to
+            // wall-clock steps, so an exact comparison reliably distinguishes the original launcher
+            // from a recycled PID: a mismatch here is trustworthy evidence the launcher is gone.
+            return !ProcessStartTimeHelper.IsProcessRunning(cliPid, cliStableStartedAt.ToUnixTimeSeconds());
         }
 
+        // Legacy fallback (older AppHost): only ASPIRE_CLI_STARTED is available, which is stamped from Process.StartTime. 
+        // On Linux that value drifts across processes after any clock correction (NTP, container suspend/resume), 
+        // so a start-time MISMATCH is NOT trustworthy evidence that the PID was reused. 
+        // We therefore only treat the AppHost as orphaned when the launching CLI PID is entirely gone, 
+        // biasing toward leaving a possible orphan (still guarded by the in-process watchdogs) over tearing down a live one.
         return !ProcessStartTimeHelper.IsProcessRunning(cliPid);
     }
 }

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -315,6 +315,13 @@ internal sealed class AppHostLauncher(
     {
         var environment = new Dictionary<string, string> { [KnownConfigNames.CliRunDetached] = "true" };
 
+        // Record the foreground launcher's identity (PID + start time) so the detached child can watch
+        // it during startup and tear the AppHost tree down if the launcher is killed before the app
+        // reaches readiness. Without this, killing `aspire start`/`aspire run --detach` mid-start (for
+        // example a test runner timing it out) leaks the AppHost + dashboard as orphaned processes.
+        environment[KnownConfigNames.CliLauncherProcessId] = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        environment[KnownConfigNames.CliLauncherProcessStarted] = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds().ToString(CultureInfo.InvariantCulture);
+
         ProfilingTelemetry.AddActivityContextToEnvironment(activity, environment);
         ProfileCaptureEnvironment.AddCurrentToEnvironment(environment);
         return environment;

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -233,27 +233,9 @@ internal sealed class AppHostLauncher(
     }
 
     /// <summary>
-    /// Computes the primary and fallback auxiliary-backchannel socket hashes used to match a
-    /// detached AppHost's backchannel connection during launch.
+    /// Computes the primary and fallback auxiliary-backchannel socket hashes used to match 
+    /// a detached AppHost's backchannel connection during launch.
     /// </summary>
-    /// <remarks>
-    /// The AppHost keys its auxiliary backchannel socket <em>file name</em> on the symlink-resolved
-    /// AppHost path (see <c>AuxiliaryBackchannelService.GetSocketKeyAppHostPath</c> in Aspire.Hosting),
-    /// and <see cref="Backchannel.AuxiliaryBackchannelMonitor"/> keys discovered connections by the
-    /// hash embedded in that file name. The OS reports the AppHost path in its physical form
-    /// (for example, on macOS <c>/var/folders/...</c> is a symlink to <c>/private/var/folders/...</c>),
-    /// which is exactly what the AppHost hashes — so the CLI must hash the <em>resolved</em> path to
-    /// compute the primary hash it waits on. Without this, a detached <c>aspire start</c> from a
-    /// symlinked temp path (the default on macOS) never matches the AppHost's socket and times out.
-    /// <para>
-    /// The fallback set keeps the raw (unresolved) path's hashes so the CLI still matches AppHosts /
-    /// instances that keyed their socket on the unresolved path — most importantly an AppHost built
-    /// against an older <c>Aspire.Hosting</c> that predates the symlink-resolved socket key, or a path
-    /// with no symlinks where resolved == raw. Two distinct hash spaces are searched: the compact
-    /// AppHost id used by current socket file names, and the legacy hex hashes used by
-    /// <c>auxi.sock.{hash}</c>-style names (<see cref="AppHostHelper.ComputeLegacyHashes"/>).
-    /// </para>
-    /// </remarks>
     /// <param name="appHostPath">The AppHost project file or assembly path as supplied to the CLI.</param>
     /// <param name="homeDirectory">The user's home directory.</param>
     /// <returns>
@@ -269,8 +251,8 @@ internal sealed class AppHostLauncher(
             AppHostHelper.ComputeAuxiliarySocketPrefix(socketKeyPath, homeDirectory))!;
 
         // Current socket file names embed the compact AppHost id (a different hash space than the
-        // legacy hex hashes below), so include the raw path's compact id explicitly. This is what
-        // matches a still-running AppHost that keyed its socket on the unresolved path before the
+        // legacy hex hashes below), so include the raw path's compact id explicitly. 
+        // This is what matches a still-running AppHost that keyed its socket on the unresolved path before the
         // AppHost side started resolving symlinks.
         var rawCompactHash = AppHostHelper.ExtractHashFromSocketPath(
             AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, homeDirectory))!;

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -260,6 +260,7 @@ internal sealed class AppHostLauncher(
         var fallbackHashes = new[] { rawCompactHash }
             .Concat(AppHostHelper.ComputeLegacyHashes(socketKeyPath))
             .Concat(AppHostHelper.ComputeLegacyHashes(appHostPath))
+            .Where(h => !string.Equals(h, expectedHash, StringComparison.Ordinal))
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -358,8 +358,7 @@ internal sealed class AppHostLauncher(
         // it during startup and tear the AppHost tree down if the launcher is killed before the app
         // reaches readiness. Without this, killing `aspire start`/`aspire run --detach` mid-start (for
         // example a test runner timing it out) leaks the AppHost + dashboard as orphaned processes.
-        environment[KnownConfigNames.CliLauncherProcessId] = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
-        environment[KnownConfigNames.CliLauncherProcessStarted] = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds().ToString(CultureInfo.InvariantCulture);
+        OrphanDetectionEnvironment.ApplyCurrentProcess(environment, KnownConfigNames.CliLauncherProcessId, KnownConfigNames.CliLauncherProcessStarted);
 
         ProfilingTelemetry.AddActivityContextToEnvironment(activity, environment);
         ProfileCaptureEnvironment.AddCurrentToEnvironment(environment);

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -398,7 +398,7 @@ internal sealed class AppHostLauncher(
             }
         }
 
-        var childStartedAt = new DateTimeOffset(childProcess.StartTime);
+        var childStartedAt = ProcessStartTimeHelper.TryGetProcessStartTime(childProcess.Id) ?? new DateTimeOffset(childProcess.StartTime);
         logger.LogDebug("Child CLI process started with PID: {PID}", childProcess.Id);
 
         var startTime = timeProvider.GetUtcNow();

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -15,6 +15,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Commands;
@@ -138,12 +139,16 @@ internal sealed class AppHostLauncher(
         executionContext.AppHostCliLogFilePath = childLogFile;
         var (executablePath, childArgs) = BuildChildProcessArgs(effectiveAppHostFile, childLogFile, isolated, globalArgs, additionalArgs);
 
-        // Compute the expected socket prefix for backchannel detection
+        // Compute the expected socket prefix for backchannel detection. The AppHost keys its
+        // auxiliary backchannel socket file on the symlink-resolved AppHost path, so the primary
+        // hash we wait on must also be computed from the resolved path (see ComputeDetachedMatchHashes).
+        var socketKeyPath = PathNormalizer.ResolveSymlinks(effectiveAppHostFile.FullName);
         var expectedSocketPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(
+            socketKeyPath,
+            executionContext.HomeDirectory.FullName);
+        var (expectedHash, legacyHashes) = ComputeDetachedMatchHashes(
             effectiveAppHostFile.FullName,
             executionContext.HomeDirectory.FullName);
-        var expectedHash = AppHostHelper.ExtractHashFromSocketPath(expectedSocketPrefix)!;
-        var legacyHashes = AppHostHelper.ComputeLegacyHashes(effectiveAppHostFile.FullName);
 
         logger.LogDebug("Waiting for socket with prefix: {SocketPrefix}, Hash: {Hash}", expectedSocketPrefix, expectedHash);
         if (legacyHashes.Length > 0)
@@ -225,6 +230,58 @@ internal sealed class AppHostLauncher(
                 throw;
             }
         }
+    }
+
+    /// <summary>
+    /// Computes the primary and fallback auxiliary-backchannel socket hashes used to match a
+    /// detached AppHost's backchannel connection during launch.
+    /// </summary>
+    /// <remarks>
+    /// The AppHost keys its auxiliary backchannel socket <em>file name</em> on the symlink-resolved
+    /// AppHost path (see <c>AuxiliaryBackchannelService.GetSocketKeyAppHostPath</c> in Aspire.Hosting),
+    /// and <see cref="Backchannel.AuxiliaryBackchannelMonitor"/> keys discovered connections by the
+    /// hash embedded in that file name. The OS reports the AppHost path in its physical form
+    /// (for example, on macOS <c>/var/folders/...</c> is a symlink to <c>/private/var/folders/...</c>),
+    /// which is exactly what the AppHost hashes — so the CLI must hash the <em>resolved</em> path to
+    /// compute the primary hash it waits on. Without this, a detached <c>aspire start</c> from a
+    /// symlinked temp path (the default on macOS) never matches the AppHost's socket and times out.
+    /// <para>
+    /// The fallback set keeps the raw (unresolved) path's hashes so the CLI still matches AppHosts /
+    /// instances that keyed their socket on the unresolved path — most importantly an AppHost built
+    /// against an older <c>Aspire.Hosting</c> that predates the symlink-resolved socket key, or a path
+    /// with no symlinks where resolved == raw. Two distinct hash spaces are searched: the compact
+    /// AppHost id used by current socket file names, and the legacy hex hashes used by
+    /// <c>auxi.sock.{hash}</c>-style names (<see cref="AppHostHelper.ComputeLegacyHashes"/>).
+    /// </para>
+    /// </remarks>
+    /// <param name="appHostPath">The AppHost project file or assembly path as supplied to the CLI.</param>
+    /// <param name="homeDirectory">The user's home directory.</param>
+    /// <returns>
+    /// The primary expected hash (the compact AppHost id of the resolved path) and the de-duplicated
+    /// fallback hashes to also search: the compact AppHost id of the raw path plus the legacy hex
+    /// hashes of both the resolved and raw paths (including any Windows drive-letter casing variants).
+    /// </returns>
+    internal static (string ExpectedHash, string[] FallbackHashes) ComputeDetachedMatchHashes(string appHostPath, string homeDirectory)
+    {
+        var socketKeyPath = PathNormalizer.ResolveSymlinks(appHostPath);
+
+        var expectedHash = AppHostHelper.ExtractHashFromSocketPath(
+            AppHostHelper.ComputeAuxiliarySocketPrefix(socketKeyPath, homeDirectory))!;
+
+        // Current socket file names embed the compact AppHost id (a different hash space than the
+        // legacy hex hashes below), so include the raw path's compact id explicitly. This is what
+        // matches a still-running AppHost that keyed its socket on the unresolved path before the
+        // AppHost side started resolving symlinks.
+        var rawCompactHash = AppHostHelper.ExtractHashFromSocketPath(
+            AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, homeDirectory))!;
+
+        var fallbackHashes = new[] { rawCompactHash }
+            .Concat(AppHostHelper.ComputeLegacyHashes(socketKeyPath))
+            .Concat(AppHostHelper.ComputeLegacyHashes(appHostPath))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return (expectedHash, fallbackHashes);
     }
 
     private async Task StopExistingInstancesAsync(FileInfo effectiveAppHostFile, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -374,7 +374,10 @@ internal sealed class DashboardRunCommand : BaseCommand
         IProcessExecution process;
         try
         {
-            process = await _layoutProcessRunner.StartAsync(managedPath, dashboardArgs, environmentVariables: environmentVariables, options: options).ConfigureAwait(false);
+            // Foreground `aspire dashboard run`: the dashboard is a child of this CLI and must not
+            // outlive it, so bind it to the Windows kill-on-close job as an OS-level backstop on top of
+            // the cross-platform parent-liveness watchdog. No-op on non-Windows hosts.
+            process = await _layoutProcessRunner.StartAsync(managedPath, dashboardArgs, environmentVariables: environmentVariables, options: options, killOnParentExit: true).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -73,6 +73,7 @@ internal sealed partial class PsCommand : BaseCommand
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
     private readonly IAuxiliaryBackchannelMonitor _backchannelMonitor;
     private readonly IEnvironment _environment;
+    private readonly OrphanedAppHostCollector _collector;
     private readonly ILogger<PsCommand> _logger;
     private static readonly Option<OutputFormat> s_formatOption = new("--format")
     {
@@ -87,12 +88,14 @@ internal sealed partial class PsCommand : BaseCommand
     public PsCommand(
         IAuxiliaryBackchannelMonitor backchannelMonitor,
         IEnvironment environment,
+        OrphanedAppHostCollector collector,
         ILogger<PsCommand> logger,
         CommonCommandServices services)
         : base("ps", PsCommandStrings.Description, services)
     {
         _backchannelMonitor = backchannelMonitor;
         _environment = environment;
+        _collector = collector;
         _logger = logger;
 
         Options.Add(s_formatOption);
@@ -109,6 +112,10 @@ internal sealed partial class PsCommand : BaseCommand
         {
             return await ExecuteFollowAsync(format, cancellationToken).ConfigureAwait(false);
         }
+
+        // Collect AppHosts whose launching CLI has died before listing, so the output reflects reality and
+        // leaked aspire-managed/AppHost processes are cleaned up. Best effort.
+        await _collector.CollectAsync(cancellationToken).ConfigureAwait(false);
 
         // Scan for running AppHosts (same as ListAppHostsTool). JSON output must not go
         // through status rendering because non-interactive status text shares stdout.

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -114,7 +114,9 @@ internal sealed partial class PsCommand : BaseCommand
         }
 
         // Collect AppHosts whose launching CLI has died before listing, so the output reflects reality and
-        // leaked aspire-managed/AppHost processes are cleaned up. Best effort.
+        // leaked aspire-managed/AppHost processes are cleaned up. Best effort: CollectAsync swallows scan/stop
+        // failures (only cancellation propagates), so a collection hiccup never fails `aspire ps`. The listing
+        // scan below still surfaces its own failures.
         await _collector.CollectAsync(cancellationToken).ConfigureAwait(false);
 
         // Scan for running AppHosts (same as ListAppHostsTool). JSON output must not go

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -208,8 +208,16 @@ internal sealed class RunCommand : BaseCommand
         AppHostProjectContext? context = null;
         Activity? runActivity = null;
         // Hoisted so the outer finally can guarantee disposal on every failure/cancellation path. The
-        // happy path disposes (and nulls) it earlier, once startup succeeds.
+        // monitor is disarmed early (once the AppHost backchannel is established); the finally is an
+        // idempotent backstop for paths that never reach that point.
         LauncherLivenessMonitor? launcherMonitor = null;
+        // Hoisted so the outer finally can tear down the AppHost (dotnet run) before a detached child
+        // process exits. A cancellation/failure during startup can otherwise return while the AppHost
+        // shutdown ladder is still running, orphaning a dotnet run process that aspire ps cannot see
+        // (its backchannel never came up). The CTS is hoisted (instead of `using var`) for the same
+        // reason: the finally needs it to cancel the run, so it cannot be scoped to the try block.
+        Task<int>? pendingRun = null;
+        CancellationTokenSource? runCancellationTokenSource = null;
 
         try
         {
@@ -296,18 +304,25 @@ internal sealed class RunCommand : BaseCommand
             }
 
             // Start the project run as a pending task - we'll handle UX while it runs
-            Task<int> pendingRun;
             var startupTimeout = TimeSpan.FromSeconds(timeoutSeconds);
             var startupStartTimestamp = _timeProvider.GetTimestamp();
-            using var runCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            runCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             // When this is a detached child, watch the foreground launcher during startup. If the launcher
-            // is killed before the app is ready, cancel the run so the AppHost tree is torn down instead of leaking. 
-            // The monitor is disarmed once startup succeeds (see below); from that point the child
-            // is intentionally independent and the launcher's normal exit must not affect it.
+            // is killed before the app is ready, cancel the run so the AppHost tree is torn down instead of leaking.
+            // The monitor is disarmed as soon as the AppHost backchannel is established (see
+            // onBackchannelEstablished below); from that point the AppHost's own orphan detector anchors to
+            // this child, so the launcher's normal exit after observing readiness must not affect us.
+            Func<ValueTask>? onBackchannelEstablished = null;
             if (IsDetachedStartChild())
             {
                 launcherMonitor = LauncherLivenessMonitor.StartIfConfigured(_configuration, runCancellationTokenSource, _timeProvider, _logger);
+                if (launcherMonitor is { } armedMonitor)
+                {
+                    // Disarm at the earliest safe point. DisposeAsync is idempotent, so the outer finally
+                    // can still dispose it as a backstop for paths that never establish the backchannel.
+                    onBackchannelEstablished = () => armedMonitor.DisposeAsync();
+                }
             }
 
             using (_profilingTelemetry.StartRunAppHostStartProject(project.LanguageId, noBuild, waitForDebugger))
@@ -361,6 +376,7 @@ internal sealed class RunCommand : BaseCommand
                     startup = await WaitForAppHostStartupAsync(
                         pendingRun,
                         backchannelCompletionSource,
+                        onBackchannelEstablished,
                         logCaptureCancellationSource,
                         context.OutputCollector,
                         appHostStartupOutputStartIndex,
@@ -378,15 +394,6 @@ internal sealed class RunCommand : BaseCommand
                 var backchannel = startup.Backchannel;
                 var dashboardUrls = startup.DashboardUrls;
                 pendingLogCapture = startup.PendingLogCapture;
-
-                // Startup succeeded and the app is ready. Disarm the launcher watchdog: from here the
-                // detached child is independent, and the foreground launcher is expected to exit normally
-                // once it has observed readiness, so it must no longer trigger a shutdown.
-                if (launcherMonitor is not null)
-                {
-                    await launcherMonitor.DisposeAsync().ConfigureAwait(false);
-                    launcherMonitor = null;
-                }
 
                 if (dashboardUrls.DashboardHealthy is false)
                 {
@@ -618,11 +625,34 @@ internal sealed class RunCommand : BaseCommand
         }
         finally
         {
+            // A detached child supervises the AppHost (dotnet run) for its whole lifetime, so it must
+            // not return while that process tree is still being torn down. Several early-exit paths above
+            // (a termination signal or other cancellation arriving before the backchannel is established)
+            // unwind without awaiting pendingRun, which only *starts* the AppHost shutdown ladder; if we
+            // returned now the CLI process would exit and orphan a dotnet run process that aspire ps cannot
+            // even see (its backchannel never came up). Cancel the run (already cancelled on the signal
+            // path) and wait, bounded, for the ladder to finish the kill. CancellationToken.None is
+            // deliberate: on the leak path the root token is already cancelled, so passing it would
+            // short-circuit the wait and re-introduce the leak.
+            if (IsDetachedStartChild() && pendingRun is { IsCompleted: false } detachedAppHostRun)
+            {
+                try
+                {
+                    runCancellationTokenSource?.Cancel();
+                    await detachedAppHostRun.WaitAsync(s_appHostStartupCancellationTimeout, _timeProvider, CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Detached child timed out or failed while awaiting AppHost teardown during early exit.");
+                }
+            }
+
             if (launcherMonitor is not null)
             {
                 await launcherMonitor.DisposeAsync().ConfigureAwait(false);
             }
 
+            runCancellationTokenSource?.Dispose();
             runActivity?.Dispose();
         }
     }
@@ -724,6 +754,7 @@ internal sealed class RunCommand : BaseCommand
     private async Task<AppHostStartupResult> WaitForAppHostStartupAsync(
         Task<int> pendingRun,
         TaskCompletionSource<IAppHostCliBackchannel> backchannelCompletionSource,
+        Func<ValueTask>? onBackchannelEstablished,
         CancellationTokenSource logCaptureCancellationSource,
         OutputCollector? outputCollector,
         int appHostStartupOutputStartIndex,
@@ -732,7 +763,7 @@ internal sealed class RunCommand : BaseCommand
         CancellationToken cancellationToken)
     {
         using var startupCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var happyPathTask = RunStartupHappyPathAsync(backchannelCompletionSource, logCaptureCancellationSource, pendingRun, startupStartTimestamp, startupTimeout, startupCts.Token);
+        var happyPathTask = RunStartupHappyPathAsync(backchannelCompletionSource, onBackchannelEstablished, logCaptureCancellationSource, pendingRun, startupStartTimestamp, startupTimeout, startupCts.Token);
 
         // Race the startup readiness signal against the AppHost system task. The AppHost
         // system is owned by the project and tears itself down (via an internal escalation
@@ -811,6 +842,7 @@ internal sealed class RunCommand : BaseCommand
 
     private async Task<AppHostStartupResult> RunStartupHappyPathAsync(
         TaskCompletionSource<IAppHostCliBackchannel> backchannelCompletionSource,
+        Func<ValueTask>? onBackchannelEstablished,
         CancellationTokenSource logCaptureCancellationSource,
         Task<int> pendingRun,
         long startupStartTimestamp,
@@ -824,6 +856,17 @@ internal sealed class RunCommand : BaseCommand
                 RunCommandStrings.ConnectingToAppHost,
                 async () => await backchannelCompletionSource.Task.WaitAsync(GetRemainingStartupTimeout(startupStartTimestamp, startupTimeout), _timeProvider, cancellationToken).ConfigureAwait(false));
             waitForBackchannelActivity.SetAppHostBackchannelConnected(true);
+        }
+
+        // The child<->AppHost backchannel now exists, which is the earliest point at which the AppHost is
+        // self-anchored: its orphan detector watches THIS child via ASPIRE_CLI_PID, and aspire ps/stop can
+        // discover it. Disarm the launcher watchdog here so the foreground launcher's normal exit (right
+        // after it observes readiness over the auxiliary backchannel) cannot be mistaken for an early death
+        // and tear the AppHost down. Doing this before GetDashboardUrlsAsync / the early-exit observation
+        // window closes the race that otherwise shuts down a healthy detached start.
+        if (onBackchannelEstablished is not null)
+        {
+            await onBackchannelEstablished().ConfigureAwait(false);
         }
 
         // Start log capture early so any output produced while we wait for dashboard URLs is

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -207,17 +207,9 @@ internal sealed class RunCommand : BaseCommand
 
         AppHostProjectContext? context = null;
         Activity? runActivity = null;
-        // Hoisted so the outer finally can guarantee disposal on every failure/cancellation path. The
-        // monitor is disarmed early (once the AppHost backchannel is established); the finally is an
-        // idempotent backstop for paths that never reach that point.
         LauncherLivenessMonitor? launcherMonitor = null;
-        // Hoisted so the outer finally can tear down the AppHost (dotnet run) before a detached child
-        // process exits. A cancellation/failure during startup can otherwise return while the AppHost
-        // shutdown ladder is still running, orphaning a dotnet run process that aspire ps cannot see
-        // (its backchannel never came up). The CTS is hoisted (instead of `using var`) for the same
-        // reason: the finally needs it to cancel the run, so it cannot be scoped to the try block.
-        Task<int>? pendingRun = null;
-        CancellationTokenSource? runCancellationTokenSource = null;
+        Task<int>? runTask = null;
+        CancellationTokenSource? runCts = null;
 
         try
         {
@@ -306,7 +298,7 @@ internal sealed class RunCommand : BaseCommand
             // Start the project run as a pending task - we'll handle UX while it runs
             var startupTimeout = TimeSpan.FromSeconds(timeoutSeconds);
             var startupStartTimestamp = _timeProvider.GetTimestamp();
-            runCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            runCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             // When this is a detached child, watch the foreground launcher during startup. If the launcher
             // is killed before the app is ready, cancel the run so the AppHost tree is torn down instead of leaking.
@@ -316,18 +308,19 @@ internal sealed class RunCommand : BaseCommand
             Func<ValueTask>? onBackchannelEstablished = null;
             if (IsDetachedStartChild())
             {
-                launcherMonitor = LauncherLivenessMonitor.StartIfConfigured(_configuration, runCancellationTokenSource, _timeProvider, _logger);
+                // Use launcher monitor to ensure that if the launcher fails or is killed,
+                // the child process(es) are not leaked.
+                launcherMonitor = LauncherLivenessMonitor.StartIfConfigured(_configuration, runCts, _timeProvider, _logger);
                 if (launcherMonitor is { } armedMonitor)
                 {
-                    // Disarm at the earliest safe point. DisposeAsync is idempotent, so the outer finally
-                    // can still dispose it as a backstop for paths that never establish the backchannel.
+                    // Disarm at the earliest safe point. DisposeAsync is idempotent.
                     onBackchannelEstablished = () => armedMonitor.DisposeAsync();
                 }
             }
 
             using (_profilingTelemetry.StartRunAppHostStartProject(project.LanguageId, noBuild, waitForDebugger))
             {
-                pendingRun = project.RunAsync(context, runCancellationTokenSource.Token);
+                runTask = project.RunAsync(context, runCts.Token);
             }
 
             // Wait for the build to complete first (project handles its own build status spinners)
@@ -341,7 +334,7 @@ internal sealed class RunCommand : BaseCommand
                 catch (TimeoutException)
                 {
                     runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "startup_timeout");
-                    await CancelAppHostStartupAsync(runCancellationTokenSource, pendingRun, cancellationToken).ConfigureAwait(false);
+                    await CancelAppHostStartupAsync(runCts, runTask, cancellationToken).ConfigureAwait(false);
                     return CreateStartupTimeoutResult(timeoutSeconds);
                 }
 
@@ -355,7 +348,7 @@ internal sealed class RunCommand : BaseCommand
                 {
                     InteractionService.DisplayLines(outputCollector.GetLines());
                 }
-                return CommandResult.Failure(await pendingRun, InteractionServiceStrings.ProjectCouldNotBeBuilt);
+                return CommandResult.Failure(await runTask, InteractionServiceStrings.ProjectCouldNotBeBuilt);
             }
             var appHostStartupOutputStartIndex = context.OutputCollector?.GetLines().Count() ?? 0;
 
@@ -374,7 +367,7 @@ internal sealed class RunCommand : BaseCommand
                 try
                 {
                     startup = await WaitForAppHostStartupAsync(
-                        pendingRun,
+                        runTask,
                         backchannelCompletionSource,
                         onBackchannelEstablished,
                         logCaptureCancellationSource,
@@ -387,7 +380,7 @@ internal sealed class RunCommand : BaseCommand
                 catch (TimeoutException)
                 {
                     runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "startup_timeout");
-                    await CancelAppHostStartupAsync(runCancellationTokenSource, pendingRun, cancellationToken).ConfigureAwait(false);
+                    await CancelAppHostStartupAsync(runCts, runTask, cancellationToken).ConfigureAwait(false);
                     return CreateStartupTimeoutResult(timeoutSeconds);
                 }
 
@@ -430,7 +423,7 @@ internal sealed class RunCommand : BaseCommand
                 var profileStopRequested = false;
                 if (captureProfile)
                 {
-                    profileStopRequested = await RequestAppHostStopForProfileAsync(backchannel, pendingRun, captureProfileDelay, _profilingTelemetry, cancellationToken).ConfigureAwait(false);
+                    profileStopRequested = await RequestAppHostStopForProfileAsync(backchannel, runTask, captureProfileDelay, _profilingTelemetry, cancellationToken).ConfigureAwait(false);
                 }
                 else if (!isRemoteEnvironment)
                 {
@@ -518,7 +511,7 @@ internal sealed class RunCommand : BaseCommand
                         pendingLogCapture = Task.CompletedTask;
                     }
 
-                    var exitCode = await pendingRun;
+                    var exitCode = await runTask;
                     lifetimeActivity.SetProcessExitCode(exitCode);
 
                     // Capture mode intentionally turns a long-running AppHost startup into a finite command.
@@ -542,7 +535,7 @@ internal sealed class RunCommand : BaseCommand
                         : CommandResult.FromExitCode(exitCode);
                 }
             }
-            catch (OperationCanceledException ex) when (ex.CancellationToken == runCancellationTokenSource.Token && cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException ex) when (ex.CancellationToken == runCts.Token && cancellationToken.IsCancellationRequested)
             {
                 runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "canceled");
 
@@ -625,20 +618,14 @@ internal sealed class RunCommand : BaseCommand
         }
         finally
         {
-            // A detached child supervises the AppHost (dotnet run) for its whole lifetime, so it must
-            // not return while that process tree is still being torn down. Several early-exit paths above
-            // (a termination signal or other cancellation arriving before the backchannel is established)
-            // unwind without awaiting pendingRun, which only *starts* the AppHost shutdown ladder; if we
-            // returned now the CLI process would exit and orphan a dotnet run process that aspire ps cannot
-            // even see (its backchannel never came up). Cancel the run (already cancelled on the signal
-            // path) and wait, bounded, for the ladder to finish the kill. CancellationToken.None is
-            // deliberate: on the leak path the root token is already cancelled, so passing it would
-            // short-circuit the wait and re-introduce the leak.
-            if (IsDetachedStartChild() && pendingRun is { IsCompleted: false } detachedAppHostRun)
+            if (IsDetachedStartChild() && runTask is { IsCompleted: false } detachedAppHostRun)
             {
+                // If the runTask is still running here, that is an abnormal exit. 
+                // Cancel the run and wait for the AppHost to teardown so we don't leak child processes.
                 try
                 {
-                    runCancellationTokenSource?.Cancel();
+                    runCts?.Cancel();
+                    // CancellationToken.None is deliberate: root token is already cancelled.
                     await detachedAppHostRun.WaitAsync(s_appHostStartupCancellationTimeout, _timeProvider, CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception ex)
@@ -652,7 +639,7 @@ internal sealed class RunCommand : BaseCommand
                 await launcherMonitor.DisposeAsync().ConfigureAwait(false);
             }
 
-            runCancellationTokenSource?.Dispose();
+            runCts?.Dispose();
             runActivity?.Dispose();
         }
     }
@@ -858,12 +845,6 @@ internal sealed class RunCommand : BaseCommand
             waitForBackchannelActivity.SetAppHostBackchannelConnected(true);
         }
 
-        // The child<->AppHost backchannel now exists, which is the earliest point at which the AppHost is
-        // self-anchored: its orphan detector watches THIS child via ASPIRE_CLI_PID, and aspire ps/stop can
-        // discover it. Disarm the launcher watchdog here so the foreground launcher's normal exit (right
-        // after it observes readiness over the auxiliary backchannel) cannot be mistaken for an early death
-        // and tear the AppHost down. Doing this before GetDashboardUrlsAsync / the early-exit observation
-        // window closes the race that otherwise shuts down a healthy detached start.
         if (onBackchannelEstablished is not null)
         {
             await onBackchannelEstablished().ConfigureAwait(false);

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -88,6 +88,12 @@ internal sealed class RunCommand : BaseCommand
     // silently dropping the CTRL_C_EVENT.
     internal static readonly TimeSpan s_gracefulShutdownBudget = TimeSpan.FromSeconds(5);
 
+    // Detached-start children do not have a parent process left to finish cleanup after they exit.
+    // Give the AppHost run task enough time to consume the full graceful budget, escalate to kill,
+    // and drain the signaler so the child does not recreate the process leak that the backstop is
+    // meant to prevent.
+    private static readonly TimeSpan s_detachedAppHostTeardownTimeout = s_gracefulShutdownBudget + TimeSpan.FromSeconds(3);
+
     // Guest AppHosts can bring up the temporary server/backchannel and then fail immediately
     // afterward when the guest startup process hits a syntax, pre-execute, or model validation
     // error. Keep guest AppHost startup waits alive briefly so those failures are reported instead of hidden.
@@ -626,7 +632,7 @@ internal sealed class RunCommand : BaseCommand
                 {
                     runCts?.Cancel();
                     // CancellationToken.None is deliberate: root token is already cancelled.
-                    await detachedAppHostRun.WaitAsync(s_appHostStartupCancellationTimeout, _timeProvider, CancellationToken.None).ConfigureAwait(false);
+                    await detachedAppHostRun.WaitAsync(s_detachedAppHostTeardownTimeout, _timeProvider, CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -12,6 +12,7 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.Diagnostics;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Processes;
 using Aspire.Cli.Profiling;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
@@ -206,6 +207,9 @@ internal sealed class RunCommand : BaseCommand
 
         AppHostProjectContext? context = null;
         Activity? runActivity = null;
+        // Hoisted so the outer finally can guarantee disposal on every failure/cancellation path. The
+        // happy path disposes (and nulls) it earlier, once startup succeeds.
+        LauncherLivenessMonitor? launcherMonitor = null;
 
         try
         {
@@ -296,6 +300,16 @@ internal sealed class RunCommand : BaseCommand
             var startupTimeout = TimeSpan.FromSeconds(timeoutSeconds);
             var startupStartTimestamp = _timeProvider.GetTimestamp();
             using var runCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            // When this is a detached child, watch the foreground launcher during startup. If the launcher
+            // is killed before the app is ready, cancel the run so the AppHost tree is torn down instead of leaking. 
+            // The monitor is disarmed once startup succeeds (see below); from that point the child
+            // is intentionally independent and the launcher's normal exit must not affect it.
+            if (IsDetachedStartChild())
+            {
+                launcherMonitor = LauncherLivenessMonitor.StartIfConfigured(_configuration, runCancellationTokenSource, _timeProvider, _logger);
+            }
+
             using (_profilingTelemetry.StartRunAppHostStartProject(project.LanguageId, noBuild, waitForDebugger))
             {
                 pendingRun = project.RunAsync(context, runCancellationTokenSource.Token);
@@ -364,6 +378,15 @@ internal sealed class RunCommand : BaseCommand
                 var backchannel = startup.Backchannel;
                 var dashboardUrls = startup.DashboardUrls;
                 pendingLogCapture = startup.PendingLogCapture;
+
+                // Startup succeeded and the app is ready. Disarm the launcher watchdog: from here the
+                // detached child is independent, and the foreground launcher is expected to exit normally
+                // once it has observed readiness, so it must no longer trigger a shutdown.
+                if (launcherMonitor is not null)
+                {
+                    await launcherMonitor.DisposeAsync().ConfigureAwait(false);
+                    launcherMonitor = null;
+                }
 
                 if (dashboardUrls.DashboardHealthy is false)
                 {
@@ -595,6 +618,11 @@ internal sealed class RunCommand : BaseCommand
         }
         finally
         {
+            if (launcherMonitor is not null)
+            {
+                await launcherMonitor.DisposeAsync().ConfigureAwait(false);
+            }
+
             runActivity?.Dispose();
         }
     }

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -24,6 +24,7 @@ internal sealed class StopCommand : BaseCommand
     private readonly ICliHostEnvironment _hostEnvironment;
     private readonly IEnvironment _environment;
     private readonly ProcessTreeGracefulShutdownService _processShutdownService;
+    private readonly OrphanedAppHostCollector _collector;
     private readonly ProfilingTelemetry _profilingTelemetry;
 
     private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", StopCommandStrings.ProjectArgumentDescription);
@@ -38,6 +39,7 @@ internal sealed class StopCommand : BaseCommand
         ICliHostEnvironment hostEnvironment,
         IEnvironment environment,
         ProcessTreeGracefulShutdownService processShutdownService,
+        OrphanedAppHostCollector collector,
         ILogger<StopCommand> logger,
         ProfilingTelemetry profilingTelemetry,
         CommonCommandServices services)
@@ -47,6 +49,7 @@ internal sealed class StopCommand : BaseCommand
         _hostEnvironment = hostEnvironment;
         _environment = environment;
         _processShutdownService = processShutdownService;
+        _collector = collector;
         _logger = logger;
         _profilingTelemetry = profilingTelemetry;
 
@@ -147,6 +150,22 @@ internal sealed class StopCommand : BaseCommand
     /// </summary>
     private async Task<int> StopAllAppHostsAsync(CancellationToken cancellationToken)
     {
+        // First collect AppHosts whose launching CLI has died. 
+        // Collecting first guarantees orphaned trees and their stale sockets are cleaned up 
+        // even if the normal stop path can't connect to one of them.
+        try
+        {
+            var collected = await _collector.CollectAsync(cancellationToken).ConfigureAwait(false);
+            if (collected > 0)
+            {
+                _logger.LogDebug("Collected {Count} orphaned AppHost(s) before stopping the rest.", collected);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "Failed to collect orphaned AppHosts during stop --all.");
+        }
+
         var allConnections = await _connectionResolver.ResolveAllConnectionsAsync(
             SharedCommandStrings.ScanningForRunningAppHosts,
             cancellationToken);

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -150,20 +150,14 @@ internal sealed class StopCommand : BaseCommand
     /// </summary>
     private async Task<int> StopAllAppHostsAsync(CancellationToken cancellationToken)
     {
-        // First collect AppHosts whose launching CLI has died. 
-        // Collecting first guarantees orphaned trees and their stale sockets are cleaned up 
-        // even if the normal stop path can't connect to one of them.
-        try
+        // First collect AppHosts whose launching CLI has died.
+        // Collecting first guarantees orphaned trees and their stale sockets are cleaned up
+        // even if the normal stop path can't connect to one of them. CollectAsync is best effort and
+        // never throws for scan/stop failures (only cancellation propagates), so no guard is needed here.
+        var collected = await _collector.CollectAsync(cancellationToken).ConfigureAwait(false);
+        if (collected > 0)
         {
-            var collected = await _collector.CollectAsync(cancellationToken).ConfigureAwait(false);
-            if (collected > 0)
-            {
-                _logger.LogDebug("Collected {Count} orphaned AppHost(s) before stopping the rest.", collected);
-            }
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _logger.LogDebug(ex, "Failed to collect orphaned AppHosts during stop --all.");
+            _logger.LogDebug("Collected {Count} orphaned AppHost(s) before stopping the rest.", collected);
         }
 
         var allConnections = await _connectionResolver.ResolveAllConnectionsAsync(

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -85,8 +85,8 @@ internal sealed class ProcessInvocationOptions
 
     /// <summary>
     /// When <c>true</c>, the child is bound to the CLI's Windows kill-on-close job so the OS terminates
-    /// it when the CLI exits unexpectedly (crash / SIGKILL), even if the child is wedged in a native
-    /// call and cannot react to cancellation. This is an OS-level, Windows-only crash-time safety net
+    /// it when the CLI exits unexpectedly (crash / SIGKILL), even if the child does not react 
+    /// to cancellation request. This is an OS-level, Windows-only crash-time safety net
     /// for background helpers that must never outlive their parent — the <c>aspire-managed</c> NuGet
     /// helper, the standalone dashboard, and the profiling collector — and, unlike
     /// <see cref="IsolateConsole"/>, it does not give the child a new console group.

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -368,28 +368,15 @@ internal sealed class DotNetCliRunner(
         public int StderrLineCount;
     }
 
-    internal static int GetCurrentProcessId() => Environment.ProcessId;
-
-    internal static long GetCurrentProcessStartTimeUnixSeconds()
-    {
-        var startTime = Process.GetCurrentProcess().StartTime;
-        return ((DateTimeOffset)startTime).ToUnixTimeSeconds();
-    }
-
     /// <summary>
     /// Configures dotnet-specific environment variables for CLI process executions.
     /// </summary>
     private void ConfigureDotNetEnvironment(IDictionary<string, string> env)
     {
-        // The AppHost uses this environment variable to signal to the CliOrphanDetector which process
-        // it should monitor in order to know when to stop the CLI. As long as the process still exists
-        // the orphan detector will allow the CLI to keep running. If the environment variable does
-        // not exist the orphan detector will exit.
-        env[KnownConfigNames.CliProcessId] = GetCurrentProcessId().ToString(CultureInfo.InvariantCulture);
-
-        // Set the CLI process start time for robust orphan detection to prevent PID reuse issues.
-        // The AppHost will verify both PID and start time to ensure it's monitoring the correct process.
-        env[KnownConfigNames.CliProcessStarted] = GetCurrentProcessStartTimeUnixSeconds().ToString(CultureInfo.InvariantCulture);
+        // Stamp the CLI's identity (PID + start time) so the AppHost's CliOrphanDetector can verify
+        // which process it is monitoring and exit once that process is gone. Verifying both PID and
+        // start time avoids acting on a recycled PID. If the variables are absent the detector exits.
+        OrphanDetectionEnvironment.ApplyCurrentProcess(env);
 
         // Pass the CLI log file path so that querying CLI processes (e.g., aspire resource, aspire stop)
         // can surface it to help users diagnose issues in the managing CLI process.

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -67,20 +67,37 @@ internal sealed class ProcessInvocationOptions
     public bool KillEntireProcessTreeOnCancel { get; set; } = true;
 
     /// <summary>
-    /// When <c>true</c>, the spawned process is given its own hidden console group (Windows)
-    /// and, on Windows, is assigned to the CLI's kill-on-close job object. Required so the
-    /// shutdown ladder in <see cref="ProcessExecution"/> can target the child with
-    /// DCP's <c>stop-process-tree</c> CTRL+C dance.
+    /// When <c>true</c>, the spawned process is given its own hidden console group (Windows) so the
+    /// shutdown ladder in <see cref="ProcessExecution"/> can target the child with DCP's
+    /// <c>stop-process-tree</c> CTRL+C dance without also signalling the CLI. On Windows a
+    /// console-isolated child is additionally bound to the process-wide
+    /// <see cref="WindowsConsoleProcessJob"/> kill-on-close job as its crash-time safety net.
     /// </summary>
     /// <remarks>
-    /// Pair with <see cref="GracefulShutdownSignaler"/> and <see cref="ShutdownService"/>.
-    /// On Windows the spawned process is bound to the process-wide
-    /// <see cref="WindowsConsoleProcessJob"/> kill-on-close job automatically.
+    /// Pair with <see cref="GracefulShutdownSignaler"/> and <see cref="ShutdownService"/> for
+    /// graceful shutdown. A non-isolated background helper that should not outlive the CLI can opt
+    /// into the same kill-on-close job — without a new console group — via <see cref="KillOnParentExit"/>.
     /// Leaving the signaler/service unset means cancellation falls back to
     /// <see cref="ProcessExecution"/>'s force-kill mode, preserving back-compat
     /// for the many non-Run callers (build, restore, package add, layout, etc.).
     /// </remarks>
     public bool IsolateConsole { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, the child is bound to the CLI's Windows kill-on-close job so the OS terminates
+    /// it when the CLI exits unexpectedly (crash / SIGKILL), even if the child is wedged in a native
+    /// call and cannot react to cancellation. This is an OS-level, Windows-only crash-time safety net
+    /// for background helpers that must never outlive their parent — the <c>aspire-managed</c> NuGet
+    /// helper, the standalone dashboard, and the profiling collector — and, unlike
+    /// <see cref="IsolateConsole"/>, it does not give the child a new console group.
+    /// </summary>
+    /// <remarks>
+    /// On non-Windows hosts this is a no-op; process-group signalling plus the in-child
+    /// parent-liveness watchdog (which self-terminates when <c>ASPIRE_CLI_PID</c> disappears) provide
+    /// the cross-platform equivalent. The two layers are complementary: the job is the instant,
+    /// guaranteed backstop on Windows, and the watchdog is the graceful, cross-platform mechanism.
+    /// </remarks>
+    public bool KillOnParentExit { get; set; }
 
     /// <summary>
     /// Issues the graceful shutdown signal during the shutdown ladder (DCP
@@ -315,11 +332,13 @@ internal sealed class DotNetCliRunner(
             KillEntireProcessTreeOnCancel = options.KillEntireProcessTreeOnCancel,
             // Forward the Run-path shutdown ladder opt-ins. Forgetting any of these silently
             // demotes the run to the force-kill fallback: IsolateConsole=false skips console
-            // isolation, and the null signaler/service pair causes ProcessExecution's OCE catch
+            // isolation, KillOnParentExit=false removes the Windows crash-time job safety net, and the
+            // null signaler/service pair causes ProcessExecution's OCE catch
             // (DotNet/ProcessExecution.cs) to route through its force-kill mode (best-effort SIGTERM
             // then kill) instead of its graceful ladder. Build/restore/etc. callers leave these unset
             // and intentionally keep the force-kill path.
             IsolateConsole = options.IsolateConsole,
+            KillOnParentExit = options.KillOnParentExit,
             GracefulShutdownSignaler = options.GracefulShutdownSignaler,
             ShutdownService = options.ShutdownService,
             StandardOutputCallback = line =>

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -113,6 +113,26 @@ internal sealed class ProcessInvocationOptions
     /// force-kill mode.
     /// </summary>
     public IGracefulShutdownWindow? ShutdownService { get; set; }
+
+    /// <summary>
+    /// Creates a shallow copy so a caller-supplied instance can be layered with additional settings
+    /// without mutating the original, which the caller may reuse across invocations. The delegate and
+    /// service references are intentionally shared with the copy.
+    /// </summary>
+    public ProcessInvocationOptions Clone() => new()
+    {
+        StandardOutputCallback = StandardOutputCallback,
+        StandardErrorCallback = StandardErrorCallback,
+        NoLaunchProfile = NoLaunchProfile,
+        StartDebugSession = StartDebugSession,
+        Debug = Debug,
+        SuppressLogging = SuppressLogging,
+        KillEntireProcessTreeOnCancel = KillEntireProcessTreeOnCancel,
+        IsolateConsole = IsolateConsole,
+        KillOnParentExit = KillOnParentExit,
+        GracefulShutdownSignaler = GracefulShutdownSignaler,
+        ShutdownService = ShutdownService,
+    };
 }
 
 internal sealed class DotNetCliRunner(

--- a/src/Aspire.Cli/DotNet/ProcessExecution.cs
+++ b/src/Aspire.Cli/DotNet/ProcessExecution.cs
@@ -9,11 +9,9 @@ namespace Aspire.Cli.DotNet;
 
 /// <summary>
 /// The single <see cref="IProcessExecution"/> implementation. Wraps an <see cref="IsolatedProcess"/>
-/// for both the isolated-console run path (Windows AppHost graceful shutdown) and ordinary
-/// non-isolated subprocesses — the only difference is the
-/// <see cref="IsolatedProcessStartInfo.IsolateConsole"/> flag the factory sets. The child is
-/// spawned lazily on <see cref="Start"/> so callers that build an execution but never start it
-/// (e.g. the extension-host launch path, which reads <see cref="Arguments"/> /
+/// for isolated-console, kill-on-parent-exit, and ordinary redirected subprocesses. The child is
+/// spawned lazily on <see cref="Start"/> so callers that build an execution but never start it (e.g.
+/// the extension-host launch path, which reads <see cref="Arguments"/> /
 /// <see cref="EnvironmentVariables"/> and returns before starting) don't orphan a process.
 /// </summary>
 internal sealed class ProcessExecution : IProcessExecution

--- a/src/Aspire.Cli/DotNet/ProcessExecutionFactory.cs
+++ b/src/Aspire.Cli/DotNet/ProcessExecutionFactory.cs
@@ -33,10 +33,7 @@ internal sealed class ProcessExecutionFactory(
             FileName = fileName,
             WorkingDirectory = workingDirectory.FullName,
             IsolateConsole = options.IsolateConsole,
-            // Only the isolated path on Windows uses the kill-on-close job; the non-isolated path
-            // and every Unix path leave it null. The job is the process-wide singleton, created on
-            // demand the first time an isolated child needs it.
-            JobHandle = options.IsolateConsole && environment.IsWindows() ? WindowsConsoleProcessJob.Shared.Handle : null,
+            KillOnParentExit = options.KillOnParentExit,
         };
 
         foreach (var a in args)
@@ -70,7 +67,7 @@ internal sealed class ProcessExecutionFactory(
             FileName = startInfo.FileName,
             WorkingDirectory = startInfo.WorkingDirectory,
             IsolateConsole = options.IsolateConsole,
-            JobHandle = options.IsolateConsole && environment.IsWindows() ? WindowsConsoleProcessJob.Shared.Handle : null,
+            KillOnParentExit = options.KillOnParentExit,
         };
 
         foreach (var arg in startInfo.ArgumentList)

--- a/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
+++ b/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Text;
 using Aspire.Cli.DotNet;
+using Aspire.Hosting;
 
 namespace Aspire.Cli.Layout;
 
@@ -32,7 +34,12 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         var args = arguments.ToArray();
         var workDir = new DirectoryInfo(workingDirectory ?? Directory.GetCurrentDirectory());
 
-        await using var execution = executionFactory.CreateExecution(toolPath, args, environmentVariables, workDir, options);
+        // Stamp the launching CLI's identity onto the child so layout tools (e.g. aspire-managed nuget)
+        // can run a parent-liveness watchdog and self-terminate if the CLI dies,
+        // preventing leaked aspire-managed processes. Does not override values the caller already set.
+        var effectiveEnvironment = WithOrphanDetectionEnvironment(environmentVariables);
+
+        await using var execution = executionFactory.CreateExecution(toolPath, args, effectiveEnvironment, workDir, options);
 
         if (!execution.Start())
         {
@@ -64,5 +71,25 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         }
 
         return execution;
+    }
+
+    private static IDictionary<string, string> WithOrphanDetectionEnvironment(IDictionary<string, string>? environmentVariables)
+    {
+        // Copy so the caller's dictionary is never mutated; tolerate a null input.
+        var environment = environmentVariables is null
+            ? new Dictionary<string, string>(StringComparer.Ordinal)
+            : new Dictionary<string, string>(environmentVariables, StringComparer.Ordinal);
+
+        if (!environment.ContainsKey(KnownConfigNames.CliProcessId))
+        {
+            environment[KnownConfigNames.CliProcessId] = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (!environment.ContainsKey(KnownConfigNames.CliProcessStarted))
+        {
+            environment[KnownConfigNames.CliProcessStarted] = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds().ToString(CultureInfo.InvariantCulture);
+        }
+
+        return environment;
     }
 }

--- a/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
+++ b/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
@@ -62,7 +62,13 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         var args = arguments.ToArray();
         var workDir = new DirectoryInfo(workingDirectory ?? Directory.GetCurrentDirectory());
 
-        var execution = executionFactory.CreateExecution(toolPath, args, environmentVariables, workDir, options ?? new ProcessInvocationOptions());
+        // Stamp the launching CLI's identity onto the child (same as RunAsync) so long-lived layout
+        // processes started here — notably aspire-managed dashboard for `aspire dashboard run` and the
+        // profiling collector — can run a parent-liveness watchdog and self-terminate if the CLI is
+        // hard-killed, preventing leaked aspire-managed processes. Does not override caller-set values.
+        var effectiveEnvironment = WithOrphanDetectionEnvironment(environmentVariables);
+
+        var execution = executionFactory.CreateExecution(toolPath, args, effectiveEnvironment, workDir, options ?? new ProcessInvocationOptions());
 
         if (!execution.Start())
         {

--- a/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
+++ b/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
@@ -29,19 +29,24 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
             SuppressLogging = true,
             StandardOutputCallback = line => outputBuilder.AppendLine(line),
             StandardErrorCallback = line => errorBuilder.AppendLine(line),
-            // Windows OS-level backstop layered on top of the cross-platform watchdog stamped below:
-            // binds the child to the CLI's kill-on-close job so a hard-killed CLI cannot leak this
-            // helper even if it is wedged in a native call. No-op on non-Windows hosts.
             KillOnParentExit = killOnParentExit,
         };
 
         var args = arguments.ToArray();
         var workDir = new DirectoryInfo(workingDirectory ?? Directory.GetCurrentDirectory());
 
-        // Stamp the launching CLI's identity onto the child so layout tools (e.g. aspire-managed nuget)
-        // can run a parent-liveness watchdog and self-terminate if the CLI dies,
-        // preventing leaked aspire-managed processes. Does not override values the caller already set.
-        var effectiveEnvironment = WithOrphanDetectionEnvironment(environmentVariables);
+        // The Windows kill-on-close job (KillOnParentExit, above) and the cross-platform cooperative
+        // parent-liveness watchdog (activated by the ASPIRE_CLI_PID identity that
+        // WithOrphanDetectionEnvironment stamps) are two implementations of the SAME "don't outlive the
+        // CLI" policy. Arming BOTH on one child races the job's kernel TerminateProcess against the
+        // watchdog's Environment.Exit(124) when the CLI exits, which can get the child stuck mid-teardown.
+        // So we use exactly one mechanism per child: on Windows the kill-on-close
+        // job is authoritative (kernel-enforced), and we do not use the watchdog.
+        // Everywhere else KillOnParentExit is a no-op, and the cooperative watchdog remains the sole mechanism 
+        // and MUST have relevant environment variables set.
+        var effectiveEnvironment = options.KillOnParentExit && OperatingSystem.IsWindows()
+            ? CopyEnvironment(environmentVariables)
+            : WithOrphanDetectionEnvironment(environmentVariables);
 
         await using var execution = executionFactory.CreateExecution(toolPath, args, effectiveEnvironment, workDir, options);
 
@@ -67,24 +72,19 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         var args = arguments.ToArray();
         var workDir = new DirectoryInfo(workingDirectory ?? Directory.GetCurrentDirectory());
 
-        // Stamp the launching CLI's identity onto the child (same as RunAsync) so long-lived layout
-        // processes started here — notably aspire-managed dashboard for `aspire dashboard run` and the
-        // profiling collector — can run a parent-liveness watchdog and self-terminate if the CLI is
-        // hard-killed, preventing leaked aspire-managed processes. Does not override caller-set values.
-        var effectiveEnvironment = WithOrphanDetectionEnvironment(environmentVariables);
-
         // Clone so the KillOnParentExit flip below never mutates the caller's options instance — the
         // caller may reuse it across invocations. Falls back to a fresh instance when none was passed.
         var effectiveOptions = options?.Clone() ?? new ProcessInvocationOptions();
 
-        // Windows OS-level backstop that complements the cross-platform watchdog above: bind the child
-        // to the CLI's kill-on-close job so the OS terminates it if the CLI dies, even when the child is
-        // wedged and cannot react to the watchdog's cancellation. Only ever turned on here (never off),
-        // so a caller that already opted in via its own options is preserved. No-op on non-Windows hosts.
         if (killOnParentExit)
         {
             effectiveOptions.KillOnParentExit = true;
         }
+
+        // Compare with RunAsync: the same logic applies here.
+        var effectiveEnvironment = effectiveOptions.KillOnParentExit && OperatingSystem.IsWindows()
+            ? CopyEnvironment(environmentVariables)
+            : WithOrphanDetectionEnvironment(environmentVariables);
 
         var execution = executionFactory.CreateExecution(toolPath, args, effectiveEnvironment, workDir, effectiveOptions);
 
@@ -99,10 +99,7 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
 
     private static IDictionary<string, string> WithOrphanDetectionEnvironment(IDictionary<string, string>? environmentVariables)
     {
-        // Copy so the caller's dictionary is never mutated; tolerate a null input.
-        var environment = environmentVariables is null
-            ? new Dictionary<string, string>(StringComparer.Ordinal)
-            : new Dictionary<string, string>(environmentVariables, StringComparer.Ordinal);
+        var environment = CopyEnvironment(environmentVariables);
 
         // Stamp the launching CLI's identity, but never override values the caller already supplied
         // so an explicit caller override always wins.
@@ -110,4 +107,9 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
 
         return environment;
     }
+
+    private static IDictionary<string, string> CopyEnvironment(IDictionary<string, string>? environmentVariables)
+        => environmentVariables is null
+            ? new Dictionary<string, string>(StringComparer.Ordinal)
+            : new Dictionary<string, string>(environmentVariables, StringComparer.Ordinal);
 }

--- a/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
+++ b/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
@@ -73,7 +73,9 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         // hard-killed, preventing leaked aspire-managed processes. Does not override caller-set values.
         var effectiveEnvironment = WithOrphanDetectionEnvironment(environmentVariables);
 
-        var effectiveOptions = options ?? new ProcessInvocationOptions();
+        // Clone so the KillOnParentExit flip below never mutates the caller's options instance — the
+        // caller may reuse it across invocations. Falls back to a fresh instance when none was passed.
+        var effectiveOptions = options?.Clone() ?? new ProcessInvocationOptions();
 
         // Windows OS-level backstop that complements the cross-platform watchdog above: bind the child
         // to the CLI's kill-on-close job so the OS terminates it if the CLI dies, even when the child is

--- a/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
+++ b/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
@@ -1,10 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using System.Text;
 using Aspire.Cli.DotNet;
-using Aspire.Hosting;
+using Aspire.Cli.Processes;
 
 namespace Aspire.Cli.Layout;
 
@@ -103,15 +102,9 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
             ? new Dictionary<string, string>(StringComparer.Ordinal)
             : new Dictionary<string, string>(environmentVariables, StringComparer.Ordinal);
 
-        if (!environment.ContainsKey(KnownConfigNames.CliProcessId))
-        {
-            environment[KnownConfigNames.CliProcessId] = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
-        }
-
-        if (!environment.ContainsKey(KnownConfigNames.CliProcessStarted))
-        {
-            environment[KnownConfigNames.CliProcessStarted] = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds().ToString(CultureInfo.InvariantCulture);
-        }
+        // Stamp the launching CLI's identity, but never override values the caller already supplied
+        // so an explicit caller override always wins.
+        OrphanDetectionEnvironment.ApplyCurrentProcess(environment, overwrite: false);
 
         return environment;
     }

--- a/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
+++ b/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
@@ -19,6 +19,7 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         IEnumerable<string> arguments,
         string? workingDirectory = null,
         IDictionary<string, string>? environmentVariables = null,
+        bool killOnParentExit = false,
         CancellationToken ct = default)
     {
         var outputBuilder = new StringBuilder();
@@ -29,6 +30,10 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
             SuppressLogging = true,
             StandardOutputCallback = line => outputBuilder.AppendLine(line),
             StandardErrorCallback = line => errorBuilder.AppendLine(line),
+            // Windows OS-level backstop layered on top of the cross-platform watchdog stamped below:
+            // binds the child to the CLI's kill-on-close job so a hard-killed CLI cannot leak this
+            // helper even if it is wedged in a native call. No-op on non-Windows hosts.
+            KillOnParentExit = killOnParentExit,
         };
 
         var args = arguments.ToArray();
@@ -57,7 +62,8 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         IEnumerable<string> arguments,
         string? workingDirectory = null,
         IDictionary<string, string>? environmentVariables = null,
-        ProcessInvocationOptions? options = null)
+        ProcessInvocationOptions? options = null,
+        bool killOnParentExit = false)
     {
         var args = arguments.ToArray();
         var workDir = new DirectoryInfo(workingDirectory ?? Directory.GetCurrentDirectory());
@@ -68,7 +74,18 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         // hard-killed, preventing leaked aspire-managed processes. Does not override caller-set values.
         var effectiveEnvironment = WithOrphanDetectionEnvironment(environmentVariables);
 
-        var execution = executionFactory.CreateExecution(toolPath, args, effectiveEnvironment, workDir, options ?? new ProcessInvocationOptions());
+        var effectiveOptions = options ?? new ProcessInvocationOptions();
+
+        // Windows OS-level backstop that complements the cross-platform watchdog above: bind the child
+        // to the CLI's kill-on-close job so the OS terminates it if the CLI dies, even when the child is
+        // wedged and cannot react to the watchdog's cancellation. Only ever turned on here (never off),
+        // so a caller that already opted in via its own options is preserved. No-op on non-Windows hosts.
+        if (killOnParentExit)
+        {
+            effectiveOptions.KillOnParentExit = true;
+        }
+
+        var execution = executionFactory.CreateExecution(toolPath, args, effectiveEnvironment, workDir, effectiveOptions);
 
         if (!execution.Start())
         {

--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -194,6 +194,9 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
             args,
             workingDirectory: workingDirectory.FullName,
             environmentVariables: environmentVariables,
+            // A package search against a slow/unresponsive NuGet source can hang; bind it to the CLI's
+            // kill-on-close job so a hard-killed CLI cannot leak this aspire-managed helper on Windows.
+            killOnParentExit: true,
             ct: cancellationToken).ConfigureAwait(false);
 
         // Log stderr output (verbose info from NuGetHelper)

--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -194,8 +194,9 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
             args,
             workingDirectory: workingDirectory.FullName,
             environmentVariables: environmentVariables,
-            // A package search against a slow/unresponsive NuGet source can hang; bind it to the CLI's
-            // kill-on-close job so a hard-killed CLI cannot leak this aspire-managed helper on Windows.
+            // A package search against a slow/unresponsive NuGet source can hang. LayoutProcessRunner uses
+            // this to bind the helper to the CLI's Windows kill-on-close job (and, on non-Windows, to
+            // instead arm the cooperative parent-liveness watchdog) so a hard-killed CLI cannot leak it.
             killOnParentExit: true,
             ct: cancellationToken).ConfigureAwait(false);
 

--- a/src/Aspire.Cli/NuGet/BundleNuGetService.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetService.cs
@@ -188,8 +188,9 @@ internal sealed class BundleNuGetService : INuGetService
             managedPath,
             restoreArgs,
             environmentVariables: environmentVariables,
-            // A restore against a slow/unresponsive NuGet source can hang; bind it to the CLI's
-            // kill-on-close job so a hard-killed CLI cannot leak this aspire-managed helper on Windows.
+            // A restore against a slow/unresponsive NuGet source can hang. LayoutProcessRunner uses this
+            // to bind the helper to the CLI's Windows kill-on-close job (and, on non-Windows, to instead
+            // arm the cooperative parent-liveness watchdog) so a hard-killed CLI cannot leak it.
             killOnParentExit: true,
             ct: ct);
 
@@ -237,8 +238,8 @@ internal sealed class BundleNuGetService : INuGetService
             managedPath,
             manifestArgs,
             environmentVariables: environmentVariables,
-            // Same rationale as the restore step above: keep this aspire-managed helper from
-            // outliving a hard-killed CLI via the Windows kill-on-close job.
+            // Same rationale as the restore step above: keep this aspire-managed helper from outliving a
+            // hard-killed CLI (Windows kill-on-close job, or the cooperative watchdog on other hosts).
             killOnParentExit: true,
             ct: ct);
 

--- a/src/Aspire.Cli/NuGet/BundleNuGetService.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetService.cs
@@ -188,6 +188,9 @@ internal sealed class BundleNuGetService : INuGetService
             managedPath,
             restoreArgs,
             environmentVariables: environmentVariables,
+            // A restore against a slow/unresponsive NuGet source can hang; bind it to the CLI's
+            // kill-on-close job so a hard-killed CLI cannot leak this aspire-managed helper on Windows.
+            killOnParentExit: true,
             ct: ct);
 
         // Log stderr at debug level for diagnostics
@@ -234,6 +237,9 @@ internal sealed class BundleNuGetService : INuGetService
             managedPath,
             manifestArgs,
             environmentVariables: environmentVariables,
+            // Same rationale as the restore step above: keep this aspire-managed helper from
+            // outliving a hard-killed CLI via the Windows kill-on-close job.
+            killOnParentExit: true,
             ct: ct);
 
         // Log stderr at debug level for diagnostics

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
@@ -12,9 +12,9 @@ namespace Aspire.Cli.Processes;
 internal static partial class DetachedProcessLauncher
 {
     /// <summary>
-    /// Windows implementation using <see cref="WindowsProcessInterop.SpawnConsoleIsolatedProcess"/>
+    /// Windows implementation using <see cref="WindowsProcessInterop.SpawnProcess"/>
     /// with NUL bound to stdout and stderr (stdin is left unset). The detached child is NOT
-    /// assigned to the CLI's kill-on-close job — the entire point of <c>aspire start</c> is
+    /// assigned to the CLI's kill-on-parent-exit job — the entire point of <c>aspire start</c> is
     /// that the AppHost outlives the launching CLI.
     /// </summary>
     [SupportedOSPlatform("windows")]
@@ -49,7 +49,7 @@ internal static partial class DetachedProcessLauncher
             Stderr: nulRawHandle);
 
         // The detached launcher's caller-facing surface takes (predicate, additional) — translate
-        // here into the single-dict shape that SpawnConsoleIsolatedProcess now expects. When the
+        // here into the single-dict shape that SpawnProcess now expects. When the
         // caller passes neither, leave environment null so the child inherits the parent env
         // verbatim (no allocation).
         IReadOnlyDictionary<string, string?>? environment = null;
@@ -77,14 +77,15 @@ internal static partial class DetachedProcessLauncher
         }
 
         // jobHandle: null — detached children must survive a CLI crash. Anything assigned to
-        // the CLI's kill-on-close job dies with the CLI, which is the opposite of what
+        // the CLI's kill-on-parent-exit job dies with the CLI, which is the opposite of what
         // `aspire start` wants.
-        var pi = WindowsProcessInterop.SpawnConsoleIsolatedProcess(
+        var pi = WindowsProcessInterop.SpawnProcess(
             fileName,
             arguments,
             workingDirectory,
             stdio,
             environment,
+            createNewConsole: true,
             jobHandle: null);
 
         Process detachedProcess;

--- a/src/Aspire.Cli/Processes/IAppHostStopper.cs
+++ b/src/Aspire.Cli/Processes/IAppHostStopper.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Backchannel;
+
+namespace Aspire.Cli.Processes;
+
+/// <summary>
+/// Abstraction over "gracefully stop this AppHost process tree (with force-kill fallback)".
+/// Implemented by <see cref="ProcessTreeGracefulShutdownService"/>; exists as an interface so the
+/// orphan-collection path can be unit tested without real process signalling or DCP plumbing.
+/// </summary>
+internal interface IAppHostStopper
+{
+    Task<bool> StopAppHostAsync(
+        AppHostInformation? appHostInfo,
+        Func<CancellationToken, Task<bool>>? requestRpcStopAsync,
+        CancellationToken cancellationToken);
+}

--- a/src/Aspire.Cli/Processes/IsolatedProcess.Windows.cs
+++ b/src/Aspire.Cli/Processes/IsolatedProcess.Windows.cs
@@ -15,10 +15,11 @@ internal sealed partial class IsolatedProcess
 {
     /// <summary>
     /// Windows implementation. Opens NUL for stdin and anonymous pipes for stdout/stderr,
-    /// then delegates to <see cref="WindowsProcessInterop.SpawnConsoleIsolatedProcess"/> for
-    /// the actual <c>CreateProcessW</c> ceremony. When <see cref="IsolatedProcessStartInfo.JobHandle"/>
-    /// is supplied, the spawn primitive does the suspended-create / assign / resume dance so
-    /// the child cannot escape the CLI's kill-on-close job between spawn and assignment.
+    /// then delegates to <see cref="WindowsProcessInterop.SpawnProcess"/> for the actual
+    /// <c>CreateProcessW</c> ceremony. Console isolation and parent-exit protection are
+    /// independent: when <see cref="IsolatedProcessStartInfo.KillOnParentExit"/> is set, the spawn
+    /// primitive does the suspended-create / assign / resume dance even if the child does not need
+    /// a new console group.
     /// </summary>
     /// <remarks>
     /// Unlike <see cref="DetachedProcessLauncher"/>, this launcher consumes the child's
@@ -75,13 +76,23 @@ internal sealed partial class IsolatedProcess
             // null = inherit parent env block.
             var environment = startInfo.GetEnvironmentForSpawn();
 
-            var pi = WindowsProcessInterop.SpawnConsoleIsolatedProcess(
+            // Assign the child to the process-wide kill-on-close job when EITHER console isolation or
+            // explicit parent-exit protection is requested. Console-isolated children (e.g. the AppHost
+            // run path) have always relied on the job as their crash-time safety net, so that coupling is
+            // preserved here; KillOnParentExit additionally opts non-console background helpers
+            // (aspire-managed nuget / dashboard, the profiling collector) into the same job so they cannot
+            // outlive a hard-killed CLI. Keeping the coupling on this side means no caller has to thread a
+            // separate "also kill on exit" flag through the AppHost guest-launch chain just to keep today's
+            // behavior.
+            var jobHandle = (startInfo.IsolateConsole || startInfo.KillOnParentExit) ? WindowsConsoleProcessJob.Shared.Handle : null;
+            var pi = WindowsProcessInterop.SpawnProcess(
                 startInfo.FileName,
                 startInfo.ArgumentList,
                 startInfo.WorkingDirectory,
                 stdio,
                 environment,
-                startInfo.JobHandle);
+                createNewConsole: startInfo.IsolateConsole,
+                jobHandle);
 
             // CreateProcess succeeded; from here, any failure must terminate the just-created
             // child instead of letting it run orphaned. Drop the parent-side copy of the

--- a/src/Aspire.Cli/Processes/IsolatedProcess.Windows.cs
+++ b/src/Aspire.Cli/Processes/IsolatedProcess.Windows.cs
@@ -81,9 +81,7 @@ internal sealed partial class IsolatedProcess
             // run path) have always relied on the job as their crash-time safety net, so that coupling is
             // preserved here; KillOnParentExit additionally opts non-console background helpers
             // (aspire-managed nuget / dashboard, the profiling collector) into the same job so they cannot
-            // outlive a hard-killed CLI. Keeping the coupling on this side means no caller has to thread a
-            // separate "also kill on exit" flag through the AppHost guest-launch chain just to keep today's
-            // behavior.
+            // outlive a hard-killed CLI. 
             var jobHandle = (startInfo.IsolateConsole || startInfo.KillOnParentExit) ? WindowsConsoleProcessJob.Shared.Handle : null;
             var pi = WindowsProcessInterop.SpawnProcess(
                 startInfo.FileName,

--- a/src/Aspire.Cli/Processes/IsolatedProcess.Windows.cs
+++ b/src/Aspire.Cli/Processes/IsolatedProcess.Windows.cs
@@ -18,8 +18,8 @@ internal sealed partial class IsolatedProcess
     /// then delegates to <see cref="WindowsProcessInterop.SpawnProcess"/> for the actual
     /// <c>CreateProcessW</c> ceremony. Console isolation and parent-exit protection are
     /// independent: when <see cref="IsolatedProcessStartInfo.KillOnParentExit"/> is set, the spawn
-    /// primitive does the suspended-create / assign / resume dance even if the child does not need
-    /// a new console group.
+    /// primitive assigns the child to the kill-on-close job atomically at creation
+    /// (<c>PROC_THREAD_ATTRIBUTE_JOB_LIST</c>) even if the child does not need a new console group.
     /// </summary>
     /// <remarks>
     /// Unlike <see cref="DetachedProcessLauncher"/>, this launcher consumes the child's

--- a/src/Aspire.Cli/Processes/IsolatedProcess.cs
+++ b/src/Aspire.Cli/Processes/IsolatedProcess.cs
@@ -4,16 +4,14 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Text;
-using Microsoft.Win32.SafeHandles;
 
 namespace Aspire.Cli.Processes;
 
 /// <summary>
 /// Mirrors <see cref="ProcessStartInfo"/>. Differences from the BCL shape:
 /// stdout/stderr are always redirected (so there is no <c>RedirectStandardOutput</c>
-/// flag — see <see cref="IsolatedProcess.Start"/>), and <see cref="JobHandle"/> adds
-/// the Windows-only kill-on-close safety net described in
-/// <see cref="WindowsConsoleProcessJob"/>.
+/// flag — see <see cref="IsolatedProcess.Start"/>), and <see cref="KillOnParentExit"/> adds
+/// a parent-lifetime safety net for children that should not outlive the CLI.
 /// </summary>
 internal sealed class IsolatedProcessStartInfo
 {
@@ -40,24 +38,21 @@ internal sealed class IsolatedProcessStartInfo
     public IDictionary<string, string?> Environment => _environment ??= LoadParentEnvironment();
 
     /// <summary>
-    /// Windows-only crash-time safety net. When set, the spawned child is atomically
-    /// assigned to this job object via the suspended-create / assign / resume dance in
-    /// <see cref="WindowsProcessInterop.SpawnConsoleIsolatedProcess"/>. Set to
-    /// <see cref="WindowsConsoleProcessJob.Handle"/> from <see cref="WindowsConsoleProcessJob.Shared"/>
-    /// on Windows hosts; <see langword="null"/> on non-Windows hosts (Unix process-group
-    /// semantics cover the equivalent case).
+    /// When <see langword="true"/>, the child should be terminated when the parent exits.
+    /// This mirrors the .NET 11 ProcessStartInfo.KillOnParentExit shape so the custom Windows
+    /// job-object implementation can be replaced by the platform implementation later.
     /// </summary>
-    public SafeFileHandle? JobHandle { get; init; }
+    public bool KillOnParentExit { get; init; }
 
     /// <summary>
     /// When <see langword="true"/> (the default) the child is spawned in its own hidden console
     /// group on Windows (CREATE_NEW_CONSOLE | SW_HIDE) so a graceful CTRL+C can target it without
     /// also signalling the CLI. When <see langword="false"/> the child
-    /// is spawned via an ordinary redirected <see cref="Process.Start(ProcessStartInfo)"/> — no new
-    /// console, no <see cref="JobHandle"/>, and stdin wired to an empty pipe — which is the shape
-    /// every non-isolated CLI subprocess (build, restore, package add, …) uses. On Unix both modes
-    /// are identical because SIGTERM via the process group covers teardown, so only Windows branches
-    /// on this flag.
+    /// is spawned via an ordinary redirected <see cref="Process.Start(ProcessStartInfo)"/> unless
+    /// <see cref="KillOnParentExit"/> is also supplied. Job-protected Windows children use the suspended-create
+    /// launcher even when they do not need graceful console isolation so they are atomically assigned
+    /// to the kill-on-parent-exit job. On Unix both modes are identical because SIGTERM via the process
+    /// group covers teardown, so only Windows branches on this flag.
     /// </summary>
     public bool IsolateConsole { get; init; } = true;
 
@@ -111,10 +106,10 @@ internal sealed class IsolatedProcessStartInfo
 
 /// <summary>
 /// Mirrors <see cref="System.Diagnostics.Process"/> for a child spawned by <see cref="Start"/>.
-/// On Windows the child gets its own hidden console (CREATE_NEW_CONSOLE | SW_HIDE) so a graceful
-/// shutdown can <c>AttachConsole</c> + post <c>CTRL_C_EVENT</c> at it without also signalling the
-/// CLI; on Unix it's a thin <see cref="Process.Start(ProcessStartInfo)"/>
-/// wrapper because SIGTERM via the process group is enough.
+/// On Windows, callers can request either kill-on-parent-exit, a hidden console
+/// (CREATE_NEW_CONSOLE | SW_HIDE) for targeted graceful shutdown, or both. On Unix it's a thin
+/// <see cref="Process.Start(ProcessStartInfo)"/> wrapper because SIGTERM via the process group is
+/// enough.
 /// </summary>
 /// <remarks>
 /// Differences from the BCL shape worth knowing about:
@@ -260,30 +255,23 @@ internal sealed partial class IsolatedProcess : IAsyncDisposable
         ArgumentNullException.ThrowIfNull(standardOutputHandler);
         ArgumentNullException.ThrowIfNull(standardErrorHandler);
 
-        // Non-isolated mode is an ordinary redirected Process.Start on every platform: no new
-        // console, no JobHandle, stdin wired to an empty pipe. On Unix the isolated mode is the
-        // same redirected spawn (SIGTERM via the process group is enough), so only the isolated
-        // Windows path needs the dedicated new-console launcher.
-        if (!startInfo.IsolateConsole)
-        {
-            return StartRedirected(startInfo, standardOutputHandler, standardErrorHandler, redirectStandardInput: true);
-        }
-
-        if (OperatingSystem.IsWindows())
+        // Windows parent-exit protection requires the suspended-create / assign / resume ceremony in
+        // StartWindows. Route protected helpers through that path even when they do not need a
+        // graceful CTRL+C console group; otherwise use the ordinary redirected Process.Start shape.
+        if (OperatingSystem.IsWindows() && (startInfo.IsolateConsole || startInfo.KillOnParentExit))
         {
             return StartWindows(startInfo, standardOutputHandler, standardErrorHandler);
         }
 
-        return StartRedirected(startInfo, standardOutputHandler, standardErrorHandler, redirectStandardInput: false);
+        return StartRedirected(startInfo, standardOutputHandler, standardErrorHandler, redirectStandardInput: !startInfo.IsolateConsole);
     }
 
     /// <summary>
     /// Cross-platform redirected spawn — a thin <see cref="Process.Start(ProcessStartInfo)"/>
     /// wrapper. Used for every non-isolated child (all platforms) and for isolated children on
     /// Unix, where SIGTERM / process groups handle cooperative shutdown so the new-console
-    /// gymnastics the Windows partial uses are unnecessary. <see cref="IsolatedProcessStartInfo.JobHandle"/>
-    /// is ignored here (Unix process-group reparenting + signal delivery cover the crash-time case
-    /// that JobHandle exists to address on Windows).
+    /// gymnastics the Windows partial uses are unnecessary. <see cref="IsolatedProcessStartInfo.KillOnParentExit"/>
+    /// is ignored here until a cross-platform platform primitive is available.
     /// </summary>
     /// <param name="startInfo">Process launch parameters.</param>
     /// <param name="standardOutputHandler">Per-line callback for stdout; receives the wrapper as sender.</param>

--- a/src/Aspire.Cli/Processes/LauncherLivenessMonitor.cs
+++ b/src/Aspire.Cli/Processes/LauncherLivenessMonitor.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Processes;
+
+/// <summary>
+/// Watches the foreground launcher process of a detached <c>aspire start</c> / <c>aspire run --detach</c>
+/// and cancels the AppHost run if that launcher dies before the app reaches readiness.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A detached child CLI is the supervisor that runs the AppHost for its whole lifetime; it is meant to
+/// outlive the foreground that spawned it. But during the startup window (build + waiting for the app to
+/// become ready) the child has no anchor to the launcher, so if the launcher is killed mid-start 
+/// — e.g. the user gets impatient and hits Ctrl-C, or a test runner times it out — 
+/// the AppHost + dashboard are leaked as orphaned processes.
+/// </para>
+/// </remarks>
+internal sealed class LauncherLivenessMonitor : IAsyncDisposable
+{
+    private readonly CancellationTokenSource _stopCts = new();
+    private readonly Task _monitorTask;
+    private int _disposed;
+
+    private LauncherLivenessMonitor(
+        int launcherPid,
+        long? launcherStartedUnix,
+        CancellationTokenSource cancelOnLauncherExit,
+        TimeProvider timeProvider,
+        ILogger logger)
+    {
+        _monitorTask = MonitorAsync(launcherPid, launcherStartedUnix, cancelOnLauncherExit, timeProvider, logger, _stopCts.Token);
+    }
+
+    /// <summary>
+    /// Starts a monitor when the launcher identity is present in configuration (i.e. this process is a detached child). 
+    /// Returns <see langword="null"/> for a normal foreground run, where there is no launcher process to watch.
+    /// </summary>
+    public static LauncherLivenessMonitor? StartIfConfigured(
+        IConfiguration configuration,
+        CancellationTokenSource cancelOnLauncherExit,
+        TimeProvider timeProvider,
+        ILogger logger)
+    {
+        if (!int.TryParse(configuration[KnownConfigNames.CliLauncherProcessId], NumberStyles.Integer, CultureInfo.InvariantCulture, out var launcherPid))
+        {
+            return null;
+        }
+
+        var launcherStartedUnix = ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(configuration[KnownConfigNames.CliLauncherProcessStarted]);
+        logger.LogDebug("Detached child: watching launcher process {LauncherPid} until the AppHost is ready.", launcherPid);
+        return new LauncherLivenessMonitor(launcherPid, launcherStartedUnix, cancelOnLauncherExit, timeProvider, logger);
+    }
+
+    private static async Task MonitorAsync(
+        int launcherPid,
+        long? launcherStartedUnix,
+        CancellationTokenSource cancelOnLauncherExit,
+        TimeProvider timeProvider,
+        ILogger logger,
+        CancellationToken stopToken)
+    {
+        try
+        {
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1), timeProvider);
+            while (await timer.WaitForNextTickAsync(stopToken).ConfigureAwait(false))
+            {
+                if (ProcessStartTimeHelper.IsProcessRunning(launcherPid, launcherStartedUnix))
+                {
+                    continue;
+                }
+
+                logger.LogWarning(
+                    "Launcher process {LauncherPid} exited before the AppHost reached readiness. Shutting the detached AppHost down to avoid leaking it.",
+                    launcherPid);
+
+                try
+                {
+                    if (!cancelOnLauncherExit.IsCancellationRequested)
+                    {
+                        cancelOnLauncherExit.Cancel();
+                    }
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The run already completed and disposed its cancellation source; nothing to do.
+                }
+
+                return;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Disarmed because the app reached readiness (the expected, common case).
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Idempotent: the run command's happy path disposes once at readiness and the outer finally is a
+        // backstop, so guard against a second Cancel on an already-disposed source.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        _stopCts.Cancel();
+        try
+        {
+            await _monitorTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when stopping the monitor loop.
+        }
+        finally
+        {
+            _stopCts.Dispose();
+        }
+    }
+}

--- a/src/Aspire.Cli/Processes/LauncherLivenessMonitor.cs
+++ b/src/Aspire.Cli/Processes/LauncherLivenessMonitor.cs
@@ -23,18 +23,11 @@ namespace Aspire.Cli.Processes;
 /// </remarks>
 internal sealed class LauncherLivenessMonitor : IAsyncDisposable
 {
-    private readonly CancellationTokenSource _stopCts = new();
-    private readonly Task _monitorTask;
-    private int _disposed;
+    private readonly ParentProcessLivenessMonitor _monitor;
 
-    private LauncherLivenessMonitor(
-        int launcherPid,
-        long? launcherStartedUnix,
-        CancellationTokenSource cancelOnLauncherExit,
-        TimeProvider timeProvider,
-        ILogger logger)
+    private LauncherLivenessMonitor(ParentProcessLivenessMonitor monitor)
     {
-        _monitorTask = MonitorAsync(launcherPid, launcherStartedUnix, cancelOnLauncherExit, timeProvider, logger, _stopCts.Token);
+        _monitor = monitor;
     }
 
     /// <summary>
@@ -54,27 +47,12 @@ internal sealed class LauncherLivenessMonitor : IAsyncDisposable
 
         var launcherStartedUnix = ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(configuration[KnownConfigNames.CliLauncherProcessStarted]);
         logger.LogDebug("Detached child: watching launcher process {LauncherPid} until the AppHost is ready.", launcherPid);
-        return new LauncherLivenessMonitor(launcherPid, launcherStartedUnix, cancelOnLauncherExit, timeProvider, logger);
-    }
 
-    private static async Task MonitorAsync(
-        int launcherPid,
-        long? launcherStartedUnix,
-        CancellationTokenSource cancelOnLauncherExit,
-        TimeProvider timeProvider,
-        ILogger logger,
-        CancellationToken stopToken)
-    {
-        try
-        {
-            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1), timeProvider);
-            while (await timer.WaitForNextTickAsync(stopToken).ConfigureAwait(false))
+        var monitor = ParentProcessLivenessMonitor.Start(
+            launcherPid,
+            launcherStartedUnix,
+            _ =>
             {
-                if (ProcessStartTimeHelper.IsProcessRunning(launcherPid, launcherStartedUnix))
-                {
-                    continue;
-                }
-
                 logger.LogWarning(
                     "Launcher process {LauncherPid} exited before the AppHost reached readiness. Shutting the detached AppHost down to avoid leaking it.",
                     launcherPid);
@@ -91,36 +69,12 @@ internal sealed class LauncherLivenessMonitor : IAsyncDisposable
                     // The run already completed and disposed its cancellation source; nothing to do.
                 }
 
-                return;
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // Disarmed because the app reached readiness (the expected, common case).
-        }
+                return Task.CompletedTask;
+            },
+            timeProvider);
+
+        return new LauncherLivenessMonitor(monitor);
     }
 
-    public async ValueTask DisposeAsync()
-    {
-        // Idempotent: the run command's happy path disposes once at readiness and the outer finally is a
-        // backstop, so guard against a second Cancel on an already-disposed source.
-        if (Interlocked.Exchange(ref _disposed, 1) != 0)
-        {
-            return;
-        }
-
-        _stopCts.Cancel();
-        try
-        {
-            await _monitorTask.ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected when stopping the monitor loop.
-        }
-        finally
-        {
-            _stopCts.Dispose();
-        }
-    }
+    public ValueTask DisposeAsync() => _monitor.DisposeAsync();
 }

--- a/src/Aspire.Cli/Processes/OrphanDetectionEnvironment.cs
+++ b/src/Aspire.Cli/Processes/OrphanDetectionEnvironment.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Hosting;
+
+namespace Aspire.Cli.Processes;
+
+/// <summary>
+/// Stamps a launching process's identity (PID plus start time, as whole Unix seconds) into a child
+/// process's environment so the child's parent-liveness watchdog / orphan detector can verify the
+/// parent by PID <em>and</em> start time and therefore survive PID reuse. Centralizes the env-var
+/// writing that would otherwise be duplicated at every process-launch site.
+/// </summary>
+internal static class OrphanDetectionEnvironment
+{
+    /// <summary>
+    /// Stamps the current CLI process's identity under the given key names, defaulting to the CLI
+    /// orphan-detection keys (<see cref="KnownConfigNames.CliProcessId"/> /
+    /// <see cref="KnownConfigNames.CliProcessStarted"/>).
+    /// </summary>
+    /// <param name="environment">The child environment to stamp.</param>
+    /// <param name="pidKey">The variable name to write the parent PID under.</param>
+    /// <param name="startedKey">The variable name to write the parent start time under.</param>
+    /// <param name="overwrite">
+    /// When <see langword="true"/> (the default) existing values are replaced. When
+    /// <see langword="false"/> a value the caller already set is preserved, so an explicit override
+    /// always wins.
+    /// </param>
+    public static void ApplyCurrentProcess(
+        IDictionary<string, string> environment,
+        string pidKey = KnownConfigNames.CliProcessId,
+        string startedKey = KnownConfigNames.CliProcessStarted,
+        bool overwrite = true)
+    {
+        // Widening a non-null-valued dictionary to the nullable-valued signature is safe: Apply only
+        // ever writes non-null values, so the caller's non-null contract is never violated.
+        Apply((IDictionary<string, string?>)environment, Environment.ProcessId, ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds(), pidKey, startedKey, overwrite);
+    }
+
+    /// <summary>
+    /// Stamps a specific process's identity, using an already-resolved <paramref name="startTimeUnixSeconds"/>.
+    /// Accepting the start time (rather than resolving it) lets a caller write the same identity under
+    /// several key pairs while only reading the start time once. The nullable value type matches
+    /// <see cref="System.Diagnostics.ProcessStartInfo.Environment"/> so it can be stamped directly.
+    /// </summary>
+    /// <param name="environment">The child environment to stamp.</param>
+    /// <param name="pid">The parent process id.</param>
+    /// <param name="startTimeUnixSeconds">
+    /// The parent's start time in whole Unix seconds, or <see langword="null"/> when it could not be
+    /// read. When <see langword="null"/> only the PID is written; the watchdog then falls back to a
+    /// PID-only existence check.
+    /// </param>
+    /// <param name="pidKey">The variable name to write the parent PID under.</param>
+    /// <param name="startedKey">The variable name to write the parent start time under.</param>
+    /// <param name="overwrite">
+    /// When <see langword="true"/> (the default) existing values are replaced; when
+    /// <see langword="false"/> caller-supplied values are preserved.
+    /// </param>
+    public static void Apply(
+        IDictionary<string, string?> environment,
+        int pid,
+        long? startTimeUnixSeconds,
+        string pidKey,
+        string startedKey,
+        bool overwrite = true)
+    {
+        if (overwrite || !environment.ContainsKey(pidKey))
+        {
+            environment[pidKey] = pid.ToString(CultureInfo.InvariantCulture);
+        }
+
+        // The start time can be unavailable (target already exited, privileged, etc.); only stamp it
+        // when it is known so a stale/empty value never masquerades as a verified identity.
+        if (startTimeUnixSeconds is { } started && (overwrite || !environment.ContainsKey(startedKey)))
+        {
+            environment[startedKey] = started.ToString(CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/Aspire.Cli/Processes/OrphanDetectionEnvironment.cs
+++ b/src/Aspire.Cli/Processes/OrphanDetectionEnvironment.cs
@@ -7,10 +7,10 @@ using Aspire.Hosting;
 namespace Aspire.Cli.Processes;
 
 /// <summary>
-/// Stamps a launching process's identity (PID plus start time, as whole Unix seconds) into a child
-/// process's environment so the child's parent-liveness watchdog / orphan detector can verify the
-/// parent by PID <em>and</em> start time and therefore survive PID reuse. Centralizes the env-var
-/// writing that would otherwise be duplicated at every process-launch site.
+/// Stamps a launching process's identity (PID plus a stable start-time value) into a child process's
+/// environment so the child's parent-liveness watchdog / orphan detector can verify the parent by PID
+/// <em>and</em> start time and therefore survive PID reuse. Centralizes the env-var writing that would
+/// otherwise be duplicated at every process-launch site.
 /// </summary>
 internal static class OrphanDetectionEnvironment
 {
@@ -47,9 +47,9 @@ internal static class OrphanDetectionEnvironment
     /// <param name="environment">The child environment to stamp.</param>
     /// <param name="pid">The parent process id.</param>
     /// <param name="startTimeUnixSeconds">
-    /// The parent's start time in whole Unix seconds, or <see langword="null"/> when it could not be
-    /// read. When <see langword="null"/> only the PID is written; the watchdog then falls back to a
-    /// PID-only existence check.
+    /// The parent's stable start time in whole Unix seconds, or <see langword="null"/> when it could
+    /// not be read. When <see langword="null"/> only the PID is written; the watchdog then falls back
+    /// to a PID-only existence check.
     /// </param>
     /// <param name="pidKey">The variable name to write the parent PID under.</param>
     /// <param name="startedKey">The variable name to write the parent start time under.</param>

--- a/src/Aspire.Cli/Processes/OrphanDetectionEnvironment.cs
+++ b/src/Aspire.Cli/Processes/OrphanDetectionEnvironment.cs
@@ -23,9 +23,8 @@ internal static class OrphanDetectionEnvironment
     /// <param name="pidKey">The variable name to write the parent PID under.</param>
     /// <param name="startedKey">The variable name to write the parent start time under.</param>
     /// <param name="overwrite">
-    /// When <see langword="true"/> (the default) existing values are replaced. When
-    /// <see langword="false"/> a value the caller already set is preserved, so an explicit override
-    /// always wins.
+    /// When <see langword="true"/> (the default) existing values are replaced. 
+    /// When <see langword="false"/> a value the caller already set is preserved.
     /// </param>
     public static void ApplyCurrentProcess(
         IDictionary<string, string> environment,
@@ -54,10 +53,8 @@ internal static class OrphanDetectionEnvironment
     /// <param name="pidKey">The variable name to write the parent PID under.</param>
     /// <param name="startedKey">The variable name to write the parent start time under.</param>
     /// <param name="overwrite">
-    /// When <see langword="true"/> (the default) existing values are replaced. When
-    /// <see langword="false"/> caller-supplied values are preserved; in particular a caller-supplied
-    /// PID is treated as authoritative, so the start-time keys are left untouched rather than being
-    /// stamped from a different process.
+    /// When <see langword="true"/> (the default) existing values are replaced. 
+    /// When <see langword="false"/> caller-supplied values are preserved.
     /// </param>
     public static void Apply(
         IDictionary<string, string?> environment,
@@ -74,12 +71,7 @@ internal static class OrphanDetectionEnvironment
         }
         else
         {
-            // A caller-supplied PID is being preserved (overwrite: false), which makes that existing
-            // PID authoritative. Our pid/startTimeUnixSeconds describe a different process, so stamping
-            // the start-time keys from them would produce an inconsistent (PID, start-time) pair that an
-            // orphan detector would verify against the wrong process. Leave the start-time keys exactly
-            // as the caller left them; when none is present the watchdog falls back to a PID-only
-            // existence check.
+            // Env var already exists and we are not allowed to overwrite it.
             return;
         }
 

--- a/src/Aspire.Cli/Processes/OrphanDetectionEnvironment.cs
+++ b/src/Aspire.Cli/Processes/OrphanDetectionEnvironment.cs
@@ -34,19 +34,19 @@ internal static class OrphanDetectionEnvironment
     {
         // Widening a non-null-valued dictionary to the nullable-valued signature is safe: Apply only
         // ever writes non-null values, so the caller's non-null contract is never violated.
-        Apply((IDictionary<string, string?>)environment, Environment.ProcessId, ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds(), pidKey, startedKey, overwrite);
+        Apply((IDictionary<string, string?>)environment, Environment.ProcessId, ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixMilliseconds(), pidKey, startedKey, overwrite);
     }
 
     /// <summary>
-    /// Stamps a specific process's identity, using an already-resolved <paramref name="startTimeUnixSeconds"/>.
+    /// Stamps a specific process's identity, using an already-resolved <paramref name="stableStartTimeUnixMilliseconds"/>.
     /// Accepting the start time (rather than resolving it) lets a caller write the same identity under
     /// several key pairs while only reading the start time once. The nullable value type matches
     /// <see cref="System.Diagnostics.ProcessStartInfo.Environment"/> so it can be stamped directly.
     /// </summary>
     /// <param name="environment">The child environment to stamp.</param>
     /// <param name="pid">The parent process id.</param>
-    /// <param name="startTimeUnixSeconds">
-    /// The parent's stable start time in whole Unix seconds, or <see langword="null"/> when it could
+    /// <param name="stableStartTimeUnixMilliseconds">
+    /// The parent's stable start time in Unix milliseconds, or <see langword="null"/> when it could
     /// not be read. When <see langword="null"/> only the PID is written; the watchdog then falls back
     /// to a PID-only existence check.
     /// </param>
@@ -59,7 +59,7 @@ internal static class OrphanDetectionEnvironment
     public static void Apply(
         IDictionary<string, string?> environment,
         int pid,
-        long? startTimeUnixSeconds,
+        long? stableStartTimeUnixMilliseconds,
         string pidKey,
         string startedKey,
         bool overwrite = true)
@@ -76,24 +76,29 @@ internal static class OrphanDetectionEnvironment
         }
 
         var isCliParentIdentity = pidKey == KnownConfigNames.CliProcessId && startedKey == KnownConfigNames.CliProcessStarted;
-        var startedForLegacyConsumers = isCliParentIdentity
-            ? ProcessStartTimeHelper.TryGetRuntimeProcessStartTimeUnixSeconds(pid) ?? startTimeUnixSeconds
-            : startTimeUnixSeconds;
+
+        // For the CLI parent identity, ASPIRE_CLI_STARTED is the value AppHosts <= Aspire version 13.4 
+        // verify with their Process.StartTime-based check, so it MUST stay in whole Unix seconds. 
+        // Every other identity's primary key carries the stable millisecond value directly. 
+        // We need to use correct units here.
+        var startedValue = isCliParentIdentity
+            ? ProcessStartTimeHelper.TryGetRuntimeProcessStartTimeUnixSeconds(pid)
+            : stableStartTimeUnixMilliseconds;
 
         // The start time can be unavailable (target already exited, privileged, etc.); only stamp it
         // when it is known so a stale/empty value never masquerades as a verified identity.
-        if (startedForLegacyConsumers is { } started && (overwrite || !environment.ContainsKey(startedKey)))
+        if (startedValue is { } started && (overwrite || !environment.ContainsKey(startedKey)))
         {
             environment[startedKey] = started.ToString(CultureInfo.InvariantCulture);
         }
 
         if (isCliParentIdentity &&
-            startTimeUnixSeconds is { } stableStarted &&
+            stableStartTimeUnixMilliseconds is { } stableStarted &&
             (overwrite || !environment.ContainsKey(KnownConfigNames.CliProcessStartedStable)))
         {
-            // ASPIRE_CLI_STARTED is consumed by released AppHosts and must remain compatible with their
-            // Process.StartTime-based verifier. Current AppHosts prefer this companion value, which is
-            // stable on Linux because it is derived from /proc start ticks.
+            // ASPIRE_CLI_STARTED_STABLE is the millisecond-precision companion current AppHosts prefer: 
+            // it survives wall-clock steps and gives exact PID-reuse detection. 
+            // AppHosts <= Aspire ver 13.4 ignore it and fall back to the seconds-based ASPIRE_CLI_STARTED above.
             environment[KnownConfigNames.CliProcessStartedStable] = stableStarted.ToString(CultureInfo.InvariantCulture);
         }
     }

--- a/src/Aspire.Cli/Processes/OrphanDetectionEnvironment.cs
+++ b/src/Aspire.Cli/Processes/OrphanDetectionEnvironment.cs
@@ -70,11 +70,26 @@ internal static class OrphanDetectionEnvironment
             environment[pidKey] = pid.ToString(CultureInfo.InvariantCulture);
         }
 
+        var isCliParentIdentity = pidKey == KnownConfigNames.CliProcessId && startedKey == KnownConfigNames.CliProcessStarted;
+        var startedForLegacyConsumers = isCliParentIdentity
+            ? ProcessStartTimeHelper.TryGetRuntimeProcessStartTimeUnixSeconds(pid) ?? startTimeUnixSeconds
+            : startTimeUnixSeconds;
+
         // The start time can be unavailable (target already exited, privileged, etc.); only stamp it
         // when it is known so a stale/empty value never masquerades as a verified identity.
-        if (startTimeUnixSeconds is { } started && (overwrite || !environment.ContainsKey(startedKey)))
+        if (startedForLegacyConsumers is { } started && (overwrite || !environment.ContainsKey(startedKey)))
         {
             environment[startedKey] = started.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (isCliParentIdentity &&
+            startTimeUnixSeconds is { } stableStarted &&
+            (overwrite || !environment.ContainsKey(KnownConfigNames.CliProcessStartedStable)))
+        {
+            // ASPIRE_CLI_STARTED is consumed by released AppHosts and must remain compatible with their
+            // Process.StartTime-based verifier. Current AppHosts prefer this companion value, which is
+            // stable on Linux because it is derived from /proc start ticks.
+            environment[KnownConfigNames.CliProcessStartedStable] = stableStarted.ToString(CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/Aspire.Cli/Processes/OrphanDetectionEnvironment.cs
+++ b/src/Aspire.Cli/Processes/OrphanDetectionEnvironment.cs
@@ -54,8 +54,10 @@ internal static class OrphanDetectionEnvironment
     /// <param name="pidKey">The variable name to write the parent PID under.</param>
     /// <param name="startedKey">The variable name to write the parent start time under.</param>
     /// <param name="overwrite">
-    /// When <see langword="true"/> (the default) existing values are replaced; when
-    /// <see langword="false"/> caller-supplied values are preserved.
+    /// When <see langword="true"/> (the default) existing values are replaced. When
+    /// <see langword="false"/> caller-supplied values are preserved; in particular a caller-supplied
+    /// PID is treated as authoritative, so the start-time keys are left untouched rather than being
+    /// stamped from a different process.
     /// </param>
     public static void Apply(
         IDictionary<string, string?> environment,
@@ -65,9 +67,20 @@ internal static class OrphanDetectionEnvironment
         string startedKey,
         bool overwrite = true)
     {
-        if (overwrite || !environment.ContainsKey(pidKey))
+        var pidWritten = overwrite || !environment.ContainsKey(pidKey);
+        if (pidWritten)
         {
             environment[pidKey] = pid.ToString(CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            // A caller-supplied PID is being preserved (overwrite: false), which makes that existing
+            // PID authoritative. Our pid/startTimeUnixSeconds describe a different process, so stamping
+            // the start-time keys from them would produce an inconsistent (PID, start-time) pair that an
+            // orphan detector would verify against the wrong process. Leave the start-time keys exactly
+            // as the caller left them; when none is present the watchdog falls back to a PID-only
+            // existence check.
+            return;
         }
 
         var isCliParentIdentity = pidKey == KnownConfigNames.CliProcessId && startedKey == KnownConfigNames.CliProcessStarted;

--- a/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
@@ -248,7 +248,7 @@ internal sealed class ProcessTreeGracefulShutdownService(
         logger.LogDebug("Sending stop signal to process {Pid}", target.Pid);
         if (target.UseRuntimeStartTime && target.StartTime is { } runtimeStartTime)
         {
-            ProcessSignaler.RequestGracefulShutdownWithRuntimeStartTime(target.Pid, runtimeStartTime, ProcessStartTimeHelper.CrossProcessIdentityTimeTolerance, logger);
+            ProcessSignaler.RequestGracefulShutdownWithRuntimeStartTime(target.Pid, runtimeStartTime, ProcessStartTimeHelper.LegacyStartTimeMatchTolerance, logger);
         }
         else
         {
@@ -374,7 +374,7 @@ internal sealed class ProcessTreeGracefulShutdownService(
             return ProcessSignaler.TryGetRunningProcess(target.Pid, target.StartTime, logger);
         }
 
-        return ProcessSignaler.TryGetRunningProcessWithRuntimeStartTime(target.Pid, target.StartTime.Value, ProcessStartTimeHelper.CrossProcessIdentityTimeTolerance, logger);
+        return ProcessSignaler.TryGetRunningProcessWithRuntimeStartTime(target.Pid, target.StartTime.Value, ProcessStartTimeHelper.LegacyStartTimeMatchTolerance, logger);
     }
 
     private void ForceKill(ProcessTarget target, bool killEntireProcessTree)

--- a/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
@@ -154,8 +154,8 @@ internal sealed class ProcessTreeGracefulShutdownService(
         if (appHostInfo.CliProcessId is int cliPid)
         {
             logger.LogDebug("Requesting AppHost process tree shutdown via root CLI PID {Pid}", cliPid);
-            // CliStartedAt is recorded with second-level precision, so validate it locally with tolerance
-            // instead of passing it to DCP's millisecond-precision process-start-time option.
+            // CliStartedAt is recorded with second-level precision, so validate it locally instead of
+            // passing it to DCP's millisecond-precision process-start-time option.
             return await RequestProcessTreeGracefulShutdownAsync(cliPid, appHostInfo.CliStartedAt, includeStartTimeForDcp: false, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
@@ -248,7 +248,7 @@ internal sealed class ProcessTreeGracefulShutdownService(
         logger.LogDebug("Sending stop signal to process {Pid}", target.Pid);
         if (target.UseRuntimeStartTime && target.StartTime is { } runtimeStartTime)
         {
-            ProcessSignaler.RequestGracefulShutdownWithRuntimeStartTime(target.Pid, runtimeStartTime, TimeSpan.FromSeconds(1), logger);
+            ProcessSignaler.RequestGracefulShutdownWithRuntimeStartTime(target.Pid, runtimeStartTime, ProcessStartTimeHelper.RuntimeStartTimeComparisonTolerance, logger);
         }
         else
         {
@@ -374,7 +374,7 @@ internal sealed class ProcessTreeGracefulShutdownService(
             return ProcessSignaler.TryGetRunningProcess(target.Pid, target.StartTime, logger);
         }
 
-        return ProcessSignaler.TryGetRunningProcessWithRuntimeStartTime(target.Pid, target.StartTime.Value, TimeSpan.FromSeconds(1), logger);
+        return ProcessSignaler.TryGetRunningProcessWithRuntimeStartTime(target.Pid, target.StartTime.Value, ProcessStartTimeHelper.RuntimeStartTimeComparisonTolerance, logger);
     }
 
     private void ForceKill(ProcessTarget target, bool killEntireProcessTree)

--- a/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
@@ -138,7 +138,7 @@ internal sealed class ProcessTreeGracefulShutdownService(
             // Routing the graceful signal through the launcher CLI (CliProcessId) cascades via
             // `dotnet run`'s child kill. That walk depends on the AppHost being visible in /proc
             // as a descendant of the `dotnet` process at the moment of the walk, and on the
-            // AppHost being observed as exited by its parent rather than orphaned. When either of those races
+            // AppHost being reaped by its parent rather than orphaned. When either of those races
             // misfires the AppHost is left running (or lingering as a zombie reparented to PID 1)
             // and the StopCommand monitor then times out reporting "Failed to stop apphost".
             // Targeting the AppHost PID directly avoids the cascade entirely.

--- a/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Bundles;
@@ -33,9 +34,10 @@ internal sealed class ProcessTreeGracefulShutdownService(
         bool includeStartTimeForDcp,
         CancellationToken cancellationToken)
     {
+        var processTarget = new ProcessTarget(pid, startTime, UseRuntimeStartTime: false);
         return StopProcessesAsync(
-            [new ProcessTarget(pid, startTime)],
-            token => RequestProcessTreeGracefulShutdownAsync(pid, startTime, includeStartTimeForDcp, token),
+            [processTarget],
+            token => RequestProcessTreeGracefulShutdownAsync(processTarget, includeStartTimeForDcp, token),
             cancellationToken);
     }
 
@@ -49,13 +51,19 @@ internal sealed class ProcessTreeGracefulShutdownService(
             return requestRpcStopAsync is not null && await TryRequestRpcStopAsync(requestRpcStopAsync, cancellationToken).ConfigureAwait(false);
         }
 
-        var appHostProcess = new ProcessTarget(appHostInfo.ProcessId, appHostInfo.StartedAt);
+        var appHostProcess = CreateAppHostProcessTarget(appHostInfo);
         var processesToForceKill = new List<ProcessTarget> { appHostProcess };
         if (appHostInfo.CliProcessId is int cliPid)
         {
             // The CLI process is a shutdown handle, not the success condition. On Unix it can remain
             // observable until its parent reaps it after the AppHost has already stopped.
-            processesToForceKill.Add(new ProcessTarget(cliPid, appHostInfo.CliStartedAt));
+            //
+            // AppHostInfo.CliStartedAt comes from ASPIRE_CLI_STARTED, which is intentionally stamped
+            // from Process.StartTime for released-AppHost compatibility. Keep that shutdown handle in
+            // the legacy/runtime clock domain. AppHost StartedAt can also be legacy/runtime metadata
+            // when talking to released AppHosts; current AppHosts send StableStartedAt so their primary
+            // process target uses the exact verifier.
+            processesToForceKill.Add(new ProcessTarget(cliPid, appHostInfo.CliStartedAt, UseRuntimeStartTime: true));
         }
 
         return await StopProcessesAsync(
@@ -120,7 +128,7 @@ internal sealed class ProcessTreeGracefulShutdownService(
             // Resolve the pid against its expected start time and hard-kill. This path never requests
             // graceful shutdown — the graceful attempt already happened (or was intentionally skipped),
             // so we go straight to the kill that the shared shutdown helper's force mode also performs.
-            ProcessSignaler.ForceKill(process.Pid, process.StartTime, logger, killEntireProcessTree);
+            ForceKill(process, killEntireProcessTree);
         }
     }
 
@@ -143,7 +151,7 @@ internal sealed class ProcessTreeGracefulShutdownService(
             // and the StopCommand monitor then times out reporting "Failed to stop apphost".
             // Targeting the AppHost PID directly avoids the cascade entirely.
             logger.LogDebug("Sending graceful shutdown to AppHost PID {Pid}", appHostInfo.ProcessId);
-            return await RequestProcessTreeGracefulShutdownAsync(appHostInfo.ProcessId, appHostInfo.StartedAt, includeStartTimeForDcp: false, cancellationToken).ConfigureAwait(false);
+            return await RequestProcessTreeGracefulShutdownAsync(CreateAppHostProcessTarget(appHostInfo), includeStartTimeForDcp: false, cancellationToken).ConfigureAwait(false);
         }
 
         // On Windows DCP is an in-tree descendant of the AppHost, so we cannot tree-kill the
@@ -154,9 +162,13 @@ internal sealed class ProcessTreeGracefulShutdownService(
         if (appHostInfo.CliProcessId is int cliPid)
         {
             logger.LogDebug("Requesting AppHost process tree shutdown via root CLI PID {Pid}", cliPid);
-            // CliStartedAt is recorded with second-level precision, so validate it locally instead of
+            // CliStartedAt is recorded in the legacy Process.StartTime clock domain and with
+            // second-level precision, so validate it locally with the runtime verifier instead of
             // passing it to DCP's millisecond-precision process-start-time option.
-            return await RequestProcessTreeGracefulShutdownAsync(cliPid, appHostInfo.CliStartedAt, includeStartTimeForDcp: false, cancellationToken).ConfigureAwait(false);
+            return await RequestProcessTreeGracefulShutdownAsync(
+                new ProcessTarget(cliPid, appHostInfo.CliStartedAt, UseRuntimeStartTime: true),
+                includeStartTimeForDcp: false,
+                cancellationToken).ConfigureAwait(false);
         }
 
         if (requestRpcStopAsync is not null && await TryRequestRpcStopAsync(requestRpcStopAsync, cancellationToken).ConfigureAwait(false))
@@ -165,7 +177,7 @@ internal sealed class ProcessTreeGracefulShutdownService(
         }
 
         logger.LogDebug("RPC stop not available, requesting shutdown via AppHost PID {Pid}", appHostInfo.ProcessId);
-        return await RequestProcessTreeGracefulShutdownAsync(appHostInfo.ProcessId, appHostInfo.StartedAt, includeStartTimeForDcp: true, cancellationToken).ConfigureAwait(false);
+        return await RequestProcessTreeGracefulShutdownAsync(CreateAppHostProcessTarget(appHostInfo), includeStartTimeForDcp: true, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<bool> TryRequestGracefulShutdownAsync(
@@ -211,7 +223,18 @@ internal sealed class ProcessTreeGracefulShutdownService(
         bool includeStartTimeForDcp,
         CancellationToken cancellationToken)
     {
-        using var process = ProcessSignaler.TryGetRunningProcess(pid, startTime, logger);
+        return await RequestProcessTreeGracefulShutdownAsync(
+            new ProcessTarget(pid, startTime, UseRuntimeStartTime: false),
+            includeStartTimeForDcp,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> RequestProcessTreeGracefulShutdownAsync(
+        ProcessTarget target,
+        bool includeStartTimeForDcp,
+        CancellationToken cancellationToken)
+    {
+        using var process = TryGetRunningProcess(target);
         if (process is null)
         {
             return true;
@@ -219,17 +242,32 @@ internal sealed class ProcessTreeGracefulShutdownService(
 
         if (environment.IsWindows())
         {
-            return await TryStopProcessTreeWithDcpAsync(pid, startTime, includeStartTimeForDcp, cancellationToken).ConfigureAwait(false);
+            return await TryStopProcessTreeWithDcpAsync(target, includeStartTimeForDcp, cancellationToken).ConfigureAwait(false);
         }
 
-        logger.LogDebug("Sending stop signal to process {Pid}", pid);
-        ProcessSignaler.RequestGracefulShutdown(pid, startTime, logger);
+        logger.LogDebug("Sending stop signal to process {Pid}", target.Pid);
+        if (target.UseRuntimeStartTime && target.StartTime is { } runtimeStartTime)
+        {
+            ProcessSignaler.RequestGracefulShutdownWithRuntimeStartTime(target.Pid, runtimeStartTime, TimeSpan.FromSeconds(1), logger);
+        }
+        else
+        {
+            ProcessSignaler.RequestGracefulShutdown(target.Pid, target.StartTime, logger);
+        }
         return true;
     }
 
     internal async Task<bool> TryStopProcessTreeWithDcpAsync(int pid, DateTimeOffset? startTime, bool includeStartTime, CancellationToken cancellationToken)
     {
-        using var process = ProcessSignaler.TryGetRunningProcess(pid, startTime, logger);
+        return await TryStopProcessTreeWithDcpAsync(
+            new ProcessTarget(pid, startTime, UseRuntimeStartTime: false),
+            includeStartTime,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> TryStopProcessTreeWithDcpAsync(ProcessTarget target, bool includeStartTime, CancellationToken cancellationToken)
+    {
+        using var process = TryGetRunningProcess(target);
         if (process is null)
         {
             return true;
@@ -257,13 +295,16 @@ internal sealed class ProcessTreeGracefulShutdownService(
             "stop-process-tree",
             "--skip-descendants",
             "--pid",
-            pid.ToString(CultureInfo.InvariantCulture)
+            target.Pid.ToString(CultureInfo.InvariantCulture)
         };
 
-        if (includeStartTime && startTime is not null)
+        if (includeStartTime && target.StartTime is not null && (!target.UseRuntimeStartTime || environment.IsWindows()))
         {
+            // Runtime-domain start times are whole-second legacy metadata on Linux/macOS, while DCP
+            // compares the platform start time with millisecond precision. On Windows the AppHost
+            // fallback also uses Process.StartTime, so keep the PID-reuse guard for that DCP path.
             arguments.Add("--process-start-time");
-            arguments.Add(FormatDcpProcessStartTime(startTime.Value));
+            arguments.Add(FormatDcpProcessStartTime(target.StartTime.Value));
         }
 
         var (exitCode, output, error) = await layoutProcessRunner.RunAsync(
@@ -309,8 +350,50 @@ internal sealed class ProcessTreeGracefulShutdownService(
 
     private bool IsProcessStopped(ProcessTarget process)
     {
-        using var runningProcess = ProcessSignaler.TryGetRunningProcess(process.Pid, process.StartTime, logger);
+        using var runningProcess = TryGetRunningProcess(process);
         return runningProcess is null;
+    }
+
+    internal static ProcessTarget CreateAppHostProcessTarget(AppHostInformation appHostInfo)
+    {
+        if (appHostInfo.StableStartedAt is { } stableStartedAt)
+        {
+            return new ProcessTarget(appHostInfo.ProcessId, stableStartedAt, UseRuntimeStartTime: false);
+        }
+
+        // Released AppHosts only report StartedAt, and that value was produced from Process.StartTime.
+        // Keep those mixed-version stop paths in the runtime clock domain; current AppHosts also send
+        // StableStartedAt above so they retain exact /proc-based PID-reuse protection.
+        return new ProcessTarget(appHostInfo.ProcessId, appHostInfo.StartedAt, UseRuntimeStartTime: appHostInfo.StartedAt is not null);
+    }
+
+    private Process? TryGetRunningProcess(ProcessTarget target)
+    {
+        if (!target.UseRuntimeStartTime || target.StartTime is null)
+        {
+            return ProcessSignaler.TryGetRunningProcess(target.Pid, target.StartTime, logger);
+        }
+
+        return ProcessSignaler.TryGetRunningProcessWithRuntimeStartTime(target.Pid, target.StartTime.Value, TimeSpan.FromSeconds(1), logger);
+    }
+
+    private void ForceKill(ProcessTarget target, bool killEntireProcessTree)
+    {
+        using var process = TryGetRunningProcess(target);
+        if (process is null)
+        {
+            return;
+        }
+
+        logger.LogDebug("Killing process {Pid} (entireProcessTree={EntireProcessTree})...", target.Pid, killEntireProcessTree);
+        try
+        {
+            process.Kill(entireProcessTree: killEntireProcessTree);
+        }
+        catch (InvalidOperationException)
+        {
+            // Process already exited.
+        }
     }
 
     internal static string FormatDcpProcessStartTime(DateTimeOffset startTime)
@@ -318,5 +401,5 @@ internal sealed class ProcessTreeGracefulShutdownService(
         return startTime.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'", CultureInfo.InvariantCulture);
     }
 
-    internal readonly record struct ProcessTarget(int Pid, DateTimeOffset? StartTime);
+    internal readonly record struct ProcessTarget(int Pid, DateTimeOffset? StartTime, bool UseRuntimeStartTime);
 }

--- a/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
@@ -138,7 +138,7 @@ internal sealed class ProcessTreeGracefulShutdownService(
             // Routing the graceful signal through the launcher CLI (CliProcessId) cascades via
             // `dotnet run`'s child kill. That walk depends on the AppHost being visible in /proc
             // as a descendant of the `dotnet` process at the moment of the walk, and on the
-            // AppHost being reaped by its parent rather than orphaned. When either of those races
+            // AppHost being observed as exited by its parent rather than orphaned. When either of those races
             // misfires the AppHost is left running (or lingering as a zombie reparented to PID 1)
             // and the StopCommand monitor then times out reporting "Failed to stop apphost".
             // Targeting the AppHost PID directly avoids the cascade entirely.

--- a/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
@@ -22,7 +22,7 @@ internal sealed class ProcessTreeGracefulShutdownService(
     CliExecutionContext executionContext,
     IEnvironment environment,
     ILogger<ProcessTreeGracefulShutdownService> logger,
-    TimeProvider timeProvider) : IProcessTreeGracefulShutdownSignaler
+    TimeProvider timeProvider) : IProcessTreeGracefulShutdownSignaler, IAppHostStopper
 {
     private static readonly TimeSpan s_processTerminationTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan s_processTerminationPollInterval = TimeSpan.FromMilliseconds(250);

--- a/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessTreeGracefulShutdownService.cs
@@ -248,7 +248,7 @@ internal sealed class ProcessTreeGracefulShutdownService(
         logger.LogDebug("Sending stop signal to process {Pid}", target.Pid);
         if (target.UseRuntimeStartTime && target.StartTime is { } runtimeStartTime)
         {
-            ProcessSignaler.RequestGracefulShutdownWithRuntimeStartTime(target.Pid, runtimeStartTime, ProcessStartTimeHelper.RuntimeStartTimeComparisonTolerance, logger);
+            ProcessSignaler.RequestGracefulShutdownWithRuntimeStartTime(target.Pid, runtimeStartTime, ProcessStartTimeHelper.CrossProcessIdentityTimeTolerance, logger);
         }
         else
         {
@@ -374,7 +374,7 @@ internal sealed class ProcessTreeGracefulShutdownService(
             return ProcessSignaler.TryGetRunningProcess(target.Pid, target.StartTime, logger);
         }
 
-        return ProcessSignaler.TryGetRunningProcessWithRuntimeStartTime(target.Pid, target.StartTime.Value, ProcessStartTimeHelper.RuntimeStartTimeComparisonTolerance, logger);
+        return ProcessSignaler.TryGetRunningProcessWithRuntimeStartTime(target.Pid, target.StartTime.Value, ProcessStartTimeHelper.CrossProcessIdentityTimeTolerance, logger);
     }
 
     private void ForceKill(ProcessTarget target, bool killEntireProcessTree)

--- a/src/Aspire.Cli/Processes/WindowsConsoleProcessJob.cs
+++ b/src/Aspire.Cli/Processes/WindowsConsoleProcessJob.cs
@@ -35,7 +35,7 @@ namespace Aspire.Cli.Processes;
 /// IMPORTANT: do NOT dispose this service during the normal shutdown ladder. The graceful
 /// shutdown path is responsible for cooperatively terminating its children; closing the
 /// job handle while they are still alive would convert clean shutdown into a hard kill.
-/// Let the OS close the handle on process exit; the kill-on-close behavior is exactly the
+/// Let the OS close the handle on process exit; the kill-on-parent-exit behavior is exactly the
 /// crash-safety net we want and is harmless when the children have already exited.
 /// </para>
 /// </remarks>
@@ -54,8 +54,8 @@ internal sealed class WindowsConsoleProcessJob : IDisposable
     private int _disposed;
 
     /// <summary>
-    /// The process-wide job, created on first access. Callers on the isolated-console spawn
-    /// path use this instead of receiving a job instance, so they cannot forget to supply one.
+    /// The process-wide job, created on first access. Callers that opt into parent-lifetime
+    /// cleanup use this instead of receiving a job instance, so they cannot forget to supply one.
     /// Intentionally never disposed in production: the OS closes the handle at process exit,
     /// which is exactly the crash-safety net we want.
     /// </summary>
@@ -66,7 +66,7 @@ internal sealed class WindowsConsoleProcessJob : IDisposable
         _jobHandle = WindowsProcessInterop.CreateJobObjectW(nint.Zero, null);
         if (_jobHandle.IsInvalid)
         {
-            throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to create CLI console-isolation job object");
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to create CLI kill-on-parent-exit job object");
         }
 
         try
@@ -94,7 +94,7 @@ internal sealed class WindowsConsoleProcessJob : IDisposable
                     infoPtr,
                     (uint)infoSize))
                 {
-                    throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to configure CLI console-isolation job object limits");
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to configure CLI kill-on-parent-exit job object limits");
                 }
             }
             finally
@@ -113,7 +113,7 @@ internal sealed class WindowsConsoleProcessJob : IDisposable
     }
 
     /// <summary>
-    /// The job handle. Pass directly to <see cref="WindowsProcessInterop.SpawnConsoleIsolatedProcess"/>
+    /// The job handle. Pass directly to <see cref="WindowsProcessInterop.SpawnProcess"/>
     /// so the spawn primitive can do the suspended-create / assign / resume dance atomically.
     /// </summary>
     public SafeFileHandle Handle => _jobHandle;

--- a/src/Aspire.Cli/Processes/WindowsConsoleProcessJob.cs
+++ b/src/Aspire.Cli/Processes/WindowsConsoleProcessJob.cs
@@ -113,8 +113,9 @@ internal sealed class WindowsConsoleProcessJob : IDisposable
     }
 
     /// <summary>
-    /// The job handle. Pass directly to <see cref="WindowsProcessInterop.SpawnProcess"/>
-    /// so the spawn primitive can do the suspended-create / assign / resume dance atomically.
+    /// The job handle. Pass directly to <see cref="WindowsProcessInterop.SpawnProcess"/> so the spawn
+    /// primitive can assign the child to this job atomically at creation via
+    /// <c>PROC_THREAD_ATTRIBUTE_JOB_LIST</c>.
     /// </summary>
     public SafeFileHandle Handle => _jobHandle;
 

--- a/src/Aspire.Cli/Processes/WindowsProcessInterop.cs
+++ b/src/Aspire.Cli/Processes/WindowsProcessInterop.cs
@@ -41,16 +41,13 @@ internal static partial class WindowsProcessInterop
     public const uint CreateNewConsole = 0x00000010;
 
     /// <summary>
-    /// Composite creation flags shared by every CLI process launcher that spawns into its own
-    /// hidden console group: CREATE_UNICODE_ENVIRONMENT (we always build a Unicode env block
+    /// Base creation flags shared by Windows launchers that need explicit handle inheritance
+    /// and/or job assignment: CREATE_UNICODE_ENVIRONMENT (we always build a Unicode env block
     /// ourselves) | EXTENDED_STARTUPINFO_PRESENT (we always pass STARTUPINFOEX with an attribute
-    /// list) | CREATE_NEW_CONSOLE (the entire point — detach from the parent's console).
-    /// Centralizing the composite prevents the two launchers from drifting (e.g. one path
-    /// accidentally dropping CREATE_UNICODE_ENVIRONMENT and silently truncating non-ASCII env
-    /// values).
+    /// list). CREATE_NEW_CONSOLE is added independently by callers that need console isolation.
     /// </summary>
-    public const uint NewConsoleCreationFlags =
-        CreateUnicodeEnvironment | ExtendedStartupInfoPresent | CreateNewConsole;
+    public const uint ExplicitHandleCreationFlags =
+        CreateUnicodeEnvironment | ExtendedStartupInfoPresent;
 
     public const ushort ShowWindowHide = 0x0000;
 
@@ -301,11 +298,10 @@ internal static partial class WindowsProcessInterop
     public readonly record struct StdioHandles(nint Stdin, nint Stdout, nint Stderr);
 
     /// <summary>
-    /// Spawns a child process in its own hidden console group with exactly the stdio handles
-    /// in <paramref name="stdio"/> made inheritable through <c>PROC_THREAD_ATTRIBUTE_HANDLE_LIST</c>.
-    /// Used by both <see cref="DetachedProcessLauncher"/> (NUL-only handles) and
-    /// <see cref="IsolatedProcess"/> (NUL stdin + anonymous pipes for stdout/stderr)
-    /// so the console-isolation ceremony lives in one place.
+    /// Spawns a child process with exactly the stdio handles in <paramref name="stdio"/> made
+    /// inheritable through <c>PROC_THREAD_ATTRIBUTE_HANDLE_LIST</c>. Console isolation
+    /// (<c>CREATE_NEW_CONSOLE</c>) and parent-exit job assignment are independent options so
+    /// short-lived helper processes can get the job safety net without creating a new console.
     /// </summary>
     /// <param name="fileName">Full path to the executable to launch.</param>
     /// <param name="arguments">Arguments to pass to the child. Quoted via <see cref="BuildCommandLine"/>.</param>
@@ -323,8 +319,13 @@ internal static partial class WindowsProcessInterop
     /// to remove a subset of parent variables must materialize the parent env, apply their
     /// removals/overlays, and pass the resulting dictionary here.
     /// </param>
+    /// <param name="createNewConsole">
+    /// When <see langword="true"/>, launches the child in a new hidden console group. Use this for
+    /// AppHost-style processes that need targeted CTRL+C delivery or detached children that must not
+    /// share the parent console. Leave it <see langword="false"/> for ordinary background helpers.
+    /// </param>
     /// <param name="jobHandle">
-    /// Optional kill-on-close job object. When supplied, the child is created suspended,
+    /// Optional parent-lifetime job object. When supplied, the child is created suspended,
     /// assigned to the job, then resumed — so there is no instruction-level window where the
     /// child could spawn a grandchild that escapes the job. <see cref="DetachedProcessLauncher"/>
     /// passes <see langword="null" /> because detached children must outlive the CLI;
@@ -338,12 +339,13 @@ internal static partial class WindowsProcessInterop
     /// <see cref="System.Diagnostics.Process.GetProcessById(int)"/>).
     /// </returns>
     [SupportedOSPlatform("windows")]
-    public static PROCESS_INFORMATION SpawnConsoleIsolatedProcess(
+    public static PROCESS_INFORMATION SpawnProcess(
         string fileName,
         IReadOnlyList<string> arguments,
         string workingDirectory,
         StdioHandles stdio,
         IReadOnlyDictionary<string, string?>? environment,
+        bool createNewConsole,
         SafeFileHandle? jobHandle)
     {
         // Build the handle whitelist from the non-zero stdio slots. We pass exactly the handles
@@ -417,7 +419,12 @@ internal static partial class WindowsProcessInterop
                     // CreateProcess and AssignProcessToJobObject so it cannot fork-and-breakaway
                     // before we put the safety net under it. Without a job, the original
                     // behavior is preserved bit-for-bit (no suspend, no resume).
-                    var flags = NewConsoleCreationFlags;
+                    var flags = ExplicitHandleCreationFlags;
+                    if (createNewConsole)
+                    {
+                        flags |= CreateNewConsole;
+                    }
+
                     if (jobHandle is not null)
                     {
                         flags |= CreateSuspended;

--- a/src/Aspire.Cli/Processes/WindowsProcessInterop.cs
+++ b/src/Aspire.Cli/Processes/WindowsProcessInterop.cs
@@ -55,6 +55,12 @@ internal static partial class WindowsProcessInterop
     // https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute
     public static readonly nint ProcThreadAttributeHandleList = (nint)0x00020002;
 
+    // PROC_THREAD_ATTRIBUTE_JOB_LIST — assigns the child to one or more job objects atomically at
+    // CreateProcess time (Windows 8 / Server 2012 and later). 
+    // See https://learn.microsoft.com/windows/win32/procthread/process-creation-flags and
+    // https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute
+    public static readonly nint ProcThreadAttributeJobList = (nint)0x0002000D;
+
     // === Structs ===
 
     /// <summary>
@@ -169,9 +175,6 @@ internal static partial class WindowsProcessInterop
     [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool TerminateProcess(nint hProcess, uint uExitCode);
 
-    [LibraryImport("kernel32.dll", SetLastError = true)]
-    public static partial uint ResumeThread(nint hThread);
-
     // GetExitCodeProcess + WaitForSingleObject are used by IsolatedProcess.Windows so that
     // IsolatedProcess.ExitCode / HasExited can query the child via the SafeProcessHandle we
     // kept open from CreateProcessW. Process objects obtained via Process.GetProcessById
@@ -216,9 +219,13 @@ internal static partial class WindowsProcessInterop
         nint lpJobObjectInformation,
         uint cbJobObjectInformationLength);
 
+    // IsProcessInJob — reports whether a process is a member of the specified job. Used to verify
+    // that a child spawned with PROC_THREAD_ATTRIBUTE_JOB_LIST is associated with the kill-on-close
+    // job the instant it is created. See
+    // https://learn.microsoft.com/windows/win32/api/jobapi/nf-jobapi-isprocessinjob
     [LibraryImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static partial bool AssignProcessToJobObject(SafeFileHandle hJob, nint hProcess);
+    public static partial bool IsProcessInJob(nint processHandle, SafeFileHandle jobHandle, [MarshalAs(UnmanagedType.Bool)] out bool result);
 
     // SetConsoleCtrlHandler — see
     // https://learn.microsoft.com/windows/console/setconsolectrlhandler
@@ -234,8 +241,6 @@ internal static partial class WindowsProcessInterop
     public static partial bool SetConsoleCtrlHandler(nint handlerRoutine, [MarshalAs(UnmanagedType.Bool)] bool add);
 
     // === Job-object constants ===
-
-    public const uint CreateSuspended = 0x00000004;
 
     // https://learn.microsoft.com/windows/win32/api/winnt/ns-winnt-jobobject_basic_limit_information
     public const uint JobObjectLimitBreakawayOk = 0x00000800;
@@ -325,11 +330,13 @@ internal static partial class WindowsProcessInterop
     /// share the parent console. Leave it <see langword="false"/> for ordinary background helpers.
     /// </param>
     /// <param name="jobHandle">
-    /// Optional parent-lifetime job object. When supplied, the child is created suspended,
-    /// assigned to the job, then resumed — so there is no instruction-level window where the
-    /// child could spawn a grandchild that escapes the job. <see cref="DetachedProcessLauncher"/>
-    /// passes <see langword="null" /> because detached children must outlive the CLI;
-    /// <see cref="IsolatedProcess"/> passes the singleton CLI job so children
+    /// Optional parent-lifetime job object. When supplied, the child is assigned to the job
+    /// atomically at <c>CreateProcess</c> time via <c>PROC_THREAD_ATTRIBUTE_JOB_LIST</c>, so there is
+    /// no window in which the child exists outside the job — even a launcher that dies (or is
+    /// SIGKILL'd) the instant after <c>CreateProcess</c> returns cannot leak it, and no child can spawn
+    /// a grandchild that escapes the job before the safety net is in place.
+    /// <see cref="DetachedProcessLauncher"/> passes <see langword="null" /> because detached children
+    /// must outlive the CLI; <see cref="IsolatedProcess"/> passes the singleton CLI job so children
     /// die with a parent crash.
     /// </param>
     /// <returns>
@@ -371,13 +378,17 @@ internal static partial class WindowsProcessInterop
         AddIfUnique(stdio.Stdout);
         AddIfUnique(stdio.Stderr);
 
+        // The child always needs the stdio handle whitelist; when a parent-lifetime job is supplied it
+        // ALSO needs PROC_THREAD_ATTRIBUTE_JOB_LIST so the child is assigned to the job atomically at creation (below).
+        var attributeCount = jobHandle is not null ? 2 : 1;
+
         var attrListSize = nint.Zero;
-        InitializeProcThreadAttributeList(nint.Zero, 1, 0, ref attrListSize);
+        InitializeProcThreadAttributeList(nint.Zero, attributeCount, 0, ref attrListSize);
 
         var attrList = Marshal.AllocHGlobal(attrListSize);
         try
         {
-            if (!InitializeProcThreadAttributeList(attrList, 1, 0, ref attrListSize))
+            if (!InitializeProcThreadAttributeList(attrList, attributeCount, 0, ref attrListSize))
             {
                 throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error(), "Failed to initialize process thread attribute list");
             }
@@ -386,6 +397,9 @@ internal static partial class WindowsProcessInterop
             {
                 var handles = inheritable.ToArray();
                 var pinnedHandles = GCHandle.Alloc(handles, GCHandleType.Pinned);
+                var pinnedJobHandles = default(GCHandle);
+                var jobHandleRefAdded = false;
+
                 try
                 {
                     if (!UpdateProcThreadAttribute(
@@ -398,6 +412,25 @@ internal static partial class WindowsProcessInterop
                         nint.Zero))
                     {
                         throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error(), "Failed to update process thread attribute list");
+                    }
+
+                    if (jobHandle is not null)
+                    {
+                        jobHandle.DangerousAddRef(ref jobHandleRefAdded);
+                        var jobHandles = new[] { jobHandle.DangerousGetHandle() };
+                        pinnedJobHandles = GCHandle.Alloc(jobHandles, GCHandleType.Pinned);
+
+                        if (!UpdateProcThreadAttribute(
+                            attrList,
+                            0,
+                            ProcThreadAttributeJobList,
+                            pinnedJobHandles.AddrOfPinnedObject(),
+                            (nint)(nint.Size * jobHandles.Length),
+                            nint.Zero,
+                            nint.Zero))
+                        {
+                            throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error(), "Failed to add job object to process thread attribute list");
+                        }
                     }
 
                     var si = new STARTUPINFOEX
@@ -415,19 +448,10 @@ internal static partial class WindowsProcessInterop
 
                     var commandLine = BuildCommandLine(fileName, arguments);
 
-                    // Only suspend when a job is involved: we need the child frozen between
-                    // CreateProcess and AssignProcessToJobObject so it cannot fork-and-breakaway
-                    // before we put the safety net under it. Without a job, the original
-                    // behavior is preserved bit-for-bit (no suspend, no resume).
                     var flags = ExplicitHandleCreationFlags;
                     if (createNewConsole)
                     {
                         flags |= CreateNewConsole;
-                    }
-
-                    if (jobHandle is not null)
-                    {
-                        flags |= CreateSuspended;
                     }
 
                     var envBlockHandle = nint.Zero;
@@ -453,33 +477,6 @@ internal static partial class WindowsProcessInterop
                             throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error(), $"Failed to create process: {fileName}");
                         }
 
-                        if (jobHandle is not null)
-                        {
-                            // Wrap the post-CreateProcess steps so any failure between here and
-                            // ResumeThread kills the suspended child — otherwise we'd leak a
-                            // process stuck in initial-suspend state.
-                            try
-                            {
-                                if (!AssignProcessToJobObject(jobHandle, pi.hProcess))
-                                {
-                                    throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error(), "Failed to assign child process to job object");
-                                }
-
-                                // ResumeThread returns the previous suspend count, or 0xFFFFFFFF on failure.
-                                if (ResumeThread(pi.hThread) == uint.MaxValue)
-                                {
-                                    throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error(), "Failed to resume suspended child thread");
-                                }
-                            }
-                            catch
-                            {
-                                try { TerminateProcess(pi.hProcess, 1); } catch { }
-                                try { CloseHandle(pi.hThread); } catch { }
-                                try { CloseHandle(pi.hProcess); } catch { }
-                                throw;
-                            }
-                        }
-
                         return pi;
                     }
                     finally
@@ -492,6 +489,16 @@ internal static partial class WindowsProcessInterop
                 }
                 finally
                 {
+                    if (pinnedJobHandles.IsAllocated)
+                    {
+                        pinnedJobHandles.Free();
+                    }
+
+                    if (jobHandleRefAdded)
+                    {
+                        jobHandle!.DangerousRelease();
+                    }
+
                     pinnedHandles.Free();
                 }
             }

--- a/src/Aspire.Cli/Profiling/ProfileCaptureService.cs
+++ b/src/Aspire.Cli/Profiling/ProfileCaptureService.cs
@@ -105,11 +105,14 @@ internal sealed class ProfileCaptureService(
             // Launch aspire-managed directly instead of calling `aspire dashboard run`. Calling
             // back through the CLI being profiled would recursively apply --capture-profile and
             // make the collector part of the measurement.
+            // Bind the collector dashboard to the Windows kill-on-close job so it cannot outlive a
+            // hard-killed CLI (OS-level backstop on top of the cross-platform watchdog). No-op off Windows.
             dashboardProcess = await layoutProcessRunner.StartAsync(
                 managedPath,
                 dashboardArgs,
                 environmentVariables: environmentVariables,
-                options: processOptions).ConfigureAwait(false);
+                options: processOptions,
+                killOnParentExit: true).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -457,6 +457,8 @@ public class Program
         // Forward the interface to the existing concrete service so consumers can depend on the
         // abstraction (used by AppHostServerSession + GuestLaunchOptions in the aspire run path).
         builder.Services.AddTransient<IProcessTreeGracefulShutdownSignaler>(sp => sp.GetRequiredService<ProcessTreeGracefulShutdownService>());
+        // Forward the AppHost-stop abstraction to the same concrete service (used by OrphanedAppHostCollector).
+        builder.Services.AddTransient<IAppHostStopper>(sp => sp.GetRequiredService<ProcessTreeGracefulShutdownService>());
         // On-demand collector for AppHost trees whose launching CLI has died (used by `aspire ps` and `aspire stop --all`).
         builder.Services.AddTransient<OrphanedAppHostCollector>();
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -457,6 +457,9 @@ public class Program
         // Forward the interface to the existing concrete service so consumers can depend on the
         // abstraction (used by AppHostServerSession + GuestLaunchOptions in the aspire run path).
         builder.Services.AddTransient<IProcessTreeGracefulShutdownSignaler>(sp => sp.GetRequiredService<ProcessTreeGracefulShutdownService>());
+        // On-demand collector for AppHost trees whose launching CLI has died (used by `aspire ps` and
+        // `aspire stop --all`).
+        builder.Services.AddTransient<OrphanedAppHostCollector>();
 
         // Register certificate tool runner - uses native CertificateManager directly (no subprocess needed)
         builder.Services.AddSingleton(sp => CertificateManager.Create(sp.GetRequiredService<ILogger<NativeCertificateToolRunner>>(), sp.GetRequiredService<IEnvironment>()));

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -457,8 +457,7 @@ public class Program
         // Forward the interface to the existing concrete service so consumers can depend on the
         // abstraction (used by AppHostServerSession + GuestLaunchOptions in the aspire run path).
         builder.Services.AddTransient<IProcessTreeGracefulShutdownSignaler>(sp => sp.GetRequiredService<ProcessTreeGracefulShutdownService>());
-        // On-demand collector for AppHost trees whose launching CLI has died (used by `aspire ps` and
-        // `aspire stop --all`).
+        // On-demand collector for AppHost trees whose launching CLI has died (used by `aspire ps` and `aspire stop --all`).
         builder.Services.AddTransient<OrphanedAppHostCollector>();
 
         // Register certificate tool runner - uses native CertificateManager directly (no subprocess needed)

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -508,7 +508,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         // Stamp the launching CLI (hostPid) as the parent under both the RemoteHost and generic CLI
         // key pairs. Resolve the start time once and pair it with the PID so the RemoteHost orphan
         // detector verifies both and does not keep the server alive against a recycled PID.
-        var hostStartedUnix = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(hostPid);
+        var hostStartedUnix = ProcessStartTimeHelper.TryGetProcessStartTimeUnixMilliseconds(hostPid);
         OrphanDetectionEnvironment.Apply(startInfo.Environment, hostPid, hostStartedUnix, KnownConfigNames.RemoteAppHostProcessId, KnownConfigNames.RemoteAppHostProcessStarted);
         OrphanDetectionEnvironment.Apply(startInfo.Environment, hostPid, hostStartedUnix, KnownConfigNames.CliProcessId, KnownConfigNames.CliProcessStarted);
 

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -502,9 +502,18 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         }
 
         startInfo.Environment["REMOTE_APP_HOST_SOCKET_PATH"] = _socketPath;
-        startInfo.Environment["REMOTE_APP_HOST_PID"] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        startInfo.Environment[KnownConfigNames.RemoteAppHostProcessId] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
         startInfo.Environment[KnownConfigNames.CliProcessId] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
         startInfo.Environment[KnownConfigNames.CliLogFilePath] = _logFilePath;
+
+        // Pair the parent PID with its start time so the RemoteHost orphan detector verifies both and
+        // does not keep the server alive against a recycled PID. hostPid is the launching CLI process.
+        if (ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(hostPid) is { } hostStartedUnix)
+        {
+            var hostStarted = hostStartedUnix.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            startInfo.Environment[KnownConfigNames.RemoteAppHostProcessStarted] = hostStarted;
+            startInfo.Environment[KnownConfigNames.CliProcessStarted] = hostStarted;
+        }
 
         // Dev mode uses debug builds which require Development environment
         // for the dashboard to resolve static web assets correctly

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -9,6 +9,7 @@ using System.Xml.Linq;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Packaging;
+using Aspire.Cli.Processes;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
 using Aspire.Shared;
@@ -502,18 +503,14 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         }
 
         startInfo.Environment["REMOTE_APP_HOST_SOCKET_PATH"] = _socketPath;
-        startInfo.Environment[KnownConfigNames.RemoteAppHostProcessId] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        startInfo.Environment[KnownConfigNames.CliProcessId] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
         startInfo.Environment[KnownConfigNames.CliLogFilePath] = _logFilePath;
 
-        // Pair the parent PID with its start time so the RemoteHost orphan detector verifies both and
-        // does not keep the server alive against a recycled PID. hostPid is the launching CLI process.
-        if (ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(hostPid) is { } hostStartedUnix)
-        {
-            var hostStarted = hostStartedUnix.ToString(System.Globalization.CultureInfo.InvariantCulture);
-            startInfo.Environment[KnownConfigNames.RemoteAppHostProcessStarted] = hostStarted;
-            startInfo.Environment[KnownConfigNames.CliProcessStarted] = hostStarted;
-        }
+        // Stamp the launching CLI (hostPid) as the parent under both the RemoteHost and generic CLI
+        // key pairs. Resolve the start time once and pair it with the PID so the RemoteHost orphan
+        // detector verifies both and does not keep the server alive against a recycled PID.
+        var hostStartedUnix = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(hostPid);
+        OrphanDetectionEnvironment.Apply(startInfo.Environment, hostPid, hostStartedUnix, KnownConfigNames.RemoteAppHostProcessId, KnownConfigNames.RemoteAppHostProcessStarted);
+        OrphanDetectionEnvironment.Apply(startInfo.Environment, hostPid, hostStartedUnix, KnownConfigNames.CliProcessId, KnownConfigNames.CliProcessStarted);
 
         // Dev mode uses debug builds which require Development environment
         // for the dashboard to resolve static web assets correctly

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -13,6 +13,7 @@ using Aspire.Cli.DotNet;
 using Aspire.Cli.Layout;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
+using Aspire.Cli.Processes;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
 using Aspire.Shared;
@@ -1016,18 +1017,14 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
 
         // Configure environment
         startInfo.Environment["REMOTE_APP_HOST_SOCKET_PATH"] = _socketPath;
-        startInfo.Environment[KnownConfigNames.RemoteAppHostProcessId] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        startInfo.Environment[KnownConfigNames.CliProcessId] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
         startInfo.Environment[KnownConfigNames.CliLogFilePath] = _executionContext.LogFilePath;
 
-        // Pair the parent PID with its start time so the RemoteHost orphan detector verifies both and
-        // does not keep the server alive against a recycled PID. hostPid is the launching CLI process.
-        if (ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(hostPid) is { } hostStartedUnix)
-        {
-            var hostStarted = hostStartedUnix.ToString(System.Globalization.CultureInfo.InvariantCulture);
-            startInfo.Environment[KnownConfigNames.RemoteAppHostProcessStarted] = hostStarted;
-            startInfo.Environment[KnownConfigNames.CliProcessStarted] = hostStarted;
-        }
+        // Stamp the launching CLI (hostPid) as the parent under both the RemoteHost and generic CLI
+        // key pairs. Resolve the start time once and pair it with the PID so the RemoteHost orphan
+        // detector verifies both and does not keep the server alive against a recycled PID.
+        var hostStartedUnix = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(hostPid);
+        OrphanDetectionEnvironment.Apply(startInfo.Environment, hostPid, hostStartedUnix, KnownConfigNames.RemoteAppHostProcessId, KnownConfigNames.RemoteAppHostProcessStarted);
+        OrphanDetectionEnvironment.Apply(startInfo.Environment, hostPid, hostStartedUnix, KnownConfigNames.CliProcessId, KnownConfigNames.CliProcessStarted);
 
         if (_integrationLibsPath is not null)
         {

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -1022,7 +1022,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
         // Stamp the launching CLI (hostPid) as the parent under both the RemoteHost and generic CLI
         // key pairs. Resolve the start time once and pair it with the PID so the RemoteHost orphan
         // detector verifies both and does not keep the server alive against a recycled PID.
-        var hostStartedUnix = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(hostPid);
+        var hostStartedUnix = ProcessStartTimeHelper.TryGetProcessStartTimeUnixMilliseconds(hostPid);
         OrphanDetectionEnvironment.Apply(startInfo.Environment, hostPid, hostStartedUnix, KnownConfigNames.RemoteAppHostProcessId, KnownConfigNames.RemoteAppHostProcessStarted);
         OrphanDetectionEnvironment.Apply(startInfo.Environment, hostPid, hostStartedUnix, KnownConfigNames.CliProcessId, KnownConfigNames.CliProcessStarted);
 

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -1016,9 +1016,18 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
 
         // Configure environment
         startInfo.Environment["REMOTE_APP_HOST_SOCKET_PATH"] = _socketPath;
-        startInfo.Environment["REMOTE_APP_HOST_PID"] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        startInfo.Environment[KnownConfigNames.RemoteAppHostProcessId] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
         startInfo.Environment[KnownConfigNames.CliProcessId] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
         startInfo.Environment[KnownConfigNames.CliLogFilePath] = _executionContext.LogFilePath;
+
+        // Pair the parent PID with its start time so the RemoteHost orphan detector verifies both and
+        // does not keep the server alive against a recycled PID. hostPid is the launching CLI process.
+        if (ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(hostPid) is { } hostStartedUnix)
+        {
+            var hostStarted = hostStartedUnix.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            startInfo.Environment[KnownConfigNames.RemoteAppHostProcessStarted] = hostStarted;
+            startInfo.Environment[KnownConfigNames.CliProcessStarted] = hostStarted;
+        }
 
         if (_integrationLibsPath is not null)
         {

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -978,10 +978,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
     /// <summary>
     /// Runs the dashboard until it shuts down or <paramref name="cancellationToken"/> is cancelled.
-    /// Cancellation triggers a graceful host shutdown, which lets the standalone
-    /// <c>aspire-managed dashboard</c> process tear itself down (e.g. when a parent-liveness watchdog
-    /// observes that the launching CLI has died) instead of lingering as an orphaned process.
+    /// Cancellation triggers a graceful host shutdown.
     /// </summary>
+    /// <param name="cancellationToken">A cancellation token that can be used to request the dashboard to stop.</param>
     public async Task<int> RunAsync(CancellationToken cancellationToken)
     {
         if (_validationFailures.Count > 0)

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -976,6 +976,48 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Runs the dashboard until it shuts down or <paramref name="cancellationToken"/> is cancelled.
+    /// Cancellation triggers a graceful host shutdown, which lets the standalone
+    /// <c>aspire-managed dashboard</c> process tear itself down (e.g. when a parent-liveness watchdog
+    /// observes that the launching CLI has died) instead of lingering as an orphaned process.
+    /// </summary>
+    public async Task<int> RunAsync(CancellationToken cancellationToken)
+    {
+        if (_validationFailures.Count > 0)
+        {
+            return ExitCodeValidationFailure;
+        }
+
+        try
+        {
+            // Cast to IHost so this binds to the CancellationToken-aware HostingAbstractionsHostExtensions.RunAsync
+            // (WebApplication's own RunAsync only takes a URL). Cancelling the token stops the host gracefully.
+            await ((IHost)_app).RunAsync(cancellationToken).ConfigureAwait(false);
+            return 0;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Cancellation is the watchdog's normal shutdown signal (or a start-time race), not a failure.
+            return 0;
+        }
+        catch (IOException ex) when (ContainsAddressInUse(ex))
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return ExitCodeAddressInUse;
+        }
+        catch (Exception ex)
+        {
+            // Include the full exception (type, stack trace, inner exceptions)
+            // so that a "dashboard silently died" report has enough breadcrumbs
+            // to find the root cause from the AppHost log alone, without
+            // requiring a debugger attach.
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            Console.Error.WriteLine(ex.ToString());
+            return ExitCodeUnexpectedError;
+        }
+    }
+
     private static bool ContainsAddressInUse(Exception ex)
     {
         for (var current = ex.InnerException; current is not null; current = current.InnerException)

--- a/src/Aspire.Hosting.RemoteHost/Aspire.Hosting.RemoteHost.csproj
+++ b/src/Aspire.Hosting.RemoteHost/Aspire.Hosting.RemoteHost.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
+    <Compile Include="$(SharedDir)ProcessStartTimeHelper.cs" Link="Utils\ProcessStartTimeHelper.cs" />
     <Compile Include="$(SharedDir)KnownOtelConfigNames.cs" Link="Utils\KnownOtelConfigNames.cs" />
     <Compile Include="$(SharedDir)IntegrationPackageProbeManifest.cs" Link="IntegrationPackageProbeManifest.cs" />
   </ItemGroup>

--- a/src/Aspire.Hosting.RemoteHost/Aspire.Hosting.RemoteHost.csproj
+++ b/src/Aspire.Hosting.RemoteHost/Aspire.Hosting.RemoteHost.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
     <SkipAspireIntegrationAnalyzersReference>true</SkipAspireIntegrationAnalyzersReference>
   </PropertyGroup>

--- a/src/Aspire.Hosting.RemoteHost/OrphanDetector.cs
+++ b/src/Aspire.Hosting.RemoteHost/OrphanDetector.cs
@@ -31,7 +31,7 @@ internal sealed class OrphanDetector : BackgroundService
 
     internal Func<int, long, bool> IsProcessRunningWithLegacyStartTime { get; set; } = static (pid, expectedStartTimeUnix) =>
     {
-        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, ProcessStartTimeHelper.CrossProcessIdentityTimeTolerance);
+        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, ProcessStartTimeHelper.LegacyStartTimeMatchTolerance);
     };
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/Aspire.Hosting.RemoteHost/OrphanDetector.cs
+++ b/src/Aspire.Hosting.RemoteHost/OrphanDetector.cs
@@ -29,6 +29,11 @@ internal sealed class OrphanDetector : BackgroundService
     // aspire-managed processes under high process churn).
     internal Func<int, long, bool> IsProcessRunningWithStartTime { get; set; } = static (pid, expectedStartTimeUnix) => ProcessStartTimeHelper.IsProcessRunning(pid, expectedStartTimeUnix);
 
+    internal Func<int, long, bool> IsProcessRunningWithLegacyStartTime { get; set; } = static (pid, expectedStartTimeUnix) =>
+    {
+        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, TimeSpan.FromSeconds(1));
+    };
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         try
@@ -43,11 +48,19 @@ internal sealed class OrphanDetector : BackgroundService
 
             _logger.LogDebug("Monitoring parent process PID: {ParentPid}", pid);
 
-            // Prefer REMOTE_APP_HOST_STARTED but fall back to ASPIRE_CLI_STARTED (the launcher sets both
-            // to the same value). When neither is present we degrade to PID-only detection.
+            // Prefer start times that current CLIs produce from /proc. ASPIRE_CLI_STARTED is kept in the
+            // Process.StartTime clock domain for released AppHosts, so only use it with the legacy verifier.
+            // When no start time is present, degrade to PID-only detection.
             long? expectedStartTimeUnix = null;
+            var useLegacyStartTime = false;
             var startTimeString = _configuration[KnownConfigNames.RemoteAppHostProcessStarted]
-                ?? _configuration[KnownConfigNames.CliProcessStarted];
+                ?? _configuration[KnownConfigNames.CliProcessStartedStable];
+            if (startTimeString is null)
+            {
+                startTimeString = _configuration[KnownConfigNames.CliProcessStarted];
+                useLegacyStartTime = true;
+            }
+
             if (ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(startTimeString) is { } parsedStartTime)
             {
                 expectedStartTimeUnix = parsedStartTime;
@@ -62,9 +75,12 @@ internal sealed class OrphanDetector : BackgroundService
 
             do
             {
-                var isProcessStillRunning = expectedStartTimeUnix is { } expected
-                    ? IsProcessRunningWithStartTime(pid, expected)
-                    : IsProcessRunning(pid);
+                var isProcessStillRunning = expectedStartTimeUnix switch
+                {
+                    { } expected when useLegacyStartTime => IsProcessRunningWithLegacyStartTime(pid, expected),
+                    { } expected => IsProcessRunningWithStartTime(pid, expected),
+                    _ => IsProcessRunning(pid)
+                };
 
                 if (!isProcessStillRunning)
                 {

--- a/src/Aspire.Hosting.RemoteHost/OrphanDetector.cs
+++ b/src/Aspire.Hosting.RemoteHost/OrphanDetector.cs
@@ -31,7 +31,7 @@ internal sealed class OrphanDetector : BackgroundService
 
     internal Func<int, long, bool> IsProcessRunningWithLegacyStartTime { get; set; } = static (pid, expectedStartTimeUnix) =>
     {
-        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, TimeSpan.FromSeconds(1));
+        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, ProcessStartTimeHelper.RuntimeStartTimeComparisonTolerance);
     };
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/Aspire.Hosting.RemoteHost/OrphanDetector.cs
+++ b/src/Aspire.Hosting.RemoteHost/OrphanDetector.cs
@@ -1,7 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -9,34 +10,30 @@ namespace Aspire.Hosting.RemoteHost;
 
 internal sealed class OrphanDetector : BackgroundService
 {
-    private const string HostProcessId = "REMOTE_APP_HOST_PID";
+    private readonly IConfiguration _configuration;
     private readonly IHostApplicationLifetime _lifetime;
     private readonly ILogger<OrphanDetector> _logger;
 
-    public OrphanDetector(IHostApplicationLifetime lifetime, ILogger<OrphanDetector> logger)
+    public OrphanDetector(IConfiguration configuration, IHostApplicationLifetime lifetime, ILogger<OrphanDetector> logger)
     {
+        _configuration = configuration;
         _lifetime = lifetime;
         _logger = logger;
     }
 
-    internal Func<int, bool> IsProcessRunning { get; set; } = (int pid) =>
-    {
-        try
-        {
-            return !Process.GetProcessById(pid).HasExited;
-        }
-        catch (ArgumentException)
-        {
-            // If Process.GetProcessById throws it means the process is not running.
-            return false;
-        }
-    };
+    // PID-only liveness check. Used as a fallback when no start time was supplied (older CLIs).
+    internal Func<int, bool> IsProcessRunning { get; set; } = static pid => ProcessStartTimeHelper.IsProcessRunning(pid);
+
+    // PID + start-time liveness check. Verifying the start time prevents a recycled PID from making
+    // an orphaned server believe its long-dead parent is still alive (the cause of leaked
+    // aspire-managed processes under high process churn).
+    internal Func<int, long, bool> IsProcessRunningWithStartTime { get; set; } = static (pid, expectedStartTimeUnix) => ProcessStartTimeHelper.IsProcessRunning(pid, expectedStartTimeUnix);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         try
         {
-            if (Environment.GetEnvironmentVariable(HostProcessId) is not { } pidString || !int.TryParse(pidString, out var pid))
+            if (_configuration[KnownConfigNames.RemoteAppHostProcessId] is not { } pidString || !int.TryParse(pidString, NumberStyles.Integer, CultureInfo.InvariantCulture, out var pid))
             {
                 // If there is no PID environment variable, we assume that the process is not a child process
                 // of the Aspire CLI and we won't continue monitoring.
@@ -46,11 +43,30 @@ internal sealed class OrphanDetector : BackgroundService
 
             _logger.LogDebug("Monitoring parent process PID: {ParentPid}", pid);
 
+            // Prefer REMOTE_APP_HOST_STARTED but fall back to ASPIRE_CLI_STARTED (the launcher sets both
+            // to the same value). When neither is present we degrade to PID-only detection.
+            long? expectedStartTimeUnix = null;
+            var startTimeString = _configuration[KnownConfigNames.RemoteAppHostProcessStarted]
+                ?? _configuration[KnownConfigNames.CliProcessStarted];
+            if (ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(startTimeString) is { } parsedStartTime)
+            {
+                expectedStartTimeUnix = parsedStartTime;
+                _logger.LogDebug("Using start time verification. Expected start time: {StartTime}", expectedStartTimeUnix);
+            }
+            else
+            {
+                _logger.LogDebug("No valid start time configured. Using PID-only detection.");
+            }
+
             using var periodic = new PeriodicTimer(TimeSpan.FromSeconds(1), TimeProvider.System);
 
             do
             {
-                if (!IsProcessRunning(pid))
+                var isProcessStillRunning = expectedStartTimeUnix is { } expected
+                    ? IsProcessRunningWithStartTime(pid, expected)
+                    : IsProcessRunning(pid);
+
+                if (!isProcessStillRunning)
                 {
                     _logger.LogWarning("Parent process {ParentPid} is no longer running, shutting down...", pid);
                     _lifetime.StopApplication();

--- a/src/Aspire.Hosting.RemoteHost/OrphanDetector.cs
+++ b/src/Aspire.Hosting.RemoteHost/OrphanDetector.cs
@@ -31,7 +31,7 @@ internal sealed class OrphanDetector : BackgroundService
 
     internal Func<int, long, bool> IsProcessRunningWithLegacyStartTime { get; set; } = static (pid, expectedStartTimeUnix) =>
     {
-        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, ProcessStartTimeHelper.RuntimeStartTimeComparisonTolerance);
+        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, ProcessStartTimeHelper.CrossProcessIdentityTimeTolerance);
     };
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -62,6 +62,7 @@
     <Compile Include="$(SharedDir)X509Certificate2Extensions.cs" Link="Utils\X509Certificate2Extensions.cs" />
     <Compile Include="$(SharedDir)PasswordGenerator.cs" Link="Utils\PasswordGenerator.cs" />
     <Compile Include="$(SharedDir)ProcessSignaler.cs" Link="Utils\ProcessSignaler.cs" />
+    <Compile Include="$(SharedDir)ProcessStartTimeHelper.cs" Link="Utils\ProcessStartTimeHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -877,12 +877,17 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
             cliStartedAt = DateTimeOffset.FromUnixTimeSeconds(parsedCliStartedAt);
         }
 
+        using var currentProcess = Process.GetCurrentProcess();
+        // StartedAt is the legacy backchannel field, and released AppHosts populate it from
+        // Process.StartTime. Keep that runtime-domain value for mixed-version CLI compatibility.
+        // StableStartedAt carries the current /proc-backed PID identity for exact reuse checks.
         return Task.FromResult(new AppHostInformation
         {
             AppHostPath = appHostPath,
             ProcessId = Environment.ProcessId,
             CliProcessId = cliProcessId,
-            StartedAt = ProcessStartTimeHelper.TryGetProcessStartTime(Environment.ProcessId) ?? new DateTimeOffset(Process.GetCurrentProcess().StartTime),
+            StartedAt = new DateTimeOffset(currentProcess.StartTime),
+            StableStartedAt = ProcessStartTimeHelper.TryGetProcessStartTime(Environment.ProcessId),
             CliStartedAt = cliStartedAt,
             CliLogFilePath = configuration[KnownConfigNames.CliLogFilePath]
         });

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -882,7 +882,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
             AppHostPath = appHostPath,
             ProcessId = Environment.ProcessId,
             CliProcessId = cliProcessId,
-            StartedAt = new DateTimeOffset(Process.GetCurrentProcess().StartTime),
+            StartedAt = ProcessStartTimeHelper.TryGetProcessStartTime(Environment.ProcessId) ?? new DateTimeOffset(Process.GetCurrentProcess().StartTime),
             CliStartedAt = cliStartedAt,
             CliLogFilePath = configuration[KnownConfigNames.CliLogFilePath]
         });

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -877,30 +877,33 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
             cliStartedAt = DateTimeOffset.FromUnixTimeSeconds(parsedCliStartedAt);
         }
 
-        // ASPIRE_CLI_STARTED_STABLE is the /proc-derived launcher-CLI identity that current CLIs stamp
-        // alongside the legacy value. It survives wall-clock steps, so surfacing it lets the CLI-side
-        // orphan collector verify the launching CLI with an exact PID-reuse check instead of the
-        // drift-prone legacy value. Older CLIs do not stamp it, so it stays null for them.
+        // ASPIRE_CLI_STARTED_STABLE is the stable launcher-CLI identity time that current CLIs stamp
+        // alongside the legacy value, in Unix milliseconds. It survives wall-clock steps, so surfacing it
+        // lets the CLI-side orphan collector verify the launching CLI with an exact PID-reuse check
+        // instead of the drift-prone legacy value. Older CLIs do not stamp it, so it stays null for them.
         DateTimeOffset? cliStableStartedAt = null;
         var cliStableStartedAtString = configuration[KnownConfigNames.CliProcessStartedStable];
         if (!string.IsNullOrEmpty(cliStableStartedAtString) && long.TryParse(cliStableStartedAtString, out var parsedCliStableStartedAt))
         {
-            cliStableStartedAt = DateTimeOffset.FromUnixTimeSeconds(parsedCliStableStartedAt);
+            cliStableStartedAt = DateTimeOffset.FromUnixTimeMilliseconds(parsedCliStableStartedAt);
         }
 
         using var currentProcess = Process.GetCurrentProcess();
-        // StartedAt is the legacy backchannel field, and released AppHosts populate it from
-        // Process.StartTime. Keep that runtime-domain value for mixed-version CLI compatibility.
-        // StableStartedAt carries the current /proc-backed PID identity for exact reuse checks.
+
         return Task.FromResult(new AppHostInformation
         {
             AppHostPath = appHostPath,
             ProcessId = Environment.ProcessId,
             CliProcessId = cliProcessId,
+
+            // StartedAt is the legacy backchannel field, and released AppHosts populate it from Process.StartTime. 
+            // Keep doing for mixed-version CLI compatibility.
+            // StableStartedAt carries millisecond-precision, stable process identity time for exact reuse checks.
             StartedAt = new DateTimeOffset(currentProcess.StartTime),
             StableStartedAt = ProcessStartTimeHelper.TryGetProcessStartTime(Environment.ProcessId),
             CliStartedAt = cliStartedAt,
             CliStableStartedAt = cliStableStartedAt,
+
             CliLogFilePath = configuration[KnownConfigNames.CliLogFilePath]
         });
     }

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -877,6 +877,17 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
             cliStartedAt = DateTimeOffset.FromUnixTimeSeconds(parsedCliStartedAt);
         }
 
+        // ASPIRE_CLI_STARTED_STABLE is the /proc-derived launcher-CLI identity that current CLIs stamp
+        // alongside the legacy value. It survives wall-clock steps, so surfacing it lets the CLI-side
+        // orphan collector verify the launching CLI with an exact PID-reuse check instead of the
+        // drift-prone legacy value. Older CLIs do not stamp it, so it stays null for them.
+        DateTimeOffset? cliStableStartedAt = null;
+        var cliStableStartedAtString = configuration[KnownConfigNames.CliProcessStartedStable];
+        if (!string.IsNullOrEmpty(cliStableStartedAtString) && long.TryParse(cliStableStartedAtString, out var parsedCliStableStartedAt))
+        {
+            cliStableStartedAt = DateTimeOffset.FromUnixTimeSeconds(parsedCliStableStartedAt);
+        }
+
         using var currentProcess = Process.GetCurrentProcess();
         // StartedAt is the legacy backchannel field, and released AppHosts populate it from
         // Process.StartTime. Keep that runtime-domain value for mixed-version CLI compatibility.
@@ -889,6 +900,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
             StartedAt = new DateTimeOffset(currentProcess.StartTime),
             StableStartedAt = ProcessStartTimeHelper.TryGetProcessStartTime(Environment.ProcessId),
             CliStartedAt = cliStartedAt,
+            CliStableStartedAt = cliStableStartedAt,
             CliLogFilePath = configuration[KnownConfigNames.CliLogFilePath]
         });
     }

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelService.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelService.cs
@@ -4,6 +4,7 @@
 using System.Net.Sockets;
 using Aspire.Hosting.Diagnostics;
 using Aspire.Hosting.Eventing;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -56,7 +57,7 @@ internal sealed class AuxiliaryBackchannelService(
             }
 
             // Clean up orphaned sockets from crashed instances of this same AppHost
-            var appHostPath = configuration["AppHost:FilePath"] ?? configuration["AppHost:Path"];
+            var appHostPath = GetSocketKeyAppHostPath(configuration);
             if (!string.IsNullOrEmpty(appHostPath))
             {
                 var appHostId = BackchannelConstants.ComputeAppHostId(appHostPath);
@@ -207,9 +208,8 @@ internal sealed class AuxiliaryBackchannelService(
     {
         var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
-        // Use AppHost:FilePath or AppHost:Path from configuration for consistent hashing
-        // This matches the logic in AuxiliaryBackchannelRpcTarget.GetAppHostInformationAsync
-        var appHostPath = configuration["AppHost:FilePath"] ?? configuration["AppHost:Path"];
+        // Use the symlink-resolved AppHost:FilePath or AppHost:Path from configuration for consistent hashing.
+        var appHostPath = GetSocketKeyAppHostPath(configuration);
 
         if (!string.IsNullOrEmpty(appHostPath))
         {
@@ -220,5 +220,14 @@ internal sealed class AuxiliaryBackchannelService(
         // Fallback: Generate socket path using process ID as the AppHost ID seed (rare edge case)
         var fallbackAppHostId = BackchannelConstants.ComputeAppHostId(Environment.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
         return BackchannelConstants.ComputeSocketPathFromAppHostId(fallbackAppHostId, homeDirectory, Environment.ProcessId);
+    }
+
+    /// <summary>
+    /// Reads the AppHost path used to key this AppHost's auxiliary backchannel socket and canonicalizes it by resolving symlinks.
+    /// </summary>
+    internal static string? GetSocketKeyAppHostPath(IConfiguration configuration)
+    {
+        var appHostPath = configuration["AppHost:FilePath"] ?? configuration["AppHost:Path"];
+        return string.IsNullOrEmpty(appHostPath) ? appHostPath : PathNormalizer.ResolveSymlinks(appHostPath);
     }
 }

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -1472,9 +1472,23 @@ internal sealed class AppHostInformation
     /// </summary>
     /// <remarks>
     /// This value comes from <c>ASPIRE_CLI_STARTED</c>, which is intentionally stamped from
-    /// <see cref="Process.StartTime"/> for released-AppHost compatibility.
+    /// <see cref="Process.StartTime"/> for released-AppHost compatibility. On Linux it drifts across
+    /// processes after a wall-clock adjustment, so prefer <see cref="CliStableStartedAt"/> when it is
+    /// present.
     /// </remarks>
     public DateTimeOffset? CliStartedAt { get; init; }
+
+    /// <summary>
+    /// Gets or sets when the CLI process that launched the AppHost started, using the stable
+    /// PID-identity clock domain.
+    /// </summary>
+    /// <remarks>
+    /// This value comes from <c>ASPIRE_CLI_STARTED_STABLE</c> and, unlike <see cref="CliStartedAt"/>,
+    /// is derived from Linux <c>/proc</c> start ticks so it survives wall-clock adjustments and can be
+    /// compared exactly to guard against CLI PID reuse. Current CLIs stamp it; older CLIs do not, so
+    /// this additive field is <see langword="null"/> when the AppHost was launched by an older CLI.
+    /// </remarks>
+    public DateTimeOffset? CliStableStartedAt { get; init; }
 
     /// <summary>
     /// Gets or sets the log file path of the CLI process that launched the AppHost.

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -1447,14 +1447,33 @@ internal sealed class AppHostInformation
     public int? CliProcessId { get; init; }
 
     /// <summary>
-    /// Gets or sets when the AppHost process started.
+    /// Gets or sets when the AppHost process started using the legacy <see cref="Process.StartTime"/> clock domain.
     /// </summary>
+    /// <remarks>
+    /// Released AppHosts only report this field. On Linux it can differ from the stable PID-identity
+    /// value by an adjacent Unix second, so callers that verify process identity should prefer
+    /// <see cref="StableStartedAt"/> when it is present and use a runtime-start-time verifier for this
+    /// fallback field.
+    /// </remarks>
     public DateTimeOffset? StartedAt { get; init; }
+
+    /// <summary>
+    /// Gets or sets when the AppHost process started using the stable PID-identity clock domain.
+    /// </summary>
+    /// <remarks>
+    /// Current AppHosts report this additive field so callers can perform exact PID-reuse checks while
+    /// still accepting older AppHosts that only sent <see cref="StartedAt"/>.
+    /// </remarks>
+    public DateTimeOffset? StableStartedAt { get; init; }
 
     /// <summary>
     /// Gets or sets when the CLI process that launched the AppHost started.
     /// This value is only set when the AppHost is launched via the Aspire CLI.
     /// </summary>
+    /// <remarks>
+    /// This value comes from <c>ASPIRE_CLI_STARTED</c>, which is intentionally stamped from
+    /// <see cref="Process.StartTime"/> for released-AppHost compatibility.
+    /// </remarks>
     public DateTimeOffset? CliStartedAt { get; init; }
 
     /// <summary>
@@ -1731,4 +1750,3 @@ internal sealed class ResourceLogBatch
     /// </summary>
     public required ResourceLogLine[] Lines { get; init; }
 }
-

--- a/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
+++ b/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
@@ -17,8 +17,7 @@ internal sealed class CliOrphanDetector(IConfiguration configuration, IHostAppli
 
     internal Func<int, long, bool> IsProcessRunningWithStartTime { get; set; } = (int pid, long expectedStartTimeUnix) =>
     {
-        using var process = ProcessSignaler.TryGetRunningProcess(pid, DateTimeOffset.FromUnixTimeSeconds(expectedStartTimeUnix), logger);
-        return process is not null;
+        return ProcessStartTimeHelper.IsProcessRunning(pid, expectedStartTimeUnix);
     };
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
+++ b/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
@@ -20,6 +20,11 @@ internal sealed class CliOrphanDetector(IConfiguration configuration, IHostAppli
         return ProcessStartTimeHelper.IsProcessRunning(pid, expectedStartTimeUnix);
     };
 
+    internal Func<int, long, bool> IsProcessRunningWithLegacyStartTime { get; set; } = (int pid, long expectedStartTimeUnix) =>
+    {
+        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, TimeSpan.FromSeconds(1));
+    };
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         if (configuration[KnownConfigNames.CliProcessId] is not { } pidString || !int.TryParse(pidString, out var pid))
@@ -32,13 +37,21 @@ internal sealed class CliOrphanDetector(IConfiguration configuration, IHostAppli
 
         logger.LogDebug("Starting orphan detection for CLI process {Pid}.", pid);
 
-        // Try to get the CLI process start time for robust orphan detection
+        // Try to get the CLI process start time for robust orphan detection.
         long? expectedStartTimeUnix = null;
-        if (configuration[KnownConfigNames.CliProcessStarted] is { } startTimeString &&
+        var useLegacyStartTime = false;
+        if (configuration[KnownConfigNames.CliProcessStartedStable] is { } stableStartTimeString &&
+            long.TryParse(stableStartTimeString, out var stableStartTimeUnix))
+        {
+            expectedStartTimeUnix = stableStartTimeUnix;
+            logger.LogDebug("Using stable start time verification. Expected start time: {StartTime}.", expectedStartTimeUnix);
+        }
+        else if (configuration[KnownConfigNames.CliProcessStarted] is { } startTimeString &&
             long.TryParse(startTimeString, out var startTimeUnix))
         {
             expectedStartTimeUnix = startTimeUnix;
-            logger.LogDebug("Using start time verification. Expected start time: {StartTime}.", expectedStartTimeUnix);
+            useLegacyStartTime = true;
+            logger.LogDebug("Using legacy start time verification. Expected start time: {StartTime}.", expectedStartTimeUnix);
         }
         else
         {
@@ -56,8 +69,9 @@ internal sealed class CliOrphanDetector(IConfiguration configuration, IHostAppli
 
                 if (expectedStartTimeUnix.HasValue)
                 {
-                    // Use robust process checking with start time verification
-                    isProcessStillRunning = IsProcessRunningWithStartTime(pid, expectedStartTimeUnix.Value);
+                    isProcessStillRunning = useLegacyStartTime
+                        ? IsProcessRunningWithLegacyStartTime(pid, expectedStartTimeUnix.Value)
+                        : IsProcessRunningWithStartTime(pid, expectedStartTimeUnix.Value);
                 }
                 else
                 {

--- a/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
+++ b/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
@@ -22,7 +22,7 @@ internal sealed class CliOrphanDetector(IConfiguration configuration, IHostAppli
 
     internal Func<int, long, bool> IsProcessRunningWithLegacyStartTime { get; set; } = (int pid, long expectedStartTimeUnix) =>
     {
-        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, ProcessStartTimeHelper.CrossProcessIdentityTimeTolerance);
+        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, ProcessStartTimeHelper.LegacyStartTimeMatchTolerance);
     };
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
+++ b/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
@@ -22,7 +22,7 @@ internal sealed class CliOrphanDetector(IConfiguration configuration, IHostAppli
 
     internal Func<int, long, bool> IsProcessRunningWithLegacyStartTime { get; set; } = (int pid, long expectedStartTimeUnix) =>
     {
-        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, TimeSpan.FromSeconds(1));
+        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, ProcessStartTimeHelper.RuntimeStartTimeComparisonTolerance);
     };
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
+++ b/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
@@ -22,7 +22,7 @@ internal sealed class CliOrphanDetector(IConfiguration configuration, IHostAppli
 
     internal Func<int, long, bool> IsProcessRunningWithLegacyStartTime { get; set; } = (int pid, long expectedStartTimeUnix) =>
     {
-        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, ProcessStartTimeHelper.RuntimeStartTimeComparisonTolerance);
+        return ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, ProcessStartTimeHelper.CrossProcessIdentityTimeTolerance);
     };
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/Aspire.Hosting/Dcp/DcpProcessMonitor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpProcessMonitor.cs
@@ -1,19 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
-using System.Runtime.InteropServices;
 using SystemProcess = System.Diagnostics.Process;
 
 namespace Aspire.Hosting.Dcp;
 
 internal sealed record DcpProcessIdentity(int ProcessId, DateTime Timestamp);
 
-internal static partial class DcpProcessMonitor
+internal static class DcpProcessMonitor
 {
-    private const int DefaultLinuxClockTicksPerSecond = 100;
-    private const int LinuxClockTicksPerSecondConfigName = 2; // _SC_CLK_TCK
-
     internal static DcpProcessIdentity GetMonitorProcessIdentity(SystemProcess parentProcess)
     {
         ArgumentNullException.ThrowIfNull(parentProcess);
@@ -50,54 +45,27 @@ internal static partial class DcpProcessMonitor
         }
     }
 
-    private static DateTime? GetLinuxProcessIdentityTimestamp(int processId)
+    private static DateTime GetLinuxProcessIdentityTimestamp(int processId)
     {
-        var statPath = Path.Combine(
-            Environment.GetEnvironmentVariable("HOST_PROC") ?? "/proc",
-            processId.ToString(CultureInfo.InvariantCulture),
-            "stat");
+        // DCP inspects the *host* process table, so honor HOST_PROC when this check runs inside a
+        // container whose host /proc is mounted elsewhere. Orphan/liveness detection deliberately uses the
+        // current namespace's /proc instead (see ProcessStartTimeHelper.TryGetProcessStartTime), which is
+        // why the /proc root is a parameter of the shared reader rather than baked into it.
+        var procRoot = Environment.GetEnvironmentVariable("HOST_PROC") ?? "/proc";
 
-        string contents;
-        try
+        // Share the /proc start-ticks reader with every other Aspire watchdog so there is one Linux
+        // process-identity implementation. The value is boot-relative (field 22 of /proc/<pid>/stat),
+        // which is why it is immune to wall-clock drift.
+        if (ProcessStartTimeHelper.TryGetLinuxProcessStartTicks(processId, procRoot) is not { } startTicks)
         {
-            contents = File.ReadAllText(statPath);
-        }
-        catch (IOException ex)
-        {
-            throw new InvalidOperationException($"Could not read monitor process stat file '{statPath}'.", ex);
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            throw new InvalidOperationException($"Could not read monitor process stat file '{statPath}'.", ex);
+            throw new InvalidOperationException($"Could not read a valid start time for monitor process {processId} from '{procRoot}'.");
         }
 
-        // /proc/<pid>/stat fields start as:
-        //   12345 (process name may contain spaces or parentheses) S 1 2 3 ...
-        // The process start time is field 22, in clock ticks since boot. Match DCP's
-        // Linux identity time by converting that monotonic value into a DateTime
-        // offset from DateTime.MinValue instead of estimating a wall-clock time.
-        var closeParenIndex = contents.LastIndexOf(')');
-        if (closeParenIndex < 0 || closeParenIndex + 2 >= contents.Length)
-        {
-            throw new InvalidOperationException($"Monitor process stat file '{statPath}' was malformed.");
-        }
-
-        var fields = contents[(closeParenIndex + 2)..].Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        if (fields.Length < 20 || !ulong.TryParse(fields[19], CultureInfo.InvariantCulture, out var startTicks))
-        {
-            throw new InvalidOperationException($"Monitor process stat file '{statPath}' did not contain a valid start time.");
-        }
-
-        var startTimeMilliseconds = (startTicks * 1000) / (ulong)GetLinuxClockTicksPerSecond();
+        // Convert the boot-relative start ticks into a DateTime offset from DateTime.MinValue instead of
+        // estimating a wall-clock time. Kept in milliseconds for parity with the timestamp DCP compares
+        // against, which is a distinct identity domain from the whole-second value used by the orphan
+        // detectors, so the two never cross-compare.
+        var startTimeMilliseconds = (startTicks * 1000) / (ulong)ProcessStartTimeHelper.GetLinuxClockTicksPerSecond();
         return DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc).AddMilliseconds(startTimeMilliseconds);
     }
-
-    private static int GetLinuxClockTicksPerSecond()
-    {
-        var result = sysconf(LinuxClockTicksPerSecondConfigName);
-        return result > 0 ? (int)result : DefaultLinuxClockTicksPerSecond;
-    }
-
-    [LibraryImport("libc", SetLastError = true, EntryPoint = "sysconf")]
-    private static partial long sysconf(int name);
 }

--- a/src/Aspire.Managed/Aspire.Managed.csproj
+++ b/src/Aspire.Managed/Aspire.Managed.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon>$(MSBuildThisFileDirectory)..\Shared\Aspire.ico</ApplicationIcon>
     <AssemblyName>aspire-managed</AssemblyName>
 
@@ -56,6 +57,10 @@
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Shared\KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)ProcessStartTimeHelper.cs" Link="Shared\ProcessStartTimeHelper.cs" />
     <Compile Include="$(SharedDir)ParentProcessLivenessMonitor.cs" Link="Shared\ParentProcessLivenessMonitor.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Managed.Tests" />
   </ItemGroup>
 
   <!-- Exclude unwanted files from publish output -->

--- a/src/Aspire.Managed/Aspire.Managed.csproj
+++ b/src/Aspire.Managed/Aspire.Managed.csproj
@@ -53,6 +53,8 @@
     <Compile Include="$(SharedDir)BundleDiscovery.cs" Link="Shared\BundleDiscovery.cs" />
     <Compile Include="$(SharedDir)BundleVersionLease.cs" Link="Shared\BundleVersionLease.cs" />
     <Compile Include="$(SharedDir)IntegrationPackageProbeManifest.cs" Link="NuGet\IntegrationPackageProbeManifest.cs" />
+    <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Shared\KnownConfigNames.cs" />
+    <Compile Include="$(SharedDir)ProcessStartTimeHelper.cs" Link="Shared\ProcessStartTimeHelper.cs" />
   </ItemGroup>
 
   <!-- Exclude unwanted files from publish output -->

--- a/src/Aspire.Managed/Aspire.Managed.csproj
+++ b/src/Aspire.Managed/Aspire.Managed.csproj
@@ -55,6 +55,7 @@
     <Compile Include="$(SharedDir)IntegrationPackageProbeManifest.cs" Link="NuGet\IntegrationPackageProbeManifest.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Shared\KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)ProcessStartTimeHelper.cs" Link="Shared\ProcessStartTimeHelper.cs" />
+    <Compile Include="$(SharedDir)ParentProcessLivenessMonitor.cs" Link="Shared\ParentProcessLivenessMonitor.cs" />
   </ItemGroup>
 
   <!-- Exclude unwanted files from publish output -->

--- a/src/Aspire.Managed/NuGet/ParentProcessWatchdog.cs
+++ b/src/Aspire.Managed/NuGet/ParentProcessWatchdog.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Hosting;
+
+namespace Aspire.Managed.NuGet;
+
+/// <summary>
+/// Watches the launching CLI process and tears this <c>aspire-managed</c> helper down if the parent
+/// disappears. Long-running NuGet search/restore operations would otherwise linger as orphaned
+/// processes when the CLI is killed (for example a test runner timeout sending SIGKILL), which is one
+/// of the ways <c>aspire-managed</c> processes accumulate over time.
+/// </summary>
+internal static class ParentProcessWatchdog
+{
+    // If the operation ignores the cancellation token (e.g. a NuGet network call already issued with
+    // CancellationToken.None), force the process to exit after a short grace period so it cannot
+    // outlive its parent. 124 mirrors the conventional "terminated by timeout" exit code.
+    private const int TerminatedExitCode = 124;
+    private static readonly TimeSpan s_forceExitGracePeriod = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Starts monitoring the parent identified by <c>ASPIRE_CLI_PID</c>/<c>ASPIRE_CLI_STARTED</c>.
+    /// When the parent is no longer alive, <paramref name="operationCts"/> is cancelled (and the
+    /// process force-exits as a backstop). Returns a handle that stops the watchdog when disposed, or
+    /// <see langword="null"/> when no parent is configured (the helper was invoked directly).
+    /// </summary>
+    public static IDisposable? Start(CancellationTokenSource operationCts)
+    {
+        if (!int.TryParse(Environment.GetEnvironmentVariable(KnownConfigNames.CliProcessId), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parentPid))
+        {
+            return null;
+        }
+
+        var expectedStartTimeUnix = ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(
+            Environment.GetEnvironmentVariable(KnownConfigNames.CliProcessStarted));
+
+        var stopCts = new CancellationTokenSource();
+        _ = MonitorAsync(parentPid, expectedStartTimeUnix, operationCts, stopCts.Token);
+        return new Stopper(stopCts);
+    }
+
+    private static async Task MonitorAsync(int parentPid, long? expectedStartTimeUnix, CancellationTokenSource operationCts, CancellationToken stopToken)
+    {
+        try
+        {
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+            while (await timer.WaitForNextTickAsync(stopToken).ConfigureAwait(false))
+            {
+                if (ProcessStartTimeHelper.IsProcessRunning(parentPid, expectedStartTimeUnix))
+                {
+                    continue;
+                }
+
+                // Parent is gone: ask the in-flight operation to stop, then hard-exit if it doesn't.
+                if (!operationCts.IsCancellationRequested)
+                {
+                    operationCts.Cancel();
+                }
+
+                await Task.Delay(s_forceExitGracePeriod, stopToken).ConfigureAwait(false);
+                Environment.Exit(TerminatedExitCode);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Stopped normally (operation completed and the watchdog was disposed).
+        }
+    }
+
+    private sealed class Stopper(CancellationTokenSource stopCts) : IDisposable
+    {
+        public void Dispose()
+        {
+            stopCts.Cancel();
+            stopCts.Dispose();
+        }
+    }
+}

--- a/src/Aspire.Managed/NuGet/ParentProcessWatchdog.cs
+++ b/src/Aspire.Managed/NuGet/ParentProcessWatchdog.cs
@@ -26,7 +26,7 @@ internal static class ParentProcessWatchdog
     /// process force-exits as a backstop). Returns a handle that stops the watchdog when disposed, or
     /// <see langword="null"/> when no parent is configured (the helper was invoked directly).
     /// </summary>
-    public static IDisposable? Start(CancellationTokenSource operationCts)
+    public static IAsyncDisposable? Start(CancellationTokenSource operationCts)
     {
         if (!int.TryParse(Environment.GetEnvironmentVariable(KnownConfigNames.CliProcessId), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parentPid))
         {
@@ -36,23 +36,11 @@ internal static class ParentProcessWatchdog
         var expectedStartTimeUnix = ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(
             Environment.GetEnvironmentVariable(KnownConfigNames.CliProcessStarted));
 
-        var stopCts = new CancellationTokenSource();
-        _ = MonitorAsync(parentPid, expectedStartTimeUnix, operationCts, stopCts.Token);
-        return new Stopper(stopCts);
-    }
-
-    private static async Task MonitorAsync(int parentPid, long? expectedStartTimeUnix, CancellationTokenSource operationCts, CancellationToken stopToken)
-    {
-        try
-        {
-            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
-            while (await timer.WaitForNextTickAsync(stopToken).ConfigureAwait(false))
+        return ParentProcessLivenessMonitor.Start(
+            parentPid,
+            expectedStartTimeUnix,
+            async stopToken =>
             {
-                if (ProcessStartTimeHelper.IsProcessRunning(parentPid, expectedStartTimeUnix))
-                {
-                    continue;
-                }
-
                 // Parent is gone: ask the in-flight operation to stop, then hard-exit if it doesn't.
                 if (!operationCts.IsCancellationRequested)
                 {
@@ -61,20 +49,6 @@ internal static class ParentProcessWatchdog
 
                 await Task.Delay(s_forceExitGracePeriod, stopToken).ConfigureAwait(false);
                 Environment.Exit(TerminatedExitCode);
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // Stopped normally (operation completed and the watchdog was disposed).
-        }
-    }
-
-    private sealed class Stopper(CancellationTokenSource stopCts) : IDisposable
-    {
-        public void Dispose()
-        {
-            stopCts.Cancel();
-            stopCts.Dispose();
-        }
+            });
     }
 }

--- a/src/Aspire.Managed/ParentProcessWatchdog.cs
+++ b/src/Aspire.Managed/ParentProcessWatchdog.cs
@@ -35,13 +35,25 @@ internal static class ParentProcessWatchdog
             return null;
         }
 
-        var expectedStartTimeUnix = ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(
-            Environment.GetEnvironmentVariable(KnownConfigNames.CliProcessStarted));
+        var expectedStartTimeUnix = GetExpectedParentStartTimeUnixSeconds(Environment.GetEnvironmentVariable, out var useRuntimeStartTime);
 
         return ParentProcessLivenessMonitor.Start(
             parentPid,
             expectedStartTimeUnix,
-            stopToken => OnParentExitedAsync(operationCts, stopToken, s_forceExitGracePeriod, Environment.Exit));
+            stopToken => OnParentExitedAsync(operationCts, stopToken, s_forceExitGracePeriod, Environment.Exit),
+            useRuntimeStartTime: useRuntimeStartTime);
+    }
+
+    internal static long? GetExpectedParentStartTimeUnixSeconds(Func<string, string?> getEnvironmentVariable, out bool useRuntimeStartTime)
+    {
+        if (ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(getEnvironmentVariable(KnownConfigNames.CliProcessStartedStable)) is { } stableStartTimeUnix)
+        {
+            useRuntimeStartTime = false;
+            return stableStartTimeUnix;
+        }
+
+        useRuntimeStartTime = true;
+        return ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(getEnvironmentVariable(KnownConfigNames.CliProcessStarted));
     }
 
     internal static async Task OnParentExitedAsync(

--- a/src/Aspire.Managed/ParentProcessWatchdog.cs
+++ b/src/Aspire.Managed/ParentProcessWatchdog.cs
@@ -35,7 +35,7 @@ internal static class ParentProcessWatchdog
             return null;
         }
 
-        var expectedStartTimeUnix = GetExpectedParentStartTimeUnixSeconds(Environment.GetEnvironmentVariable, out var useRuntimeStartTime);
+        var expectedStartTimeUnix = GetExpectedParentStartTimeUnix(Environment.GetEnvironmentVariable, out var useRuntimeStartTime);
 
         return ParentProcessLivenessMonitor.Start(
             parentPid,
@@ -44,7 +44,10 @@ internal static class ParentProcessWatchdog
             useRuntimeStartTime: useRuntimeStartTime);
     }
 
-    internal static long? GetExpectedParentStartTimeUnixSeconds(Func<string, string?> getEnvironmentVariable, out bool useRuntimeStartTime)
+    // Returns the stable identity value (ASPIRE_CLI_STARTED_STABLE, Unix milliseconds) when present,
+    // otherwise the legacy value (ASPIRE_CLI_STARTED, whole Unix seconds). The out flag tells the caller
+    // which clock domain the returned value is in.
+    internal static long? GetExpectedParentStartTimeUnix(Func<string, string?> getEnvironmentVariable, out bool useRuntimeStartTime)
     {
         if (ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(getEnvironmentVariable(KnownConfigNames.CliProcessStartedStable)) is { } stableStartTimeUnix)
         {

--- a/src/Aspire.Managed/ParentProcessWatchdog.cs
+++ b/src/Aspire.Managed/ParentProcessWatchdog.cs
@@ -26,7 +26,10 @@ internal static class ParentProcessWatchdog
     /// Starts monitoring the parent identified by <c>ASPIRE_CLI_PID</c>/<c>ASPIRE_CLI_STARTED</c>.
     /// When the parent is no longer alive, <paramref name="operationCts"/> is cancelled (and the
     /// process force-exits as a backstop). Returns a handle that stops the watchdog when disposed, or
-    /// <see langword="null"/> when no parent is configured (the helper was invoked directly).
+    /// <see langword="null"/> when no parent identity is present — either because the helper was invoked
+    /// directly, or because the launching CLI deliberately omitted the identity on Windows, where the
+    /// kernel kill-on-close job already terminates this helper and running the cooperative watchdog too
+    /// would race that kill (see <c>LayoutProcessRunner</c>).
     /// </summary>
     public static IAsyncDisposable? Start(CancellationTokenSource operationCts)
     {

--- a/src/Aspire.Managed/ParentProcessWatchdog.cs
+++ b/src/Aspire.Managed/ParentProcessWatchdog.cs
@@ -44,9 +44,16 @@ internal static class ParentProcessWatchdog
             async stopToken =>
             {
                 // Parent is gone: ask the in-flight operation to stop, then hard-exit if it doesn't.
-                if (!operationCts.IsCancellationRequested)
+                try
                 {
-                    operationCts.Cancel();
+                    if (!operationCts.IsCancellationRequested)
+                    {
+                        operationCts.Cancel();
+                    }
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The operation already completed and disposed its CTS; nothing left to cancel.
                 }
 
                 await Task.Delay(s_forceExitGracePeriod, stopToken).ConfigureAwait(false);

--- a/src/Aspire.Managed/ParentProcessWatchdog.cs
+++ b/src/Aspire.Managed/ParentProcessWatchdog.cs
@@ -41,23 +41,34 @@ internal static class ParentProcessWatchdog
         return ParentProcessLivenessMonitor.Start(
             parentPid,
             expectedStartTimeUnix,
-            async stopToken =>
-            {
-                // Parent is gone: ask the in-flight operation to stop, then hard-exit if it doesn't.
-                try
-                {
-                    if (!operationCts.IsCancellationRequested)
-                    {
-                        operationCts.Cancel();
-                    }
-                }
-                catch (ObjectDisposedException)
-                {
-                    // The operation already completed and disposed its CTS; nothing left to cancel.
-                }
+            stopToken => OnParentExitedAsync(operationCts, stopToken, s_forceExitGracePeriod, Environment.Exit));
+    }
 
-                await Task.Delay(s_forceExitGracePeriod, stopToken).ConfigureAwait(false);
-                Environment.Exit(TerminatedExitCode);
-            });
+    internal static async Task OnParentExitedAsync(
+        CancellationTokenSource operationCts,
+        CancellationToken stopToken,
+        TimeSpan forceExitGracePeriod,
+        Action<int> exit)
+    {
+        // Parent is gone: ask the in-flight operation to stop, then hard-exit if it doesn't.
+        try
+        {
+            if (!operationCts.IsCancellationRequested)
+            {
+                operationCts.Cancel();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // The operation already completed and disposed its CTS; nothing left to cancel.
+        }
+        catch (AggregateException)
+        {
+            // Cancellation callbacks run synchronously from Cancel(). A faulty callback must not skip
+            // the force-exit backstop because that is what prevents aspire-managed from leaking.
+        }
+
+        await Task.Delay(forceExitGracePeriod, stopToken).ConfigureAwait(false);
+        exit(TerminatedExitCode);
     }
 }

--- a/src/Aspire.Managed/ParentProcessWatchdog.cs
+++ b/src/Aspire.Managed/ParentProcessWatchdog.cs
@@ -4,19 +4,21 @@
 using System.Globalization;
 using Aspire.Hosting;
 
-namespace Aspire.Managed.NuGet;
+namespace Aspire.Managed;
 
 /// <summary>
 /// Watches the launching CLI process and tears this <c>aspire-managed</c> helper down if the parent
-/// disappears. Long-running NuGet search/restore operations would otherwise linger as orphaned
-/// processes when the CLI is killed (for example a test runner timeout sending SIGKILL), which is one
-/// of the ways <c>aspire-managed</c> processes accumulate over time.
+/// disappears. Long-running operations — a NuGet search/restore, or the standalone dashboard started
+/// by <c>aspire dashboard run</c> — would otherwise linger as orphaned processes when the CLI is killed
+/// (for example a test runner timeout sending SIGKILL), which is one of the ways <c>aspire-managed</c>
+/// processes accumulate over time.
 /// </summary>
 internal static class ParentProcessWatchdog
 {
     // If the operation ignores the cancellation token (e.g. a NuGet network call already issued with
-    // CancellationToken.None), force the process to exit after a short grace period so it cannot
-    // outlive its parent. 124 mirrors the conventional "terminated by timeout" exit code.
+    // CancellationToken.None, or a dashboard host that is slow to shut down), force the process to exit
+    // after a short grace period so it cannot outlive its parent. 124 mirrors the conventional
+    // "terminated by timeout" exit code.
     private const int TerminatedExitCode = 124;
     private static readonly TimeSpan s_forceExitGracePeriod = TimeSpan.FromSeconds(5);
 

--- a/src/Aspire.Managed/Program.cs
+++ b/src/Aspire.Managed/Program.cs
@@ -22,14 +22,14 @@ using var bundleLease = acquiredBundleLease;
 
 return args switch
 {
-    ["dashboard", .. var rest] => RunDashboard(rest),
+    ["dashboard", .. var rest] => await RunDashboard(rest).ConfigureAwait(false),
     ["server", .. var rest] => await RunServer(rest).ConfigureAwait(false),
     ["nuget", .. var rest] => await RunNuGet(rest).ConfigureAwait(false),
     ["terminalhost", .. var rest] => await RunTerminalHost(rest).ConfigureAwait(false),
     _ => ShowUsage()
 };
 
-static int RunDashboard(string[] args)
+static async Task<int> RunDashboard(string[] args)
 {
     var options = new WebApplicationOptions
     {
@@ -38,7 +38,24 @@ static int RunDashboard(string[] args)
     };
 
     var app = new DashboardWebApplication(options: options);
-    return app.Run();
+
+    // Tear the dashboard down if the launching CLI dies so a hard-killed `aspire dashboard run` (or the
+    // profiling collector, which also launches aspire-managed dashboard) cannot leave an orphaned
+    // dashboard process behind. No-op when ASPIRE_CLI_PID is not set (e.g. the dashboard is launched
+    // directly), so the embedded/in-process dashboard is unaffected.
+    using var shutdownCts = new CancellationTokenSource();
+    var parentWatchdog = Aspire.Managed.ParentProcessWatchdog.Start(shutdownCts);
+    try
+    {
+        return await app.RunAsync(shutdownCts.Token).ConfigureAwait(false);
+    }
+    finally
+    {
+        if (parentWatchdog is not null)
+        {
+            await parentWatchdog.DisposeAsync().ConfigureAwait(false);
+        }
+    }
 }
 
 static async Task<int> RunServer(string[] args)
@@ -52,7 +69,7 @@ static async Task<int> RunNuGet(string[] args)
     // Tear this helper down if the launching CLI dies so a hung/slow NuGet operation cannot linger as
     // an orphaned aspire-managed process. No-op when ASPIRE_CLI_PID is not set (invoked directly).
     using var operationCts = new CancellationTokenSource();
-    var parentWatchdog = Aspire.Managed.NuGet.ParentProcessWatchdog.Start(operationCts);
+    var parentWatchdog = Aspire.Managed.ParentProcessWatchdog.Start(operationCts);
     try
     {
         var rootCommand = new RootCommand("Aspire NuGet Helper - Package operations for Aspire CLI bundle");

--- a/src/Aspire.Managed/Program.cs
+++ b/src/Aspire.Managed/Program.cs
@@ -49,12 +49,17 @@ static async Task<int> RunServer(string[] args)
 
 static async Task<int> RunNuGet(string[] args)
 {
+    // Tear this helper down if the launching CLI dies so a hung/slow NuGet operation cannot linger as
+    // an orphaned aspire-managed process. No-op when ASPIRE_CLI_PID is not set (invoked directly).
+    using var operationCts = new CancellationTokenSource();
+    using var parentWatchdog = Aspire.Managed.NuGet.ParentProcessWatchdog.Start(operationCts);
+
     var rootCommand = new RootCommand("Aspire NuGet Helper - Package operations for Aspire CLI bundle");
     rootCommand.Subcommands.Add(SearchCommand.Create());
     rootCommand.Subcommands.Add(RestoreCommand.Create());
     rootCommand.Subcommands.Add(LayoutCommand.Create());
     rootCommand.Subcommands.Add(ManifestCommand.Create());
-    return await rootCommand.Parse(args).InvokeAsync().ConfigureAwait(false);
+    return await rootCommand.Parse(args).InvokeAsync(cancellationToken: operationCts.Token).ConfigureAwait(false);
 }
 
 static async Task<int> RunTerminalHost(string[] args)

--- a/src/Aspire.Managed/Program.cs
+++ b/src/Aspire.Managed/Program.cs
@@ -52,14 +52,23 @@ static async Task<int> RunNuGet(string[] args)
     // Tear this helper down if the launching CLI dies so a hung/slow NuGet operation cannot linger as
     // an orphaned aspire-managed process. No-op when ASPIRE_CLI_PID is not set (invoked directly).
     using var operationCts = new CancellationTokenSource();
-    using var parentWatchdog = Aspire.Managed.NuGet.ParentProcessWatchdog.Start(operationCts);
-
-    var rootCommand = new RootCommand("Aspire NuGet Helper - Package operations for Aspire CLI bundle");
-    rootCommand.Subcommands.Add(SearchCommand.Create());
-    rootCommand.Subcommands.Add(RestoreCommand.Create());
-    rootCommand.Subcommands.Add(LayoutCommand.Create());
-    rootCommand.Subcommands.Add(ManifestCommand.Create());
-    return await rootCommand.Parse(args).InvokeAsync(cancellationToken: operationCts.Token).ConfigureAwait(false);
+    var parentWatchdog = Aspire.Managed.NuGet.ParentProcessWatchdog.Start(operationCts);
+    try
+    {
+        var rootCommand = new RootCommand("Aspire NuGet Helper - Package operations for Aspire CLI bundle");
+        rootCommand.Subcommands.Add(SearchCommand.Create());
+        rootCommand.Subcommands.Add(RestoreCommand.Create());
+        rootCommand.Subcommands.Add(LayoutCommand.Create());
+        rootCommand.Subcommands.Add(ManifestCommand.Create());
+        return await rootCommand.Parse(args).InvokeAsync(cancellationToken: operationCts.Token).ConfigureAwait(false);
+    }
+    finally
+    {
+        if (parentWatchdog is not null)
+        {
+            await parentWatchdog.DisposeAsync().ConfigureAwait(false);
+        }
+    }
 }
 
 static async Task<int> RunTerminalHost(string[] args)

--- a/src/Aspire.Managed/Program.cs
+++ b/src/Aspire.Managed/Program.cs
@@ -41,8 +41,9 @@ static async Task<int> RunDashboard(string[] args)
 
     // Tear the dashboard down if the launching CLI dies so a hard-killed `aspire dashboard run` (or the
     // profiling collector, which also launches aspire-managed dashboard) cannot leave an orphaned
-    // dashboard process behind. No-op when ASPIRE_CLI_PID is not set (e.g. the dashboard is launched
-    // directly), so the embedded/in-process dashboard is unaffected.
+    // dashboard process behind. No-op when ASPIRE_CLI_PID is not set — either the dashboard is launched
+    // directly (so the embedded/in-process dashboard is unaffected), or on Windows where the CLI relies
+    // on the kernel kill-on-close job instead (see LayoutProcessRunner).
     using var shutdownCts = new CancellationTokenSource();
     var parentWatchdog = Aspire.Managed.ParentProcessWatchdog.Start(shutdownCts);
     try
@@ -66,8 +67,9 @@ static async Task<int> RunServer(string[] args)
 
 static async Task<int> RunNuGet(string[] args)
 {
-    // Tear this helper down if the launching CLI dies so a hung/slow NuGet operation cannot linger as
-    // an orphaned aspire-managed process. No-op when ASPIRE_CLI_PID is not set (invoked directly).
+    // Tear this helper down if the launching CLI dies so a hung/slow NuGet operation cannot linger as an
+    // orphaned aspire-managed process. No-op when ASPIRE_CLI_PID is not set — either invoked directly, or
+    // on Windows where the CLI relies on the kernel kill-on-close job instead (see LayoutProcessRunner).
     using var operationCts = new CancellationTokenSource();
     var parentWatchdog = Aspire.Managed.ParentProcessWatchdog.Start(operationCts);
     try

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -31,14 +31,30 @@ internal static class KnownConfigNames
     public const string WaitForDebuggerTimeout = "ASPIRE_DEBUGGER_TIMEOUT";
     public const string UnixSocketPath = "ASPIRE_BACKCHANNEL_PATH";
     public const string RemoteAppHostToken = "ASPIRE_REMOTE_APPHOST_TOKEN";
+
+    // Identifies the RemoteHost server's parent (the CLI process that launched aspire-managed server).
+    // Paired with RemoteAppHostProcessStarted so the RemoteHost orphan detector can verify PID + start
+    // time and avoid acting on a recycled PID.
+    public const string RemoteAppHostProcessId = "REMOTE_APP_HOST_PID";
+    public const string RemoteAppHostProcessStarted = "REMOTE_APP_HOST_STARTED";
+
     public const string CliProcessId = "ASPIRE_CLI_PID";
     public const string CliProcessStarted = "ASPIRE_CLI_STARTED";
+
+    // Identity (PID + start time) of the foreground CLI that spawned a detached `aspire start` /
+    // `aspire run --detach` child. The detached child watches this during startup and tears the
+    // AppHost tree down if the launcher dies before the app reaches readiness, preventing leaked
+    // aspire-managed processes when the foreground is killed mid-start.
+    public const string CliLauncherProcessId = "ASPIRE_LAUNCHER_PID";
+    public const string CliLauncherProcessStarted = "ASPIRE_LAUNCHER_STARTED";
+
     public const string CliLogFilePath = "ASPIRE_CLI_LOG_FILE";
     public const string CliRunDetached = "ASPIRE_CLI_RUN_DETACHED";
     public const string CliGenerateHttpsCertificate = "ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE";
     public const string SuppressCliRunHook = "ASPIRE_SUPPRESS_CLI_RUN_HOOK";
     public const string IntegrationLibsPath = "ASPIRE_INTEGRATION_LIBS_PATH";
     public const string IntegrationProbeManifestPath = "ASPIRE_INTEGRATION_PROBE_MANIFEST_PATH";
+
     public const string ForceRichConsole = "ASPIRE_FORCE_RICH_CONSOLE";
     public const string AppHostLogLevel = "ASPIRE_APPHOST_LOGLEVEL";
     public const string AspireLogLevel = "ASPIRE_LOGLEVEL";

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -40,6 +40,7 @@ internal static class KnownConfigNames
 
     public const string CliProcessId = "ASPIRE_CLI_PID";
     public const string CliProcessStarted = "ASPIRE_CLI_STARTED";
+    public const string CliProcessStartedStable = "ASPIRE_CLI_STARTED_STABLE";
 
     // Identity (PID + start time) of the foreground CLI that spawned a detached `aspire start` /
     // `aspire run --detach` child. The detached child watches this during startup and tears the

--- a/src/Shared/ParentProcessLivenessMonitor.cs
+++ b/src/Shared/ParentProcessLivenessMonitor.cs
@@ -74,7 +74,7 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
                 stopToken.ThrowIfCancellationRequested();
 
                 var isProcessRunning = useRuntimeStartTime && parentStartedUnixSeconds is { } legacyStartTime
-                    ? ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(parentPid, legacyStartTime, TimeSpan.FromSeconds(1))
+                    ? ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(parentPid, legacyStartTime, ProcessStartTimeHelper.RuntimeStartTimeComparisonTolerance)
                     : ProcessStartTimeHelper.IsProcessRunning(parentPid, parentStartedUnixSeconds);
                 if (isProcessRunning)
                 {

--- a/src/Shared/ParentProcessLivenessMonitor.cs
+++ b/src/Shared/ParentProcessLivenessMonitor.cs
@@ -74,7 +74,7 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
                 stopToken.ThrowIfCancellationRequested();
 
                 var isProcessRunning = useRuntimeStartTime && parentStartedUnixSeconds is { } legacyStartTime
-                    ? ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(parentPid, legacyStartTime, ProcessStartTimeHelper.RuntimeStartTimeComparisonTolerance)
+                    ? ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(parentPid, legacyStartTime, ProcessStartTimeHelper.CrossProcessIdentityTimeTolerance)
                     : ProcessStartTimeHelper.IsProcessRunning(parentPid, parentStartedUnixSeconds);
                 if (isProcessRunning)
                 {

--- a/src/Shared/ParentProcessLivenessMonitor.cs
+++ b/src/Shared/ParentProcessLivenessMonitor.cs
@@ -18,35 +18,39 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
 
     private ParentProcessLivenessMonitor(
         int parentPid,
-        long? parentStartedUnixSeconds,
+        long? parentStartedUnix,
         Func<CancellationToken, Task> onParentExited,
         TimeProvider timeProvider,
         bool useRuntimeStartTime)
     {
-        _monitorTask = MonitorAsync(parentPid, parentStartedUnixSeconds, onParentExited, timeProvider, useRuntimeStartTime, _stopCts.Token);
+        _monitorTask = MonitorAsync(parentPid, parentStartedUnix, onParentExited, timeProvider, useRuntimeStartTime, _stopCts.Token);
     }
 
     /// <summary>
     /// Starts polling the parent identified by <paramref name="parentPid"/> (and, when supplied,
-    /// <paramref name="parentStartedUnixSeconds"/> to guard against PID reuse). The parent is probed once
+    /// <paramref name="parentStartedUnix"/> to guard against PID reuse). The parent is probed once
     /// immediately, then on every poll interval, so a parent that is already gone is detected without
     /// waiting a full tick. When the parent is gone, <paramref name="onParentExited"/> is invoked exactly
     /// once. The token passed to that callback is cancelled when this monitor is disposed, so any grace
     /// delay inside the callback is unwound if the caller disarms first.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="parentStartedUnix"/> is interpreted per <paramref name="useRuntimeStartTime"/>:
+    /// whole Unix seconds for the legacy <c>Process.StartTime</c> domain, or Unix milliseconds for the stable identity time.
+    /// </remarks>
     public static ParentProcessLivenessMonitor Start(
         int parentPid,
-        long? parentStartedUnixSeconds,
+        long? parentStartedUnix,
         Func<CancellationToken, Task> onParentExited,
         TimeProvider? timeProvider = null,
         bool useRuntimeStartTime = false)
     {
-        return new ParentProcessLivenessMonitor(parentPid, parentStartedUnixSeconds, onParentExited, timeProvider ?? TimeProvider.System, useRuntimeStartTime);
+        return new ParentProcessLivenessMonitor(parentPid, parentStartedUnix, onParentExited, timeProvider ?? TimeProvider.System, useRuntimeStartTime);
     }
 
     private static async Task MonitorAsync(
         int parentPid,
-        long? parentStartedUnixSeconds,
+        long? parentStartedUnix,
         Func<CancellationToken, Task> onParentExited,
         TimeProvider timeProvider,
         bool useRuntimeStartTime,
@@ -73,9 +77,9 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
                 // first; ThrowIfCancellationRequested preserves that when we probe before the timer.
                 stopToken.ThrowIfCancellationRequested();
 
-                var isProcessRunning = useRuntimeStartTime && parentStartedUnixSeconds is { } legacyStartTime
+                var isProcessRunning = useRuntimeStartTime && parentStartedUnix is { } legacyStartTime
                     ? ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(parentPid, legacyStartTime, ProcessStartTimeHelper.LegacyStartTimeMatchTolerance)
-                    : ProcessStartTimeHelper.IsProcessRunning(parentPid, parentStartedUnixSeconds);
+                    : ProcessStartTimeHelper.IsProcessRunning(parentPid, parentStartedUnix);
                 if (isProcessRunning)
                 {
                     continue;

--- a/src/Shared/ParentProcessLivenessMonitor.cs
+++ b/src/Shared/ParentProcessLivenessMonitor.cs
@@ -20,9 +20,10 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
         int parentPid,
         long? parentStartedUnixSeconds,
         Func<CancellationToken, Task> onParentExited,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        bool useRuntimeStartTime)
     {
-        _monitorTask = MonitorAsync(parentPid, parentStartedUnixSeconds, onParentExited, timeProvider, _stopCts.Token);
+        _monitorTask = MonitorAsync(parentPid, parentStartedUnixSeconds, onParentExited, timeProvider, useRuntimeStartTime, _stopCts.Token);
     }
 
     /// <summary>
@@ -37,9 +38,10 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
         int parentPid,
         long? parentStartedUnixSeconds,
         Func<CancellationToken, Task> onParentExited,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        bool useRuntimeStartTime = false)
     {
-        return new ParentProcessLivenessMonitor(parentPid, parentStartedUnixSeconds, onParentExited, timeProvider ?? TimeProvider.System);
+        return new ParentProcessLivenessMonitor(parentPid, parentStartedUnixSeconds, onParentExited, timeProvider ?? TimeProvider.System, useRuntimeStartTime);
     }
 
     private static async Task MonitorAsync(
@@ -47,6 +49,7 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
         long? parentStartedUnixSeconds,
         Func<CancellationToken, Task> onParentExited,
         TimeProvider timeProvider,
+        bool useRuntimeStartTime,
         CancellationToken stopToken)
     {
         try
@@ -70,7 +73,10 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
                 // first; ThrowIfCancellationRequested preserves that when we probe before the timer.
                 stopToken.ThrowIfCancellationRequested();
 
-                if (ProcessStartTimeHelper.IsProcessRunning(parentPid, parentStartedUnixSeconds))
+                var isProcessRunning = useRuntimeStartTime && parentStartedUnixSeconds is { } legacyStartTime
+                    ? ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(parentPid, legacyStartTime, TimeSpan.FromSeconds(1))
+                    : ProcessStartTimeHelper.IsProcessRunning(parentPid, parentStartedUnixSeconds);
+                if (isProcessRunning)
                 {
                     continue;
                 }

--- a/src/Shared/ParentProcessLivenessMonitor.cs
+++ b/src/Shared/ParentProcessLivenessMonitor.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/// <summary>
+/// Watches a parent process (by PID plus start time) and invokes a caller-supplied action once when that
+/// parent is no longer running. Shared by the CLI's launcher monitor and the <c>aspire-managed</c> parent
+/// watchdog so both get the same poll loop and teardown semantics.
+/// </summary>
+internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
+{
+    // The poll interval is intentionally coarse: this is a backstop for a parent that died abnormally, so
+    // a one-second granularity is plenty and keeps the wakeups cheap.
+    private static readonly TimeSpan s_pollInterval = TimeSpan.FromSeconds(1);
+
+    private readonly CancellationTokenSource _stopCts = new();
+    private readonly Task _monitorTask;
+    private int _disposed;
+
+    private ParentProcessLivenessMonitor(
+        int parentPid,
+        long? parentStartedUnixSeconds,
+        Func<CancellationToken, Task> onParentExited,
+        TimeProvider timeProvider)
+    {
+        _monitorTask = MonitorAsync(parentPid, parentStartedUnixSeconds, onParentExited, timeProvider, _stopCts.Token);
+    }
+
+    /// <summary>
+    /// Starts polling the parent identified by <paramref name="parentPid"/> (and, when supplied,
+    /// <paramref name="parentStartedUnixSeconds"/> to guard against PID reuse). When the parent is gone,
+    /// <paramref name="onParentExited"/> is invoked exactly once. The token passed to that callback is
+    /// cancelled when this monitor is disposed, so any grace delay inside the callback is unwound if the
+    /// caller disarms first.
+    /// </summary>
+    public static ParentProcessLivenessMonitor Start(
+        int parentPid,
+        long? parentStartedUnixSeconds,
+        Func<CancellationToken, Task> onParentExited,
+        TimeProvider? timeProvider = null)
+    {
+        return new ParentProcessLivenessMonitor(parentPid, parentStartedUnixSeconds, onParentExited, timeProvider ?? TimeProvider.System);
+    }
+
+    private static async Task MonitorAsync(
+        int parentPid,
+        long? parentStartedUnixSeconds,
+        Func<CancellationToken, Task> onParentExited,
+        TimeProvider timeProvider,
+        CancellationToken stopToken)
+    {
+        try
+        {
+            using var timer = new PeriodicTimer(s_pollInterval, timeProvider);
+            while (await timer.WaitForNextTickAsync(stopToken).ConfigureAwait(false))
+            {
+                if (ProcessStartTimeHelper.IsProcessRunning(parentPid, parentStartedUnixSeconds))
+                {
+                    continue;
+                }
+
+                // Pass stopToken through so a callback that waits (e.g. a force-exit grace period) is
+                // cancelled if the caller disposes the monitor while the callback is running.
+                await onParentExited(stopToken).ConfigureAwait(false);
+                return;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Disarmed (stopped/disposed) before the parent exited — the expected, common case.
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Idempotent: callers may dispose on a happy path and again from an outer finally backstop.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        _stopCts.Cancel();
+        try
+        {
+            await _monitorTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when stopping the monitor loop.
+        }
+        finally
+        {
+            _stopCts.Dispose();
+        }
+    }
+}

--- a/src/Shared/ParentProcessLivenessMonitor.cs
+++ b/src/Shared/ParentProcessLivenessMonitor.cs
@@ -27,10 +27,11 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
 
     /// <summary>
     /// Starts polling the parent identified by <paramref name="parentPid"/> (and, when supplied,
-    /// <paramref name="parentStartedUnixSeconds"/> to guard against PID reuse). When the parent is gone,
-    /// <paramref name="onParentExited"/> is invoked exactly once. The token passed to that callback is
-    /// cancelled when this monitor is disposed, so any grace delay inside the callback is unwound if the
-    /// caller disarms first.
+    /// <paramref name="parentStartedUnixSeconds"/> to guard against PID reuse). The parent is probed once
+    /// immediately, then on every poll interval, so a parent that is already gone is detected without
+    /// waiting a full tick. When the parent is gone, <paramref name="onParentExited"/> is invoked exactly
+    /// once. The token passed to that callback is cancelled when this monitor is disposed, so any grace
+    /// delay inside the callback is unwound if the caller disarms first.
     /// </summary>
     public static ParentProcessLivenessMonitor Start(
         int parentPid,
@@ -50,9 +51,25 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
     {
         try
         {
+            // Hop off the caller's thread so Start() stays non-blocking (the original first operation was
+            // an async timer await). The probe below then still runs on the very next scheduler turn
+            // instead of after a full poll interval.
+            await Task.Yield();
+
             using var timer = new PeriodicTimer(s_pollInterval, timeProvider);
-            while (await timer.WaitForNextTickAsync(stopToken).ConfigureAwait(false))
+
+            // Probe once before awaiting the first tick. If the parent already died during our startup
+            // window it is detected immediately instead of after a full poll interval, which closes the
+            // gap where the parent is gone before the watchdog notices. This matches CliOrphanDetector,
+            // whose do/while loop also checks once before it awaits its timer. See
+            // src/Aspire.Hosting/Cli/CliOrphanDetector.cs.
+            do
             {
+                // Honor a disarm that raced with this probe: a disposed monitor must never invoke the
+                // callback. The original loop guaranteed this by awaiting the (already-cancelled) timer
+                // first; ThrowIfCancellationRequested preserves that when we probe before the timer.
+                stopToken.ThrowIfCancellationRequested();
+
                 if (ProcessStartTimeHelper.IsProcessRunning(parentPid, parentStartedUnixSeconds))
                 {
                     continue;
@@ -75,7 +92,7 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
                 }
 
                 return;
-            }
+            } while (await timer.WaitForNextTickAsync(stopToken).ConfigureAwait(false));
         }
         catch (OperationCanceledException)
         {

--- a/src/Shared/ParentProcessLivenessMonitor.cs
+++ b/src/Shared/ParentProcessLivenessMonitor.cs
@@ -74,7 +74,7 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
                 stopToken.ThrowIfCancellationRequested();
 
                 var isProcessRunning = useRuntimeStartTime && parentStartedUnixSeconds is { } legacyStartTime
-                    ? ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(parentPid, legacyStartTime, ProcessStartTimeHelper.CrossProcessIdentityTimeTolerance)
+                    ? ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(parentPid, legacyStartTime, ProcessStartTimeHelper.LegacyStartTimeMatchTolerance)
                     : ProcessStartTimeHelper.IsProcessRunning(parentPid, parentStartedUnixSeconds);
                 if (isProcessRunning)
                 {

--- a/src/Shared/ParentProcessLivenessMonitor.cs
+++ b/src/Shared/ParentProcessLivenessMonitor.cs
@@ -60,7 +60,20 @@ internal sealed class ParentProcessLivenessMonitor : IAsyncDisposable
 
                 // Pass stopToken through so a callback that waits (e.g. a force-exit grace period) is
                 // cancelled if the caller disposes the monitor while the callback is running.
-                await onParentExited(stopToken).ConfigureAwait(false);
+                try
+                {
+                    await onParentExited(stopToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch
+                {
+                    // The callback is only a best-effort cleanup hook after the parent is gone. Don't
+                    // let callback failures fault monitor disposal paths that are already unwinding.
+                }
+
                 return;
             }
         }

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -78,12 +78,6 @@ internal static partial class ProcessSignaler
 
             if (expectedStartTime is not null)
             {
-                // Compare the stable process identity at millisecond precision. Callers on this path supply a
-                // millisecond-domain start time (the AppHost's StableStartedAt, or a locally captured
-                // ProcessStartTimeHelper.TryGetProcessStartTime value), so truncating to whole seconds here would
-                // let a PID recycled later within the same second impersonate the target and defeat the reuse
-                // guard. The legacy Process.StartTime domain keeps its seconds-based, jitter-tolerant comparison
-                // via TryGetRunningProcessWithRuntimeStartTime instead.
                 var actualStartTimeUnixMilliseconds = ProcessStartTimeHelper.TryGetProcessStartTimeUnixMilliseconds(pid);
                 if (actualStartTimeUnixMilliseconds is null)
                 {

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -78,17 +78,24 @@ internal static partial class ProcessSignaler
 
             if (expectedStartTime is not null)
             {
-                var processStartTime = ProcessStartTimeHelper.TryGetProcessStartTime(pid);
-                if (processStartTime is null)
+                // Compare the stable process identity at millisecond precision. Callers on this path supply a
+                // millisecond-domain start time (the AppHost's StableStartedAt, or a locally captured
+                // ProcessStartTimeHelper.TryGetProcessStartTime value), so truncating to whole seconds here would
+                // let a PID recycled later within the same second impersonate the target and defeat the reuse
+                // guard. The legacy Process.StartTime domain keeps its seconds-based, jitter-tolerant comparison
+                // via TryGetRunningProcessWithRuntimeStartTime instead.
+                var actualStartTimeUnixMilliseconds = ProcessStartTimeHelper.TryGetProcessStartTimeUnixMilliseconds(pid);
+                if (actualStartTimeUnixMilliseconds is null)
                 {
                     logger.LogDebug("Could not inspect process {Pid} start time. Treating it as not running.", pid);
                     process.Dispose();
                     return null;
                 }
 
-                if (!AreClose(expectedStartTime, processStartTime.Value))
+                var expectedStartTimeUnixMilliseconds = expectedStartTime.Value.ToUnixTimeMilliseconds();
+                if (!ProcessStartTimeHelper.AreCloseMilliseconds(expectedStartTimeUnixMilliseconds, actualStartTimeUnixMilliseconds.Value))
                 {
-                    logger.LogDebug("Process {Pid} start time {ProcessStartTime} does not match expected start time {ExpectedStartTime}", pid, processStartTime, expectedStartTime);
+                    logger.LogDebug("Process {Pid} start time {ProcessStartTimeMs}ms does not match expected start time {ExpectedStartTimeMs}ms", pid, actualStartTimeUnixMilliseconds, expectedStartTimeUnixMilliseconds);
                     process.Dispose();
                     return null; // Do not return processes that do not match the expected start time
                 }
@@ -176,27 +183,6 @@ internal static partial class ProcessSignaler
             process?.Dispose();
             return null;
         }
-    }
-
-    internal static bool AreClose(DateTimeOffset? expectedStartTime, DateTime processStartTime, TimeSpan? tolerance = default)
-        => AreClose(expectedStartTime, new DateTimeOffset(processStartTime), tolerance);
-
-    internal static bool AreClose(DateTimeOffset? expectedStartTime, DateTimeOffset processStartTime, TimeSpan? tolerance = default)
-    {
-        if (expectedStartTime is null)
-        {
-            return true;
-        }
-
-        // Truncate both sides to whole seconds before comparing. The expected start time
-        // may already be at second granularity (e.g. from the orphan detector via ToUnixTimeSeconds()),
-        // and the OS-reported start time can have sub-second precision that would cause false mismatches.
-        // The truncate-and-compare math lives in the dependency-free ProcessStartTimeHelper so the
-        // RemoteHost and aspire-managed watchdogs (which cannot reference ProcessSignaler) share it.
-        var processStartTruncated = processStartTime.ToUnixTimeSeconds();
-        var expectedSeconds = ((DateTimeOffset)expectedStartTime).ToUnixTimeSeconds();
-
-        return ProcessStartTimeHelper.AreClose(expectedSeconds, processStartTruncated, tolerance);
     }
 
     private const int SigTerm = 15;

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -62,8 +62,15 @@ internal static partial class ProcessSignaler
 
             if (expectedStartTime is not null)
             {
-                var processStartTime = process.StartTime;
-                if (!AreClose(expectedStartTime, processStartTime))
+                var processStartTime = ProcessStartTimeHelper.TryGetProcessStartTime(pid);
+                if (processStartTime is null)
+                {
+                    logger.LogDebug("Could not inspect process {Pid} start time. Treating it as not running.", pid);
+                    process.Dispose();
+                    return null;
+                }
+
+                if (!AreClose(expectedStartTime, processStartTime.Value))
                 {
                     logger.LogDebug("Process {Pid} start time {ProcessStartTime} does not match expected start time {ExpectedStartTime}", pid, processStartTime, expectedStartTime);
                     process.Dispose();
@@ -104,6 +111,9 @@ internal static partial class ProcessSignaler
     }
 
     internal static bool AreClose(DateTimeOffset? expectedStartTime, DateTime processStartTime, TimeSpan? tolerance = default)
+        => AreClose(expectedStartTime, new DateTimeOffset(processStartTime), tolerance);
+
+    internal static bool AreClose(DateTimeOffset? expectedStartTime, DateTimeOffset processStartTime, TimeSpan? tolerance = default)
     {
         if (expectedStartTime is null)
         {
@@ -112,10 +122,10 @@ internal static partial class ProcessSignaler
 
         // Truncate both sides to whole seconds before comparing. The expected start time
         // may already be at second granularity (e.g. from the orphan detector via ToUnixTimeSeconds()),
-        // and the OS-reported start time has sub-second precision that would cause false mismatches.
+        // and the OS-reported start time can have sub-second precision that would cause false mismatches.
         // The truncate-and-compare math lives in the dependency-free ProcessStartTimeHelper so the
         // RemoteHost and aspire-managed watchdogs (which cannot reference ProcessSignaler) share it.
-        var processStartTruncated = new DateTimeOffset(processStartTime).ToUnixTimeSeconds();
+        var processStartTruncated = processStartTime.ToUnixTimeSeconds();
         var expectedSeconds = ((DateTimeOffset)expectedStartTime).ToUnixTimeSeconds();
 
         return ProcessStartTimeHelper.AreClose(expectedSeconds, processStartTruncated, tolerance);

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -19,6 +19,22 @@ internal static partial class ProcessSignaler
             return; // Process is not running or does not match the expected start time
         }
 
+        RequestGracefulShutdown(pid, logger);
+    }
+
+    public static void RequestGracefulShutdownWithRuntimeStartTime(int pid, DateTimeOffset expectedStartTime, TimeSpan tolerance, ILogger logger)
+    {
+        using var process = TryGetRunningProcessWithRuntimeStartTime(pid, expectedStartTime, tolerance, logger);
+        if (process is null)
+        {
+            return; // Process is not running or does not match the expected start time
+        }
+
+        RequestGracefulShutdown(pid, logger);
+    }
+
+    private static void RequestGracefulShutdown(int pid, ILogger logger)
+    {
         logger.LogDebug("Requesting graceful shutdown of process {Pid}...", pid);
 
         if (OperatingSystem.IsWindows())
@@ -82,6 +98,58 @@ internal static partial class ProcessSignaler
                     process.Dispose();
                     return null;
                 }
+            }
+
+            return process;
+        }
+        catch (ArgumentException)
+        {
+            // Process doesn't exist - already terminated.
+            process?.Dispose();
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            // Process has already exited.
+            process?.Dispose();
+            return null;
+        }
+        catch (Win32Exception ex)
+        {
+            // Process inspection can race with process exit. On macOS, StartTime can throw:
+            //   Win32Exception (3): Unable to retrieve the specified information about the process or thread. It may have exited or may be privileged.
+            // If we cannot inspect the process enough to prove it is the expected target, do
+            // not signal or kill it.
+            logger.LogDebug(ex, "Could not inspect process {Pid}. Treating it as not running.", pid);
+            process?.Dispose();
+            return null;
+        }
+    }
+
+    public static Process? TryGetRunningProcessWithRuntimeStartTime(int pid, DateTimeOffset expectedStartTime, TimeSpan tolerance, ILogger logger)
+    {
+        Process? process = null;
+        try
+        {
+            process = Process.GetProcessById(pid);
+            if (process.HasExited)
+            {
+                process.Dispose();
+                return null;
+            }
+
+            var expectedStartTimeUnix = expectedStartTime.ToUnixTimeSeconds();
+            if (!ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(pid, expectedStartTimeUnix, tolerance))
+            {
+                logger.LogDebug("Process {Pid} legacy start time does not match expected start time {ExpectedStartTime}.", pid, expectedStartTime);
+                process.Dispose();
+                return null;
+            }
+
+            if (process.HasExited)
+            {
+                process.Dispose();
+                return null;
             }
 
             return process;

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -113,11 +113,12 @@ internal static partial class ProcessSignaler
         // Truncate both sides to whole seconds before comparing. The expected start time
         // may already be at second granularity (e.g. from the orphan detector via ToUnixTimeSeconds()),
         // and the OS-reported start time has sub-second precision that would cause false mismatches.
+        // The truncate-and-compare math lives in the dependency-free ProcessStartTimeHelper so the
+        // RemoteHost and aspire-managed watchdogs (which cannot reference ProcessSignaler) share it.
         var processStartTruncated = new DateTimeOffset(processStartTime).ToUnixTimeSeconds();
         var expectedSeconds = ((DateTimeOffset)expectedStartTime).ToUnixTimeSeconds();
 
-        tolerance ??= TimeSpan.FromSeconds(1);
-        return Math.Abs(expectedSeconds - processStartTruncated) <= (long)tolerance.Value.TotalSeconds;
+        return ProcessStartTimeHelper.AreClose(expectedSeconds, processStartTruncated, tolerance);
     }
 
     private const int SigTerm = 15;

--- a/src/Shared/ProcessStartTimeHelper.cs
+++ b/src/Shared/ProcessStartTimeHelper.cs
@@ -18,14 +18,9 @@ internal static partial class ProcessStartTimeHelper
     private const int LinuxClockTicksPerSecondConfigName = 2; // _SC_CLK_TCK
 
     /// <summary>
-    /// The tolerance cross-process callers must use when comparing a legacy <see cref="Process.StartTime"/>-based
-    /// start time (see <see cref="IsProcessRunningWithRuntimeStartTime"/>). On Linux that value is reconstructed
-    /// from an independently sampled boot time and can differ by one second between two processes reading the same
-    /// PID, so an exact comparison would produce false "process gone" results and prematurely tear down a live
-    /// process tree. See https://github.com/dotnet/runtime/issues/56546. Centralized here so every orphan/liveness
-    /// watchdog applies the same value; <see cref="TimeSpan"/> cannot be <c>const</c>, so it is <c>static readonly</c>.
+    /// The comparison tolerance cross-process callers must use when comparing process identity time. 
     /// </summary>
-    public static readonly TimeSpan RuntimeStartTimeComparisonTolerance = TimeSpan.FromSeconds(1);
+    public static readonly TimeSpan CrossProcessIdentityTimeTolerance = TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// Gets the current process's start time as whole Unix seconds. This is the value that should be
@@ -180,14 +175,14 @@ internal static partial class ProcessStartTimeHelper
     /// Determines whether a process matches a legacy start time that was produced from
     /// <see cref="Process.StartTime"/>. Cross-process callers should pass a one-second
     /// <paramref name="tolerance"/> because on Linux <see cref="Process.StartTime"/> is reconstructed from
-    /// an independently sampled boot time and can differ by ±1s between processes reading the same PID
-    /// (see https://github.com/dotnet/runtime/issues/56546).
+    /// an independently sampled boot time and can differ by CrossProcessIdentityTimeTolerance 
+    /// between processes reading the same PID.
     /// </summary>
     /// <param name="pid">The process ID to check.</param>
     /// <param name="expectedStartTimeUnixSeconds">The expected legacy start time (whole Unix seconds).</param>
     /// <param name="tolerance">
     /// Allowed difference between the expected and observed start time. Defaults to an exact match; the
-    /// cross-process orphan/liveness callers pass <see cref="RuntimeStartTimeComparisonTolerance"/> to absorb
+    /// cross-process orphan/liveness callers pass <see cref="CrossProcessIdentityTimeTolerance"/> to absorb
     /// the boot-time jitter described above.
     /// </param>
     /// <returns><see langword="true"/> if the process exists and its legacy start time matches; otherwise <see langword="false"/>.</returns>

--- a/src/Shared/ProcessStartTimeHelper.cs
+++ b/src/Shared/ProcessStartTimeHelper.cs
@@ -77,10 +77,15 @@ internal static partial class ProcessStartTimeHelper
     /// Gets the start time of the process with the given <paramref name="pid"/>.
     /// </summary>
     /// <remarks>
-    /// On Linux this deliberately uses <c>/proc</c> start ticks plus <c>btime</c> instead of
-    /// <see cref="Process.StartTime"/>. The runtime computes <see cref="Process.StartTime"/> from an
-    /// independently sampled boot time, so two processes can observe adjacent Unix seconds for the same
-    /// PID near a second boundary.
+    /// On Linux this deliberately uses boot-relative <c>/proc</c> start ticks (matching
+    /// <c>DcpProcessMonitor.GetLinuxProcessIdentityTimestamp</c>) instead of <see cref="Process.StartTime"/>
+    /// or any wall-clock time. The returned value is an opaque <em>seconds-since-boot</em> identity token,
+    /// not a real calendar time: field 22 of <c>/proc/&lt;pid&gt;/stat</c> is fixed at process start relative
+    /// to boot, so every process on the machine computes the same value for a given PID even after the wall
+    /// clock is stepped (NTP correction, container host clock sync). Using <see cref="Process.StartTime"/>
+    /// (which the runtime derives from an independently sampled boot time) or adding <c>/proc/stat</c>
+    /// <c>btime</c> (which itself shifts with wall-clock adjustments) would re-introduce that drift and let a
+    /// parent and child disagree about the same PID's start time, defeating the PID-reuse guard.
     /// </remarks>
     /// <returns>The start time, or <see langword="null"/> when the process cannot be inspected (already exited, privileged, etc.).</returns>
     public static DateTimeOffset? TryGetProcessStartTime(int pid)
@@ -237,7 +242,38 @@ internal static partial class ProcessStartTimeHelper
         // These identities are always stamped with PIDs from the current process namespace.
         // Do not honor HOST_PROC here: that is only for DCP host-process inspection, and
         // mixing local PIDs with host /proc data can make orphan detection act on the wrong process.
-        var procRoot = LinuxProcRoot;
+        if (TryGetLinuxProcessStartTicks(pid, LinuxProcRoot) is not { } startTicks)
+        {
+            return null;
+        }
+
+        // Boot-relative seconds only. startTicks is field 22 of /proc/<pid>/stat, fixed at process start
+        // relative to boot, so this is identical for every reader regardless of any later wall-clock step.
+        // We intentionally do NOT add /proc/stat btime: btime re-expresses this as wall-clock time and
+        // itself shifts on clock sync, which would re-introduce the drift this guards against. The result
+        // is an opaque same-machine identity token (seconds since boot), not a real calendar time. This
+        // mirrors DcpProcessMonitor.GetLinuxProcessIdentityTimestamp so every Aspire watchdog computes the
+        // same value for a given PID.
+        var startTimeSecondsSinceBoot = (long)(startTicks / (ulong)GetLinuxClockTicksPerSecond());
+        return DateTimeOffset.FromUnixTimeSeconds(startTimeSecondsSinceBoot);
+    }
+
+    /// <summary>
+    /// Reads the raw start time of the process with the given <paramref name="pid"/> as clock ticks since
+    /// boot (field 22 of <c>/proc/&lt;pid&gt;/stat</c>). This is the drift-immune building block for Linux
+    /// process identity: the value is fixed at process start relative to boot, so every reader on the
+    /// machine observes the same number even after a wall-clock adjustment. Divide by
+    /// <see cref="GetLinuxClockTicksPerSecond"/> to obtain seconds since boot.
+    /// </summary>
+    /// <param name="pid">The process to inspect.</param>
+    /// <param name="procRoot">
+    /// The <c>/proc</c> filesystem root to read from. Orphan/liveness detection must pass
+    /// <see cref="LinuxProcRoot"/> (the current namespace's <c>/proc</c>); only DCP host-process inspection
+    /// passes <c>HOST_PROC</c>.
+    /// </param>
+    /// <returns>The start ticks, or <see langword="null"/> when the stat file cannot be read or parsed.</returns>
+    internal static ulong? TryGetLinuxProcessStartTicks(int pid, string procRoot)
+    {
         var statPath = Path.Combine(procRoot, pid.ToString(CultureInfo.InvariantCulture), "stat");
 
         string contents;
@@ -250,14 +286,7 @@ internal static partial class ProcessStartTimeHelper
             return null;
         }
 
-        if (TryParseLinuxStatStartTicks(contents) is not { } startTicks ||
-            TryGetLinuxBootTimeUnixSeconds(procRoot) is not { } bootTimeUnixSeconds)
-        {
-            return null;
-        }
-
-        var startTimeUnixSeconds = bootTimeUnixSeconds + (long)(startTicks / (ulong)GetLinuxClockTicksPerSecond());
-        return DateTimeOffset.FromUnixTimeSeconds(startTimeUnixSeconds);
+        return TryParseLinuxStatStartTicks(contents);
     }
 
     internal static ulong? TryParseLinuxStatStartTicks(string contents)
@@ -278,31 +307,12 @@ internal static partial class ProcessStartTimeHelper
             : null;
     }
 
-    private static long? TryGetLinuxBootTimeUnixSeconds(string procRoot)
-    {
-        var statPath = Path.Combine(procRoot, "stat");
-        try
-        {
-            foreach (var line in File.ReadLines(statPath))
-            {
-                // /proc/stat contains a boot-time line shaped as:
-                //   btime 1719876543
-                if (line.StartsWith("btime ", StringComparison.Ordinal) &&
-                    long.TryParse(line["btime ".Length..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var bootTimeUnixSeconds))
-                {
-                    return bootTimeUnixSeconds;
-                }
-            }
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            return null;
-        }
-
-        return null;
-    }
-
-    private static int GetLinuxClockTicksPerSecond()
+    /// <summary>
+    /// Gets the Linux clock resolution (<c>_SC_CLK_TCK</c>) used to convert <c>/proc</c> start ticks to
+    /// seconds. Shared so every Linux process-identity computation (including <c>DcpProcessMonitor</c>) uses
+    /// the same value.
+    /// </summary>
+    internal static int GetLinuxClockTicksPerSecond()
     {
         var result = sysconf(LinuxClockTicksPerSecondConfigName);
         return result > 0 ? (int)result : DefaultLinuxClockTicksPerSecond;

--- a/src/Shared/ProcessStartTimeHelper.cs
+++ b/src/Shared/ProcessStartTimeHelper.cs
@@ -168,8 +168,18 @@ internal static partial class ProcessStartTimeHelper
 
     /// <summary>
     /// Determines whether a process matches a legacy start time that was produced from
-    /// <see cref="Process.StartTime"/>.
+    /// <see cref="Process.StartTime"/>. Cross-process callers should pass a one-second
+    /// <paramref name="tolerance"/> because on Linux <see cref="Process.StartTime"/> is reconstructed from
+    /// an independently sampled boot time and can differ by ±1s between processes reading the same PID
+    /// (see https://github.com/dotnet/runtime/issues/56546).
     /// </summary>
+    /// <param name="pid">The process ID to check.</param>
+    /// <param name="expectedStartTimeUnixSeconds">The expected legacy start time (whole Unix seconds).</param>
+    /// <param name="tolerance">
+    /// Allowed difference between the expected and observed start time. Defaults to an exact match; the
+    /// cross-process orphan/liveness callers pass one second to absorb the boot-time jitter described above.
+    /// </param>
+    /// <returns><see langword="true"/> if the process exists and its legacy start time matches; otherwise <see langword="false"/>.</returns>
     public static bool IsProcessRunningWithRuntimeStartTime(int pid, long expectedStartTimeUnixSeconds, TimeSpan? tolerance = null)
     {
         try
@@ -216,9 +226,7 @@ internal static partial class ProcessStartTimeHelper
     /// <param name="actualStartTimeUnixSeconds">The observed start time, in whole Unix seconds.</param>
     /// <param name="tolerance">
     /// Optional allowed difference between the two values. Defaults to an exact match. Callers should only
-    /// opt into a non-zero tolerance when they must absorb cross-process jitter in the OS-reported start
-    /// time. The normal process-liveness paths should not need this because Linux start times are read
-    /// from <c>/proc</c> so both sides use the same clock domain.
+    /// opt into a non-zero tolerance when they must absorb cross-process jitter in the OS-reported start time. 
     /// </param>
     public static bool AreClose(long expectedStartTimeUnixSeconds, long actualStartTimeUnixSeconds, TimeSpan? tolerance = null)
     {

--- a/src/Shared/ProcessStartTimeHelper.cs
+++ b/src/Shared/ProcessStartTimeHelper.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+
+/// <summary>
+/// Dependency-free helpers for identifying a process by PID plus its start time, used by the
+/// various orphan/parent-liveness watchdogs that must survive PID reuse.
+/// </summary>
+/// <remarks>
+/// Lives in the global namespace (like <c>ProcessSignaler</c>) and takes no logging or
+/// P/Invoke dependency so it can be linked into assemblies that cannot reference the richer
+/// <c>ProcessSignaler</c> (for example <c>Aspire.Hosting.RemoteHost</c> and the
+/// <c>aspire-managed</c> host). It is the single source of truth for the "±tolerance start-time
+/// match" comparison; <c>ProcessSignaler.AreClose</c> delegates here.
+/// </remarks>
+internal static class ProcessStartTimeHelper
+{
+    // Process start times reported by the OS have sub-second precision, while the values we
+    // round-trip through environment variables / sockets are second-granularity Unix timestamps.
+    // Compare with a one-second tolerance so a truncated expected value still matches.
+    private static readonly TimeSpan s_defaultTolerance = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Gets the current process's start time as whole Unix seconds. This is the value that should be
+    /// propagated to child processes so they can verify the parent's identity (PID + start time).
+    /// </summary>
+    public static long GetCurrentProcessStartTimeUnixSeconds()
+    {
+        using var process = Process.GetCurrentProcess();
+        return ((DateTimeOffset)process.StartTime).ToUnixTimeSeconds();
+    }
+
+    /// <summary>
+    /// Gets the start time, as whole Unix seconds, of the process with the given <paramref name="pid"/>.
+    /// </summary>
+    /// <returns>The start time, or <see langword="null"/> when the process cannot be inspected (already exited, privileged, etc.).</returns>
+    public static long? TryGetProcessStartTimeUnixSeconds(int pid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            return ((DateTimeOffset)process.StartTime).ToUnixTimeSeconds();
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException or Win32Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses a Unix-seconds start time previously produced by
+    /// <see cref="GetCurrentProcessStartTimeUnixSeconds"/> (for example from an environment variable).
+    /// </summary>
+    /// <returns>The parsed value, or <see langword="null"/> when <paramref name="value"/> is missing or invalid.</returns>
+    public static long? TryParseStartTimeUnixSeconds(string? value)
+        => long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
+
+    /// <summary>
+    /// Determines whether a process with the given <paramref name="pid"/> is currently running and,
+    /// when <paramref name="expectedStartTimeUnixSeconds"/> is supplied, whether its start time matches
+    /// (guarding against PID reuse). When the expected start time is <see langword="null"/> this falls
+    /// back to a PID-only existence check.
+    /// </summary>
+    /// <param name="pid">The process ID to check.</param>
+    /// <param name="expectedStartTimeUnixSeconds">The expected start time (whole Unix seconds), or <see langword="null"/> for PID-only.</param>
+    /// <param name="tolerance">Allowed difference between the expected and observed start time. Defaults to one second.</param>
+    /// <returns><see langword="true"/> if the process exists and matches; otherwise <see langword="false"/>.</returns>
+    public static bool IsProcessRunning(int pid, long? expectedStartTimeUnixSeconds = null, TimeSpan? tolerance = null)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            if (process.HasExited)
+            {
+                return false;
+            }
+
+            if (expectedStartTimeUnixSeconds is { } expected)
+            {
+                // Reading StartTime can race with process exit. On macOS it can throw:
+                //   Win32Exception (3): Unable to retrieve the specified information about the process or thread.
+                // If we cannot prove this is the expected target, treat it as not running so callers
+                // never act on a recycled PID.
+                var actual = new DateTimeOffset(process.StartTime).ToUnixTimeSeconds();
+                if (!AreClose(expected, actual, tolerance))
+                {
+                    return false;
+                }
+
+                if (process.HasExited)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            // Process doesn't exist - already terminated.
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            // Process has already exited.
+            return false;
+        }
+        catch (Win32Exception)
+        {
+            // Could not inspect the process (e.g. it exited mid-check, or is privileged). Without
+            // proof of identity, do not report it as the expected running process.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Returns whether two start times, expressed as whole Unix seconds, are within
+    /// <paramref name="tolerance"/> (default one second) of each other.
+    /// </summary>
+    public static bool AreClose(long expectedStartTimeUnixSeconds, long actualStartTimeUnixSeconds, TimeSpan? tolerance = null)
+    {
+        tolerance ??= s_defaultTolerance;
+        return Math.Abs(expectedStartTimeUnixSeconds - actualStartTimeUnixSeconds) <= (long)tolerance.Value.TotalSeconds;
+    }
+}

--- a/src/Shared/ProcessStartTimeHelper.cs
+++ b/src/Shared/ProcessStartTimeHelper.cs
@@ -11,11 +11,6 @@ using System.Globalization;
 /// </summary>
 internal static class ProcessStartTimeHelper
 {
-    // Process start times reported by the OS have sub-second precision, while the values we
-    // round-trip through environment variables / sockets are second-granularity Unix timestamps.
-    // Compare with a one-second tolerance so a truncated expected value still matches.
-    private static readonly TimeSpan s_defaultTolerance = TimeSpan.FromSeconds(1);
-
     /// <summary>
     /// Gets the current process's start time as whole Unix seconds. This is the value that should be
     /// propagated to child processes so they can verify the parent's identity (PID + start time).
@@ -59,7 +54,7 @@ internal static class ProcessStartTimeHelper
     /// </summary>
     /// <param name="pid">The process ID to check.</param>
     /// <param name="expectedStartTimeUnixSeconds">The expected start time (whole Unix seconds), or <see langword="null"/> for PID-only.</param>
-    /// <param name="tolerance">Allowed difference between the expected and observed start time. Defaults to one second.</param>
+    /// <param name="tolerance">Allowed difference between the expected and observed start time. Defaults to an exact match.</param>
     /// <returns><see langword="true"/> if the process exists and matches; otherwise <see langword="false"/>.</returns>
     public static bool IsProcessRunning(int pid, long? expectedStartTimeUnixSeconds = null, TimeSpan? tolerance = null)
     {
@@ -110,12 +105,23 @@ internal static class ProcessStartTimeHelper
     }
 
     /// <summary>
-    /// Returns whether two start times, expressed as whole Unix seconds, are within
-    /// <paramref name="tolerance"/> (default one second) of each other.
+    /// Returns whether two start times, expressed as whole Unix seconds, identify the same process.
+    /// The comparison is exact by default: both values are already truncated to whole seconds, so
+    /// accepting an adjacent second would let a PID recycled into the neighboring second impersonate the
+    /// original process and defeat the reuse guard.
     /// </summary>
+    /// <param name="expectedStartTimeUnixSeconds">The expected start time, in whole Unix seconds.</param>
+    /// <param name="actualStartTimeUnixSeconds">The observed start time, in whole Unix seconds.</param>
+    /// <param name="tolerance">
+    /// Optional allowed difference between the two values. Defaults to an exact match. Callers should only
+    /// opt into a non-zero tolerance when they must absorb cross-process jitter in the OS-reported start
+    /// time. For example, on Linux <see cref="Process.StartTime"/> is derived from an independently sampled
+    /// boot time (a coarse clock), so reading the same process from two different processes can truncate to
+    /// adjacent seconds near a second boundary. No caller needs this today.
+    /// </param>
     public static bool AreClose(long expectedStartTimeUnixSeconds, long actualStartTimeUnixSeconds, TimeSpan? tolerance = null)
     {
-        tolerance ??= s_defaultTolerance;
-        return Math.Abs(expectedStartTimeUnixSeconds - actualStartTimeUnixSeconds) <= (long)tolerance.Value.TotalSeconds;
+        var toleranceSeconds = tolerance is { } value ? (long)value.TotalSeconds : 0;
+        return Math.Abs(expectedStartTimeUnixSeconds - actualStartTimeUnixSeconds) <= toleranceSeconds;
     }
 }

--- a/src/Shared/ProcessStartTimeHelper.cs
+++ b/src/Shared/ProcessStartTimeHelper.cs
@@ -18,13 +18,13 @@ internal static partial class ProcessStartTimeHelper
     private const int LinuxClockTicksPerSecondConfigName = 2; // _SC_CLK_TCK
 
     /// <summary>
-    /// The comparison tolerance cross-process callers must use when comparing process identity time. 
+    /// The tolerance legacy callers must apply when comparing process start times (idetity times).
     /// </summary>
-    public static readonly TimeSpan CrossProcessIdentityTimeTolerance = TimeSpan.FromSeconds(1);
+    public static readonly TimeSpan LegacyStartTimeMatchTolerance = TimeSpan.FromSeconds(1);
 
     /// <summary>
-    /// Gets the current process's start time as whole Unix seconds. This is the value that should be
-    /// propagated to child processes so they can verify the parent's identity (PID + start time).
+    /// Gets the current process's start time (identity time) as whole Unix seconds-since-boot. 
+    /// This is the value that should be propagated to child processes so they can verify the parent's identity (PID + start time).
     /// </summary>
     public static long GetCurrentProcessStartTimeUnixSeconds()
         => GetCurrentProcessStartTime().ToUnixTimeSeconds();
@@ -175,14 +175,14 @@ internal static partial class ProcessStartTimeHelper
     /// Determines whether a process matches a legacy start time that was produced from
     /// <see cref="Process.StartTime"/>. Cross-process callers should pass a one-second
     /// <paramref name="tolerance"/> because on Linux <see cref="Process.StartTime"/> is reconstructed from
-    /// an independently sampled boot time and can differ by CrossProcessIdentityTimeTolerance 
+    /// an independently sampled boot time and can differ by <see cref="LegacyStartTimeMatchTolerance"/>
     /// between processes reading the same PID.
     /// </summary>
     /// <param name="pid">The process ID to check.</param>
     /// <param name="expectedStartTimeUnixSeconds">The expected legacy start time (whole Unix seconds).</param>
     /// <param name="tolerance">
     /// Allowed difference between the expected and observed start time. Defaults to an exact match; the
-    /// cross-process orphan/liveness callers pass <see cref="CrossProcessIdentityTimeTolerance"/> to absorb
+    /// cross-process orphan/liveness callers pass <see cref="LegacyStartTimeMatchTolerance"/> to absorb
     /// the boot-time jitter described above.
     /// </param>
     /// <returns><see langword="true"/> if the process exists and its legacy start time matches; otherwise <see langword="false"/>.</returns>

--- a/src/Shared/ProcessStartTimeHelper.cs
+++ b/src/Shared/ProcessStartTimeHelper.cs
@@ -4,21 +4,39 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.InteropServices;
 
 /// <summary>
 /// Dependency-free helpers for identifying a process by PID plus its start time, used by the
 /// various orphan/parent-liveness watchdogs that must survive PID reuse.
 /// </summary>
-internal static class ProcessStartTimeHelper
+internal static partial class ProcessStartTimeHelper
 {
+    internal const string LinuxProcRoot = "/proc";
+
+    private const int DefaultLinuxClockTicksPerSecond = 100;
+    private const int LinuxClockTicksPerSecondConfigName = 2; // _SC_CLK_TCK
+
     /// <summary>
     /// Gets the current process's start time as whole Unix seconds. This is the value that should be
     /// propagated to child processes so they can verify the parent's identity (PID + start time).
     /// </summary>
     public static long GetCurrentProcessStartTimeUnixSeconds()
+        => GetCurrentProcessStartTime().ToUnixTimeSeconds();
+
+    /// <summary>
+    /// Gets the current process's start time using the same platform-specific source as
+    /// <see cref="TryGetProcessStartTime"/>.
+    /// </summary>
+    public static DateTimeOffset GetCurrentProcessStartTime()
     {
+        if (TryGetProcessStartTime(Environment.ProcessId) is { } startTime)
+        {
+            return startTime;
+        }
+
         using var process = Process.GetCurrentProcess();
-        return ((DateTimeOffset)process.StartTime).ToUnixTimeSeconds();
+        return new DateTimeOffset(process.StartTime);
     }
 
     /// <summary>
@@ -26,11 +44,29 @@ internal static class ProcessStartTimeHelper
     /// </summary>
     /// <returns>The start time, or <see langword="null"/> when the process cannot be inspected (already exited, privileged, etc.).</returns>
     public static long? TryGetProcessStartTimeUnixSeconds(int pid)
+        => TryGetProcessStartTime(pid)?.ToUnixTimeSeconds();
+
+    /// <summary>
+    /// Gets the start time of the process with the given <paramref name="pid"/>.
+    /// </summary>
+    /// <remarks>
+    /// On Linux this deliberately uses <c>/proc</c> start ticks plus <c>btime</c> instead of
+    /// <see cref="Process.StartTime"/>. The runtime computes <see cref="Process.StartTime"/> from an
+    /// independently sampled boot time, so two processes can observe adjacent Unix seconds for the same
+    /// PID near a second boundary.
+    /// </remarks>
+    /// <returns>The start time, or <see langword="null"/> when the process cannot be inspected (already exited, privileged, etc.).</returns>
+    public static DateTimeOffset? TryGetProcessStartTime(int pid)
     {
+        if (OperatingSystem.IsLinux())
+        {
+            return TryGetLinuxProcessStartTime(pid);
+        }
+
         try
         {
             using var process = Process.GetProcessById(pid);
-            return ((DateTimeOffset)process.StartTime).ToUnixTimeSeconds();
+            return new DateTimeOffset(process.StartTime);
         }
         catch (Exception ex) when (ex is ArgumentException or InvalidOperationException or Win32Exception)
         {
@@ -68,12 +104,17 @@ internal static class ProcessStartTimeHelper
 
             if (expectedStartTimeUnixSeconds is { } expected)
             {
-                // Reading StartTime can race with process exit. On macOS it can throw:
+                // Reading the process start time can race with process exit. On macOS it can throw:
                 //   Win32Exception (3): Unable to retrieve the specified information about the process or thread.
                 // If we cannot prove this is the expected target, treat it as not running so callers
                 // never act on a recycled PID.
-                var actual = new DateTimeOffset(process.StartTime).ToUnixTimeSeconds();
-                if (!AreClose(expected, actual, tolerance))
+                var actual = TryGetProcessStartTimeUnixSeconds(pid);
+                if (actual is null)
+                {
+                    return false;
+                }
+
+                if (!AreClose(expected, actual.Value, tolerance))
                 {
                     return false;
                 }
@@ -115,13 +156,91 @@ internal static class ProcessStartTimeHelper
     /// <param name="tolerance">
     /// Optional allowed difference between the two values. Defaults to an exact match. Callers should only
     /// opt into a non-zero tolerance when they must absorb cross-process jitter in the OS-reported start
-    /// time. For example, on Linux <see cref="Process.StartTime"/> is derived from an independently sampled
-    /// boot time (a coarse clock), so reading the same process from two different processes can truncate to
-    /// adjacent seconds near a second boundary. No caller needs this today.
+    /// time. The normal process-liveness paths should not need this because Linux start times are read
+    /// from <c>/proc</c> so both sides use the same clock domain.
     /// </param>
     public static bool AreClose(long expectedStartTimeUnixSeconds, long actualStartTimeUnixSeconds, TimeSpan? tolerance = null)
     {
         var toleranceSeconds = tolerance is { } value ? (long)value.TotalSeconds : 0;
         return Math.Abs(expectedStartTimeUnixSeconds - actualStartTimeUnixSeconds) <= toleranceSeconds;
     }
+
+    private static DateTimeOffset? TryGetLinuxProcessStartTime(int pid)
+    {
+        // These identities are always stamped with PIDs from the current process namespace.
+        // Do not honor HOST_PROC here: that is only for DCP host-process inspection, and
+        // mixing local PIDs with host /proc data can make orphan detection act on the wrong process.
+        var procRoot = LinuxProcRoot;
+        var statPath = Path.Combine(procRoot, pid.ToString(CultureInfo.InvariantCulture), "stat");
+
+        string contents;
+        try
+        {
+            contents = File.ReadAllText(statPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+
+        if (TryParseLinuxStatStartTicks(contents) is not { } startTicks ||
+            TryGetLinuxBootTimeUnixSeconds(procRoot) is not { } bootTimeUnixSeconds)
+        {
+            return null;
+        }
+
+        var startTimeUnixSeconds = bootTimeUnixSeconds + (long)(startTicks / (ulong)GetLinuxClockTicksPerSecond());
+        return DateTimeOffset.FromUnixTimeSeconds(startTimeUnixSeconds);
+    }
+
+    internal static ulong? TryParseLinuxStatStartTicks(string contents)
+    {
+        // /proc/<pid>/stat fields start as:
+        //   12345 (process name may contain spaces or parentheses) S 1 2 3 ...
+        // The process start time is field 22, in clock ticks since boot. Split after the final
+        // ')' so process names containing spaces or parentheses do not shift the field indexes.
+        var closeParenIndex = contents.LastIndexOf(')');
+        if (closeParenIndex < 0 || closeParenIndex + 2 >= contents.Length)
+        {
+            return null;
+        }
+
+        var fields = contents[(closeParenIndex + 2)..].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return fields.Length >= 20 && ulong.TryParse(fields[19], NumberStyles.None, CultureInfo.InvariantCulture, out var startTicks)
+            ? startTicks
+            : null;
+    }
+
+    private static long? TryGetLinuxBootTimeUnixSeconds(string procRoot)
+    {
+        var statPath = Path.Combine(procRoot, "stat");
+        try
+        {
+            foreach (var line in File.ReadLines(statPath))
+            {
+                // /proc/stat contains a boot-time line shaped as:
+                //   btime 1719876543
+                if (line.StartsWith("btime ", StringComparison.Ordinal) &&
+                    long.TryParse(line["btime ".Length..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var bootTimeUnixSeconds))
+                {
+                    return bootTimeUnixSeconds;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+
+    private static int GetLinuxClockTicksPerSecond()
+    {
+        var result = sysconf(LinuxClockTicksPerSecondConfigName);
+        return result > 0 ? (int)result : DefaultLinuxClockTicksPerSecond;
+    }
+
+    [LibraryImport("libc", SetLastError = true, EntryPoint = "sysconf")]
+    private static partial long sysconf(int name);
 }

--- a/src/Shared/ProcessStartTimeHelper.cs
+++ b/src/Shared/ProcessStartTimeHelper.cs
@@ -9,13 +9,6 @@ using System.Globalization;
 /// Dependency-free helpers for identifying a process by PID plus its start time, used by the
 /// various orphan/parent-liveness watchdogs that must survive PID reuse.
 /// </summary>
-/// <remarks>
-/// Lives in the global namespace (like <c>ProcessSignaler</c>) and takes no logging or
-/// P/Invoke dependency so it can be linked into assemblies that cannot reference the richer
-/// <c>ProcessSignaler</c> (for example <c>Aspire.Hosting.RemoteHost</c> and the
-/// <c>aspire-managed</c> host). It is the single source of truth for the "±tolerance start-time
-/// match" comparison; <c>ProcessSignaler.AreClose</c> delegates here.
-/// </remarks>
 internal static class ProcessStartTimeHelper
 {
     // Process start times reported by the OS have sub-second precision, while the values we

--- a/src/Shared/ProcessStartTimeHelper.cs
+++ b/src/Shared/ProcessStartTimeHelper.cs
@@ -18,16 +18,31 @@ internal static partial class ProcessStartTimeHelper
     private const int LinuxClockTicksPerSecondConfigName = 2; // _SC_CLK_TCK
 
     /// <summary>
-    /// The tolerance legacy callers must apply when comparing process start times (idetity times).
+    /// The tolerance legacy callers apply when comparing a <see cref="Process.StartTime"/>-derived
+    /// start time across processes. It absorbs the boot-time jitter that makes the same PID's runtime
+    /// start time differ between readers on Linux. The stable millisecond identity is far tighter — see
+    /// <see cref="StableStartTimeMatchTolerance"/>.
     /// </summary>
     public static readonly TimeSpan LegacyStartTimeMatchTolerance = TimeSpan.FromSeconds(1);
 
     /// <summary>
-    /// Gets the current process's start time (identity time) as whole Unix seconds-since-boot. 
-    /// This is the value that should be propagated to child processes so they can verify the parent's identity (PID + start time).
+    /// The tolerance callers apply when comparing the stable (millisecond) process-identity start time.
     /// </summary>
-    public static long GetCurrentProcessStartTimeUnixSeconds()
-        => GetCurrentProcessStartTime().ToUnixTimeSeconds();
+    // The stable identity is only as precise as its coarsest source. On Linux the /proc start time is
+    // expressed in clock ticks whose resolution is sysconf(_SC_CLK_TCK) — effectively 100 Hz / 10 ms
+    // (USER_HZ) on every mainstream distro. 20 ms is two of those ticks: it absorbs a one-tick rounding
+    // difference on each side of a tick boundary while still shrinking the PID-reuse window ~50x versus
+    // the previous whole-second identity. Windows (100 ns FILETIME) and macOS (1 us) are far finer, 
+    // so 20 ms is comfortably within their resolution too.
+    public static readonly TimeSpan StableStartTimeMatchTolerance = TimeSpan.FromMilliseconds(20);
+
+    /// <summary>
+    /// Gets the current process's stable identity start time as Unix milliseconds. This is the value
+    /// that should be propagated to child processes so they can verify the parent's identity
+    /// (PID + start time) at millisecond granularity.
+    /// </summary>
+    public static long GetCurrentProcessStartTimeUnixMilliseconds()
+        => GetCurrentProcessStartTime().ToUnixTimeMilliseconds();
 
     /// <summary>
     /// Gets the current process's start time as reported by <see cref="Process.StartTime"/>.
@@ -54,11 +69,12 @@ internal static partial class ProcessStartTimeHelper
     }
 
     /// <summary>
-    /// Gets the start time, as whole Unix seconds, of the process with the given <paramref name="pid"/>.
+    /// Gets the stable identity start time, as Unix milliseconds, of the process with the given
+    /// <paramref name="pid"/>.
     /// </summary>
     /// <returns>The start time, or <see langword="null"/> when the process cannot be inspected (already exited, privileged, etc.).</returns>
-    public static long? TryGetProcessStartTimeUnixSeconds(int pid)
-        => TryGetProcessStartTime(pid)?.ToUnixTimeSeconds();
+    public static long? TryGetProcessStartTimeUnixMilliseconds(int pid)
+        => TryGetProcessStartTime(pid)?.ToUnixTimeMilliseconds();
 
     /// <summary>
     /// Gets the start time, as whole Unix seconds, of the process with the given <paramref name="pid"/>
@@ -101,8 +117,8 @@ internal static partial class ProcessStartTimeHelper
     }
 
     /// <summary>
-    /// Parses a Unix-seconds start time previously produced by
-    /// <see cref="GetCurrentProcessStartTimeUnixSeconds"/> (for example from an environment variable).
+    /// Parses a Unix start-time value previously produced for an identity environment variable (whole
+    /// seconds for the legacy domain, milliseconds for the stable domain).
     /// </summary>
     /// <returns>The parsed value, or <see langword="null"/> when <paramref name="value"/> is missing or invalid.</returns>
     public static long? TryParseStartTimeUnixSeconds(string? value)
@@ -110,15 +126,15 @@ internal static partial class ProcessStartTimeHelper
 
     /// <summary>
     /// Determines whether a process with the given <paramref name="pid"/> is currently running and,
-    /// when <paramref name="expectedStartTimeUnixSeconds"/> is supplied, whether its start time matches
-    /// (guarding against PID reuse). When the expected start time is <see langword="null"/> this falls
-    /// back to a PID-only existence check.
+    /// when <paramref name="expectedStartTimeUnixMilliseconds"/> is supplied, whether its stable start
+    /// time matches (guarding against PID reuse). When the expected start time is <see langword="null"/>
+    /// this falls back to a PID-only existence check.
     /// </summary>
     /// <param name="pid">The process ID to check.</param>
-    /// <param name="expectedStartTimeUnixSeconds">The expected start time (whole Unix seconds), or <see langword="null"/> for PID-only.</param>
-    /// <param name="tolerance">Allowed difference between the expected and observed start time. Defaults to an exact match.</param>
+    /// <param name="expectedStartTimeUnixMilliseconds">The expected stable start time (Unix milliseconds), or <see langword="null"/> for PID-only.</param>
+    /// <param name="tolerance">Allowed difference between the expected and observed start time. Defaults to <see cref="StableStartTimeMatchTolerance"/>.</param>
     /// <returns><see langword="true"/> if the process exists and matches; otherwise <see langword="false"/>.</returns>
-    public static bool IsProcessRunning(int pid, long? expectedStartTimeUnixSeconds = null, TimeSpan? tolerance = null)
+    public static bool IsProcessRunning(int pid, long? expectedStartTimeUnixMilliseconds = null, TimeSpan? tolerance = null)
     {
         try
         {
@@ -128,19 +144,19 @@ internal static partial class ProcessStartTimeHelper
                 return false;
             }
 
-            if (expectedStartTimeUnixSeconds is { } expected)
+            if (expectedStartTimeUnixMilliseconds is { } expected)
             {
                 // Reading the process start time can race with process exit. On macOS it can throw:
                 //   Win32Exception (3): Unable to retrieve the specified information about the process or thread.
                 // If we cannot prove this is the expected target, treat it as not running so callers
                 // never act on a recycled PID.
-                var actual = TryGetProcessStartTimeUnixSeconds(pid);
+                var actual = TryGetProcessStartTimeUnixMilliseconds(pid);
                 if (actual is null)
                 {
                     return false;
                 }
 
-                if (!AreClose(expected, actual.Value, tolerance))
+                if (!AreCloseMilliseconds(expected, actual.Value, tolerance))
                 {
                     return false;
                 }
@@ -240,25 +256,39 @@ internal static partial class ProcessStartTimeHelper
         return Math.Abs(expectedStartTimeUnixSeconds - actualStartTimeUnixSeconds) <= toleranceSeconds;
     }
 
+    /// <summary>
+    /// Returns whether two stable-identity start times, expressed as Unix milliseconds, identify the same
+    /// process. Defaults to <see cref="StableStartTimeMatchTolerance"/> so a within-tick rounding
+    /// difference is accepted while a recycled PID (which starts a later, larger boot-relative time) is
+    /// still rejected.
+    /// </summary>
+    /// <param name="expectedStartTimeUnixMilliseconds">The expected start time, in Unix milliseconds.</param>
+    /// <param name="actualStartTimeUnixMilliseconds">The observed start time, in Unix milliseconds.</param>
+    /// <param name="tolerance">Optional allowed difference; defaults to <see cref="StableStartTimeMatchTolerance"/>.</param>
+    public static bool AreCloseMilliseconds(long expectedStartTimeUnixMilliseconds, long actualStartTimeUnixMilliseconds, TimeSpan? tolerance = null)
+    {
+        var toleranceMilliseconds = (long)(tolerance ?? StableStartTimeMatchTolerance).TotalMilliseconds;
+        return Math.Abs(expectedStartTimeUnixMilliseconds - actualStartTimeUnixMilliseconds) <= toleranceMilliseconds;
+    }
+
     private static DateTimeOffset? TryGetLinuxProcessStartTime(int pid)
     {
         // These identities are always stamped with PIDs from the current process namespace.
-        // Do not honor HOST_PROC here: that is only for DCP host-process inspection, and
-        // mixing local PIDs with host /proc data can make orphan detection act on the wrong process.
+        // Do not honor HOST_PROC here: that is only for DCP host-process inspection.
         if (TryGetLinuxProcessStartTicks(pid, LinuxProcRoot) is not { } startTicks)
         {
             return null;
         }
 
-        // Boot-relative seconds only. startTicks is field 22 of /proc/<pid>/stat, fixed at process start
+        // Boot-relative milliseconds. startTicks is field 22 of /proc/<pid>/stat, fixed at process start
         // relative to boot, so this is identical for every reader regardless of any later wall-clock step.
         // We intentionally do NOT add /proc/stat btime: btime re-expresses this as wall-clock time and
         // itself shifts on clock sync, which would re-introduce the drift this guards against. The result
-        // is an opaque same-machine identity token (seconds since boot), not a real calendar time. This
-        // mirrors DcpProcessMonitor.GetLinuxProcessIdentityTimestamp so every Aspire watchdog computes the
-        // same value for a given PID.
-        var startTimeSecondsSinceBoot = (long)(startTicks / (ulong)GetLinuxClockTicksPerSecond());
-        return DateTimeOffset.FromUnixTimeSeconds(startTimeSecondsSinceBoot);
+        // is an opaque same-machine identity token (milliseconds since boot), not a real calendar time.
+        // Milliseconds (startTicks * 1000 / _SC_CLK_TCK) preserves the sub-second precision needed to
+        // detect a PID reused within the same second; the source resolution is one _SC_CLK_TCK tick (~10 ms). 
+        var startTimeMillisecondsSinceBoot = (long)((startTicks * 1000) / (ulong)GetLinuxClockTicksPerSecond());
+        return DateTimeOffset.FromUnixTimeMilliseconds(startTimeMillisecondsSinceBoot);
     }
 
     /// <summary>

--- a/src/Shared/ProcessStartTimeHelper.cs
+++ b/src/Shared/ProcessStartTimeHelper.cs
@@ -18,6 +18,16 @@ internal static partial class ProcessStartTimeHelper
     private const int LinuxClockTicksPerSecondConfigName = 2; // _SC_CLK_TCK
 
     /// <summary>
+    /// The tolerance cross-process callers must use when comparing a legacy <see cref="Process.StartTime"/>-based
+    /// start time (see <see cref="IsProcessRunningWithRuntimeStartTime"/>). On Linux that value is reconstructed
+    /// from an independently sampled boot time and can differ by one second between two processes reading the same
+    /// PID, so an exact comparison would produce false "process gone" results and prematurely tear down a live
+    /// process tree. See https://github.com/dotnet/runtime/issues/56546. Centralized here so every orphan/liveness
+    /// watchdog applies the same value; <see cref="TimeSpan"/> cannot be <c>const</c>, so it is <c>static readonly</c>.
+    /// </summary>
+    public static readonly TimeSpan RuntimeStartTimeComparisonTolerance = TimeSpan.FromSeconds(1);
+
+    /// <summary>
     /// Gets the current process's start time as whole Unix seconds. This is the value that should be
     /// propagated to child processes so they can verify the parent's identity (PID + start time).
     /// </summary>
@@ -177,7 +187,8 @@ internal static partial class ProcessStartTimeHelper
     /// <param name="expectedStartTimeUnixSeconds">The expected legacy start time (whole Unix seconds).</param>
     /// <param name="tolerance">
     /// Allowed difference between the expected and observed start time. Defaults to an exact match; the
-    /// cross-process orphan/liveness callers pass one second to absorb the boot-time jitter described above.
+    /// cross-process orphan/liveness callers pass <see cref="RuntimeStartTimeComparisonTolerance"/> to absorb
+    /// the boot-time jitter described above.
     /// </param>
     /// <returns><see langword="true"/> if the process exists and its legacy start time matches; otherwise <see langword="false"/>.</returns>
     public static bool IsProcessRunningWithRuntimeStartTime(int pid, long expectedStartTimeUnixSeconds, TimeSpan? tolerance = null)

--- a/src/Shared/ProcessStartTimeHelper.cs
+++ b/src/Shared/ProcessStartTimeHelper.cs
@@ -25,6 +25,15 @@ internal static partial class ProcessStartTimeHelper
         => GetCurrentProcessStartTime().ToUnixTimeSeconds();
 
     /// <summary>
+    /// Gets the current process's start time as reported by <see cref="Process.StartTime"/>.
+    /// </summary>
+    public static long GetCurrentProcessRuntimeStartTimeUnixSeconds()
+    {
+        using var process = Process.GetCurrentProcess();
+        return new DateTimeOffset(process.StartTime).ToUnixTimeSeconds();
+    }
+
+    /// <summary>
     /// Gets the current process's start time using the same platform-specific source as
     /// <see cref="TryGetProcessStartTime"/>.
     /// </summary>
@@ -45,6 +54,24 @@ internal static partial class ProcessStartTimeHelper
     /// <returns>The start time, or <see langword="null"/> when the process cannot be inspected (already exited, privileged, etc.).</returns>
     public static long? TryGetProcessStartTimeUnixSeconds(int pid)
         => TryGetProcessStartTime(pid)?.ToUnixTimeSeconds();
+
+    /// <summary>
+    /// Gets the start time, as whole Unix seconds, of the process with the given <paramref name="pid"/>
+    /// using <see cref="Process.StartTime"/>.
+    /// </summary>
+    /// <returns>The start time, or <see langword="null"/> when the process cannot be inspected (already exited, privileged, etc.).</returns>
+    public static long? TryGetRuntimeProcessStartTimeUnixSeconds(int pid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            return new DateTimeOffset(process.StartTime).ToUnixTimeSeconds();
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException or Win32Exception)
+        {
+            return null;
+        }
+    }
 
     /// <summary>
     /// Gets the start time of the process with the given <paramref name="pid"/>.
@@ -126,6 +153,46 @@ internal static partial class ProcessStartTimeHelper
             }
 
             return true;
+        }
+        catch (ArgumentException)
+        {
+            // Process doesn't exist - already terminated.
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            // Process has already exited.
+            return false;
+        }
+        catch (Win32Exception)
+        {
+            // Could not inspect the process (e.g. it exited mid-check, or is privileged). Without
+            // proof of identity, do not report it as the expected running process.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether a process matches a legacy start time that was produced from
+    /// <see cref="Process.StartTime"/>.
+    /// </summary>
+    public static bool IsProcessRunningWithRuntimeStartTime(int pid, long expectedStartTimeUnixSeconds, TimeSpan? tolerance = null)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            if (process.HasExited)
+            {
+                return false;
+            }
+
+            if (TryGetRuntimeProcessStartTimeUnixSeconds(pid) is not { } actual ||
+                !AreClose(expectedStartTimeUnixSeconds, actual, tolerance))
+            {
+                return false;
+            }
+
+            return !process.HasExited;
         }
         catch (ArgumentException)
         {

--- a/src/Shared/ProcessStartTimeHelper.cs
+++ b/src/Shared/ProcessStartTimeHelper.cs
@@ -76,17 +76,6 @@ internal static partial class ProcessStartTimeHelper
     /// <summary>
     /// Gets the start time of the process with the given <paramref name="pid"/>.
     /// </summary>
-    /// <remarks>
-    /// On Linux this deliberately uses boot-relative <c>/proc</c> start ticks (matching
-    /// <c>DcpProcessMonitor.GetLinuxProcessIdentityTimestamp</c>) instead of <see cref="Process.StartTime"/>
-    /// or any wall-clock time. The returned value is an opaque <em>seconds-since-boot</em> identity token,
-    /// not a real calendar time: field 22 of <c>/proc/&lt;pid&gt;/stat</c> is fixed at process start relative
-    /// to boot, so every process on the machine computes the same value for a given PID even after the wall
-    /// clock is stepped (NTP correction, container host clock sync). Using <see cref="Process.StartTime"/>
-    /// (which the runtime derives from an independently sampled boot time) or adding <c>/proc/stat</c>
-    /// <c>btime</c> (which itself shifts with wall-clock adjustments) would re-introduce that drift and let a
-    /// parent and child disagree about the same PID's start time, defeating the PID-reuse guard.
-    /// </remarks>
     /// <returns>The start time, or <see langword="null"/> when the process cannot be inspected (already exited, privileged, etc.).</returns>
     public static DateTimeOffset? TryGetProcessStartTime(int pid)
     {
@@ -262,14 +251,16 @@ internal static partial class ProcessStartTimeHelper
     /// Reads the raw start time of the process with the given <paramref name="pid"/> as clock ticks since
     /// boot (field 22 of <c>/proc/&lt;pid&gt;/stat</c>). This is the drift-immune building block for Linux
     /// process identity: the value is fixed at process start relative to boot, so every reader on the
-    /// machine observes the same number even after a wall-clock adjustment. Divide by
-    /// <see cref="GetLinuxClockTicksPerSecond"/> to obtain seconds since boot.
+    /// machine observes the same number even after a wall-clock adjustment. 
+    /// Divide by <see cref="GetLinuxClockTicksPerSecond"/> to obtain seconds since boot.
     /// </summary>
+    /// <remarks>
+    /// Using this is especially important for containers, where suspension and resumption of the host can cause
+    /// the wall clock to jump. 
+    /// </remarks>
     /// <param name="pid">The process to inspect.</param>
-    /// <param name="procRoot">
-    /// The <c>/proc</c> filesystem root to read from. Orphan/liveness detection must pass
-    /// <see cref="LinuxProcRoot"/> (the current namespace's <c>/proc</c>); only DCP host-process inspection
-    /// passes <c>HOST_PROC</c>.
+    /// <param name="procRoot"> The <c>/proc</c> filesystem root to read from. 
+    /// Normally /proc, but can be overridden for container environments to read the host process namespace.
     /// </param>
     /// <returns>The start ticks, or <see langword="null"/> when the stat file cannot be read or parsed.</returns>
     internal static ulong? TryGetLinuxProcessStartTicks(int pid, string procRoot)

--- a/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
+++ b/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
     <Compile Include="$(TestsSharedDir)TemporaryRepo.cs" Link="shared\TemporaryRepo.cs" />
     <Compile Include="$(TestsSharedDir)TempDirectory.cs" Link="shared\TempDirectory.cs" />
+    <Compile Include="$(TestsSharedDir)TestProcesses.cs" Link="shared\TestProcesses.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Cli.Tests/Backchannel/AuxiliaryBackchannelMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AuxiliaryBackchannelMonitorTests.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Backchannel;
+
+namespace Aspire.Cli.Tests.Backchannel;
+
+public class AuxiliaryBackchannelMonitorTests
+{
+    [Fact]
+    public void IsAppHostInScopeOfDirectory_WithSymlinkedPaths_IsInScope()
+    {
+        // The OS reports a process's current directory physically (for example macOS temp dirs under
+        // /var -> /private/var), while a file-based AppHost reports its path unresolved. The in-scope check
+        // must resolve symlinks on both operands or it treats an in-scope AppHost as out of scope, which made
+        // CWD-based 'aspire describe' report "No running AppHost found". See https://github.com/microsoft/aspire/issues/17618.
+        Assert.SkipUnless(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
+            "Symlink resolution test only runs on Linux/macOS where unprivileged symlink creation is reliable.");
+
+        var tempRoot = Directory.CreateTempSubdirectory("aspire-scope-symlink-");
+        try
+        {
+            var realDirectory = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "real"));
+            var symlinkDirectory = Path.Combine(tempRoot.FullName, "link");
+            Directory.CreateSymbolicLink(symlinkDirectory, realDirectory.FullName);
+
+            // AppHost reported through the real directory, working directory reached through the symlink.
+            var appHostPathViaReal = Path.Combine(realDirectory.FullName, "apphost.cs");
+            Assert.True(AuxiliaryBackchannelMonitor.IsAppHostInScopeOfDirectory(appHostPathViaReal, symlinkDirectory));
+
+            // And the reverse: AppHost reached through the symlink, working directory the real path.
+            var appHostPathViaSymlink = Path.Combine(symlinkDirectory, "apphost.cs");
+            Assert.True(AuxiliaryBackchannelMonitor.IsAppHostInScopeOfDirectory(appHostPathViaSymlink, realDirectory.FullName));
+        }
+        finally
+        {
+            tempRoot.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IsAppHostInScopeOfDirectory_AppHostOutsideWorkingDirectory_IsNotInScope()
+    {
+        var tempRoot = Directory.CreateTempSubdirectory("aspire-scope-");
+        try
+        {
+            var workingDirectory = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "wd")).FullName;
+            var outsideAppHost = Path.Combine(tempRoot.FullName, "other", "apphost.cs");
+
+            Assert.False(AuxiliaryBackchannelMonitor.IsAppHostInScopeOfDirectory(outsideAppHost, workingDirectory));
+        }
+        finally
+        {
+            tempRoot.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IsAppHostInScopeOfDirectory_NullOrEmptyAppHostPath_IsNotInScope()
+    {
+        Assert.False(AuxiliaryBackchannelMonitor.IsAppHostInScopeOfDirectory(null, Path.GetTempPath()));
+        Assert.False(AuxiliaryBackchannelMonitor.IsAppHostInScopeOfDirectory(string.Empty, Path.GetTempPath()));
+    }
+}

--- a/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
@@ -46,7 +46,28 @@ public class OrphanedAppHostCollectorTests
                 AppHostPath = "/tmp/AppHost.csproj",
                 ProcessId = 4242,
                 CliProcessId = Environment.ProcessId,
-                CliStartedAt = ProcessStartTimeHelper.GetCurrentProcessStartTime(),
+                CliStartedAt = GetCurrentProcessRuntimeStartTime(),
+            },
+        };
+
+        Assert.False(OrphanedAppHostCollector.IsOrphaned(connection));
+    }
+
+    [Fact]
+    public void IsOrphaned_LiveCliProcessWithAdjacentRuntimeStartTime_ReturnsFalse()
+    {
+        // The AppHost backchannel reports ASPIRE_CLI_STARTED, which is intentionally stamped from
+        // Process.StartTime for released-AppHost compatibility. Different processes can observe that
+        // runtime value on adjacent Unix seconds, so the collector must use the same tolerant legacy
+        // comparison as the AppHost orphan detectors.
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = "/tmp/AppHost.csproj",
+                ProcessId = 4242,
+                CliProcessId = Environment.ProcessId,
+                CliStartedAt = GetCurrentProcessRuntimeStartTime().AddSeconds(1),
             },
         };
 
@@ -254,10 +275,13 @@ public class OrphanedAppHostCollectorTests
                 // Live: the current process's real start time matches, so the launching CLI still looks alive.
                 CliStartedAt = orphaned
                     ? DateTimeOffset.FromUnixTimeSeconds(1)
-                    : ProcessStartTimeHelper.GetCurrentProcessStartTime(),
+                    : GetCurrentProcessRuntimeStartTime(),
             },
         };
     }
+
+    private static DateTimeOffset GetCurrentProcessRuntimeStartTime()
+        => DateTimeOffset.FromUnixTimeSeconds(ProcessStartTimeHelper.GetCurrentProcessRuntimeStartTimeUnixSeconds());
 
     private static DateTimeOffset GetProcessStartTime(Process process)
     {

--- a/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
@@ -254,6 +254,44 @@ public class OrphanedAppHostCollectorTests
         Assert.Equal(1, monitor.ScanCallCount);
     }
 
+    [Fact]
+    public async Task CollectAsync_WhenScanThrows_ReturnsZero()
+    {
+        // Collection is best effort: a non-cancellation scan failure must not surface to the caller
+        // (e.g. `aspire ps`), even when an orphan is present that would otherwise have been collected.
+        var monitor = new TestAuxiliaryBackchannelMonitor
+        {
+            ScanAsyncCallback = _ => throw new InvalidOperationException("scan boom")
+        };
+        var stopper = new TestAppHostStopper();
+
+        const string socketPath = "/tmp/aspire-orphan-tests-scan-throw.sock";
+        monitor.AddConnection("orphan-hash", socketPath, CreateConnection(socketPath, appHostPid: 4242, orphaned: true));
+
+        var collector = new OrphanedAppHostCollector(monitor, stopper, NullLogger<OrphanedAppHostCollector>.Instance);
+
+        var collected = await collector.CollectAsync(CancellationToken.None);
+
+        Assert.Equal(0, collected);
+        Assert.Empty(stopper.StopRequests);
+    }
+
+    [Fact]
+    public async Task CollectAsync_WhenScanCancelled_Throws()
+    {
+        // Cancellation is the one failure that must NOT be swallowed, so callers can abort promptly.
+        var monitor = new TestAuxiliaryBackchannelMonitor
+        {
+            ScanAsyncCallback = _ => throw new OperationCanceledException()
+        };
+        var stopper = new TestAppHostStopper();
+
+        var collector = new OrphanedAppHostCollector(monitor, stopper, NullLogger<OrphanedAppHostCollector>.Instance);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => collector.CollectAsync(CancellationToken.None));
+        Assert.Empty(stopper.StopRequests);
+    }
+
     private static string CreateSocketFile(DirectoryInfo directory, string name)
     {
         var path = Path.Combine(directory.FullName, name);

--- a/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
@@ -96,11 +96,10 @@ public class OrphanedAppHostCollectorTests
     [Fact]
     public void IsOrphaned_DeadCliProcess_ReturnsTrue()
     {
-        var psi = OperatingSystem.IsWindows()
-            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
-            : new ProcessStartInfo("tail", "-f /dev/null") { CreateNoWindow = true };
-        using var cliProcess = Process.Start(psi);
-        Assert.NotNull(cliProcess);
+        // A dead launcher: start the shared bounded, self-terminating helper (so an aborted test host
+        // can't leak it), capture its start time, then kill it. The collector must then see the
+        // recorded PID + start time as no-longer-running and report the AppHost orphaned.
+        using var cliProcess = TestProcesses.StartLongRunning();
 
         var cliStartedAt = GetProcessStartTime(cliProcess);
         cliProcess.Kill(entireProcessTree: true);

--- a/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Tests.TestServices;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Backchannel;
 
@@ -96,5 +97,165 @@ public class OrphanedAppHostCollectorTests
         };
 
         Assert.True(OrphanedAppHostCollector.IsOrphaned(connection));
+    }
+
+    [Fact]
+    public async Task CollectAsync_ScansThenStopsOnlyOrphans()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-orphan-collect-tests");
+        try
+        {
+            var monitor = new TestAuxiliaryBackchannelMonitor();
+            var stopper = new TestAppHostStopper();
+
+            var orphanSocket = CreateSocketFile(tempDir, "orphan.sock");
+            var liveSocket = CreateSocketFile(tempDir, "live.sock");
+            monitor.AddConnection("orphan-hash", orphanSocket, CreateConnection(orphanSocket, appHostPid: 4242, orphaned: true));
+            monitor.AddConnection("live-hash", liveSocket, CreateConnection(liveSocket, appHostPid: 4343, orphaned: false));
+
+            var collector = new OrphanedAppHostCollector(monitor, stopper, NullLogger<OrphanedAppHostCollector>.Instance);
+
+            var collected = await collector.CollectAsync(CancellationToken.None);
+
+            Assert.Equal(1, collected);
+            // The collector must scan for fresh state before deciding what to collect.
+            Assert.Equal(1, monitor.ScanCallCount);
+            // Only the orphaned AppHost is stopped; the live one is left running.
+            var stopped = Assert.Single(stopper.StopRequests);
+            Assert.Equal(4242, stopped?.ProcessId);
+        }
+        finally
+        {
+            Directory.Delete(tempDir.FullName, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CollectAsync_SuccessfulStop_DeletesSocketAndCounts()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-orphan-collect-tests");
+        try
+        {
+            var monitor = new TestAuxiliaryBackchannelMonitor();
+            var stopper = new TestAppHostStopper { DefaultResult = true };
+
+            var socketPath = CreateSocketFile(tempDir, "orphan.sock");
+            monitor.AddConnection("orphan-hash", socketPath, CreateConnection(socketPath, appHostPid: 4242, orphaned: true));
+
+            var collector = new OrphanedAppHostCollector(monitor, stopper, NullLogger<OrphanedAppHostCollector>.Instance);
+
+            var collected = await collector.CollectAsync(CancellationToken.None);
+
+            Assert.Equal(1, collected);
+            // A confirmed stop must remove the now-dead AppHost's stale socket.
+            Assert.False(File.Exists(socketPath));
+        }
+        finally
+        {
+            Directory.Delete(tempDir.FullName, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CollectAsync_FailedStop_DoesNotDeleteSocketOrCount()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-orphan-collect-tests");
+        try
+        {
+            var monitor = new TestAuxiliaryBackchannelMonitor();
+            var stopper = new TestAppHostStopper { DefaultResult = false };
+
+            var socketPath = CreateSocketFile(tempDir, "orphan.sock");
+            monitor.AddConnection("orphan-hash", socketPath, CreateConnection(socketPath, appHostPid: 4242, orphaned: true));
+
+            var collector = new OrphanedAppHostCollector(monitor, stopper, NullLogger<OrphanedAppHostCollector>.Instance);
+
+            var collected = await collector.CollectAsync(CancellationToken.None);
+
+            Assert.Equal(0, collected);
+            // The process is not confirmed gone, so the socket must be left for a later cleanup pass.
+            Assert.True(File.Exists(socketPath));
+        }
+        finally
+        {
+            Directory.Delete(tempDir.FullName, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CollectAsync_WhenStopThrows_SwallowsAndContinues()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("aspire-orphan-collect-tests");
+        try
+        {
+            var monitor = new TestAuxiliaryBackchannelMonitor();
+
+            var throwingSocket = CreateSocketFile(tempDir, "throwing.sock");
+            var okSocket = CreateSocketFile(tempDir, "ok.sock");
+            monitor.AddConnection("throwing-hash", throwingSocket, CreateConnection(throwingSocket, appHostPid: 1, orphaned: true));
+            monitor.AddConnection("ok-hash", okSocket, CreateConnection(okSocket, appHostPid: 2, orphaned: true));
+
+            var stopper = new TestAppHostStopper
+            {
+                ThrowSelector = info => info?.ProcessId == 1 ? new InvalidOperationException("boom") : null,
+            };
+
+            var collector = new OrphanedAppHostCollector(monitor, stopper, NullLogger<OrphanedAppHostCollector>.Instance);
+
+            var collected = await collector.CollectAsync(CancellationToken.None);
+
+            // Collection is best effort: one orphan throwing must not abort the rest.
+            Assert.Equal(1, collected);
+            Assert.True(File.Exists(throwingSocket));
+            Assert.False(File.Exists(okSocket));
+        }
+        finally
+        {
+            Directory.Delete(tempDir.FullName, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CollectAsync_NoOrphans_ReturnsZeroWithoutStopping()
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var stopper = new TestAppHostStopper();
+
+        const string socketPath = "/tmp/aspire-orphan-tests-live.sock";
+        monitor.AddConnection("live-hash", socketPath, CreateConnection(socketPath, appHostPid: 4343, orphaned: false));
+
+        var collector = new OrphanedAppHostCollector(monitor, stopper, NullLogger<OrphanedAppHostCollector>.Instance);
+
+        var collected = await collector.CollectAsync(CancellationToken.None);
+
+        Assert.Equal(0, collected);
+        Assert.Empty(stopper.StopRequests);
+        Assert.Equal(1, monitor.ScanCallCount);
+    }
+
+    private static string CreateSocketFile(DirectoryInfo directory, string name)
+    {
+        var path = Path.Combine(directory.FullName, name);
+        File.WriteAllText(path, string.Empty);
+        return path;
+    }
+
+    private static TestAppHostAuxiliaryBackchannel CreateConnection(string socketPath, int appHostPid, bool orphaned)
+    {
+        return new TestAppHostAuxiliaryBackchannel
+        {
+            SocketPath = socketPath,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = "/tmp/AppHost.csproj",
+                ProcessId = appHostPid,
+                CliProcessId = Environment.ProcessId,
+                // Orphaned: a mismatched start time simulates a recycled CLI PID (the original launcher is gone).
+                // Live: the current process's real start time matches, so the launching CLI still looks alive.
+                CliStartedAt = orphaned
+                    ? DateTimeOffset.FromUnixTimeSeconds(1)
+                    : new DateTimeOffset(Process.GetCurrentProcess().StartTime),
+            },
+        };
     }
 }

--- a/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
@@ -46,7 +46,7 @@ public class OrphanedAppHostCollectorTests
                 AppHostPath = "/tmp/AppHost.csproj",
                 ProcessId = 4242,
                 CliProcessId = Environment.ProcessId,
-                CliStartedAt = new DateTimeOffset(Process.GetCurrentProcess().StartTime),
+                CliStartedAt = ProcessStartTimeHelper.GetCurrentProcessStartTime(),
             },
         };
 
@@ -81,7 +81,7 @@ public class OrphanedAppHostCollectorTests
         using var cliProcess = Process.Start(psi);
         Assert.NotNull(cliProcess);
 
-        var cliStartedAt = new DateTimeOffset(cliProcess.StartTime);
+        var cliStartedAt = GetProcessStartTime(cliProcess);
         cliProcess.Kill(entireProcessTree: true);
         cliProcess.WaitForExit();
 
@@ -254,8 +254,15 @@ public class OrphanedAppHostCollectorTests
                 // Live: the current process's real start time matches, so the launching CLI still looks alive.
                 CliStartedAt = orphaned
                     ? DateTimeOffset.FromUnixTimeSeconds(1)
-                    : new DateTimeOffset(Process.GetCurrentProcess().StartTime),
+                    : ProcessStartTimeHelper.GetCurrentProcessStartTime(),
             },
         };
+    }
+
+    private static DateTimeOffset GetProcessStartTime(Process process)
+    {
+        var startTime = ProcessStartTimeHelper.TryGetProcessStartTime(process.Id);
+        Assert.NotNull(startTime);
+        return startTime.Value;
     }
 }

--- a/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
@@ -68,7 +68,7 @@ public class OrphanedAppHostCollectorTests
                 AppHostPath = "/tmp/AppHost.csproj",
                 ProcessId = 4242,
                 CliProcessId = Environment.ProcessId,
-                CliStableStartedAt = DateTimeOffset.FromUnixTimeSeconds(1),
+                CliStableStartedAt = DateTimeOffset.FromUnixTimeMilliseconds(1),
             },
         };
 
@@ -385,7 +385,7 @@ public class OrphanedAppHostCollectorTests
                 // Orphaned: a mismatched stable start time is trustworthy evidence of a recycled CLI PID.
                 // Live: the current process's real stable start time matches, so the launching CLI is alive.
                 CliStableStartedAt = orphaned
-                    ? DateTimeOffset.FromUnixTimeSeconds(1)
+                    ? DateTimeOffset.FromUnixTimeMilliseconds(1)
                     : GetCurrentProcessStableStartTime(),
             },
         };
@@ -395,7 +395,7 @@ public class OrphanedAppHostCollectorTests
         => DateTimeOffset.FromUnixTimeSeconds(ProcessStartTimeHelper.GetCurrentProcessRuntimeStartTimeUnixSeconds());
 
     private static DateTimeOffset GetCurrentProcessStableStartTime()
-        => DateTimeOffset.FromUnixTimeSeconds(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds());
+        => DateTimeOffset.FromUnixTimeMilliseconds(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixMilliseconds());
 
     private static DateTimeOffset GetProcessStartTime(Process process)
     {

--- a/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
@@ -36,9 +36,71 @@ public class OrphanedAppHostCollectorTests
     }
 
     [Fact]
-    public void IsOrphaned_LiveCliProcess_ReturnsFalse()
+    public void IsOrphaned_StableStartTimeMatchesLiveCli_ReturnsFalse()
     {
-        // The current process stands in for a launching CLI that is still alive.
+        // Current AppHosts report CliStableStartedAt (the launcher CLI's /proc-based identity). The
+        // current process stands in for a launching CLI that is still alive, so its stable start time
+        // matches exactly and the AppHost is not orphaned.
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = "/tmp/AppHost.csproj",
+                ProcessId = 4242,
+                CliProcessId = Environment.ProcessId,
+                CliStableStartedAt = GetCurrentProcessStableStartTime(),
+            },
+        };
+
+        Assert.False(OrphanedAppHostCollector.IsOrphaned(connection));
+    }
+
+    [Fact]
+    public void IsOrphaned_StableStartTimeMismatchOnLiveCli_ReturnsTrue()
+    {
+        // The PID is alive but its stable /proc start time does not match — a recycled PID. The stable
+        // identity is immune to clock drift, so this mismatch is trustworthy evidence the original
+        // launcher is gone and the AppHost is orphaned.
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = "/tmp/AppHost.csproj",
+                ProcessId = 4242,
+                CliProcessId = Environment.ProcessId,
+                CliStableStartedAt = DateTimeOffset.FromUnixTimeSeconds(1),
+            },
+        };
+
+        Assert.True(OrphanedAppHostCollector.IsOrphaned(connection));
+    }
+
+    [Fact]
+    public void IsOrphaned_StablePreferredOverMismatchedLegacy_ReturnsFalse()
+    {
+        // Both identities are present. The stable value matches the live CLI while the legacy value does
+        // not (as can happen after a clock step). The collector must trust the drift-immune stable value
+        // and leave the live AppHost alone.
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = "/tmp/AppHost.csproj",
+                ProcessId = 4242,
+                CliProcessId = Environment.ProcessId,
+                CliStableStartedAt = GetCurrentProcessStableStartTime(),
+                CliStartedAt = DateTimeOffset.FromUnixTimeSeconds(1),
+            },
+        };
+
+        Assert.False(OrphanedAppHostCollector.IsOrphaned(connection));
+    }
+
+    [Fact]
+    public void IsOrphaned_LegacyLiveCliProcess_ReturnsFalse()
+    {
+        // Older AppHost: only the legacy CliStartedAt is reported. The current process stands in for a
+        // launching CLI that is still alive, so the AppHost is not orphaned.
         var connection = new TestAppHostAuxiliaryBackchannel
         {
             AppHostInfo = new AppHostInformation
@@ -54,31 +116,12 @@ public class OrphanedAppHostCollectorTests
     }
 
     [Fact]
-    public void IsOrphaned_LiveCliProcessWithAdjacentRuntimeStartTime_ReturnsFalse()
+    public void IsOrphaned_LegacyMismatchedStartTimeOnLiveCli_ReturnsFalse()
     {
-        // The AppHost backchannel reports ASPIRE_CLI_STARTED, which is intentionally stamped from
-        // Process.StartTime for released-AppHost compatibility. Different processes can observe that
-        // runtime value on adjacent Unix seconds, so the collector must use the same tolerant legacy
-        // comparison as the AppHost orphan detectors.
-        var connection = new TestAppHostAuxiliaryBackchannel
-        {
-            AppHostInfo = new AppHostInformation
-            {
-                AppHostPath = "/tmp/AppHost.csproj",
-                ProcessId = 4242,
-                CliProcessId = Environment.ProcessId,
-                CliStartedAt = GetCurrentProcessRuntimeStartTime().AddSeconds(1),
-            },
-        };
-
-        Assert.False(OrphanedAppHostCollector.IsOrphaned(connection));
-    }
-
-    [Fact]
-    public void IsOrphaned_LiveCliProcessWithMismatchedStartTime_ReturnsTrue()
-    {
-        // The PID is alive but its start time does not match — a recycled PID. The original launcher is
-        // gone, so the AppHost is orphaned.
+        // Older AppHost: only the drift-prone legacy CliStartedAt is available and it does NOT match the
+        // live CLI PID (as happens after a wall-clock step, not just PID reuse). Collecting is
+        // destructive, so an ambiguous legacy mismatch on a still-live PID must NOT tear down the app.
+        // The collector only acts on the legacy path when the CLI PID is entirely gone.
         var connection = new TestAppHostAuxiliaryBackchannel
         {
             AppHostInfo = new AppHostInformation
@@ -90,7 +133,7 @@ public class OrphanedAppHostCollectorTests
             },
         };
 
-        Assert.True(OrphanedAppHostCollector.IsOrphaned(connection));
+        Assert.False(OrphanedAppHostCollector.IsOrphaned(connection));
     }
 
     [Fact]
@@ -105,6 +148,36 @@ public class OrphanedAppHostCollectorTests
         cliProcess.Kill(entireProcessTree: true);
         cliProcess.WaitForExit();
 
+        // The launching CLI PID is entirely gone, so the AppHost is orphaned regardless of which
+        // identity domain was reported.
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = "/tmp/AppHost.csproj",
+                ProcessId = 4242,
+                CliProcessId = cliProcess.Id,
+                CliStableStartedAt = cliStartedAt,
+            },
+        };
+
+        Assert.True(OrphanedAppHostCollector.IsOrphaned(connection));
+    }
+
+    [Fact]
+    public void IsOrphaned_LegacyDeadCliProcess_ReturnsTrue()
+    {
+        var psi = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
+            : new ProcessStartInfo("tail", "-f /dev/null") { CreateNoWindow = true };
+        using var cliProcess = Process.Start(psi);
+        Assert.NotNull(cliProcess);
+
+        var cliStartedAt = GetProcessStartTime(cliProcess);
+        cliProcess.Kill(entireProcessTree: true);
+        cliProcess.WaitForExit();
+
+        // Older AppHost reporting only the legacy identity: the PID is gone, so it is orphaned.
         var connection = new TestAppHostAuxiliaryBackchannel
         {
             AppHostInfo = new AppHostInformation
@@ -308,17 +381,21 @@ public class OrphanedAppHostCollectorTests
                 AppHostPath = "/tmp/AppHost.csproj",
                 ProcessId = appHostPid,
                 CliProcessId = Environment.ProcessId,
-                // Orphaned: a mismatched start time simulates a recycled CLI PID (the original launcher is gone).
-                // Live: the current process's real start time matches, so the launching CLI still looks alive.
-                CliStartedAt = orphaned
+                // Drive the decision through the stable /proc identity the collector prefers.
+                // Orphaned: a mismatched stable start time is trustworthy evidence of a recycled CLI PID.
+                // Live: the current process's real stable start time matches, so the launching CLI is alive.
+                CliStableStartedAt = orphaned
                     ? DateTimeOffset.FromUnixTimeSeconds(1)
-                    : GetCurrentProcessRuntimeStartTime(),
+                    : GetCurrentProcessStableStartTime(),
             },
         };
     }
 
     private static DateTimeOffset GetCurrentProcessRuntimeStartTime()
         => DateTimeOffset.FromUnixTimeSeconds(ProcessStartTimeHelper.GetCurrentProcessRuntimeStartTimeUnixSeconds());
+
+    private static DateTimeOffset GetCurrentProcessStableStartTime()
+        => DateTimeOffset.FromUnixTimeSeconds(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds());
 
     private static DateTimeOffset GetProcessStartTime(Process process)
     {

--- a/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/OrphanedAppHostCollectorTests.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Tests.TestServices;
+
+namespace Aspire.Cli.Tests.Backchannel;
+
+public class OrphanedAppHostCollectorTests
+{
+    [Fact]
+    public void IsOrphaned_NoAppHostInfo_ReturnsFalse()
+    {
+        var connection = new TestAppHostAuxiliaryBackchannel { AppHostInfo = null };
+
+        Assert.False(OrphanedAppHostCollector.IsOrphaned(connection));
+    }
+
+    [Fact]
+    public void IsOrphaned_NoCliProcessId_ReturnsFalse()
+    {
+        // Without a known launching CLI we cannot attribute ownership, so never collect.
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = "/tmp/AppHost.csproj",
+                ProcessId = 4242,
+                CliProcessId = null,
+            },
+        };
+
+        Assert.False(OrphanedAppHostCollector.IsOrphaned(connection));
+    }
+
+    [Fact]
+    public void IsOrphaned_LiveCliProcess_ReturnsFalse()
+    {
+        // The current process stands in for a launching CLI that is still alive.
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = "/tmp/AppHost.csproj",
+                ProcessId = 4242,
+                CliProcessId = Environment.ProcessId,
+                CliStartedAt = new DateTimeOffset(Process.GetCurrentProcess().StartTime),
+            },
+        };
+
+        Assert.False(OrphanedAppHostCollector.IsOrphaned(connection));
+    }
+
+    [Fact]
+    public void IsOrphaned_LiveCliProcessWithMismatchedStartTime_ReturnsTrue()
+    {
+        // The PID is alive but its start time does not match — a recycled PID. The original launcher is
+        // gone, so the AppHost is orphaned.
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = "/tmp/AppHost.csproj",
+                ProcessId = 4242,
+                CliProcessId = Environment.ProcessId,
+                CliStartedAt = DateTimeOffset.FromUnixTimeSeconds(1),
+            },
+        };
+
+        Assert.True(OrphanedAppHostCollector.IsOrphaned(connection));
+    }
+
+    [Fact]
+    public void IsOrphaned_DeadCliProcess_ReturnsTrue()
+    {
+        var psi = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
+            : new ProcessStartInfo("tail", "-f /dev/null") { CreateNoWindow = true };
+        using var cliProcess = Process.Start(psi);
+        Assert.NotNull(cliProcess);
+
+        var cliStartedAt = new DateTimeOffset(cliProcess.StartTime);
+        cliProcess.Kill(entireProcessTree: true);
+        cliProcess.WaitForExit();
+
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = "/tmp/AppHost.csproj",
+                ProcessId = 4242,
+                CliProcessId = cliProcess.Id,
+                CliStartedAt = cliStartedAt,
+            },
+        };
+
+        Assert.True(OrphanedAppHostCollector.IsOrphaned(connection));
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
@@ -448,6 +448,21 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void DetachedChildEnvironment_StampsLauncherIdentityForLivenessMonitor()
+    {
+        // The detached child's LauncherLivenessMonitor watches this launcher identity (PID + start time)
+        // to tear the AppHost down if the foreground launcher dies before readiness. Without it the child
+        // cannot detect a dead launcher and the AppHost + dashboard leak as orphaned processes.
+        var environment = AppHostLauncher.CreateDetachedChildEnvironment(null);
+
+        Assert.Equal("true", environment[KnownConfigNames.CliRunDetached]);
+        Assert.Equal(
+            Environment.ProcessId.ToString(CultureInfo.InvariantCulture),
+            environment[KnownConfigNames.CliLauncherProcessId]);
+        Assert.NotNull(ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(environment[KnownConfigNames.CliLauncherProcessStarted]));
+    }
+
+    [Fact]
     public void DetachedChildEnvironment_IncludesProfilingTelemetryContextFromActiveProfilingSpan()
     {
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(

--- a/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
@@ -16,6 +16,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Telemetry;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Hosting;
+using Aspire.Hosting.Backchannel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -65,6 +66,57 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
         Assert.StartsWith("cli_20260212T180000000_detach-child_", fileName, StringComparison.Ordinal);
         Assert.EndsWith(".log", fileName, StringComparison.Ordinal);
         Assert.DoesNotContain($"_{Environment.ProcessId}", fileName, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComputeDetachedMatchHashes_ResolvesSymlinkForPrimaryHash_AndKeepsRawHashInFallback()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
+            "Symlink resolution test only runs on Linux/macOS where unprivileged symlink creation is reliable.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var homeDirectory = workspace.WorkspaceRoot.FullName;
+
+        // Reference the same AppHost through a directory symlink ("link" -> "real"). This mirrors the
+        // macOS temp-path shape (/var/folders/... is a symlink to /private/var/folders/...) that made
+        // detached `aspire start` wait on a hash the AppHost never used.
+        var realDirectory = workspace.WorkspaceRoot.CreateSubdirectory("real");
+        var symlinkDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "link");
+        Directory.CreateSymbolicLink(symlinkDirectory, realDirectory.FullName);
+
+        var realProjectPath = Path.Combine(realDirectory.FullName, "AppHost.csproj");
+        File.WriteAllText(realProjectPath, "<Project />");
+        var appHostPathViaSymlink = Path.Combine(symlinkDirectory, "AppHost.csproj");
+
+        var resolvedPath = PathNormalizer.ResolveSymlinks(appHostPathViaSymlink);
+        // The test is only meaningful when resolution actually rewrites the path.
+        Assert.NotEqual(appHostPathViaSymlink, resolvedPath);
+
+        var resolvedPathHash = AppHostHelper.ExtractHashFromSocketPath(
+            AppHostHelper.ComputeAuxiliarySocketPrefix(resolvedPath, homeDirectory))!;
+        var rawPathHash = AppHostHelper.ExtractHashFromSocketPath(
+            AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPathViaSymlink, homeDirectory))!;
+        var rawFallbackHashes = AppHostHelper.ComputeLegacyHashes(appHostPathViaSymlink);
+        var resolvedFallbackHashes = AppHostHelper.ComputeLegacyHashes(resolvedPath);
+
+        var (expectedHash, fallbackHashes) = AppHostLauncher.ComputeDetachedMatchHashes(appHostPathViaSymlink, homeDirectory);
+
+        // The primary hash is computed from the resolved path — the value the AppHost actually keys
+        // its socket on — and therefore differs from the raw-path hash the buggy code waited on.
+        Assert.Equal(resolvedPathHash, expectedHash);
+        Assert.NotEqual(rawPathHash, expectedHash);
+
+        // The fallback set keeps the raw path's compact hash so an AppHost still keyed on the
+        // unresolved path continues to match, plus the legacy hex hashes of both paths.
+        Assert.Contains(rawPathHash, fallbackHashes);
+        Assert.Contains(rawFallbackHashes[0], fallbackHashes);
+        Assert.Contains(resolvedFallbackHashes[0], fallbackHashes);
+
+        // Cross-side agreement: the AppHost builds its socket file name with the same shared code,
+        // keyed on the resolved path (AuxiliaryBackchannelService resolves symlinks before naming the
+        // socket via ComputeSocketPath, which embeds ComputeAppHostId(resolvedPath)). The CLI's
+        // primary hash must equal that embedded id so it waits on exactly the AppHost's socket.
+        Assert.Equal(BackchannelConstants.ComputeAppHostId(resolvedPath), expectedHash);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -249,7 +249,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             {
                 config[KnownConfigNames.CliRunDetached] = "true";
                 config[KnownConfigNames.CliLauncherProcessId] = launcher.Id.ToString(CultureInfo.InvariantCulture);
-                config[KnownConfigNames.CliLauncherProcessStarted] = GetProcessStartTimeUnixSeconds(launcher).ToString(CultureInfo.InvariantCulture);
+                config[KnownConfigNames.CliLauncherProcessStarted] = GetProcessStartTimeUnixMilliseconds(launcher).ToString(CultureInfo.InvariantCulture);
             };
         });
 
@@ -347,7 +347,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             {
                 config[KnownConfigNames.CliRunDetached] = "true";
                 config[KnownConfigNames.CliLauncherProcessId] = launcher.Id.ToString(CultureInfo.InvariantCulture);
-                config[KnownConfigNames.CliLauncherProcessStarted] = GetProcessStartTimeUnixSeconds(launcher).ToString(CultureInfo.InvariantCulture);
+                config[KnownConfigNames.CliLauncherProcessStarted] = GetProcessStartTimeUnixMilliseconds(launcher).ToString(CultureInfo.InvariantCulture);
             };
         });
 
@@ -3444,9 +3444,9 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal("certificate_trust_failed", tags[TelemetryConstants.Tags.ErrorType]);
     }
 
-    private static long GetProcessStartTimeUnixSeconds(Process process)
+    private static long GetProcessStartTimeUnixMilliseconds(Process process)
     {
-        var startTime = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(process.Id);
+        var startTime = ProcessStartTimeHelper.TryGetProcessStartTimeUnixMilliseconds(process.Id);
         Assert.NotNull(startTime);
         return startTime.Value;
     }

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -285,6 +285,13 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var interactionService = new TestInteractionService();
 
+        // Drive the launcher watchdog off a fake clock so the "monitor stays disarmed" guarantee can be
+        // observed deterministically. After the backchannel disarms the monitor we advance the clock past
+        // several poll intervals: a still-armed monitor would fire and cancel the run, but a correctly
+        // disarmed one has no live timer, so nothing happens. This replaces a real-time sleep that raced
+        // the 5s teardown budget and made the regression test flaky under CI load.
+        var timeProvider = new FakeTimeProvider();
+
         var appHostDir = workspace.WorkspaceRoot.CreateSubdirectory("AppHost");
         var appHostFile = new FileInfo(Path.Combine(appHostDir.FullName, "AppHost.csproj"));
         await File.WriteAllTextAsync(appHostFile.FullName, "<Project />", TestContext.Current.CancellationToken);
@@ -344,6 +351,9 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             };
         });
 
+        services.RemoveAll<TimeProvider>();
+        services.AddSingleton<TimeProvider>(timeProvider);
+
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse($"run --apphost {appHostFile.FullName}");
@@ -354,11 +364,13 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         // is disarmed before this point.
         await dashboardRequested.Task.WaitAsync(TimeSpan.FromSeconds(30));
 
-        // Kill the launcher and give the monitor's ~1s poll generous time to (incorrectly) fire. With the
-        // fix the monitor is already disarmed, so the run must survive and reach readiness.
+        // Kill the launcher, then advance the fake clock well past the monitor's 1s poll interval. If the
+        // monitor were still armed it would tick, observe the dead launcher, and cancel the run; because it
+        // was disarmed when the backchannel came up, there is no live timer and advancing is a no-op. The
+        // run must survive and reach readiness.
         launcher.Kill(entireProcessTree: true);
         launcher.WaitForExit();
-        await Task.Delay(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        timeProvider.Advance(TimeSpan.FromSeconds(5));
 
         dashboardCanReturn.SetResult();
         await appHostReady.Task.WaitAsync(TimeSpan.FromSeconds(30));

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -395,6 +395,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         using var cts = new CancellationTokenSource();
         var interactionService = new TestInteractionService();
+        var timeProvider = new FakeTimeProvider();
 
         var appHostDir = workspace.WorkspaceRoot.CreateSubdirectory("AppHost");
         var appHostFile = new FileInfo(Path.Combine(appHostDir.FullName, "AppHost.csproj"));
@@ -407,6 +408,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         };
 
         var startupReached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var teardownStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var teardownCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var projectFactory = new TestAppHostProjectFactory
@@ -427,7 +429,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
                     // Stand in for the dotnet run shutdown ladder, which takes real time to kill the process
                     // tree. The CLI must not exit until this has finished. CancellationToken.None is
                     // deliberate: this represents teardown work that the same signal cannot itself cancel.
-                    await Task.Delay(TimeSpan.FromMilliseconds(500), CancellationToken.None);
+                    teardownStarted.TrySetResult();
+                    await Task.Delay(RunCommand.s_gracefulShutdownBudget + TimeSpan.FromSeconds(1), timeProvider, CancellationToken.None);
                     teardownCompleted.TrySetResult();
                 }
 
@@ -440,6 +443,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.InteractionServiceFactory = _ => interactionService;
             options.ProjectLocatorFactory = _ => projectLocator;
             options.AppHostProjectFactory = _ => projectFactory;
+            options.TimeProvider = timeProvider;
             options.ConfigurationCallback += config => config[KnownConfigNames.CliRunDetached] = "true";
         });
 
@@ -452,6 +456,15 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         // Once the run is in the startup window (no backchannel yet), deliver the termination signal.
         await startupReached.Task.WaitAsync(TimeSpan.FromSeconds(30));
         cts.Cancel();
+        await teardownStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        // The detached child must outlive the graceful-shutdown budget; otherwise a TERM-ignoring
+        // AppHost can still be pre-kill when the CLI child exits.
+        timeProvider.Advance(RunCommand.s_gracefulShutdownBudget + TimeSpan.FromMilliseconds(100));
+        await Task.Yield();
+        Assert.False(pendingCommand.IsCompleted, "Detached child exited before the force-kill window elapsed.");
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
 
         var exitCode = await pendingCommand.DefaultTimeout();
 

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -192,6 +192,88 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task RunCommand_DetachedChild_WhenLauncherDiesBeforeReadiness_CancelsRun()
+    {
+        // End-to-end coverage for the detached launcher-death wiring: a detached child CLI
+        // (ASPIRE_CLI_RUN_DETACHED) must watch the foreground launcher (ASPIRE_LAUNCHER_PID/STARTED) and,
+        // if the launcher dies before the AppHost reaches readiness, cancel the run so the AppHost tree is
+        // torn down instead of leaking. This exercises IsDetachedStartChild() ->
+        // LauncherLivenessMonitor.StartIfConfigured -> run cancellation that the isolated monitor unit
+        // tests do not cover.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var runCancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var buildCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var appHostDir = workspace.WorkspaceRoot.CreateSubdirectory("AppHost");
+        var appHostFile = new FileInfo(Path.Combine(appHostDir.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />", TestContext.Current.CancellationToken);
+
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                Task.FromResult(new AppHostProjectSearchResult(appHostFile, [appHostFile]))
+        };
+
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            RunAsyncCallback = async (context, ct) =>
+            {
+                context.BuildCompletionSource?.TrySetResult(true);
+                buildCompleted.SetResult();
+
+                try
+                {
+                    // Block during startup without ever signaling the backchannel, so the only thing that
+                    // can end the run is the launcher-death watchdog cancelling the run token.
+                    await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    runCancellationObserved.SetResult();
+                    throw;
+                }
+
+                return 0;
+            }
+        };
+
+        // A real, short-lived process stands in for the foreground launcher that spawned this detached
+        // child. The child watches it via ASPIRE_LAUNCHER_PID/STARTED and must react to its death.
+        using var launcher = TestProcesses.StartLongRunning();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => projectLocator;
+            options.AppHostProjectFactory = _ => projectFactory;
+            options.ConfigurationCallback += config =>
+            {
+                config[KnownConfigNames.CliRunDetached] = "true";
+                config[KnownConfigNames.CliLauncherProcessId] = launcher.Id.ToString(CultureInfo.InvariantCulture);
+                config[KnownConfigNames.CliLauncherProcessStarted] = ((DateTimeOffset)launcher.StartTime).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"run --apphost {appHostFile.FullName}");
+
+        var pendingRun = result.InvokeAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Once build completes the child is in the startup window with the launcher watchdog armed.
+        // Killing the launcher now must cancel the run rather than leak the AppHost.
+        await buildCompleted.Task.DefaultTimeout();
+        launcher.Kill(entireProcessTree: true);
+        launcher.WaitForExit();
+
+        // The monitor polls roughly once a second; allow generous margin for CI contention.
+        await runCancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        var exitCode = await pendingRun.DefaultTimeout();
+
+        Assert.True(runCancellationObserved.Task.IsCompletedSuccessfully);
+        Assert.Equal(CliExitCodes.FailedToDotnetRunAppHost, exitCode);
+    }
+
+    [Fact]
     public async Task RunCommand_StartupTimeoutBudgetIncludesBuildAndBackchannelWaits()
     {
         var interactionService = new TestInteractionService();

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -249,7 +249,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             {
                 config[KnownConfigNames.CliRunDetached] = "true";
                 config[KnownConfigNames.CliLauncherProcessId] = launcher.Id.ToString(CultureInfo.InvariantCulture);
-                config[KnownConfigNames.CliLauncherProcessStarted] = ((DateTimeOffset)launcher.StartTime).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+                config[KnownConfigNames.CliLauncherProcessStarted] = GetProcessStartTimeUnixSeconds(launcher).ToString(CultureInfo.InvariantCulture);
             };
         });
 
@@ -347,7 +347,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             {
                 config[KnownConfigNames.CliRunDetached] = "true";
                 config[KnownConfigNames.CliLauncherProcessId] = launcher.Id.ToString(CultureInfo.InvariantCulture);
-                config[KnownConfigNames.CliLauncherProcessStarted] = ((DateTimeOffset)launcher.StartTime).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+                config[KnownConfigNames.CliLauncherProcessStarted] = GetProcessStartTimeUnixSeconds(launcher).ToString(CultureInfo.InvariantCulture);
             };
         });
 
@@ -3429,6 +3429,13 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(detached, tags[TelemetryConstants.Tags.AppHostDetached]);
         Assert.Equal(isolated, tags[TelemetryConstants.Tags.AppHostIsolated]);
         Assert.Equal("certificate_trust_failed", tags[TelemetryConstants.Tags.ErrorType]);
+    }
+
+    private static long GetProcessStartTimeUnixSeconds(Process process)
+    {
+        var startTime = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(process.Id);
+        Assert.NotNull(startTime);
+        return startTime.Value;
     }
 
 }

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -274,6 +274,182 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task RunCommand_DetachedChild_WhenLauncherDiesAfterBackchannelEstablished_DoesNotCancelRun()
+    {
+        // Regression test for the detached-start happy-path race (PR #18566 scenario 2): once the
+        // child<->AppHost backchannel is established the launcher watchdog must be disarmed, so the
+        // foreground launcher exiting normally (right after it observes readiness) does NOT tear the
+        // detached AppHost down. Before the fix the monitor was only disarmed after full readiness, so a
+        // launcher exit during GetDashboardUrlsAsync / the early-exit observation window cancelled a
+        // healthy run.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        var appHostDir = workspace.WorkspaceRoot.CreateSubdirectory("AppHost");
+        var appHostFile = new FileInfo(Path.Combine(appHostDir.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />", TestContext.Current.CancellationToken);
+
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                Task.FromResult(new AppHostProjectSearchResult(appHostFile, [appHostFile]))
+        };
+
+        var dashboardRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var dashboardCanReturn = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appHostReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appHostCanExit = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            RunAsyncCallback = async (context, cancellationToken) =>
+            {
+                context.BuildCompletionSource?.TrySetResult(true);
+                context.BackchannelCompletionSource?.TrySetResult(new TestAppHostBackchannel
+                {
+                    NotifyAppHostReadyAsyncCalled = appHostReady,
+                    GetDashboardUrlsAsyncCallback = async ct =>
+                    {
+                        // The backchannel is established and the launcher watchdog has already been
+                        // disarmed by the time GetDashboardUrlsAsync runs. Signal the test so it can kill
+                        // the launcher, then wait for the test to confirm the run survived before returning
+                        // healthy dashboard URLs so startup can proceed to readiness.
+                        dashboardRequested.TrySetResult();
+                        await dashboardCanReturn.Task.WaitAsync(ct);
+                        return new DashboardUrlsState { DashboardHealthy = true };
+                    }
+                });
+
+                // Keep the AppHost "running" until the test allows it to exit, so the run stays alive after
+                // readiness instead of completing during the early-exit observation window.
+                await appHostCanExit.Task.WaitAsync(cancellationToken);
+                return CliExitCodes.Success;
+            }
+        };
+
+        // A real, short-lived process stands in for the foreground launcher. The child watches it via
+        // ASPIRE_LAUNCHER_PID/STARTED and must stop reacting to its death once the backchannel is up.
+        using var launcher = TestProcesses.StartLongRunning();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.ProjectLocatorFactory = _ => projectLocator;
+            options.AppHostProjectFactory = _ => projectFactory;
+            options.ConfigurationCallback += config =>
+            {
+                config[KnownConfigNames.CliRunDetached] = "true";
+                config[KnownConfigNames.CliLauncherProcessId] = launcher.Id.ToString(CultureInfo.InvariantCulture);
+                config[KnownConfigNames.CliLauncherProcessStarted] = ((DateTimeOffset)launcher.StartTime).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"run --apphost {appHostFile.FullName}");
+
+        var pendingCommand = result.InvokeAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Wait until startup has established the backchannel and is fetching dashboard URLs; the monitor
+        // is disarmed before this point.
+        await dashboardRequested.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Kill the launcher and give the monitor's ~1s poll generous time to (incorrectly) fire. With the
+        // fix the monitor is already disarmed, so the run must survive and reach readiness.
+        launcher.Kill(entireProcessTree: true);
+        launcher.WaitForExit();
+        await Task.Delay(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+
+        dashboardCanReturn.SetResult();
+        await appHostReady.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Tear down cleanly and confirm the run completed successfully rather than being cancelled by the
+        // dead launcher.
+        appHostCanExit.SetResult();
+        var exitCode = await pendingCommand.DefaultTimeout();
+
+        Assert.True(appHostReady.Task.IsCompletedSuccessfully);
+        Assert.Equal(CliExitCodes.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task RunCommand_DetachedChild_WhenSignaledBeforeReadiness_AwaitsAppHostTeardownBeforeExit()
+    {
+        // Regression test for the detached-start teardown leak (PR #18566 scenario 3): when a termination
+        // signal cancels the run before the AppHost backchannel is established, the detached child must wait
+        // for the AppHost (dotnet run) shutdown to finish before the CLI process exits. Before the fix the
+        // child returned immediately, abandoning the in-flight teardown and orphaning a dotnet run process
+        // that aspire ps could not even see (its backchannel never came up).
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var cts = new CancellationTokenSource();
+        var interactionService = new TestInteractionService();
+
+        var appHostDir = workspace.WorkspaceRoot.CreateSubdirectory("AppHost");
+        var appHostFile = new FileInfo(Path.Combine(appHostDir.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />", TestContext.Current.CancellationToken);
+
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                Task.FromResult(new AppHostProjectSearchResult(appHostFile, [appHostFile]))
+        };
+
+        var startupReached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var teardownCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            RunAsyncCallback = async (context, cancellationToken) =>
+            {
+                // Report a successful build but never establish the backchannel, mirroring an AppHost that
+                // is still in a long startup delay when the termination signal arrives.
+                context.BuildCompletionSource?.TrySetResult(true);
+                startupReached.TrySetResult();
+
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Stand in for the dotnet run shutdown ladder, which takes real time to kill the process
+                    // tree. The CLI must not exit until this has finished. CancellationToken.None is
+                    // deliberate: this represents teardown work that the same signal cannot itself cancel.
+                    await Task.Delay(TimeSpan.FromMilliseconds(500), CancellationToken.None);
+                    teardownCompleted.TrySetResult();
+                }
+
+                return CliExitCodes.Cancelled;
+            }
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.ProjectLocatorFactory = _ => projectLocator;
+            options.AppHostProjectFactory = _ => projectFactory;
+            options.ConfigurationCallback += config => config[KnownConfigNames.CliRunDetached] = "true";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"run --apphost {appHostFile.FullName}");
+
+        var pendingCommand = result.InvokeAsync(cancellationToken: cts.Token);
+
+        // Once the run is in the startup window (no backchannel yet), deliver the termination signal.
+        await startupReached.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        cts.Cancel();
+
+        var exitCode = await pendingCommand.DefaultTimeout();
+
+        // The command must not have returned until the AppHost teardown finished; otherwise the real
+        // dotnet run process would be orphaned below the backchannel-ready point.
+        Assert.True(teardownCompleted.Task.IsCompletedSuccessfully, "Detached child exited before the AppHost teardown completed.");
+        Assert.Equal(CliExitCodes.Success, exitCode);
+    }
+
+    [Fact]
     public async Task RunCommand_StartupTimeoutBudgetIncludesBuildAndBackchannelWaits()
     {
         var interactionService = new TestInteractionService();

--- a/tests/Aspire.Cli.Tests/DotNet/ProcessInvocationOptionsTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/ProcessInvocationOptionsTests.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Aspire.Cli.DotNet;
+using Aspire.Cli.Tests.TestServices;
+
+namespace Aspire.Cli.Tests.DotNet;
+
+public sealed class ProcessInvocationOptionsTests
+{
+    [Fact]
+    public void Clone_CopiesEveryProperty()
+    {
+        // Reflection-driven on purpose: adding a property to ProcessInvocationOptions without also
+        // forwarding it in Clone() must fail this test rather than silently drop the value on the copy —
+        // the exact "silently break" hazard Clone() exists to guard against.
+        var original = new ProcessInvocationOptions
+        {
+            StandardOutputCallback = _ => { },
+            StandardErrorCallback = _ => { },
+            NoLaunchProfile = true,
+            StartDebugSession = true,
+            Debug = true,
+            SuppressLogging = true,
+            // Non-default: this property initializes to true, so false is the "changed" value.
+            KillEntireProcessTreeOnCancel = false,
+            IsolateConsole = true,
+            KillOnParentExit = true,
+            GracefulShutdownSignaler = new RecordingGracefulSignaler(),
+            ShutdownService = new TestGracefulShutdownWindow(),
+        };
+
+        // Compare against a pristine instance so we assert every property was given a value that
+        // actually differs from its default; otherwise the copy check below could pass vacuously.
+        var defaults = new ProcessInvocationOptions();
+        foreach (var property in GetSettableProperties())
+        {
+            Assert.False(
+                Equals(property.GetValue(original), property.GetValue(defaults)),
+                $"Property '{property.Name}' was not set to a non-default value in this test; add one so Clone() coverage stays meaningful.");
+        }
+
+        var clone = original.Clone();
+
+        Assert.NotSame(original, clone);
+        foreach (var property in GetSettableProperties())
+        {
+            Assert.Equal(property.GetValue(original), property.GetValue(clone));
+        }
+    }
+
+    private static IEnumerable<PropertyInfo> GetSettableProperties() =>
+        typeof(ProcessInvocationOptions)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p is { CanRead: true, CanWrite: true });
+}

--- a/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Cli.Layout;
+using Aspire.Cli.Tests.TestServices;
+
+namespace Aspire.Cli.Tests.LayoutTests;
+
+public class LayoutProcessRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_InjectsOrphanDetectionEnvironment()
+    {
+        IDictionary<string, string>? capturedEnv = null;
+        var factory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (_, env, _, _) => capturedEnv = env,
+            DefaultExitCode = 0,
+        };
+        var runner = new LayoutProcessRunner(factory);
+
+        await runner.RunAsync("tool", ["arg"], ct: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(capturedEnv);
+        Assert.Equal(Environment.ProcessId.ToString(CultureInfo.InvariantCulture), capturedEnv["ASPIRE_CLI_PID"]);
+        Assert.True(capturedEnv.ContainsKey("ASPIRE_CLI_STARTED"));
+    }
+
+    [Fact]
+    public async Task RunAsync_DoesNotOverrideCallerSuppliedOrphanEnvironment()
+    {
+        IDictionary<string, string>? capturedEnv = null;
+        var factory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (_, env, _, _) => capturedEnv = env,
+            DefaultExitCode = 0,
+        };
+        var runner = new LayoutProcessRunner(factory);
+
+        var callerEnv = new Dictionary<string, string> { ["ASPIRE_CLI_PID"] = "999" };
+
+        await runner.RunAsync("tool", ["arg"], environmentVariables: callerEnv, ct: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(capturedEnv);
+        Assert.Equal("999", capturedEnv["ASPIRE_CLI_PID"]);
+        // The caller's dictionary must not be mutated.
+        Assert.False(callerEnv.ContainsKey("ASPIRE_CLI_STARTED"));
+    }
+}

--- a/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
@@ -47,4 +47,46 @@ public class LayoutProcessRunnerTests
         // The caller's dictionary must not be mutated.
         Assert.False(callerEnv.ContainsKey("ASPIRE_CLI_STARTED"));
     }
+
+    [Fact]
+    public async Task StartAsync_InjectsOrphanDetectionEnvironment()
+    {
+        // StartAsync launches long-lived children (aspire-managed dashboard for `aspire dashboard run`
+        // and the profiling collector), so it must stamp the same orphan-detection identity as RunAsync
+        // or those children cannot self-terminate when the CLI is hard-killed.
+        IDictionary<string, string>? capturedEnv = null;
+        var factory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (_, env, _, _) => capturedEnv = env,
+            DefaultExitCode = 0,
+        };
+        var runner = new LayoutProcessRunner(factory);
+
+        await using var execution = await runner.StartAsync("tool", ["arg"]);
+
+        Assert.NotNull(capturedEnv);
+        Assert.Equal(Environment.ProcessId.ToString(CultureInfo.InvariantCulture), capturedEnv["ASPIRE_CLI_PID"]);
+        Assert.True(capturedEnv.ContainsKey("ASPIRE_CLI_STARTED"));
+    }
+
+    [Fact]
+    public async Task StartAsync_DoesNotOverrideCallerSuppliedOrphanEnvironment()
+    {
+        IDictionary<string, string>? capturedEnv = null;
+        var factory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (_, env, _, _) => capturedEnv = env,
+            DefaultExitCode = 0,
+        };
+        var runner = new LayoutProcessRunner(factory);
+
+        var callerEnv = new Dictionary<string, string> { ["ASPIRE_CLI_PID"] = "999" };
+
+        await using var execution = await runner.StartAsync("tool", ["arg"], environmentVariables: callerEnv);
+
+        Assert.NotNull(capturedEnv);
+        Assert.Equal("999", capturedEnv["ASPIRE_CLI_PID"]);
+        // The caller's dictionary must not be mutated.
+        Assert.False(callerEnv.ContainsKey("ASPIRE_CLI_STARTED"));
+    }
 }

--- a/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Cli.DotNet;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Tests.TestServices;
 
@@ -88,5 +89,82 @@ public class LayoutProcessRunnerTests
         Assert.Equal("999", capturedEnv["ASPIRE_CLI_PID"]);
         // The caller's dictionary must not be mutated.
         Assert.False(callerEnv.ContainsKey("ASPIRE_CLI_STARTED"));
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenKillOnParentExitRequested_SetsInvocationOption()
+    {
+        // killOnParentExit is the Windows OS-level backstop (kill-on-close job) layered on top of the
+        // cross-platform env-stamped watchdog; it must flow through to the ProcessInvocationOptions the
+        // factory receives so the spawn path can assign the child to the job.
+        ProcessInvocationOptions? capturedOptions = null;
+        var factory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (_, _, _, options) => capturedOptions = options,
+            DefaultExitCode = 0,
+        };
+        var runner = new LayoutProcessRunner(factory);
+
+        await runner.RunAsync("tool", ["arg"], killOnParentExit: true, ct: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(capturedOptions);
+        Assert.True(capturedOptions.KillOnParentExit);
+    }
+
+    [Fact]
+    public async Task RunAsync_DefaultsKillOnParentExitToFalse()
+    {
+        // The backstop is opt-in: build/restore/etc. callers that don't ask for it must not be bound to
+        // the kill-on-close job, preserving the existing force-kill/back-compat behavior.
+        ProcessInvocationOptions? capturedOptions = null;
+        var factory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (_, _, _, options) => capturedOptions = options,
+            DefaultExitCode = 0,
+        };
+        var runner = new LayoutProcessRunner(factory);
+
+        await runner.RunAsync("tool", ["arg"], ct: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(capturedOptions);
+        Assert.False(capturedOptions.KillOnParentExit);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenKillOnParentExitRequested_SetsInvocationOption()
+    {
+        ProcessInvocationOptions? capturedOptions = null;
+        var factory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (_, _, _, options) => capturedOptions = options,
+            DefaultExitCode = 0,
+        };
+        var runner = new LayoutProcessRunner(factory);
+
+        await using var execution = await runner.StartAsync("tool", ["arg"], killOnParentExit: true);
+
+        Assert.NotNull(capturedOptions);
+        Assert.True(capturedOptions.KillOnParentExit);
+    }
+
+    [Fact]
+    public async Task StartAsync_PreservesCallerSuppliedKillOnParentExit()
+    {
+        // StartAsync only ever turns the flag on, never off, so a caller that already opted in via its
+        // own options is not silently downgraded when it omits the killOnParentExit argument.
+        ProcessInvocationOptions? capturedOptions = null;
+        var factory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (_, _, _, options) => capturedOptions = options,
+            DefaultExitCode = 0,
+        };
+        var runner = new LayoutProcessRunner(factory);
+
+        var callerOptions = new ProcessInvocationOptions { KillOnParentExit = true };
+
+        await using var execution = await runner.StartAsync("tool", ["arg"], options: callerOptions);
+
+        Assert.NotNull(capturedOptions);
+        Assert.True(capturedOptions.KillOnParentExit);
     }
 }

--- a/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
@@ -167,4 +167,30 @@ public class LayoutProcessRunnerTests
         Assert.NotNull(capturedOptions);
         Assert.True(capturedOptions.KillOnParentExit);
     }
+
+    [Fact]
+    public async Task StartAsync_WhenKillOnParentExitRequested_DoesNotMutateCallerOptions()
+    {
+        // The killOnParentExit flag is applied to a clone, never the caller's instance, so a caller that
+        // reuses a single ProcessInvocationOptions across calls is not silently bound to the kill-on-close
+        // job on a later invocation that happens to request it.
+        ProcessInvocationOptions? capturedOptions = null;
+        var factory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (_, _, _, options) => capturedOptions = options,
+            DefaultExitCode = 0,
+        };
+        var runner = new LayoutProcessRunner(factory);
+
+        var callerOptions = new ProcessInvocationOptions { KillOnParentExit = false };
+
+        await using var execution = await runner.StartAsync("tool", ["arg"], options: callerOptions, killOnParentExit: true);
+
+        Assert.NotNull(capturedOptions);
+        // The child was launched with the flag set...
+        Assert.True(capturedOptions.KillOnParentExit);
+        // ...but the caller's own instance was left untouched.
+        Assert.NotSame(callerOptions, capturedOptions);
+        Assert.False(callerOptions.KillOnParentExit);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
@@ -94,9 +94,9 @@ public class LayoutProcessRunnerTests
     [Fact]
     public async Task RunAsync_WhenKillOnParentExitRequested_SetsInvocationOption()
     {
-        // killOnParentExit is the Windows OS-level backstop (kill-on-close job) layered on top of the
-        // cross-platform env-stamped watchdog; it must flow through to the ProcessInvocationOptions the
-        // factory receives so the spawn path can assign the child to the job.
+        // killOnParentExit binds the child to the Windows kill-on-close job; it must flow through to the
+        // ProcessInvocationOptions the factory receives so the spawn path can assign the child to the job.
+        // (On Windows this also disarms the cooperative watchdog identity — asserted separately below.)
         ProcessInvocationOptions? capturedOptions = null;
         var factory = new TestProcessExecutionFactory
         {
@@ -192,5 +192,67 @@ public class LayoutProcessRunnerTests
         // ...but the caller's own instance was left untouched.
         Assert.NotSame(callerOptions, capturedOptions);
         Assert.False(callerOptions.KillOnParentExit);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenKillOnParentExit_DisarmsCooperativeWatchdogOnWindowsOnly()
+    {
+        // The Windows kill-on-close job and the cross-platform cooperative watchdog are redundant
+        // implementations of the same "don't outlive the CLI" policy; arming both on one child races the
+        // job's kernel TerminateProcess against the watchdog's Environment.Exit at CLI exit and can get the child stuck. 
+        // So on Windows (where the job applies) the watchdog identity is NOT stamped via environment variables, 
+        // while on other hosts (where KillOnParentExit is a no-op) the watchdog is the mechanism 
+        // and receivers relevant environment variables.
+        IDictionary<string, string>? capturedEnv = null;
+        ProcessInvocationOptions? capturedOptions = null;
+        var factory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (_, env, _, options) => { capturedEnv = env; capturedOptions = options; },
+            DefaultExitCode = 0,
+        };
+        var runner = new LayoutProcessRunner(factory);
+
+        await runner.RunAsync("tool", ["arg"], killOnParentExit: true, ct: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(capturedOptions);
+        Assert.True(capturedOptions.KillOnParentExit);
+        Assert.NotNull(capturedEnv);
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.False(capturedEnv.ContainsKey("ASPIRE_CLI_PID"));
+        }
+        else
+        {
+            Assert.True(capturedEnv.ContainsKey("ASPIRE_CLI_PID"));
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenKillOnParentExit_DisarmsCooperativeWatchdogOnWindowsOnly()
+    {
+        // Same mutual-exclusion contract as RunAsync above, for the long-lived StartAsync helpers
+        // (aspire-managed dashboard, profiling collector).
+        IDictionary<string, string>? capturedEnv = null;
+        ProcessInvocationOptions? capturedOptions = null;
+        var factory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (_, env, _, options) => { capturedEnv = env; capturedOptions = options; },
+            DefaultExitCode = 0,
+        };
+        var runner = new LayoutProcessRunner(factory);
+
+        await using var execution = await runner.StartAsync("tool", ["arg"], killOnParentExit: true);
+
+        Assert.NotNull(capturedOptions);
+        Assert.True(capturedOptions.KillOnParentExit);
+        Assert.NotNull(capturedEnv);
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.False(capturedEnv.ContainsKey("ASPIRE_CLI_PID"));
+        }
+        else
+        {
+            Assert.True(capturedEnv.ContainsKey("ASPIRE_CLI_PID"));
+        }
     }
 }

--- a/tests/Aspire.Cli.Tests/NuGet/BundleNuGetPackageCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/BundleNuGetPackageCacheTests.cs
@@ -62,4 +62,53 @@ public class BundleNuGetPackageCacheTests(ITestOutputHelper outputHelper)
             package => Assert.Equal("13.2.0", package.Version),
             package => Assert.Equal("13.3.0", package.Version));
     }
+
+    [Fact]
+    public async Task GetPackageVersionsAsync_RequestsKillOnParentExitForSearchHelper()
+    {
+        // The aspire-managed NuGet search helper can hang against a slow/unresponsive source, so the
+        // search launch must bind it to the Windows kill-on-close job (KillOnParentExit) as an OS-level
+        // backstop against leaking the helper when the CLI is hard-killed.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var layout = new LayoutConfiguration
+        {
+            LayoutPath = workspace.WorkspaceRoot.FullName,
+            Components = new LayoutComponents
+            {
+                Managed = "managed"
+            }
+        };
+
+        var managedDirectory = workspace.WorkspaceRoot.CreateSubdirectory("managed");
+        var managedPath = layout.GetManagedPath();
+        Assert.NotNull(managedPath);
+        await File.WriteAllTextAsync(managedPath!, string.Empty);
+
+        var bundleService = new TestBundleService(isBundle: true)
+        {
+            Layout = layout
+        };
+
+        var executionFactory = new TestProcessExecutionFactory
+        {
+            AttemptCallback = (_, _) => (0, """{"packages":[],"totalHits":0}""")
+        };
+
+        var cache = new BundleNuGetPackageCache(
+            bundleService,
+            new LayoutProcessRunner(executionFactory),
+            NullLogger<BundleNuGetPackageCache>.Instance,
+            new TestFeatures());
+
+        await cache.GetPackageVersionsAsync(
+            workspace.WorkspaceRoot,
+            "Aspire.Hosting.Redis",
+            prerelease: false,
+            nugetConfigFile: null,
+            useCache: true,
+            CancellationToken.None);
+
+        Assert.True(executionFactory.LastProcessInvocationOptions?.KillOnParentExit);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Processes/DetachedProcessLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/DetachedProcessLauncherTests.cs
@@ -13,7 +13,7 @@ public class DetachedProcessLauncherTests
     // DetachedProcessLauncher.StartWindows points both Stdout and Stderr at the same NUL
     // handle, and PROC_THREAD_ATTRIBUTE_HANDLE_LIST rejects duplicate handle values —
     // CreateProcessW returns ERROR_INVALID_PARAMETER (87). The unified
-    // WindowsProcessInterop.SpawnConsoleIsolatedProcess de-duplicates the inheritable
+    // WindowsProcessInterop.SpawnProcess de-duplicates the inheritable
     // handle list, so this spawn must succeed.
     [Fact]
     [SupportedOSPlatform("windows")]

--- a/tests/Aspire.Cli.Tests/Processes/LauncherLivenessMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/LauncherLivenessMonitorTests.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using Aspire.Cli.Processes;
+using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -103,15 +104,5 @@ public class LauncherLivenessMonitorTests
             .Build();
     }
 
-    private static Process StartLongRunningProcess()
-    {
-        // Mirrors CliOrphanDetectorTests' cross-platform process choice for CI reliability.
-        var psi = OperatingSystem.IsWindows()
-            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
-            : new ProcessStartInfo("tail", "-f /dev/null") { CreateNoWindow = true };
-
-        var process = Process.Start(psi);
-        Assert.NotNull(process);
-        return process;
-    }
+    private static Process StartLongRunningProcess() => TestProcesses.StartLongRunning();
 }

--- a/tests/Aspire.Cli.Tests/Processes/LauncherLivenessMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/LauncherLivenessMonitorTests.cs
@@ -55,7 +55,7 @@ public class LauncherLivenessMonitorTests
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["ASPIRE_LAUNCHER_PID"] = Environment.ProcessId.ToString(CultureInfo.InvariantCulture),
-                ["ASPIRE_LAUNCHER_STARTED"] = ((DateTimeOffset)Process.GetCurrentProcess().StartTime).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture),
+                ["ASPIRE_LAUNCHER_STARTED"] = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds().ToString(CultureInfo.InvariantCulture),
             })
             .Build();
         using var runCts = new CancellationTokenSource();
@@ -99,10 +99,17 @@ public class LauncherLivenessMonitorTests
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["ASPIRE_LAUNCHER_PID"] = launcher.Id.ToString(CultureInfo.InvariantCulture),
-                ["ASPIRE_LAUNCHER_STARTED"] = ((DateTimeOffset)launcher.StartTime).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture),
+                ["ASPIRE_LAUNCHER_STARTED"] = GetProcessStartTimeUnixSeconds(launcher).ToString(CultureInfo.InvariantCulture),
             })
             .Build();
     }
 
     private static Process StartLongRunningProcess() => TestProcesses.StartLongRunning();
+
+    private static long GetProcessStartTimeUnixSeconds(Process process)
+    {
+        var startTime = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(process.Id);
+        Assert.NotNull(startTime);
+        return startTime.Value;
+    }
 }

--- a/tests/Aspire.Cli.Tests/Processes/LauncherLivenessMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/LauncherLivenessMonitorTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Globalization;
 using Aspire.Cli.Processes;
-using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/tests/Aspire.Cli.Tests/Processes/LauncherLivenessMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/LauncherLivenessMonitorTests.cs
@@ -54,7 +54,7 @@ public class LauncherLivenessMonitorTests
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["ASPIRE_LAUNCHER_PID"] = Environment.ProcessId.ToString(CultureInfo.InvariantCulture),
-                ["ASPIRE_LAUNCHER_STARTED"] = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds().ToString(CultureInfo.InvariantCulture),
+                ["ASPIRE_LAUNCHER_STARTED"] = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixMilliseconds().ToString(CultureInfo.InvariantCulture),
             })
             .Build();
         using var runCts = new CancellationTokenSource();
@@ -98,16 +98,16 @@ public class LauncherLivenessMonitorTests
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["ASPIRE_LAUNCHER_PID"] = launcher.Id.ToString(CultureInfo.InvariantCulture),
-                ["ASPIRE_LAUNCHER_STARTED"] = GetProcessStartTimeUnixSeconds(launcher).ToString(CultureInfo.InvariantCulture),
+                ["ASPIRE_LAUNCHER_STARTED"] = GetProcessStartTimeUnixMilliseconds(launcher).ToString(CultureInfo.InvariantCulture),
             })
             .Build();
     }
 
     private static Process StartLongRunningProcess() => TestProcesses.StartLongRunning();
 
-    private static long GetProcessStartTimeUnixSeconds(Process process)
+    private static long GetProcessStartTimeUnixMilliseconds(Process process)
     {
-        var startTime = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(process.Id);
+        var startTime = ProcessStartTimeHelper.TryGetProcessStartTimeUnixMilliseconds(process.Id);
         Assert.NotNull(startTime);
         return startTime.Value;
     }

--- a/tests/Aspire.Cli.Tests/Processes/LauncherLivenessMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/LauncherLivenessMonitorTests.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Globalization;
+using Aspire.Cli.Processes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Processes;
+
+public class LauncherLivenessMonitorTests
+{
+    private static readonly TimeSpan s_observationTimeout = TimeSpan.FromSeconds(15);
+
+    [Fact]
+    public void StartIfConfigured_WithoutLauncherConfig_ReturnsNull()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        using var runCts = new CancellationTokenSource();
+
+        var monitor = LauncherLivenessMonitor.StartIfConfigured(configuration, runCts, TimeProvider.System, NullLogger.Instance);
+
+        Assert.Null(monitor);
+        Assert.False(runCts.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task LauncherExit_CancelsRun()
+    {
+        using var launcher = StartLongRunningProcess();
+        var configuration = CreateLauncherConfiguration(launcher);
+        using var runCts = new CancellationTokenSource();
+
+        var cancelTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var registration = runCts.Token.Register(() => cancelTcs.TrySetResult());
+
+        await using var monitor = LauncherLivenessMonitor.StartIfConfigured(configuration, runCts, TimeProvider.System, NullLogger.Instance);
+        Assert.NotNull(monitor);
+
+        // The launcher dies while the monitor is armed: the run must be cancelled so the AppHost is torn down.
+        launcher.Kill(entireProcessTree: true);
+        launcher.WaitForExit();
+
+        await cancelTcs.Task.WaitAsync(s_observationTimeout);
+        Assert.True(runCts.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task LauncherAlive_DoesNotCancelRun()
+    {
+        // The current process stands in for a launcher that stays alive through startup.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPIRE_LAUNCHER_PID"] = Environment.ProcessId.ToString(CultureInfo.InvariantCulture),
+                ["ASPIRE_LAUNCHER_STARTED"] = ((DateTimeOffset)Process.GetCurrentProcess().StartTime).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture),
+            })
+            .Build();
+        using var runCts = new CancellationTokenSource();
+
+        await using (var monitor = LauncherLivenessMonitor.StartIfConfigured(configuration, runCts, TimeProvider.System, NullLogger.Instance))
+        {
+            Assert.NotNull(monitor);
+
+            // Give the monitor several poll intervals to (incorrectly) fire.
+            await Task.Delay(TimeSpan.FromSeconds(3));
+            Assert.False(runCts.IsCancellationRequested);
+        }
+
+        Assert.False(runCts.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task Dispose_DisarmsMonitor()
+    {
+        using var launcher = StartLongRunningProcess();
+        var configuration = CreateLauncherConfiguration(launcher);
+        using var runCts = new CancellationTokenSource();
+
+        var monitor = LauncherLivenessMonitor.StartIfConfigured(configuration, runCts, TimeProvider.System, NullLogger.Instance);
+        Assert.NotNull(monitor);
+
+        // Disarm first (mimicking startup reaching readiness), then kill the launcher. A disarmed monitor
+        // must not cancel the run when the launcher later exits normally.
+        await monitor.DisposeAsync();
+
+        launcher.Kill(entireProcessTree: true);
+        launcher.WaitForExit();
+
+        await Task.Delay(TimeSpan.FromSeconds(3));
+        Assert.False(runCts.IsCancellationRequested);
+    }
+
+    private static IConfiguration CreateLauncherConfiguration(Process launcher)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPIRE_LAUNCHER_PID"] = launcher.Id.ToString(CultureInfo.InvariantCulture),
+                ["ASPIRE_LAUNCHER_STARTED"] = ((DateTimeOffset)launcher.StartTime).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture),
+            })
+            .Build();
+    }
+
+    private static Process StartLongRunningProcess()
+    {
+        // Mirrors CliOrphanDetectorTests' cross-platform process choice for CI reliability.
+        var psi = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
+            : new ProcessStartInfo("tail", "-f /dev/null") { CreateNoWindow = true };
+
+        var process = Process.Start(psi);
+        Assert.NotNull(process);
+        return process;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Processes/OrphanDetectionEnvironmentTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/OrphanDetectionEnvironmentTests.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Cli.Processes;
+using Aspire.Hosting;
+
+namespace Aspire.Cli.Tests.Processes;
+
+public class OrphanDetectionEnvironmentTests
+{
+    [Fact]
+    public void ApplyCurrentProcess_StampsPidAndStartTime()
+    {
+        var environment = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        OrphanDetectionEnvironment.ApplyCurrentProcess(environment);
+
+        Assert.Equal(Environment.ProcessId.ToString(CultureInfo.InvariantCulture), environment[KnownConfigNames.CliProcessId]);
+        Assert.NotNull(ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(environment[KnownConfigNames.CliProcessStarted]));
+    }
+
+    [Fact]
+    public void ApplyCurrentProcess_UsesSuppliedKeyNames()
+    {
+        var environment = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        OrphanDetectionEnvironment.ApplyCurrentProcess(environment, KnownConfigNames.CliLauncherProcessId, KnownConfigNames.CliLauncherProcessStarted);
+
+        Assert.Equal(Environment.ProcessId.ToString(CultureInfo.InvariantCulture), environment[KnownConfigNames.CliLauncherProcessId]);
+        Assert.NotNull(ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(environment[KnownConfigNames.CliLauncherProcessStarted]));
+        Assert.False(environment.ContainsKey(KnownConfigNames.CliProcessId));
+    }
+
+    [Fact]
+    public void ApplyCurrentProcess_WithoutOverwrite_PreservesCallerValues()
+    {
+        var environment = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [KnownConfigNames.CliProcessId] = "999",
+        };
+
+        OrphanDetectionEnvironment.ApplyCurrentProcess(environment, overwrite: false);
+
+        Assert.Equal("999", environment[KnownConfigNames.CliProcessId]);
+        // The caller did not supply a start time, so it is still stamped even under overwrite: false.
+        Assert.NotNull(ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(environment[KnownConfigNames.CliProcessStarted]));
+    }
+
+    [Fact]
+    public void ApplyCurrentProcess_WithOverwrite_ReplacesCallerValues()
+    {
+        var environment = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [KnownConfigNames.CliProcessId] = "999",
+        };
+
+        OrphanDetectionEnvironment.ApplyCurrentProcess(environment, overwrite: true);
+
+        Assert.Equal(Environment.ProcessId.ToString(CultureInfo.InvariantCulture), environment[KnownConfigNames.CliProcessId]);
+    }
+
+    [Fact]
+    public void Apply_WithStartTime_StampsBothKeys()
+    {
+        var environment = new Dictionary<string, string?>(StringComparer.Ordinal);
+
+        OrphanDetectionEnvironment.Apply(environment, pid: 4321, startTimeUnixSeconds: 1000, KnownConfigNames.RemoteAppHostProcessId, KnownConfigNames.RemoteAppHostProcessStarted);
+
+        Assert.Equal("4321", environment[KnownConfigNames.RemoteAppHostProcessId]);
+        Assert.Equal("1000", environment[KnownConfigNames.RemoteAppHostProcessStarted]);
+    }
+
+    [Fact]
+    public void Apply_WithNullStartTime_StampsPidOnly()
+    {
+        var environment = new Dictionary<string, string?>(StringComparer.Ordinal);
+
+        OrphanDetectionEnvironment.Apply(environment, pid: 4321, startTimeUnixSeconds: null, KnownConfigNames.CliProcessId, KnownConfigNames.CliProcessStarted);
+
+        Assert.Equal("4321", environment[KnownConfigNames.CliProcessId]);
+        Assert.False(environment.ContainsKey(KnownConfigNames.CliProcessStarted));
+    }
+
+    [Fact]
+    public void Apply_WithoutOverwrite_PreservesCallerValues()
+    {
+        var environment = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [KnownConfigNames.CliProcessId] = "999",
+            [KnownConfigNames.CliProcessStarted] = "111",
+        };
+
+        OrphanDetectionEnvironment.Apply(environment, pid: 4321, startTimeUnixSeconds: 1000, KnownConfigNames.CliProcessId, KnownConfigNames.CliProcessStarted, overwrite: false);
+
+        Assert.Equal("999", environment[KnownConfigNames.CliProcessId]);
+        Assert.Equal("111", environment[KnownConfigNames.CliProcessStarted]);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Processes/OrphanDetectionEnvironmentTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/OrphanDetectionEnvironmentTests.cs
@@ -45,7 +45,23 @@ public class OrphanDetectionEnvironmentTests
         OrphanDetectionEnvironment.ApplyCurrentProcess(environment, overwrite: false);
 
         Assert.Equal("999", environment[KnownConfigNames.CliProcessId]);
-        // The caller did not supply a start time, so it is still stamped even under overwrite: false.
+        // The caller-supplied PID is authoritative, so no start time is stamped: doing so would pair
+        // PID 999 with the current process's start time. Leaving the keys unset keeps the identity
+        // consistent and lets the watchdog fall back to a PID-only existence check.
+        Assert.False(environment.ContainsKey(KnownConfigNames.CliProcessStarted));
+        Assert.False(environment.ContainsKey(KnownConfigNames.CliProcessStartedStable));
+    }
+
+    [Fact]
+    public void ApplyCurrentProcess_WithoutOverwrite_StampsFullIdentityWhenNoPidPresent()
+    {
+        var environment = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        OrphanDetectionEnvironment.ApplyCurrentProcess(environment, overwrite: false);
+
+        // With no caller-supplied PID (the common LayoutProcessRunner path), the current process's
+        // identity is stamped in full and the PID and start-time values describe the same process.
+        Assert.Equal(Environment.ProcessId.ToString(CultureInfo.InvariantCulture), environment[KnownConfigNames.CliProcessId]);
         Assert.NotNull(ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(environment[KnownConfigNames.CliProcessStarted]));
         Assert.NotNull(ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(environment[KnownConfigNames.CliProcessStartedStable]));
     }
@@ -99,6 +115,8 @@ public class OrphanDetectionEnvironmentTests
 
         Assert.Equal("999", environment[KnownConfigNames.CliProcessId]);
         Assert.Equal("111", environment[KnownConfigNames.CliProcessStarted]);
-        Assert.Equal("1000", environment[KnownConfigNames.CliProcessStartedStable]);
+        // The existing PID (999) is authoritative, so the stable start time for the passed pid (4321)
+        // is not stamped — doing so would pair PID 999 with a different process's start time.
+        Assert.False(environment.ContainsKey(KnownConfigNames.CliProcessStartedStable));
     }
 }

--- a/tests/Aspire.Cli.Tests/Processes/OrphanDetectionEnvironmentTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/OrphanDetectionEnvironmentTests.cs
@@ -84,7 +84,7 @@ public class OrphanDetectionEnvironmentTests
     {
         var environment = new Dictionary<string, string?>(StringComparer.Ordinal);
 
-        OrphanDetectionEnvironment.Apply(environment, pid: 4321, startTimeUnixSeconds: 1000, KnownConfigNames.RemoteAppHostProcessId, KnownConfigNames.RemoteAppHostProcessStarted);
+        OrphanDetectionEnvironment.Apply(environment, pid: 4321, stableStartTimeUnixMilliseconds: 1000, KnownConfigNames.RemoteAppHostProcessId, KnownConfigNames.RemoteAppHostProcessStarted);
 
         Assert.Equal("4321", environment[KnownConfigNames.RemoteAppHostProcessId]);
         Assert.Equal("1000", environment[KnownConfigNames.RemoteAppHostProcessStarted]);
@@ -95,7 +95,7 @@ public class OrphanDetectionEnvironmentTests
     {
         var environment = new Dictionary<string, string?>(StringComparer.Ordinal);
 
-        OrphanDetectionEnvironment.Apply(environment, pid: 4321, startTimeUnixSeconds: null, KnownConfigNames.CliProcessId, KnownConfigNames.CliProcessStarted);
+        OrphanDetectionEnvironment.Apply(environment, pid: 4321, stableStartTimeUnixMilliseconds: null, KnownConfigNames.CliProcessId, KnownConfigNames.CliProcessStarted);
 
         Assert.Equal("4321", environment[KnownConfigNames.CliProcessId]);
         Assert.False(environment.ContainsKey(KnownConfigNames.CliProcessStarted));
@@ -111,7 +111,7 @@ public class OrphanDetectionEnvironmentTests
             [KnownConfigNames.CliProcessStarted] = "111",
         };
 
-        OrphanDetectionEnvironment.Apply(environment, pid: 4321, startTimeUnixSeconds: 1000, KnownConfigNames.CliProcessId, KnownConfigNames.CliProcessStarted, overwrite: false);
+        OrphanDetectionEnvironment.Apply(environment, pid: 4321, stableStartTimeUnixMilliseconds: 1000, KnownConfigNames.CliProcessId, KnownConfigNames.CliProcessStarted, overwrite: false);
 
         Assert.Equal("999", environment[KnownConfigNames.CliProcessId]);
         Assert.Equal("111", environment[KnownConfigNames.CliProcessStarted]);

--- a/tests/Aspire.Cli.Tests/Processes/OrphanDetectionEnvironmentTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/OrphanDetectionEnvironmentTests.cs
@@ -18,6 +18,7 @@ public class OrphanDetectionEnvironmentTests
 
         Assert.Equal(Environment.ProcessId.ToString(CultureInfo.InvariantCulture), environment[KnownConfigNames.CliProcessId]);
         Assert.NotNull(ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(environment[KnownConfigNames.CliProcessStarted]));
+        Assert.NotNull(ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(environment[KnownConfigNames.CliProcessStartedStable]));
     }
 
     [Fact]
@@ -30,6 +31,7 @@ public class OrphanDetectionEnvironmentTests
         Assert.Equal(Environment.ProcessId.ToString(CultureInfo.InvariantCulture), environment[KnownConfigNames.CliLauncherProcessId]);
         Assert.NotNull(ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(environment[KnownConfigNames.CliLauncherProcessStarted]));
         Assert.False(environment.ContainsKey(KnownConfigNames.CliProcessId));
+        Assert.False(environment.ContainsKey(KnownConfigNames.CliProcessStartedStable));
     }
 
     [Fact]
@@ -45,6 +47,7 @@ public class OrphanDetectionEnvironmentTests
         Assert.Equal("999", environment[KnownConfigNames.CliProcessId]);
         // The caller did not supply a start time, so it is still stamped even under overwrite: false.
         Assert.NotNull(ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(environment[KnownConfigNames.CliProcessStarted]));
+        Assert.NotNull(ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(environment[KnownConfigNames.CliProcessStartedStable]));
     }
 
     [Fact]
@@ -80,6 +83,7 @@ public class OrphanDetectionEnvironmentTests
 
         Assert.Equal("4321", environment[KnownConfigNames.CliProcessId]);
         Assert.False(environment.ContainsKey(KnownConfigNames.CliProcessStarted));
+        Assert.False(environment.ContainsKey(KnownConfigNames.CliProcessStartedStable));
     }
 
     [Fact]
@@ -95,5 +99,6 @@ public class OrphanDetectionEnvironmentTests
 
         Assert.Equal("999", environment[KnownConfigNames.CliProcessId]);
         Assert.Equal("111", environment[KnownConfigNames.CliProcessStarted]);
+        Assert.Equal("1000", environment[KnownConfigNames.CliProcessStartedStable]);
     }
 }

--- a/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Aspire.Cli.Tests.Processes;

--- a/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Cli.Tests.Processes;
+
+public class ParentProcessLivenessMonitorTests
+{
+    private static readonly TimeSpan s_observationTimeout = TimeSpan.FromSeconds(15);
+
+    [Fact]
+    public async Task ParentExit_InvokesCallback()
+    {
+        using var parent = StartLongRunningProcess();
+        var parentStartedUnix = ((DateTimeOffset)parent.StartTime).ToUnixTimeSeconds();
+
+        var exitedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var monitor = ParentProcessLivenessMonitor.Start(
+            parent.Id,
+            parentStartedUnix,
+            _ =>
+            {
+                exitedTcs.TrySetResult();
+                return Task.CompletedTask;
+            });
+
+        parent.Kill(entireProcessTree: true);
+        parent.WaitForExit();
+
+        await exitedTcs.Task.WaitAsync(s_observationTimeout);
+    }
+
+    [Fact]
+    public async Task ParentAlive_DoesNotInvokeCallback()
+    {
+        // The current process stands in for a parent that stays alive.
+        var parentStartedUnix = ((DateTimeOffset)Process.GetCurrentProcess().StartTime).ToUnixTimeSeconds();
+
+        var invoked = false;
+        await using (var monitor = ParentProcessLivenessMonitor.Start(
+            Environment.ProcessId,
+            parentStartedUnix,
+            _ =>
+            {
+                invoked = true;
+                return Task.CompletedTask;
+            }))
+        {
+            // Give the monitor several poll intervals to (incorrectly) fire.
+            await Task.Delay(TimeSpan.FromSeconds(3));
+            Assert.False(invoked);
+        }
+
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public async Task Dispose_DisarmsBeforeParentExit()
+    {
+        using var parent = StartLongRunningProcess();
+        var parentStartedUnix = ((DateTimeOffset)parent.StartTime).ToUnixTimeSeconds();
+
+        var invoked = false;
+        var monitor = ParentProcessLivenessMonitor.Start(
+            parent.Id,
+            parentStartedUnix,
+            _ =>
+            {
+                invoked = true;
+                return Task.CompletedTask;
+            });
+
+        // Disarm first, then kill the parent. A disposed monitor must not invoke the callback.
+        await monitor.DisposeAsync();
+
+        parent.Kill(entireProcessTree: true);
+        parent.WaitForExit();
+
+        await Task.Delay(TimeSpan.FromSeconds(3));
+        Assert.False(invoked);
+    }
+
+    private static Process StartLongRunningProcess()
+    {
+        // Mirrors CliOrphanDetectorTests' cross-platform process choice for CI reliability.
+        var psi = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
+            : new ProcessStartInfo("tail", "-f /dev/null") { CreateNoWindow = true };
+
+        var process = Process.Start(psi);
+        Assert.NotNull(process);
+        return process;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
@@ -82,5 +82,44 @@ public class ParentProcessLivenessMonitorTests
         Assert.False(invoked);
     }
 
+    [Fact]
+    public async Task ParentExit_CallbackFailureDoesNotFaultDispose()
+    {
+        using var parent = StartLongRunningProcess();
+        var parentStartedUnix = ((DateTimeOffset)parent.StartTime).ToUnixTimeSeconds();
+
+        var callbackInvokedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var monitor = ParentProcessLivenessMonitor.Start(
+            parent.Id,
+            parentStartedUnix,
+            _ =>
+            {
+                callbackInvokedTcs.TrySetResult();
+                throw new InvalidOperationException("Callback failure should not fault monitor disposal.");
+            });
+
+        try
+        {
+            parent.Kill(entireProcessTree: true);
+            parent.WaitForExit();
+
+            await callbackInvokedTcs.Task.WaitAsync(s_observationTimeout);
+
+            var exception = await Record.ExceptionAsync(async () => await monitor.DisposeAsync());
+
+            Assert.Null(exception);
+        }
+        finally
+        {
+            if (!parent.HasExited)
+            {
+                parent.Kill(entireProcessTree: true);
+                parent.WaitForExit();
+            }
+
+            await monitor.DisposeAsync();
+        }
+    }
+
     private static Process StartLongRunningProcess() => TestProcesses.StartLongRunning();
 }

--- a/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
@@ -3,12 +3,43 @@
 
 using System.Diagnostics;
 using Aspire.Cli.Tests.TestServices;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Aspire.Cli.Tests.Processes;
 
 public class ParentProcessLivenessMonitorTests
 {
     private static readonly TimeSpan s_observationTimeout = TimeSpan.FromSeconds(15);
+
+    [Fact]
+    public async Task ParentAlreadyExited_InvokesCallbackWithoutWaitingForFirstTick()
+    {
+        // Immediate-first-check: when the parent is already gone at Start time, the callback must fire on
+        // the pre-tick probe rather than after a full poll interval. A FakeTimeProvider that is never
+        // advanced proves it: with the immediate probe the callback still fires; if detection depended on
+        // the timer, WaitForNextTickAsync would never complete and this would time out.
+        using var parent = StartLongRunningProcess();
+        var parentStartedUnix = ((DateTimeOffset)parent.StartTime).ToUnixTimeSeconds();
+        var parentPid = parent.Id;
+
+        parent.Kill(entireProcessTree: true);
+        parent.WaitForExit();
+
+        var timeProvider = new FakeTimeProvider();
+        var exitedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var monitor = ParentProcessLivenessMonitor.Start(
+            parentPid,
+            parentStartedUnix,
+            _ =>
+            {
+                exitedTcs.TrySetResult();
+                return Task.CompletedTask;
+            },
+            timeProvider);
+
+        // Deliberately never advance the fake clock. The callback must still fire from the initial probe.
+        await exitedTcs.Task.WaitAsync(s_observationTimeout);
+    }
 
     [Fact]
     public async Task ParentExit_InvokesCallback()

--- a/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using Aspire.Cli.Tests.TestServices;
 
 namespace Aspire.Cli.Tests.Processes;
 
@@ -81,15 +82,5 @@ public class ParentProcessLivenessMonitorTests
         Assert.False(invoked);
     }
 
-    private static Process StartLongRunningProcess()
-    {
-        // Mirrors CliOrphanDetectorTests' cross-platform process choice for CI reliability.
-        var psi = OperatingSystem.IsWindows()
-            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
-            : new ProcessStartInfo("tail", "-f /dev/null") { CreateNoWindow = true };
-
-        var process = Process.Start(psi);
-        Assert.NotNull(process);
-        return process;
-    }
+    private static Process StartLongRunningProcess() => TestProcesses.StartLongRunning();
 }

--- a/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
@@ -19,7 +19,7 @@ public class ParentProcessLivenessMonitorTests
         // advanced proves it: with the immediate probe the callback still fires; if detection depended on
         // the timer, WaitForNextTickAsync would never complete and this would time out.
         using var parent = StartLongRunningProcess();
-        var parentStartedUnix = ((DateTimeOffset)parent.StartTime).ToUnixTimeSeconds();
+        var parentStartedUnix = GetProcessStartTimeUnixSeconds(parent);
         var parentPid = parent.Id;
 
         parent.Kill(entireProcessTree: true);
@@ -45,7 +45,7 @@ public class ParentProcessLivenessMonitorTests
     public async Task ParentExit_InvokesCallback()
     {
         using var parent = StartLongRunningProcess();
-        var parentStartedUnix = ((DateTimeOffset)parent.StartTime).ToUnixTimeSeconds();
+        var parentStartedUnix = GetProcessStartTimeUnixSeconds(parent);
 
         var exitedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         await using var monitor = ParentProcessLivenessMonitor.Start(
@@ -67,7 +67,7 @@ public class ParentProcessLivenessMonitorTests
     public async Task ParentAlive_DoesNotInvokeCallback()
     {
         // The current process stands in for a parent that stays alive.
-        var parentStartedUnix = ((DateTimeOffset)Process.GetCurrentProcess().StartTime).ToUnixTimeSeconds();
+        var parentStartedUnix = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds();
 
         var invoked = false;
         await using (var monitor = ParentProcessLivenessMonitor.Start(
@@ -91,7 +91,7 @@ public class ParentProcessLivenessMonitorTests
     public async Task Dispose_DisarmsBeforeParentExit()
     {
         using var parent = StartLongRunningProcess();
-        var parentStartedUnix = ((DateTimeOffset)parent.StartTime).ToUnixTimeSeconds();
+        var parentStartedUnix = GetProcessStartTimeUnixSeconds(parent);
 
         var invoked = false;
         var monitor = ParentProcessLivenessMonitor.Start(
@@ -117,7 +117,7 @@ public class ParentProcessLivenessMonitorTests
     public async Task ParentExit_CallbackFailureDoesNotFaultDispose()
     {
         using var parent = StartLongRunningProcess();
-        var parentStartedUnix = ((DateTimeOffset)parent.StartTime).ToUnixTimeSeconds();
+        var parentStartedUnix = GetProcessStartTimeUnixSeconds(parent);
 
         var callbackInvokedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var monitor = ParentProcessLivenessMonitor.Start(
@@ -153,4 +153,11 @@ public class ParentProcessLivenessMonitorTests
     }
 
     private static Process StartLongRunningProcess() => TestProcesses.StartLongRunning();
+
+    private static long GetProcessStartTimeUnixSeconds(Process process)
+    {
+        var startTime = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(process.Id);
+        Assert.NotNull(startTime);
+        return startTime.Value;
+    }
 }

--- a/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/ParentProcessLivenessMonitorTests.cs
@@ -18,7 +18,7 @@ public class ParentProcessLivenessMonitorTests
         // advanced proves it: with the immediate probe the callback still fires; if detection depended on
         // the timer, WaitForNextTickAsync would never complete and this would time out.
         using var parent = StartLongRunningProcess();
-        var parentStartedUnix = GetProcessStartTimeUnixSeconds(parent);
+        var parentStartedUnix = GetProcessStartTimeUnixMilliseconds(parent);
         var parentPid = parent.Id;
 
         parent.Kill(entireProcessTree: true);
@@ -44,7 +44,7 @@ public class ParentProcessLivenessMonitorTests
     public async Task ParentExit_InvokesCallback()
     {
         using var parent = StartLongRunningProcess();
-        var parentStartedUnix = GetProcessStartTimeUnixSeconds(parent);
+        var parentStartedUnix = GetProcessStartTimeUnixMilliseconds(parent);
 
         var exitedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         await using var monitor = ParentProcessLivenessMonitor.Start(
@@ -66,7 +66,7 @@ public class ParentProcessLivenessMonitorTests
     public async Task ParentAlive_DoesNotInvokeCallback()
     {
         // The current process stands in for a parent that stays alive.
-        var parentStartedUnix = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds();
+        var parentStartedUnix = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixMilliseconds();
 
         var invoked = false;
         await using (var monitor = ParentProcessLivenessMonitor.Start(
@@ -90,7 +90,7 @@ public class ParentProcessLivenessMonitorTests
     public async Task Dispose_DisarmsBeforeParentExit()
     {
         using var parent = StartLongRunningProcess();
-        var parentStartedUnix = GetProcessStartTimeUnixSeconds(parent);
+        var parentStartedUnix = GetProcessStartTimeUnixMilliseconds(parent);
 
         var invoked = false;
         var monitor = ParentProcessLivenessMonitor.Start(
@@ -116,7 +116,7 @@ public class ParentProcessLivenessMonitorTests
     public async Task ParentExit_CallbackFailureDoesNotFaultDispose()
     {
         using var parent = StartLongRunningProcess();
-        var parentStartedUnix = GetProcessStartTimeUnixSeconds(parent);
+        var parentStartedUnix = GetProcessStartTimeUnixMilliseconds(parent);
 
         var callbackInvokedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var monitor = ParentProcessLivenessMonitor.Start(
@@ -153,9 +153,9 @@ public class ParentProcessLivenessMonitorTests
 
     private static Process StartLongRunningProcess() => TestProcesses.StartLongRunning();
 
-    private static long GetProcessStartTimeUnixSeconds(Process process)
+    private static long GetProcessStartTimeUnixMilliseconds(Process process)
     {
-        var startTime = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(process.Id);
+        var startTime = ProcessStartTimeHelper.TryGetProcessStartTimeUnixMilliseconds(process.Id);
         Assert.NotNull(startTime);
         return startTime.Value;
     }

--- a/tests/Aspire.Cli.Tests/Processes/ProcessTreeGracefulShutdownServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/ProcessTreeGracefulShutdownServiceTests.cs
@@ -105,6 +105,98 @@ public class ProcessTreeGracefulShutdownServiceTests(ITestOutputHelper outputHel
     }
 
     [Fact]
+    public void CreateAppHostProcessTarget_PrefersStableStartedAt()
+    {
+        var runtimeStartedAt = DateTimeOffset.FromUnixTimeSeconds(1000);
+        var stableStartedAt = DateTimeOffset.FromUnixTimeSeconds(2000);
+
+        var target = ProcessTreeGracefulShutdownService.CreateAppHostProcessTarget(new AppHostInformation
+        {
+            AppHostPath = "apphost.cs",
+            ProcessId = 1234,
+            StartedAt = runtimeStartedAt,
+            StableStartedAt = stableStartedAt
+        });
+
+        Assert.Equal(1234, target.Pid);
+        Assert.Equal(stableStartedAt, target.StartTime);
+        Assert.False(target.UseRuntimeStartTime);
+    }
+
+    [Fact]
+    public void CreateAppHostProcessTarget_UsesRuntimeStartedAtWhenStableStartedAtIsMissing()
+    {
+        var runtimeStartedAt = DateTimeOffset.FromUnixTimeSeconds(1000);
+
+        var target = ProcessTreeGracefulShutdownService.CreateAppHostProcessTarget(new AppHostInformation
+        {
+            AppHostPath = "apphost.cs",
+            ProcessId = 1234,
+            StartedAt = runtimeStartedAt
+        });
+
+        Assert.Equal(1234, target.Pid);
+        Assert.Equal(runtimeStartedAt, target.StartTime);
+        Assert.True(target.UseRuntimeStartTime);
+    }
+
+    [Fact]
+    public async Task StopAppHostAsync_PassesRuntimeStartTimeToDcpForLegacyAppHostOnWindows()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "The test uses a Unix sleep process while simulating the Windows shutdown path.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dcpDirectory = workspace.WorkspaceRoot.CreateSubdirectory("dcp");
+        File.WriteAllText(BundleDiscovery.GetDcpExecutablePath(dcpDirectory.FullName), string.Empty);
+
+        using var appHostProcess = StartTerminatingShellProcess();
+        try
+        {
+            var runtimeStartedAt = GetRuntimeProcessStartTime(appHostProcess);
+            string[]? capturedArguments = null;
+            var executionFactory = new TestProcessExecutionFactory
+            {
+                AssertionCallback = (arguments, _, _, _) =>
+                {
+                    capturedArguments = arguments;
+                    appHostProcess.Kill(entireProcessTree: true);
+                    appHostProcess.WaitForExit(5000);
+                }
+            };
+            var signaler = CreateService(
+                workspace,
+                dcpDirectory.FullName,
+                executionFactory,
+                environment: TestEnvironment.CreateWindows());
+
+            var result = await signaler.StopAppHostAsync(
+                new AppHostInformation
+                {
+                    AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"),
+                    ProcessId = appHostProcess.Id,
+                    StartedAt = runtimeStartedAt
+                },
+                requestRpcStopAsync: null,
+                CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.True(result);
+            Assert.NotNull(capturedArguments);
+            Assert.Equal([
+                "stop-process-tree",
+                "--skip-descendants",
+                "--pid",
+                appHostProcess.Id.ToString(CultureInfo.InvariantCulture),
+                "--process-start-time",
+                ProcessTreeGracefulShutdownService.FormatDcpProcessStartTime(runtimeStartedAt)
+            ], capturedArguments);
+        }
+        finally
+        {
+            await StopProcessAsync(appHostProcess);
+        }
+    }
+
+    [Fact]
     public async Task StopAppHostAsync_CleansUpCliProcessWithoutWaitingForItAsSuccessCondition()
     {
         Assert.SkipWhen(OperatingSystem.IsWindows(), "The signal-ignoring shell process is Unix-specific.");
@@ -129,7 +221,7 @@ public class ProcessTreeGracefulShutdownServiceTests(ITestOutputHelper outputHel
                     ProcessId = int.MaxValue,
                     StartedAt = null,
                     CliProcessId = cliProcess.Id,
-                    CliStartedAt = GetProcessStartTime(cliProcess)
+                    CliStartedAt = GetRuntimeProcessStartTime(cliProcess)
                 },
                 requestRpcStopAsync: null,
                 CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2));
@@ -143,12 +235,91 @@ public class ProcessTreeGracefulShutdownServiceTests(ITestOutputHelper outputHel
         }
     }
 
+    [Fact]
+    public async Task StopAppHostAsync_CleansUpCliProcessWithAdjacentRuntimeStartTime()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "The signal-ignoring shell process is Unix-specific.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dcpDirectory = workspace.WorkspaceRoot.CreateSubdirectory("dcp");
+        File.WriteAllText(BundleDiscovery.GetDcpExecutablePath(dcpDirectory.FullName), string.Empty);
+
+        using var cliProcess = StartSignalIgnoringShellProcess();
+        try
+        {
+            var signaler = CreateService(
+                workspace,
+                dcpDirectory.FullName,
+                new TestProcessExecutionFactory(),
+                timeProvider: new FakeTimeProvider());
+
+            var result = await signaler.StopAppHostAsync(
+                new AppHostInformation
+                {
+                    AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"),
+                    ProcessId = int.MaxValue,
+                    StartedAt = null,
+                    CliProcessId = cliProcess.Id,
+                    CliStartedAt = GetRuntimeProcessStartTime(cliProcess).AddSeconds(1)
+                },
+                requestRpcStopAsync: null,
+                CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.True(result);
+            await cliProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            await StopProcessAsync(cliProcess);
+        }
+    }
+
+    [Fact]
+    public async Task StopAppHostAsync_StopsLegacyAppHostWithAdjacentRuntimeStartTime()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "The SIGTERM-based AppHost stop path is Unix-specific.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dcpDirectory = workspace.WorkspaceRoot.CreateSubdirectory("dcp");
+        File.WriteAllText(BundleDiscovery.GetDcpExecutablePath(dcpDirectory.FullName), string.Empty);
+
+        using var appHostProcess = StartTerminatingShellProcess();
+        try
+        {
+            var signaler = CreateService(
+                workspace,
+                dcpDirectory.FullName,
+                new TestProcessExecutionFactory());
+
+            var result = await signaler.StopAppHostAsync(
+                new AppHostInformation
+                {
+                    AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"),
+                    ProcessId = appHostProcess.Id,
+                    // Released AppHosts report StartedAt from Process.StartTime and do not send
+                    // StableStartedAt. The stop path must still signal the AppHost when the runtime
+                    // value lands on an adjacent Unix second.
+                    StartedAt = GetRuntimeProcessStartTime(appHostProcess).AddSeconds(1),
+                },
+                requestRpcStopAsync: null,
+                CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.True(result);
+            await appHostProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            await StopProcessAsync(appHostProcess);
+        }
+    }
+
     private static ProcessTreeGracefulShutdownService CreateService(
         TemporaryWorkspace workspace,
         string dcpDirectory,
         TestProcessExecutionFactory executionFactory,
         IBundleService? bundleService = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        IEnvironment? environment = null)
     {
         var executionContext = new CliExecutionContext(
             workspace.WorkspaceRoot,
@@ -163,7 +334,7 @@ public class ProcessTreeGracefulShutdownServiceTests(ITestOutputHelper outputHel
             new FixedLayoutDiscovery(dcpDirectory),
             bundleService ?? new NullBundleService(),
             new LayoutProcessRunner(executionFactory),
-            executionContext, new TestEnvironment(),
+            executionContext, environment ?? new TestEnvironment(),
             NullLogger<ProcessTreeGracefulShutdownService>.Instance,
             timeProvider ?? TimeProvider.System);
     }
@@ -184,11 +355,27 @@ public class ProcessTreeGracefulShutdownServiceTests(ITestOutputHelper outputHel
         return process;
     }
 
-    private static DateTimeOffset GetProcessStartTime(Process process)
+    private static Process StartTerminatingShellProcess()
     {
-        var startTime = ProcessStartTimeHelper.TryGetProcessStartTime(process.Id);
+        var startInfo = new ProcessStartInfo("/bin/sh")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add("exec sleep 60");
+
+        var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        return process;
+    }
+
+    private static DateTimeOffset GetRuntimeProcessStartTime(Process process)
+    {
+        var startTime = ProcessStartTimeHelper.TryGetRuntimeProcessStartTimeUnixSeconds(process.Id);
         Assert.NotNull(startTime);
-        return startTime.Value;
+        return DateTimeOffset.FromUnixTimeSeconds(startTime.Value);
     }
 
     private static async Task StopProcessAsync(Process process)

--- a/tests/Aspire.Cli.Tests/Processes/ProcessTreeGracefulShutdownServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/ProcessTreeGracefulShutdownServiceTests.cs
@@ -34,7 +34,7 @@ public class ProcessTreeGracefulShutdownServiceTests(ITestOutputHelper outputHel
                 capturedWorkingDirectory = workingDirectory;
             }
         };
-        var startTime = new DateTimeOffset(Process.GetCurrentProcess().StartTime);
+        var startTime = ProcessStartTimeHelper.GetCurrentProcessStartTime();
         var signaler = CreateService(workspace, dcpDirectory.FullName, executionFactory);
 
         var result = await signaler.TryStopProcessTreeWithDcpAsync(Environment.ProcessId, startTime, includeStartTime: true, CancellationToken.None);
@@ -70,7 +70,7 @@ public class ProcessTreeGracefulShutdownServiceTests(ITestOutputHelper outputHel
 
         var result = await signaler.TryStopProcessTreeWithDcpAsync(
             Environment.ProcessId,
-            new DateTimeOffset(Process.GetCurrentProcess().StartTime),
+            ProcessStartTimeHelper.GetCurrentProcessStartTime(),
             includeStartTime: false,
             CancellationToken.None);
 
@@ -98,7 +98,7 @@ public class ProcessTreeGracefulShutdownServiceTests(ITestOutputHelper outputHel
         };
         var signaler = CreateService(workspace, mutableDcpDirectory.FullName, executionFactory, bundleService);
 
-        var result = await signaler.TryStopProcessTreeWithDcpAsync(Environment.ProcessId, new DateTimeOffset(Process.GetCurrentProcess().StartTime), includeStartTime: false, CancellationToken.None);
+        var result = await signaler.TryStopProcessTreeWithDcpAsync(Environment.ProcessId, ProcessStartTimeHelper.GetCurrentProcessStartTime(), includeStartTime: false, CancellationToken.None);
 
         Assert.True(result);
         Assert.Equal(leasedDcpPath, executionFactory.LastFileName);
@@ -129,7 +129,7 @@ public class ProcessTreeGracefulShutdownServiceTests(ITestOutputHelper outputHel
                     ProcessId = int.MaxValue,
                     StartedAt = null,
                     CliProcessId = cliProcess.Id,
-                    CliStartedAt = new DateTimeOffset(cliProcess.StartTime)
+                    CliStartedAt = GetProcessStartTime(cliProcess)
                 },
                 requestRpcStopAsync: null,
                 CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2));
@@ -182,6 +182,13 @@ public class ProcessTreeGracefulShutdownServiceTests(ITestOutputHelper outputHel
         var process = Process.Start(startInfo);
         Assert.NotNull(process);
         return process;
+    }
+
+    private static DateTimeOffset GetProcessStartTime(Process process)
+    {
+        var startTime = ProcessStartTimeHelper.TryGetProcessStartTime(process.Id);
+        Assert.NotNull(startTime);
+        return startTime.Value;
     }
 
     private static async Task StopProcessAsync(Process process)

--- a/tests/Aspire.Cli.Tests/Processes/WindowsConsoleProcessJobTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/WindowsConsoleProcessJobTests.cs
@@ -63,6 +63,60 @@ public class WindowsConsoleProcessJobTests
         Assert.True(spawnedProcess.HasExited);
     }
 
+    [Fact]
+    [SupportedOSPlatform("windows")]
+    public void SpawnProcess_WithJob_AssignsChildToJobAtomicallyAtCreation()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Windows-only test.");
+
+        using var job = new WindowsConsoleProcessJob();
+
+        using var nulHandle = WindowsProcessInterop.CreateFileW(
+            "NUL",
+            WindowsProcessInterop.GenericRead | WindowsProcessInterop.GenericWrite,
+            WindowsProcessInterop.FileShareRead | WindowsProcessInterop.FileShareWrite,
+            nint.Zero,
+            WindowsProcessInterop.OpenExisting,
+            0,
+            nint.Zero);
+
+        Assert.False(nulHandle.IsInvalid);
+        Assert.True(WindowsProcessInterop.SetHandleInformation(
+            nulHandle,
+            WindowsProcessInterop.HandleFlagInherit,
+            WindowsProcessInterop.HandleFlagInherit));
+
+        var nulRawHandle = nulHandle.DangerousGetHandle();
+        var stdio = new WindowsProcessInterop.StdioHandles(
+            Stdin: nulRawHandle,
+            Stdout: nulRawHandle,
+            Stderr: nulRawHandle);
+
+        var pi = WindowsProcessInterop.SpawnProcess(
+            "cmd.exe",
+            ["/c", "ping", "-n", "60", "127.0.0.1"],
+            Environment.CurrentDirectory,
+            stdio,
+            environment: null,
+            createNewConsole: false,
+            job.Handle);
+
+        try
+        {
+            // PROC_THREAD_ATTRIBUTE_JOB_LIST associates the child with the job before it runs, so the
+            // membership is observable the instant CreateProcess returns — there is no separate assign
+            // step that a parent dying mid-spawn could skip, and the child was never suspended.
+            Assert.True(WindowsProcessInterop.IsProcessInJob(pi.hProcess, job.Handle, out var isInJob));
+            Assert.True(isInJob);
+        }
+        finally
+        {
+            WindowsProcessInterop.TerminateProcess(pi.hProcess, 1);
+            WindowsProcessInterop.CloseHandle(pi.hProcess);
+            WindowsProcessInterop.CloseHandle(pi.hThread);
+        }
+    }
+
     [SupportedOSPlatform("windows")]
     private static Process SpawnJobAssignedChildProcess(WindowsConsoleProcessJob job, bool createNewConsole)
     {

--- a/tests/Aspire.Cli.Tests/Processes/WindowsConsoleProcessJobTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/WindowsConsoleProcessJobTests.cs
@@ -30,42 +30,80 @@ public class WindowsConsoleProcessJobTests
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Windows-only test.");
 
         var job = new WindowsConsoleProcessJob();
-        Process spawnedProcess;
+        using var spawnedProcess = SpawnJobAssignedChildProcess(job, createNewConsole: true);
 
-        // Long-running ping (~60s) so we can verify it's still alive between spawn and
-        // job dispose; the process exits exactly because JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-        // fires when the last handle to the job closes (i.e. inside Dispose below).
-        var startInfo = new IsolatedProcessStartInfo
+        // Confirm the child is up before disposing the job — otherwise a fast spawn
+        // failure would look identical to successful parent-exit cleanup.
+        Assert.False(spawnedProcess.HasExited);
+
+        job.Dispose();
+
+        // KILL_ON_JOB_CLOSE is reliably observable within a couple of seconds;
+        // give a generous window for CI under load.
+        await spawnedProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(15));
+
+        Assert.True(spawnedProcess.HasExited);
+    }
+
+    [Fact]
+    [SupportedOSPlatform("windows")]
+    public async Task Dispose_KillsAssignedChildProcessWithoutConsoleIsolation()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Windows-only test.");
+
+        var job = new WindowsConsoleProcessJob();
+        using var spawnedProcess = SpawnJobAssignedChildProcess(job, createNewConsole: false);
+
+        Assert.False(spawnedProcess.HasExited);
+
+        job.Dispose();
+
+        await spawnedProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(15));
+
+        Assert.True(spawnedProcess.HasExited);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static Process SpawnJobAssignedChildProcess(WindowsConsoleProcessJob job, bool createNewConsole)
+    {
+        using var nulHandle = WindowsProcessInterop.CreateFileW(
+            "NUL",
+            WindowsProcessInterop.GenericRead | WindowsProcessInterop.GenericWrite,
+            WindowsProcessInterop.FileShareRead | WindowsProcessInterop.FileShareWrite,
+            nint.Zero,
+            WindowsProcessInterop.OpenExisting,
+            0,
+            nint.Zero);
+
+        Assert.False(nulHandle.IsInvalid);
+        Assert.True(WindowsProcessInterop.SetHandleInformation(
+            nulHandle,
+            WindowsProcessInterop.HandleFlagInherit,
+            WindowsProcessInterop.HandleFlagInherit));
+
+        var nulRawHandle = nulHandle.DangerousGetHandle();
+        var stdio = new WindowsProcessInterop.StdioHandles(
+            Stdin: nulRawHandle,
+            Stdout: nulRawHandle,
+            Stderr: nulRawHandle);
+
+        var pi = WindowsProcessInterop.SpawnProcess(
+            "cmd.exe",
+            ["/c", "ping", "-n", "60", "127.0.0.1"],
+            Environment.CurrentDirectory,
+            stdio,
+            environment: null,
+            createNewConsole,
+            job.Handle);
+
+        try
         {
-            FileName = "cmd.exe",
-            WorkingDirectory = Environment.CurrentDirectory,
-            JobHandle = job.Handle,
-        };
-        startInfo.ArgumentList.Add("/c");
-        startInfo.ArgumentList.Add("ping");
-        startInfo.ArgumentList.Add("-n");
-        startInfo.ArgumentList.Add("60");
-        startInfo.ArgumentList.Add("127.0.0.1");
-
-        await using (var child = IsolatedProcess.Start(
-            startInfo,
-            standardOutputHandler: static (_, _) => { },
-            standardErrorHandler: static (_, _) => { }))
+            return Process.GetProcessById(pi.dwProcessId);
+        }
+        finally
         {
-            spawnedProcess = child.Process;
-
-            // Confirm the child is up before disposing the job — otherwise a fast spawn
-            // failure would look identical to a successful kill-on-close.
-            Assert.False(spawnedProcess.HasExited);
-
-            job.Dispose();
-
-            // KILL_ON_JOB_CLOSE is reliably observable within a couple of seconds;
-            // give a generous window for CI under load.
-            await spawnedProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(15));
-
-            Assert.True(spawnedProcess.HasExited);
+            WindowsProcessInterop.CloseHandle(pi.hProcess);
+            WindowsProcessInterop.CloseHandle(pi.hThread);
         }
     }
 }
-

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostStopper.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostStopper.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Processes;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+/// <summary>
+/// A test <see cref="IAppHostStopper"/> that records stop requests and returns a controllable result,
+/// so <see cref="OrphanedAppHostCollector"/> orchestration can be tested without real process signalling.
+/// </summary>
+internal sealed class TestAppHostStopper : IAppHostStopper
+{
+    /// <summary>
+    /// The AppHosts that <see cref="StopAppHostAsync"/> was asked to stop, in call order.
+    /// </summary>
+    public List<AppHostInformation?> StopRequests { get; } = [];
+
+    /// <summary>
+    /// Result to return for a given AppHost. When null, <see cref="DefaultResult"/> is used.
+    /// </summary>
+    public Func<AppHostInformation?, bool>? StopResultSelector { get; set; }
+
+    /// <summary>
+    /// When it returns a non-null exception for a given AppHost, that exception is thrown instead of returning a result.
+    /// </summary>
+    public Func<AppHostInformation?, Exception?>? ThrowSelector { get; set; }
+
+    /// <summary>
+    /// Result used when <see cref="StopResultSelector"/> is null or returns null-equivalent.
+    /// </summary>
+    public bool DefaultResult { get; set; } = true;
+
+    public Task<bool> StopAppHostAsync(
+        AppHostInformation? appHostInfo,
+        Func<CancellationToken, Task<bool>>? requestRpcStopAsync,
+        CancellationToken cancellationToken)
+    {
+        StopRequests.Add(appHostInfo);
+
+        if (ThrowSelector?.Invoke(appHostInfo) is { } ex)
+        {
+            throw ex;
+        }
+
+        var result = StopResultSelector?.Invoke(appHostInfo) ?? DefaultResult;
+        return Task.FromResult(result);
+    }
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestProcesses.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestProcesses.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal static class TestProcesses
+{
+    /// <summary>
+    /// Starts a cross-platform, long-running child process that stands in for a launcher/parent process
+    /// in liveness tests. The caller owns the returned process and must kill and dispose it.
+    /// </summary>
+    public static Process StartLongRunning()
+    {
+        // Mirrors CliOrphanDetectorTests' cross-platform process choice for CI reliability: a trivially
+        // available command that blocks indefinitely until it is killed.
+        var psi = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
+            : new ProcessStartInfo("tail", "-f /dev/null") { CreateNoWindow = true };
+
+        return Process.Start(psi) ?? throw new InvalidOperationException("Failed to start long-running test process.");
+    }
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestProcesses.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestProcesses.cs
@@ -1,24 +1,77 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Aspire.Cli.Tests.TestServices;
 
 internal static class TestProcesses
 {
+    // A leaked long-running child lingers on a CI agent until the box is recycled. The process-lifecycle
+    // tests kill it explicitly within seconds, but if a test aborts before its `using` disposes (or the
+    // test host is SIGKILLed for a hangdump), the child can be orphaned. Two backstops guard against that:
+    //
+    //  1. Every started process is tracked and reaped on a graceful test-host shutdown (ProcessExit).
+    //  2. The process self-terminates after a generous ceiling, so even an ungraceful SIGKILL (where
+    //     ProcessExit never runs) cannot leave it running forever.
+    //
+    // The ceiling only matters when normal cleanup was skipped; healthy tests never come close to it.
+    private static readonly TimeSpan s_maxLifetime = TimeSpan.FromMinutes(5);
+
+    private static readonly ConcurrentDictionary<int, Process> s_tracked = new();
+    private static int s_exitHookInstalled;
+
     /// <summary>
     /// Starts a cross-platform, long-running child process that stands in for a launcher/parent process
-    /// in liveness tests. The caller owns the returned process and must kill and dispose it.
+    /// in liveness tests. The caller owns the returned process and should kill and dispose it; the helper
+    /// tracks it and reaps it on a graceful test-host shutdown, and the process self-terminates after a
+    /// bounded lifetime as a last-resort backstop against leaks.
     /// </summary>
     public static Process StartLongRunning()
     {
-        // Mirrors CliOrphanDetectorTests' cross-platform process choice for CI reliability: a trivially
-        // available command that blocks indefinitely until it is killed.
-        var psi = OperatingSystem.IsWindows()
-            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
-            : new ProcessStartInfo("tail", "-f /dev/null") { CreateNoWindow = true };
+        EnsureExitHookInstalled();
 
-        return Process.Start(psi) ?? throw new InvalidOperationException("Failed to start long-running test process.");
+        // Bounded stand-in for the previous indefinite `ping -t` / `tail -f /dev/null`: a trivially
+        // available command that blocks for a fixed, generous duration and then exits on its own.
+        //   Windows: `ping -n <seconds> 127.0.0.1` sends one echo per ~second, so the count ≈ seconds.
+        //   Unix:    `sleep <seconds>`.
+        var seconds = ((int)s_maxLifetime.TotalSeconds).ToString(CultureInfo.InvariantCulture);
+        var psi = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("ping", $"-n {seconds} 127.0.0.1") { CreateNoWindow = true }
+            : new ProcessStartInfo("sleep", seconds) { CreateNoWindow = true };
+
+        var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start long-running test process.");
+        s_tracked[process.Id] = process;
+        return process;
+    }
+
+    private static void EnsureExitHookInstalled()
+    {
+        if (Interlocked.Exchange(ref s_exitHookInstalled, 1) != 0)
+        {
+            return;
+        }
+
+        // Best-effort reaping when the test host shuts down cleanly. ProcessExit does not run on SIGKILL,
+        // which is why StartLongRunning also caps the child's lifetime.
+        AppDomain.CurrentDomain.ProcessExit += static (_, _) =>
+        {
+            foreach (var process in s_tracked.Values)
+            {
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                }
+                catch
+                {
+                    // The process may already be gone or disposed by its owning test; nothing to do.
+                }
+            }
+        };
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -440,6 +440,43 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Assert.Collection(remainingSockets, socket => Assert.Equal(liveSocket, socket));
     }
 
+    [Fact]
+    public void ComputeAuxiliarySocketPrefix_ResolvedSymlinkPath_MatchesRealTargetPrefix()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
+            "Symlink resolution test only runs on Linux/macOS where unprivileged symlink creation is reliable.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var homeDirectory = workspace.WorkspaceRoot.FullName;
+
+        // Build a directory symlink ("link" -> "real") and reference the same on-disk AppHost
+        // through both paths. This reproduces the macOS temp-path shape where /var/folders/...
+        // is a symlink to /private/var/folders/..., so the symlinked and real paths are the same
+        // file but differ textually.
+        var realDirectory = workspace.WorkspaceRoot.CreateSubdirectory("real");
+        var symlinkDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "link");
+        Directory.CreateSymbolicLink(symlinkDirectory, realDirectory.FullName);
+
+        var realProjectPath = Path.Combine(realDirectory.FullName, "TestAppHost.csproj");
+        File.WriteAllText(realProjectPath, "<Project />");
+        var projectFileViaSymlink = Path.Combine(symlinkDirectory, "TestAppHost.csproj");
+
+        // The AppHost keys its auxiliary backchannel socket on the symlink-resolved path, so the CLI
+        // must resolve the symlinked path to arrive at the same socket prefix as the real target.
+        var resolvedViaSymlink = PathNormalizer.ResolveSymlinks(projectFileViaSymlink);
+        var resolvedRealTarget = PathNormalizer.ResolveSymlinks(realProjectPath);
+        Assert.Equal(resolvedRealTarget, resolvedViaSymlink);
+
+        var prefixViaResolvedSymlink = AppHostHelper.ComputeAuxiliarySocketPrefix(resolvedViaSymlink, homeDirectory);
+        var prefixForRealTarget = AppHostHelper.ComputeAuxiliarySocketPrefix(resolvedRealTarget, homeDirectory);
+        Assert.Equal(prefixForRealTarget, prefixViaResolvedSymlink);
+
+        // The raw (unresolved) symlinked path hashes to a different prefix — exactly the mismatch that
+        // caused detached `aspire start` to wait on a hash the AppHost never used and time out.
+        var prefixViaRawSymlink = AppHostHelper.ComputeAuxiliarySocketPrefix(projectFileViaSymlink, homeDirectory);
+        Assert.NotEqual(prefixForRealTarget, prefixViaRawSymlink);
+    }
+
     [Theory]
     [InlineData("10.0.0", true)]
     [InlineData("9.2.0", true)]

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -176,6 +176,7 @@ internal static class CliTestHelper
         // wraps. Without this, DI returns null and Run-path tests construct the project with
         // a missing dependency, masking wiring regressions.
         services.AddTransient<IProcessTreeGracefulShutdownSignaler>(sp => sp.GetRequiredService<ProcessTreeGracefulShutdownService>());
+        services.AddTransient<IAppHostStopper>(sp => sp.GetRequiredService<ProcessTreeGracefulShutdownService>());
         services.AddTransient<OrphanedAppHostCollector>();
         // Match Program.Main's ConsoleCancellationManager (5s finalDrainBudget) so tests exercise the
         // same shutdown ladder budget as production. RunCommand and GuestAppHostProject require these

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -176,6 +176,7 @@ internal static class CliTestHelper
         // wraps. Without this, DI returns null and Run-path tests construct the project with
         // a missing dependency, masking wiring regressions.
         services.AddTransient<IProcessTreeGracefulShutdownSignaler>(sp => sp.GetRequiredService<ProcessTreeGracefulShutdownService>());
+        services.AddTransient<OrphanedAppHostCollector>();
         // Match Program.Main's ConsoleCancellationManager (5s finalDrainBudget) so tests exercise the
         // same shutdown ladder budget as production. RunCommand and GuestAppHostProject require these
         // services in production wiring. IGracefulShutdownWindow resolves to the same CCM instance,

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -66,6 +66,42 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task RunAsync_TokenCancelled_ShutsDownAndReturnsZero()
+    {
+        // The standalone `aspire-managed dashboard` process relies on RunAsync honoring its cancellation
+        // token so the parent-liveness watchdog can tear the dashboard down when the launching CLI dies.
+        // Verify a running dashboard shuts down gracefully and reports success when the token is cancelled.
+        var loggerFactory = IntegrationTestHelpers.CreateLoggerFactory(testOutputHelper);
+        var logger = loggerFactory.CreateLogger<StartupTests>();
+
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(loggerFactory);
+
+        using var cts = new CancellationTokenSource();
+        var runTask = app.RunAsync(cts.Token);
+
+        // Wait until the dashboard is actually serving so we exercise the running -> graceful-shutdown
+        // path rather than a start-time cancellation race. FrontendEndPointsAccessor throws until started.
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () =>
+            {
+                try
+                {
+                    return app.FrontendEndPointsAccessor.Count > 0;
+                }
+                catch (InvalidOperationException)
+                {
+                    return false;
+                }
+            },
+            "Dashboard reached startup.", logger);
+
+        cts.Cancel();
+
+        var exitCode = await runTask.DefaultTimeout();
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
     public async Task EndPointAccessors_AppStarted_IPv4OrIPv6()
     {
         // Arrange

--- a/tests/Aspire.Hosting.RemoteHost.Tests/OrphanDetectorTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/OrphanDetectorTests.cs
@@ -114,8 +114,39 @@ public class OrphanDetectorTests
 
         var detector = new OrphanDetector(configuration, lifetime, NullLogger<OrphanDetector>.Instance)
         {
-            IsProcessRunning = _ => throw new InvalidOperationException("Start time from ASPIRE_CLI_STARTED should select the start-time path."),
-            IsProcessRunningWithStartTime = (_, _) => false,
+            IsProcessRunning = _ => throw new InvalidOperationException("Start time from ASPIRE_CLI_STARTED should select the legacy start-time path."),
+            IsProcessRunningWithStartTime = (_, _) => throw new InvalidOperationException("Legacy ASPIRE_CLI_STARTED should not use the stable start-time path."),
+            IsProcessRunningWithLegacyStartTime = (_, _) => false,
+        };
+
+        await detector.StartAsync(CancellationToken.None).WaitAsync(s_timeout);
+        await stopTcs.Task.WaitAsync(s_timeout);
+    }
+
+    [Fact]
+    public async Task PrefersStableAspireCliStartedWhenRemoteStartedMissing()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["REMOTE_APP_HOST_PID"] = "1111",
+                ["ASPIRE_CLI_STARTED"] = "1700000000",
+                ["ASPIRE_CLI_STARTED_STABLE"] = "1700000001",
+            })
+            .Build();
+
+        var stopTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifetime = new HostLifetimeStub(() => stopTcs.TrySetResult());
+
+        var detector = new OrphanDetector(configuration, lifetime, NullLogger<OrphanDetector>.Instance)
+        {
+            IsProcessRunning = _ => throw new InvalidOperationException("Start time from ASPIRE_CLI_STARTED_STABLE should select the start-time path."),
+            IsProcessRunningWithStartTime = (_, startTime) =>
+            {
+                Assert.Equal(1700000001, startTime);
+                return false;
+            },
+            IsProcessRunningWithLegacyStartTime = (_, _) => throw new InvalidOperationException("Stable ASPIRE_CLI_STARTED_STABLE should be preferred."),
         };
 
         await detector.StartAsync(CancellationToken.None).WaitAsync(s_timeout);

--- a/tests/Aspire.Hosting.RemoteHost.Tests/OrphanDetectorTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/OrphanDetectorTests.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Aspire.Hosting.RemoteHost.Tests;
+
+public class OrphanDetectorTests
+{
+    private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task CompletesWithoutStoppingWhenNoParentPidConfigured()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        var stopCalled = false;
+        var lifetime = new HostLifetimeStub(() => stopCalled = true);
+
+        var detector = new OrphanDetector(configuration, lifetime, NullLogger<OrphanDetector>.Instance);
+
+        await detector.StartAsync(CancellationToken.None).WaitAsync(s_timeout);
+        await detector.ExecuteTask!.WaitAsync(s_timeout);
+
+        Assert.False(stopCalled);
+    }
+
+    [Fact]
+    public async Task StopsWhenParentPidNotRunning_PidOnly()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["REMOTE_APP_HOST_PID"] = "1111" })
+            .Build();
+
+        var stopTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifetime = new HostLifetimeStub(() => stopTcs.TrySetResult());
+
+        var detector = new OrphanDetector(configuration, lifetime, NullLogger<OrphanDetector>.Instance)
+        {
+            IsProcessRunning = _ => false,
+            // Ensure the start-time path is not used when no start time is configured.
+            IsProcessRunningWithStartTime = (_, _) => throw new InvalidOperationException("Start-time path should not be used without REMOTE_APP_HOST_STARTED."),
+        };
+
+        await detector.StartAsync(CancellationToken.None).WaitAsync(s_timeout);
+        await stopTcs.Task.WaitAsync(s_timeout);
+    }
+
+    [Fact]
+    public async Task StopsWhenParentPidNotRunning_WithStartTimeVerification()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["REMOTE_APP_HOST_PID"] = "1111",
+                ["REMOTE_APP_HOST_STARTED"] = "1700000000",
+            })
+            .Build();
+
+        var stopTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifetime = new HostLifetimeStub(() => stopTcs.TrySetResult());
+
+        var detector = new OrphanDetector(configuration, lifetime, NullLogger<OrphanDetector>.Instance)
+        {
+            // PID-only path must not run when a start time is configured.
+            IsProcessRunning = _ => throw new InvalidOperationException("PID-only path should not be used when REMOTE_APP_HOST_STARTED is set."),
+            IsProcessRunningWithStartTime = (_, _) => false,
+        };
+
+        await detector.StartAsync(CancellationToken.None).WaitAsync(s_timeout);
+        await stopTcs.Task.WaitAsync(s_timeout);
+    }
+
+    [Fact]
+    public async Task StopsWhenStartTimeMismatch_PidReuse()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["REMOTE_APP_HOST_PID"] = "1111",
+                ["REMOTE_APP_HOST_STARTED"] = "1700000000",
+            })
+            .Build();
+
+        var stopTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifetime = new HostLifetimeStub(() => stopTcs.TrySetResult());
+
+        // The PID exists but its start time does not match — a recycled PID. The detector must treat the
+        // parent as gone rather than keeping the orphaned server alive.
+        var detector = new OrphanDetector(configuration, lifetime, NullLogger<OrphanDetector>.Instance)
+        {
+            IsProcessRunningWithStartTime = (_, _) => false,
+        };
+
+        await detector.StartAsync(CancellationToken.None).WaitAsync(s_timeout);
+        await stopTcs.Task.WaitAsync(s_timeout);
+    }
+
+    [Fact]
+    public async Task FallsBackToAspireCliStartedWhenRemoteStartedMissing()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["REMOTE_APP_HOST_PID"] = "1111",
+                ["ASPIRE_CLI_STARTED"] = "1700000000",
+            })
+            .Build();
+
+        var stopTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifetime = new HostLifetimeStub(() => stopTcs.TrySetResult());
+
+        var detector = new OrphanDetector(configuration, lifetime, NullLogger<OrphanDetector>.Instance)
+        {
+            IsProcessRunning = _ => throw new InvalidOperationException("Start time from ASPIRE_CLI_STARTED should select the start-time path."),
+            IsProcessRunningWithStartTime = (_, _) => false,
+        };
+
+        await detector.StartAsync(CancellationToken.None).WaitAsync(s_timeout);
+        await stopTcs.Task.WaitAsync(s_timeout);
+    }
+
+    private sealed class HostLifetimeStub(Action stopImplementation) : IHostApplicationLifetime
+    {
+        public CancellationToken ApplicationStarted => throw new NotImplementedException();
+
+        public CancellationToken ApplicationStopped => throw new NotImplementedException();
+
+        public CancellationToken ApplicationStopping => throw new NotImplementedException();
+
+        public void StopApplication() => stopImplementation();
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="$(TestsSharedDir)ConsoleLogging\*.cs" LinkBase="shared" />
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
+    <Compile Include="$(TestsSharedDir)TestProcesses.cs" Link="shared/TestProcesses.cs" />
     <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="shared/ComputeEnvironmentEndpointResolver.cs" />
     <Compile Include="$(TestsSharedDir)TestInteractionService.cs" LinkBase="shared" />
     <Compile Include="$(TestsSharedDir)TestPipelineActivityReporter.cs" Link="shared/TestPipelineActivityReporter.cs" />

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -2144,6 +2144,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
                 ["AppHost:Path"] = "/path/to/apphost.csproj",
                 [KnownConfigNames.CliProcessId] = "5678",
                 [KnownConfigNames.CliProcessStarted] = "1783180199",
+                [KnownConfigNames.CliProcessStartedStable] = "1783180250",
                 [KnownConfigNames.CliLogFilePath] = "/logs/cli_20260516T120000_abcd1234.log"
             })
             .Build();
@@ -2164,6 +2165,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         Assert.Equal("/logs/cli_20260516T120000_abcd1234.log", result.CliLogFilePath);
         Assert.Equal(5678, result.CliProcessId);
         Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1783180199), result.CliStartedAt);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1783180250), result.CliStableStartedAt);
         Assert.NotNull(result.StartedAt);
         Assert.NotNull(result.StableStartedAt);
         Assert.True(ProcessStartTimeHelper.AreClose(

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -2143,6 +2143,7 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
             {
                 ["AppHost:Path"] = "/path/to/apphost.csproj",
                 [KnownConfigNames.CliProcessId] = "5678",
+                [KnownConfigNames.CliProcessStarted] = "1783180199",
                 [KnownConfigNames.CliLogFilePath] = "/logs/cli_20260516T120000_abcd1234.log"
             })
             .Build();
@@ -2162,6 +2163,14 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
 
         Assert.Equal("/logs/cli_20260516T120000_abcd1234.log", result.CliLogFilePath);
         Assert.Equal(5678, result.CliProcessId);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1783180199), result.CliStartedAt);
+        Assert.NotNull(result.StartedAt);
+        Assert.NotNull(result.StableStartedAt);
+        Assert.True(ProcessStartTimeHelper.AreClose(
+            ProcessStartTimeHelper.GetCurrentProcessRuntimeStartTimeUnixSeconds(),
+            result.StartedAt.Value.ToUnixTimeSeconds(),
+            TimeSpan.FromSeconds(1)));
+        Assert.Equal(ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(Environment.ProcessId), result.StableStartedAt.Value.ToUnixTimeSeconds());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -2165,14 +2165,14 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         Assert.Equal("/logs/cli_20260516T120000_abcd1234.log", result.CliLogFilePath);
         Assert.Equal(5678, result.CliProcessId);
         Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1783180199), result.CliStartedAt);
-        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1783180250), result.CliStableStartedAt);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1783180250), result.CliStableStartedAt);
         Assert.NotNull(result.StartedAt);
         Assert.NotNull(result.StableStartedAt);
         Assert.True(ProcessStartTimeHelper.AreClose(
             ProcessStartTimeHelper.GetCurrentProcessRuntimeStartTimeUnixSeconds(),
             result.StartedAt.Value.ToUnixTimeSeconds(),
             TimeSpan.FromSeconds(1)));
-        Assert.Equal(ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(Environment.ProcessId), result.StableStartedAt.Value.ToUnixTimeSeconds());
+        Assert.Equal(ProcessStartTimeHelper.TryGetProcessStartTimeUnixMilliseconds(Environment.ProcessId), result.StableStartedAt.Value.ToUnixTimeMilliseconds());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using Aspire.Hosting.Utils;
 using Aspire.TestUtilities;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -609,5 +610,45 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         }, "Expected a Debug log for client disconnect and no Error logs from AuxiliaryBackchannelService");
 
         await app.StopAsync().DefaultTimeout();
+    }
+
+    [Fact]
+    public void GetSocketKeyAppHostPath_ResolvesSymlinksSoSocketKeyMatchesCli()
+    {
+        // The CLI resolves symlinks before searching for an AppHost's backchannel socket
+        // (AppHostHelper.FindMatchingNonOrphanedSockets), so the AppHost must key its socket off the same
+        // symlink-resolved physical path. File-based AppHosts otherwise report AppHost:FilePath as
+        // Path.GetFullPath(EntryPointFilePath), which leaves intermediate symlinks unresolved and made
+        // 'aspire describe/stop --apphost' miss the AppHost. See https://github.com/microsoft/aspire/issues/17618.
+        Assert.SkipUnless(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
+            "Symlink resolution test only runs on Linux/macOS where unprivileged symlink creation is reliable.");
+
+        var tempRoot = Directory.CreateTempSubdirectory("aspire-auxbch-symlink-");
+        try
+        {
+            var realDirectory = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "real"));
+            var symlinkDirectory = Path.Combine(tempRoot.FullName, "link");
+            Directory.CreateSymbolicLink(symlinkDirectory, realDirectory.FullName);
+
+            var appHostFileViaSymlink = Path.Combine(symlinkDirectory, "apphost.cs");
+            File.WriteAllText(appHostFileViaSymlink, "// apphost");
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["AppHost:FilePath"] = appHostFileViaSymlink,
+                })
+                .Build();
+
+            var socketKeyPath = AuxiliaryBackchannelService.GetSocketKeyAppHostPath(configuration);
+
+            Assert.Equal(PathNormalizer.ResolveSymlinks(appHostFileViaSymlink), socketKeyPath);
+            // Guards against the symlink not actually being unwrapped (otherwise the assertion above is vacuous).
+            Assert.NotEqual(appHostFileViaSymlink, socketKeyPath);
+        }
+        finally
+        {
+            tempRoot.Delete(recursive: true);
+        }
     }
 }

--- a/tests/Aspire.Hosting.Tests/Cli/CliOrphanDetectorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/CliOrphanDetectorTests.cs
@@ -70,7 +70,38 @@ public class CliOrphanDetectorTests(ITestOutputHelper testOutputHelper)
 
         var loggerFactory = CreateLoggerFactory(testOutputHelper);
         var detector = CreateCliOrphanDetector(loggerFactory, configuration, lifetime);
-        detector.IsProcessRunningWithStartTime = (pid, startTime) => false;
+        detector.IsProcessRunningWithLegacyStartTime = (pid, startTime) => false;
+
+        await detector.StartAsync(CancellationToken.None).DefaultTimeout();
+        await stopSignalTcs.Task.DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task CliOrphanDetectorPrefersStableTimestampDetectionWhenProvided()
+    {
+        var legacyStartTime = DateTime.Now.AddMinutes(-5);
+        var legacyStartTimeUnixSeconds = ((DateTimeOffset)legacyStartTime).ToUnixTimeSeconds();
+        var stableStartTimeUnixSeconds = legacyStartTimeUnixSeconds + 1;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "ASPIRE_CLI_PID", "1111" },
+                { "ASPIRE_CLI_STARTED", legacyStartTimeUnixSeconds.ToString() },
+                { "ASPIRE_CLI_STARTED_STABLE", stableStartTimeUnixSeconds.ToString() }
+            })
+            .Build();
+
+        var stopSignalTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifetime = new HostLifetimeStub(() => stopSignalTcs.TrySetResult());
+
+        var loggerFactory = CreateLoggerFactory(testOutputHelper);
+        var detector = CreateCliOrphanDetector(loggerFactory, configuration, lifetime);
+        detector.IsProcessRunningWithStartTime = (pid, startTime) =>
+        {
+            Assert.Equal(stableStartTimeUnixSeconds, startTime);
+            return false;
+        };
+        detector.IsProcessRunningWithLegacyStartTime = (_, _) => throw new InvalidOperationException("Stable start time should be preferred.");
 
         await detector.StartAsync(CancellationToken.None).DefaultTimeout();
         await stopSignalTcs.Task.DefaultTimeout();
@@ -107,7 +138,7 @@ public class CliOrphanDetectorTests(ITestOutputHelper testOutputHelper)
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 { "ASPIRE_CLI_PID", "1111" },
-                { "ASPIRE_CLI_STARTED", expectedStartTimeUnix.ToString() }
+                { "ASPIRE_CLI_STARTED_STABLE", expectedStartTimeUnix.ToString() }
             })
             .Build();
         var fakeTimeProvider = new FakeTimeProvider(DateTimeOffset.Now);
@@ -164,7 +195,7 @@ public class CliOrphanDetectorTests(ITestOutputHelper testOutputHelper)
         var detector = CreateCliOrphanDetector(loggerFactory, configuration, lifetime);
 
         // Simulate process with different start time (PID reuse scenario)
-        detector.IsProcessRunningWithStartTime = (pid, startTime) =>
+        detector.IsProcessRunningWithLegacyStartTime = (pid, startTime) =>
         {
             // Process exists but has different start time - indicates PID reuse
             return false;

--- a/tests/Aspire.Hosting.Tests/Cli/CliOrphanDetectorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/CliOrphanDetectorTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Threading.Channels;
 using Aspire.Hosting.Cli;
 using Aspire.Hosting.Utils;
@@ -257,17 +256,10 @@ public class CliOrphanDetectorTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task AppHostExitsWhenCliProcessPidDies()
     {
-        // Start a long-running process that will stay alive until killed
-        // These are system utilities on their respective platforms and don't require any additional dependencies.
-        var psi = OperatingSystem.IsWindows()
-            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
-            : new ProcessStartInfo("tail", "-f /dev/null");
-
-        psi.RedirectStandardOutput = true;
-        psi.RedirectStandardError = true;
-
-        using var fakeCliProcess = Process.Start(psi);
-        Assert.NotNull(fakeCliProcess);
+        // A long-running stand-in for the launching CLI. The shared helper is bounded and
+        // self-terminating so an aborted test host can't leak it; it is killed below to drive
+        // the orphan-exit path.
+        using var fakeCliProcess = TestProcesses.StartLongRunning();
 
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
         builder.Configuration["ASPIRE_CLI_PID"] = fakeCliProcess.Id.ToString();

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
@@ -35,8 +35,7 @@ public class ProcessSignalerTests(ITestOutputHelper testOutputHelper)
         var currentProcess = Process.GetCurrentProcess();
 
         // Simulate what the CLI does: truncate to unix seconds
-        var truncatedStartTime = DateTimeOffset.FromUnixTimeSeconds(
-            ((DateTimeOffset)currentProcess.StartTime).ToUnixTimeSeconds());
+        var truncatedStartTime = DateTimeOffset.FromUnixTimeSeconds(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds());
 
         using var result = ProcessSignaler.TryGetRunningProcess(
             currentProcess.Id, truncatedStartTime, logger);
@@ -45,4 +44,3 @@ public class ProcessSignalerTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(currentProcess.Id, result.Id);
     }
 }
-

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
@@ -35,7 +35,7 @@ public class ProcessSignalerTests(ITestOutputHelper testOutputHelper)
         var currentProcess = Process.GetCurrentProcess();
 
         // Simulate what the CLI does: truncate to unix seconds
-        var truncatedStartTime = DateTimeOffset.FromUnixTimeSeconds(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds());
+        var truncatedStartTime = DateTimeOffset.FromUnixTimeSeconds(ProcessStartTimeHelper.GetCurrentProcessStartTime().ToUnixTimeSeconds());
 
         using var result = ProcessSignaler.TryGetRunningProcess(
             currentProcess.Id, truncatedStartTime, logger);

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
@@ -9,38 +9,41 @@ namespace Aspire.Hosting.Tests;
 [Trait("Partition", "4")]
 public class ProcessSignalerTests(ITestOutputHelper testOutputHelper)
 {
-    [Theory]
-    [InlineData(0, true)]       // Exact match
-    [InlineData(0.8, true)]     // Sub-second difference within the same second after truncation
-    [InlineData(1.2, false)]    // Next second: a recycled PID must not match
-    [InlineData(1, false)]      // Exactly one second later is a different whole second
-    [InlineData(3, false)]      // 3 seconds apart (PID reuse)
-    [InlineData(-0.5, false)]   // Previous second after truncation
-    public void AreClose_ComparesAtSecondGranularity(double offsetSeconds, bool expected)
-    {
-        var baseTime = new DateTime(2025, 6, 12, 10, 30, 45, 0, DateTimeKind.Local);
-        var expectedStartTime = new DateTimeOffset(baseTime);
-        var processStartTime = baseTime.AddSeconds(offsetSeconds);
-
-        var result = ProcessSignaler.AreClose(expectedStartTime, processStartTime);
-
-        Assert.Equal(expected, result);
-    }
-
     [Fact]
-    public void TryGetRunningProcess_CurrentProcess_WithTruncatedStartTime_ReturnsProcess()
+    public void TryGetRunningProcess_CurrentProcess_WithStableStartTime_ReturnsProcess()
     {
         var loggerFactory = LoggerFactory.Create(b => b.AddXunit(testOutputHelper));
         var logger = loggerFactory.CreateLogger<ProcessSignalerTests>();
         var currentProcess = Process.GetCurrentProcess();
 
-        // Simulate what the CLI does: truncate to unix seconds
-        var truncatedStartTime = DateTimeOffset.FromUnixTimeSeconds(ProcessStartTimeHelper.GetCurrentProcessStartTime().ToUnixTimeSeconds());
+        // The stable path receives the full millisecond-precision identity time (the AppHost's
+        // StableStartedAt, or a locally captured TryGetProcessStartTime value), so an exact reading
+        // of the same process must match.
+        var stableStartTime = ProcessStartTimeHelper.GetCurrentProcessStartTime();
 
         using var result = ProcessSignaler.TryGetRunningProcess(
-            currentProcess.Id, truncatedStartTime, logger);
+            currentProcess.Id, stableStartTime, logger);
 
         Assert.NotNull(result);
         Assert.Equal(currentProcess.Id, result.Id);
+    }
+
+    [Fact]
+    public void TryGetRunningProcess_CurrentProcess_WithStartTimeBeyondTolerance_ReturnsNull()
+    {
+        var loggerFactory = LoggerFactory.Create(b => b.AddXunit(testOutputHelper));
+        var logger = loggerFactory.CreateLogger<ProcessSignalerTests>();
+        var currentProcess = Process.GetCurrentProcess();
+
+        // One second off is still the same (or an immediately adjacent) wall-clock second, but far beyond
+        // the millisecond reuse tolerance. This models a PID recycled within the same second: it must not
+        // match now that the stable path compares identity at millisecond precision rather than truncating
+        // to whole seconds.
+        var mismatchedStartTime = ProcessStartTimeHelper.GetCurrentProcessStartTime().AddSeconds(1);
+
+        using var result = ProcessSignaler.TryGetRunningProcess(
+            currentProcess.Id, mismatchedStartTime, logger);
+
+        Assert.Null(result);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessSignalerTests.cs
@@ -11,11 +11,11 @@ public class ProcessSignalerTests(ITestOutputHelper testOutputHelper)
 {
     [Theory]
     [InlineData(0, true)]       // Exact match
-    [InlineData(0.8, true)]     // Sub-second difference within same second after truncation
-    [InlineData(1.2, true)]
-    [InlineData(1, true)]       // Exactly 1 second apart (within tolerance)
+    [InlineData(0.8, true)]     // Sub-second difference within the same second after truncation
+    [InlineData(1.2, false)]    // Next second: a recycled PID must not match
+    [InlineData(1, false)]      // Exactly one second later is a different whole second
     [InlineData(3, false)]      // 3 seconds apart (PID reuse)
-    [InlineData(-0.5, true)]    // Negative sub-second difference
+    [InlineData(-0.5, false)]   // Previous second after truncation
     public void AreClose_ComparesAtSecondGranularity(double offsetSeconds, bool expected)
     {
         var baseTime = new DateTime(2025, 6, 12, 10, 30, 45, 0, DateTimeKind.Local);

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
@@ -94,6 +94,49 @@ public class ProcessStartTimeHelperTests
         Assert.Equal("/proc", ProcessStartTimeHelper.LinuxProcRoot);
     }
 
+    [Fact]
+    public void GetCurrentProcessStartTime_OnLinux_IsBootRelativeWithoutBtime()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "Boot-relative /proc start-tick identity is Linux-specific.");
+
+        // The stable Linux identity is boot-relative: field 22 of /proc/<pid>/stat (start ticks since boot)
+        // divided by _SC_CLK_TCK, with NO /proc/stat btime added. Adding btime would re-express the value as
+        // wall-clock time and reintroduce the clock-sync drift the identity guard must survive, so assert the
+        // public value equals the pure boot-relative computation. Under the old btime-based code this would
+        // instead be a ~1.7-billion Unix-epoch value, so this test also guards against regressing to it.
+        var startTicks = ProcessStartTimeHelper.TryGetLinuxProcessStartTicks(Environment.ProcessId, ProcessStartTimeHelper.LinuxProcRoot);
+        Assert.NotNull(startTicks);
+
+        var expectedSecondsSinceBoot = (long)(startTicks.Value / (ulong)ProcessStartTimeHelper.GetLinuxClockTicksPerSecond());
+        Assert.Equal(expectedSecondsSinceBoot, ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds());
+    }
+
+    [Fact]
+    public void TryGetLinuxProcessStartTicks_ReadsField22FromProcRoot()
+    {
+        // Exercise the shared /proc reader against a synthetic proc root so it runs on every OS (the real
+        // /proc only exists on Linux). This is the same reader (and procRoot seam) DcpProcessMonitor uses
+        // when it points at HOST_PROC for host-process inspection.
+        using var procRoot = new TestTempDirectory();
+        const int pid = 4242;
+        const ulong expectedStartTicks = 9876543UL;
+
+        var statDirectory = Directory.CreateDirectory(Path.Combine(procRoot.Path, pid.ToString(CultureInfo.InvariantCulture)));
+        var fields = Enumerable.Range(0, 20).Select(static i => i.ToString(CultureInfo.InvariantCulture)).ToArray();
+        fields[0] = "S";
+        fields[19] = expectedStartTicks.ToString(CultureInfo.InvariantCulture);
+        File.WriteAllText(Path.Combine(statDirectory.FullName, "stat"), $"{pid} (proc name) {string.Join(' ', fields)}");
+
+        Assert.Equal(expectedStartTicks, ProcessStartTimeHelper.TryGetLinuxProcessStartTicks(pid, procRoot.Path));
+    }
+
+    [Fact]
+    public void TryGetLinuxProcessStartTicks_MissingStatFile_ReturnsNull()
+    {
+        using var procRoot = new TestTempDirectory();
+        Assert.Null(ProcessStartTimeHelper.TryGetLinuxProcessStartTicks(999999, procRoot.Path));
+    }
+
     [Theory]
     [InlineData("12345 missing-close-paren S 1 2 3")]
     [InlineData("12345 (dotnet) S 1 2 3")]

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
@@ -23,7 +23,7 @@ public class ProcessStartTimeHelperTests
     [Fact]
     public void IsProcessRunning_CurrentProcessWithWrongStartTime_ReturnsFalse()
     {
-        // A start time decades off can never be within tolerance, simulating PID reuse.
+        // A start time decades off can never match, simulating PID reuse.
         Assert.False(ProcessStartTimeHelper.IsProcessRunning(Environment.ProcessId, expectedStartTimeUnixSeconds: 1));
     }
 
@@ -84,12 +84,21 @@ public class ProcessStartTimeHelperTests
     }
 
     [Theory]
-    [InlineData(1000L, 1000L, true)]   // exact
-    [InlineData(1000L, 1001L, true)]   // within default 1s tolerance
-    [InlineData(1000L, 999L, true)]    // within default 1s tolerance
-    [InlineData(1000L, 1002L, false)]  // outside tolerance
-    public void AreClose_RespectsDefaultTolerance(long expected, long actual, bool expectedResult)
+    [InlineData(1000L, 1000L, true)]   // exact match
+    [InlineData(1000L, 1001L, false)]  // adjacent second: a recycled PID must not match
+    [InlineData(1000L, 999L, false)]   // adjacent second: a recycled PID must not match
+    [InlineData(1000L, 1002L, false)]  // clearly different
+    public void AreClose_DefaultsToExactMatch(long expected, long actual, bool expectedResult)
     {
         Assert.Equal(expectedResult, ProcessStartTimeHelper.AreClose(expected, actual));
+    }
+
+    [Theory]
+    [InlineData(1000L, 1001L, true)]   // within the opt-in one-second tolerance
+    [InlineData(1000L, 999L, true)]    // within the opt-in one-second tolerance
+    [InlineData(1000L, 1002L, false)]  // outside the opt-in one-second tolerance
+    public void AreClose_WithOptInTolerance_AllowsNeighboringSeconds(long expected, long actual, bool expectedResult)
+    {
+        Assert.Equal(expectedResult, ProcessStartTimeHelper.AreClose(expected, actual, TimeSpan.FromSeconds(1)));
     }
 }

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Aspire.Hosting.Tests;
 
@@ -39,16 +40,17 @@ public class ProcessStartTimeHelperTests
         Assert.NotNull(process);
 
         var pid = process.Id;
-        var startedUnix = ((DateTimeOffset)process.StartTime).ToUnixTimeSeconds();
+        var startedUnix = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(process.Id);
+        Assert.NotNull(startedUnix);
 
         Assert.True(ProcessStartTimeHelper.IsProcessRunning(pid));
-        Assert.True(ProcessStartTimeHelper.IsProcessRunning(pid, startedUnix));
+        Assert.True(ProcessStartTimeHelper.IsProcessRunning(pid, startedUnix.Value));
 
         process.Kill(entireProcessTree: true);
         process.WaitForExit();
 
         Assert.False(ProcessStartTimeHelper.IsProcessRunning(pid));
-        Assert.False(ProcessStartTimeHelper.IsProcessRunning(pid, startedUnix));
+        Assert.False(ProcessStartTimeHelper.IsProcessRunning(pid, startedUnix.Value));
     }
 
     [Fact]
@@ -63,6 +65,33 @@ public class ProcessStartTimeHelperTests
         var fromPid = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(Environment.ProcessId);
         Assert.NotNull(fromPid);
         Assert.Equal(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds(), fromPid);
+    }
+
+    [Theory]
+    [InlineData("dotnet", 123456UL)]
+    [InlineData("process name with ) parenthesis", 987654UL)]
+    public void TryParseLinuxStatStartTicks_ParsesField22AfterProcessName(string processName, ulong expectedStartTicks)
+    {
+        var fields = Enumerable.Range(0, 20).Select(static i => i.ToString(CultureInfo.InvariantCulture)).ToArray();
+        fields[0] = "S";
+        fields[19] = expectedStartTicks.ToString(CultureInfo.InvariantCulture);
+        var stat = $"12345 ({processName}) {string.Join(' ', fields)}";
+
+        Assert.Equal(expectedStartTicks, ProcessStartTimeHelper.TryParseLinuxStatStartTicks(stat));
+    }
+
+    [Fact]
+    public void LinuxProcRoot_UsesCurrentProcessNamespace()
+    {
+        Assert.Equal("/proc", ProcessStartTimeHelper.LinuxProcRoot);
+    }
+
+    [Theory]
+    [InlineData("12345 missing-close-paren S 1 2 3")]
+    [InlineData("12345 (dotnet) S 1 2 3")]
+    public void TryParseLinuxStatStartTicks_Malformed_ReturnsNull(string stat)
+    {
+        Assert.Null(ProcessStartTimeHelper.TryParseLinuxStatStartTicks(stat));
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
@@ -67,6 +67,14 @@ public class ProcessStartTimeHelperTests
         Assert.Equal(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds(), fromPid);
     }
 
+    [Fact]
+    public void IsProcessRunningWithRuntimeStartTime_CurrentProcess_ReturnsTrue()
+    {
+        var startedUnix = ProcessStartTimeHelper.GetCurrentProcessRuntimeStartTimeUnixSeconds();
+
+        Assert.True(ProcessStartTimeHelper.IsProcessRunningWithRuntimeStartTime(Environment.ProcessId, startedUnix));
+    }
+
     [Theory]
     [InlineData("dotnet", 123456UL)]
     [InlineData("process name with ) parenthesis", 987654UL)]

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
@@ -95,15 +95,10 @@ public class ProcessStartTimeHelperTests
     }
 
     [Fact]
-    public void GetCurrentProcessStartTime_OnLinux_IsBootRelativeWithoutBtime()
+    public void GetCurrentProcessStartTime_IsStartTicksTicksDividedByTicksPerSecond()
     {
         Assert.SkipUnless(OperatingSystem.IsLinux(), "Boot-relative /proc start-tick identity is Linux-specific.");
 
-        // The stable Linux identity is boot-relative: field 22 of /proc/<pid>/stat (start ticks since boot)
-        // divided by _SC_CLK_TCK, with NO /proc/stat btime added. Adding btime would re-express the value as
-        // wall-clock time and reintroduce the clock-sync drift the identity guard must survive, so assert the
-        // public value equals the pure boot-relative computation. Under the old btime-based code this would
-        // instead be a ~1.7-billion Unix-epoch value, so this test also guards against regressing to it.
         var startTicks = ProcessStartTimeHelper.TryGetLinuxProcessStartTicks(Environment.ProcessId, ProcessStartTimeHelper.LinuxProcRoot);
         Assert.NotNull(startTicks);
 

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Globalization;
 
 namespace Aspire.Hosting.Tests;
@@ -31,13 +30,9 @@ public class ProcessStartTimeHelperTests
     [Fact]
     public void IsProcessRunning_TracksRealProcessLifetime()
     {
-        // Mirrors CliOrphanDetectorTests' process choice for cross-platform reliability in CI.
-        var psi = OperatingSystem.IsWindows()
-            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
-            : new ProcessStartInfo("tail", "-f /dev/null") { CreateNoWindow = true };
-
-        using var process = Process.Start(psi);
-        Assert.NotNull(process);
+        // Use the shared bounded, self-terminating helper so an aborted test host (hang dump / SIGKILL)
+        // can't leak this child on a CI agent. The test still kills it explicitly below.
+        using var process = TestProcesses.StartLongRunning();
 
         var pid = process.Id;
         var startedUnix = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(process.Id);

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Hosting.Tests;
+
+public class ProcessStartTimeHelperTests
+{
+    [Fact]
+    public void IsProcessRunning_CurrentProcess_ReturnsTrue()
+    {
+        Assert.True(ProcessStartTimeHelper.IsProcessRunning(Environment.ProcessId));
+    }
+
+    [Fact]
+    public void IsProcessRunning_CurrentProcessWithMatchingStartTime_ReturnsTrue()
+    {
+        var startedUnix = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds();
+        Assert.True(ProcessStartTimeHelper.IsProcessRunning(Environment.ProcessId, startedUnix));
+    }
+
+    [Fact]
+    public void IsProcessRunning_CurrentProcessWithWrongStartTime_ReturnsFalse()
+    {
+        // A start time decades off can never be within tolerance, simulating PID reuse.
+        Assert.False(ProcessStartTimeHelper.IsProcessRunning(Environment.ProcessId, expectedStartTimeUnixSeconds: 1));
+    }
+
+    [Fact]
+    public void IsProcessRunning_TracksRealProcessLifetime()
+    {
+        // Mirrors CliOrphanDetectorTests' process choice for cross-platform reliability in CI.
+        var psi = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
+            : new ProcessStartInfo("tail", "-f /dev/null") { CreateNoWindow = true };
+
+        using var process = Process.Start(psi);
+        Assert.NotNull(process);
+
+        var pid = process.Id;
+        var startedUnix = ((DateTimeOffset)process.StartTime).ToUnixTimeSeconds();
+
+        Assert.True(ProcessStartTimeHelper.IsProcessRunning(pid));
+        Assert.True(ProcessStartTimeHelper.IsProcessRunning(pid, startedUnix));
+
+        process.Kill(entireProcessTree: true);
+        process.WaitForExit();
+
+        Assert.False(ProcessStartTimeHelper.IsProcessRunning(pid));
+        Assert.False(ProcessStartTimeHelper.IsProcessRunning(pid, startedUnix));
+    }
+
+    [Fact]
+    public void GetCurrentProcessStartTimeUnixSeconds_ReturnsPositiveValue()
+    {
+        Assert.True(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds() > 0);
+    }
+
+    [Fact]
+    public void TryGetProcessStartTimeUnixSeconds_CurrentProcess_MatchesCurrentValue()
+    {
+        var fromPid = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(Environment.ProcessId);
+        Assert.NotNull(fromPid);
+        Assert.Equal(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds(), fromPid);
+    }
+
+    [Theory]
+    [InlineData("123", 123L)]
+    [InlineData("0", 0L)]
+    [InlineData(" 456 ", 456L)]
+    public void TryParseStartTimeUnixSeconds_Valid_ReturnsValue(string value, long expected)
+    {
+        Assert.Equal(expected, ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(value));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-number")]
+    public void TryParseStartTimeUnixSeconds_Invalid_ReturnsNull(string? value)
+    {
+        Assert.Null(ProcessStartTimeHelper.TryParseStartTimeUnixSeconds(value));
+    }
+
+    [Theory]
+    [InlineData(1000L, 1000L, true)]   // exact
+    [InlineData(1000L, 1001L, true)]   // within default 1s tolerance
+    [InlineData(1000L, 999L, true)]    // within default 1s tolerance
+    [InlineData(1000L, 1002L, false)]  // outside tolerance
+    public void AreClose_RespectsDefaultTolerance(long expected, long actual, bool expectedResult)
+    {
+        Assert.Equal(expectedResult, ProcessStartTimeHelper.AreClose(expected, actual));
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/ProcessStartTimeHelperTests.cs
@@ -16,7 +16,7 @@ public class ProcessStartTimeHelperTests
     [Fact]
     public void IsProcessRunning_CurrentProcessWithMatchingStartTime_ReturnsTrue()
     {
-        var startedUnix = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds();
+        var startedUnix = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixMilliseconds();
         Assert.True(ProcessStartTimeHelper.IsProcessRunning(Environment.ProcessId, startedUnix));
     }
 
@@ -24,7 +24,7 @@ public class ProcessStartTimeHelperTests
     public void IsProcessRunning_CurrentProcessWithWrongStartTime_ReturnsFalse()
     {
         // A start time decades off can never match, simulating PID reuse.
-        Assert.False(ProcessStartTimeHelper.IsProcessRunning(Environment.ProcessId, expectedStartTimeUnixSeconds: 1));
+        Assert.False(ProcessStartTimeHelper.IsProcessRunning(Environment.ProcessId, expectedStartTimeUnixMilliseconds: 1));
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public class ProcessStartTimeHelperTests
         using var process = TestProcesses.StartLongRunning();
 
         var pid = process.Id;
-        var startedUnix = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(process.Id);
+        var startedUnix = ProcessStartTimeHelper.TryGetProcessStartTimeUnixMilliseconds(process.Id);
         Assert.NotNull(startedUnix);
 
         Assert.True(ProcessStartTimeHelper.IsProcessRunning(pid));
@@ -49,17 +49,17 @@ public class ProcessStartTimeHelperTests
     }
 
     [Fact]
-    public void GetCurrentProcessStartTimeUnixSeconds_ReturnsPositiveValue()
+    public void GetCurrentProcessStartTimeUnixMilliseconds_ReturnsPositiveValue()
     {
-        Assert.True(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds() > 0);
+        Assert.True(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixMilliseconds() > 0);
     }
 
     [Fact]
-    public void TryGetProcessStartTimeUnixSeconds_CurrentProcess_MatchesCurrentValue()
+    public void TryGetProcessStartTimeUnixMilliseconds_CurrentProcess_MatchesCurrentValue()
     {
-        var fromPid = ProcessStartTimeHelper.TryGetProcessStartTimeUnixSeconds(Environment.ProcessId);
+        var fromPid = ProcessStartTimeHelper.TryGetProcessStartTimeUnixMilliseconds(Environment.ProcessId);
         Assert.NotNull(fromPid);
-        Assert.Equal(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds(), fromPid);
+        Assert.Equal(ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixMilliseconds(), fromPid);
     }
 
     [Fact]
@@ -90,15 +90,15 @@ public class ProcessStartTimeHelperTests
     }
 
     [Fact]
-    public void GetCurrentProcessStartTime_IsStartTicksTicksDividedByTicksPerSecond()
+    public void GetCurrentProcessStartTimeUnixMilliseconds_IsStartTicksTimes1000DividedByTicksPerSecond()
     {
         Assert.SkipUnless(OperatingSystem.IsLinux(), "Boot-relative /proc start-tick identity is Linux-specific.");
 
         var startTicks = ProcessStartTimeHelper.TryGetLinuxProcessStartTicks(Environment.ProcessId, ProcessStartTimeHelper.LinuxProcRoot);
         Assert.NotNull(startTicks);
 
-        var expectedSecondsSinceBoot = (long)(startTicks.Value / (ulong)ProcessStartTimeHelper.GetLinuxClockTicksPerSecond());
-        Assert.Equal(expectedSecondsSinceBoot, ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixSeconds());
+        var expectedMillisecondsSinceBoot = (long)((startTicks.Value * 1000) / (ulong)ProcessStartTimeHelper.GetLinuxClockTicksPerSecond());
+        Assert.Equal(expectedMillisecondsSinceBoot, ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixMilliseconds());
     }
 
     [Fact]
@@ -170,5 +170,31 @@ public class ProcessStartTimeHelperTests
     public void AreClose_WithOptInTolerance_AllowsNeighboringSeconds(long expected, long actual, bool expectedResult)
     {
         Assert.Equal(expectedResult, ProcessStartTimeHelper.AreClose(expected, actual, TimeSpan.FromSeconds(1)));
+    }
+
+    [Theory]
+    [InlineData(100000L, 100000L, true)]    // exact match
+    [InlineData(100000L, 100010L, true)]    // within one _SC_CLK_TCK tick (~10 ms): same process
+    [InlineData(100000L, 100020L, true)]    // at the 20 ms boundary: accepted
+    [InlineData(100000L, 100021L, false)]   // just beyond 20 ms: rejected
+    [InlineData(100000L, 100500L, false)]   // reused 500 ms later (same wall-clock second): rejected
+    public void AreCloseMilliseconds_DefaultsToStableTolerance(long expected, long actual, bool expectedResult)
+    {
+        Assert.Equal(expectedResult, ProcessStartTimeHelper.AreCloseMilliseconds(expected, actual));
+    }
+
+    [Fact]
+    public void StableStartTimeMatchTolerance_IsTwentyMilliseconds()
+    {
+        Assert.Equal(TimeSpan.FromMilliseconds(20), ProcessStartTimeHelper.StableStartTimeMatchTolerance);
+    }
+
+    [Fact]
+    public void IsProcessRunning_StartTimeOffByMoreThanTolerance_ReturnsFalse()
+    {
+        // A recycled PID that starts 500 ms after the original (same wall-clock second) collided under the
+        // old whole-second identity; the millisecond identity + 20 ms tolerance distinguishes them.
+        var startedMs = ProcessStartTimeHelper.GetCurrentProcessStartTimeUnixMilliseconds();
+        Assert.False(ProcessStartTimeHelper.IsProcessRunning(Environment.ProcessId, startedMs + 500));
     }
 }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -2377,20 +2377,9 @@ public class DistributedApplicationTests
         return resourceEvent.Snapshot.Properties.FirstOrDefault(p => p.Name == propertyName)?.Value;
     }
 
-    private static Process StartLongRunningProcess()
-    {
-        var startInfo = OperatingSystem.IsWindows()
-            ? new ProcessStartInfo("ping", "-t localhost") { CreateNoWindow = true }
-            : new ProcessStartInfo("tail", "-f /dev/null");
-
-        startInfo.RedirectStandardOutput = true;
-        startInfo.RedirectStandardError = true;
-
-        var process = Process.Start(startInfo);
-        Assert.NotNull(process);
-
-        return process;
-    }
+    // Delegates to the shared bounded, self-terminating helper so an aborted test host can't leak
+    // this child on a CI agent.
+    private static Process StartLongRunningProcess() => TestProcesses.StartLongRunning();
 
     private static async Task KillProcessAsync(Process process, CancellationToken cancellationToken)
     {

--- a/tests/Aspire.Managed.Tests/ParentProcessWatchdogTests.cs
+++ b/tests/Aspire.Managed.Tests/ParentProcessWatchdogTests.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Aspire.Managed.Tests;
+
+public class ParentProcessWatchdogTests
+{
+    [Fact]
+    public async Task ParentExitedCallback_StillForceExitsWhenCancellationCallbackThrows()
+    {
+        using var operationCts = new CancellationTokenSource();
+        using var registration = operationCts.Token.Register(static () => throw new InvalidOperationException("simulated cancellation callback failure"));
+        int? exitCode = null;
+
+        await ParentProcessWatchdog.OnParentExitedAsync(
+            operationCts,
+            CancellationToken.None,
+            forceExitGracePeriod: TimeSpan.Zero,
+            exit: code => exitCode = code);
+
+        Assert.True(operationCts.IsCancellationRequested);
+        Assert.Equal(124, exitCode);
+    }
+}

--- a/tests/Aspire.Managed.Tests/ParentProcessWatchdogTests.cs
+++ b/tests/Aspire.Managed.Tests/ParentProcessWatchdogTests.cs
@@ -9,7 +9,7 @@ namespace Aspire.Managed.Tests;
 public class ParentProcessWatchdogTests
 {
     [Fact]
-    public void GetExpectedParentStartTimeUnixSeconds_PrefersStableValue()
+    public void GetExpectedParentStartTimeUnix_PrefersStableValue()
     {
         var environment = new Dictionary<string, string?>
         {
@@ -17,21 +17,21 @@ public class ParentProcessWatchdogTests
             [KnownConfigNames.CliProcessStartedStable] = "1001"
         };
 
-        var startTime = ParentProcessWatchdog.GetExpectedParentStartTimeUnixSeconds(environment.GetValueOrDefault, out var useRuntimeStartTime);
+        var startTime = ParentProcessWatchdog.GetExpectedParentStartTimeUnix(environment.GetValueOrDefault, out var useRuntimeStartTime);
 
         Assert.Equal(1001, startTime);
         Assert.False(useRuntimeStartTime);
     }
 
     [Fact]
-    public void GetExpectedParentStartTimeUnixSeconds_UsesRuntimeComparisonForLegacyValue()
+    public void GetExpectedParentStartTimeUnix_UsesRuntimeComparisonForLegacyValue()
     {
         var environment = new Dictionary<string, string?>
         {
             [KnownConfigNames.CliProcessStarted] = "1000"
         };
 
-        var startTime = ParentProcessWatchdog.GetExpectedParentStartTimeUnixSeconds(environment.GetValueOrDefault, out var useRuntimeStartTime);
+        var startTime = ParentProcessWatchdog.GetExpectedParentStartTimeUnix(environment.GetValueOrDefault, out var useRuntimeStartTime);
 
         Assert.Equal(1000, startTime);
         Assert.True(useRuntimeStartTime);

--- a/tests/Aspire.Managed.Tests/ParentProcessWatchdogTests.cs
+++ b/tests/Aspire.Managed.Tests/ParentProcessWatchdogTests.cs
@@ -1,12 +1,42 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting;
 using Xunit;
 
 namespace Aspire.Managed.Tests;
 
 public class ParentProcessWatchdogTests
 {
+    [Fact]
+    public void GetExpectedParentStartTimeUnixSeconds_PrefersStableValue()
+    {
+        var environment = new Dictionary<string, string?>
+        {
+            [KnownConfigNames.CliProcessStarted] = "1000",
+            [KnownConfigNames.CliProcessStartedStable] = "1001"
+        };
+
+        var startTime = ParentProcessWatchdog.GetExpectedParentStartTimeUnixSeconds(environment.GetValueOrDefault, out var useRuntimeStartTime);
+
+        Assert.Equal(1001, startTime);
+        Assert.False(useRuntimeStartTime);
+    }
+
+    [Fact]
+    public void GetExpectedParentStartTimeUnixSeconds_UsesRuntimeComparisonForLegacyValue()
+    {
+        var environment = new Dictionary<string, string?>
+        {
+            [KnownConfigNames.CliProcessStarted] = "1000"
+        };
+
+        var startTime = ParentProcessWatchdog.GetExpectedParentStartTimeUnixSeconds(environment.GetValueOrDefault, out var useRuntimeStartTime);
+
+        Assert.Equal(1000, startTime);
+        Assert.True(useRuntimeStartTime);
+    }
+
     [Fact]
     public async Task ParentExitedCallback_StillForceExitsWhenCancellationCallbackThrows()
     {

--- a/tests/Shared/TestProcesses.cs
+++ b/tests/Shared/TestProcesses.cs
@@ -5,8 +5,8 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 
-namespace Aspire.Cli.Tests.TestServices;
-
+// Global namespace (no wrapper) so both Aspire.Cli.Tests and Aspire.Hosting.Tests can link this
+// shared helper without a project-specific using, matching the sibling TempDirectory.cs.
 internal static class TestProcesses
 {
     // A leaked long-running child lingers on a CI agent until the box is recycled. The process-lifecycle


### PR DESCRIPTION
## Description

There are at least 4 scenarios when `aspire-managed` processes may leak:

1. PID-reuse. `RemoteHost/OrphanDetector.cs` polls the parent by PID only (REMOTE_APP_HOST_PID), no start-time check, and the CLI's start time is never propagated. When the launching CLI dies and its PID is reused (pretty common if machine is heavily used, e.g. during test run), the server thinks its parent is alive and never exits → permanent leak. The .NET AppHost path (`CliOrphanDetector`) already does PID+start-time; the `RemoteHost` path was never brought to that bar.

2. `dashboard` and `nuget` commands have no orphan detection at all. A hard-killed CLI (SIGKILL from a test runner, Ctrl-C during a slow restore) leaves them lingering forever. 

3. During `aspire start`, if the launcher CLI process is killed (SIGKILL) mid-start, the detached CLI process wil just complete the startup and keep running.

4.  There is no active reaping of already-leaked orphans. once leaked they persist and get rediscovered by the auxiliary backchannel monitor, producing the "started successfully but isn't running" false success. 

Fixes https://github.com/microsoft/aspire/issues/18050

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No -- not really necessary
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
