### PR TITLE
Fix NuGet prefetch process leaks

### DIFF
--- a/src/Aspire.Cli/Commands/BaseConfigSubCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseConfigSubCommand.cs
@@ -2,12 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Configuration;
+using Aspire.Cli.NuGet;
 
 namespace Aspire.Cli.Commands;
 
-internal abstract class BaseConfigSubCommand(string name, string description, IConfigurationService configurationService, CommonCommandServices services) : BaseCommand(name, description, services)
+internal abstract class BaseConfigSubCommand(string name, string description, IConfigurationService configurationService, CommonCommandServices services) : BaseCommand(name, description, services), IPackageMetaPrefetchingCommand
 {
     protected IConfigurationService ConfigurationService { get; } = configurationService;
+
+    public bool PrefetchesTemplatePackageMetadata => false;
+
+    public bool PrefetchesCliPackageMetadata => false;
 
     /// <summary>
     /// Extension-compatible method to execute the subcommand. Prompts for input if necessary.

--- a/src/Aspire.Cli/Commands/ConfigCommand.cs
+++ b/src/Aspire.Cli/Commands/ConfigCommand.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.NuGet;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
@@ -14,9 +15,13 @@ using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
 
-internal sealed class ConfigCommand : BaseCommand
+internal sealed class ConfigCommand : BaseCommand, IPackageMetaPrefetchingCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.ToolsAndConfiguration;
+
+    public bool PrefetchesTemplatePackageMetadata => false;
+
+    public bool PrefetchesCliPackageMetadata => false;
 
     private readonly IConfiguration _configuration;
 

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -68,19 +68,25 @@ internal sealed class ProcessInvocationOptions
 
     /// <summary>
     /// When <c>true</c>, the spawned process is given its own hidden console group (Windows)
-    /// and, on Windows, is assigned to the CLI's kill-on-close job object. Required so the
-    /// shutdown ladder in <see cref="ProcessExecution"/> can target the child with
-    /// DCP's <c>stop-process-tree</c> CTRL+C dance.
+    /// so the shutdown ladder in <see cref="ProcessExecution"/> can target the child with
+    /// DCP's <c>stop-process-tree</c> CTRL+C dance without also signalling the CLI.
     /// </summary>
     /// <remarks>
-    /// Pair with <see cref="GracefulShutdownSignaler"/> and <see cref="ShutdownService"/>.
-    /// On Windows the spawned process is bound to the process-wide
-    /// <see cref="WindowsConsoleProcessJob"/> kill-on-close job automatically.
+    /// Pair with <see cref="GracefulShutdownSignaler"/> and <see cref="ShutdownService"/> for
+    /// graceful shutdown. Pair with <see cref="KillOnParentExit"/> when the child should also
+    /// be bound to the parent-lifetime safety net.
     /// Leaving the signaler/service unset means cancellation falls back to
     /// <see cref="ProcessExecution"/>'s force-kill mode, preserving back-compat
     /// for the many non-Run callers (build, restore, package add, layout, etc.).
     /// </remarks>
     public bool IsolateConsole { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, the child process should be terminated when the CLI exits unexpectedly.
+    /// This provides a crash-time safety net for short-lived background helpers that should never
+    /// outlive their parent.
+    /// </summary>
+    public bool KillOnParentExit { get; set; }
 
     /// <summary>
     /// Issues the graceful shutdown signal during the shutdown ladder (DCP
@@ -315,11 +321,13 @@ internal sealed class DotNetCliRunner(
             KillEntireProcessTreeOnCancel = options.KillEntireProcessTreeOnCancel,
             // Forward the Run-path shutdown ladder opt-ins. Forgetting any of these silently
             // demotes the run to the force-kill fallback: IsolateConsole=false skips console
-            // isolation, and the null signaler/service pair causes ProcessExecution's OCE catch
+            // isolation, KillOnParentExit=false removes the crash-time safety net, and the
+            // null signaler/service pair causes ProcessExecution's OCE catch
             // (DotNet/ProcessExecution.cs) to route through its force-kill mode (best-effort SIGTERM
             // then kill) instead of its graceful ladder. Build/restore/etc. callers leave these unset
             // and intentionally keep the force-kill path.
             IsolateConsole = options.IsolateConsole,
+            KillOnParentExit = options.KillOnParentExit,
             GracefulShutdownSignaler = options.GracefulShutdownSignaler,
             ShutdownService = options.ShutdownService,
             StandardOutputCallback = line =>
@@ -1318,6 +1326,8 @@ internal sealed class DotNetCliRunner(
     public async Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesAsync(DirectoryInfo workingDirectory, string query, bool exactMatch, bool prerelease, int take, int skip, FileInfo? nugetConfigFile, bool useCache, ProcessInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = telemetry.StartDiagnosticActivity();
+
+        options.KillOnParentExit = true;
 
         string? rawKey = null;
         var cacheEnabled = useCache;

--- a/src/Aspire.Cli/DotNet/ProcessExecution.cs
+++ b/src/Aspire.Cli/DotNet/ProcessExecution.cs
@@ -9,11 +9,9 @@ namespace Aspire.Cli.DotNet;
 
 /// <summary>
 /// The single <see cref="IProcessExecution"/> implementation. Wraps an <see cref="IsolatedProcess"/>
-/// for both the isolated-console run path (Windows AppHost graceful shutdown) and ordinary
-/// non-isolated subprocesses — the only difference is the
-/// <see cref="IsolatedProcessStartInfo.IsolateConsole"/> flag the factory sets. The child is
-/// spawned lazily on <see cref="Start"/> so callers that build an execution but never start it
-/// (e.g. the extension-host launch path, which reads <see cref="Arguments"/> /
+/// for isolated-console, kill-on-parent-exit, and ordinary redirected subprocesses. The child is
+/// spawned lazily on <see cref="Start"/> so callers that build an execution but never start it (e.g.
+/// the extension-host launch path, which reads <see cref="Arguments"/> /
 /// <see cref="EnvironmentVariables"/> and returns before starting) don't orphan a process.
 /// </summary>
 internal sealed class ProcessExecution : IProcessExecution

--- a/src/Aspire.Cli/DotNet/ProcessExecutionFactory.cs
+++ b/src/Aspire.Cli/DotNet/ProcessExecutionFactory.cs
@@ -33,10 +33,7 @@ internal sealed class ProcessExecutionFactory(
             FileName = fileName,
             WorkingDirectory = workingDirectory.FullName,
             IsolateConsole = options.IsolateConsole,
-            // Only the isolated path on Windows uses the kill-on-close job; the non-isolated path
-            // and every Unix path leave it null. The job is the process-wide singleton, created on
-            // demand the first time an isolated child needs it.
-            JobHandle = options.IsolateConsole && environment.IsWindows() ? WindowsConsoleProcessJob.Shared.Handle : null,
+            KillOnParentExit = options.KillOnParentExit,
         };
 
         foreach (var a in args)
@@ -70,7 +67,7 @@ internal sealed class ProcessExecutionFactory(
             FileName = startInfo.FileName,
             WorkingDirectory = startInfo.WorkingDirectory,
             IsolateConsole = options.IsolateConsole,
-            JobHandle = options.IsolateConsole && environment.IsWindows() ? WindowsConsoleProcessJob.Shared.Handle : null,
+            KillOnParentExit = options.KillOnParentExit,
         };
 
         foreach (var arg in startInfo.ArgumentList)

--- a/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
+++ b/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
@@ -17,6 +17,7 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         IEnumerable<string> arguments,
         string? workingDirectory = null,
         IDictionary<string, string>? environmentVariables = null,
+        bool killOnParentExit = false,
         CancellationToken ct = default)
     {
         var outputBuilder = new StringBuilder();
@@ -27,6 +28,7 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
             SuppressLogging = true,
             StandardOutputCallback = line => outputBuilder.AppendLine(line),
             StandardErrorCallback = line => errorBuilder.AppendLine(line),
+            KillOnParentExit = killOnParentExit,
         };
 
         var args = arguments.ToArray();

--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -45,7 +45,7 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
         var packages = await SearchPackagesInternalAsync(
             workingDirectory,
             query: "Aspire.ProjectTemplates",
-            exactMatch: false,
+            exactMatch: true,
             prerelease,
             nugetConfigFile,
             cancellationToken).ConfigureAwait(false);
@@ -79,7 +79,7 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
         var packages = await SearchPackagesInternalAsync(
             workingDirectory,
             query: "Aspire.Cli",
-            exactMatch: false,
+            exactMatch: true,
             prerelease,
             nugetConfigFile,
             cancellationToken).ConfigureAwait(false);
@@ -123,7 +123,7 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
             nugetConfigFile,
             cancellationToken).ConfigureAwait(false);
 
-        bool FilterExactIdMatch(string? id) => string.Equals(id, exactPackageId, StringComparison.Ordinal);
+        bool FilterExactIdMatch(string? id) => string.Equals(id, exactPackageId, StringComparison.OrdinalIgnoreCase);
         return FilterPackages(packages, FilterExactIdMatch);
     }
 
@@ -155,9 +155,15 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
             "nuget",
             "search",
             "--query", query,
-            "--take", "1000",
+            "--take", exactMatch ? "1" : NuGetPackageSearchDefaults.PageSize.ToString(CultureInfo.InvariantCulture),
+            "--timeout-seconds", NuGetPackageSearchDefaults.TimeoutSeconds.ToString(CultureInfo.InvariantCulture),
             "--format", "json"
         };
+
+        if (exactMatch)
+        {
+            args.Add("--exact-match");
+        }
 
         if (prerelease)
         {
@@ -189,12 +195,26 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
         var environmentVariables = new Dictionary<string, string>();
         layoutLease?.AddEnvironment(environmentVariables);
 
-        var (exitCode, output, error) = await _layoutProcessRunner.RunAsync(
-            managedPath,
-            args,
-            workingDirectory: workingDirectory.FullName,
-            environmentVariables: environmentVariables,
-            ct: cancellationToken).ConfigureAwait(false);
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(NuGetPackageSearchDefaults.Timeout);
+
+        (int exitCode, string output, string error) processResult;
+        try
+        {
+            processResult = await _layoutProcessRunner.RunAsync(
+                managedPath,
+                args,
+                workingDirectory: workingDirectory.FullName,
+                environmentVariables: environmentVariables,
+                killOnParentExit: true,
+                ct: timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+        {
+            throw new NuGetPackageCacheException(string.Format(CultureInfo.CurrentCulture, ErrorStrings.FailedToSearchForPackages, CliExitCodes.FailedToSearchIntegrations));
+        }
+
+        var (exitCode, output, error) = processResult;
 
         // Log stderr output (verbose info from NuGetHelper)
         if (!string.IsNullOrWhiteSpace(error))
@@ -239,7 +259,7 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
             else
             {
                 var exactMatchResultPackage = result.Packages
-                    .FirstOrDefault(p => p.Id.Equals(query, StringComparison.Ordinal));
+                    .FirstOrDefault(p => p.Id.Equals(query, StringComparison.OrdinalIgnoreCase));
                 if (exactMatchResultPackage is null || exactMatchResultPackage.AllVersions is null)
                 {
                     return [];

--- a/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
@@ -21,6 +21,13 @@ internal interface INuGetPackageCache
     Task<IEnumerable<NuGetPackage>> GetPackageVersionsAsync(DirectoryInfo workingDirectory, string exactPackageId, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken);
 }
 
+internal static class NuGetPackageSearchDefaults
+{
+    public const int PageSize = 1000;
+    public const int TimeoutSeconds = 30;
+    public static readonly TimeSpan Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
+}
+
 /// <summary>
 /// Packages that have been superseded and should be hidden from integration listings by default.
 /// </summary>
@@ -69,8 +76,6 @@ internal static class PackageIdFilters
 
 internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache memoryCache, AspireCliTelemetry telemetry, IFeatures features) : INuGetPackageCache
 {
-    private const int SearchPageSize = 1000;
-
     public async Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
     {
         var nuGetConfigHashSuffix = nugetConfigFile is not null ? await ComputeNuGetConfigHashSuffixAsync(nugetConfigFile, cancellationToken) : string.Empty;
@@ -78,7 +83,7 @@ internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache
 
         var packages = await memoryCache.GetOrCreateAsync(key, async (entry) =>
         {
-            var packages = await GetPackagesAsync(workingDirectory, "Aspire.ProjectTemplates", null, prerelease, nugetConfigFile, true, cancellationToken);
+            var packages = await GetPackageVersionsAsync(workingDirectory, "Aspire.ProjectTemplates", prerelease, nugetConfigFile, true, cancellationToken);
             return packages.Where(p => p.Id.Equals("Aspire.ProjectTemplates", StringComparison.OrdinalIgnoreCase));
 
         }) ?? throw new NuGetPackageCacheException(ErrorStrings.FailedToRetrieveCachedTemplatePackages);
@@ -100,7 +105,7 @@ internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache
         {
             // Set cache expiration to 1 hour for CLI updates
             entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
-            var packages = await GetPackagesAsync(workingDirectory, "Aspire.Cli", null, prerelease, nugetConfigFile, false, cancellationToken);
+            var packages = await GetPackageVersionsAsync(workingDirectory, "Aspire.Cli", prerelease, nugetConfigFile, false, cancellationToken);
             return packages.Where(p => p.Id.Equals("Aspire.Cli", StringComparison.OrdinalIgnoreCase));
         }) ?? [];
 
@@ -126,18 +131,19 @@ internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache
         do
         {
             // This search should pick up Aspire.Hosting.* and CommunityToolkit.Aspire.Hosting.*
-            var result = await cliRunner.SearchPackagesAsync(
-                workingDirectory,
-                query,
-                exactMatch: false,
-                prerelease,
-                SearchPageSize,
-                skip,
-                nugetConfigFile,
-                useCache, // Pass through the useCache parameter
-                new ProcessInvocationOptions { SuppressLogging = true },
-                cancellationToken
-                );
+            var result = await SearchPackagesWithTimeoutAsync(
+                operation: ct => cliRunner.SearchPackagesAsync(
+                    workingDirectory,
+                    query,
+                    exactMatch: false,
+                    prerelease,
+                    NuGetPackageSearchDefaults.PageSize,
+                    skip,
+                    nugetConfigFile,
+                    useCache, // Pass through the useCache parameter
+                    new ProcessInvocationOptions { SuppressLogging = true },
+                    ct),
+                cancellationToken);
 
             if (result.ExitCode != 0)
             {
@@ -150,14 +156,14 @@ internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache
                     collectedPackages.AddRange(result.Packages);
                 }
 
-                if (result.Packages?.Length < SearchPageSize)
+                if (result.Packages?.Length < NuGetPackageSearchDefaults.PageSize)
                 {
                     continueFetching = false;
                 }
                 else
                 {
                     continueFetching = true;
-                    skip += SearchPageSize;
+                    skip += NuGetPackageSearchDefaults.PageSize;
                 }
             }
         } while (continueFetching);
@@ -192,18 +198,19 @@ internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache
 
         var collectedPackages = new List<NuGetPackage>();
 
-        var result = await cliRunner.SearchPackagesAsync(
-                workingDirectory,
-                exactPackageId,
-                exactMatch: true,
-                prerelease,
-                take: 0,
-                skip: 0, // skip and take parameters are ignored when exactMatch is true
-                nugetConfigFile,
-                useCache, // Pass through the useCache parameter
-                new ProcessInvocationOptions { SuppressLogging = true },
-                cancellationToken
-                );
+        var result = await SearchPackagesWithTimeoutAsync(
+                operation: ct => cliRunner.SearchPackagesAsync(
+                    workingDirectory,
+                    exactPackageId,
+                    exactMatch: true,
+                    prerelease,
+                    take: 0,
+                    skip: 0, // skip and take parameters are ignored when exactMatch is true
+                    nugetConfigFile,
+                    useCache, // Pass through the useCache parameter
+                    new ProcessInvocationOptions { SuppressLogging = true },
+                    ct),
+                cancellationToken);
 
         if (result.ExitCode != 0)
         {
@@ -215,19 +222,24 @@ internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache
             collectedPackages.AddRange(result.Packages);
         }
 
-        // If no specific filter is specified we use the fallback filter which is useful in most circumstances
-        // other that aspire update which really needs to see all the packages to work effectively.
-        var effectiveFilter = (NuGetPackage p) =>
-        {
-            // Apply deprecated package filter unless the user wants to show deprecated packages
-            if (!features.IsFeatureEnabled(KnownFeatures.ShowDeprecatedPackages, defaultValue: false))
-            {
-                return !DeprecatedPackages.IsDeprecated(p.Id);
-            }
-            return true;
-        };
+        return collectedPackages;
+    }
 
-        return collectedPackages.Where(effectiveFilter);
+    private static async Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesWithTimeoutAsync(
+        Func<CancellationToken, Task<(int ExitCode, NuGetPackage[]? Packages)>> operation,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(NuGetPackageSearchDefaults.Timeout);
+
+        try
+        {
+            return await operation(timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+        {
+            throw new NuGetPackageCacheException(string.Format(CultureInfo.CurrentCulture, ErrorStrings.FailedToSearchForPackages, CliExitCodes.FailedToSearchIntegrations));
+        }
     }
 }
 

--- a/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
@@ -19,60 +19,69 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
 
         var shouldPrefetchTemplates = ShouldPrefetchTemplatePackages(command);
         var shouldPrefetchCli = ShouldPrefetchCliPackages(command);
+        var prefetchTasks = new List<Task>();
 
         // Prefetch template packages if needed
         if (shouldPrefetchTemplates)
         {
-            _ = Task.Run(async () =>
-            {
-                try
-                {
-                    var channels = await packagingService.GetChannelsAsync(stoppingToken);
-
-                    foreach (var channel in channels)
-                    {
-                        // Discard the results here, we just want them in the cache.
-                        _ = await channel.GetTemplatePackagesAsync(executionContext.WorkingDirectory, stoppingToken);
-                    }
-                }
-                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-                {
-                    logger.LogTrace("Template package prefetching was cancelled because the CLI is shutting down.");
-                }
-                catch (Exception ex)
-                {
-                    logger.LogDebug(ex, "Non-fatal error while prefetching template packages. This is not critical to the operation of the CLI.");
-                    // This prefetching is best effort. If it fails we log (above) and then the
-                    // background service will exit gracefully. Code paths that depend on this
-                    // data will handle the absence of pre-fetched packages gracefully.
-                }
-            }, stoppingToken);
+            prefetchTasks.Add(Task.Run(() => PrefetchTemplatePackagesAsync(stoppingToken), CancellationToken.None));
         }
 
         // Prefetch CLI packages if needed
         if (shouldPrefetchCli)
         {
-            _ = Task.Run(async () =>
+            prefetchTasks.Add(Task.Run(() => PrefetchCliPackagesAsync(stoppingToken), CancellationToken.None));
+        }
+
+        await Task.WhenAll(prefetchTasks).ConfigureAwait(false);
+    }
+
+    private async Task PrefetchTemplatePackagesAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            var channels = await packagingService.GetChannelsAsync(stoppingToken);
+
+            foreach (var channel in channels)
             {
-                if (features.IsFeatureEnabled(KnownFeatures.UpdateNotificationsEnabled, true))
-                {
-                    try
-                    {
-                        await cliUpdateNotifier.CheckForCliUpdatesAsync(
-                            workingDirectory: executionContext.WorkingDirectory,
-                            cancellationToken: stoppingToken
-                            );
-                    }
-                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-                    {
-                        logger.LogTrace("CLI package prefetching was cancelled because the CLI is shutting down.");
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogDebug(ex, "Non-fatal error while prefetching CLI packages. This is not critical to the operation of the CLI.");
-                    }
-                }
-            }, stoppingToken);
+                // Discard the results here, we just want them in the cache.
+                _ = await channel.GetTemplatePackagesAsync(executionContext.WorkingDirectory, stoppingToken);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            logger.LogTrace("Template package prefetching was cancelled because the CLI is shutting down.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Non-fatal error while prefetching template packages. This is not critical to the operation of the CLI.");
+            // This prefetching is best effort. If it fails we log (above) and then the
+            // background service will exit gracefully. Code paths that depend on this
+            // data will handle the absence of pre-fetched packages gracefully.
+        }
+    }
+
+    private async Task PrefetchCliPackagesAsync(CancellationToken stoppingToken)
+    {
+        if (!features.IsFeatureEnabled(KnownFeatures.UpdateNotificationsEnabled, true))
+        {
+            return;
+        }
+
+        try
+        {
+            await cliUpdateNotifier.CheckForCliUpdatesAsync(
+                workingDirectory: executionContext.WorkingDirectory,
+                cancellationToken: stoppingToken
+                );
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            logger.LogTrace("CLI package prefetching was cancelled because the CLI is shutting down.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Non-fatal error while prefetching CLI packages. This is not critical to the operation of the CLI.");
         }
     }
 
@@ -88,9 +97,9 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
             var command = await executionContext.CommandSelected.Task.WaitAsync(combined.Token);
             return command;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
-            // Timeout or cancellation occurred - proceed with no command (default behavior)
+            // Timeout occurred - proceed with no command (default behavior)
             return null;
         }
     }

--- a/src/Aspire.Cli/Packaging/PackageChannel.cs
+++ b/src/Aspire.Cli/Packaging/PackageChannel.cs
@@ -393,10 +393,9 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
 
         if (Quality is PackageChannelQuality.Stable || Quality is PackageChannelQuality.Both)
         {
-            tasks.Add(nuGetPackageCache.GetPackagesAsync(
+            tasks.Add(nuGetPackageCache.GetPackageVersionsAsync(
                 workingDirectory: workingDirectory,
-                packageId: packageId,
-                filter: id => id.Equals(packageId, StringComparisons.NuGetPackageId),
+                exactPackageId: packageId,
                 prerelease: false,
                 nugetConfigFile: tempNuGetConfig?.ConfigFile,
                 useCache: true, // Enable caching for package channel resolution
@@ -405,10 +404,9 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
 
         if (Quality is PackageChannelQuality.Prerelease || Quality is PackageChannelQuality.Both)
         {
-            tasks.Add(nuGetPackageCache.GetPackagesAsync(
+            tasks.Add(nuGetPackageCache.GetPackageVersionsAsync(
                 workingDirectory: workingDirectory,
-                packageId: packageId,
-                filter: id => id.Equals(packageId, StringComparisons.NuGetPackageId),
+                exactPackageId: packageId,
                 prerelease: true,
                 nugetConfigFile: tempNuGetConfig?.ConfigFile,
                 useCache: true, // Enable caching for package channel resolution
@@ -426,10 +424,9 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
         // in preview (Aspire.Hosting.Docker circa 9.4).
         if (Quality is PackageChannelQuality.Stable && !packages.Any())
         {
-            packages = await nuGetPackageCache.GetPackagesAsync(
+            packages = await nuGetPackageCache.GetPackageVersionsAsync(
                 workingDirectory: workingDirectory,
-                packageId: packageId,
-                filter: id => id.Equals(packageId, StringComparisons.NuGetPackageId),
+                exactPackageId: packageId,
                 prerelease: true,
                 nugetConfigFile: tempNuGetConfig?.ConfigFile,
                 useCache: true, // Enable caching for package channel resolution

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
@@ -12,9 +12,9 @@ namespace Aspire.Cli.Processes;
 internal static partial class DetachedProcessLauncher
 {
     /// <summary>
-    /// Windows implementation using <see cref="WindowsProcessInterop.SpawnConsoleIsolatedProcess"/>
+    /// Windows implementation using <see cref="WindowsProcessInterop.SpawnProcess"/>
     /// with NUL bound to stdout and stderr (stdin is left unset). The detached child is NOT
-    /// assigned to the CLI's kill-on-close job — the entire point of <c>aspire start</c> is
+    /// assigned to the CLI's kill-on-parent-exit job — the entire point of <c>aspire start</c> is
     /// that the AppHost outlives the launching CLI.
     /// </summary>
     [SupportedOSPlatform("windows")]
@@ -49,7 +49,7 @@ internal static partial class DetachedProcessLauncher
             Stderr: nulRawHandle);
 
         // The detached launcher's caller-facing surface takes (predicate, additional) — translate
-        // here into the single-dict shape that SpawnConsoleIsolatedProcess now expects. When the
+        // here into the single-dict shape that SpawnProcess now expects. When the
         // caller passes neither, leave environment null so the child inherits the parent env
         // verbatim (no allocation).
         IReadOnlyDictionary<string, string?>? environment = null;
@@ -77,14 +77,15 @@ internal static partial class DetachedProcessLauncher
         }
 
         // jobHandle: null — detached children must survive a CLI crash. Anything assigned to
-        // the CLI's kill-on-close job dies with the CLI, which is the opposite of what
+        // the CLI's kill-on-parent-exit job dies with the CLI, which is the opposite of what
         // `aspire start` wants.
-        var pi = WindowsProcessInterop.SpawnConsoleIsolatedProcess(
+        var pi = WindowsProcessInterop.SpawnProcess(
             fileName,
             arguments,
             workingDirectory,
             stdio,
             environment,
+            createNewConsole: true,
             jobHandle: null);
 
         Process detachedProcess;

--- a/src/Aspire.Cli/Processes/IsolatedProcess.Windows.cs
+++ b/src/Aspire.Cli/Processes/IsolatedProcess.Windows.cs
@@ -15,10 +15,11 @@ internal sealed partial class IsolatedProcess
 {
     /// <summary>
     /// Windows implementation. Opens NUL for stdin and anonymous pipes for stdout/stderr,
-    /// then delegates to <see cref="WindowsProcessInterop.SpawnConsoleIsolatedProcess"/> for
-    /// the actual <c>CreateProcessW</c> ceremony. When <see cref="IsolatedProcessStartInfo.JobHandle"/>
-    /// is supplied, the spawn primitive does the suspended-create / assign / resume dance so
-    /// the child cannot escape the CLI's kill-on-close job between spawn and assignment.
+    /// then delegates to <see cref="WindowsProcessInterop.SpawnProcess"/> for the actual
+    /// <c>CreateProcessW</c> ceremony. Console isolation and parent-exit protection are
+    /// independent: when <see cref="IsolatedProcessStartInfo.KillOnParentExit"/> is set, the spawn
+    /// primitive does the suspended-create / assign / resume dance even if the child does not need
+    /// a new console group.
     /// </summary>
     /// <remarks>
     /// Unlike <see cref="DetachedProcessLauncher"/>, this launcher consumes the child's
@@ -75,13 +76,15 @@ internal sealed partial class IsolatedProcess
             // null = inherit parent env block.
             var environment = startInfo.GetEnvironmentForSpawn();
 
-            var pi = WindowsProcessInterop.SpawnConsoleIsolatedProcess(
+            var jobHandle = startInfo.KillOnParentExit ? WindowsConsoleProcessJob.Shared.Handle : null;
+            var pi = WindowsProcessInterop.SpawnProcess(
                 startInfo.FileName,
                 startInfo.ArgumentList,
                 startInfo.WorkingDirectory,
                 stdio,
                 environment,
-                startInfo.JobHandle);
+                createNewConsole: startInfo.IsolateConsole,
+                jobHandle);
 
             // CreateProcess succeeded; from here, any failure must terminate the just-created
             // child instead of letting it run orphaned. Drop the parent-side copy of the

--- a/src/Aspire.Cli/Processes/IsolatedProcess.cs
+++ b/src/Aspire.Cli/Processes/IsolatedProcess.cs
@@ -4,16 +4,14 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Text;
-using Microsoft.Win32.SafeHandles;
 
 namespace Aspire.Cli.Processes;
 
 /// <summary>
 /// Mirrors <see cref="ProcessStartInfo"/>. Differences from the BCL shape:
 /// stdout/stderr are always redirected (so there is no <c>RedirectStandardOutput</c>
-/// flag — see <see cref="IsolatedProcess.Start"/>), and <see cref="JobHandle"/> adds
-/// the Windows-only kill-on-close safety net described in
-/// <see cref="WindowsConsoleProcessJob"/>.
+/// flag — see <see cref="IsolatedProcess.Start"/>), and <see cref="KillOnParentExit"/> adds
+/// a parent-lifetime safety net for children that should not outlive the CLI.
 /// </summary>
 internal sealed class IsolatedProcessStartInfo
 {
@@ -40,24 +38,21 @@ internal sealed class IsolatedProcessStartInfo
     public IDictionary<string, string?> Environment => _environment ??= LoadParentEnvironment();
 
     /// <summary>
-    /// Windows-only crash-time safety net. When set, the spawned child is atomically
-    /// assigned to this job object via the suspended-create / assign / resume dance in
-    /// <see cref="WindowsProcessInterop.SpawnConsoleIsolatedProcess"/>. Set to
-    /// <see cref="WindowsConsoleProcessJob.Handle"/> from <see cref="WindowsConsoleProcessJob.Shared"/>
-    /// on Windows hosts; <see langword="null"/> on non-Windows hosts (Unix process-group
-    /// semantics cover the equivalent case).
+    /// When <see langword="true"/>, the child should be terminated when the parent exits.
+    /// This mirrors the .NET 11 ProcessStartInfo.KillOnParentExit shape so the custom Windows
+    /// job-object implementation can be replaced by the platform implementation later.
     /// </summary>
-    public SafeFileHandle? JobHandle { get; init; }
+    public bool KillOnParentExit { get; init; }
 
     /// <summary>
     /// When <see langword="true"/> (the default) the child is spawned in its own hidden console
     /// group on Windows (CREATE_NEW_CONSOLE | SW_HIDE) so a graceful CTRL+C can target it without
     /// also signalling the CLI. When <see langword="false"/> the child
-    /// is spawned via an ordinary redirected <see cref="Process.Start(ProcessStartInfo)"/> — no new
-    /// console, no <see cref="JobHandle"/>, and stdin wired to an empty pipe — which is the shape
-    /// every non-isolated CLI subprocess (build, restore, package add, …) uses. On Unix both modes
-    /// are identical because SIGTERM via the process group covers teardown, so only Windows branches
-    /// on this flag.
+    /// is spawned via an ordinary redirected <see cref="Process.Start(ProcessStartInfo)"/> unless
+    /// <see cref="KillOnParentExit"/> is also supplied. Job-protected Windows children use the suspended-create
+    /// launcher even when they do not need graceful console isolation so they are atomically assigned
+    /// to the kill-on-parent-exit job. On Unix both modes are identical because SIGTERM via the process
+    /// group covers teardown, so only Windows branches on this flag.
     /// </summary>
     public bool IsolateConsole { get; init; } = true;
 
@@ -111,10 +106,10 @@ internal sealed class IsolatedProcessStartInfo
 
 /// <summary>
 /// Mirrors <see cref="System.Diagnostics.Process"/> for a child spawned by <see cref="Start"/>.
-/// On Windows the child gets its own hidden console (CREATE_NEW_CONSOLE | SW_HIDE) so a graceful
-/// shutdown can <c>AttachConsole</c> + post <c>CTRL_C_EVENT</c> at it without also signalling the
-/// CLI; on Unix it's a thin <see cref="Process.Start(ProcessStartInfo)"/>
-/// wrapper because SIGTERM via the process group is enough.
+/// On Windows, callers can request either kill-on-parent-exit, a hidden console
+/// (CREATE_NEW_CONSOLE | SW_HIDE) for targeted graceful shutdown, or both. On Unix it's a thin
+/// <see cref="Process.Start(ProcessStartInfo)"/> wrapper because SIGTERM via the process group is
+/// enough.
 /// </summary>
 /// <remarks>
 /// Differences from the BCL shape worth knowing about:
@@ -260,30 +255,23 @@ internal sealed partial class IsolatedProcess : IAsyncDisposable
         ArgumentNullException.ThrowIfNull(standardOutputHandler);
         ArgumentNullException.ThrowIfNull(standardErrorHandler);
 
-        // Non-isolated mode is an ordinary redirected Process.Start on every platform: no new
-        // console, no JobHandle, stdin wired to an empty pipe. On Unix the isolated mode is the
-        // same redirected spawn (SIGTERM via the process group is enough), so only the isolated
-        // Windows path needs the dedicated new-console launcher.
-        if (!startInfo.IsolateConsole)
-        {
-            return StartRedirected(startInfo, standardOutputHandler, standardErrorHandler, redirectStandardInput: true);
-        }
-
-        if (OperatingSystem.IsWindows())
+        // Windows parent-exit protection requires the suspended-create / assign / resume ceremony in
+        // StartWindows. Route protected helpers through that path even when they do not need a
+        // graceful CTRL+C console group; otherwise use the ordinary redirected Process.Start shape.
+        if (OperatingSystem.IsWindows() && (startInfo.IsolateConsole || startInfo.KillOnParentExit))
         {
             return StartWindows(startInfo, standardOutputHandler, standardErrorHandler);
         }
 
-        return StartRedirected(startInfo, standardOutputHandler, standardErrorHandler, redirectStandardInput: false);
+        return StartRedirected(startInfo, standardOutputHandler, standardErrorHandler, redirectStandardInput: !startInfo.IsolateConsole);
     }
 
     /// <summary>
     /// Cross-platform redirected spawn — a thin <see cref="Process.Start(ProcessStartInfo)"/>
     /// wrapper. Used for every non-isolated child (all platforms) and for isolated children on
     /// Unix, where SIGTERM / process groups handle cooperative shutdown so the new-console
-    /// gymnastics the Windows partial uses are unnecessary. <see cref="IsolatedProcessStartInfo.JobHandle"/>
-    /// is ignored here (Unix process-group reparenting + signal delivery cover the crash-time case
-    /// that JobHandle exists to address on Windows).
+    /// gymnastics the Windows partial uses are unnecessary. <see cref="IsolatedProcessStartInfo.KillOnParentExit"/>
+    /// is ignored here until a cross-platform platform primitive is available.
     /// </summary>
     /// <param name="startInfo">Process launch parameters.</param>
     /// <param name="standardOutputHandler">Per-line callback for stdout; receives the wrapper as sender.</param>

--- a/src/Aspire.Cli/Processes/WindowsConsoleProcessJob.cs
+++ b/src/Aspire.Cli/Processes/WindowsConsoleProcessJob.cs
@@ -35,7 +35,7 @@ namespace Aspire.Cli.Processes;
 /// IMPORTANT: do NOT dispose this service during the normal shutdown ladder. The graceful
 /// shutdown path is responsible for cooperatively terminating its children; closing the
 /// job handle while they are still alive would convert clean shutdown into a hard kill.
-/// Let the OS close the handle on process exit; the kill-on-close behavior is exactly the
+/// Let the OS close the handle on process exit; the kill-on-parent-exit behavior is exactly the
 /// crash-safety net we want and is harmless when the children have already exited.
 /// </para>
 /// </remarks>
@@ -54,8 +54,8 @@ internal sealed class WindowsConsoleProcessJob : IDisposable
     private int _disposed;
 
     /// <summary>
-    /// The process-wide job, created on first access. Callers on the isolated-console spawn
-    /// path use this instead of receiving a job instance, so they cannot forget to supply one.
+    /// The process-wide job, created on first access. Callers that opt into parent-lifetime
+    /// cleanup use this instead of receiving a job instance, so they cannot forget to supply one.
     /// Intentionally never disposed in production: the OS closes the handle at process exit,
     /// which is exactly the crash-safety net we want.
     /// </summary>
@@ -66,7 +66,7 @@ internal sealed class WindowsConsoleProcessJob : IDisposable
         _jobHandle = WindowsProcessInterop.CreateJobObjectW(nint.Zero, null);
         if (_jobHandle.IsInvalid)
         {
-            throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to create CLI console-isolation job object");
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to create CLI kill-on-parent-exit job object");
         }
 
         try
@@ -94,7 +94,7 @@ internal sealed class WindowsConsoleProcessJob : IDisposable
                     infoPtr,
                     (uint)infoSize))
                 {
-                    throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to configure CLI console-isolation job object limits");
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to configure CLI kill-on-parent-exit job object limits");
                 }
             }
             finally
@@ -113,7 +113,7 @@ internal sealed class WindowsConsoleProcessJob : IDisposable
     }
 
     /// <summary>
-    /// The job handle. Pass directly to <see cref="WindowsProcessInterop.SpawnConsoleIsolatedProcess"/>
+    /// The job handle. Pass directly to <see cref="WindowsProcessInterop.SpawnProcess"/>
     /// so the spawn primitive can do the suspended-create / assign / resume dance atomically.
     /// </summary>
     public SafeFileHandle Handle => _jobHandle;

--- a/src/Aspire.Cli/Processes/WindowsProcessInterop.cs
+++ b/src/Aspire.Cli/Processes/WindowsProcessInterop.cs
@@ -41,16 +41,13 @@ internal static partial class WindowsProcessInterop
     public const uint CreateNewConsole = 0x00000010;
 
     /// <summary>
-    /// Composite creation flags shared by every CLI process launcher that spawns into its own
-    /// hidden console group: CREATE_UNICODE_ENVIRONMENT (we always build a Unicode env block
+    /// Base creation flags shared by Windows launchers that need explicit handle inheritance
+    /// and/or job assignment: CREATE_UNICODE_ENVIRONMENT (we always build a Unicode env block
     /// ourselves) | EXTENDED_STARTUPINFO_PRESENT (we always pass STARTUPINFOEX with an attribute
-    /// list) | CREATE_NEW_CONSOLE (the entire point — detach from the parent's console).
-    /// Centralizing the composite prevents the two launchers from drifting (e.g. one path
-    /// accidentally dropping CREATE_UNICODE_ENVIRONMENT and silently truncating non-ASCII env
-    /// values).
+    /// list). CREATE_NEW_CONSOLE is added independently by callers that need console isolation.
     /// </summary>
-    public const uint NewConsoleCreationFlags =
-        CreateUnicodeEnvironment | ExtendedStartupInfoPresent | CreateNewConsole;
+    public const uint ExplicitHandleCreationFlags =
+        CreateUnicodeEnvironment | ExtendedStartupInfoPresent;
 
     public const ushort ShowWindowHide = 0x0000;
 
@@ -301,11 +298,10 @@ internal static partial class WindowsProcessInterop
     public readonly record struct StdioHandles(nint Stdin, nint Stdout, nint Stderr);
 
     /// <summary>
-    /// Spawns a child process in its own hidden console group with exactly the stdio handles
-    /// in <paramref name="stdio"/> made inheritable through <c>PROC_THREAD_ATTRIBUTE_HANDLE_LIST</c>.
-    /// Used by both <see cref="DetachedProcessLauncher"/> (NUL-only handles) and
-    /// <see cref="IsolatedProcess"/> (NUL stdin + anonymous pipes for stdout/stderr)
-    /// so the console-isolation ceremony lives in one place.
+    /// Spawns a child process with exactly the stdio handles in <paramref name="stdio"/> made
+    /// inheritable through <c>PROC_THREAD_ATTRIBUTE_HANDLE_LIST</c>. Console isolation
+    /// (<c>CREATE_NEW_CONSOLE</c>) and parent-exit job assignment are independent options so
+    /// short-lived helper processes can get the job safety net without creating a new console.
     /// </summary>
     /// <param name="fileName">Full path to the executable to launch.</param>
     /// <param name="arguments">Arguments to pass to the child. Quoted via <see cref="BuildCommandLine"/>.</param>
@@ -323,8 +319,13 @@ internal static partial class WindowsProcessInterop
     /// to remove a subset of parent variables must materialize the parent env, apply their
     /// removals/overlays, and pass the resulting dictionary here.
     /// </param>
+    /// <param name="createNewConsole">
+    /// When <see langword="true"/>, launches the child in a new hidden console group. Use this for
+    /// AppHost-style processes that need targeted CTRL+C delivery or detached children that must not
+    /// share the parent console. Leave it <see langword="false"/> for ordinary background helpers.
+    /// </param>
     /// <param name="jobHandle">
-    /// Optional kill-on-close job object. When supplied, the child is created suspended,
+    /// Optional parent-lifetime job object. When supplied, the child is created suspended,
     /// assigned to the job, then resumed — so there is no instruction-level window where the
     /// child could spawn a grandchild that escapes the job. <see cref="DetachedProcessLauncher"/>
     /// passes <see langword="null" /> because detached children must outlive the CLI;
@@ -338,12 +339,13 @@ internal static partial class WindowsProcessInterop
     /// <see cref="System.Diagnostics.Process.GetProcessById(int)"/>).
     /// </returns>
     [SupportedOSPlatform("windows")]
-    public static PROCESS_INFORMATION SpawnConsoleIsolatedProcess(
+    public static PROCESS_INFORMATION SpawnProcess(
         string fileName,
         IReadOnlyList<string> arguments,
         string workingDirectory,
         StdioHandles stdio,
         IReadOnlyDictionary<string, string?>? environment,
+        bool createNewConsole,
         SafeFileHandle? jobHandle)
     {
         // Build the handle whitelist from the non-zero stdio slots. We pass exactly the handles
@@ -417,7 +419,12 @@ internal static partial class WindowsProcessInterop
                     // CreateProcess and AssignProcessToJobObject so it cannot fork-and-breakaway
                     // before we put the safety net under it. Without a job, the original
                     // behavior is preserved bit-for-bit (no suspend, no resume).
-                    var flags = NewConsoleCreationFlags;
+                    var flags = ExplicitHandleCreationFlags;
+                    if (createNewConsole)
+                    {
+                        flags |= CreateNewConsole;
+                    }
+
                     if (jobHandle is not null)
                     {
                         flags |= CreateSuspended;

--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -205,7 +205,11 @@ internal sealed class AppHostServerSession : IAppHostServerSession
                     serverEnvironmentVariables,
                     additionalArgs: null,
                     debug: _debug,
-                    runControl: new AppHostServerRunControl(_isolateConsole, _gracefulShutdownSignaler, _shutdownService)).ConfigureAwait(false);
+                    runControl: new AppHostServerRunControl(
+                        IsolateConsole: _isolateConsole,
+                        GracefulShutdownSignaler: _gracefulShutdownSignaler,
+                        ShutdownService: _shutdownService,
+                        KillOnParentExit: _isolateConsole)).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -529,6 +529,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             // package add, layout, and other short-lived invocations leave these unset so
             // they continue to use the shared ladder's force-kill mode.
             IsolateConsole = true,
+            KillOnParentExit = true,
             GracefulShutdownSignaler = _gracefulShutdownSignaler,
             ShutdownService = _shutdownService,
         };

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -569,6 +569,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
             StandardOutputCallback = OnStdout,
             StandardErrorCallback = OnStderr,
             IsolateConsole = runControl?.IsolateConsole ?? false,
+            KillOnParentExit = runControl?.KillOnParentExit ?? false,
             GracefulShutdownSignaler = runControl?.GracefulShutdownSignaler,
             ShutdownService = runControl?.ShutdownService,
             // The graceful ladder always tree-kills on escalation; this fallback only matters when

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -645,7 +645,8 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 var guestLaunchOptions = new GuestLaunchOptions(
                     IsolateConsoleForGracefulShutdown: true,
                     GracefulShutdownSignaler: _gracefulShutdownSignaler,
-                    ShutdownService: _shutdownService);
+                    ShutdownService: _shutdownService,
+                    KillOnParentExit: true);
                 (guestExitCode, guestOutput) = await ExecuteGuestAppHostAsync(
                     appHostFile, directory, environmentVariables, enableHotReload, context.NoBuild, rpcClient, launcher, StartBackchannelConnectionAfterGuestAppHostLaunchesAsync, guestLaunchOptions, appHostSystemToken);
             }

--- a/src/Aspire.Cli/Projects/IAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/IAppHostServerProject.cs
@@ -50,9 +50,12 @@ internal sealed record AppHostServerRunResult(
 /// <param name="IsolateConsole">
 /// When <see langword="true"/>, on Windows the server is spawned via <see cref="IsolatedProcess"/>
 /// into its own hidden console (CREATE_NEW_CONSOLE | SW_HIDE) so a graceful shutdown can
-/// <c>AttachConsole</c> + post <c>CTRL_C_EVENT</c> against the server without also signalling the CLI,
-/// and the child is bound to the process-wide <see cref="WindowsConsoleProcessJob"/> kill-on-close
-/// safety net. On Unix the spawn is effectively the same as today's path.
+/// <c>AttachConsole</c> + post <c>CTRL_C_EVENT</c> against the server without also signalling the CLI.
+/// On Unix the spawn is effectively the same as today's path.
+/// </param>
+/// <param name="KillOnParentExit">
+/// When <see langword="true"/>, the server child is bound to the process-wide
+/// <see cref="WindowsConsoleProcessJob"/> parent-lifetime safety net on Windows.
 /// </param>
 /// <param name="GracefulShutdownSignaler">
 /// Issues the graceful shutdown signal during the shared ladder, or <see langword="null"/> to fall
@@ -65,7 +68,8 @@ internal sealed record AppHostServerRunResult(
 internal sealed record AppHostServerRunControl(
     bool IsolateConsole = false,
     IProcessTreeGracefulShutdownSignaler? GracefulShutdownSignaler = null,
-    IGracefulShutdownWindow? ShutdownService = null);
+    IGracefulShutdownWindow? ShutdownService = null,
+    bool KillOnParentExit = false);
 
 /// <summary>
 /// Represents an AppHost server that can be prepared and run.

--- a/src/Aspire.Cli/Projects/IGuestProcessLauncher.cs
+++ b/src/Aspire.Cli/Projects/IGuestProcessLauncher.cs
@@ -21,6 +21,9 @@ namespace Aspire.Cli.Projects;
 /// <see cref="ProcessTreeGracefulShutdownService"/>) can target the guest
 /// without also signalling the CLI itself. No-op on Unix where SIGTERM is sufficient.
 /// </param>
+/// <param name="KillOnParentExit">
+/// When <see langword="true"/>, bind the guest to the parent-lifetime safety net on Windows.
+/// </param>
 /// <param name="GracefulShutdownSignaler">
 /// The per-OS "ask this process tree to shut down" primitive (DCP <c>stop-process-tree</c>
 /// on Windows, SIGTERM via <c>ProcessSignaler</c> on Unix). When non-<see langword="null"/>
@@ -36,7 +39,8 @@ namespace Aspire.Cli.Projects;
 internal sealed record GuestLaunchOptions(
     bool IsolateConsoleForGracefulShutdown = false,
     IProcessTreeGracefulShutdownSignaler? GracefulShutdownSignaler = null,
-    IGracefulShutdownWindow? ShutdownService = null);
+    IGracefulShutdownWindow? ShutdownService = null,
+    bool KillOnParentExit = false);
 
 /// <summary>
 /// Strategy for launching a guest language process.

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -963,6 +963,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
             StandardOutputCallback = OnStdout,
             StandardErrorCallback = OnStderr,
             IsolateConsole = runControl?.IsolateConsole ?? false,
+            KillOnParentExit = runControl?.KillOnParentExit ?? false,
             GracefulShutdownSignaler = runControl?.GracefulShutdownSignaler,
             ShutdownService = runControl?.ShutdownService,
             KillEntireProcessTreeOnCancel = !_environment.IsWindows(),

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -131,6 +131,7 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             // Run-path spawn: isolated console group + anonymous-pipe stdio so a graceful CTRL+C can
             // target the guest without also signalling the CLI.
             IsolateConsole = options?.IsolateConsoleForGracefulShutdown == true,
+            KillOnParentExit = options?.KillOnParentExit == true,
             GracefulShutdownSignaler = options?.GracefulShutdownSignaler,
             ShutdownService = options?.ShutdownService,
             // The guest is the AppHost's primary process; always tree-kill on escalation so no

--- a/src/Aspire.Managed/NuGet/Commands/SearchCommand.cs
+++ b/src/Aspire.Managed/NuGet/Commands/SearchCommand.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 using NuGet.Configuration;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 using INuGetLogger = NuGet.Common.ILogger;
 
 namespace Aspire.Managed.NuGet.Commands;
@@ -51,6 +52,26 @@ public static class SearchCommand
         };
         command.Options.Add(skipOption);
 
+        var exactMatchOption = new Option<bool>("--exact-match")
+        {
+            Description = "Only return packages whose ID exactly matches the query"
+        };
+        command.Options.Add(exactMatchOption);
+
+        var timeoutSecondsOption = new Option<int>("--timeout-seconds")
+        {
+            Description = "Maximum time to wait for package source queries (default: 30)",
+            DefaultValueFactory = _ => 30
+        };
+        timeoutSecondsOption.Validators.Add(result =>
+        {
+            if (result.GetValueOrDefault<int>() <= 0)
+            {
+                result.AddError("--timeout-seconds must be greater than zero.");
+            }
+        });
+        command.Options.Add(timeoutSecondsOption);
+
         var sourceOption = new Option<string[]>("--source")
         {
             Description = "NuGet feed URL (can specify multiple)",
@@ -90,13 +111,15 @@ public static class SearchCommand
             var prerelease = parseResult.GetValue(prereleaseOption);
             var take = parseResult.GetValue(takeOption);
             var skip = parseResult.GetValue(skipOption);
+            var exactMatch = parseResult.GetValue(exactMatchOption);
+            var timeoutSeconds = parseResult.GetValue(timeoutSecondsOption);
             var sources = parseResult.GetValue(sourceOption) ?? [];
             var configPath = parseResult.GetValue(configOption);
             var workingDir = parseResult.GetValue(workingDirOption);
             var format = parseResult.GetValue(formatOption) ?? "json";
             var verbose = parseResult.GetValue(verboseOption);
 
-            return await ExecuteSearchAsync(query, prerelease, take, skip, sources, configPath, workingDir, format, verbose).ConfigureAwait(false);
+            return await ExecuteSearchAsync(query, prerelease, take, skip, exactMatch, timeoutSeconds, sources, configPath, workingDir, format, verbose, ct).ConfigureAwait(false);
         });
 
         return command;
@@ -107,11 +130,14 @@ public static class SearchCommand
         bool prerelease,
         int take,
         int skip,
+        bool exactMatch,
+        int timeoutSeconds,
         string[] explicitSources,
         string? configPath,
         string? workingDir,
         string format,
-        bool verbose)
+        bool verbose,
+        CancellationToken cancellationToken)
     {
         var logger = new NuGetLogger(verbose);
         var allPackages = new List<PackageInfo>();
@@ -129,6 +155,9 @@ public static class SearchCommand
 
             // Search each source in parallel using NuGet.Protocol
             var searchFilter = new SearchFilter(prerelease);
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+
             var searchTasks = packageSources.Select(async source =>
             {
                 try
@@ -138,7 +167,16 @@ public static class SearchCommand
                         Console.Error.WriteLine($"Searching {source.Name} ({source.Source})...");
                     }
 
-                    return await SearchSourceAsync(source, query, searchFilter, skip, take, logger).ConfigureAwait(false);
+                    return await SearchSourceAsync(source, query, searchFilter, skip, take, exactMatch, logger, timeoutCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+                {
+                    Console.Error.WriteLine($"Warning: Timed out searching {source.Name} after {timeoutSeconds} seconds.");
+                    return [];
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
                 }
                 catch (Exception ex)
                 {
@@ -156,9 +194,9 @@ public static class SearchCommand
             // Deduplicate by package ID, keeping the highest version
             var dedupedPackages = allPackages
                 .GroupBy(p => p.Id, StringComparer.OrdinalIgnoreCase)
-                .Select(g => g.OrderByDescending(p => p.Version).First())
+                .Select(group => exactMatch ? MergeExactPackageResults(group) : SelectLatestPackage(group))
                 .OrderBy(p => p.Id)
-                .Take(take)
+                .Take(take > 0 ? take : int.MaxValue)
                 .ToList();
 
             OutputResults(dedupedPackages, format);
@@ -237,10 +275,18 @@ public static class SearchCommand
         SearchFilter filter,
         int skip,
         int take,
-        INuGetLogger logger)
+        bool exactMatch,
+        INuGetLogger logger,
+        CancellationToken cancellationToken)
     {
         var repository = Repository.Factory.GetCoreV3(source);
-        var searchResource = await repository.GetResourceAsync<PackageSearchResource>().ConfigureAwait(false);
+
+        if (exactMatch)
+        {
+            return await SearchExactPackageAsync(repository, source, query, filter, logger, cancellationToken).ConfigureAwait(false);
+        }
+
+        var searchResource = await repository.GetResourceAsync<PackageSearchResource>(cancellationToken).ConfigureAwait(false);
 
         if (searchResource is null)
         {
@@ -253,11 +299,13 @@ public static class SearchCommand
             skip,
             take,
             logger,
-            CancellationToken.None).ConfigureAwait(false);
+            cancellationToken).ConfigureAwait(false);
 
         var packages = new List<PackageInfo>();
         foreach (var result in results)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var versions = await result.GetVersionsAsync().ConfigureAwait(false);
             var allVersions = versions?.Select(v => v.Version.ToString()).ToList() ?? [];
 
@@ -274,6 +322,81 @@ public static class SearchCommand
         }
 
         return packages;
+    }
+
+    private static PackageInfo SelectLatestPackage(IGrouping<string, PackageInfo> packages)
+    {
+        return packages.OrderByDescending(p => NuGetVersion.Parse(p.Version), VersionComparer.VersionReleaseMetadata).First();
+    }
+
+    private static PackageInfo MergeExactPackageResults(IGrouping<string, PackageInfo> packages)
+    {
+        var latestPackage = SelectLatestPackage(packages);
+        var allVersions = packages
+            .SelectMany(package => package.AllVersions.Count == 0 ? [package.Version] : package.AllVersions.Append(package.Version))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(NuGetVersion.Parse, VersionComparer.VersionReleaseMetadata)
+            .ToList();
+
+        return new PackageInfo
+        {
+            Id = latestPackage.Id,
+            Version = allVersions.Last(),
+            Description = latestPackage.Description,
+            Authors = latestPackage.Authors,
+            AllVersions = allVersions,
+            Source = latestPackage.Source,
+            Deprecated = latestPackage.Deprecated
+        };
+    }
+
+    private static async Task<List<PackageInfo>> SearchExactPackageAsync(
+        SourceRepository repository,
+        PackageSource source,
+        string packageId,
+        SearchFilter filter,
+        INuGetLogger logger,
+        CancellationToken cancellationToken)
+    {
+        var metadataResource = await repository.GetResourceAsync<PackageMetadataResource>(cancellationToken).ConfigureAwait(false);
+        if (metadataResource is null)
+        {
+            return [];
+        }
+
+        using var cacheContext = new SourceCacheContext();
+        var metadata = (await metadataResource.GetMetadataAsync(
+            packageId,
+            filter.IncludePrerelease,
+            includeUnlisted: false,
+            cacheContext,
+            logger,
+            cancellationToken).ConfigureAwait(false)).ToList();
+
+        if (metadata.Count == 0)
+        {
+            return [];
+        }
+
+        var latest = metadata.OrderByDescending(m => m.Identity.Version).First();
+        var allVersions = metadata
+            .Select(m => m.Identity.Version.ToString())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return
+        [
+            new PackageInfo
+            {
+                Id = latest.Identity.Id,
+                Version = latest.Identity.Version.ToString(),
+                Description = latest.Description,
+                Authors = latest.Authors,
+                AllVersions = allVersions,
+                Source = source.Source,
+                Deprecated = await latest.GetDeprecationMetadataAsync().ConfigureAwait(false) is not null
+            }
+        ];
     }
 
     private static void OutputResults(List<PackageInfo> packages, string format)

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -2171,6 +2171,8 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             executionContext,
             (attempt, options) =>
             {
+                Assert.True(options.KillOnParentExit);
+
                 // Always succeed
                 return (0, "{\"version\":1,\"searchResult\":[{\"sourceName\":\"nuget.org\",\"packages\":[{\"id\":\"Aspire.Hosting.Redis\",\"latestVersion\":\"9.0.0\"}]}]}");
             },
@@ -2246,6 +2248,54 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 Assert.Equal("Aspire.Hosting.Redis", package.Id);
                 Assert.Equal("13.3.0", package.Version);
             });
+    }
+
+    [Fact]
+    public async Task SearchPackagesAsync_WithCacheEnabled_ProtectsNuGetConfigProbeWithKillOnParentExit()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var observedCommands = new List<string>();
+        var options = new ProcessInvocationOptions { SuppressLogging = true };
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (args, _, _, invocationOptions) =>
+            {
+                Assert.True(invocationOptions.KillOnParentExit);
+
+                observedCommands.Add(string.Join(" ", args));
+                if (args is ["package", "search", ..])
+                {
+                    invocationOptions.StandardOutputCallback?.Invoke(
+                        """
+                        {"version":1,"searchResult":[{"sourceName":"nuget.org","packages":[{"id":"Aspire.Cli","version":"13.4.0"}]}]}
+                        """);
+                }
+            },
+            0);
+
+        var result = await runner.SearchPackagesAsync(
+            workspace.WorkspaceRoot,
+            "Aspire.Cli",
+            exactMatch: true,
+            prerelease: true,
+            take: 0,
+            skip: 0,
+            nugetConfigFile: null,
+            useCache: true,
+            options,
+            CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Collection(
+            observedCommands,
+            command => Assert.Equal("nuget config paths", command),
+            command => Assert.Equal("package search Aspire.Cli --format json --exact-match --prerelease", command));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/DotNet/ProcessExecutionTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/ProcessExecutionTests.cs
@@ -251,6 +251,26 @@ public sealed class ProcessExecutionTests(ITestOutputHelper outputHelper)
         Assert.True(WaitForProcessExit(execution.ProcessId, TimeSpan.FromSeconds(10)), $"Expected process {execution.ProcessId} to be killed after signaler failure.");
     }
 
+    [Fact]
+    public void CreateExecution_IsolateConsoleDoesNotRequireWindowsKillOnParentExitJob()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var factory = new ProcessExecutionFactory(TestEnvironment.CreateWindows(), NullLogger<ProcessExecutionFactory>.Instance);
+
+        var execution = factory.CreateExecution(
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : "/bin/sh",
+            args: [],
+            env: null,
+            workspace.WorkspaceRoot,
+            new ProcessInvocationOptions
+            {
+                IsolateConsole = true,
+                KillOnParentExit = false,
+            });
+
+        Assert.NotNull(execution);
+    }
+
     private static string CreateJsonPayload(int lineCount)
     {
         var builder = new StringBuilder();
@@ -410,7 +430,7 @@ public sealed class ProcessExecutionTests(ITestOutputHelper outputHelper)
         IProcessTreeGracefulShutdownSignaler signaler,
         IGracefulShutdownWindow shutdownService)
     {
-        // The Windows kill-on-close job is now resolved on-demand inside the factory via
+        // The Windows kill-on-parent-exit job is now resolved on-demand inside the factory via
         // WindowsConsoleProcessJob.Shared, so the test no longer creates or disposes one.
         return CreateExecution(
             scriptFile,

--- a/tests/Aspire.Cli.Tests/NuGet/BundleNuGetPackageCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/BundleNuGetPackageCacheTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Aspire.Cli.Layout;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Tests.TestServices;
@@ -11,6 +12,71 @@ namespace Aspire.Cli.Tests.NuGet;
 
 public class BundleNuGetPackageCacheTests(ITestOutputHelper outputHelper)
 {
+    [Theory]
+    [InlineData("Aspire.Cli")]
+    [InlineData("Aspire.ProjectTemplates")]
+    public async Task PrefetchedPackageMetadataUsesExactMatchAndTimeout(string packageId)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var layout = new LayoutConfiguration
+        {
+            LayoutPath = workspace.WorkspaceRoot.FullName,
+            Components = new LayoutComponents
+            {
+                Managed = "managed"
+            }
+        };
+
+        var managedDirectory = workspace.WorkspaceRoot.CreateSubdirectory("managed");
+        var managedPath = layout.GetManagedPath();
+        Assert.NotNull(managedPath);
+        await File.WriteAllTextAsync(managedPath!, string.Empty);
+
+        var bundleService = new TestBundleService(isBundle: true)
+        {
+            Layout = layout
+        };
+
+        var executionFactory = new TestProcessExecutionFactory
+        {
+            AttemptCallback = (_, _) => (0,
+                $$"""
+                {"packages":[{"id":"{{packageId}}","version":"13.4.0","allVersions":["13.3.0","13.4.0"],"source":"nuget.org"}],"totalHits":1}
+                """)
+        };
+
+        var cache = new BundleNuGetPackageCache(
+            bundleService,
+            new LayoutProcessRunner(executionFactory),
+            NullLogger<BundleNuGetPackageCache>.Instance,
+            new TestFeatures());
+
+        var packages = packageId switch
+        {
+            "Aspire.Cli" => await cache.GetCliPackagesAsync(workspace.WorkspaceRoot, prerelease: false, nugetConfigFile: null, CancellationToken.None),
+            "Aspire.ProjectTemplates" => await cache.GetTemplatePackagesAsync(workspace.WorkspaceRoot, prerelease: false, nugetConfigFile: null, CancellationToken.None),
+            _ => throw new InvalidOperationException()
+        };
+
+        Assert.Contains("--exact-match", executionFactory.LastArguments!);
+        Assert.Contains("--timeout-seconds", executionFactory.LastArguments!);
+        Assert.Equal("1", executionFactory.LastArguments![Array.IndexOf(executionFactory.LastArguments, "--take") + 1]);
+        Assert.Equal(NuGetPackageSearchDefaults.TimeoutSeconds.ToString(CultureInfo.InvariantCulture), executionFactory.LastArguments![Array.IndexOf(executionFactory.LastArguments, "--timeout-seconds") + 1]);
+        Assert.Collection(
+            packages.OrderBy(package => package.Version),
+            package =>
+            {
+                Assert.Equal(packageId, package.Id);
+                Assert.Equal("13.3.0", package.Version);
+            },
+            package =>
+            {
+                Assert.Equal(packageId, package.Id);
+                Assert.Equal("13.4.0", package.Version);
+            });
+    }
+
     [Fact]
     public async Task GetPackageVersionsAsync_ExpandsAllVersionsFromExactMatchResult()
     {
@@ -61,5 +127,61 @@ public class BundleNuGetPackageCacheTests(ITestOutputHelper outputHelper)
             packages,
             package => Assert.Equal("13.2.0", package.Version),
             package => Assert.Equal("13.3.0", package.Version));
+        Assert.True(executionFactory.LastProcessInvocationOptions?.KillOnParentExit);
+    }
+
+    [Fact]
+    public async Task GetPackageVersionsAsync_MatchesPackageIdCaseInsensitively()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var layout = new LayoutConfiguration
+        {
+            LayoutPath = workspace.WorkspaceRoot.FullName,
+            Components = new LayoutComponents
+            {
+                Managed = "managed"
+            }
+        };
+
+        var managedDirectory = workspace.WorkspaceRoot.CreateSubdirectory("managed");
+        var managedPath = layout.GetManagedPath();
+        Assert.NotNull(managedPath);
+        await File.WriteAllTextAsync(managedPath!, string.Empty);
+
+        var bundleService = new TestBundleService(isBundle: true)
+        {
+            Layout = layout
+        };
+
+        var executionFactory = new TestProcessExecutionFactory
+        {
+            AttemptCallback = (_, _) => (0,
+                """
+                {"packages":[{"id":"Aspire.Hosting.Redis","version":"13.3.0","allVersions":["13.3.0"],"source":"nuget.org"}],"totalHits":1}
+                """)
+        };
+
+        var cache = new BundleNuGetPackageCache(
+            bundleService,
+            new LayoutProcessRunner(executionFactory),
+            NullLogger<BundleNuGetPackageCache>.Instance,
+            new TestFeatures());
+
+        var packages = await cache.GetPackageVersionsAsync(
+            workspace.WorkspaceRoot,
+            "aspire.hosting.redis",
+            prerelease: false,
+            nugetConfigFile: null,
+            useCache: true,
+            CancellationToken.None);
+
+        Assert.Collection(
+            packages,
+            package =>
+            {
+                Assert.Equal("Aspire.Hosting.Redis", package.Id);
+                Assert.Equal("13.3.0", package.Version);
+            });
     }
 }

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackageCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackageCacheTests.cs
@@ -45,6 +45,67 @@ public class NuGetPackageCacheTests(ITestOutputHelper outputHelper)
         );
     }
 
+    [Theory]
+    [InlineData("Aspire.Cli")]
+    [InlineData("Aspire.ProjectTemplates")]
+    public async Task PrefetchedPackageMetadataUsesExactPackageLookup(string packageId)
+    {
+        bool? observedExactMatch = null;
+        string? observedQuery = null;
+        int observedTake = -1;
+        int observedSkip = -1;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, configure =>
+        {
+            configure.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, query, exactMatch, prerelease, take, skip, nugetConfigFile, useCache, options, cancellationToken) =>
+                {
+                    observedQuery = query;
+                    observedExactMatch = exactMatch;
+                    observedTake = take;
+                    observedSkip = skip;
+
+                    return (0, [
+                        new NuGetPackage { Id = packageId, Version = "13.3.0", Source = "nuget.org" },
+                        new NuGetPackage { Id = packageId, Version = "13.4.0", Source = "nuget.org" }
+                    ]);
+                };
+
+                return runner;
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var nuGetPackageCache = provider.GetRequiredService<INuGetPackageCache>();
+        var packages = packageId switch
+        {
+            "Aspire.Cli" => await nuGetPackageCache.GetCliPackagesAsync(workspace.WorkspaceRoot, prerelease: true, nugetConfigFile: null, CancellationToken.None).DefaultTimeout(),
+            "Aspire.ProjectTemplates" => await nuGetPackageCache.GetTemplatePackagesAsync(workspace.WorkspaceRoot, prerelease: true, nugetConfigFile: null, CancellationToken.None).DefaultTimeout(),
+            _ => throw new InvalidOperationException()
+        };
+
+        Assert.Equal(packageId, observedQuery);
+        Assert.True(observedExactMatch);
+        Assert.Equal(0, observedTake);
+        Assert.Equal(0, observedSkip);
+        Assert.Collection(
+            packages.OrderBy(package => package.Version),
+            package =>
+            {
+                Assert.Equal(packageId, package.Id);
+                Assert.Equal("13.3.0", package.Version);
+            },
+            package =>
+            {
+                Assert.Equal(packageId, package.Id);
+                Assert.Equal("13.4.0", package.Version);
+            });
+    }
+
     [Fact]
     public async Task DeprecatedPackagesAreFilteredByDefault()
     {
@@ -292,5 +353,50 @@ public class NuGetPackageCacheTests(ITestOutputHelper outputHelper)
             packages,
             package => Assert.Equal("13.2.0", package.Version),
             package => Assert.Equal("13.3.0", package.Version));
+    }
+
+    [Fact]
+    public async Task GetPackageVersionsAsync_DoesNotFilterDeprecatedExactPackage()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, configure =>
+        {
+            configure.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, query, exactMatch, prerelease, take, skip, nugetConfigFile, useCache, options, cancellationToken) =>
+                {
+                    Assert.True(exactMatch);
+                    return query switch
+                    {
+                        "Aspire.Hosting.Dapr" => (0, [
+                            new NuGetPackage { Id = "Aspire.Hosting.Dapr", Version = "13.4.0", Source = "nuget.org" }
+                        ]),
+                        _ => (0, Array.Empty<NuGetPackage>())
+                    };
+                };
+
+                return runner;
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var nuGetPackageCache = provider.GetRequiredService<INuGetPackageCache>();
+        var packages = await nuGetPackageCache.GetPackageVersionsAsync(
+            workspace.WorkspaceRoot,
+            "Aspire.Hosting.Dapr",
+            prerelease: false,
+            nugetConfigFile: null,
+            useCache: true,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Collection(
+            packages,
+            package =>
+            {
+                Assert.Equal("Aspire.Hosting.Dapr", package.Id);
+                Assert.Equal("13.4.0", package.Version);
+            });
     }
 }

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -60,6 +60,22 @@ public class NuGetPackagePrefetcherTests
     }
 
     [Fact]
+    public void ConfigCommandDisablesPackageMetadataPrefetching()
+    {
+        var configCommand = new ConfigCommand(null!, null!, new CommonCommandServices(null!, null!, null!, null!, null!, null!, null!, null!));
+        var prefetchingCommand = Assert.IsAssignableFrom<IPackageMetaPrefetchingCommand>(configCommand);
+
+        Assert.False(prefetchingCommand.PrefetchesTemplatePackageMetadata);
+        Assert.False(prefetchingCommand.PrefetchesCliPackageMetadata);
+
+        var infoCommand = Assert.Single(configCommand.Subcommands, c => c.Name == "info");
+        var prefetchingInfoCommand = Assert.IsAssignableFrom<IPackageMetaPrefetchingCommand>(infoCommand);
+
+        Assert.False(prefetchingInfoCommand.PrefetchesTemplatePackageMetadata);
+        Assert.False(prefetchingInfoCommand.PrefetchesCliPackageMetadata);
+    }
+
+    [Fact]
     public void PackageMetaPrefetchingCommandDefaultsToTrueForBothPackageTypes()
     {
         var testCommandWithInterface = new TestCommandWithInterface();
@@ -140,6 +156,53 @@ public class NuGetPackagePrefetcherTests
         await Task.WhenAll(templateTcs.Task, cliTcs.Task).DefaultTimeout();
 
         await prefetcher.StopAsync(CancellationToken.None).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task StopAsyncWaitsForCanceledTemplatePrefetchToFinish()
+    {
+        var logger = new TestLogger<NuGetPackagePrefetcher>(new TestLoggerFactory(new TestSink(), enabled: true));
+
+        var executionContext = CreateExecutionContext();
+        executionContext.CommandSelected.TrySetResult(new TestCommand("new"));
+
+        var prefetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowPrefetchToFinish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = async cancellationToken =>
+            {
+                prefetchStarted.SetResult();
+                await cancellationToken.WaitUntilCancelledAsync();
+                cancellationObserved.SetResult();
+                await allowPrefetchToFinish.Task;
+
+                return [];
+            }
+        };
+
+        var features = new TestFeatures();
+        features.SetFeature(KnownFeatures.UpdateNotificationsEnabled, false);
+
+        var prefetcher = new NuGetPackagePrefetcher(
+            logger,
+            executionContext,
+            features,
+            packagingService,
+            new TestCliUpdateNotifier());
+
+        await prefetcher.StartAsync(CancellationToken.None).DefaultTimeout();
+        await prefetchStarted.Task.DefaultTimeout();
+
+        var stopTask = prefetcher.StopAsync(CancellationToken.None);
+        await cancellationObserved.Task.DefaultTimeout();
+
+        Assert.False(stopTask.IsCompleted);
+
+        allowPrefetchToFinish.SetResult();
+        await stopTask.DefaultTimeout();
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Processes/DetachedProcessLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/DetachedProcessLauncherTests.cs
@@ -13,7 +13,7 @@ public class DetachedProcessLauncherTests
     // DetachedProcessLauncher.StartWindows points both Stdout and Stderr at the same NUL
     // handle, and PROC_THREAD_ATTRIBUTE_HANDLE_LIST rejects duplicate handle values —
     // CreateProcessW returns ERROR_INVALID_PARAMETER (87). The unified
-    // WindowsProcessInterop.SpawnConsoleIsolatedProcess de-duplicates the inheritable
+    // WindowsProcessInterop.SpawnProcess de-duplicates the inheritable
     // handle list, so this spawn must succeed.
     [Fact]
     [SupportedOSPlatform("windows")]

--- a/tests/Aspire.Cli.Tests/Processes/WindowsConsoleProcessJobTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/WindowsConsoleProcessJobTests.cs
@@ -30,42 +30,80 @@ public class WindowsConsoleProcessJobTests
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Windows-only test.");
 
         var job = new WindowsConsoleProcessJob();
-        Process spawnedProcess;
+        using var spawnedProcess = SpawnJobAssignedChildProcess(job, createNewConsole: true);
 
-        // Long-running ping (~60s) so we can verify it's still alive between spawn and
-        // job dispose; the process exits exactly because JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-        // fires when the last handle to the job closes (i.e. inside Dispose below).
-        var startInfo = new IsolatedProcessStartInfo
+        // Confirm the child is up before disposing the job — otherwise a fast spawn
+        // failure would look identical to successful parent-exit cleanup.
+        Assert.False(spawnedProcess.HasExited);
+
+        job.Dispose();
+
+        // KILL_ON_JOB_CLOSE is reliably observable within a couple of seconds;
+        // give a generous window for CI under load.
+        await spawnedProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(15));
+
+        Assert.True(spawnedProcess.HasExited);
+    }
+
+    [Fact]
+    [SupportedOSPlatform("windows")]
+    public async Task Dispose_KillsAssignedChildProcessWithoutConsoleIsolation()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Windows-only test.");
+
+        var job = new WindowsConsoleProcessJob();
+        using var spawnedProcess = SpawnJobAssignedChildProcess(job, createNewConsole: false);
+
+        Assert.False(spawnedProcess.HasExited);
+
+        job.Dispose();
+
+        await spawnedProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(15));
+
+        Assert.True(spawnedProcess.HasExited);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static Process SpawnJobAssignedChildProcess(WindowsConsoleProcessJob job, bool createNewConsole)
+    {
+        using var nulHandle = WindowsProcessInterop.CreateFileW(
+            "NUL",
+            WindowsProcessInterop.GenericRead | WindowsProcessInterop.GenericWrite,
+            WindowsProcessInterop.FileShareRead | WindowsProcessInterop.FileShareWrite,
+            nint.Zero,
+            WindowsProcessInterop.OpenExisting,
+            0,
+            nint.Zero);
+
+        Assert.False(nulHandle.IsInvalid);
+        Assert.True(WindowsProcessInterop.SetHandleInformation(
+            nulHandle,
+            WindowsProcessInterop.HandleFlagInherit,
+            WindowsProcessInterop.HandleFlagInherit));
+
+        var nulRawHandle = nulHandle.DangerousGetHandle();
+        var stdio = new WindowsProcessInterop.StdioHandles(
+            Stdin: nulRawHandle,
+            Stdout: nulRawHandle,
+            Stderr: nulRawHandle);
+
+        var pi = WindowsProcessInterop.SpawnProcess(
+            "cmd.exe",
+            ["/c", "ping", "-n", "60", "127.0.0.1"],
+            Environment.CurrentDirectory,
+            stdio,
+            environment: null,
+            createNewConsole,
+            job.Handle);
+
+        try
         {
-            FileName = "cmd.exe",
-            WorkingDirectory = Environment.CurrentDirectory,
-            JobHandle = job.Handle,
-        };
-        startInfo.ArgumentList.Add("/c");
-        startInfo.ArgumentList.Add("ping");
-        startInfo.ArgumentList.Add("-n");
-        startInfo.ArgumentList.Add("60");
-        startInfo.ArgumentList.Add("127.0.0.1");
-
-        await using (var child = IsolatedProcess.Start(
-            startInfo,
-            standardOutputHandler: static (_, _) => { },
-            standardErrorHandler: static (_, _) => { }))
+            return Process.GetProcessById(pi.dwProcessId);
+        }
+        finally
         {
-            spawnedProcess = child.Process;
-
-            // Confirm the child is up before disposing the job — otherwise a fast spawn
-            // failure would look identical to a successful kill-on-close.
-            Assert.False(spawnedProcess.HasExited);
-
-            job.Dispose();
-
-            // KILL_ON_JOB_CLOSE is reliably observable within a couple of seconds;
-            // give a generous window for CI under load.
-            await spawnedProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(15));
-
-            Assert.True(spawnedProcess.HasExited);
+            WindowsProcessInterop.CloseHandle(pi.hProcess);
+            WindowsProcessInterop.CloseHandle(pi.hThread);
         }
     }
 }
-

--- a/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
@@ -19,12 +19,15 @@ public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper) : IDispos
     public void Dispose() => _loggerFactory.Dispose();
 
     private ProcessGuestLauncher CreateLauncher()
+        => CreateLauncher(new ProcessExecutionFactory(new TestEnvironment(), _loggerFactory.CreateLogger<ProcessExecutionFactory>()));
+
+    private ProcessGuestLauncher CreateLauncher(IProcessExecutionFactory processExecutionFactory)
         => new(
             "test",
             _loggerFactory.CreateLogger<ProcessGuestLauncher>(),
             fileLoggerProvider: null,
             commandResolver: PathLookupHelper.FindFullPathFromPath,
-            processExecutionFactory: new ProcessExecutionFactory(new TestEnvironment(), _loggerFactory.CreateLogger<ProcessExecutionFactory>()));
+            processExecutionFactory);
 
     [Fact]
     public async Task LaunchAsync_NoOptions_OnCancellation_ForceKillsProcessTreeAndReturns()
@@ -114,6 +117,36 @@ public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper) : IDispos
         Assert.NotEqual(0, exitCode);
         Assert.Single(signaler.Pids);
         Assert.False(shutdownService.GracefulShutdownToken.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task LaunchAsync_ForwardsKillOnParentExitSeparatelyFromConsoleIsolation()
+    {
+        var executionFactory = new TestProcessExecutionFactory
+        {
+            AssertionCallback = (_, _, _, options) =>
+            {
+                Assert.True(options.IsolateConsole);
+                Assert.True(options.KillOnParentExit);
+            }
+        };
+        var launcher = CreateLauncher(executionFactory);
+
+        var command = OperatingSystem.IsWindows() ? "cmd.exe" : "sh";
+        var options = new GuestLaunchOptions(
+            IsolateConsoleForGracefulShutdown: true,
+            KillOnParentExit: true);
+
+        var (exitCode, _) = await launcher.LaunchAsync(
+            command,
+            args: [],
+            new DirectoryInfo(Path.GetTempPath()),
+            new Dictionary<string, string>(),
+            afterLaunchAsync: null,
+            options: options,
+            CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/TestServices/FakeNuGetPackageCache.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakeNuGetPackageCache.cs
@@ -49,6 +49,17 @@ internal sealed class FakeNuGetPackageCache : INuGetPackageCache
     }
 
     public Task<IEnumerable<NuGetPackage>> GetPackageVersionsAsync(DirectoryInfo workingDirectory, string exactPackageId, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
-        => GetPackageVersionsAsyncCallback?.Invoke(workingDirectory, exactPackageId, prerelease, nugetConfigFile, useCache, cancellationToken)
-           ?? Task.FromResult<IEnumerable<NuGetPackage>>([]);
+    {
+        if (GetPackageVersionsAsyncCallback is not null)
+        {
+            return GetPackageVersionsAsyncCallback.Invoke(workingDirectory, exactPackageId, prerelease, nugetConfigFile, useCache, cancellationToken);
+        }
+
+        if (GetPackagesAsyncCallback is not null)
+        {
+            return GetPackagesAsyncCallback.Invoke(workingDirectory, exactPackageId, id => id.Equals(exactPackageId, StringComparison.OrdinalIgnoreCase), prerelease, nugetConfigFile, useCache, cancellationToken);
+        }
+
+        return Task.FromResult<IEnumerable<NuGetPackage>>([]);
+    }
 }

--- a/tests/Aspire.Managed.Tests/NuGet/SearchCommandTests.cs
+++ b/tests/Aspire.Managed.Tests/NuGet/SearchCommandTests.cs
@@ -1,0 +1,145 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using System.Text.Json;
+using Aspire.Managed.NuGet.Commands;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+
+namespace Aspire.Managed.Tests.NuGet;
+
+public class SearchCommandTests : IDisposable
+{
+    private readonly TestTempDirectory _tempDir = new();
+
+    public void Dispose() => _tempDir.Dispose();
+
+    [Fact]
+    public void SearchCommand_AcceptsExactMatchWithBoundedTimeout()
+    {
+        RemoteExecutor.Invoke(static async (tempDirPath) =>
+        {
+            var packageSourcePath = Path.Combine(tempDirPath, "packages");
+            Directory.CreateDirectory(packageSourcePath);
+
+            var command = SearchCommand.Create();
+            await using var outputWriter = new StringWriter();
+            var oldOutput = Console.Out;
+            Console.SetOut(outputWriter);
+
+            try
+            {
+                var exitCode = await command.Parse([
+                    "--query", "Aspire.Cli",
+                    "--exact-match",
+                    "--timeout-seconds", "1",
+                    "--source", packageSourcePath,
+                    "--format", "json"]).InvokeAsync();
+
+                Assert.Equal(0, exitCode);
+            }
+            finally
+            {
+                Console.SetOut(oldOutput);
+            }
+
+            Assert.Contains("\"totalHits\":0", outputWriter.ToString());
+        }, _tempDir.Path).Dispose();
+    }
+
+    [Fact]
+    public void SearchCommand_ExactMatchMergesVersionsAcrossSources()
+    {
+        RemoteExecutor.Invoke(static async (tempDirPath) =>
+        {
+            var firstSourcePath = Path.Combine(tempDirPath, "source1");
+            var secondSourcePath = Path.Combine(tempDirPath, "source2");
+            Directory.CreateDirectory(firstSourcePath);
+            Directory.CreateDirectory(secondSourcePath);
+            CreatePackage(firstSourcePath, "Aspire.Cli", "13.3.0");
+            CreatePackage(secondSourcePath, "Aspire.Cli", "13.4.0");
+
+            var command = SearchCommand.Create();
+            await using var outputWriter = new StringWriter();
+            var oldOutput = Console.Out;
+            Console.SetOut(outputWriter);
+
+            try
+            {
+                var exitCode = await command.Parse([
+                    "--query", "Aspire.Cli",
+                    "--exact-match",
+                    "--timeout-seconds", "5",
+                    "--source", firstSourcePath,
+                    "--source", secondSourcePath,
+                    "--format", "json"]).InvokeAsync();
+
+                Assert.Equal(0, exitCode);
+            }
+            finally
+            {
+                Console.SetOut(oldOutput);
+            }
+
+            using var document = JsonDocument.Parse(outputWriter.ToString());
+            var package = document.RootElement.GetProperty("packages").EnumerateArray().Single();
+            Assert.Equal("13.4.0", package.GetProperty("version").GetString());
+            Assert.Equal(
+                ["13.3.0", "13.4.0"],
+                package.GetProperty("allVersions").EnumerateArray().Select(version => version.GetString()!).ToArray());
+        }, _tempDir.Path).Dispose();
+    }
+
+    [Fact]
+    public void SearchCommand_CallerCancellationReturnsFailure()
+    {
+        RemoteExecutor.Invoke(static async (tempDirPath) =>
+        {
+            var packageSourcePath = Path.Combine(tempDirPath, "packages");
+            Directory.CreateDirectory(packageSourcePath);
+
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            var executeSearchAsync = typeof(SearchCommand).GetMethod("ExecuteSearchAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            Assert.NotNull(executeSearchAsync);
+
+            var task = (Task<int>)executeSearchAsync.Invoke(null, [
+                "Aspire.Cli",
+                false,
+                100,
+                0,
+                true,
+                30,
+                new[] { packageSourcePath },
+                null,
+                tempDirPath,
+                "json",
+                false,
+                cts.Token])!;
+            var exitCode = await task;
+
+            Assert.NotEqual(0, exitCode);
+        }, _tempDir.Path).Dispose();
+    }
+
+    private static void CreatePackage(string packagesDirectory, string packageId, string version)
+    {
+        var packagePath = Path.Combine(packagesDirectory, $"{packageId}.{version}.nupkg");
+        using var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create);
+        var entry = archive.CreateEntry($"{packageId}.nuspec");
+        using var writer = new StreamWriter(entry.Open());
+        writer.Write($"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+              <metadata>
+                <id>{packageId}</id>
+                <version>{version}</version>
+                <authors>Aspire</authors>
+                <description>Test package</description>
+              </metadata>
+            </package>
+            """);
+    }
+}


### PR DESCRIPTION
## Description

NuGet package metadata prefetches could outlive the CLI process and, with problematic NuGet sources, remain stuck doing broad package searches for CLI releases and template updates. This hardens both sides of the issue: prefetch tasks are tracked through host shutdown, child helper processes opt into parent-exit cleanup, and exact package metadata lookups are bounded so they can finish on their own.

The query path now uses exact package ID lookups for `Aspire.Cli`, `Aspire.ProjectTemplates`, and exact package version checks while preserving all available versions for update detection. The bundled `aspire-managed nuget search` helper supports exact-match and timeout options, propagates cancellation into NuGet.Protocol calls, merges exact versions across sources, and handles caller cancellation separately from source timeouts.

Validation included focused CLI NuGet/package/update tests, managed NuGet tests, diff whitespace checks, code-review follow-up tests, and a manual smoke test with a local NuGet source that accepts connections but never responds. The smoke test confirmed the helper timed out the hung source, still returned `Aspire.Cli` versions from nuget.org, and did not leave a new helper process behind.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No