### PR TITLE
Handle missing certutil during cert cleanup

### DIFF
--- a/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using Aspire.Cli;
+using Aspire.Cli.Certificates;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Certificates.Generation;
@@ -39,8 +40,6 @@ internal sealed partial class UnixCertificateManager : CertificateManager
     private const string WslFriendlyName = AspNetHttpsOidFriendlyName + " (WSL)";
 
     private const string OpenSslCommand = "openssl";
-    private const string CertUtilCommand = "certutil";
-
     private const int MaxHashCollisions = 10; // Something is going badly wrong if we have this many dev certs with the same hash
 
     private HashSet<string>? _availableCommands;
@@ -140,11 +139,11 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         var nssDbs = GetNssDbs(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
         if (nssDbs.Count > 0)
         {
-            if (!IsCommandAvailable(CertUtilCommand))
+            if (!IsCommandAvailable(CertificateHelpers.CertUtilCommand))
             {
                 // If there are browsers but we don't have certutil, we can't check trust and,
                 // in all probability, we can't have previously established it.
-                Log.UnixMissingCertUtilCommand(CertUtilCommand);
+                Log.UnixMissingCertUtilCommand(CertificateHelpers.CertUtilCommand);
                 sawTrustFailure = true;
             }
             else
@@ -308,10 +307,10 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         var nssDbs = GetNssDbs(homeDirectory);
         if (nssDbs.Count > 0)
         {
-            var isCertUtilAvailable = IsCommandAvailable(CertUtilCommand);
+            var isCertUtilAvailable = IsCommandAvailable(CertificateHelpers.CertUtilCommand);
             if (!isCertUtilAvailable)
             {
-                Log.UnixMissingCertUtilCommand(CertUtilCommand);
+                Log.UnixMissingCertUtilCommand(CertificateHelpers.CertUtilCommand);
                 // We'll loop over the nssdbs anyway so they'll be listed
             }
 
@@ -509,23 +508,24 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         var nssDbs = GetNssDbs(homeDirectory);
         if (nssDbs.Count > 0)
         {
-            var isCertUtilAvailable = IsCommandAvailable(CertUtilCommand);
+            var isCertUtilAvailable = IsCommandAvailable(CertificateHelpers.CertUtilCommand);
             if (!isCertUtilAvailable)
             {
-                Log.UnixMissingCertUtilCommand(CertUtilCommand);
-                // We'll loop over the nssdbs anyway so they'll be listed
+                Log.UnixMissingCertUtilCommand(CertificateHelpers.CertUtilCommand);
             }
-
-            foreach (var nssDb in nssDbs)
+            else
             {
-                if (isCertUtilAvailable && TryRemoveCertificateFromNssDb(nickname, nssDb))
+                foreach (var nssDb in nssDbs)
                 {
-                    Log.UnixNssDbUntrustSucceeded(nssDb.Path);
-                }
-                else
-                {
-                    Log.UnixNssDbUntrustFailed(nssDb.Path);
-                    sawUntrustFailure = true;
+                    if (TryRemoveCertificateFromNssDb(nickname, nssDb))
+                    {
+                        Log.UnixNssDbUntrustSucceeded(nssDb.Path);
+                    }
+                    else
+                    {
+                        Log.UnixNssDbUntrustFailed(nssDb.Path);
+                        sawUntrustFailure = true;
+                    }
                 }
             }
         }
@@ -592,7 +592,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
 
         // We need OpenSSL 1.1.1h or newer (to pick up https://github.com/openssl/openssl/pull/12357),
         // but, given that all of v1 is EOL, it doesn't seem worthwhile to check the version.
-        var commands = new[] { OpenSslCommand, CertUtilCommand };
+        var commands = new[] { OpenSslCommand, CertificateHelpers.CertUtilCommand };
 
         var searchPath = _environment.GetEnvironmentVariable("PATH");
 
@@ -702,7 +702,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
     }
 
     /// <remarks>
-    /// It is the caller's responsibility to ensure that <see cref="CertUtilCommand"/> is available.
+    /// It is the caller's responsibility to ensure that <see cref="CertificateHelpers.CertUtilCommand"/> is available.
     /// </remarks>
     private bool IsCertificateInNssDb(string nickname, NssDb nssDb)
     {
@@ -711,7 +711,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         // (The docs suggest that "-V -u A" should do this, but it seems to accept all certs.)
         var operation = nssDb.IsFirefox ? "-L" : "-V -u V";
 
-        var startInfo = new ProcessStartInfo(CertUtilCommand, $"-d sql:{nssDb.Path} -n {nickname} {operation}")
+        var startInfo = new ProcessStartInfo(CertificateHelpers.CertUtilCommand, $"-d sql:{nssDb.Path} -n {nickname} {operation}")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -732,7 +732,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
     }
 
     /// <remarks>
-    /// It is the caller's responsibility to ensure that <see cref="CertUtilCommand"/> is available.
+    /// It is the caller's responsibility to ensure that <see cref="CertificateHelpers.CertUtilCommand"/> is available.
     /// </remarks>
     private bool TryAddCertificateToNssDb(string certificatePath, string nickname, NssDb nssDb)
     {
@@ -740,7 +740,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         var usage = nssDb.IsFirefox ? "C" : "P";
 
         // This silently clobbers an existing entry, so there's no need to check for existence first.
-        var startInfo = new ProcessStartInfo(CertUtilCommand, $"-d sql:{nssDb.Path} -n {nickname} -A -i {certificatePath} -t \"{usage},,\"")
+        var startInfo = new ProcessStartInfo(CertificateHelpers.CertUtilCommand, $"-d sql:{nssDb.Path} -n {nickname} -A -i {certificatePath} -t \"{usage},,\"")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -760,11 +760,11 @@ internal sealed partial class UnixCertificateManager : CertificateManager
     }
 
     /// <remarks>
-    /// It is the caller's responsibility to ensure that <see cref="CertUtilCommand"/> is available.
+    /// It is the caller's responsibility to ensure that <see cref="CertificateHelpers.CertUtilCommand"/> is available.
     /// </remarks>
     private bool TryRemoveCertificateFromNssDb(string nickname, NssDb nssDb)
     {
-        var startInfo = new ProcessStartInfo(CertUtilCommand, $"-d sql:{nssDb.Path} -D -n {nickname}")
+        var startInfo = new ProcessStartInfo(CertificateHelpers.CertUtilCommand, $"-d sql:{nssDb.Path} -D -n {nickname}")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
@@ -582,56 +582,10 @@ internal sealed partial class UnixCertificateManager : CertificateManager
 
     private bool IsCommandAvailable(string command)
     {
-        _availableCommands ??= FindAvailableCommands();
-        return _availableCommands.Contains(command);
-    }
-
-    private HashSet<string> FindAvailableCommands()
-    {
-        var availableCommands = new HashSet<string>();
-
         // We need OpenSSL 1.1.1h or newer (to pick up https://github.com/openssl/openssl/pull/12357),
         // but, given that all of v1 is EOL, it doesn't seem worthwhile to check the version.
-        var commands = new[] { OpenSslCommand, CertificateHelpers.CertUtilCommand };
-
-        var searchPath = _environment.GetEnvironmentVariable("PATH");
-
-        if (searchPath is null)
-        {
-            return availableCommands;
-        }
-
-        var searchFolders = searchPath.Split(Path.PathSeparator);
-
-        foreach (var searchFolder in searchFolders)
-        {
-            foreach (var command in commands)
-            {
-                if (!availableCommands.Contains(command))
-                {
-                    try
-                    {
-                        if (File.Exists(Path.Combine(searchFolder, command)))
-                        {
-                            availableCommands.Add(command);
-                        }
-                    }
-                    catch
-                    {
-                        // It's not interesting to report (e.g.) permission errors here.
-                    }
-                }
-            }
-
-            // Stop early if we've found all the required commands.
-            // They're usually all in the same folder (/bin or /usr/bin).
-            if (availableCommands.Count == commands.Length)
-            {
-                break;
-            }
-        }
-
-        return availableCommands;
+        _availableCommands ??= CertificateHelpers.FindAvailableCommands(_environment, OpenSslCommand, CertificateHelpers.CertUtilCommand);
+        return _availableCommands.Contains(command);
     }
 
     private static string GetCertificateNickname(X509Certificate2 certificate)

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
@@ -582,10 +582,31 @@ internal sealed partial class UnixCertificateManager : CertificateManager
 
     private bool IsCommandAvailable(string command)
     {
+        _availableCommands ??= FindAvailableCommands();
+        return _availableCommands.Contains(command);
+    }
+
+    private HashSet<string> FindAvailableCommands()
+    {
+        var availableCommands = new HashSet<string>();
+
         // We need OpenSSL 1.1.1h or newer (to pick up https://github.com/openssl/openssl/pull/12357),
         // but, given that all of v1 is EOL, it doesn't seem worthwhile to check the version.
-        _availableCommands ??= CertificateHelpers.FindAvailableCommands(_environment, OpenSslCommand, CertificateHelpers.CertUtilCommand);
-        return _availableCommands.Contains(command);
+        var commands = new[] { OpenSslCommand, CertificateHelpers.CertUtilCommand };
+
+        var environmentVariables = _environment.GetEnvironmentVariables()
+            .Where(kv => kv.Value is not null)
+            .ToDictionary(kv => kv.Name, kv => kv.Value!);
+
+        foreach (var command in commands)
+        {
+            if (PathLookupHelper.TryResolveExecutablePath(command, out _, environmentVariables))
+            {
+                availableCommands.Add(command);
+            }
+        }
+
+        return availableCommands;
     }
 
     private static string GetCertificateNickname(X509Certificate2 certificate)

--- a/src/Aspire.Cli/Certificates/CertificateHelpers.cs
+++ b/src/Aspire.Cli/Certificates/CertificateHelpers.cs
@@ -17,6 +17,11 @@ namespace Aspire.Cli.Certificates;
 internal static partial class CertificateHelpers
 {
     /// <summary>
+    /// The command used to query and update NSS certificate databases.
+    /// </summary>
+    internal const string CertUtilCommand = "certutil";
+
+    /// <summary>
     /// The environment variable name for overriding the dev-certs OpenSSL certificate directory.
     /// </summary>
     internal const string DevCertsOpenSslCertDirEnvVar = "DOTNET_DEV_CERTS_OPENSSL_CERTIFICATE_DIRECTORY";
@@ -94,6 +99,41 @@ internal static partial class CertificateHelpers
             or EnsureCertificateResult.ValidCertificatePresent
             or EnsureCertificateResult.ExistingHttpsCertificateTrusted
             or EnsureCertificateResult.NewHttpsCertificateTrusted;
+
+    /// <summary>
+    /// Determines whether the specified command can be found in <c>PATH</c>.
+    /// </summary>
+    /// <param name="command">The command name to locate.</param>
+    /// <param name="environment">The environment abstraction for reading <c>PATH</c>.</param>
+    /// <returns><see langword="true"/> if the command was found; otherwise, <see langword="false"/>.</returns>
+    internal static bool IsCommandAvailable(string command, IEnvironment environment)
+    {
+        var searchPath = environment.GetEnvironmentVariable("PATH");
+
+        if (searchPath is null)
+        {
+            return false;
+        }
+
+        var searchFolders = searchPath.Split(Path.PathSeparator);
+
+        foreach (var searchFolder in searchFolders)
+        {
+            try
+            {
+                if (File.Exists(Path.Combine(searchFolder, command)))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                // It's not interesting to report (e.g.) permission errors here.
+            }
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Tries to detect the OpenSSL directory by running 'openssl version -d'.

--- a/src/Aspire.Cli/Certificates/CertificateHelpers.cs
+++ b/src/Aspire.Cli/Certificates/CertificateHelpers.cs
@@ -108,31 +108,58 @@ internal static partial class CertificateHelpers
     /// <returns><see langword="true"/> if the command was found; otherwise, <see langword="false"/>.</returns>
     internal static bool IsCommandAvailable(string command, IEnvironment environment)
     {
-        var searchPath = environment.GetEnvironmentVariable("PATH");
+        var availableCommands = FindAvailableCommands(environment, command);
+        return availableCommands.Contains(command);
+    }
 
-        if (searchPath is null)
+    /// <summary>
+    /// Finds the specified commands in <c>PATH</c>.
+    /// </summary>
+    /// <param name="environment">The environment abstraction for reading <c>PATH</c>.</param>
+    /// <param name="commands">The command names to locate.</param>
+    /// <returns>The commands found in <c>PATH</c>.</returns>
+    internal static HashSet<string> FindAvailableCommands(IEnvironment environment, params string[] commands)
+    {
+        var searchPath = environment.GetEnvironmentVariable("PATH");
+        var availableCommands = new HashSet<string>();
+
+        if (commands.Length == 0 || searchPath is null)
         {
-            return false;
+            return availableCommands;
         }
 
+        var expectedCommandCount = new HashSet<string>(commands).Count;
         var searchFolders = searchPath.Split(Path.PathSeparator);
 
         foreach (var searchFolder in searchFolders)
         {
-            try
+            foreach (var command in commands)
             {
-                if (File.Exists(Path.Combine(searchFolder, command)))
+                if (!availableCommands.Contains(command))
                 {
-                    return true;
+                    try
+                    {
+                        if (File.Exists(Path.Combine(searchFolder, command)))
+                        {
+                            availableCommands.Add(command);
+                        }
+                    }
+                    catch
+                    {
+                        // It's not interesting to report (e.g.) permission errors here.
+                    }
                 }
             }
-            catch
+
+            // Stop early if we've found all the required commands.
+            // They're usually all in the same folder (/bin or /usr/bin).
+            if (availableCommands.Count == expectedCommandCount)
             {
-                // It's not interesting to report (e.g.) permission errors here.
+                break;
             }
         }
 
-        return false;
+        return availableCommands;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Certificates/CertificateHelpers.cs
+++ b/src/Aspire.Cli/Certificates/CertificateHelpers.cs
@@ -101,68 +101,6 @@ internal static partial class CertificateHelpers
             or EnsureCertificateResult.NewHttpsCertificateTrusted;
 
     /// <summary>
-    /// Determines whether the specified command can be found in <c>PATH</c>.
-    /// </summary>
-    /// <param name="command">The command name to locate.</param>
-    /// <param name="environment">The environment abstraction for reading <c>PATH</c>.</param>
-    /// <returns><see langword="true"/> if the command was found; otherwise, <see langword="false"/>.</returns>
-    internal static bool IsCommandAvailable(string command, IEnvironment environment)
-    {
-        var availableCommands = FindAvailableCommands(environment, command);
-        return availableCommands.Contains(command);
-    }
-
-    /// <summary>
-    /// Finds the specified commands in <c>PATH</c>.
-    /// </summary>
-    /// <param name="environment">The environment abstraction for reading <c>PATH</c>.</param>
-    /// <param name="commands">The command names to locate.</param>
-    /// <returns>The commands found in <c>PATH</c>.</returns>
-    internal static HashSet<string> FindAvailableCommands(IEnvironment environment, params string[] commands)
-    {
-        var searchPath = environment.GetEnvironmentVariable("PATH");
-        var availableCommands = new HashSet<string>();
-
-        if (commands.Length == 0 || searchPath is null)
-        {
-            return availableCommands;
-        }
-
-        var expectedCommandCount = new HashSet<string>(commands).Count;
-        var searchFolders = searchPath.Split(Path.PathSeparator);
-
-        foreach (var searchFolder in searchFolders)
-        {
-            foreach (var command in commands)
-            {
-                if (!availableCommands.Contains(command))
-                {
-                    try
-                    {
-                        if (File.Exists(Path.Combine(searchFolder, command)))
-                        {
-                            availableCommands.Add(command);
-                        }
-                    }
-                    catch
-                    {
-                        // It's not interesting to report (e.g.) permission errors here.
-                    }
-                }
-            }
-
-            // Stop early if we've found all the required commands.
-            // They're usually all in the same folder (/bin or /usr/bin).
-            if (availableCommands.Count == expectedCommandCount)
-            {
-                break;
-            }
-        }
-
-        return availableCommands;
-    }
-
-    /// <summary>
     /// Tries to detect the OpenSSL directory by running 'openssl version -d'.
     /// Parses the OPENSSLDIR value from the output (e.g. OPENSSLDIR: "/usr/lib/ssl").
     /// </summary>

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -393,6 +393,33 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to certutil is not available; browser certificate trust may be incomplete.
+        /// </summary>
+        public static string DevCertsMissingCertUtilMessage {
+            get {
+                return ResourceManager.GetString("DevCertsMissingCertUtilMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux..
+        /// </summary>
+        public static string DevCertsMissingCertUtilDetails {
+            get {
+                return ResourceManager.GetString("DevCertsMissingCertUtilDetails", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Install certutil from your distribution's NSS tools package (for example, libnss3-tools)..
+        /// </summary>
+        public static string DevCertsMissingCertUtilFix {
+            get {
+                return ResourceManager.GetString("DevCertsMissingCertUtilFix", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Developer Control Plane (DCP) bundle not found; skipping connection health checks.
         /// </summary>
         public static string DcpBundleNotFoundMessage {

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -179,6 +179,15 @@
   <data name="DevCertsOldVersionDetailsFormat" xml:space="preserve">
     <value>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</value>
   </data>
+  <data name="DevCertsMissingCertUtilMessage" xml:space="preserve">
+    <value>certutil is not available; browser certificate trust may be incomplete</value>
+  </data>
+  <data name="DevCertsMissingCertUtilDetails" xml:space="preserve">
+    <value>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</value>
+  </data>
+  <data name="DevCertsMissingCertUtilFix" xml:space="preserve">
+    <value>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</value>
+  </data>
   <data name="DcpBundleNotFoundMessage" xml:space="preserve">
     <value>Developer Control Plane (DCP) bundle not found; skipping connection health checks</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -222,6 +222,21 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilDetails">
+        <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
+        <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilFix">
+        <source>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</source>
+        <target state="new">Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsMissingCertUtilMessage">
+        <source>certutil is not available; browser certificate trust may be incomplete</source>
+        <target state="new">certutil is not available; browser certificate trust may be incomplete</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsMultipleNoneTrustedDetailsFormat">
         <source>Found certificates: {0}. Having multiple certificates can cause confusion.</source>
         <target state="new">Found certificates: {0}. Having multiple certificates can cause confusion.</target>

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -205,12 +205,16 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
 
     private static void AddLinuxCertificateToolWarnings(List<EnvironmentCheckResult> results, IEnvironment environment)
     {
+        if (!environment.IsLinux())
+        {
+            return;
+        }
+
         var environmentVariables = environment.GetEnvironmentVariables()
             .Where(kv => kv.Value is not null)
             .ToDictionary(kv => kv.Name, kv => kv.Value!);
 
-        if (!environment.IsLinux() ||
-            PathLookupHelper.TryResolveExecutablePath(CertificateHelpers.CertUtilCommand, out _, environmentVariables))
+        if (PathLookupHelper.TryResolveExecutablePath(CertificateHelpers.CertUtilCommand, out _, environmentVariables))
         {
             return;
         }

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -17,6 +17,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
 {
     internal const string CheckName = "dev-certs";
     internal const string VersionCheckName = "dev-certs-version";
+    internal const string CertUtilCheckName = "dev-certs-certutil";
 
     public int Order => 35; // After SDK check (30), before container checks (40+)
 
@@ -29,6 +30,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         {
             var trustResult = certificateToolRunner.CheckHttpCertificate();
             var results = EvaluateCertificateResults(trustResult.Certificates, environment);
+            AddLinuxCertificateToolWarnings(results, environment);
 
             return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>(results);
         }
@@ -199,6 +201,25 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         }
 
         return results;
+    }
+
+    private static void AddLinuxCertificateToolWarnings(List<EnvironmentCheckResult> results, IEnvironment environment)
+    {
+        if (!environment.IsLinux() || CertificateHelpers.IsCommandAvailable(CertificateHelpers.CertUtilCommand, environment))
+        {
+            return;
+        }
+
+        results.Add(new EnvironmentCheckResult
+        {
+            Category = EnvironmentCheckCategories.Environment,
+            Name = CertUtilCheckName,
+            Status = EnvironmentCheckStatus.Warning,
+            Message = DoctorCommandStrings.DevCertsMissingCertUtilMessage,
+            Details = DoctorCommandStrings.DevCertsMissingCertUtilDetails,
+            Fix = DoctorCommandStrings.DevCertsMissingCertUtilFix,
+            Link = "https://aka.ms/aspire-prerequisites#dev-certs"
+        });
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -205,7 +205,12 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
 
     private static void AddLinuxCertificateToolWarnings(List<EnvironmentCheckResult> results, IEnvironment environment)
     {
-        if (!environment.IsLinux() || CertificateHelpers.IsCommandAvailable(CertificateHelpers.CertUtilCommand, environment))
+        var environmentVariables = environment.GetEnvironmentVariables()
+            .Where(kv => kv.Value is not null)
+            .ToDictionary(kv => kv.Name, kv => kv.Value!);
+
+        if (!environment.IsLinux() ||
+            PathLookupHelper.TryResolveExecutablePath(CertificateHelpers.CertUtilCommand, out _, environmentVariables))
         {
             return;
         }

--- a/src/Shared/PathLookupHelper.cs
+++ b/src/Shared/PathLookupHelper.cs
@@ -11,7 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 internal static class PathLookupHelper
 {
     /// <summary>
-    /// Resolves an executable path or command name to a full path by searching the system PATH.
+    /// Resolves an executable path or command name by returning explicit paths as-is or by searching the system PATH.
     /// </summary>
     /// <param name="executablePath">The executable path or command name to resolve.</param>
     /// <param name="environmentVariables">Optional environment variable overrides to use for lookup.</param>
@@ -46,12 +46,12 @@ internal static class PathLookupHelper
     }
 
     /// <summary>
-    /// Tries to resolve an executable path or command name to a full path by searching the system PATH.
+    /// Tries to resolve an executable path or command name by returning explicit paths as-is or by searching the system PATH.
     /// </summary>
     /// <param name="executablePath">The executable path or command name to resolve.</param>
-    /// <param name="resolvedExecutablePath">The resolved executable path if found.</param>
+    /// <param name="resolvedExecutablePath">The resolved command path, or the original value when <paramref name="executablePath"/> is explicit.</param>
     /// <param name="environmentVariables">Optional environment variable overrides to use for lookup.</param>
-    /// <returns><see langword="true"/> when the executable was resolved; otherwise, <see langword="false"/>.</returns>
+    /// <returns><see langword="true"/> when the executable path is explicit or the command name was resolved; otherwise, <see langword="false"/>.</returns>
     public static bool TryResolveExecutablePath(
         string executablePath,
         [NotNullWhen(true)] out string? resolvedExecutablePath,

--- a/src/Shared/PathLookupHelper.cs
+++ b/src/Shared/PathLookupHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 /// <summary>
 /// Provides helper methods for looking up executables on the system PATH.
@@ -42,6 +43,30 @@ internal static class PathLookupHelper
         // See https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw
         return FindFullPathFromPath(executablePath, path, Path.PathSeparator, FileExistsAndIsExecutable, pathExtensions)
             ?? throw new FileNotFoundException($"Executable '{executablePath}' was not found on PATH.", executablePath);
+    }
+
+    /// <summary>
+    /// Tries to resolve an executable path or command name to a full path by searching the system PATH.
+    /// </summary>
+    /// <param name="executablePath">The executable path or command name to resolve.</param>
+    /// <param name="resolvedExecutablePath">The resolved executable path if found.</param>
+    /// <param name="environmentVariables">Optional environment variable overrides to use for lookup.</param>
+    /// <returns><see langword="true"/> when the executable was resolved; otherwise, <see langword="false"/>.</returns>
+    public static bool TryResolveExecutablePath(
+        string executablePath,
+        [NotNullWhen(true)] out string? resolvedExecutablePath,
+        IDictionary<string, string>? environmentVariables = null)
+    {
+        try
+        {
+            resolvedExecutablePath = ResolveExecutablePath(executablePath, environmentVariables);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            resolvedExecutablePath = null;
+            return false;
+        }
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Certificates;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.Certificates.Generation;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Certificates;
+
+public class UnixCertificateManagerTests
+{
+    [Fact]
+    public void RemoveCertificate_WithMissingCertUtilAndNssDbs_SkipsNssCleanup()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "NSS certificate cleanup is only exercised on Linux.");
+
+        var nssDbDirectory = Directory.CreateTempSubdirectory();
+        var openSslDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = Path.Combine(nssDbDirectory.FullName, "missing-certutil"),
+                ["DOTNET_DEV_CERTS_NSSDB_PATHS"] = nssDbDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = openSslDirectory.FullName
+            });
+            var manager = new UnixCertificateManager(NullLogger.Instance, environment);
+            using var certificate = manager.CreateAspNetCoreHttpsDevelopmentCertificate(
+                DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddDays(365));
+
+            var exception = Record.Exception(() => manager.RemoveCertificate(certificate, CertificateManager.RemoveLocations.Trusted));
+
+            Assert.Null(exception);
+        }
+        finally
+        {
+            nssDbDirectory.Delete(recursive: true);
+            openSslDirectory.Delete(recursive: true);
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -305,4 +305,32 @@ public class DevCertsCheckTests
             tempDirectory.Delete(recursive: true);
         }
     }
+
+    [Fact]
+    public async Task CheckAsync_NonLinux_DoesNotReadEnvironmentVariablesForCertUtilWarning()
+    {
+        var certs = new List<DevCertInfo>
+        {
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+        };
+        var toolRunner = new TestCertificateToolRunner
+        {
+            CheckHttpCertificateCallback = () => new CertificateTrustResult
+            {
+                HasCertificates = true,
+                TrustLevel = CertificateManager.TrustLevel.Full,
+                Certificates = certs
+            }
+        };
+        var environment = TestEnvironment.CreateMacOS(new Dictionary<string, string?>
+        {
+            ["PATH"] = Path.Combine(AppContext.BaseDirectory, Guid.NewGuid().ToString("N"))
+        });
+        var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+
+        var results = await check.CheckAsync();
+
+        Assert.Equal(0, environment.GetEnvironmentVariablesCallCount);
+        Assert.Collection(results, result => Assert.Equal(DevCertsCheck.CheckName, result.Name));
+    }
 }

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -270,7 +270,13 @@ public class DevCertsCheckTests
 
         try
         {
-            File.WriteAllText(Path.Combine(tempDirectory.FullName, CertificateHelpers.CertUtilCommand), "");
+            var certUtilPath = Path.Combine(tempDirectory.FullName, CertificateHelpers.CertUtilCommand);
+            File.WriteAllText(certUtilPath, "");
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(certUtilPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+            }
+
             var certs = new List<DevCertInfo>
             {
                 CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Certificates;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Utils.EnvironmentChecker;
 using Microsoft.AspNetCore.Certificates.Generation;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Utils;
 
@@ -230,5 +232,71 @@ public class DevCertsCheckTests
 
         var devCertsResult = Assert.Single(results);
         Assert.Null(devCertsResult.Metadata);
+    }
+
+    [Fact]
+    public async Task CheckAsync_LinuxWithoutCertUtil_ReturnsCertUtilWarning()
+    {
+        var certs = new List<DevCertInfo>
+        {
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+        };
+        var toolRunner = new TestCertificateToolRunner
+        {
+            CheckHttpCertificateCallback = () => new CertificateTrustResult
+            {
+                HasCertificates = true,
+                TrustLevel = CertificateManager.TrustLevel.Full,
+                Certificates = certs
+            }
+        };
+        var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+        {
+            ["PATH"] = Path.Combine(AppContext.BaseDirectory, Guid.NewGuid().ToString("N"))
+        });
+        var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+
+        var results = await check.CheckAsync();
+
+        var certUtilResult = Assert.Single(results, r => r.Name == DevCertsCheck.CertUtilCheckName);
+        Assert.Equal(EnvironmentCheckStatus.Warning, certUtilResult.Status);
+        Assert.Contains("certutil", certUtilResult.Message);
+    }
+
+    [Fact]
+    public async Task CheckAsync_LinuxWithCertUtil_DoesNotReturnCertUtilWarning()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDirectory.FullName, CertificateHelpers.CertUtilCommand), "");
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName
+            });
+            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+
+            var results = await check.CheckAsync();
+
+            Assert.DoesNotContain(results, r => r.Name == DevCertsCheck.CertUtilCheckName);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/TestEnvironment.cs
+++ b/tests/Aspire.Cli.Tests/Utils/TestEnvironment.cs
@@ -11,6 +11,8 @@ internal sealed class TestEnvironment : IEnvironment
 {
     public IReadOnlyDictionary<string, string?> Variables { get; }
 
+    public int GetEnvironmentVariablesCallCount { get; private set; }
+
     public TestEnvironment(IReadOnlyDictionary<string, string?>? variables = null)
     {
         Variables = variables ?? new Dictionary<string, string?>();
@@ -23,6 +25,7 @@ internal sealed class TestEnvironment : IEnvironment
 
     public IEnumerable<(string Name, string? Value)> GetEnvironmentVariables()
     {
+        GetEnvironmentVariablesCallCount++;
         return Variables.Select(pair => (pair.Key, pair.Value));
     }
 


### PR DESCRIPTION
## Description

Linux certificate cleanup should not fail just because `certutil` is unavailable. NSS database cleanup is best effort, so this change logs the missing tool and continues with the rest of certificate cleanup instead of treating browser cleanup as a hard failure.

This also updates `aspire doctor` on Linux to report a warning when `certutil` is missing, since Firefox and Chromium browser certificate trust may be incomplete without NSS tools. The warning uses localized CLI resources and the generated XLF files were updated.

### User-facing usage

When `certutil` is missing on Linux, `aspire certs clean` can still complete cleanup for the available certificate stores. `aspire doctor` now reports a warning explaining that browser certificate trust may be incomplete and suggests installing the distribution NSS tools package, for example `libnss3-tools`.

Validation:

```text
dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.DevCertsCheckTests" --filter-class "*.UnixCertificateManagerTests" --filter-class "*.NativeCertificateToolRunnerTests" --filter-class "*.CertificatesCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No